### PR TITLE
Feat(eos_cli_config_gen): Add schema for daemons

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -67,6 +67,26 @@ community_lists:
     action: <str>
 ```
 
+## Custom Daemons
+
+### Variables
+
+| Variable | Type | Required | Default | Value Restrictions | Description |
+| -------- | ---- | -------- | ------- | ------------------ | ----------- |
+| [<samp>daemons</samp>](## "daemons") | List, items: Dictionary |  |  |  | Custom Daemons |
+| [<samp>&nbsp;&nbsp;- name</samp>](## "daemons.[].name") | String | Required, Unique |  |  | Daemon Name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;exec</samp>](## "daemons.[].exec") | String | Required |  |  | command to run as a daemon<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "daemons.[].enabled") | Boolean |  | True |  |  |
+
+### YAML
+
+```yaml
+daemons:
+  - name: <str>
+    exec: <str>
+    enabled: <bool>
+```
+
 ## Interface Profiles
 
 ### Variables

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -93,6 +93,28 @@ keys:
           description: 'Action as string
 
             Example: "permit GSHUT 65123:123"'
+  daemons:
+    type: list
+    primary_key: name
+    convert_types:
+    - dict
+    display_name: Custom Daemons
+    items:
+      type: dict
+      keys:
+        name:
+          type: str
+          required: true
+          display_name: Daemon Name
+        exec:
+          type: str
+          required: true
+          description: 'command to run as a daemon
+
+            '
+        enabled:
+          type: bool
+          default: true
   interface_profiles:
     type: list
     primary_key: name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/daemons.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/daemons.schema.yml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  daemons:
+    type: list
+    primary_key: name
+    convert_types:
+    - dict
+    display_name: Custom Daemons
+    items:
+      type: dict
+      keys:
+        name:
+          type: str
+          required: true
+          display_name: Daemon Name
+        exec:
+          type: str
+          required: true
+          description: |
+            command to run as a daemon
+        enabled:
+          type: bool

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/daemons.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/daemons.schema.yml
@@ -23,3 +23,4 @@ keys:
             command to run as a daemon
         enabled:
           type: bool
+          default: true

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/daemons.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/daemons.j2
@@ -1,6 +1,6 @@
 {# eos - daemons #}
 {% if daemons is arista.avd.defined %}
-{%     for daemon in daemons | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%     for daemon in daemons | arista.avd.natural_sort('name') %}
 !
 daemon {{ daemon.name }}
 {%         if daemon.exec is arista.avd.defined %}


### PR DESCRIPTION
## Add schema for data model

<!-- Use this PR Title: Feat(eos_cli_config_gen): Add schema for 'daemons' -->

## Checklist

### Contributor Checklist

- [x] Create schema fragment matching data model described in README.md and README_v4.0.md
  - README.md is most complete with all keys. README_v4.0 includes partial data models after conversion to lists.
  - Schema fragment path is `roles/eos_cli_config_gen/schemas/schema_fragments/<data_model_key>.schema.yml`.
  - Copy line 1-5 from another schema (comments and outer type:dict).
  - Refer to [schema documentation](https://avd.sh/en/devel/docs/input-variable-validation-BETA.html) for syntax and/or use YAML Lint plugin from Redhat in VSCode.
  - Use `convert_types` on value that could be mixed type or misinterpreted like integers and numeric strings.
- [x] If the data model has been converted from wildcard dicts:
  - Add `convert_types: ['dict']` to the schema.
  - Remove `convert_dicts` from the `templates/eos/<>.j2` and `templates/documentation/<>.j2` templates.
- [x] Run `molecule converge -s build_schemas_and_docs` to update schema and documentation.
- [x] Test by running `molecule converge -s eos_cli_config_gen` and verify no errors or changes to generated configs/docs.

### Reviewer Checklist

- Reviewer 1 (Claus):
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2 (Carl):
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
