### PR TITLE
Feat(eos_cli_config_gen): Add schema for maintenance

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -291,6 +291,74 @@ local_users:
     ssh_key: <str>
 ```
 
+## Maintenance Mode
+
+### Variables
+
+| Variable | Type | Required | Default | Value Restrictions | Description |
+| -------- | ---- | -------- | ------- | ------------------ | ----------- |
+| [<samp>maintenance</samp>](## "maintenance") | Dictionary |  |  |  | Maintenance Mode |
+| [<samp>&nbsp;&nbsp;default_interface_profile</samp>](## "maintenance.default_interface_profile") | String |  |  |  | Name of default Interface Profile<br> |
+| [<samp>&nbsp;&nbsp;default_bgp_profile</samp>](## "maintenance.default_bgp_profile") | String |  |  |  | Name of default BGP Profile<br> |
+| [<samp>&nbsp;&nbsp;default_unit_profile</samp>](## "maintenance.default_unit_profile") | String |  |  |  | Name of default Unit Profile<br> |
+| [<samp>&nbsp;&nbsp;interface_profiles</samp>](## "maintenance.interface_profiles") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "maintenance.interface_profiles.[].name") | String | Required, Unique |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rate_monitoring</samp>](## "maintenance.interface_profiles.[].rate_monitoring") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;load_interval</samp>](## "maintenance.interface_profiles.[].rate_monitoring.load_interval") | Integer |  |  |  | Load Interval in Seconds<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;threshold</samp>](## "maintenance.interface_profiles.[].rate_monitoring.threshold") | Integer |  |  |  | Threshold in kbps<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;shutdown</samp>](## "maintenance.interface_profiles.[].shutdown") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;max_delay</samp>](## "maintenance.interface_profiles.[].shutdown.max_delay") | Integer |  |  |  | Max delay in seconds<br> |
+| [<samp>&nbsp;&nbsp;bgp_profiles</samp>](## "maintenance.bgp_profiles") | List, items: Dictionary |  |  |  | BGP Profiles |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "maintenance.bgp_profiles.[].name") | String | Required, Unique |  |  | BGP Profile Name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;initiator</samp>](## "maintenance.bgp_profiles.[].initiator") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map_inout</samp>](## "maintenance.bgp_profiles.[].initiator.route_map_inout") | String |  |  |  | Route Map |
+| [<samp>&nbsp;&nbsp;unit_profiles</samp>](## "maintenance.unit_profiles") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "maintenance.unit_profiles.[].name") | String | Required, Unique |  |  | Unit Profile Name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;on_boot</samp>](## "maintenance.unit_profiles.[].on_boot") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;duration</samp>](## "maintenance.unit_profiles.[].on_boot.duration") | Integer |  |  | Min: 300<br>Max: 3600 | On-boot in seconds<br> |
+| [<samp>&nbsp;&nbsp;units</samp>](## "maintenance.units") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "maintenance.units.[].name") | String | Required, Unique |  |  | Unit Name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;quiesce</samp>](## "maintenance.units.[].quiesce") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;profile</samp>](## "maintenance.units.[].profile") | String | Required |  |  | Name of Unit Profile<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;groups</samp>](## "maintenance.units.[].groups") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bgp_groups</samp>](## "maintenance.units.[].groups.bgp_groups") | List, items: String |  |  |  | BGP Groups |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "maintenance.units.[].groups.bgp_groups.[].&lt;str&gt;") | String |  |  |  | Name of BGP Group<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interface_groups</samp>](## "maintenance.units.[].groups.interface_groups") | List, items: String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "maintenance.units.[].groups.interface_groups.[].&lt;str&gt;") | String |  |  |  | Name of Interface Group |
+
+### YAML
+
+```yaml
+maintenance:
+  default_interface_profile: <str>
+  default_bgp_profile: <str>
+  default_unit_profile: <str>
+  interface_profiles:
+    - name: <str>
+      rate_monitoring:
+        load_interval: <int>
+        threshold: <int>
+      shutdown:
+        max_delay: <int>
+  bgp_profiles:
+    - name: <str>
+      initiator:
+        route_map_inout: <str>
+  unit_profiles:
+    - name: <str>
+      on_boot:
+        duration: <int>
+  units:
+    - name: <str>
+      quiesce: <bool>
+      profile: <str>
+      groups:
+        bgp_groups:
+          - <str>
+        interface_groups:
+          - <str>
+```
+
 ## Match Lists
 
 ### Variables

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -376,6 +376,142 @@ keys:
         ssh_key:
           display_name: SSH Key
           type: str
+  maintenance:
+    type: dict
+    display_name: Maintenance Mode
+    keys:
+      default_interface_profile:
+        type: str
+        description: 'Name of default Interface Profile
+
+          '
+      default_bgp_profile:
+        type: str
+        description: 'Name of default BGP Profile
+
+          '
+      default_unit_profile:
+        type: str
+        description: 'Name of default Unit Profile
+
+          '
+      interface_profiles:
+        type: list
+        primary_key: name
+        convert_types:
+        - dict
+        items:
+          type: dict
+          keys:
+            name:
+              type: str
+              required: true
+            rate_monitoring:
+              type: dict
+              keys:
+                load_interval:
+                  type: int
+                  convert_types:
+                  - str
+                  description: 'Load Interval in Seconds
+
+                    '
+                threshold:
+                  type: int
+                  convert_types:
+                  - str
+                  description: 'Threshold in kbps
+
+                    '
+            shutdown:
+              type: dict
+              keys:
+                max_delay:
+                  type: int
+                  convert_types:
+                  - str
+                  description: 'Max delay in seconds
+
+                    '
+      bgp_profiles:
+        type: list
+        display_name: BGP Profiles
+        primary_key: name
+        convert_types:
+        - dict
+        items:
+          type: dict
+          keys:
+            name:
+              type: str
+              required: true
+              display_name: BGP Profile Name
+            initiator:
+              type: dict
+              keys:
+                route_map_inout:
+                  type: str
+                  display_name: Route Map
+      unit_profiles:
+        type: list
+        primary_key: name
+        convert_types:
+        - dict
+        items:
+          type: dict
+          keys:
+            name:
+              type: str
+              required: true
+              display_name: Unit Profile Name
+            on_boot:
+              type: dict
+              keys:
+                duration:
+                  type: int
+                  convert_types:
+                  - str
+                  min: 300
+                  max: 3600
+                  description: 'On-boot in seconds
+
+                    '
+      units:
+        type: list
+        primary_key: name
+        convert_types:
+        - dict
+        items:
+          type: dict
+          keys:
+            name:
+              type: str
+              required: true
+              display_name: Unit Name
+            quiesce:
+              type: bool
+            profile:
+              type: str
+              required: true
+              description: 'Name of Unit Profile
+
+                '
+            groups:
+              type: dict
+              keys:
+                bgp_groups:
+                  type: list
+                  display_name: BGP Groups
+                  items:
+                    type: str
+                    description: 'Name of BGP Group
+
+                      '
+                interface_groups:
+                  type: list
+                  items:
+                    type: str
+                    description: Name of Interface Group
   match_list_input:
     type: dict
     display_name: Match Lists

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/maintenance.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/maintenance.schema.yml
@@ -6,7 +6,7 @@ allow_other_keys: true
 keys:
   maintenance:
     type: dict
-    display_name: Profiles and units
+    display_name: Maintenance Mode
     keys:
       default_interface_profile:
         type: str
@@ -36,17 +36,28 @@ keys:
               keys:
                 load_interval:
                   type: int
+                  convert_types:
+                  - str
                   description: |
                     Load Interval in Seconds
                 threshold:
                   type: int
+                  convert_types:
+                  - str
+                  description: |
+                    Threshold in kbps
             shutdown:
               type: dict
               keys:
                 max_delay:
                   type: int
+                  convert_types:
+                  - str
+                  description: |
+                    Max delay in seconds
       bgp_profiles:
         type: list
+        display_name: BGP Profiles
         primary_key: name
         convert_types:
         - dict
@@ -80,6 +91,12 @@ keys:
               keys:
                 duration:
                   type: int
+                  convert_types:
+                  - str
+                  min: 300
+                  max: 3600
+                  description: |
+                    On-boot in seconds
       units:
         type: list
         primary_key: name
@@ -104,6 +121,7 @@ keys:
               keys:
                 bgp_groups:
                   type: list
+                  display_name: BGP Groups
                   items:
                     type: str
                     description: |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/maintenance.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/maintenance.schema.yml
@@ -1,0 +1,116 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+allow_other_keys: true
+keys:
+  maintenance:
+    type: dict
+    display_name: Profiles and units
+    keys:
+      default_interface_profile:
+        type: str
+        description: |
+          Name of default Interface Profile
+      default_bgp_profile:
+        type: str
+        description: |
+          Name of default BGP Profile
+      default_unit_profile:
+        type: str
+        description: |
+          Name of default Unit Profile
+      interface_profiles:
+        type: list
+        primary_key: name
+        convert_types:
+        - dict
+        items:
+          type: dict
+          keys:
+            name:
+              type: str
+              required: true
+            rate_monitoring:
+              type: dict
+              keys:
+                load_interval:
+                  type: int
+                  description: |
+                    Load Interval in Seconds
+                threshold:
+                  type: int
+            shutdown:
+              type: dict
+              keys:
+                max_delay:
+                  type: int
+      bgp_profiles:
+        type: list
+        primary_key: name
+        convert_types:
+        - dict
+        items:
+          type: dict
+          keys:
+            name:
+              type: str
+              required: true
+              display_name: BGP Profile Name
+            initiator:
+              type: dict
+              keys:
+                route_map_inout:
+                  type: int
+                  display_name: Route Map
+      unit_profiles:
+        type: list
+        primary_key: name
+        convert_types:
+        - dict
+        items:
+          type: dict
+          keys:
+            name:
+              type: str
+              required: true
+              display_name: Unit Profile Name
+            on_boot:
+              type: dict
+              keys:
+                duration:
+                  type: int
+      units:
+        type: list
+        primary_key: name
+        convert_types:
+        - dict
+        items:
+          type: dict
+          keys:
+            name:
+              type: str
+              required: true
+              display_name: Unit Name
+            quiesce:
+              type: bool
+            profile:
+              type: str
+              required: true
+              description: |
+                Name of Unit Profile
+            groups:
+              type: dict
+              keys:
+                bgp_groups:
+                  type: list
+                  items:
+                    type: str
+                    description: |
+                      Name of BGP Group
+                interface_groups:
+                  type: list
+                  items:
+                    type: str
+                    description: |
+                      Name of Interface Group

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/maintenance.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/maintenance.schema.yml
@@ -72,7 +72,7 @@ keys:
               type: dict
               keys:
                 route_map_inout:
-                  type: int
+                  type: str
                   display_name: Route Map
       unit_profiles:
         type: list

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/maintenance.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/maintenance.j2
@@ -14,13 +14,13 @@ Default maintenance unit profile: **{{ maintenance.default_unit_profile | arista
 
 | BGP profile | Initiator route-map |
 | ----------- | ------------------- |
-{%     for bgp_profile in maintenance.bgp_profiles | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%     for bgp_profile in maintenance.bgp_profiles | arista.avd.natural_sort('name') %}
 | {{ bgp_profile.name }} | {{ bgp_profile.initiator.route_map_inout | arista.avd.default('SystemGenerated') }} |
 {%     endfor %}
 
 | Interface profile | Rate monitoring load interval (s) | Rate monitoring threshold in/out (kbps) | Shutdown Max Delay |
 |-------------------|-----------------------------------|-----------------------------------------|--------------------|
-{%     for interface_profile in maintenance.interface_profiles | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%     for interface_profile in maintenance.interface_profiles | arista.avd.natural_sort('name') %}
 {%         set row_load_interval = interface_profile.rate_monitoring.load_interval | arista.avd.default(60) %}
 {%         set row_threshold = interface_profile.rate_monitoring.threshold | arista.avd.default(100) %}
 {%         set row_shutdown = interface_profile.shutdown.max_delay | arista.avd.default('disabled') %}
@@ -29,7 +29,7 @@ Default maintenance unit profile: **{{ maintenance.default_unit_profile | arista
 
 | Unit profile | on-boot duration (s) |
 | ------------ | -------------------- |
-{%     for unit_profile in maintenance.unit_profiles | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%     for unit_profile in maintenance.unit_profiles | arista.avd.natural_sort('name') %}
 | {{ unit_profile.name }} | {{ unit_profile.on_boot.duration | arista.avd.default('disabled') }} |
 {%     endfor %}
 
@@ -37,7 +37,7 @@ Default maintenance unit profile: **{{ maintenance.default_unit_profile | arista
 
 | Unit | Interface groups | BGP groups | Unit profile | Quiesce |
 | ---- | ---------------- | ---------- | ------------ | ------- |
-{%     for unit in maintenance.units | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%     for unit in maintenance.units | arista.avd.natural_sort('name') %}
 {%         set row_interface_groups = unit.groups.interface_groups | arista.avd.default(['-']) | arista.avd.natural_sort | join('<br/>') %}
 {%         set row_bgp_groups = unit.groups.bgp_groups | arista.avd.default(['-']) | arista.avd.natural_sort | join('<br/>') %}
 {%         set row_unit_profile = unit.profile | arista.avd.default(maintenance.default_unit_profile, 'Default') %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/maintenance.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/maintenance.j2
@@ -3,7 +3,7 @@
 {% if maintenance is arista.avd.defined %}
 !
 maintenance
-{%     for bgp_profile in maintenance.bgp_profiles | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%     for bgp_profile in maintenance.bgp_profiles | arista.avd.natural_sort('name') %}
 {%         if loop.index0 > 0 %}
    !
 {%         endif %}
@@ -25,7 +25,7 @@ maintenance
 {%         set first_line = {'flag': False} %}
    profile unit {{ maintenance.default_unit_profile }} default
 {%     endif %}
-{%     for interface_profile in maintenance.interface_profiles | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%     for interface_profile in maintenance.interface_profiles | arista.avd.natural_sort('name') %}
 {%         if not first_line.flag %}
    !
 {%         endif %}
@@ -41,7 +41,7 @@ maintenance
       shutdown max-delay {{ interface_profile.shutdown.max_delay }}
 {%         endif %}
 {%     endfor %}
-{%     for unit_profile in maintenance.unit_profiles | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%     for unit_profile in maintenance.unit_profiles | arista.avd.natural_sort('name') %}
 {%         if not first_line.flag %}
    !
 {%         endif %}
@@ -51,7 +51,7 @@ maintenance
       on-boot duration {{ unit_profile.on_boot.duration }}
 {%         endif %}
 {%     endfor %}
-{%     for unit in maintenance.units | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%     for unit in maintenance.units | arista.avd.natural_sort('name') %}
 {%         if not first_line.flag %}
    !
 {%         endif %}


### PR DESCRIPTION
## Add schema for data model

<!-- Use this PR Title: Feat(eos_cli_config_gen): Add schema for < data_model_key > -->

## Checklist

### Contributor Checklist

- [x] Create schema fragment matching data model described in README.md and README_v4.0.md
  - README.md is most complete with all keys. README_v4.0 includes partial data models after conversion to lists.
  - Schema fragment path is `roles/eos_cli_config_gen/schemas/schema_fragments/<data_model_key>.schema.yml`.
  - Copy line 1-5 from another schema (comments and outer type:dict).
  - Refer to [schema documentation](https://avd.sh/en/devel/docs/input-variable-validation-BETA.html) for syntax and/or use YAML Lint plugin from Redhat in VSCode.
  - Use `convert_types` on value that could be mixed type or misinterpreted like integers and numeric strings.
- [x] If the data model has been converted from wildcard dicts:
  - Add `convert_types: ['dict']` to the schema.
  - Remove `convert_dicts` from the `templates/eos/<>.j2` and `templates/documentation/<>.j2` templates.
- [x] Run `molecule converge -s build_schemas_and_docs` to update schema and documentation.
- [x] Test by running `molecule converge -s eos_cli_config_gen` and verify no errors or changes to generated configs/docs.

### Reviewer Checklist

- Reviewer 1: Claus
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2: Carl
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
