### PR TITLE
Feat(eos_cli_config_gen): Add schema for event_handlers

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/event-handlers.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/event-handlers.md
@@ -55,16 +55,18 @@ interface Management1
 
 | Handler | Action Type | Action | Trigger |
 | ------- | ----------- | ------ | ------- |
-| tracking | bash | /mnt/flash/tracking.sh | on-boot |
+| evpn-blacklist-recovery | bash | FastCli -p 15 -c "clear bgp evpn host-flap" | on-logging |
 
 ### Event Handler Device Configuration
 
 ```eos
 !
-event-handler tracking
-   trigger on-boot
-   action bash /mnt/flash/tracking.sh
+event-handler evpn-blacklist-recovery
+   trigger on-logging
+      regex EVPN-3-BLACKLISTED_DUPLICATE_MAC
+   action bash FastCli -p 15 -c "clear bgp evpn host-flap"
    delay 300
+   asynchronous
 ```
 
 # Internal VLAN Allocation Policy

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/event-handlers.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/event-handlers.cfg
@@ -12,9 +12,11 @@ interface Management1
    vrf MGMT
    ip address 10.73.255.122/24
 !
-event-handler tracking
-   trigger on-boot
-   action bash /mnt/flash/tracking.sh
+event-handler evpn-blacklist-recovery
+   trigger on-logging
+      regex EVPN-3-BLACKLISTED_DUPLICATE_MAC
+   action bash FastCli -p 15 -c "clear bgp evpn host-flap"
    delay 300
+   asynchronous
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/event-handlers.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/event-handlers.yml
@@ -1,6 +1,8 @@
 event_handlers:
-  tracking:
+  evpn-blacklist-recovery:
     action_type: bash
-    action: /mnt/flash/tracking.sh
+    action: FastCli -p 15 -c "clear bgp evpn host-flap"
     delay: 300
-    trigger: on-boot
+    trigger: on-logging
+    regex: EVPN-3-BLACKLISTED_DUPLICATE_MAC
+    asynchronous: true

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/event-handlers.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/event-handlers.md
@@ -55,16 +55,18 @@ interface Management1
 
 | Handler | Action Type | Action | Trigger |
 | ------- | ----------- | ------ | ------- |
-| tracking | bash | /mnt/flash/tracking.sh | on-boot |
+| evpn-blacklist-recovery | bash | FastCli -p 15 -c "clear bgp evpn host-flap" | on-logging |
 
 ### Event Handler Device Configuration
 
 ```eos
 !
-event-handler tracking
-   trigger on-boot
-   action bash /mnt/flash/tracking.sh
+event-handler evpn-blacklist-recovery
+   trigger on-logging
+      regex EVPN-3-BLACKLISTED_DUPLICATE_MAC
+   action bash FastCli -p 15 -c "clear bgp evpn host-flap"
    delay 300
+   asynchronous
 ```
 
 # Internal VLAN Allocation Policy

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/event-handlers.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/event-handlers.cfg
@@ -12,9 +12,11 @@ interface Management1
    vrf MGMT
    ip address 10.73.255.122/24
 !
-event-handler tracking
-   trigger on-boot
-   action bash /mnt/flash/tracking.sh
+event-handler evpn-blacklist-recovery
+   trigger on-logging
+      regex EVPN-3-BLACKLISTED_DUPLICATE_MAC
+   action bash FastCli -p 15 -c "clear bgp evpn host-flap"
    delay 300
+   asynchronous
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/event-handlers.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/event-handlers.yml
@@ -1,6 +1,8 @@
 event_handlers:
-  - name: tracking
+  - name: evpn-blacklist-recovery
     action_type: bash
-    action: /mnt/flash/tracking.sh
+    action: FastCli -p 15 -c "clear bgp evpn host-flap"
     delay: 300
