### PR TITLE
Fix: pr labeler action

### DIFF
--- a/.github/actions/rn-pr-labeler-action/action.yml
+++ b/.github/actions/rn-pr-labeler-action/action.yml
@@ -25,7 +25,7 @@ runs:
       # the color of the label though so it may not be desirable.
     - name: Check if label exist
       run: |
-        EXIST=$(gh label list --json name -q '.[] | select(.name=="rn: ${{ env.LABEL }}").name')
+        EXIST=$(gh label list --search "rn:" --json name -q '.[] | select(.name=="rn: ${{ env.LABEL }}").name')
         echo "EXIST=$EXIST" >> $GITHUB_ENV
       shell: bash
     - name: Create Label if auto-create and label does not exist already

--- a/.github/actions/rn-pr-labeler-action/action.yml
+++ b/.github/actions/rn-pr-labeler-action/action.yml
@@ -25,7 +25,7 @@ runs:
       # the color of the label though so it may not be desirable.
     - name: Check if label exist
       run: |
-        EXIST=$(gh label list --search "rn:" --json name -q '.[] | select(.name=="rn: ${{ env.LABEL }}").name')
+        EXIST=$(gh label list -L 100 --search "rn:" --json name -q '.[] | select(.name=="rn: ${{ env.LABEL }}").name')
         echo "EXIST=$EXIST" >> $GITHUB_ENV
       shell: bash
     - name: Create Label if auto-create and label does not exist already


### PR DESCRIPTION
* AVD list of labels is too long and only the first 30 in alphabetical orders are returned. This led to the action failing for PR #1984

## Change Summary

The github action is supposed to label the PRs when merged with a release note labels.
It turns out that the command line that checks before the label already exists before creating it uses some github cli command that will return ONLY the first 30 labels. This explains the failure for labeling PR #1984 when it merged.

This PR intends to fix this by adding a search string for only the "rn:" labels and extend the number of retrieved labels to 100 which should cover the use case.

## Component(s) name

`ci`

## Proposed changes

Add extra parameters to verify if a label already exists.

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
