### PR TITLE
Feat(eos_cli_config_gen): Add schema for ip_domain_lookup

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -67,6 +67,26 @@ community_lists:
     action: <str>
 ```
 
+## Domain Lookup
+
+### Variables
+
+| Variable | Type | Required | Default | Value Restrictions | Description |
+| -------- | ---- | -------- | ------- | ------------------ | ----------- |
+| [<samp>ip_domain_lookup</samp>](## "ip_domain_lookup") | Dictionary |  |  |  | Domain Lookup |
+| [<samp>&nbsp;&nbsp;source_interfaces</samp>](## "ip_domain_lookup.source_interfaces") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "ip_domain_lookup.source_interfaces.[].name") | String | Required, Unique |  |  | Name of Source Interface<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "ip_domain_lookup.source_interfaces.[].vrf") | String |  |  |  | Name of vrf |
+
+### YAML
+
+```yaml
+ip_domain_lookup:
+  source_interfaces:
+    - name: <str>
+      vrf: <str>
+```
+
 ## Standard Access-Lists
 
 ### Variables

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -75,8 +75,8 @@ community_lists:
 | -------- | ---- | -------- | ------- | ------------------ | ----------- |
 | [<samp>ip_domain_lookup</samp>](## "ip_domain_lookup") | Dictionary |  |  |  | Domain Lookup |
 | [<samp>&nbsp;&nbsp;source_interfaces</samp>](## "ip_domain_lookup.source_interfaces") | List, items: Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "ip_domain_lookup.source_interfaces.[].name") | String | Required, Unique |  |  | Name of Source Interface<br> |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "ip_domain_lookup.source_interfaces.[].vrf") | String |  |  |  | Name of vrf |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "ip_domain_lookup.source_interfaces.[].name") | String | Required, Unique |  |  | Source Interface<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "ip_domain_lookup.source_interfaces.[].vrf") | String |  |  |  | VRF |
 
 ### YAML
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -108,12 +108,12 @@ keys:
             name:
               type: str
               required: true
-              description: 'Name of Source Interface
+              description: 'Source Interface
 
                 '
             vrf:
               type: str
-              description: Name of vrf
+              display_name: VRF
   standard_access_lists:
     type: list
     primary_key: name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -93,6 +93,27 @@ keys:
           description: 'Action as string
 
             Example: "permit GSHUT 65123:123"'
+  ip_domain_lookup:
+    type: dict
+    display_name: Domain Lookup
+    keys:
+      source_interfaces:
+        type: list
+        primary_key: name
+        convert_types:
+        - dict
+        items:
+          type: dict
+          keys:
+            name:
+              type: str
+              required: true
+              description: 'Name of Source Interface
+
+                '
+            vrf:
+              type: str
+              description: Name of vrf
   standard_access_lists:
     type: list
     primary_key: name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ip_domain_lookup.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ip_domain_lookup.schema.yml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  ip_domain_lookup:
+    type: dict
+    display_name: Domain Lookup
+    keys:
+      source_interfaces:
+        type: list
+        primary_key: name
+        convert_types:
+        - dict
+        items:
+          type: dict
+          keys:
+            name:
+              type: str
+              required: true
+              description: |
+                Name of Source Interface
+            vrf:
+              type: str
+              description: |
+                Name of vrf

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ip_domain_lookup.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ip_domain_lookup.schema.yml
@@ -19,8 +19,7 @@ keys:
               type: str
               required: true
               description: |
-                Name of Source Interface
+                Source Interface
             vrf:
               type: str
-              description: |
-                Name of vrf
+              display_name: VRF

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/domain-lookup.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/domain-lookup.j2
@@ -6,7 +6,7 @@
 
 | Source interface | vrf |
 | ---------------- | --- |
-{%     for source in ip_domain_lookup.source_interfaces | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%     for source in ip_domain_lookup.source_interfaces | arista.avd.natural_sort('name') %}
 {%         set vrf = source.vrf | arista.avd.default('-') %}
 | {{ source.name }} | {{ vrf }} |
 {%     endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/domain-lookup.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/domain-lookup.j2
@@ -1,6 +1,6 @@
 {# eos - domain lookup #}
 {% if ip_domain_lookup is arista.avd.defined %}
-{%     for source in ip_domain_lookup.source_interfaces | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%     for source in ip_domain_lookup.source_interfaces | arista.avd.natural_sort('name') %}
 {%         set ip_domain_cli = "ip domain lookup" %}
 {%         if source.vrf is arista.avd.defined %}
 {%             set ip_domain_cli = ip_domain_cli ~ " vrf " ~ source.vrf %}


### PR DESCRIPTION
## Add schema for data model

<!-- Use this PR Title: Feat(eos_cli_config_gen): Add schema for < data_model_key > -->

## Checklist

### Contributor Checklist

- [x] Create schema fragment matching data model described in README.md and README_v4.0.md
  - README.md is most complete with all keys. README_v4.0 includes partial data models after conversion to lists.
  - Schema fragment path is `roles/eos_cli_config_gen/schemas/schema_fragments/<data_model_key>.schema.yml`.
  - Copy line 1-5 from another schema (comments and outer type:dict).
  - Refer to [schema documentation](https://avd.sh/en/devel/docs/input-variable-validation-BETA.html) for syntax and/or use YAML Lint plugin from Redhat in VSCode.
  - Use `convert_types` on value that could be mixed type or misinterpreted like integers and numeric strings.
- [x] If the data model has been converted from wildcard dicts:
  - Add `convert_types: ['dict']` to the schema.
  - Remove `convert_dicts` from the `templates/eos/<>.j2` and `templates/documentation/<>.j2` templates.
- [x] Run `molecule converge -s build_schemas_and_docs` to update schema and documentation.
- [x] Test by running `molecule converge -s eos_cli_config_gen` and verify no errors or changes to generated configs/docs.

### Reviewer Checklist

- Reviewer 1:
  - [ ] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [ ] Verify that `convert_dicts` has been removed from templates as applicable.
  - [ ] Verify no changes to configs/docs on any molecule scenario
  - [ ] Verify that CI pass

- Reviewer 2: Guillaume
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