-    trigger: on-boot
+    trigger: on-logging
+    regex: EVPN-3-BLACKLISTED_DUPLICATE_MAC
+    asynchronous: true

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -87,6 +87,34 @@ daemons:
     enabled: <bool>
 ```
 
+## Event Handlers
+
+### Variables
+
+| Variable | Type | Required | Default | Value Restrictions | Description |
+| -------- | ---- | -------- | ------- | ------------------ | ----------- |
+| [<samp>event_handlers</samp>](## "event_handlers") | List, items: Dictionary |  |  |  | Event Handlers |
+| [<samp>&nbsp;&nbsp;- name</samp>](## "event_handlers.[].name") | String |  |  |  | Event Handler Name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;action_type</samp>](## "event_handlers.[].action_type") | String |  |  | Valid Values:<br>- bash<br>- increment<br>- log | Action Type<br>Type of action<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;action</samp>](## "event_handlers.[].action") | String |  |  |  | Command to execute<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;delay</samp>](## "event_handlers.[].delay") | Integer |  |  |  | Event-handler delay in seconds<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger</samp>](## "event_handlers.[].trigger") | String |  |  | Valid Values:<br>- on-logging | Configure event trigger condition.<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;regex</samp>](## "event_handlers.[].regex") | String |  |  |  | Regular expression to use for searching log messages. Required for on-logging trigger<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;asynchronous</samp>](## "event_handlers.[].asynchronous") | Boolean |  | False |  | Set the action to be non-blocking. |
+
+### YAML
+
+```yaml
+event_handlers:
+  - name: <str>
+    action_type: <str>
+    action: <str>
+    delay: <int>
+    trigger: <str>
+    regex: <str>
+    asynchronous: <bool>
+```
+
 ## Maintenance Interface Groups
 
 ### Variables

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -115,6 +115,55 @@ keys:
         enabled:
           type: bool
           default: true
+  event_handlers:
+    type: list
+    primary_key: name
+    convert_types:
+    - dict
+    display_name: Event Handlers
+    items:
+      type: dict
+      keys:
+        name:
+          type: str
+          display_name: Event Handler Name
+        action_type:
+          type: str
+          display_name: Action Type
+          description: 'Type of action
+
+            '
+          valid_values:
+          - bash
+          - increment
+          - log
+        action:
+          type: str
+          description: 'Command to execute
+
+            '
+        delay:
+          type: int
+          description: 'Event-handler delay in seconds
+
+            '
+        trigger:
+          type: str
+          description: 'Configure event trigger condition.
+
+            '
+          valid_values:
+          - on-logging
+        regex:
+          type: str
+          description: 'Regular expression to use for searching log messages. Required
+            for on-logging trigger
+
+            '
+        asynchronous:
+          type: bool
+          default: false
+          description: Set the action to be non-blocking.
   interface_groups:
     type: list
     display_name: Maintenance Interface Groups

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/event_handlers.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/event_handlers.schema.yml
@@ -8,7 +8,7 @@ keys:
     primary_key: name
     convert_types:
     - dict
-    display_name: Event Handler
+    display_name: Event Handlers
     items:
       type: dict
       keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/event_handlers.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/event_handlers.schema.yml
@@ -41,4 +41,4 @@ keys:
           type: bool
           default: False
           description: |
-            Set the action to be non-blocking. if unset, default is False
+            Set the action to be non-blocking.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/event_handlers.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/event_handlers.schema.yml
@@ -1,0 +1,44 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  event_handlers:
+    type: list
+    primary_key: name
+    convert_types:
+    - dict
+    display_name: Event Handler
+    items:
+      type: dict
+      keys:
+        name:
+          type: str
+          display_name: Event Handler Name
+        action_type:
+          type: str
+          display_name: Action Type
+          description: |
+            Type of action
+          valid_values: ["bash", "increment", "log"]
+        action:
+          type: str
+          description: |
+            Command to execute
+        delay:
+          type: int
+          description: |
+            Event-handler delay in seconds
+        trigger:
+          type: str
+          description: |
+            Configure event trigger condition. Only supports on-logging
+        regex:
+          type: str
+          description: |
+            Regular expression to use for searching log messages. Required for on-logging trigger
+        asynchronous:
+          type: bool
+          default: False
+          description: |
+            Set the action to be non-blocking. if unset, default is False

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/event_handlers.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/event_handlers.schema.yml
@@ -32,7 +32,8 @@ keys:
         trigger:
           type: str
           description: |
-            Configure event trigger condition. Only supports on-logging
+            Configure event trigger condition.
+          valid_values: ["on-logging"]
         regex:
           type: str
           description: |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/event-handler.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/event-handler.j2
@@ -7,7 +7,7 @@
 
 | Handler | Action Type | Action | Trigger |
 | ------- | ----------- | ------ | ------- |
-{%     for handler in event_handlers | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%     for handler in event_handlers | arista.avd.natural_sort('name') %}
 | {{ handler.name }} | {{ handler.action_type }} | {{ handler.action }} | {{ handler.trigger }} |
 {%     endfor %}
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/event-handler.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/event-handler.j2
@@ -1,6 +1,6 @@
 {# eos - Event handlers #}
 {% if event_handlers is arista.avd.defined %}
-{%     for handler in event_handlers | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%     for handler in event_handlers | arista.avd.natural_sort('name') %}
 !
 event-handler {{ handler.name }}
 {%         if handler.trigger is arista.avd.defined %}


### PR DESCRIPTION
## Add schema for data model

<!-- Use this PR Title: Feat(eos_cli_config_gen): Add schema for < data_model_key > -->

## Checklist

### Contributor Checklist

- [x] Create schema fragment matching data model described in README.md and README_v4.0.md
  - README.md is most complete with all keys. README_v4.0 includes partial data models after conversion to lists.
  - Schema fragment path is `roles/eos_cli_config_gen/schemas/schema_fragments/<data_model_key>.schema.yml`.
  - Copy line 1-5 from another schema (comments and outer type:dict).
  - Refer to [schema documentation](https://avd.sh/en/devel/docs/input-variable-validation-BETA.html) for syntax and/or use YAML Lint plugin from Redhat in VSCode.
  - Use `convert_types` on value that could be mixed type or misinterpreted like integers and numeric strings.
- [x] If the data model has been converted from wildcard dicts:
  - Add `convert_types: ['dict']` to the schema.
  - Remove `convert_dicts` from the `templates/eos/<>.j2` and `templates/documentation/<>.j2` templates.
- [x] Run `molecule converge -s build_schemas_and_docs` to update schema and documentation.
- [x] Test by running `molecule converge -s eos_cli_config_gen` and verify no errors or changes to generated configs/docs.

Note: Also updated molecule scenarios `eos_cli_config_gen` & `eos_cli_config_gen_v4.0` to conform with what is stated we support in the documentation for `event_handlers.[].trigger`

### Reviewer Checklist

- Reviewer 1: Claus
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [ ] Verify that CI pass

- Reviewer 2: Emil
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
