### PR TITLE
Fix(eos_designs): Missing defined check for enable_trunk_groups

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/ethernet-interfaces.j2
@@ -88,7 +88,7 @@ ethernet_interfaces:
 {%                 endif %}
     mode: {{ adapter_settings.mode | arista.avd.default }}
     vlans: {{ adapter_settings.vlans | arista.avd.default }}
-{%                 if switch.enable_trunk_groups
+{%                 if switch.enable_trunk_groups is arista.avd.defined(true)
                            and "trunk" in adapter_settings.mode | arista.avd.default("")
                            and adapter_settings.trunk_groups is arista.avd.defined(fail_action="error", var_name="'trunk_groups' for the connected_endpoint " ~ connected_endpoint.name) %}
     trunk_groups: {{ adapter_settings.trunk_groups }}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/port-channel-interfaces.j2
@@ -48,7 +48,7 @@ port_channel_interfaces:
     l2_mtu: {{ adapter_settings.l2_mtu }}
 {%                         endif %}
     vlans: {{ adapter_settings.vlans | arista.avd.default }}
-{%                         if switch.enable_trunk_groups
+{%                         if switch.enable_trunk_groups is arista.avd.defined(true)
                                    and "trunk" in adapter_settings.mode | arista.avd.default("")
                                    and adapter_settings.trunk_groups is arista.avd.defined(fail_action="error", var_name="'trunk_groups' for the connected_endpoint " ~ connected_endpoint.name) %}
     trunk_groups: {{ adapter_settings.trunk_groups }}


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Fix(eos_designs): Missing defined check for enable_trunk_groups

## Related Issue(s)

In the unlikely situation of having a node_type with `connected_endpoints: true` and `network_services: false` we would end up with `switch.enable_trunk_groups: null` which means it will be removed, so not existing when the templates run.

```sh
TASK [arista.avd.eos_designs : Generate device configuration in structured format] *********************************************************************************************************************************************************************************
fatal: [blue-spine1 -> localhost]: FAILED! => {"msg": "'dict object' has no attribute 'enable_trunk_groups'"}
fatal: [amber-spine1 -> localhost]: FAILED! => {"msg": "'dict object' has no attribute 'enable_trunk_groups'"}
```

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->
Ensure `arista.avd.defined` checks.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
