### PR TITLE
Feat(eos_cli_config_gen): Add schema for sflow

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -195,17 +195,16 @@ match_list_input:
 | [<samp>&nbsp;&nbsp;vrfs</samp>](## "sflow.vrfs") | List, items: Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "sflow.vrfs.[].name") | String |  |  |  | VRF |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;destinations</samp>](## "sflow.vrfs.[].destinations") | List, items: Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- destination</samp>](## "sflow.vrfs.[].destinations.[].destination") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- destination</samp>](## "sflow.vrfs.[].destinations.[].destination") | String |  |  |  | Sflow Destination IP |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;port</samp>](## "sflow.vrfs.[].destinations.[].port") | Integer |  |  |  | Port Number |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_interface</samp>](## "sflow.vrfs.[].source_interface") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_interface</samp>](## "sflow.vrfs.[].source_interface") | String |  |  |  | Source Interface |
 | [<samp>&nbsp;&nbsp;destinations</samp>](## "sflow.destinations") | List, items: Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- destination</samp>](## "sflow.destinations.[].destination") | String |  |  |  | Sflow Destination IP |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;port</samp>](## "sflow.destinations.[].port") | Integer |  |  |  | Port Number |
 | [<samp>&nbsp;&nbsp;source_interface</samp>](## "sflow.source_interface") | String |  |  |  | Source Interface |
 | [<samp>&nbsp;&nbsp;interface</samp>](## "sflow.interface") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;disable</samp>](## "sflow.interface.disable") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;disable</samp>](## "sflow.interface.disable.disable") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;default</samp>](## "sflow.interface.disable.disable.default") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;default</samp>](## "sflow.interface.disable.default") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;run</samp>](## "sflow.run") | Boolean |  |  |  |  |
 
 ### YAML
@@ -226,8 +225,7 @@ sflow:
   source_interface: <str>
   interface:
     disable:
-      disable:
-        default: <bool>
+      default: <bool>
   run: <bool>
 ```
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -183,6 +183,54 @@ match_list_input:
           match_regex: <str>
 ```
 
+## Sflow
+
+### Variables
+
+| Variable | Type | Required | Default | Value Restrictions | Description |
+| -------- | ---- | -------- | ------- | ------------------ | ----------- |
+| [<samp>sflow</samp>](## "sflow") | Dictionary |  |  |  | Sflow |
+| [<samp>&nbsp;&nbsp;sample</samp>](## "sflow.sample") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;dangerous</samp>](## "sflow.dangerous") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;vrfs</samp>](## "sflow.vrfs") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "sflow.vrfs.[].name") | String |  |  |  | VRF |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;destinations</samp>](## "sflow.vrfs.[].destinations") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- destination</samp>](## "sflow.vrfs.[].destinations.[].destination") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;port</samp>](## "sflow.vrfs.[].destinations.[].port") | Integer |  |  |  | Port Number |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_interface</samp>](## "sflow.vrfs.[].source_interface") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;destinations</samp>](## "sflow.destinations") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- destination</samp>](## "sflow.destinations.[].destination") | String |  |  |  | Sflow Destination IP |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;port</samp>](## "sflow.destinations.[].port") | Integer |  |  |  | Port Number |
+| [<samp>&nbsp;&nbsp;source_interface</samp>](## "sflow.source_interface") | String |  |  |  | Source Interface |
+| [<samp>&nbsp;&nbsp;interface</samp>](## "sflow.interface") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;disable</samp>](## "sflow.interface.disable") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;disable</samp>](## "sflow.interface.disable.disable") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;default</samp>](## "sflow.interface.disable.disable.default") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;run</samp>](## "sflow.run") | Boolean |  |  |  |  |
+
+### YAML
+
+```yaml
+sflow:
+  sample: <str>
+  dangerous: <bool>
+  vrfs:
+    - name: <str>
+      destinations:
+        - destination: <str>
+          port: <int>
+      source_interface: <str>
+  destinations:
+    - destination: <str>
+      port: <int>
+  source_interface: <str>
+  interface:
+    disable:
+      disable:
+        default: <bool>
+  run: <bool>
+```
+
 ## Standard Access-Lists
 
 ### Variables

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -258,11 +258,13 @@ keys:
                 keys:
                   destination:
                     type: str
+                    display_name: Sflow Destination IP
                   port:
                     type: int
                     display_name: Port Number
             source_interface:
               type: str
+              display_name: Source Interface
       destinations:
         type: list
         primary_key: destination
@@ -286,11 +288,8 @@ keys:
           disable:
             type: dict
             keys:
-              disable:
-                type: dict
-                keys:
-                  default:
-                    type: bool
+              default:
+                type: bool
       run:
         type: bool
   standard_access_lists:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -262,6 +262,8 @@ keys:
                   port:
                     type: int
                     display_name: Port Number
+                    convert_types:
+                    - str
             source_interface:
               type: str
               display_name: Source Interface
@@ -279,6 +281,8 @@ keys:
             port:
               type: int
               display_name: Port Number
+              convert_types:
+              - str
       source_interface:
         type: str
         display_name: Source Interface

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -229,6 +229,70 @@ keys:
                     type: str
                     required: true
                     display_name: Regular Expression
+  sflow:
+    type: dict
+    display_name: Sflow
+    keys:
+      sample:
+        type: str
+      dangerous:
+        type: bool
+      vrfs:
+        type: list
+        primary_key: name
+        convert_types:
+        - dict
+        items:
+          type: dict
+          keys:
+            name:
+              type: str
+              display_name: VRF
+            destinations:
+              type: list
+              primary_key: destination
+              convert_types:
+              - dict
+              items:
+                type: dict
+                keys:
+                  destination:
+                    type: str
+                  port:
+                    type: int
+                    display_name: Port Number
+            source_interface:
+              type: str
+      destinations:
+        type: list
+        primary_key: destination
+        convert_types:
+        - dict
+        items:
+          type: dict
+          keys:
+            destination:
+              type: str
+              display_name: Sflow Destination IP
+            port:
+              type: int
+              display_name: Port Number
+      source_interface:
+        type: str
+        display_name: Source Interface
+      interface:
+        type: dict
+        keys:
+          disable:
+            type: dict
+            keys:
+              disable:
+                type: dict
+                keys:
+                  default:
+                    type: bool
+      run:
+        type: bool
   standard_access_lists:
     type: list
     primary_key: name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/sflow.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/sflow.schema.yml
@@ -37,6 +37,8 @@ keys:
                   port:
                     type: int
                     display_name: Port Number
+                    convert_types:
+                      - str
             source_interface:
               type: str
               display_name: Source Interface
@@ -54,6 +56,8 @@ keys:
             port:
               type: int
               display_name: Port Number
+              convert_types:
+                - str
       source_interface:
         type: str
         display_name: Source Interface

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/sflow.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/sflow.schema.yml
@@ -33,11 +33,13 @@ keys:
                 keys:
                   destination:
                     type: str
+                    display_name: Sflow Destination IP
                   port:
                     type: int
                     display_name: Port Number
             source_interface:
               type: str
+              display_name: Source Interface
       destinations:
         type: list
         primary_key: destination
@@ -61,10 +63,7 @@ keys:
           disable:
             type: dict
             keys:
-              disable:
-                type: dict
-                keys:
-                  default:
-                    type: bool
+              default:
+                type: bool
       run:
         type: bool

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/sflow.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/sflow.schema.yml
@@ -66,8 +66,5 @@ keys:
                 keys:
                   default:
                     type: bool
-
-
-
       run:
         type: bool

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/sflow.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/sflow.schema.yml
@@ -1,0 +1,73 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+allow_other_keys: true
+keys:
+  sflow:
+    type: dict
+    display_name: Sflow
+    keys:
+      sample:
+        type: str
+      dangerous:
+        type: bool
+      vrfs:
+        type: list
+        primary_key: name
+        convert_types:
+        - dict
+        items:
+          type: dict
+          keys:
+            name:
+              type: str
+              display_name: VRF
+            destinations:
+              type: list
+              primary_key: destination
+              convert_types:
+              - dict
+              items:
+                type: dict
+                keys:
+                  destination:
+                    type: str
+                  port:
+                    type: int
+                    display_name: Port Number
+            source_interface:
+              type: str
+      destinations:
+        type: list
+        primary_key: destination
+        convert_types:
+        - dict
+        items:
+          type: dict
+          keys:
+            destination:
+              type: str
+              display_name: Sflow Destination IP
+            port:
+              type: int
+              display_name: Port Number
+      source_interface:
+        type: str
+        display_name: Source Interface
+      interface:
+        type: dict
+        keys:
+          disable:
+            type: dict
+            keys:
+              disable:
+                type: dict
+                keys:
+                  default:
+                    type: bool
+
+
+
+      run:
+        type: bool

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/sflow.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/sflow.schema.yml
@@ -38,7 +38,7 @@ keys:
                     type: int
                     display_name: Port Number
                     convert_types:
-                      - str
+                    - str
             source_interface:
               type: str
               display_name: Source Interface
@@ -57,7 +57,7 @@ keys:
               type: int
               display_name: Port Number
               convert_types:
-                - str
+              - str
       source_interface:
         type: str
         display_name: Source Interface

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/sflow.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/sflow.j2
@@ -8,9 +8,9 @@
 | VRF | SFlow Source Interface | SFlow Destination | Port |
 | --- | ---------------------- | ----------------- | ---- |
 {%         if sflow.vrfs is arista.avd.defined %}
-{%             for vrf in sflow.vrfs | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%             for vrf in sflow.vrfs | arista.avd.natural_sort('name') %}
 {%                 if vrf.destinations is arista.avd.defined %}
-{%                     for destination in vrf.destinations | arista.avd.convert_dicts('destination') | arista.avd.natural_sort('destination') %}
+{%                     for destination in vrf.destinations | arista.avd.natural_sort('destination') %}
 {%                         set port = destination.port | arista.avd.default('6343') %}
 | {{ vrf.name }} | - | {{ destination.destination }} | {{ port }} |
 {%                     endfor %}
@@ -21,7 +21,7 @@
 {%             endfor %}
 {%         endif %}
 {%         if sflow.destinations is arista.avd.defined %}
-{%             for destination in sflow.destinations | arista.avd.convert_dicts('destination') %}
+{%             for destination in sflow.destinations  %}
 {%                 set port = destination.port | arista.avd.default('6343') %}
 | default | - | {{ destination.destination }} | {{ port }} |
 {%             endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/sflow.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/sflow.j2
@@ -9,8 +9,8 @@
 {%         set sample_cli = sample_cli ~ sflow.sample %}
 {{ sample_cli }}
 {%     endif %}
-{%     for vrf in sflow.vrfs | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
-{%         for destination in vrf.destinations | arista.avd.convert_dicts('destination') | arista.avd.natural_sort('destination') %}
+{%     for vrf in sflow.vrfs | arista.avd.natural_sort('name') %}
+{%         for destination in vrf.destinations | arista.avd.natural_sort('destination') %}
 {%             set vrf_cli = "sflow vrf " ~ vrf.name ~ " destination " ~ destination.destination %}
 {%             if destination.port is arista.avd.defined %}
 {%                 set vrf_cli = vrf_cli ~ " " ~ destination.port %}
@@ -21,7 +21,7 @@
 sflow vrf {{ vrf.name }} source-interface {{ vrf.source_interface }}
 {%         endif %}
 {%     endfor %}
-{%     for destination in sflow.destinations | arista.avd.convert_dicts('destination') | arista.avd.natural_sort('destination') %}
+{%     for destination in sflow.destinations | arista.avd.natural_sort('destination') %}
 {%         set destination_cli = "sflow destination " ~ destination.destination %}
 {%         if destination.port is arista.avd.defined %}
 {%             set destination_cli = destination_cli ~ " " ~ destination.port %}


### PR DESCRIPTION
## Add schema for data model

<!-- Use this PR Title: Feat(eos_cli_config_gen): Add schema for < data_model_key > -->

## Checklist

### Contributor Checklist

- [x] Create schema fragment matching data model described in README.md and README_v4.0.md
  - README.md is most complete with all keys. README_v4.0 includes partial data models after conversion to lists.
  - Schema fragment path is `roles/eos_cli_config_gen/schemas/schema_fragments/<data_model_key>.schema.yml`.
  - Copy line 1-5 from another schema (comments and outer type:dict).
  - Refer to [schema documentation](https://avd.sh/en/devel/docs/input-variable-validation-BETA.html) for syntax and/or use YAML Lint plugin from Redhat in VSCode.
  - Use `convert_types` on value that could be mixed type or misinterpreted like integers and numeric strings.
- [x] If the data model has been converted from wildcard dicts:
  - Add `convert_types: ['dict']` to the schema.
  - Remove `convert_dicts` from the `templates/eos/<>.j2` and `templates/documentation/<>.j2` templates.
- [x] Run `molecule converge -s build_schemas_and_docs` to update schema and documentation.
- [x] Test by running `molecule converge -s eos_cli_config_gen` and verify no errors or changes to generated configs/docs.

### Reviewer Checklist

- Reviewer 1:
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2:
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
