### PR TITLE
Feat(plugins): Add schema support for secondary_key

### DIFF
--- a/ansible_collections/arista/avd/docs/input-variable-validation-BETA.md
+++ b/ansible_collections/arista/avd/docs/input-variable-validation-BETA.md
@@ -209,6 +209,7 @@ The meta-schema does not allow for other keys to be set in the schema.
 | <samp>max_length</samp> | Integer | | | | Maximum length |
 | <samp>min_length</samp> | Integer | | | | Minimum length |
 | <samp>primary_key</samp> | String | | | Pattern: `^[a-z][a-z0-9_]*$` | Name of a primary key in a list of dictionaries.<br>The configured key is implicitly required and must have unique values between the list elements |
+| <samp>secondary_key</samp> | String | | | Pattern: `^[a-z][a-z0-9_]*$` | Name of a secondary key, which is used with `convert_types:['dict']` in case of values not being dictionaries |
 | <samp>display_name</samp> | String | | | Regex Pattern: `"^[^\n]+$"` | Free text display name for forms and documentation (single line) |
 | <samp>description</samp> | String | | | Minimum Length: 1 | Free text description for forms and documentation (multi line) |
 | <samp>required</samp> | Boolean | | | | Set if variable is required |

--- a/ansible_collections/arista/avd/plugins/plugin_utils/schema/avd_meta_schema.json
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/schema/avd_meta_schema.json
@@ -199,6 +199,12 @@
                             "pattern": "^[a-z][a-z0-9_]*$",
                             "description": "Name of a primary key in a list of dictionaries.\nThe configured key is implicitly required and must have unique values between the list elements"
                         },
+                        "secondary_key": {
+                            "type": "string",
+                            "$comment": "The regex here matches valid key names",
+                            "pattern": "^[a-z][a-z0-9_]*$",
+                            "description": "Name of a secondary key, which is used with `convert_types:[dict]` in case of values not being dictionaries."
+                        },
                         "display_name": { "$ref": "#/$def/display_name" },
                         "description": { "$ref": "#/$def/description" },
                         "required": { "$ref": "#/$def/required" },

--- a/ansible_collections/arista/avd/plugins/plugin_utils/schema/avddataconverter.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/schema/avddataconverter.py
@@ -182,7 +182,7 @@ def _convert_types(validator, convert_types: list, instance, schema: dict):
                 and "primary_key" in schema
             ):
                 try:
-                    converted_instance = convert_dicts(instance, schema["primary_key"])
+                    converted_instance = convert_dicts(instance, schema["primary_key"], secondary_key=schema.get("secondary_key"))
                 except Exception:
                     # Ignore errors and return original
                     converted_instance = instance


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Add schema support for secondary_key

## Related Issue(s)

Fixes issue with schema-based data conversion of dicts where the values are dicts.

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->
Adding support for the key `secondary_key` in the schema for lists.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Cherrypicked the open PR for ip-extended-community-lists, which is where we saw the problem.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
