### PR TITLE
Refactor(eos_cli_config_gen): Ensure that validation always runs in eos_cli_config_gen

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/molecule.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/molecule.yml
@@ -37,7 +37,6 @@ provisioner:
       group_vars: 'inventory/group_vars/'
   ansible_args:
     - --inventory=inventory/hosts.ini
-    - --tags=build, validate
 verifier:
   name: ansible
   inventory:
@@ -47,7 +46,6 @@ verifier:
       group_vars: 'inventory/group_vars/'
   ansible_args:
     - --inventory=inventory/hosts.ini
-    - --tags=build, validate
   config_options:
     defaults:
       jinja2_extensions: 'jinja2.ext.loopcontrols,jinja2.ext.do,jinja2.ext.i18n'

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/molecule.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/molecule.yml
@@ -55,4 +55,4 @@ verifier:
       jinja2_extensions: 'jinja2.ext.loopcontrols,jinja2.ext.do,jinja2.ext.i18n'
       gathering: explicit
   ansible_args:
-    - --tags=build, validate
+    - --skip-tags=documentation

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/tasks/main.yml
@@ -35,7 +35,9 @@
     filename: "{{ structured_dir }}/{{ inventory_hostname }}.{{ avd_structured_config_file_format }}"
 
 - name: Validate & update input vars according to AVD eos_cli_config_gen schema
-  tags: [validate, build, provision]
+  # This task should not be skipped when using AVD v3.x input data,
+  # since it is responsible for upgrading input data to v4.0 models.
+  tags: [always, validate]
   arista.avd.validate:
     schema: "{{ lookup('ansible.builtin.file', role_schema_path) | from_yaml }}"
     conversion_mode: "{{ avd_validate_conversion_mode }}"

--- a/ansible_collections/arista/avd/roles/eos_designs/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/tasks/main.yml
@@ -24,7 +24,7 @@
   run_once: true
 
 - name: Validate & update input vars according to AVD eos_designs schema
-  tags: [validate, never]
+  tags: [never, validate]
   arista.avd.validate:
     schema: "{{ lookup('ansible.builtin.file', role_schema_path) | from_yaml }}"
     conversion_mode: "{{ avd_validate_conversion_mode }}"


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Refactor(eos_cli_config_gen): Ensure that validation always runs in eos_cli_config_gen

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

- Add `always` tag and a comment to the validation task in eos_cli_config_gen
- Clean up molecule configs to leverage the `always` tag.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
no changes to molecule.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
