### PR TITLE
Feat(eos_cli_config_gen): Add schema for standard_access_lists

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -66,3 +66,27 @@ community_lists:
   - name: <str>
     action: <str>
 ```
+
+## Standard Access-Lists
+
+### Variables
+
+| Variable | Type | Required | Default | Value Restrictions | Description |
+| -------- | ---- | -------- | ------- | ------------------ | ----------- |
+| [<samp>standard_access_lists</samp>](## "standard_access_lists") | List, items: Dictionary |  |  |  | Standard Access-Lists |
+| [<samp>&nbsp;&nbsp;- name</samp>](## "standard_access_lists.[].name") | String | Required, Unique |  |  | Access-list Name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;counters_per_entry</samp>](## "standard_access_lists.[].counters_per_entry") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;sequence_numbers</samp>](## "standard_access_lists.[].sequence_numbers") | List, items: Dictionary | Required |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- sequence</samp>](## "standard_access_lists.[].sequence_numbers.[].sequence") | Integer | Required, Unique |  |  | Sequence ID |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;action</samp>](## "standard_access_lists.[].sequence_numbers.[].action") | String | Required |  |  | Action as string<br>Example: "deny ip any any" |
+
+### YAML
+
+```yaml
+standard_access_lists:
+  - name: <str>
+    counters_per_entry: <bool>
+    sequence_numbers:
+      - sequence: <int>
+        action: <str>
+```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -127,4 +127,5 @@ keys:
                 type: str
                 required: true
                 description: 'Action as string
+
                   Example: "deny ip any any"'

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -93,3 +93,38 @@ keys:
           description: 'Action as string
 
             Example: "permit GSHUT 65123:123"'
+  standard_access_lists:
+    type: list
+    primary_key: name
+    convert_types:
+      - dict
+    display_name: Standard Access-Lists
+    items:
+      type: dict
+      keys:
+        name:
+          type: str
+          required: true
+          display_name: Access-list Name
+        counters_per_entry:
+          type: bool
+        sequence_numbers:
+          type: list
+          required: true
+          primary_key: sequence
+          convert_types:
+            - dict
+          items:
+            type: dict
+            keys:
+              sequence:
+                type: int
+                required: true
+                display_name: Sequence ID
+                convert_types:
+                  - str
+              action:
+                type: str
+                required: true
+                description: 'Action as string
+                    Example: "deny ip any any"'

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -97,7 +97,7 @@ keys:
     type: list
     primary_key: name
     convert_types:
-      - dict
+    - dict
     display_name: Standard Access-Lists
     items:
       type: dict
@@ -113,7 +113,7 @@ keys:
           required: true
           primary_key: sequence
           convert_types:
-            - dict
+          - dict
           items:
             type: dict
             keys:
@@ -122,9 +122,9 @@ keys:
                 required: true
                 display_name: Sequence ID
                 convert_types:
-                  - str
+                - str
               action:
                 type: str
                 required: true
                 description: 'Action as string
-                    Example: "deny ip any any"'
+                  Example: "deny ip any any"'

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/standard_access_lists.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/standard_access_lists.schema.yml
@@ -1,0 +1,42 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+allow_other_keys: true
+keys:
+  standard_access_lists:
+    type: list
+    primary_key: name
+    convert_types:
+      - dict
+    display_name: Standard Access-Lists
+    items:
+      type: dict
+      keys:
+        name:
+          type: str
+          required: true
+          display_name: Access-list Name
+        counters_per_entry:
+          type: bool
+        sequence_numbers:
+          type: list
+          required: true
+          primary_key: sequence
+          convert_types:
+            - dict
+          items:
+            type: dict
+            keys:
+              sequence:
+                type: int
+                required: true
+                display_name: Sequence ID
+                convert_types:
+                  - str
+              action:
+                type: str
+                required: true
+                description: |
+                  Action as string
+                  Example: "deny ip any any"

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/standard-access-lists.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/standard-access-lists.j2
@@ -4,7 +4,7 @@
 
 ### Standard Access-lists Summary
 
-{%     for standard_access_list in standard_access_lists | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%     for standard_access_list in standard_access_lists | arista.avd.natural_sort('name') %}
 #### {{ standard_access_list.name }}
 {%         if standard_access_list.counters_per_entry is arista.avd.defined(true) %}
 
@@ -13,7 +13,7 @@ ACL has counting mode `counters per-entry` enabled!
 
 | Sequence | Action |
 | -------- | ------ |
-{%         for sequence in standard_access_list.sequence_numbers | arista.avd.convert_dicts('sequence') | arista.avd.natural_sort('sequence') %}
+{%         for sequence in standard_access_list.sequence_numbers | arista.avd.natural_sort('sequence') %}
 | {{ sequence.sequence }} | {{ sequence.action }} |
 {%         endfor %}
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/standard-access-lists.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/standard-access-lists.j2
@@ -1,11 +1,11 @@
 {# eos - standard access-lists #}
-{% for standard_access_list in standard_access_lists | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{% for standard_access_list in standard_access_lists | arista.avd.natural_sort('name') %}
 !
 ip access-list standard {{ standard_access_list.name }}
 {%     if standard_access_list.counters_per_entry is arista.avd.defined(true) %}
    counters per-entry
 {%     endif %}
-{%     for sequence in standard_access_list.sequence_numbers | arista.avd.convert_dicts('sequence') | arista.avd.natural_sort('sequence') %}
+{%     for sequence in standard_access_list.sequence_numbers | arista.avd.natural_sort('sequence') %}
 {%         if sequence.action is arista.avd.defined %}
    {{ sequence.sequence }} {{ sequence.action }}
 {%         endif %}


### PR DESCRIPTION
## Add schema for data model

<!-- Use this PR Title: Feat(eos_cli_config_gen): Add schema for < standard_access_lists > -->

## Checklist

### Contributor Checklist

- [ ] Create schema fragment matching data model described in README.md and README_v4.0.md
  - README.md is most complete with all keys. README_v4.0 includes partial data models after conversion to lists.
  - Schema fragment path is `roles/eos_cli_config_gen/schemas/schema_fragments/<data_model_key>.schema.yml`.
  - Copy line 1-5 from another schema (comments and outer type:dict).
  - Refer to [schema documentation](https://avd.sh/en/devel/docs/input-variable-validation-BETA.html) for syntax and/or use YAML Lint plugin from Redhat in VSCode.
  - Use `convert_types` on value that could be mixed type or misinterpreted like integers and numeric strings.
- [ ] If the data model has been converted from wildcard dicts:
  - Add `convert_types: ['dict']` to the schema.
  - Remove `convert_dicts` from the `templates/eos/<>.j2` and `templates/documentation/<>.j2` templates.
- [ ] Run `molecule converge -s build_schemas_and_docs` to update schema and documentation.
- [ ] Test by running `molecule converge -s eos_cli_config_gen` and verify no errors or changes to generated configs/docs.

### Reviewer Checklist

- Reviewer 1: Claus
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2: Guillaume
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
