### PR TITLE
Feat(plugins): New arista.avd.include_vars plugin

### DIFF
--- a/ansible_collections/arista/avd/docs/release-notes/3.x.x.md
+++ b/ansible_collections/arista/avd/docs/release-notes/3.x.x.md
@@ -8,6 +8,19 @@
 
 ## Release 3.8.0
 
+!!! info "Variable precedence changed in eos_cli_config_gen"
+    In cases where `eos_cli_config_gen` is invoked in a separate playbook, variables are imported from "structured_config" files. These variables are now imported as regular facts with `host_facts` precedence instead of the special `include_vars` precedence.
+
+    This change means that any other vars included with the `ansible.builtin.include_vars` module may take precedence over the imported "structured_config".
+
+    It is recommended to replace `include_vars` or `ansible.builtin.include_vars` with `arista.avd.include_vars` in any tasks running
+    before AVD.
+
+    The purpose of this change is to allow AVD to override and perform automatic type conversion of input variables.
+
+    `arista.avd.include_vars` is also recommended over `ansible.builtin.include_vars` for importing shared variables across multiple inventories,
+    while avoiding any interference with AVD generated facts.
+
 ### Data model modifications (non-breaking)
 
 This section provides an overview of the data models that have ***changed*** from the previous release, but are backwards compatible.

--- a/ansible_collections/arista/avd/docs/release-notes/3.x.x.md
+++ b/ansible_collections/arista/avd/docs/release-notes/3.x.x.md
@@ -9,6 +9,7 @@
 ## Release 3.8.0
 
 !!! info "Variable precedence changed in eos_cli_config_gen"
+
     In cases where `eos_cli_config_gen` is invoked in a separate playbook, variables are imported from "structured_config" files. These variables are now imported as regular facts with `host_facts` precedence instead of the special `include_vars` precedence.
 
     This change means that any other vars included with the `ansible.builtin.include_vars` module may take precedence over the imported "structured_config".

--- a/ansible_collections/arista/avd/docs/release-notes/3.x.x.md
+++ b/ansible_collections/arista/avd/docs/release-notes/3.x.x.md
@@ -10,7 +10,7 @@
 
 !!! info "Variable precedence changed in eos_cli_config_gen"
 
-    In cases where `eos_cli_config_gen` is invoked in a separate playbook, variables are imported from "structured_config" files. These variables are now imported as regular facts with `host_facts` precedence instead of the special `include_vars` precedence.
+    In cases where `eos_cli_config_gen` is invoked in a separate playbook, variables are imported from "structured_config" files. These variables are now imported as regular facts with `host_facts` precedence instead of the higher `include_vars` precedence.
 
     This change means that any other vars included with the `ansible.builtin.include_vars` module may take precedence over the imported "structured_config".
 

--- a/ansible_collections/arista/avd/plugins/action/include_vars.py
+++ b/ansible_collections/arista/avd/plugins/action/include_vars.py
@@ -1,0 +1,23 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.plugins.action.include_vars import ActionModule as IncludeVarsActionModule
+
+
+class ActionModule(IncludeVarsActionModule):
+    '''
+    This class is wrapping the builtin action plugin "include_vars" 1:1.
+    We need this to avoid the Ansible behavior of injecting variables from
+    "include_vars" with special precedence.
+
+    Since Ansible uses the task name (fqcn) to detect if it is "include_vars"
+    or some other module returning "ansible_facts", we only need to provide
+    a different name, to avoid the builtin behavior.
+
+    If we did not have this, we would have no way of overriding included_vars
+    with structured_config or the automatic input variable conversion.
+
+    Ref. https://github.com/ansible/ansible/blob/v2.13.3/lib/ansible/plugins/strategy/__init__.py#L738
+    '''
+    def run(self, tmp=None, task_vars=None):
+        return super().run(tmp, task_vars)

--- a/ansible_collections/arista/avd/plugins/modules/include_vars.py
+++ b/ansible_collections/arista/avd/plugins/modules/include_vars.py
@@ -1,0 +1,40 @@
+# Copyright 2022 Arista Networks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+DOCUMENTATION = r'''
+---
+module: include_vars
+version_added: "3.8.0"
+author: Arista Ansible Team (@aristanetworks)
+short_description: Include Variables from files
+description:
+    This class is wrapping the builtin action plugin "include_vars" 1:1.
+    We need this to avoid the Ansible behavior of injecting variables from
+    "include_vars" with special precedence.
+
+    Since Ansible uses the task name (fqcn) to detect if it is "include_vars"
+    or some other module returning "ansible_facts", we only need to provide
+    a different name, to avoid the builtin behavior.
+
+    If we did not have this, we would have no way of overriding included_vars
+    with structured_config or the automatic input variable conversion.
+
+    Ref. https://github.com/ansible/ansible/blob/v2.13.3/lib/ansible/plugins/strategy/__init__.py#L738
+'''
+
+EXAMPLES = r'''
+- arista.avd.include_vars:
+    file: "{{ filename }}"
+'''

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/tasks/main.yml
@@ -27,7 +27,8 @@
 
 - name: Include device intended structure configuration variables
   tags: [build, provision]
-  include_vars: "{{ filename }}"
+  arista.avd.include_vars:
+    file: "{{ filename }}"
   delegate_to: localhost
   # errors='ignore' is needed for compatibility with ansible-core < 2.12
   when: structured_config is not defined and lookup('first_found', filename, skip=True, errors='ignore')

--- a/ansible_collections/arista/avd/tests/sanity/ignore-2.11.txt
+++ b/ansible_collections/arista/avd/tests/sanity/ignore-2.11.txt
@@ -1,5 +1,6 @@
 plugins/modules/configlet_build_config.py validate-modules:missing-gplv3-license
 plugins/modules/eos_designs_facts.py validate-modules:missing-gplv3-license
+plugins/modules/include_vars.py validate-modules:missing-gplv3-license
 plugins/modules/inventory_to_container.py validate-modules:missing-gplv3-license
 plugins/modules/validate.py validate-modules:missing-gplv3-license
 plugins/modules/yaml_templates_to_facts.py validate-modules:missing-gplv3-license

--- a/ansible_collections/arista/avd/tests/sanity/ignore-2.12.txt
+++ b/ansible_collections/arista/avd/tests/sanity/ignore-2.12.txt
@@ -1,5 +1,6 @@
 plugins/modules/configlet_build_config.py validate-modules:missing-gplv3-license
 plugins/modules/eos_designs_facts.py validate-modules:missing-gplv3-license
+plugins/modules/include_vars.py validate-modules:missing-gplv3-license
 plugins/modules/inventory_to_container.py validate-modules:missing-gplv3-license
 plugins/modules/validate.py validate-modules:missing-gplv3-license
 plugins/modules/yaml_templates_to_facts.py validate-modules:missing-gplv3-license


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Feat(plugin): New arista.avd.include_vars plugin

## Related Issue(s)

When using `ansible.builtin.include_vars` the vars are loaded with a higher var precedence than anything we can set during the play. This blocks us from doing any variable type conversion during execution, since the original imported vars always take precedence.

## Component(s) name

`arista.avd.include_vars`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

Since Ansible detects the module FQCN `ansible.builtin.include_vars` and handles the returned `ansible_facts` differently than any other module, we just need another name, to avoid this behavior.
The plugin `arista.avd.include_vars` simply wraps the builtin class to fool Ansible.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

When importing vars from file, debug var before and after validation to see if validation can overwrite the vars or not.

Also tested with PR #2024 where the issue was seen first.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
