### PR TITLE
Feat(eos_cli_config_gen): Add schema for vmtracer_sessions

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -403,7 +403,7 @@ vlan_internal_order:
 | [<samp>&nbsp;&nbsp;- name</samp>](## "vmtracer_sessions.[].name") | String | Required, Unique |  |  | Vmtracer Session Name |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;url</samp>](## "vmtracer_sessions.[].url") | String |  |  |  | URL |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;username</samp>](## "vmtracer_sessions.[].username") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;password</samp>](## "vmtracer_sessions.[].password") | String |  |  |  | Encrypted Password |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;password</samp>](## "vmtracer_sessions.[].password") | String |  |  |  | Type 7 Password Hash |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;autovlan_disable</samp>](## "vmtracer_sessions.[].autovlan_disable") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;source_interface</samp>](## "vmtracer_sessions.[].source_interface") | String |  |  |  |  |
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -392,3 +392,29 @@ vlan_internal_order:
     beginning: <int>
     ending: <int>
 ```
+
+## VM Tracer Sessions
+
+### Variables
+
+| Variable | Type | Required | Default | Value Restrictions | Description |
+| -------- | ---- | -------- | ------- | ------------------ | ----------- |
+| [<samp>vmtracer_sessions</samp>](## "vmtracer_sessions") | List, items: Dictionary |  |  |  | VM Tracer Sessions |
+| [<samp>&nbsp;&nbsp;- name</samp>](## "vmtracer_sessions.[].name") | String | Required, Unique |  |  | Vmtracer Session Name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;url</samp>](## "vmtracer_sessions.[].url") | String |  |  |  | URL |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;username</samp>](## "vmtracer_sessions.[].username") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;password</samp>](## "vmtracer_sessions.[].password") | String |  |  |  | Encrypted Password |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;autovlan_disable</samp>](## "vmtracer_sessions.[].autovlan_disable") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;source_interface</samp>](## "vmtracer_sessions.[].source_interface") | String |  |  |  |  |
+
+### YAML
+
+```yaml
+vmtracer_sessions:
+  - name: <str>
+    url: <str>
+    username: <str>
+    password: <str>
+    autovlan_disable: <bool>
+    source_interface: <str>
+```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -542,7 +542,7 @@ keys:
           type: str
         password:
           type: str
-          description: Encrypted Password
+          description: Type 7 Password Hash
         autovlan_disable:
           type: bool
         source_interface:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -522,3 +522,28 @@ keys:
             display_name: Vlan ID
             convert_types:
             - str
+  vmtracer_sessions:
+    type: list
+    primary_key: name
+    convert_types:
+    - dict
+    display_name: VM Tracer Sessions
+    items:
+      type: dict
+      keys:
+        name:
+          type: str
+          required: true
+          display_name: Vmtracer Session Name
+        url:
+          type: str
+          display_name: URL
+        username:
+          type: str
+        password:
+          type: str
+          description: Encrypted Password
+        autovlan_disable:
+          type: bool
+        source_interface:
+          type: str

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/vmtracer_sessions.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/vmtracer_sessions.schema.yml
@@ -23,7 +23,7 @@ keys:
           type: str
         password:
           type: str
-          description: Encrypted Password
+          description: Type 7 Password Hash
         autovlan_disable:
           type: bool
         source_interface:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/vmtracer_sessions.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/vmtracer_sessions.schema.yml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  vmtracer_sessions:
+    type: list
+    primary_key: name
+    convert_types:
+      - dict
+    display_name: VM Tracer Sessions
+    items:
+      type: dict
+      keys:
+        name:
+          type: str
+          required: true
+          display_name: Vmtracer Session Name
+        url:
+          type: str
+          display_name: URL
+        username:
+          type: str
+        password:
+          type: str
+          description: Encrypted Password
+        autovlan_disable:
+          type: bool
+        source_interface:
+          type: str

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vmtracer-sessions.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vmtracer-sessions.j2
@@ -6,7 +6,7 @@
 
 | Session | URL | Username | Autovlan | Source Interface |
 | ------- | --- | -------- | -------- | ---------------- |
-{%     for session in vmtracer_sessions | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%     for session in vmtracer_sessions | arista.avd.natural_sort('name') %}
 {%         set url = session.url | arista.avd.default('-') %}
 {%         if session.autovlan_disable is arista.avd.defined(true) %}
 {%             set autovlan = 'disabled' %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vmtracer-sessions.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vmtracer-sessions.j2
@@ -1,5 +1,5 @@
 {# eos - vmtracer sessions #}
-{% for session in vmtracer_sessions | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{% for session in vmtracer_sessions | arista.avd.natural_sort('name') %}
 !
 vmtracer session {{ session.name }}
 {%     if session.url is arista.avd.defined %}


### PR DESCRIPTION
## Add schema for data model

<!-- Use this PR Title: Feat(eos_cli_config_gen): Add schema for < data_model_key > -->

## Checklist

### Contributor Checklist

- [x] Create schema fragment matching data model described in README.md and README_v4.0.md
  - README.md is most complete with all keys. README_v4.0 includes partial data models after conversion to lists.
  - Schema fragment path is `roles/eos_cli_config_gen/schemas/schema_fragments/<data_model_key>.schema.yml`.
  - Copy line 1-5 from another schema (comments and outer type:dict).
  - Refer to [schema documentation](https://avd.sh/en/devel/docs/input-variable-validation-BETA.html) for syntax and/or use YAML Lint plugin from Redhat in VSCode.
  - Use `convert_types` on value that could be mixed type or misinterpreted like integers and numeric strings.
- [x] If the data model has been converted from wildcard dicts:
  - Add `convert_types: ['dict']` to the schema.
  - Remove `convert_dicts` from the `templates/eos/<>.j2` and `templates/documentation/<>.j2` templates.
- [x] Run `molecule converge -s build_schemas_and_docs` to update schema and documentation.
- [x] Test by running `molecule converge -s eos_cli_config_gen` and verify no errors or changes to generated configs/docs.

### Reviewer Checklist

- Reviewer 1:
  - [ ] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [ ] Verify that `convert_dicts` has been removed from templates as applicable.
  - [ ] Verify no changes to configs/docs on any molecule scenario
  - [ ] Verify that CI pass

- Reviewer 2:
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
