### PR TITLE
Test: enable config generation for eos_designs_unit_tests_4.0

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/DC1-BL1A.cfg
@@ -1,0 +1,399 @@
+!RANCID-CONTENT-TYPE: arista
+!
+boot secret sha512 a153de6290ff1409257ade45f
+!
+daemon TerminAttr
+   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key, -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   no shutdown
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname DC1-BL1A
+ip name-server vrf MGMT 1.1.1.1
+ip name-server vrf MGMT 8.8.8.8
+ip name-server vrf MGMT 192.168.200.5
+!
+snmp-server contact example@example.com
+snmp-server location EOS_DESIGNS_UNIT_TESTS DC1-BL1A
+!
+hardware speed-group 1 serdes 10G
+hardware speed-group 2 serdes 25G
+hardware speed-group 3 serdes 25G
+hardware speed-group 4 serdes 10G
+!
+spanning-tree root super
+spanning-tree mode mstp
+spanning-tree mst 0 priority 4096
+!
+platform sand lag hardware-only
+!
+no enable password
+no aaa root
+!
+username admin privilege 15 role network-admin nopassword
+username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
+username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
+!
+vlan 150
+   name Tenant_A_WAN_Zone_1
+!
+vlan 250
+   name Tenant_B_WAN_Zone_1
+!
+vlan 350
+   name Tenant_C_WAN_Zone_1
+!
+vrf instance MGMT
+!
+vrf instance Tenant_A_WAN_Zone
+!
+vrf instance Tenant_B_OP_Zone
+!
+vrf instance Tenant_B_WAN_Zone
+!
+vrf instance Tenant_C_WAN_Zone
+!
+vrf instance Tenant_L3_VRF_Zone
+!
+interface Ethernet1
+   description P2P_LINK_TO_DC1-SPINE1_Ethernet6
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.81/31
+!
+interface Ethernet2
+   description P2P_LINK_TO_DC1-SPINE2_Ethernet6
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.83/31
+!
+interface Ethernet3
+   description P2P_LINK_TO_DC1-SPINE3_Ethernet6
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.85/31
+!
+interface Ethernet4
+   description P2P_LINK_TO_DC1-SPINE4_Ethernet6
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.87/31
+!
+interface Ethernet7
+   description test
+   no shutdown
+   mtu 9000
+   no switchport
+   vrf Tenant_A_WAN_Zone
+   ip address 10.10.10.10/24
+   ip ospf cost 100
+   ip ospf network point-to-point
+   ip ospf authentication message-digest
+   ip ospf area 0
+   ip ospf message-digest-key 1 sha1 7 AQQvKeimxJu+uGQ/yYvv9w==
+   ip ospf message-digest-key 2 sha512 7 AQQvKeimxJu+uGQ/yYvv9w==
+!
+interface Ethernet8
+   description test
+   no shutdown
+   mtu 9000
+   no switchport
+   vrf Tenant_L3_VRF_Zone
+   ip address 10.10.10.10/24
+!
+interface Ethernet9
+   description test
+   no shutdown
+   mtu 9000
+   no switchport
+   vrf Tenant_L3_VRF_Zone
+   ip address 10.10.20.20/24
+!
+interface Ethernet4000
+   description My test
+   no shutdown
+   mtu 1500
+   no switchport
+   ip address 10.3.2.1/21
+!
+interface Loopback0
+   description MY_OVERLAY_LOOPBACK
+   no shutdown
+   ip address 192.168.255.14/32
+!
+interface Loopback1
+   description VTEP_VXLAN_Tunnel_Source
+   no shutdown
+   ip address 192.168.254.14/32
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 192.168.200.110/24
+!
+interface Vlan150
+   description Tenant_A_WAN_Zone_1
+   no shutdown
+   vrf Tenant_A_WAN_Zone
+   ip ospf area 1
+   ip ospf cost 100
+   ip ospf authentication
+   ip ospf authentication-key 7 AQQvKeimxJu+uGQ/yYvv9w==
+   ip address virtual 10.1.40.1/24
+!
+interface Vlan250
+   description Tenant_B_WAN_Zone_1
+   no shutdown
+   vrf Tenant_B_WAN_Zone
+   ip address virtual 10.2.50.1/24
+!
+interface Vlan350
+   description Tenant_C_WAN_Zone_1
+   no shutdown
+   vrf Tenant_C_WAN_Zone
+   ip address virtual 10.3.50.1/24
+!
+interface Vxlan1
+   description DC1-BL1A_VTEP
+   vxlan source-interface Loopback1
+   vxlan udp-port 4789
+   vxlan vlan 150 vni 10150
+   vxlan vlan 250 vni 20250
+   vxlan vlan 350 vni 30350
+   vxlan vrf Tenant_A_WAN_Zone vni 14
+   vxlan vrf Tenant_B_OP_Zone vni 20
+   vxlan vrf Tenant_B_WAN_Zone vni 21
+   vxlan vrf Tenant_C_WAN_Zone vni 31
+   vxlan vrf Tenant_L3_VRF_Zone vni 15
+!
+hardware tcam
+   system profile vxlan-routing
+!
+ip virtual-router mac-address 00:dc:00:00:00:0a
+!
+event-handler evpn-blacklist-recovery
+   trigger on-logging
+      regex EVPN-3-BLACKLISTED_DUPLICATE_MAC
+   action bash FastCli -p 15 -c "clear bgp evpn host-flap"
+   delay 300
+!
+ip routing
+no ip routing vrf MGMT
+ip routing vrf Tenant_A_WAN_Zone
+ip routing vrf Tenant_B_OP_Zone
+ip routing vrf Tenant_B_WAN_Zone
+ip routing vrf Tenant_C_WAN_Zone
+ip routing vrf Tenant_L3_VRF_Zone
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+   seq 20 permit 192.168.254.0/24 eq 32
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.200.5
+ip route vrf Tenant_A_WAN_Zone 10.3.4.0/24 1.2.3.4
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+route-map RM-Tenant_A_WAN_Zone-123.1.1.10-SET-NEXT-HOP-OUT permit 10
+   set ip next-hop 123.1.1.1
+!
+route-map RM-Tenant_A_WAN_Zone-fd5a:fe45:8831:06c5::a-SET-NEXT-HOP-OUT permit 10
+   set ipv6 next-hop fd5a:fe45:8831:06c5::1
+!
+router bfd
+   multihop interval 1200 min-rx 1200 multiplier 3
+!
+router bgp 65104
+   router-id 192.168.255.14
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
+   maximum-paths 4 ecmp 4
+   neighbor EVPN-OVERLAY-CORE peer group
+   neighbor EVPN-OVERLAY-CORE update-source Loopback0
+   neighbor EVPN-OVERLAY-CORE bfd
+   neighbor EVPN-OVERLAY-CORE ebgp-multihop 15
+   neighbor EVPN-OVERLAY-CORE send-community
+   neighbor EVPN-OVERLAY-CORE maximum-routes 0
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor UNDERLAY-PEERS peer group
+   neighbor UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor UNDERLAY-PEERS send-community
+   neighbor UNDERLAY-PEERS maximum-routes 12000
+   neighbor 172.31.255.80 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.80 remote-as 65001
+   neighbor 172.31.255.80 description DC1-SPINE1_Ethernet6
+   neighbor 172.31.255.82 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.82 remote-as 65001
+   neighbor 172.31.255.82 description DC1-SPINE2_Ethernet6
+   neighbor 172.31.255.84 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.84 remote-as 65001
+   neighbor 172.31.255.84 description DC1-SPINE3_Ethernet6
+   neighbor 172.31.255.86 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.86 remote-as 65001
+   neighbor 172.31.255.86 description DC1-SPINE4_Ethernet6
+   neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.1 remote-as 65001
+   neighbor 192.168.255.1 description DC1-SPINE1
+   neighbor 192.168.255.2 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.2 remote-as 65001
+   neighbor 192.168.255.2 description DC1-SPINE2
+   neighbor 192.168.255.3 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.3 remote-as 65001
+   neighbor 192.168.255.3 description DC1-SPINE3
+   neighbor 192.168.255.4 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.4 remote-as 65001
+   neighbor 192.168.255.4 description DC1-SPINE4
+   neighbor 192.168.255.16 peer group EVPN-OVERLAY-CORE
+   neighbor 192.168.255.16 remote-as 65106
+   neighbor 192.168.255.16 description DC1-BL2A
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   vlan-aware-bundle Tenant_A_WAN_Zone
+      rd 192.168.254.14:14
+      rd evpn domain remote 192.168.254.14:14
+      route-target both 65104:14
+      route-target import export evpn domain remote 65104:14
+      redistribute learned
+      vlan 150
+   !
+   vlan-aware-bundle Tenant_B_WAN_Zone
+      rd 192.168.254.14:21
+      rd evpn domain remote 192.168.254.14:21
+      route-target both 65104:21
+      route-target import export evpn domain remote 65104:21
+      redistribute learned
+      vlan 250
+   !
+   vlan-aware-bundle Tenant_C_WAN_Zone
+      rd 192.168.254.14:31
+      rd evpn domain remote 192.168.254.14:31
+      route-target both 65104:31
+      route-target import export evpn domain remote 65104:31
+      redistribute learned
+      vlan 350
+   !
+   address-family evpn
+      host-flap detection window 180 threshold 5 expiry timeout 10 seconds
+      neighbor EVPN-OVERLAY-CORE activate
+      neighbor EVPN-OVERLAY-CORE domain remote
+      neighbor EVPN-OVERLAY-PEERS activate
+      neighbor default next-hop-self received-evpn-routes route-type ip-prefix inter-domain
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-CORE activate
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor UNDERLAY-PEERS activate
+   !
+   vrf Tenant_A_WAN_Zone
+      rd 192.168.254.14:14
+      route-target import evpn 65104:14
+      route-target import evpn 65000:456
+      route-target import vpn-ipv4 65000:123
+      route-target export evpn 65104:14
+      route-target export evpn 65000:789
+      route-target export vpn-ipv4 65000:123
+      router-id 192.168.255.14
+      neighbor 123.1.1.10 remote-as 1234
+      neighbor 123.1.1.10 password 7 AQQvKeimxJu+uGQ/yYvv9w==
+      neighbor 123.1.1.10 local-as 123 no-prepend replace-as
+      neighbor 123.1.1.10 description External IPv4 BGP peer
+      neighbor 123.1.1.10 ebgp-multihop 3
+      neighbor 123.1.1.10 send-community standard extended
+      neighbor 123.1.1.10 maximum-routes 0
+      neighbor 123.1.1.10 default-originate
+      neighbor 123.1.1.10 update-source Loopback123
+      neighbor 123.1.1.10 route-map RM-Tenant_A_WAN_Zone-123.1.1.10-SET-NEXT-HOP-OUT out
+      neighbor 123.1.1.10 route-map RM-123-1-1-10-IN in
+      neighbor 123.1.1.11 remote-as 1234
+      neighbor 123.1.1.11 password 7 AQQvKeimxJu+uGQ/yYvv9w==
+      neighbor 123.1.1.11 local-as 123 no-prepend replace-as
+      neighbor 123.1.1.11 description External IPv4 BGP peer
+      neighbor 123.1.1.11 ebgp-multihop 3
+      neighbor 123.1.1.11 bfd
+      neighbor 123.1.1.11 send-community standard extended
+      neighbor 123.1.1.11 maximum-routes 0
+      neighbor 123.1.1.11 default-originate
+      neighbor 123.1.1.11 update-source Loopback123
+      neighbor 123.1.1.11 route-map RM-123-1-1-11-OUT out
+      neighbor 123.1.1.11 route-map RM-123-1-1-11-IN in
+      neighbor fd5a:fe45:8831:06c5::a remote-as 12345
+      neighbor fd5a:fe45:8831:06c5::a send-community
+      neighbor fd5a:fe45:8831:06c5::a route-map RM-Tenant_A_WAN_Zone-fd5a:fe45:8831:06c5::a-SET-NEXT-HOP-OUT out
+      neighbor fd5a:fe45:8831:06c5::b remote-as 12345
+      redistribute connected
+      redistribute ospf
+      redistribute static
+      !
+      address-family ipv4
+         neighbor 123.1.1.10 activate
+         neighbor 123.1.1.11 activate
+      !
+      address-family ipv6
+         neighbor fd5a:fe45:8831:06c5::a activate
+         neighbor fd5a:fe45:8831:06c5::b activate
+   !
+   vrf Tenant_B_OP_Zone
+      rd 192.168.254.14:20
+      route-target import evpn 65104:20
+      route-target export evpn 65104:20
+      router-id 192.168.255.14
+      redistribute connected
+   !
+   vrf Tenant_B_WAN_Zone
+      rd 192.168.254.14:21
+      route-target import evpn 65104:21
+      route-target export evpn 65104:21
+      router-id 192.168.255.14
+      redistribute connected
+   !
+   vrf Tenant_C_WAN_Zone
+      rd 192.168.254.14:31
+      route-target import evpn 65104:31
+      route-target export evpn 65104:31
+      router-id 192.168.255.14
+      redistribute connected
+   !
+   vrf Tenant_L3_VRF_Zone
+      rd 192.168.254.14:15
+      route-target import evpn 65104:15
+      route-target export evpn 65104:15
+      router-id 192.168.255.14
+      redistribute connected
+!
+router ospf 14 vrf Tenant_A_WAN_Zone
+   router-id 192.168.255.14
+   passive-interface default
+   no passive-interface Ethernet7
+   no passive-interface Vlan150
+   max-lsa 15000
+   redistribute bgp
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/DC1-BL1B.cfg
@@ -1,0 +1,385 @@
+!RANCID-CONTENT-TYPE: arista
+!
+boot secret sha512 a153de6290ff1409257ade45f
+!
+daemon TerminAttr
+   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   no shutdown
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname DC1-BL1B
+ip name-server vrf MGMT 8.8.8.8
+ip name-server vrf MGMT 192.168.200.5
+!
+snmp-server contact example@example.com
+snmp-server location EOS_DESIGNS_UNIT_TESTS DC1-BL1B
+!
+hardware speed-group 1 serdes 10G
+hardware speed-group 2 serdes 25G
+hardware speed-group 3 serdes 25G
+hardware speed-group 4 serdes 10G
+!
+spanning-tree root super
+spanning-tree mode mstp
+spanning-tree mst 0 priority 4096
+!
+platform sand lag hardware-only
+!
+no enable password
+no aaa root
+!
+username admin privilege 15 role network-admin nopassword
+username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
+username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
+!
+vlan 150
+   name Tenant_A_WAN_Zone_1
+!
+vlan 250
+   name Tenant_B_WAN_Zone_1
+!
+vlan 350
+   name Tenant_C_WAN_Zone_1
+!
+vrf instance MGMT
+!
+vrf instance Tenant_A_WAN_Zone
+!
+vrf instance Tenant_B_OP_Zone
+!
+vrf instance Tenant_B_WAN_Zone
+!
+vrf instance Tenant_C_WAN_Zone
+!
+vrf instance Tenant_L3_VRF_Zone
+!
+interface Ethernet1
+   description P2P_LINK_TO_DC1-SPINE1_Ethernet7
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.97/31
+!
+interface Ethernet2
+   description P2P_LINK_TO_DC1-SPINE2_Ethernet7
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.99/31
+!
+interface Ethernet3
+   description P2P_LINK_TO_DC1-SPINE3_Ethernet7
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.101/31
+!
+interface Ethernet4
+   description P2P_LINK_TO_DC1-SPINE4_Ethernet7
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.103/31
+!
+interface Ethernet7
+   description test
+   no shutdown
+   mtu 9000
+   no switchport
+   vrf Tenant_A_WAN_Zone
+   ip address 10.10.20.20/24
+!
+interface Ethernet8
+   description test
+   no shutdown
+   mtu 9000
+   no switchport
+   vrf Tenant_L3_VRF_Zone
+   ip address 10.10.30.10/24
+!
+interface Ethernet9
+   description test
+   no shutdown
+   mtu 9000
+   no switchport
+   vrf Tenant_L3_VRF_Zone
+   ip address 10.10.40.20/24
+!
+interface Ethernet4000
+   description My second test
+   no shutdown
+   mtu 1500
+   no switchport
+   ip address 10.1.2.3/12
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 192.168.255.15/32
+!
+interface Loopback1
+   description VTEP_VXLAN_Tunnel_Source
+   no shutdown
+   ip address 192.168.254.15/32
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 192.168.200.111/24
+!
+interface Vlan150
+   description Tenant_A_WAN_Zone_1
+   no shutdown
+   vrf Tenant_A_WAN_Zone
+   ip ospf area 1
+   ip ospf cost 100
+   ip ospf authentication
+   ip ospf authentication-key 7 AQQvKeimxJu+uGQ/yYvv9w==
+   ip address virtual 10.1.40.1/24
+!
+interface Vlan250
+   description Tenant_B_WAN_Zone_1
+   no shutdown
+   vrf Tenant_B_WAN_Zone
+   ip address virtual 10.2.50.1/24
+!
+interface Vlan350
+   description Tenant_C_WAN_Zone_1
+   no shutdown
+   vrf Tenant_C_WAN_Zone
+   ip address virtual 10.3.50.1/24
+!
+interface Vxlan1
+   description DC1-BL1B_VTEP
+   vxlan source-interface Loopback1
+   vxlan udp-port 4789
+   vxlan vlan 150 vni 10150
+   vxlan vlan 250 vni 20250
+   vxlan vlan 350 vni 30350
+   vxlan vrf Tenant_A_WAN_Zone vni 14
+   vxlan vrf Tenant_B_OP_Zone vni 20
+   vxlan vrf Tenant_B_WAN_Zone vni 21
+   vxlan vrf Tenant_C_WAN_Zone vni 31
+   vxlan vrf Tenant_L3_VRF_Zone vni 15
+!
+hardware tcam
+   system profile vxlan-routing
+!
+ip virtual-router mac-address 00:dc:00:00:00:0a
+!
+ip routing
+no ip routing vrf MGMT
+ip routing vrf Tenant_A_WAN_Zone
+ip routing vrf Tenant_B_OP_Zone
+ip routing vrf Tenant_B_WAN_Zone
+ip routing vrf Tenant_C_WAN_Zone
+ip routing vrf Tenant_L3_VRF_Zone
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+   seq 20 permit 192.168.254.0/24 eq 32
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.200.5
+ip route vrf Tenant_A_WAN_Zone 10.3.4.0/24 1.2.3.4
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+route-map RM-Tenant_A_WAN_Zone-123.1.1.10-SET-NEXT-HOP-OUT permit 10
+   set ip next-hop 123.1.1.1
+!
+route-map RM-Tenant_A_WAN_Zone-fd5a:fe45:8831:06c5::a-SET-NEXT-HOP-OUT permit 10
+   set ipv6 next-hop fd5a:fe45:8831:06c5::1
+!
+router bfd
+   multihop interval 1200 min-rx 1200 multiplier 3
+!
+router bgp 65105
+   router-id 192.168.255.15
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
+   maximum-paths 4 ecmp 4
+   neighbor EVPN-OVERLAY-CORE peer group
+   neighbor EVPN-OVERLAY-CORE update-source Loopback0
+   neighbor EVPN-OVERLAY-CORE bfd
+   neighbor EVPN-OVERLAY-CORE ebgp-multihop 15
+   neighbor EVPN-OVERLAY-CORE send-community
+   neighbor EVPN-OVERLAY-CORE maximum-routes 0
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor UNDERLAY-PEERS peer group
+   neighbor UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor UNDERLAY-PEERS send-community
+   neighbor UNDERLAY-PEERS maximum-routes 12000
+   neighbor 1.1.1.1 peer group EVPN-OVERLAY-CORE
+   neighbor 1.1.1.1 remote-as 65555
+   neighbor 1.1.1.1 description MY_EVPN_GW_USER_DEFINED
+   neighbor 172.31.255.96 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.96 remote-as 65001
+   neighbor 172.31.255.96 description DC1-SPINE1_Ethernet7
+   neighbor 172.31.255.98 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.98 remote-as 65001
+   neighbor 172.31.255.98 description DC1-SPINE2_Ethernet7
+   neighbor 172.31.255.100 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.100 remote-as 65001
+   neighbor 172.31.255.100 description DC1-SPINE3_Ethernet7
+   neighbor 172.31.255.102 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.102 remote-as 65001
+   neighbor 172.31.255.102 description DC1-SPINE4_Ethernet7
+   neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.1 remote-as 65001
+   neighbor 192.168.255.1 description DC1-SPINE1
+   neighbor 192.168.255.2 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.2 remote-as 65001
+   neighbor 192.168.255.2 description DC1-SPINE2
+   neighbor 192.168.255.3 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.3 remote-as 65001
+   neighbor 192.168.255.3 description DC1-SPINE3
+   neighbor 192.168.255.4 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.4 remote-as 65001
+   neighbor 192.168.255.4 description DC1-SPINE4
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   vlan-aware-bundle Tenant_A_WAN_Zone
+      rd 192.168.254.15:14
+      rd evpn domain remote 192.168.254.15:14
+      route-target both 65105:14
+      route-target import export evpn domain remote 65105:14
+      redistribute learned
+      vlan 150
+   !
+   vlan-aware-bundle Tenant_B_WAN_Zone
+      rd 192.168.254.15:21
+      rd evpn domain remote 192.168.254.15:21
+      route-target both 65105:21
+      route-target import export evpn domain remote 65105:21
+      redistribute learned
+      vlan 250
+   !
+   vlan-aware-bundle Tenant_C_WAN_Zone
+      rd 192.168.254.15:31
+      rd evpn domain remote 192.168.254.15:31
+      route-target both 65105:31
+      route-target import export evpn domain remote 65105:31
+      redistribute learned
+      vlan 350
+   !
+   address-family evpn
+      host-flap detection window 180 threshold 5 expiry timeout 10 seconds
+      neighbor EVPN-OVERLAY-CORE activate
+      neighbor EVPN-OVERLAY-CORE domain remote
+      neighbor EVPN-OVERLAY-PEERS activate
+      neighbor default next-hop-self received-evpn-routes route-type ip-prefix
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-CORE activate
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor UNDERLAY-PEERS activate
+   !
+   vrf Tenant_A_WAN_Zone
+      rd 192.168.254.15:14
+      route-target import evpn 65105:14
+      route-target import evpn 65000:456
+      route-target import vpn-ipv4 65000:123
+      route-target export evpn 65105:14
+      route-target export evpn 65000:789
+      route-target export vpn-ipv4 65000:123
+      router-id 192.168.255.15
+      neighbor 123.1.1.10 remote-as 1234
+      neighbor 123.1.1.10 password 7 AQQvKeimxJu+uGQ/yYvv9w==
+      neighbor 123.1.1.10 local-as 123 no-prepend replace-as
+      neighbor 123.1.1.10 description External IPv4 BGP peer
+      neighbor 123.1.1.10 ebgp-multihop 3
+      neighbor 123.1.1.10 send-community standard extended
+      neighbor 123.1.1.10 maximum-routes 0
+      neighbor 123.1.1.10 default-originate
+      neighbor 123.1.1.10 update-source Loopback123
+      neighbor 123.1.1.10 route-map RM-Tenant_A_WAN_Zone-123.1.1.10-SET-NEXT-HOP-OUT out
+      neighbor 123.1.1.10 route-map RM-123-1-1-10-IN in
+      neighbor 123.1.1.11 remote-as 1234
+      neighbor 123.1.1.11 password 7 AQQvKeimxJu+uGQ/yYvv9w==
+      neighbor 123.1.1.11 local-as 123 no-prepend replace-as
+      neighbor 123.1.1.11 description External IPv4 BGP peer
+      neighbor 123.1.1.11 ebgp-multihop 3
+      neighbor 123.1.1.11 bfd
+      neighbor 123.1.1.11 send-community standard extended
+      neighbor 123.1.1.11 maximum-routes 0
+      neighbor 123.1.1.11 default-originate
+      neighbor 123.1.1.11 update-source Loopback123
+      neighbor 123.1.1.11 route-map RM-123-1-1-11-OUT out
+      neighbor 123.1.1.11 route-map RM-123-1-1-11-IN in
+      neighbor fd5a:fe45:8831:06c5::a remote-as 12345
+      neighbor fd5a:fe45:8831:06c5::a send-community
+      neighbor fd5a:fe45:8831:06c5::a route-map RM-Tenant_A_WAN_Zone-fd5a:fe45:8831:06c5::a-SET-NEXT-HOP-OUT out
+      neighbor fd5a:fe45:8831:06c5::b remote-as 12345
+      redistribute connected
+      redistribute ospf
+      redistribute static
+      !
+      address-family ipv4
+         neighbor 123.1.1.10 activate
+         neighbor 123.1.1.11 activate
+      !
+      address-family ipv6
+         neighbor fd5a:fe45:8831:06c5::a activate
+         neighbor fd5a:fe45:8831:06c5::b activate
+   !
+   vrf Tenant_B_OP_Zone
+      rd 192.168.254.15:20
+      route-target import evpn 65105:20
+      route-target export evpn 65105:20
+      router-id 192.168.255.15
+      redistribute connected
+   !
+   vrf Tenant_B_WAN_Zone
+      rd 192.168.254.15:21
+      route-target import evpn 65105:21
+      route-target export evpn 65105:21
+      router-id 192.168.255.15
+      redistribute connected
+   !
+   vrf Tenant_C_WAN_Zone
+      rd 192.168.254.15:31
+      route-target import evpn 65105:31
+      route-target export evpn 65105:31
+      router-id 192.168.255.15
+      redistribute connected
+   !
+   vrf Tenant_L3_VRF_Zone
+      rd 192.168.254.15:15
+      route-target import evpn 65105:15
+      route-target export evpn 65105:15
+      router-id 192.168.255.15
+      redistribute connected
+!
+router ospf 14 vrf Tenant_A_WAN_Zone
+   router-id 192.168.255.15
+   passive-interface default
+   no passive-interface Vlan150
+   max-lsa 15000
+   redistribute bgp
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/DC1-BL2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/DC1-BL2A.cfg
@@ -1,0 +1,269 @@
+!RANCID-CONTENT-TYPE: arista
+!
+boot secret sha512 a153de6290ff1409257ade45f
+!
+daemon TerminAttr
+   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   no shutdown
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname DC1-BL2A
+ip name-server vrf MGMT 8.8.8.8
+ip name-server vrf MGMT 192.168.200.5
+!
+ntp local-interface vrf MGMT Management1
+ntp server vrf MGMT 192.168.200.5 prefer
+!
+snmp-server contact example@example.com
+snmp-server location EOS_DESIGNS_UNIT_TESTS DC1-BL2A
+!
+spanning-tree root super
+spanning-tree mode mstp
+spanning-tree mst 0 priority 4096
+!
+platform sand lag hardware-only
+!
+no enable password
+no aaa root
+!
+username admin privilege 15 role network-admin nopassword
+username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
+username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
+!
+vlan 150
+   name Tenant_A_WAN_Zone_1
+!
+vlan 250
+   name Tenant_B_WAN_Zone_1
+!
+vlan 350
+   name Tenant_C_WAN_Zone_1
+!
+vrf instance MGMT
+!
+vrf instance Tenant_A_WAN_Zone
+!
+vrf instance Tenant_B_OP_Zone
+!
+vrf instance Tenant_B_WAN_Zone
+!
+vrf instance Tenant_C_WAN_Zone
+!
+interface Ethernet1
+   description P2P_LINK_TO_DC1-SPINE1_Ethernet8
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.113/31
+!
+interface Ethernet2
+   description P2P_LINK_TO_DC1-SPINE2_Ethernet8
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.115/31
+!
+interface Ethernet3
+   description P2P_LINK_TO_DC1-SPINE3_Ethernet8
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.117/31
+!
+interface Ethernet4
+   description P2P_LINK_TO_DC1-SPINE4_Ethernet8
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.119/31
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 192.168.255.16/32
+!
+interface Loopback1
+   description VTEP_VXLAN_Tunnel_Source
+   no shutdown
+   ip address 192.168.254.16/32
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 192.168.200.117/24
+!
+interface Vlan150
+   description Tenant_A_WAN_Zone_1
+   no shutdown
+   vrf Tenant_A_WAN_Zone
+   ip ospf area 1
+   ip ospf cost 100
+   ip ospf authentication
+   ip ospf authentication-key 7 AQQvKeimxJu+uGQ/yYvv9w==
+   ip address virtual 10.1.40.1/24
+!
+interface Vlan250
+   description Tenant_B_WAN_Zone_1
+   no shutdown
+   vrf Tenant_B_WAN_Zone
+   ip address virtual 10.2.50.1/24
+!
+interface Vlan350
+   description Tenant_C_WAN_Zone_1
+   no shutdown
+   vrf Tenant_C_WAN_Zone
+   ip address virtual 10.3.50.1/24
+!
+interface Vxlan1
+   description DC1-BL2A_VTEP
+   vxlan source-interface Loopback1
+   vxlan udp-port 4789
+   vxlan vlan 150 vni 10150
+   vxlan vlan 250 vni 20250
+   vxlan vlan 350 vni 30350
+   vxlan vrf Tenant_A_WAN_Zone vni 14
+   vxlan vrf Tenant_B_OP_Zone vni 20
+   vxlan vrf Tenant_B_WAN_Zone vni 21
+   vxlan vrf Tenant_C_WAN_Zone vni 31
+!
+hardware tcam
+   system profile vxlan-routing
+!
+ip virtual-router mac-address 00:dc:00:00:00:0a
+!
+ip routing
+no ip routing vrf MGMT
+ip routing vrf Tenant_A_WAN_Zone
+ip routing vrf Tenant_B_OP_Zone
+ip routing vrf Tenant_B_WAN_Zone
+ip routing vrf Tenant_C_WAN_Zone
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+   seq 20 permit 192.168.254.0/24 eq 32
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.200.5
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+router bfd
+   multihop interval 1200 min-rx 1200 multiplier 3
+!
+router bgp 65106
+   router-id 192.168.255.16
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
+   maximum-paths 4 ecmp 4
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor UNDERLAY-PEERS peer group
+   neighbor UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor UNDERLAY-PEERS send-community
+   neighbor UNDERLAY-PEERS maximum-routes 12000
+   neighbor 172.31.255.112 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.112 remote-as 65001
+   neighbor 172.31.255.112 description DC1-SPINE1_Ethernet8
+   neighbor 172.31.255.114 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.114 remote-as 65001
+   neighbor 172.31.255.114 description DC1-SPINE2_Ethernet8
+   neighbor 172.31.255.116 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.116 remote-as 65001
+   neighbor 172.31.255.116 description DC1-SPINE3_Ethernet8
+   neighbor 172.31.255.118 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.118 remote-as 65001
+   neighbor 172.31.255.118 description DC1-SPINE4_Ethernet8
+   neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.1 remote-as 65001
+   neighbor 192.168.255.1 description DC1-SPINE1
+   neighbor 192.168.255.2 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.2 remote-as 65001
+   neighbor 192.168.255.2 description DC1-SPINE2
+   neighbor 192.168.255.3 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.3 remote-as 65001
+   neighbor 192.168.255.3 description DC1-SPINE3
+   neighbor 192.168.255.4 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.4 remote-as 65001
+   neighbor 192.168.255.4 description DC1-SPINE4
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   vlan-aware-bundle Tenant_A_WAN_Zone
+      rd 192.168.255.16:14
+      route-target both 14:14
+      redistribute learned
+      vlan 150
+   !
+   vlan-aware-bundle Tenant_B_WAN_Zone
+      rd 192.168.255.16:21
+      route-target both 21:21
+      redistribute learned
+      vlan 250
+   !
+   vlan-aware-bundle Tenant_C_WAN_Zone
+      rd 192.168.255.16:31
+      route-target both 31:31
+      redistribute learned
+      vlan 350
+   !
+   address-family evpn
+      host-flap detection window 180 threshold 5 expiry timeout 10 seconds
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor UNDERLAY-PEERS activate
+   !
+   vrf Tenant_A_WAN_Zone
+      rd 192.168.255.16:14
+      route-target import evpn 14:14
+      route-target import evpn 65000:456
+      route-target export evpn 14:14
+      route-target export evpn 65000:789
+      router-id 192.168.255.16
+      redistribute connected
+   !
+   vrf Tenant_B_OP_Zone
+      rd 192.168.255.16:20
+      route-target import evpn 20:20
+      route-target export evpn 20:20
+      router-id 192.168.255.16
+      redistribute connected
+   !
+   vrf Tenant_B_WAN_Zone
+      rd 192.168.255.16:21
+      route-target import evpn 21:21
+      route-target export evpn 21:21
+      router-id 192.168.255.16
+      redistribute connected
+   !
+   vrf Tenant_C_WAN_Zone
+      rd 192.168.255.16:31
+      route-target import evpn 31:31
+      route-target export evpn 31:31
+      router-id 192.168.255.16
+      redistribute connected
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/DC1-BL2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/DC1-BL2B.cfg
@@ -1,0 +1,264 @@
+!RANCID-CONTENT-TYPE: arista
+!
+boot secret sha512 a153de6290ff1409257ade45f
+!
+daemon TerminAttr
+   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   no shutdown
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname DC1-BL2B
+ip name-server vrf MGMT 8.8.8.8
+ip name-server vrf MGMT 192.168.200.5
+!
+ntp local-interface vrf MGMT Management1
+ntp server vrf MGMT 192.168.200.5 prefer
+!
+snmp-server contact example@example.com
+snmp-server location EOS_DESIGNS_UNIT_TESTS DC1-BL2B
+!
+spanning-tree root super
+spanning-tree mode mstp
+spanning-tree mst 0 priority 4096
+!
+no enable password
+no aaa root
+!
+username admin privilege 15 role network-admin nopassword
+username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
+username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
+!
+vlan 150
+   name Tenant_A_WAN_Zone_1
+!
+vlan 250
+   name Tenant_B_WAN_Zone_1
+!
+vlan 350
+   name Tenant_C_WAN_Zone_1
+!
+vrf instance MGMT
+!
+vrf instance Tenant_A_WAN_Zone
+!
+vrf instance Tenant_B_OP_Zone
+!
+vrf instance Tenant_B_WAN_Zone
+!
+vrf instance Tenant_C_WAN_Zone
+!
+interface Ethernet1
+   description P2P_LINK_TO_DC1-SPINE1_Ethernet9
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.129/31
+!
+interface Ethernet2
+   description P2P_LINK_TO_DC1-SPINE2_Ethernet9
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.131/31
+!
+interface Ethernet3
+   description P2P_LINK_TO_DC1-SPINE3_Ethernet9
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.133/31
+!
+interface Ethernet4
+   description P2P_LINK_TO_DC1-SPINE4_Ethernet9
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.135/31
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 192.168.255.17/32
+!
+interface Loopback1
+   description VTEP_VXLAN_Tunnel_Source
+   no shutdown
+   ip address 192.168.254.17/32
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 192.168.200.118/24
+!
+interface Vlan150
+   description Tenant_A_WAN_Zone_1
+   no shutdown
+   vrf Tenant_A_WAN_Zone
+   ip ospf area 1
+   ip ospf cost 100
+   ip ospf authentication
+   ip ospf authentication-key 7 AQQvKeimxJu+uGQ/yYvv9w==
+   ip address virtual 10.1.40.1/24
+!
+interface Vlan250
+   description Tenant_B_WAN_Zone_1
+   no shutdown
+   vrf Tenant_B_WAN_Zone
+   ip address virtual 10.2.50.1/24
+!
+interface Vlan350
+   description Tenant_C_WAN_Zone_1
+   no shutdown
+   vrf Tenant_C_WAN_Zone
+   ip address virtual 10.3.50.1/24
+!
+interface Vxlan1
+   description DC1-BL2B_VTEP
+   vxlan source-interface Loopback1
+   vxlan udp-port 4789
+   vxlan vlan 150 vni 10150
+   vxlan vlan 250 vni 20250
+   vxlan vlan 350 vni 30350
+   vxlan vrf Tenant_A_WAN_Zone vni 14
+   vxlan vrf Tenant_B_OP_Zone vni 20
+   vxlan vrf Tenant_B_WAN_Zone vni 21
+   vxlan vrf Tenant_C_WAN_Zone vni 31
+!
+ip virtual-router mac-address 00:dc:00:00:00:0a
+!
+ip routing
+no ip routing vrf MGMT
+ip routing vrf Tenant_A_WAN_Zone
+ip routing vrf Tenant_B_OP_Zone
+ip routing vrf Tenant_B_WAN_Zone
+ip routing vrf Tenant_C_WAN_Zone
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+   seq 20 permit 192.168.254.0/24 eq 32
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.200.5
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+router bfd
+   multihop interval 1200 min-rx 1200 multiplier 3
+!
+router bgp 65107
+   router-id 192.168.255.17
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
+   maximum-paths 4 ecmp 4
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor UNDERLAY-PEERS peer group
+   neighbor UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor UNDERLAY-PEERS send-community
+   neighbor UNDERLAY-PEERS maximum-routes 12000
+   neighbor 172.31.255.128 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.128 remote-as 65001
+   neighbor 172.31.255.128 description DC1-SPINE1_Ethernet9
+   neighbor 172.31.255.130 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.130 remote-as 65001
+   neighbor 172.31.255.130 description DC1-SPINE2_Ethernet9
+   neighbor 172.31.255.132 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.132 remote-as 65001
+   neighbor 172.31.255.132 description DC1-SPINE3_Ethernet9
+   neighbor 172.31.255.134 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.134 remote-as 65001
+   neighbor 172.31.255.134 description DC1-SPINE4_Ethernet9
+   neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.1 remote-as 65001
+   neighbor 192.168.255.1 description DC1-SPINE1
+   neighbor 192.168.255.2 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.2 remote-as 65001
+   neighbor 192.168.255.2 description DC1-SPINE2
+   neighbor 192.168.255.3 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.3 remote-as 65001
+   neighbor 192.168.255.3 description DC1-SPINE3
+   neighbor 192.168.255.4 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.4 remote-as 65001
+   neighbor 192.168.255.4 description DC1-SPINE4
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   vlan-aware-bundle Tenant_A_WAN_Zone
+      rd 192.168.255.17:14
+      route-target both 14:14
+      redistribute learned
+      vlan 150
+   !
+   vlan-aware-bundle Tenant_B_WAN_Zone
+      rd 192.168.255.17:21
+      route-target both 21:21
+      redistribute learned
+      vlan 250
+   !
+   vlan-aware-bundle Tenant_C_WAN_Zone
+      rd 192.168.255.17:31
+      route-target both 31:31
+      redistribute learned
+      vlan 350
+   !
+   address-family evpn
+      host-flap detection window 180 threshold 5 expiry timeout 10 seconds
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor UNDERLAY-PEERS activate
+   !
+   vrf Tenant_A_WAN_Zone
+      rd 192.168.255.17:14
+      route-target import evpn 14:14
+      route-target import evpn 65000:456
+      route-target export evpn 14:14
+      route-target export evpn 65000:789
+      router-id 192.168.255.17
+      redistribute connected
+   !
+   vrf Tenant_B_OP_Zone
+      rd 192.168.255.17:20
+      route-target import evpn 20:20
+      route-target export evpn 20:20
+      router-id 192.168.255.17
+      redistribute connected
+   !
+   vrf Tenant_B_WAN_Zone
+      rd 192.168.255.17:21
+      route-target import evpn 21:21
+      route-target export evpn 21:21
+      router-id 192.168.255.17
+      redistribute connected
+   !
+   vrf Tenant_C_WAN_Zone
+      rd 192.168.255.17:31
+      route-target import evpn 31:31
+      route-target export evpn 31:31
+      router-id 192.168.255.17
+      redistribute connected
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/DC1-CL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/DC1-CL1A.cfg
@@ -1,0 +1,371 @@
+!RANCID-CONTENT-TYPE: arista
+!
+boot secret sha512 a153de6290ff1409257ade45f
+!
+daemon TerminAttr
+   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   no shutdown
+!
+vlan internal order ascending range 1006 1199
+!
+no ip igmp snooping vlan 120
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname DC1-CL1A
+ip name-server vrf MGMT 8.8.8.8
+ip name-server vrf MGMT 192.168.200.5
+!
+ntp local-interface vrf MGMT Management1
+ntp server vrf MGMT 192.168.200.5 prefer
+!
+snmp-server contact example@example.com
+snmp-server location EOS_DESIGNS_UNIT_TESTS DC1-CL1A
+!
+spanning-tree root super
+spanning-tree mode mstp
+no spanning-tree vlan-id 4090,4092
+spanning-tree mst 0 priority 4096
+!
+no enable password
+no aaa root
+!
+username admin privilege 15 role network-admin nopassword
+username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
+username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
+!
+vlan 110
+   name Tenant_A_OP_Zone_1
+!
+vlan 111
+   name Tenant_A_OP_Zone_2
+!
+vlan 112
+   name Tenant_A_OP_Zone_3
+!
+vlan 120
+   name Tenant_A_WEB_Zone_1
+!
+vlan 121
+   name Tenant_A_WEBZone_2
+!
+vlan 130
+   name Tenant_A_APP_Zone_1
+!
+vlan 131
+   name Tenant_A_APP_Zone_2
+!
+vlan 140
+   name Tenant_A_DB_BZone_1
+!
+vlan 141
+   name Tenant_A_DB_Zone_2
+!
+vlan 150
+   name Tenant_A_WAN_Zone_1
+!
+vlan 160
+   name Tenant_A_VMOTION
+!
+vlan 161
+   name Tenant_A_NFS
+!
+vlan 210
+   name Tenant_B_OP_Zone_1
+!
+vlan 211
+   name Tenant_B_OP_Zone_2
+!
+vlan 250
+   name Tenant_B_WAN_Zone_1
+!
+vlan 310
+   name Tenant_C_OP_Zone_1
+!
+vlan 311
+   name Tenant_C_OP_Zone_2
+!
+vlan 350
+   name Tenant_C_WAN_Zone_1
+!
+vlan 4090
+   name LEAF_PEER_L3
+   trunk group LEAF_PEER_L3
+!
+vlan 4092
+   name MLAG_PEER
+   trunk group MLAG
+!
+vrf instance MGMT
+!
+interface Port-Channel5
+   description MLAG_PEER_DC1-CL1B_Po5
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 1-4094
+   switchport mode trunk
+   switchport trunk group LEAF_PEER_L3
+   switchport trunk group MLAG
+!
+interface Ethernet1
+   description P2P_LINK_TO_DC1-SPINE1_Ethernet14
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.145/31
+!
+interface Ethernet2
+   description P2P_LINK_TO_DC1-SPINE2_Ethernet14
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.147/31
+!
+interface Ethernet3
+   description P2P_LINK_TO_DC1-SPINE3_Ethernet14
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.149/31
+!
+interface Ethernet4
+   description P2P_LINK_TO_DC1-SPINE4_Ethernet14
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.151/31
+!
+interface Ethernet5
+   description MLAG_PEER_DC1-CL1B_Ethernet5
+   no shutdown
+   speed 100g
+   channel-group 5 mode active
+!
+interface Ethernet6
+   description MLAG_PEER_DC1-CL1B_Ethernet6
+   no shutdown
+   speed 100g
+   channel-group 5 mode active
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 192.168.255.18/32
+!
+interface Loopback1
+   description VTEP_VXLAN_Tunnel_Source
+   no shutdown
+   ip address 192.168.254.18/32
+!
+interface Management0
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 192.168.200.119/24
+!
+interface Vlan4090
+   description MLAG_PEER_L3_PEERING
+   no shutdown
+   mtu 1500
+   ip address 10.255.251.18/31
+!
+interface Vlan4092
+   description MLAG_PEER
+   no shutdown
+   mtu 1500
+   no autostate
+   ip address 10.255.252.18/31
+!
+interface Vxlan1
+   description DC1-CL1A_VTEP
+   vxlan source-interface Loopback1
+   vxlan virtual-router encapsulation mac-address mlag-system-id
+   vxlan udp-port 4789
+   vxlan vlan 110 vni 10110
+   vxlan vlan 111 vni 50111
+   vxlan vlan 112 vni 10112
+   vxlan vlan 120 vni 10120
+   vxlan vlan 121 vni 10121
+   vxlan vlan 130 vni 10130
+   vxlan vlan 131 vni 10131
+   vxlan vlan 140 vni 10140
+   vxlan vlan 141 vni 10141
+   vxlan vlan 150 vni 10150
+   vxlan vlan 160 vni 10160
+   vxlan vlan 161 vni 10161
+   vxlan vlan 210 vni 20210
+   vxlan vlan 211 vni 20211
+   vxlan vlan 250 vni 20250
+   vxlan vlan 310 vni 30310
+   vxlan vlan 311 vni 30311
+   vxlan vlan 350 vni 30350
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+   seq 20 permit 192.168.254.0/24 eq 32
+!
+mlag configuration
+   domain-id DC1_CL1
+   local-interface Vlan4092
+   peer-address 10.255.252.19
+   peer-link Port-Channel5
+   reload-delay mlag 300
+   reload-delay non-mlag 330
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.200.5
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+route-map RM-MLAG-PEER-IN permit 10
+   description Make routes learned over MLAG Peer-link less preferred on spines to ensure optimal routing
+   set origin incomplete
+!
+router bfd
+   multihop interval 1200 min-rx 1200 multiplier 3
+!
+router bgp 65108
+   router-id 192.168.255.18
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
+   maximum-paths 4 ecmp 4
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor MLAG-PEERS peer group
+   neighbor MLAG-PEERS remote-as 65108
+   neighbor MLAG-PEERS next-hop-self
+   neighbor MLAG-PEERS description DC1-CL1B
+   neighbor MLAG-PEERS password 7 vnEaG8gMeQf3d3cN6PktXQ==
+   neighbor MLAG-PEERS send-community
+   neighbor MLAG-PEERS maximum-routes 12000
+   neighbor MLAG-PEERS route-map RM-MLAG-PEER-IN in
+   neighbor UNDERLAY-PEERS peer group
+   neighbor UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor UNDERLAY-PEERS send-community
+   neighbor UNDERLAY-PEERS maximum-routes 12000
+   neighbor 10.255.251.19 peer group MLAG-PEERS
+   neighbor 10.255.251.19 description DC1-CL1B
+   neighbor 172.31.255.144 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.144 remote-as 65001
+   neighbor 172.31.255.144 description DC1-SPINE1_Ethernet14
+   neighbor 172.31.255.146 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.146 remote-as 65001
+   neighbor 172.31.255.146 description DC1-SPINE2_Ethernet14
+   neighbor 172.31.255.148 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.148 remote-as 65001
+   neighbor 172.31.255.148 description DC1-SPINE3_Ethernet14
+   neighbor 172.31.255.150 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.150 remote-as 65001
+   neighbor 172.31.255.150 description DC1-SPINE4_Ethernet14
+   neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.1 remote-as 65001
+   neighbor 192.168.255.1 description DC1-SPINE1
+   neighbor 192.168.255.2 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.2 remote-as 65001
+   neighbor 192.168.255.2 description DC1-SPINE2
+   neighbor 192.168.255.3 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.3 remote-as 65001
+   neighbor 192.168.255.3 description DC1-SPINE3
+   neighbor 192.168.255.4 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.4 remote-as 65001
+   neighbor 192.168.255.4 description DC1-SPINE4
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   vlan-aware-bundle Tenant_A_APP_Zone
+      rd 192.168.255.18:12
+      route-target both 12:12
+      redistribute learned
+      vlan 130-131
+   !
+   vlan-aware-bundle Tenant_A_DB_Zone
+      rd 192.168.255.18:13
+      route-target both 13:13
+      redistribute learned
+      vlan 140-141
+   !
+   vlan-aware-bundle Tenant_A_NFS
+      rd 192.168.255.18:20161
+      route-target both 20161:20161
+      redistribute learned
+      vlan 161
+   !
+   vlan-aware-bundle Tenant_A_OP_Zone
+      rd 192.168.255.18:9
+      route-target both 9:9
+      redistribute learned
+      vlan 110-112
+   !
+   vlan-aware-bundle Tenant_A_VMOTION
+      rd 192.168.255.18:20160
+      route-target both 20160:20160
+      redistribute learned
+      vlan 160
+   !
+   vlan-aware-bundle Tenant_A_WAN_Zone
+      rd 192.168.255.18:14
+      route-target both 14:14
+      redistribute learned
+      vlan 150
+   !
+   vlan-aware-bundle Tenant_A_WEB_Zone
+      rd 192.168.255.18:11
+      route-target both 11:11
+      redistribute learned
+      vlan 120-121
+   !
+   vlan-aware-bundle Tenant_B_OP_Zone
+      rd 192.168.255.18:20
+      route-target both 20:20
+      redistribute learned
+      vlan 210-211
+   !
+   vlan-aware-bundle Tenant_B_WAN_Zone
+      rd 192.168.255.18:21
+      route-target both 21:21
+      redistribute learned
+      vlan 250
+   !
+   vlan-aware-bundle Tenant_C_OP_Zone
+      rd 192.168.255.18:30
+      route-target both 30:30
+      redistribute learned
+      vlan 310-311
+   !
+   vlan-aware-bundle Tenant_C_WAN_Zone
+      rd 192.168.255.18:31
+      route-target both 31:31
+      redistribute learned
+      vlan 350
+   !
+   address-family evpn
+      host-flap detection window 180 threshold 5 expiry timeout 10 seconds
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor MLAG-PEERS activate
+      neighbor UNDERLAY-PEERS activate
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/DC1-CL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/DC1-CL1B.cfg
@@ -1,0 +1,381 @@
+!RANCID-CONTENT-TYPE: arista
+!
+boot secret sha512 a153de6290ff1409257ade45f
+!
+daemon TerminAttr
+   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   no shutdown
+!
+vlan internal order ascending range 1006 1199
+!
+no ip igmp snooping vlan 120
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname DC1-CL1B
+ip name-server vrf MGMT 8.8.8.8
+ip name-server vrf MGMT 192.168.200.5
+!
+ntp local-interface vrf MGMT Management1
+ntp server vrf MGMT 192.168.200.5 prefer
+!
+snmp-server contact example@example.com
+snmp-server location EOS_DESIGNS_UNIT_TESTS DC1-CL1B
+!
+hardware speed-group 1 serdes 10G
+hardware speed-group 2 serdes 25G
+hardware speed-group 3 serdes 25G
+hardware speed-group 4 serdes 10G
+!
+spanning-tree root super
+spanning-tree mode mstp
+no spanning-tree vlan-id 4090,4092
+spanning-tree mst 0 priority 4096
+!
+platform sand lag hardware-only
+!
+no enable password
+no aaa root
+!
+username admin privilege 15 role network-admin nopassword
+username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
+username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
+!
+vlan 110
+   name Tenant_A_OP_Zone_1
+!
+vlan 111
+   name Tenant_A_OP_Zone_2
+!
+vlan 112
+   name Tenant_A_OP_Zone_3
+!
+vlan 120
+   name Tenant_A_WEB_Zone_1
+!
+vlan 121
+   name Tenant_A_WEBZone_2
+!
+vlan 130
+   name Tenant_A_APP_Zone_1
+!
+vlan 131
+   name Tenant_A_APP_Zone_2
+!
+vlan 140
+   name Tenant_A_DB_BZone_1
+!
+vlan 141
+   name Tenant_A_DB_Zone_2
+!
+vlan 150
+   name Tenant_A_WAN_Zone_1
+!
+vlan 160
+   name Tenant_A_VMOTION
+!
+vlan 161
+   name Tenant_A_NFS
+!
+vlan 210
+   name Tenant_B_OP_Zone_1
+!
+vlan 211
+   name Tenant_B_OP_Zone_2
+!
+vlan 250
+   name Tenant_B_WAN_Zone_1
+!
+vlan 310
+   name Tenant_C_OP_Zone_1
+!
+vlan 311
+   name Tenant_C_OP_Zone_2
+!
+vlan 350
+   name Tenant_C_WAN_Zone_1
+!
+vlan 4090
+   name LEAF_PEER_L3
+   trunk group LEAF_PEER_L3
+!
+vlan 4092
+   name MLAG_PEER
+   trunk group MLAG
+!
+vrf instance MGMT
+!
+interface Port-Channel5
+   description MLAG_PEER_DC1-CL1A_Po5
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 1-4094
+   switchport mode trunk
+   switchport trunk group LEAF_PEER_L3
+   switchport trunk group MLAG
+!
+interface Ethernet1
+   description P2P_LINK_TO_DC1-SPINE1_Ethernet15
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.161/31
+!
+interface Ethernet2
+   description P2P_LINK_TO_DC1-SPINE2_Ethernet15
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.163/31
+!
+interface Ethernet3
+   description P2P_LINK_TO_DC1-SPINE3_Ethernet15
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.165/31
+!
+interface Ethernet4
+   description P2P_LINK_TO_DC1-SPINE4_Ethernet15
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.167/31
+!
+interface Ethernet5
+   description MLAG_PEER_DC1-CL1A_Ethernet5
+   no shutdown
+   speed 100g
+   channel-group 5 mode active
+!
+interface Ethernet6
+   description MLAG_PEER_DC1-CL1A_Ethernet6
+   no shutdown
+   speed 100g
+   channel-group 5 mode active
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 192.168.255.19/32
+!
+interface Loopback1
+   description VTEP_VXLAN_Tunnel_Source
+   no shutdown
+   ip address 192.168.254.18/32
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 192.168.200.120/24
+!
+interface Vlan4090
+   description MLAG_PEER_L3_PEERING
+   no shutdown
+   mtu 1500
+   ip address 10.255.251.19/31
+!
+interface Vlan4092
+   description MLAG_PEER
+   no shutdown
+   mtu 1500
+   no autostate
+   ip address 10.255.252.19/31
+!
+interface Vxlan1
+   description DC1-CL1B_VTEP
+   vxlan source-interface Loopback1
+   vxlan virtual-router encapsulation mac-address mlag-system-id
+   vxlan udp-port 4789
+   vxlan vlan 110 vni 10110
+   vxlan vlan 111 vni 50111
+   vxlan vlan 112 vni 10112
+   vxlan vlan 120 vni 10120
+   vxlan vlan 121 vni 10121
+   vxlan vlan 130 vni 10130
+   vxlan vlan 131 vni 10131
+   vxlan vlan 140 vni 10140
+   vxlan vlan 141 vni 10141
+   vxlan vlan 150 vni 10150
+   vxlan vlan 160 vni 10160
+   vxlan vlan 161 vni 10161
+   vxlan vlan 210 vni 20210
+   vxlan vlan 211 vni 20211
+   vxlan vlan 250 vni 20250
+   vxlan vlan 310 vni 30310
+   vxlan vlan 311 vni 30311
+   vxlan vlan 350 vni 30350
+!
+hardware tcam
+   system profile vxlan-routing
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+   seq 20 permit 192.168.254.0/24 eq 32
+!
+mlag configuration
+   domain-id DC1_CL1
+   local-interface Vlan4092
+   peer-address 10.255.252.18
+   peer-link Port-Channel5
+   reload-delay mlag 900
+   reload-delay non-mlag 1020
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.200.5
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+route-map RM-MLAG-PEER-IN permit 10
+   description Make routes learned over MLAG Peer-link less preferred on spines to ensure optimal routing
+   set origin incomplete
+!
+router bfd
+   multihop interval 1200 min-rx 1200 multiplier 3
+!
+router bgp 65109
+   router-id 192.168.255.19
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
+   maximum-paths 4 ecmp 4
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor MLAG-PEERS peer group
+   neighbor MLAG-PEERS remote-as 65109
+   neighbor MLAG-PEERS next-hop-self
+   neighbor MLAG-PEERS description DC1-CL1A
+   neighbor MLAG-PEERS password 7 vnEaG8gMeQf3d3cN6PktXQ==
+   neighbor MLAG-PEERS send-community
+   neighbor MLAG-PEERS maximum-routes 12000
+   neighbor MLAG-PEERS route-map RM-MLAG-PEER-IN in
+   neighbor UNDERLAY-PEERS peer group
+   neighbor UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor UNDERLAY-PEERS send-community
+   neighbor UNDERLAY-PEERS maximum-routes 12000
+   neighbor 10.255.251.18 peer group MLAG-PEERS
+   neighbor 10.255.251.18 description DC1-CL1A
+   neighbor 172.31.255.160 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.160 remote-as 65001
+   neighbor 172.31.255.160 description DC1-SPINE1_Ethernet15
+   neighbor 172.31.255.162 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.162 remote-as 65001
+   neighbor 172.31.255.162 description DC1-SPINE2_Ethernet15
+   neighbor 172.31.255.164 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.164 remote-as 65001
+   neighbor 172.31.255.164 description DC1-SPINE3_Ethernet15
+   neighbor 172.31.255.166 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.166 remote-as 65001
+   neighbor 172.31.255.166 description DC1-SPINE4_Ethernet15
+   neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.1 remote-as 65001
+   neighbor 192.168.255.1 description DC1-SPINE1
+   neighbor 192.168.255.2 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.2 remote-as 65001
+   neighbor 192.168.255.2 description DC1-SPINE2
+   neighbor 192.168.255.3 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.3 remote-as 65001
+   neighbor 192.168.255.3 description DC1-SPINE3
+   neighbor 192.168.255.4 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.4 remote-as 65001
+   neighbor 192.168.255.4 description DC1-SPINE4
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   vlan-aware-bundle Tenant_A_APP_Zone
+      rd 192.168.255.19:12
+      route-target both 12:12
+      redistribute learned
+      vlan 130-131
+   !
+   vlan-aware-bundle Tenant_A_DB_Zone
+      rd 192.168.255.19:13
+      route-target both 13:13
+      redistribute learned
+      vlan 140-141
+   !
+   vlan-aware-bundle Tenant_A_NFS
+      rd 192.168.255.19:20161
+      route-target both 20161:20161
+      redistribute learned
+      vlan 161
+   !
+   vlan-aware-bundle Tenant_A_OP_Zone
+      rd 192.168.255.19:9
+      route-target both 9:9
+      redistribute learned
+      vlan 110-112
+   !
+   vlan-aware-bundle Tenant_A_VMOTION
+      rd 192.168.255.19:20160
+      route-target both 20160:20160
+      redistribute learned
+      vlan 160
+   !
+   vlan-aware-bundle Tenant_A_WAN_Zone
+      rd 192.168.255.19:14
+      route-target both 14:14
+      redistribute learned
+      vlan 150
+   !
+   vlan-aware-bundle Tenant_A_WEB_Zone
+      rd 192.168.255.19:11
+      route-target both 11:11
+      redistribute learned
+      vlan 120-121
+   !
+   vlan-aware-bundle Tenant_B_OP_Zone
+      rd 192.168.255.19:20
+      route-target both 20:20
+      redistribute learned
+      vlan 210-211
+   !
+   vlan-aware-bundle Tenant_B_WAN_Zone
+      rd 192.168.255.19:21
+      route-target both 21:21
+      redistribute learned
+      vlan 250
+   !
+   vlan-aware-bundle Tenant_C_OP_Zone
+      rd 192.168.255.19:30
+      route-target both 30:30
+      redistribute learned
+      vlan 310-311
+   !
+   vlan-aware-bundle Tenant_C_WAN_Zone
+      rd 192.168.255.19:31
+      route-target both 31:31
+      redistribute learned
+      vlan 350
+   !
+   address-family evpn
+      host-flap detection window 180 threshold 5 expiry timeout 10 seconds
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor MLAG-PEERS activate
+      neighbor UNDERLAY-PEERS activate
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/DC1-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/DC1-L2LEAF1A.cfg
@@ -1,0 +1,143 @@
+!RANCID-CONTENT-TYPE: arista
+!
+boot secret sha512 a153de6290ff1409257ade45f
+!
+daemon TerminAttr
+   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   no shutdown
+!
+vlan internal order ascending range 1006 1199
+!
+no ip igmp snooping vlan 120
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname DC1-L2LEAF1A
+ip name-server vrf MGMT 8.8.8.8
+ip name-server vrf MGMT 192.168.200.5
+!
+ntp local-interface vrf MGMT Management1
+ntp server vrf MGMT 192.168.200.5 prefer
+!
+snmp-server contact example@example.com
+snmp-server location EOS_DESIGNS_UNIT_TESTS rackE DC1-L2LEAF1A
+!
+spanning-tree mode mstp
+no spanning-tree vlan-id 4091
+spanning-tree mst 0 priority 16384
+!
+no enable password
+no aaa root
+!
+username admin privilege 15 role network-admin nopassword
+username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
+username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
+!
+vlan 110
+   name Tenant_A_OP_Zone_1
+!
+vlan 111
+   name Tenant_A_OP_Zone_2
+!
+vlan 112
+   name Tenant_A_OP_Zone_3
+!
+vlan 120
+   name Tenant_A_WEB_Zone_1
+!
+vlan 121
+   name Tenant_A_WEBZone_2
+!
+vlan 130
+   name Tenant_A_APP_Zone_1
+!
+vlan 131
+   name Tenant_A_APP_Zone_2
+!
+vlan 160
+   name Tenant_A_VMOTION
+!
+vlan 161
+   name Tenant_A_NFS
+!
+vlan 4091
+   name MLAG_PEER
+   trunk group MLAG
+!
+vrf instance MGMT
+!
+interface Port-Channel1
+   description DC1_LEAF2_Po7
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 110-112,120-121,130-131,160-161
+   switchport mode trunk
+   mlag 1
+!
+interface Port-Channel3
+   description MLAG_PEER_DC1-L2LEAF1B_Po3
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 2-4094
+   switchport mode trunk
+   switchport trunk group MLAG
+!
+interface Ethernet1
+   description DC1-LEAF2A_Ethernet7
+   no shutdown
+   channel-group 1 mode active
+!
+interface Ethernet2
+   description DC1-LEAF2B_Ethernet7
+   no shutdown
+   channel-group 1 mode active
+!
+interface Ethernet3
+   description MLAG_PEER_DC1-L2LEAF1B_Ethernet3
+   no shutdown
+   speed forced 40gfull
+   channel-group 3 mode active
+!
+interface Ethernet4
+   description MLAG_PEER_DC1-L2LEAF1B_Ethernet4
+   no shutdown
+   speed forced 40gfull
+   channel-group 3 mode active
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 192.168.200.112/24
+!
+interface Vlan4091
+   description MLAG_PEER
+   no shutdown
+   mtu 1500
+   no autostate
+   ip address 10.255.252.14/31
+!
+ip routing
+no ip routing vrf MGMT
+!
+mlag configuration
+   domain-id DC1_L2LEAF1
+   local-interface Vlan4091
+   peer-address 10.255.252.15
+   peer-link Port-Channel3
+   reload-delay mlag 300
+   reload-delay non-mlag 330
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.200.5
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/DC1-L2LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/DC1-L2LEAF1B.cfg
@@ -1,0 +1,143 @@
+!RANCID-CONTENT-TYPE: arista
+!
+boot secret sha512 a153de6290ff1409257ade45f
+!
+daemon TerminAttr
+   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   no shutdown
+!
+vlan internal order ascending range 1006 1199
+!
+no ip igmp snooping vlan 120
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname DC1-L2LEAF1B
+ip name-server vrf MGMT 8.8.8.8
+ip name-server vrf MGMT 192.168.200.5
+!
+ntp local-interface vrf MGMT Management1
+ntp server vrf MGMT 192.168.200.5 prefer
+!
+snmp-server contact example@example.com
+snmp-server location EOS_DESIGNS_UNIT_TESTS rackE DC1-L2LEAF1B
+!
+spanning-tree mode mstp
+no spanning-tree vlan-id 4091
+spanning-tree mst 0 priority 16384
+!
+no enable password
+no aaa root
+!
+username admin privilege 15 role network-admin nopassword
+username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
+username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
+!
+vlan 110
+   name Tenant_A_OP_Zone_1
+!
+vlan 111
+   name Tenant_A_OP_Zone_2
+!
+vlan 112
+   name Tenant_A_OP_Zone_3
+!
+vlan 120
+   name Tenant_A_WEB_Zone_1
+!
+vlan 121
+   name Tenant_A_WEBZone_2
+!
+vlan 130
+   name Tenant_A_APP_Zone_1
+!
+vlan 131
+   name Tenant_A_APP_Zone_2
+!
+vlan 160
+   name Tenant_A_VMOTION
+!
+vlan 161
+   name Tenant_A_NFS
+!
+vlan 4091
+   name MLAG_PEER
+   trunk group MLAG
+!
+vrf instance MGMT
+!
+interface Port-Channel1
+   description DC1_LEAF2_Po7
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 110-112,120-121,130-131,160-161
+   switchport mode trunk
+   mlag 1
+!
+interface Port-Channel3
+   description MLAG_PEER_DC1-L2LEAF1A_Po3
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 2-4094
+   switchport mode trunk
+   switchport trunk group MLAG
+!
+interface Ethernet1
+   description DC1-LEAF2A_Ethernet8
+   no shutdown
+   channel-group 1 mode active
+!
+interface Ethernet2
+   description DC1-LEAF2B_Ethernet8
+   no shutdown
+   channel-group 1 mode active
+!
+interface Ethernet3
+   description MLAG_PEER_DC1-L2LEAF1A_Ethernet3
+   no shutdown
+   speed forced 40gfull
+   channel-group 3 mode active
+!
+interface Ethernet4
+   description MLAG_PEER_DC1-L2LEAF1A_Ethernet4
+   no shutdown
+   speed forced 40gfull
+   channel-group 3 mode active
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 192.168.200.115/24
+!
+interface Vlan4091
+   description MLAG_PEER
+   no shutdown
+   mtu 1500
+   no autostate
+   ip address 10.255.252.15/31
+!
+ip routing
+no ip routing vrf MGMT
+!
+mlag configuration
+   domain-id DC1_L2LEAF1
+   local-interface Vlan4091
+   peer-address 10.255.252.14
+   peer-link Port-Channel3
+   reload-delay mlag 300
+   reload-delay non-mlag 330
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.200.5
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/DC1-L2LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/DC1-L2LEAF2A.cfg
@@ -1,0 +1,170 @@
+!RANCID-CONTENT-TYPE: arista
+!
+boot secret sha512 a153de6290ff1409257ade45f
+!
+daemon TerminAttr
+   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   no shutdown
+!
+vlan internal order ascending range 1006 1199
+!
+no ip igmp snooping vlan 120
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname DC1-L2LEAF2A
+ip name-server vrf MGMT 8.8.8.8
+ip name-server vrf MGMT 192.168.200.5
+!
+ntp local-interface vrf MGMT Management1
+ntp server vrf MGMT 192.168.200.5 prefer
+!
+snmp-server contact example@example.com
+snmp-server location EOS_DESIGNS_UNIT_TESTS rackE DC1-L2LEAF2A
+!
+spanning-tree mode mstp
+no spanning-tree vlan-id 4091
+spanning-tree mst 0 priority 16384
+!
+no enable password
+no aaa root
+!
+username admin privilege 15 role network-admin nopassword
+username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
+username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
+!
+vlan 110
+   name Tenant_A_OP_Zone_1
+!
+vlan 111
+   name Tenant_A_OP_Zone_2
+!
+vlan 112
+   name Tenant_A_OP_Zone_3
+!
+vlan 120
+   name Tenant_A_WEB_Zone_1
+!
+vlan 121
+   name Tenant_A_WEBZone_2
+!
+vlan 130
+   name Tenant_A_APP_Zone_1
+!
+vlan 131
+   name Tenant_A_APP_Zone_2
+!
+vlan 140
+   name Tenant_A_DB_BZone_1
+!
+vlan 141
+   name Tenant_A_DB_Zone_2
+!
+vlan 150
+   name Tenant_A_WAN_Zone_1
+!
+vlan 160
+   name Tenant_A_VMOTION
+!
+vlan 161
+   name Tenant_A_NFS
+!
+vlan 210
+   name Tenant_B_OP_Zone_1
+!
+vlan 211
+   name Tenant_B_OP_Zone_2
+!
+vlan 250
+   name Tenant_B_WAN_Zone_1
+!
+vlan 310
+   name Tenant_C_OP_Zone_1
+!
+vlan 311
+   name Tenant_C_OP_Zone_2
+!
+vlan 350
+   name Tenant_C_WAN_Zone_1
+!
+vlan 4091
+   name MLAG_PEER
+   trunk group MLAG
+!
+vrf instance MGMT
+!
+interface Port-Channel1
+   description DC1_SVC3_Po7
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 110-112,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350
+   switchport mode trunk
+   mlag 1
+!
+interface Port-Channel3
+   description MLAG_PEER_DC1-L2LEAF2B_Po3
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 2-4094
+   switchport mode trunk
+   switchport trunk group MLAG
+!
+interface Ethernet1
+   description DC1-SVC3A_Ethernet7
+   no shutdown
+   channel-group 1 mode active
+!
+interface Ethernet2
+   description DC1-SVC3B_Ethernet7
+   no shutdown
+   channel-group 1 mode active
+!
+interface Ethernet3
+   description MLAG_PEER_DC1-L2LEAF2B_Ethernet3
+   no shutdown
+   channel-group 3 mode active
+!
+interface Ethernet4
+   description MLAG_PEER_DC1-L2LEAF2B_Ethernet4
+   no shutdown
+   channel-group 3 mode active
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 192.168.200.113/24
+!
+interface Vlan4091
+   description MLAG_PEER
+   no shutdown
+   mtu 1500
+   no autostate
+   ip address 10.255.252.16/31
+!
+ip routing
+no ip routing vrf MGMT
+!
+mlag configuration
+   domain-id DC1_L2LEAF2
+   local-interface Vlan4091
+   peer-address 10.255.252.17
+   peer-address heartbeat 192.168.200.114 vrf MGMT
+   peer-link Port-Channel3
+   dual-primary detection delay 5 action errdisable all-interfaces
+   reload-delay mlag 300
+   reload-delay non-mlag 330
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.200.5
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/DC1-L2LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/DC1-L2LEAF2B.cfg
@@ -1,0 +1,170 @@
+!RANCID-CONTENT-TYPE: arista
+!
+boot secret sha512 a153de6290ff1409257ade45f
+!
+daemon TerminAttr
+   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   no shutdown
+!
+vlan internal order ascending range 1006 1199
+!
+no ip igmp snooping vlan 120
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname DC1-L2LEAF2B
+ip name-server vrf MGMT 8.8.8.8
+ip name-server vrf MGMT 192.168.200.5
+!
+ntp local-interface vrf MGMT Management1
+ntp server vrf MGMT 192.168.200.5 prefer
+!
+snmp-server contact example@example.com
+snmp-server location EOS_DESIGNS_UNIT_TESTS rackE DC1-L2LEAF2B
+!
+spanning-tree mode mstp
+no spanning-tree vlan-id 4091
+spanning-tree mst 0 priority 16384
+!
+no enable password
+no aaa root
+!
+username admin privilege 15 role network-admin nopassword
+username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
+username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
+!
+vlan 110
+   name Tenant_A_OP_Zone_1
+!
+vlan 111
+   name Tenant_A_OP_Zone_2
+!
+vlan 112
+   name Tenant_A_OP_Zone_3
+!
+vlan 120
+   name Tenant_A_WEB_Zone_1
+!
+vlan 121
+   name Tenant_A_WEBZone_2
+!
+vlan 130
+   name Tenant_A_APP_Zone_1
+!
+vlan 131
+   name Tenant_A_APP_Zone_2
+!
+vlan 140
+   name Tenant_A_DB_BZone_1
+!
+vlan 141
+   name Tenant_A_DB_Zone_2
+!
+vlan 150
+   name Tenant_A_WAN_Zone_1
+!
+vlan 160
+   name Tenant_A_VMOTION
+!
+vlan 161
+   name Tenant_A_NFS
+!
+vlan 210
+   name Tenant_B_OP_Zone_1
+!
+vlan 211
+   name Tenant_B_OP_Zone_2
+!
+vlan 250
+   name Tenant_B_WAN_Zone_1
+!
+vlan 310
+   name Tenant_C_OP_Zone_1
+!
+vlan 311
+   name Tenant_C_OP_Zone_2
+!
+vlan 350
+   name Tenant_C_WAN_Zone_1
+!
+vlan 4091
+   name MLAG_PEER
+   trunk group MLAG
+!
+vrf instance MGMT
+!
+interface Port-Channel1
+   description DC1_SVC3_Po7
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 110-112,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350
+   switchport mode trunk
+   mlag 1
+!
+interface Port-Channel3
+   description MLAG_PEER_DC1-L2LEAF2A_Po3
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 2-4094
+   switchport mode trunk
+   switchport trunk group MLAG
+!
+interface Ethernet1
+   description DC1-SVC3A_Ethernet8
+   no shutdown
+   channel-group 1 mode active
+!
+interface Ethernet2
+   description DC1-SVC3B_Ethernet8
+   no shutdown
+   channel-group 1 mode active
+!
+interface Ethernet3
+   description MLAG_PEER_DC1-L2LEAF2A_Ethernet3
+   no shutdown
+   channel-group 3 mode active
+!
+interface Ethernet4
+   description MLAG_PEER_DC1-L2LEAF2A_Ethernet4
+   no shutdown
+   channel-group 3 mode active
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 192.168.200.114/24
+!
+interface Vlan4091
+   description MLAG_PEER
+   no shutdown
+   mtu 1500
+   no autostate
+   ip address 10.255.252.17/31
+!
+ip routing
+no ip routing vrf MGMT
+!
+mlag configuration
+   domain-id DC1_L2LEAF2
+   local-interface Vlan4091
+   peer-address 10.255.252.16
+   peer-address heartbeat 192.168.200.113 vrf MGMT
+   peer-link Port-Channel3
+   dual-primary detection delay 5 action errdisable all-interfaces
+   reload-delay mlag 300
+   reload-delay non-mlag 330
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.200.5
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/DC1-L2LEAF3A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/DC1-L2LEAF3A.cfg
@@ -1,0 +1,102 @@
+!RANCID-CONTENT-TYPE: arista
+!
+boot secret sha512 a153de6290ff1409257ade45f
+!
+daemon TerminAttr
+   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   no shutdown
+!
+vlan internal order ascending range 1006 1199
+!
+no ip igmp snooping vlan 120
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname DC1-L2LEAF3A
+ip name-server vrf MGMT 8.8.8.8
+ip name-server vrf MGMT 192.168.200.5
+!
+ntp local-interface vrf MGMT Management1
+ntp server vrf MGMT 192.168.200.5 prefer
+!
+snmp-server contact example@example.com
+snmp-server location EOS_DESIGNS_UNIT_TESTS rackE DC1-L2LEAF3A
+!
+spanning-tree mode mstp
+spanning-tree mst 0 priority 16384
+!
+no enable password
+no aaa root
+!
+username admin privilege 15 role network-admin nopassword
+username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
+username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
+!
+vlan 110
+   name Tenant_A_OP_Zone_1
+!
+vlan 111
+   name Tenant_A_OP_Zone_2
+!
+vlan 112
+   name Tenant_A_OP_Zone_3
+!
+vlan 120
+   name Tenant_A_WEB_Zone_1
+!
+vlan 121
+   name Tenant_A_WEBZone_2
+!
+vlan 130
+   name Tenant_A_APP_Zone_1
+!
+vlan 131
+   name Tenant_A_APP_Zone_2
+!
+vlan 160
+   name Tenant_A_VMOTION
+!
+vlan 161
+   name Tenant_A_NFS
+!
+vrf instance MGMT
+!
+interface Port-Channel1
+   description DC1_LEAF2_Po9
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 110-112,120-121,130-131,160-161
+   switchport mode trunk
+!
+interface Ethernet1
+   description DC1-LEAF2A_Ethernet9
+   no shutdown
+   channel-group 1 mode active
+!
+interface Ethernet2
+   description DC1-LEAF2B_Ethernet9
+   no shutdown
+   channel-group 1 mode active
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 192.168.200.116/24
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.200.5
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/DC1-L2LEAF4A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/DC1-L2LEAF4A.cfg
@@ -1,0 +1,102 @@
+!RANCID-CONTENT-TYPE: arista
+!
+boot secret sha512 a153de6290ff1409257ade45f
+!
+daemon TerminAttr
+   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   no shutdown
+!
+vlan internal order ascending range 1006 1199
+!
+no ip igmp snooping vlan 120
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname DC1-L2LEAF4A
+ip name-server vrf MGMT 8.8.8.8
+ip name-server vrf MGMT 192.168.200.5
+!
+ntp local-interface vrf MGMT Management1
+ntp server vrf MGMT 192.168.200.5 prefer
+!
+snmp-server contact example@example.com
+snmp-server location EOS_DESIGNS_UNIT_TESTS rackE DC1-L2LEAF4A
+!
+spanning-tree mode mstp
+spanning-tree mst 0 priority 16384
+!
+no enable password
+no aaa root
+!
+username admin privilege 15 role network-admin nopassword
+username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
+username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
+!
+vlan 110
+   name Tenant_A_OP_Zone_1
+!
+vlan 111
+   name Tenant_A_OP_Zone_2
+!
+vlan 112
+   name Tenant_A_OP_Zone_3
+!
+vlan 120
+   name Tenant_A_WEB_Zone_1
+!
+vlan 121
+   name Tenant_A_WEBZone_2
+!
+vlan 130
+   name Tenant_A_APP_Zone_1
+!
+vlan 131
+   name Tenant_A_APP_Zone_2
+!
+vlan 160
+   name Tenant_A_VMOTION
+!
+vlan 161
+   name Tenant_A_NFS
+!
+vrf instance MGMT
+!
+interface Port-Channel1
+   description DC1_LEAF2_Po13
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 110-112,120-121,130-131,160-161
+   switchport mode trunk
+!
+interface Ethernet1
+   description DC1-LEAF2A_Ethernet13
+   no shutdown
+   channel-group 1 mode active
+!
+interface Ethernet2
+   description DC1-LEAF2B_Ethernet13
+   no shutdown
+   channel-group 1 mode active
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 192.168.200.119/24
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.200.5
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/DC1-L2LEAF5A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/DC1-L2LEAF5A.cfg
@@ -1,0 +1,141 @@
+!RANCID-CONTENT-TYPE: arista
+!
+boot secret sha512 a153de6290ff1409257ade45f
+!
+daemon TerminAttr
+   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   no shutdown
+!
+vlan internal order ascending range 1006 1199
+!
+no ip igmp snooping vlan 120
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname DC1-L2LEAF5A
+ip name-server vrf MGMT 8.8.8.8
+ip name-server vrf MGMT 192.168.200.5
+!
+ntp local-interface vrf MGMT Management1
+ntp server vrf MGMT 192.168.200.5 prefer
+!
+snmp-server contact example@example.com
+snmp-server location EOS_DESIGNS_UNIT_TESTS rackE DC1-L2LEAF5A
+!
+spanning-tree mode mstp
+no spanning-tree vlan-id 4091
+spanning-tree mst 0 priority 16384
+!
+no enable password
+no aaa root
+!
+username admin privilege 15 role network-admin nopassword
+username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
+username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
+!
+vlan 110
+   name Tenant_A_OP_Zone_1
+!
+vlan 111
+   name Tenant_A_OP_Zone_2
+!
+vlan 112
+   name Tenant_A_OP_Zone_3
+!
+vlan 120
+   name Tenant_A_WEB_Zone_1
+!
+vlan 121
+   name Tenant_A_WEBZone_2
+!
+vlan 130
+   name Tenant_A_APP_Zone_1
+!
+vlan 131
+   name Tenant_A_APP_Zone_2
+!
+vlan 160
+   name Tenant_A_VMOTION
+!
+vlan 161
+   name Tenant_A_NFS
+!
+vlan 4091
+   name MLAG_PEER
+   trunk group MLAG
+!
+vrf instance MGMT
+!
+interface Port-Channel1
+   description DC1_LEAF2_Po14
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 110-112,120-121,130-131,160-161
+   switchport mode trunk
+   mlag 1
+!
+interface Port-Channel3
+   description MLAG_PEER_DC1-L2LEAF5B_Po3
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 2-4094
+   switchport mode trunk
+   switchport trunk group MLAG
+!
+interface Ethernet1
+   description DC1-LEAF2A_Ethernet14
+   no shutdown
+   channel-group 1 mode active
+!
+interface Ethernet2
+   description DC1-LEAF2B_Ethernet14
+   no shutdown
+   channel-group 1 mode active
+!
+interface Ethernet3
+   description MLAG_PEER_DC1-L2LEAF5B_Ethernet3
+   no shutdown
+   channel-group 3 mode active
+!
+interface Ethernet4
+   description MLAG_PEER_DC1-L2LEAF5B_Ethernet4
+   no shutdown
+   channel-group 3 mode active
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 192.168.200.120/24
+!
+interface Vlan4091
+   description MLAG_PEER
+   no shutdown
+   mtu 1500
+   no autostate
+   ip address 10.255.252.26/31
+!
+ip routing
+no ip routing vrf MGMT
+!
+mlag configuration
+   domain-id DC1_L2LEAF5
+   local-interface Vlan4091
+   peer-address 10.255.252.27
+   peer-link Port-Channel3
+   reload-delay mlag 300
+   reload-delay non-mlag 330
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.200.5
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/DC1-L2LEAF5B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/DC1-L2LEAF5B.cfg
@@ -1,0 +1,141 @@
+!RANCID-CONTENT-TYPE: arista
+!
+boot secret sha512 a153de6290ff1409257ade45f
+!
+daemon TerminAttr
+   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   no shutdown
+!
+vlan internal order ascending range 1006 1199
+!
+no ip igmp snooping vlan 120
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname DC1-L2LEAF5B
+ip name-server vrf MGMT 8.8.8.8
+ip name-server vrf MGMT 192.168.200.5
+!
+ntp local-interface vrf MGMT Management1
+ntp server vrf MGMT 192.168.200.5 prefer
+!
+snmp-server contact example@example.com
+snmp-server location EOS_DESIGNS_UNIT_TESTS rackE DC1-L2LEAF5B
+!
+spanning-tree mode mstp
+no spanning-tree vlan-id 4091
+spanning-tree mst 0 priority 16384
+!
+no enable password
+no aaa root
+!
+username admin privilege 15 role network-admin nopassword
+username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
+username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
+!
+vlan 110
+   name Tenant_A_OP_Zone_1
+!
+vlan 111
+   name Tenant_A_OP_Zone_2
+!
+vlan 112
+   name Tenant_A_OP_Zone_3
+!
+vlan 120
+   name Tenant_A_WEB_Zone_1
+!
+vlan 121
+   name Tenant_A_WEBZone_2
+!
+vlan 130
+   name Tenant_A_APP_Zone_1
+!
+vlan 131
+   name Tenant_A_APP_Zone_2
+!
+vlan 160
+   name Tenant_A_VMOTION
+!
+vlan 161
+   name Tenant_A_NFS
+!
+vlan 4091
+   name MLAG_PEER
+   trunk group MLAG
+!
+vrf instance MGMT
+!
+interface Port-Channel1
+   description DC1_LEAF2_Po14
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 110-112,120-121,130-131,160-161
+   switchport mode trunk
+   mlag 1
+!
+interface Port-Channel3
+   description MLAG_PEER_DC1-L2LEAF5A_Po3
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 2-4094
+   switchport mode trunk
+   switchport trunk group MLAG
+!
+interface Ethernet1
+   description DC1-LEAF2A_Ethernet15
+   no shutdown
+   channel-group 1 mode active
+!
+interface Ethernet2
+   description DC1-LEAF2B_Ethernet15
+   no shutdown
+   channel-group 1 mode active
+!
+interface Ethernet3
+   description MLAG_PEER_DC1-L2LEAF5A_Ethernet3
+   no shutdown
+   channel-group 3 mode active
+!
+interface Ethernet4
+   description MLAG_PEER_DC1-L2LEAF5A_Ethernet4
+   no shutdown
+   channel-group 3 mode active
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 192.168.200.121/24
+!
+interface Vlan4091
+   description MLAG_PEER
+   no shutdown
+   mtu 1500
+   no autostate
+   ip address 10.255.252.27/31
+!
+ip routing
+no ip routing vrf MGMT
+!
+mlag configuration
+   domain-id DC1_L2LEAF5
+   local-interface Vlan4091
+   peer-address 10.255.252.26
+   peer-link Port-Channel3
+   reload-delay mlag 300
+   reload-delay non-mlag 330
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.200.5
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/DC1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/DC1-LEAF1A.cfg
@@ -1,0 +1,281 @@
+!RANCID-CONTENT-TYPE: arista
+!
+boot secret sha512 a153de6290ff1409257ade45f
+!
+daemon TerminAttr
+   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   no shutdown
+!
+vlan internal order ascending range 1006 1199
+!
+no ip igmp snooping vlan 120
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname DC1-LEAF1A
+ip name-server vrf MGMT 8.8.8.8
+ip name-server vrf MGMT 192.168.200.5
+!
+ntp local-interface vrf MGMT Management1
+ntp server vrf MGMT 192.168.200.5 prefer
+!
+snmp-server contact example@example.com
+snmp-server location EOS_DESIGNS_UNIT_TESTS rackA DC1-LEAF1A
+!
+spanning-tree root super
+spanning-tree mode mstp
+spanning-tree mst 0 priority 4096
+!
+no enable password
+no aaa root
+!
+username admin privilege 15 role network-admin nopassword
+username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
+username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
+!
+vlan 120
+   name Tenant_A_WEB_Zone_1
+!
+vlan 121
+   name Tenant_A_WEBZone_2
+!
+vlan 130
+   name Tenant_A_APP_Zone_1
+!
+vlan 131
+   name Tenant_A_APP_Zone_2
+!
+vlan 132
+   name Tenant_A_APP_Zone_3
+!
+vrf instance MGMT
+!
+vrf instance Tenant_A_APP_Zone
+!
+vrf instance Tenant_A_WEB_Zone
+!
+interface Ethernet1
+   description P2P_LINK_TO_DC1-SPINE1_Ethernet1
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.1/31
+!
+interface Ethernet2
+   description P2P_LINK_TO_DC1-SPINE2_Ethernet1
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.3/31
+!
+interface Ethernet3
+   description P2P_LINK_TO_DC1-SPINE3_Ethernet1
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.5/31
+!
+interface Ethernet4
+   description P2P_LINK_TO_DC1-SPINE4_Ethernet1
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.7/31
+!
+interface Ethernet6
+   description server02_SINGLE_NODE_TRUNK_Eth1
+   no shutdown
+   l2 mtu 8000
+   switchport trunk allowed vlan 1-4094
+   switchport mode trunk
+   switchport
+   storm-control all level 10
+   storm-control broadcast level pps 100
+   storm-control multicast level 1
+   storm-control unknown-unicast level 2
+   spanning-tree portfast
+!
+interface Ethernet7
+   description server02_SINGLE_NODE_Eth1
+   no shutdown
+   switchport access vlan 110
+   switchport mode access
+   switchport
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 192.168.255.9/32
+!
+interface Loopback1
+   description VTEP_VXLAN_Tunnel_Source
+   no shutdown
+   ip address 192.168.254.9/32
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 192.168.200.105/24
+!
+interface Vlan120
+   description Tenant_A_WEB_Zone_1
+   no shutdown
+   vrf Tenant_A_WEB_Zone
+   ip helper-address 1.1.1.1 vrf TEST source-interface lo100
+   ip address virtual 10.1.20.1/24
+   ip address virtual 10.2.20.1/24 secondary
+   ip address virtual 10.2.21.1/24 secondary
+!
+interface Vlan121
+   description Tenant_A_WEBZone_2
+   shutdown
+   mtu 1560
+   vrf Tenant_A_WEB_Zone
+   ip address virtual 10.1.10.254/24
+!
+interface Vlan130
+   description Tenant_A_APP_Zone_1
+   no shutdown
+   vrf Tenant_A_APP_Zone
+   ip address virtual 10.1.30.1/24
+!
+interface Vlan131
+   description Tenant_A_APP_Zone_2
+   no shutdown
+   vrf Tenant_A_APP_Zone
+   ip address virtual 10.1.31.1/24
+!
+interface Vlan132
+   description Tenant_A_APP_Zone_3
+   no shutdown
+   vrf Tenant_A_APP_Zone
+   ip address 10.1.32.1/24
+   ip virtual-router address 10.1.32.254
+   ip virtual-router address 10.2.32.254/24
+   ip virtual-router address 10.3.32.254/24
+!
+interface Vxlan1
+   description DC1-LEAF1A_VTEP
+   vxlan source-interface Loopback1
+   vxlan udp-port 4789
+   vxlan vlan 120 vni 10120
+   vxlan vlan 121 vni 10121
+   vxlan vlan 130 vni 10130
+   vxlan vlan 131 vni 10131
+   vxlan vlan 132 vni 10132
+   vxlan vrf Tenant_A_APP_Zone vni 12
+   vxlan vrf Tenant_A_WEB_Zone vni 11
+!
+ip virtual-router mac-address 00:dc:00:00:00:0a
+!
+ip routing
+no ip routing vrf MGMT
+ip routing vrf Tenant_A_APP_Zone
+ip routing vrf Tenant_A_WEB_Zone
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+   seq 20 permit 192.168.254.0/24 eq 32
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.200.5
+ip route vrf Tenant_A_APP_Zone 10.2.32.0/24 Vlan132 name VARP
+ip route vrf Tenant_A_APP_Zone 10.3.32.0/24 Vlan132 name VARP
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+router bfd
+   multihop interval 1200 min-rx 1200 multiplier 3
+!
+router bgp 65101
+   router-id 192.168.255.9
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
+   maximum-paths 4 ecmp 4
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor UNDERLAY-PEERS peer group
+   neighbor UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor UNDERLAY-PEERS send-community
+   neighbor UNDERLAY-PEERS maximum-routes 12000
+   neighbor 172.31.255.0 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.0 remote-as 65001
+   neighbor 172.31.255.0 description DC1-SPINE1_Ethernet1
+   neighbor 172.31.255.2 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.2 remote-as 65001
+   neighbor 172.31.255.2 description DC1-SPINE2_Ethernet1
+   neighbor 172.31.255.4 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.4 remote-as 65001
+   neighbor 172.31.255.4 description DC1-SPINE3_Ethernet1
+   neighbor 172.31.255.6 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.6 remote-as 65001
+   neighbor 172.31.255.6 description DC1-SPINE4_Ethernet1
+   neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.1 remote-as 65001
+   neighbor 192.168.255.1 description DC1-SPINE1
+   neighbor 192.168.255.2 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.2 remote-as 65001
+   neighbor 192.168.255.2 description DC1-SPINE2
+   neighbor 192.168.255.3 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.3 remote-as 65001
+   neighbor 192.168.255.3 description DC1-SPINE3
+   neighbor 192.168.255.4 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.4 remote-as 65001
+   neighbor 192.168.255.4 description DC1-SPINE4
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   vlan-aware-bundle Tenant_A_APP_Zone
+      rd 1.1.1.1:12
+      route-target both 1234:12
+      redistribute learned
+      vlan 130-132
+   !
+   vlan-aware-bundle Tenant_A_WEB_Zone
+      rd 1.1.1.1:11
+      route-target both 1234:11
+      redistribute learned
+      vlan 120-121
+   !
+   address-family evpn
+      host-flap detection window 180 threshold 5 expiry timeout 10 seconds
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor UNDERLAY-PEERS activate
+   !
+   vrf Tenant_A_APP_Zone
+      rd 1.1.1.1:12
+      route-target import evpn 1234:12
+      route-target export evpn 1234:12
+      router-id 192.168.255.9
+      redistribute connected
+   !
+   vrf Tenant_A_WEB_Zone
+      rd 1.1.1.1:11
+      route-target import evpn 1234:11
+      route-target export evpn 1234:11
+      router-id 192.168.255.9
+      redistribute connected
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/DC1-LEAF2A.cfg
@@ -1,0 +1,579 @@
+!RANCID-CONTENT-TYPE: arista
+!
+boot secret sha512 a153de6290ff1409257ade45f
+!
+daemon TerminAttr
+   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   no shutdown
+!
+vlan internal order ascending range 1006 1199
+!
+no ip igmp snooping vlan 120
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname DC1-LEAF2A
+ip name-server vrf MGMT 8.8.8.8
+ip name-server vrf MGMT 192.168.200.5
+!
+ntp local-interface vrf MGMT Management1
+ntp server vrf MGMT 192.168.200.5 prefer
+!
+snmp-server contact example@example.com
+snmp-server location EOS_DESIGNS_UNIT_TESTS rackC DC1-LEAF2A
+!
+hardware speed-group 1 serdes 10G
+hardware speed-group 2 serdes 25G
+hardware speed-group 3 serdes 25G
+hardware speed-group 4 serdes 10G
+!
+spanning-tree root super
+spanning-tree mode mstp
+spanning-tree mst 0 priority 4096
+!
+platform sand lag hardware-only
+!
+no enable password
+no aaa root
+!
+username admin privilege 15 role network-admin nopassword
+username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
+username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
+!
+vlan 110
+   name Tenant_A_OP_Zone_1
+!
+vlan 111
+   name Tenant_A_OP_Zone_2
+!
+vlan 112
+   name Tenant_A_OP_Zone_3
+!
+vlan 120
+   name Tenant_A_WEB_Zone_1
+!
+vlan 121
+   name Tenant_A_WEBZone_2
+!
+vlan 130
+   name Tenant_A_APP_Zone_1
+!
+vlan 131
+   name Tenant_A_APP_Zone_2
+!
+vlan 140
+   name Tenant_A_DB_BZone_1
+!
+vlan 141
+   name Tenant_A_DB_Zone_2
+!
+vlan 160
+   name Tenant_A_VMOTION
+!
+vlan 161
+   name Tenant_A_NFS
+!
+vlan 210
+   name Tenant_B_OP_Zone_1
+!
+vlan 211
+   name Tenant_B_OP_Zone_2
+!
+vlan 310
+   name Tenant_C_OP_Zone_1
+!
+vlan 311
+   name Tenant_C_OP_Zone_2
+!
+vrf instance MGMT
+!
+vrf instance Tenant_A_APP_Zone
+!
+vrf instance Tenant_A_DB_Zone
+!
+vrf instance Tenant_A_OP_Zone
+   description Tenant_A_OP_Zone
+!
+vrf instance Tenant_A_WEB_Zone
+!
+vrf instance Tenant_B_OP_Zone
+!
+vrf instance Tenant_C_OP_Zone
+!
+interface Port-Channel7
+   description DC1_L2LEAF1_Po1
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 110-112,120-121,130-131,160-161
+   switchport mode trunk
+   evpn ethernet-segment
+      identifier 0000:0000:0808:0707:0606
+      route-target import 08:08:07:07:06:06
+   lacp system-id 0808.0707.0606
+!
+interface Port-Channel9
+   description DC1-L2LEAF3A_Po1
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 110-112,120-121,130-131,160-161
+   switchport mode trunk
+   evpn ethernet-segment
+      identifier 0000:0000:0606:0707:0808
+      route-target import 06:06:07:07:08:08
+   lacp system-id 0606.0707.0808
+!
+interface Port-Channel10
+   description server01_MLAG_PortChanne1
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 210-211
+   switchport mode trunk
+   spanning-tree bpduguard disable
+   spanning-tree bpdufilter disable
+!
+interface Port-Channel11
+   description server01_MTU_PROFILE_MLAG_PortChanne1
+   no shutdown
+   mtu 1600
+   switchport
+   switchport access vlan 110
+   spanning-tree bpduguard enable
+   spanning-tree bpdufilter enable
+!
+interface Port-Channel12
+   description server01_MTU_ADAPTOR_MLAG_PortChanne1
+   no shutdown
+   mtu 1601
+   switchport
+   spanning-tree bpduguard enable
+   spanning-tree bpdufilter enable
+!
+interface Port-Channel13
+   description DC1-L2LEAF4A_Po1
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 110-112,120-121,130-131,160-161
+   switchport mode trunk
+   evpn ethernet-segment
+      identifier 0000:0000:a36b:7013:457b
+      route-target import a3:6b:70:13:45:7b
+   lacp system-id a36b.7013.457b
+!
+interface Port-Channel14
+   description DC1_L2LEAF5_Po1
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 110-112,120-121,130-131,160-161
+   switchport mode trunk
+   evpn ethernet-segment
+      identifier 0000:0000:71da:d362:2084
+      route-target import 71:da:d3:62:20:84
+   lacp system-id 71da.d362.2084
+!
+interface Port-Channel20
+   description FIREWALL01_PortChanne1
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 110-111,210-211
+   switchport mode trunk
+!
+interface Ethernet1
+   description P2P_LINK_TO_DC1-SPINE1_Ethernet2
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.17/31
+!
+interface Ethernet2
+   description P2P_LINK_TO_DC1-SPINE2_Ethernet2
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.19/31
+!
+interface Ethernet3
+   description P2P_LINK_TO_DC1-SPINE3_Ethernet2
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.21/31
+!
+interface Ethernet4
+   description P2P_LINK_TO_DC1-SPINE4_Ethernet2
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.23/31
+!
+interface Ethernet7
+   description DC1-L2LEAF1A_Ethernet1
+   no shutdown
+   channel-group 7 mode active
+!
+interface Ethernet8
+   description DC1-L2LEAF1B_Ethernet1
+   no shutdown
+   channel-group 7 mode active
+!
+interface Ethernet9
+   description DC1-L2LEAF3A_Ethernet1
+   no shutdown
+   channel-group 9 mode active
+!
+interface Ethernet10
+   description server01_MLAG_Eth2
+   no shutdown
+   channel-group 10 mode active
+!
+interface Ethernet11
+   description server01_MTU_PROFILE_MLAG_Eth4
+   no shutdown
+   channel-group 11 mode active
+!
+interface Ethernet12
+   description server01_MTU_ADAPTOR_MLAG_Eth6
+   no shutdown
+   channel-group 12 mode active
+!
+interface Ethernet13
+   description DC1-L2LEAF4A_Ethernet1
+   no shutdown
+   channel-group 13 mode active
+!
+interface Ethernet14
+   description DC1-L2LEAF5A_Ethernet1
+   no shutdown
+   channel-group 14 mode active
+!
+interface Ethernet15
+   description DC1-L2LEAF5B_Ethernet1
+   no shutdown
+   channel-group 14 mode active
+!
+interface Ethernet20
+   description FIREWALL01_E0
+   no shutdown
+   channel-group 20 mode active
+!
+interface Ethernet21
+   description ROUTER01_Eth0
+   no shutdown
+   switchport access vlan 110
+   switchport mode access
+   switchport
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 192.168.255.10/32
+!
+interface Loopback1
+   description VTEP_VXLAN_Tunnel_Source
+   no shutdown
+   ip address 192.168.254.10/32
+!
+interface Loopback100
+   description Tenant_A_OP_Zone_VTEP_DIAGNOSTICS
+   no shutdown
+   vrf Tenant_A_OP_Zone
+   ip address 10.255.1.10/32
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 192.168.200.106/24
+!
+interface Vlan110
+   description Tenant_A_OP_Zone_1
+   no shutdown
+   vrf Tenant_A_OP_Zone
+   ip address virtual 10.1.10.1/24
+!
+interface Vlan111
+   description Tenant_A_OP_Zone_2
+   no shutdown
+   vrf Tenant_A_OP_Zone
+   ip helper-address 1.1.1.1 vrf MGMT source-interface lo100
+   ip address virtual 10.1.11.1/24
+!
+interface Vlan112
+   description Tenant_A_OP_Zone_3
+   no shutdown
+   mtu 1560
+   vrf Tenant_A_OP_Zone
+   ip helper-address 2.2.2.2 vrf MGMT source-interface lo101
+!
+interface Vlan120
+   description Tenant_A_WEB_Zone_1
+   no shutdown
+   vrf Tenant_A_WEB_Zone
+   ip helper-address 1.1.1.1 vrf TEST source-interface lo100
+   ip address virtual 10.1.20.1/24
+   ip address virtual 10.2.20.1/24 secondary
+   ip address virtual 10.2.21.1/24 secondary
+!
+interface Vlan121
+   description Tenant_A_WEBZone_2
+   shutdown
+   mtu 1560
+   vrf Tenant_A_WEB_Zone
+   ip address virtual 10.1.10.254/24
+!
+interface Vlan130
+   description Tenant_A_APP_Zone_1
+   no shutdown
+   vrf Tenant_A_APP_Zone
+   ip address virtual 10.1.30.1/24
+!
+interface Vlan131
+   description Tenant_A_APP_Zone_2
+   no shutdown
+   vrf Tenant_A_APP_Zone
+   ip address virtual 10.1.31.1/24
+!
+interface Vlan140
+   description Tenant_A_DB_BZone_1
+   no shutdown
+   vrf Tenant_A_DB_Zone
+   ip address virtual 10.1.40.1/24
+!
+interface Vlan141
+   description Tenant_A_DB_Zone_2
+   no shutdown
+   vrf Tenant_A_DB_Zone
+   ip address virtual 10.1.41.1/24
+!
+interface Vlan210
+   description Tenant_B_OP_Zone_1
+   no shutdown
+   vrf Tenant_B_OP_Zone
+   ip address virtual 10.2.10.1/24
+!
+interface Vlan211
+   description Tenant_B_OP_Zone_2
+   no shutdown
+   vrf Tenant_B_OP_Zone
+   ip address virtual 10.2.11.1/24
+!
+interface Vlan310
+   description Tenant_C_OP_Zone_1
+   no shutdown
+   vrf Tenant_C_OP_Zone
+   ip address virtual 10.3.10.1/24
+!
+interface Vlan311
+   description Tenant_C_OP_Zone_2
+   no shutdown
+   vrf Tenant_C_OP_Zone
+   ip address virtual 10.3.11.1/24
+!
+interface Vxlan1
+   description DC1-LEAF2A_VTEP
+   vxlan source-interface Loopback1
+   vxlan udp-port 4789
+   vxlan vlan 110 vni 10110
+   vxlan vlan 111 vni 50111
+   vxlan vlan 112 vni 10112
+   vxlan vlan 120 vni 10120
+   vxlan vlan 121 vni 10121
+   vxlan vlan 130 vni 10130
+   vxlan vlan 131 vni 10131
+   vxlan vlan 140 vni 10140
+   vxlan vlan 141 vni 10141
+   vxlan vlan 160 vni 10160
+   vxlan vlan 161 vni 10161
+   vxlan vlan 210 vni 20210
+   vxlan vlan 211 vni 20211
+   vxlan vlan 310 vni 30310
+   vxlan vlan 311 vni 30311
+   vxlan vrf Tenant_A_APP_Zone vni 12
+   vxlan vrf Tenant_A_DB_Zone vni 13
+   vxlan vrf Tenant_A_OP_Zone vni 10
+   vxlan vrf Tenant_A_WEB_Zone vni 11
+   vxlan vrf Tenant_B_OP_Zone vni 20
+   vxlan vrf Tenant_C_OP_Zone vni 30
+!
+hardware tcam
+   system profile vxlan-routing
+!
+ip virtual-router mac-address 00:dc:00:00:00:0a
+!
+ip address virtual source-nat vrf Tenant_A_OP_Zone address 10.255.1.10
+!
+ip routing
+no ip routing vrf MGMT
+ip routing vrf Tenant_A_APP_Zone
+ip routing vrf Tenant_A_DB_Zone
+ip routing vrf Tenant_A_OP_Zone
+ip routing vrf Tenant_A_WEB_Zone
+ip routing vrf Tenant_B_OP_Zone
+ip routing vrf Tenant_C_OP_Zone
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+   seq 20 permit 192.168.254.0/24 eq 32
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.200.5
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+router bfd
+   multihop interval 1200 min-rx 1200 multiplier 3
+!
+router bgp 65102
+   router-id 192.168.255.10
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
+   maximum-paths 4 ecmp 4
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor UNDERLAY-PEERS peer group
+   neighbor UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor UNDERLAY-PEERS send-community
+   neighbor UNDERLAY-PEERS maximum-routes 12000
+   neighbor 172.31.255.16 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.16 remote-as 65001
+   neighbor 172.31.255.16 description DC1-SPINE1_Ethernet2
+   neighbor 172.31.255.18 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.18 remote-as 65001
+   neighbor 172.31.255.18 description DC1-SPINE2_Ethernet2
+   neighbor 172.31.255.20 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.20 remote-as 65001
+   neighbor 172.31.255.20 description DC1-SPINE3_Ethernet2
+   neighbor 172.31.255.22 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.22 remote-as 65001
+   neighbor 172.31.255.22 description DC1-SPINE4_Ethernet2
+   neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.1 remote-as 65001
+   neighbor 192.168.255.1 description DC1-SPINE1
+   neighbor 192.168.255.2 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.2 remote-as 65001
+   neighbor 192.168.255.2 description DC1-SPINE2
+   neighbor 192.168.255.3 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.3 remote-as 65001
+   neighbor 192.168.255.3 description DC1-SPINE3
+   neighbor 192.168.255.4 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.4 remote-as 65001
+   neighbor 192.168.255.4 description DC1-SPINE4
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   vlan-aware-bundle Tenant_A_APP_Zone
+      rd 65001:12
+      route-target both 100000:12
+      redistribute learned
+      vlan 130-131
+   !
+   vlan-aware-bundle Tenant_A_DB_Zone
+      rd 65001:13
+      route-target both 100000:13
+      redistribute learned
+      vlan 140-141
+   !
+   vlan-aware-bundle Tenant_A_NFS
+      rd 65001:20161
+      route-target both 100000:20161
+      redistribute learned
+      vlan 161
+   !
+   vlan-aware-bundle Tenant_A_OP_Zone
+      rd 65001:9
+      route-target both 100000:9
+      redistribute learned
+      vlan 110-112
+   !
+   vlan-aware-bundle Tenant_A_VMOTION
+      rd 65001:20160
+      route-target both 100000:20160
+      redistribute learned
+      vlan 160
+   !
+   vlan-aware-bundle Tenant_A_WEB_Zone
+      rd 65001:11
+      route-target both 100000:11
+      redistribute learned
+      vlan 120-121
+   !
+   vlan-aware-bundle Tenant_B_OP_Zone
+      rd 65001:20
+      route-target both 100000:20
+      redistribute learned
+      vlan 210-211
+   !
+   vlan-aware-bundle Tenant_C_OP_Zone
+      rd 65001:30
+      route-target both 100000:30
+      redistribute learned
+      vlan 310-311
+   !
+   address-family evpn
+      host-flap detection window 180 threshold 5 expiry timeout 10 seconds
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor UNDERLAY-PEERS activate
+   !
+   vrf Tenant_A_APP_Zone
+      rd 65001:12
+      route-target import evpn 100000:12
+      route-target export evpn 100000:12
+      router-id 192.168.255.10
+      redistribute connected
+   !
+   vrf Tenant_A_DB_Zone
+      rd 65001:13
+      route-target import evpn 100000:13
+      route-target export evpn 100000:13
+      router-id 192.168.255.10
+      redistribute connected
+   !
+   vrf Tenant_A_OP_Zone
+      rd 65001:9
+      route-target import evpn 100000:9
+      route-target export evpn 100000:9
+      router-id 192.168.255.10
+      redistribute connected
+   !
+   vrf Tenant_A_WEB_Zone
+      rd 65001:11
+      route-target import evpn 100000:11
+      route-target export evpn 100000:11
+      router-id 192.168.255.10
+      redistribute connected
+   !
+   vrf Tenant_B_OP_Zone
+      rd 65001:20
+      route-target import evpn 100000:20
+      route-target export evpn 100000:20
+      router-id 192.168.255.10
+      redistribute connected
+   !
+   vrf Tenant_C_OP_Zone
+      rd 65001:30
+      route-target import evpn 100000:30
+      route-target export evpn 100000:30
+      router-id 192.168.255.10
+      redistribute connected
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/DC1-LEAF2B.cfg
@@ -1,0 +1,579 @@
+!RANCID-CONTENT-TYPE: arista
+!
+boot secret sha512 a153de6290ff1409257ade45f
+!
+daemon TerminAttr
+   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   no shutdown
+!
+vlan internal order ascending range 1006 1199
+!
+no ip igmp snooping vlan 120
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname DC1-LEAF2B
+ip name-server vrf MGMT 8.8.8.8
+ip name-server vrf MGMT 192.168.200.5
+!
+ntp local-interface vrf MGMT Management1
+ntp server vrf MGMT 192.168.200.5 prefer
+!
+snmp-server contact example@example.com
+snmp-server location EOS_DESIGNS_UNIT_TESTS rackD DC1-LEAF2B
+!
+hardware speed-group 1 serdes 10G
+hardware speed-group 2 serdes 25G
+hardware speed-group 3 serdes 25G
+hardware speed-group 4 serdes 10G
+!
+spanning-tree root super
+spanning-tree mode mstp
+spanning-tree mst 0 priority 4096
+!
+platform sand lag hardware-only
+!
+no enable password
+no aaa root
+!
+username admin privilege 15 role network-admin nopassword
+username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
+username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
+!
+vlan 110
+   name Tenant_A_OP_Zone_1
+!
+vlan 111
+   name Tenant_A_OP_Zone_2
+!
+vlan 112
+   name Tenant_A_OP_Zone_3
+!
+vlan 120
+   name Tenant_A_WEB_Zone_1
+!
+vlan 121
+   name Tenant_A_WEBZone_2
+!
+vlan 130
+   name Tenant_A_APP_Zone_1
+!
+vlan 131
+   name Tenant_A_APP_Zone_2
+!
+vlan 140
+   name Tenant_A_DB_BZone_1
+!
+vlan 141
+   name Tenant_A_DB_Zone_2
+!
+vlan 160
+   name Tenant_A_VMOTION
+!
+vlan 161
+   name Tenant_A_NFS
+!
+vlan 210
+   name Tenant_B_OP_Zone_1
+!
+vlan 211
+   name Tenant_B_OP_Zone_2
+!
+vlan 310
+   name Tenant_C_OP_Zone_1
+!
+vlan 311
+   name Tenant_C_OP_Zone_2
+!
+vrf instance MGMT
+!
+vrf instance Tenant_A_APP_Zone
+!
+vrf instance Tenant_A_DB_Zone
+!
+vrf instance Tenant_A_OP_Zone
+   description Tenant_A_OP_Zone
+!
+vrf instance Tenant_A_WEB_Zone
+!
+vrf instance Tenant_B_OP_Zone
+!
+vrf instance Tenant_C_OP_Zone
+!
+interface Port-Channel7
+   description DC1_L2LEAF1_Po1
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 110-112,120-121,130-131,160-161
+   switchport mode trunk
+   evpn ethernet-segment
+      identifier 0000:0000:0808:0707:0606
+      route-target import 08:08:07:07:06:06
+   lacp system-id 0808.0707.0606
+!
+interface Port-Channel9
+   description DC1-L2LEAF3A_Po1
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 110-112,120-121,130-131,160-161
+   switchport mode trunk
+   evpn ethernet-segment
+      identifier 0000:0000:0606:0707:0808
+      route-target import 06:06:07:07:08:08
+   lacp system-id 0606.0707.0808
+!
+interface Port-Channel10
+   description server01_MLAG_PortChanne1
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 210-211
+   switchport mode trunk
+   spanning-tree bpduguard disable
+   spanning-tree bpdufilter disable
+!
+interface Port-Channel11
+   description server01_MTU_PROFILE_MLAG_PortChanne1
+   no shutdown
+   mtu 1600
+   switchport
+   switchport access vlan 110
+   spanning-tree bpduguard enable
+   spanning-tree bpdufilter enable
+!
+interface Port-Channel12
+   description server01_MTU_ADAPTOR_MLAG_PortChanne1
+   no shutdown
+   mtu 1601
+   switchport
+   spanning-tree bpduguard enable
+   spanning-tree bpdufilter enable
+!
+interface Port-Channel13
+   description DC1-L2LEAF4A_Po1
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 110-112,120-121,130-131,160-161
+   switchport mode trunk
+   evpn ethernet-segment
+      identifier 0000:0000:a36b:7013:457b
+      route-target import a3:6b:70:13:45:7b
+   lacp system-id a36b.7013.457b
+!
+interface Port-Channel14
+   description DC1_L2LEAF5_Po1
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 110-112,120-121,130-131,160-161
+   switchport mode trunk
+   evpn ethernet-segment
+      identifier 0000:0000:71da:d362:2084
+      route-target import 71:da:d3:62:20:84
+   lacp system-id 71da.d362.2084
+!
+interface Port-Channel20
+   description FIREWALL01_PortChanne1
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 110-111,210-211
+   switchport mode trunk
+!
+interface Ethernet1
+   description P2P_LINK_TO_DC1-SPINE1_Ethernet3
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.33/31
+!
+interface Ethernet2
+   description P2P_LINK_TO_DC1-SPINE2_Ethernet3
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.35/31
+!
+interface Ethernet3
+   description P2P_LINK_TO_DC1-SPINE3_Ethernet3
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.37/31
+!
+interface Ethernet4
+   description P2P_LINK_TO_DC1-SPINE4_Ethernet3
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.39/31
+!
+interface Ethernet7
+   description DC1-L2LEAF1A_Ethernet2
+   no shutdown
+   channel-group 7 mode active
+!
+interface Ethernet8
+   description DC1-L2LEAF1B_Ethernet2
+   no shutdown
+   channel-group 7 mode active
+!
+interface Ethernet9
+   description DC1-L2LEAF3A_Ethernet2
+   no shutdown
+   channel-group 9 mode active
+!
+interface Ethernet10
+   description server01_MLAG_Eth3
+   no shutdown
+   channel-group 10 mode active
+!
+interface Ethernet11
+   description server01_MTU_PROFILE_MLAG_Eth5
+   no shutdown
+   channel-group 11 mode active
+!
+interface Ethernet12
+   description server01_MTU_ADAPTOR_MLAG_Eth7
+   no shutdown
+   channel-group 12 mode active
+!
+interface Ethernet13
+   description DC1-L2LEAF4A_Ethernet2
+   no shutdown
+   channel-group 13 mode active
+!
+interface Ethernet14
+   description DC1-L2LEAF5A_Ethernet2
+   no shutdown
+   channel-group 14 mode active
+!
+interface Ethernet15
+   description DC1-L2LEAF5B_Ethernet2
+   no shutdown
+   channel-group 14 mode active
+!
+interface Ethernet20
+   description FIREWALL01_E1
+   no shutdown
+   channel-group 20 mode active
+!
+interface Ethernet21
+   description ROUTER01_Eth1
+   no shutdown
+   switchport access vlan 110
+   switchport mode access
+   switchport
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 192.168.255.11/32
+!
+interface Loopback1
+   description VTEP_VXLAN_Tunnel_Source
+   no shutdown
+   ip address 192.168.254.11/32
+!
+interface Loopback100
+   description Tenant_A_OP_Zone_VTEP_DIAGNOSTICS
+   no shutdown
+   vrf Tenant_A_OP_Zone
+   ip address 10.255.1.11/32
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 192.168.200.107/24
+!
+interface Vlan110
+   description Tenant_A_OP_Zone_1
+   no shutdown
+   vrf Tenant_A_OP_Zone
+   ip address virtual 10.1.10.1/24
+!
+interface Vlan111
+   description Tenant_A_OP_Zone_2
+   no shutdown
+   vrf Tenant_A_OP_Zone
+   ip helper-address 1.1.1.1 vrf MGMT source-interface lo100
+   ip address virtual 10.1.11.1/24
+!
+interface Vlan112
+   description Tenant_A_OP_Zone_3
+   no shutdown
+   mtu 1560
+   vrf Tenant_A_OP_Zone
+   ip helper-address 2.2.2.2 vrf MGMT source-interface lo101
+!
+interface Vlan120
+   description Tenant_A_WEB_Zone_1
+   no shutdown
+   vrf Tenant_A_WEB_Zone
+   ip helper-address 1.1.1.1 vrf TEST source-interface lo100
+   ip address virtual 10.1.20.1/24
+   ip address virtual 10.2.20.1/24 secondary
+   ip address virtual 10.2.21.1/24 secondary
+!
+interface Vlan121
+   description Tenant_A_WEBZone_2
+   shutdown
+   mtu 1560
+   vrf Tenant_A_WEB_Zone
+   ip address virtual 10.1.10.254/24
+!
+interface Vlan130
+   description Tenant_A_APP_Zone_1
+   no shutdown
+   vrf Tenant_A_APP_Zone
+   ip address virtual 10.1.30.1/24
+!
+interface Vlan131
+   description Tenant_A_APP_Zone_2
+   no shutdown
+   vrf Tenant_A_APP_Zone
+   ip address virtual 10.1.31.1/24
+!
+interface Vlan140
+   description Tenant_A_DB_BZone_1
+   no shutdown
+   vrf Tenant_A_DB_Zone
+   ip address virtual 10.1.40.1/24
+!
+interface Vlan141
+   description Tenant_A_DB_Zone_2
+   no shutdown
+   vrf Tenant_A_DB_Zone
+   ip address virtual 10.1.41.1/24
+!
+interface Vlan210
+   description Tenant_B_OP_Zone_1
+   no shutdown
+   vrf Tenant_B_OP_Zone
+   ip address virtual 10.2.10.1/24
+!
+interface Vlan211
+   description Tenant_B_OP_Zone_2
+   no shutdown
+   vrf Tenant_B_OP_Zone
+   ip address virtual 10.2.11.1/24
+!
+interface Vlan310
+   description Tenant_C_OP_Zone_1
+   no shutdown
+   vrf Tenant_C_OP_Zone
+   ip address virtual 10.3.10.1/24
+!
+interface Vlan311
+   description Tenant_C_OP_Zone_2
+   no shutdown
+   vrf Tenant_C_OP_Zone
+   ip address virtual 10.3.11.1/24
+!
+interface Vxlan1
+   description DC1-LEAF2B_VTEP
+   vxlan source-interface Loopback1
+   vxlan udp-port 4789
+   vxlan vlan 110 vni 10110
+   vxlan vlan 111 vni 50111
+   vxlan vlan 112 vni 10112
+   vxlan vlan 120 vni 10120
+   vxlan vlan 121 vni 10121
+   vxlan vlan 130 vni 10130
+   vxlan vlan 131 vni 10131
+   vxlan vlan 140 vni 10140
+   vxlan vlan 141 vni 10141
+   vxlan vlan 160 vni 10160
+   vxlan vlan 161 vni 10161
+   vxlan vlan 210 vni 20210
+   vxlan vlan 211 vni 20211
+   vxlan vlan 310 vni 30310
+   vxlan vlan 311 vni 30311
+   vxlan vrf Tenant_A_APP_Zone vni 12
+   vxlan vrf Tenant_A_DB_Zone vni 13
+   vxlan vrf Tenant_A_OP_Zone vni 10
+   vxlan vrf Tenant_A_WEB_Zone vni 11
+   vxlan vrf Tenant_B_OP_Zone vni 20
+   vxlan vrf Tenant_C_OP_Zone vni 30
+!
+hardware tcam
+   system profile vxlan-routing
+!
+ip virtual-router mac-address 00:dc:00:00:00:0a
+!
+ip address virtual source-nat vrf Tenant_A_OP_Zone address 10.255.1.11
+!
+ip routing
+no ip routing vrf MGMT
+ip routing vrf Tenant_A_APP_Zone
+ip routing vrf Tenant_A_DB_Zone
+ip routing vrf Tenant_A_OP_Zone
+ip routing vrf Tenant_A_WEB_Zone
+ip routing vrf Tenant_B_OP_Zone
+ip routing vrf Tenant_C_OP_Zone
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+   seq 20 permit 192.168.254.0/24 eq 32
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.200.5
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+router bfd
+   multihop interval 1200 min-rx 1200 multiplier 3
+!
+router bgp 65102
+   router-id 192.168.255.11
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
+   maximum-paths 4 ecmp 4
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor UNDERLAY-PEERS peer group
+   neighbor UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor UNDERLAY-PEERS send-community
+   neighbor UNDERLAY-PEERS maximum-routes 12000
+   neighbor 172.31.255.32 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.32 remote-as 65001
+   neighbor 172.31.255.32 description DC1-SPINE1_Ethernet3
+   neighbor 172.31.255.34 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.34 remote-as 65001
+   neighbor 172.31.255.34 description DC1-SPINE2_Ethernet3
+   neighbor 172.31.255.36 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.36 remote-as 65001
+   neighbor 172.31.255.36 description DC1-SPINE3_Ethernet3
+   neighbor 172.31.255.38 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.38 remote-as 65001
+   neighbor 172.31.255.38 description DC1-SPINE4_Ethernet3
+   neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.1 remote-as 65001
+   neighbor 192.168.255.1 description DC1-SPINE1
+   neighbor 192.168.255.2 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.2 remote-as 65001
+   neighbor 192.168.255.2 description DC1-SPINE2
+   neighbor 192.168.255.3 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.3 remote-as 65001
+   neighbor 192.168.255.3 description DC1-SPINE3
+   neighbor 192.168.255.4 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.4 remote-as 65001
+   neighbor 192.168.255.4 description DC1-SPINE4
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   vlan-aware-bundle Tenant_A_APP_Zone
+      rd 65001:12
+      route-target both 100000:12
+      redistribute learned
+      vlan 130-131
+   !
+   vlan-aware-bundle Tenant_A_DB_Zone
+      rd 65001:13
+      route-target both 100000:13
+      redistribute learned
+      vlan 140-141
+   !
+   vlan-aware-bundle Tenant_A_NFS
+      rd 65001:20161
+      route-target both 100000:20161
+      redistribute learned
+      vlan 161
+   !
+   vlan-aware-bundle Tenant_A_OP_Zone
+      rd 65001:9
+      route-target both 100000:9
+      redistribute learned
+      vlan 110-112
+   !
+   vlan-aware-bundle Tenant_A_VMOTION
+      rd 65001:20160
+      route-target both 100000:20160
+      redistribute learned
+      vlan 160
+   !
+   vlan-aware-bundle Tenant_A_WEB_Zone
+      rd 65001:11
+      route-target both 100000:11
+      redistribute learned
+      vlan 120-121
+   !
+   vlan-aware-bundle Tenant_B_OP_Zone
+      rd 65001:20
+      route-target both 100000:20
+      redistribute learned
+      vlan 210-211
+   !
+   vlan-aware-bundle Tenant_C_OP_Zone
+      rd 65001:30
+      route-target both 100000:30
+      redistribute learned
+      vlan 310-311
+   !
+   address-family evpn
+      host-flap detection window 180 threshold 5 expiry timeout 10 seconds
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor UNDERLAY-PEERS activate
+   !
+   vrf Tenant_A_APP_Zone
+      rd 65001:12
+      route-target import evpn 100000:12
+      route-target export evpn 100000:12
+      router-id 192.168.255.11
+      redistribute connected
+   !
+   vrf Tenant_A_DB_Zone
+      rd 65001:13
+      route-target import evpn 100000:13
+      route-target export evpn 100000:13
+      router-id 192.168.255.11
+      redistribute connected
+   !
+   vrf Tenant_A_OP_Zone
+      rd 65001:9
+      route-target import evpn 100000:9
+      route-target export evpn 100000:9
+      router-id 192.168.255.11
+      redistribute connected
+   !
+   vrf Tenant_A_WEB_Zone
+      rd 65001:11
+      route-target import evpn 100000:11
+      route-target export evpn 100000:11
+      router-id 192.168.255.11
+      redistribute connected
+   !
+   vrf Tenant_B_OP_Zone
+      rd 65001:20
+      route-target import evpn 100000:20
+      route-target export evpn 100000:20
+      router-id 192.168.255.11
+      redistribute connected
+   !
+   vrf Tenant_C_OP_Zone
+      rd 65001:30
+      route-target import evpn 100000:30
+      route-target export evpn 100000:30
+      router-id 192.168.255.11
+      redistribute connected
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/DC1-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/DC1-SPINE1.cfg
@@ -1,0 +1,288 @@
+!RANCID-CONTENT-TYPE: arista
+!
+boot secret sha512 a153de6290ff1409257ade45f
+!
+daemon TerminAttr
+   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   no shutdown
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname DC1-SPINE1
+ip name-server vrf MGMT 8.8.8.8
+ip name-server vrf MGMT 192.168.200.5
+!
+ntp local-interface vrf MGMT Management1
+ntp server vrf MGMT 192.168.200.5 prefer
+!
+snmp-server contact example@example.com
+snmp-server location EOS_DESIGNS_UNIT_TESTS DC1-SPINE1
+!
+spanning-tree mode none
+!
+no enable password
+no aaa root
+!
+username admin privilege 15 role network-admin nopassword
+username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
+username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
+!
+vrf instance MGMT
+!
+interface Ethernet1
+   description P2P_LINK_TO_DC1-LEAF1A_Ethernet1
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.0/31
+!
+interface Ethernet2
+   description P2P_LINK_TO_DC1-LEAF2A_Ethernet1
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.16/31
+!
+interface Ethernet3
+   description P2P_LINK_TO_DC1-LEAF2B_Ethernet1
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.32/31
+!
+interface Ethernet4
+   description P2P_LINK_TO_DC1-SVC3A_Ethernet1
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.48/31
+!
+interface Ethernet5
+   description P2P_LINK_TO_DC1-SVC3B_Ethernet1
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.64/31
+!
+interface Ethernet6
+   description P2P_LINK_TO_DC1-BL1A_Ethernet1
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.80/31
+!
+interface Ethernet7
+   description P2P_LINK_TO_DC1-BL1B_Ethernet1
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.96/31
+!
+interface Ethernet8
+   description P2P_LINK_TO_DC1-BL2A_Ethernet1
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.112/31
+!
+interface Ethernet9
+   description P2P_LINK_TO_DC1-BL2B_Ethernet1
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.128/31
+!
+interface Ethernet10
+   description P2P_LINK_TO_MH-LEAF1A_Ethernet1
+   no shutdown
+   mtu 1500
+   no switchport
+   ip address 10.10.101.0/31
+!
+interface Ethernet11
+   description P2P_LINK_TO_MH-LEAF1B_Ethernet1
+   no shutdown
+   mtu 1500
+   no switchport
+   ip address 10.10.101.2/31
+!
+interface Ethernet12
+   description P2P_LINK_TO_MH-LEAF2A_Ethernet1
+   no shutdown
+   mtu 1500
+   no switchport
+   ip address 10.10.101.4/31
+!
+interface Ethernet14
+   description P2P_LINK_TO_DC1-CL1A_Ethernet1
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.144/31
+!
+interface Ethernet15
+   description P2P_LINK_TO_DC1-CL1B_Ethernet1
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.160/31
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 192.168.255.1/32
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 192.168.200.101/24
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.200.5
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+router bfd
+   multihop interval 1200 min-rx 1200 multiplier 3
+!
+router bgp 65001
+   router-id 192.168.255.1
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
+   maximum-paths 4 ecmp 4
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor UNDERLAY-PEERS peer group
+   neighbor UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor UNDERLAY-PEERS send-community
+   neighbor UNDERLAY-PEERS maximum-routes 12000
+   neighbor 10.10.101.1 peer group UNDERLAY-PEERS
+   neighbor 10.10.101.1 remote-as 65151
+   neighbor 10.10.101.1 description MH-LEAF1A_Ethernet1
+   neighbor 10.10.101.3 peer group UNDERLAY-PEERS
+   neighbor 10.10.101.3 remote-as 65152
+   neighbor 10.10.101.3 description MH-LEAF1B_Ethernet1
+   neighbor 10.10.101.5 peer group UNDERLAY-PEERS
+   neighbor 10.10.101.5 remote-as 65153
+   neighbor 10.10.101.5 description MH-LEAF2A_Ethernet1
+   neighbor 172.31.255.1 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.1 remote-as 65101
+   neighbor 172.31.255.1 description DC1-LEAF1A_Ethernet1
+   neighbor 172.31.255.17 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.17 remote-as 65102
+   neighbor 172.31.255.17 description DC1-LEAF2A_Ethernet1
+   neighbor 172.31.255.33 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.33 remote-as 65102
+   neighbor 172.31.255.33 description DC1-LEAF2B_Ethernet1
+   neighbor 172.31.255.49 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.49 remote-as 65103
+   neighbor 172.31.255.49 description DC1-SVC3A_Ethernet1
+   neighbor 172.31.255.65 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.65 remote-as 65103
+   neighbor 172.31.255.65 description DC1-SVC3B_Ethernet1
+   neighbor 172.31.255.81 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.81 remote-as 65104
+   neighbor 172.31.255.81 description DC1-BL1A_Ethernet1
+   neighbor 172.31.255.97 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.97 remote-as 65105
+   neighbor 172.31.255.97 description DC1-BL1B_Ethernet1
+   neighbor 172.31.255.113 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.113 remote-as 65106
+   neighbor 172.31.255.113 description DC1-BL2A_Ethernet1
+   neighbor 172.31.255.129 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.129 remote-as 65107
+   neighbor 172.31.255.129 description DC1-BL2B_Ethernet1
+   neighbor 172.31.255.145 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.145 remote-as 65108
+   neighbor 172.31.255.145 description DC1-CL1A_Ethernet1
+   neighbor 172.31.255.161 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.161 remote-as 65109
+   neighbor 172.31.255.161 description DC1-CL1B_Ethernet1
+   neighbor 192.168.255.9 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.9 remote-as 65101
+   neighbor 192.168.255.9 description DC1-LEAF1A
+   neighbor 192.168.255.10 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.10 remote-as 65102
+   neighbor 192.168.255.10 description DC1-LEAF2A
+   neighbor 192.168.255.11 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.11 remote-as 65102
+   neighbor 192.168.255.11 description DC1-LEAF2B
+   neighbor 192.168.255.12 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.12 remote-as 65103
+   neighbor 192.168.255.12 description DC1-SVC3A
+   neighbor 192.168.255.13 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.13 remote-as 65103
+   neighbor 192.168.255.13 description DC1-SVC3B
+   neighbor 192.168.255.14 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.14 remote-as 65104
+   neighbor 192.168.255.14 description DC1-BL1A
+   neighbor 192.168.255.15 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.15 remote-as 65105
+   neighbor 192.168.255.15 description DC1-BL1B
+   neighbor 192.168.255.16 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.16 remote-as 65106
+   neighbor 192.168.255.16 description DC1-BL2A
+   neighbor 192.168.255.17 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.17 remote-as 65107
+   neighbor 192.168.255.17 description DC1-BL2B
+   neighbor 192.168.255.18 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.18 remote-as 65108
+   neighbor 192.168.255.18 description DC1-CL1A
+   neighbor 192.168.255.19 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.19 remote-as 65109
+   neighbor 192.168.255.19 description DC1-CL1B
+   neighbor 192.168.255.33 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.33 remote-as 65151
+   neighbor 192.168.255.33 description MH-LEAF1A
+   neighbor 192.168.255.34 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.34 remote-as 65152
+   neighbor 192.168.255.34 description MH-LEAF1B
+   neighbor 192.168.255.35 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.35 remote-as 65153
+   neighbor 192.168.255.35 description MH-LEAF2A
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   address-family evpn
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor UNDERLAY-PEERS activate
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/DC1-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/DC1-SPINE2.cfg
@@ -1,0 +1,254 @@
+!RANCID-CONTENT-TYPE: arista
+!
+boot secret sha512 a153de6290ff1409257ade45f
+!
+daemon TerminAttr
+   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   no shutdown
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname DC1-SPINE2
+ip name-server vrf MGMT 8.8.8.8
+ip name-server vrf MGMT 192.168.200.5
+!
+ntp local-interface vrf MGMT Management1
+ntp server vrf MGMT 192.168.200.5 prefer
+!
+snmp-server contact example@example.com
+snmp-server location EOS_DESIGNS_UNIT_TESTS DC1-SPINE2
+!
+spanning-tree mode none
+!
+platform sand lag hardware-only
+!
+no enable password
+no aaa root
+!
+username admin privilege 15 role network-admin nopassword
+username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
+username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
+!
+vrf instance MGMT
+!
+interface Ethernet1
+   description P2P_LINK_TO_DC1-LEAF1A_Ethernet2
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.2/31
+!
+interface Ethernet2
+   description P2P_LINK_TO_DC1-LEAF2A_Ethernet2
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.18/31
+!
+interface Ethernet3
+   description P2P_LINK_TO_DC1-LEAF2B_Ethernet2
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.34/31
+!
+interface Ethernet4
+   description P2P_LINK_TO_DC1-SVC3A_Ethernet2
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.50/31
+!
+interface Ethernet5
+   description P2P_LINK_TO_DC1-SVC3B_Ethernet2
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.66/31
+!
+interface Ethernet6
+   description P2P_LINK_TO_DC1-BL1A_Ethernet2
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.82/31
+!
+interface Ethernet7
+   description P2P_LINK_TO_DC1-BL1B_Ethernet2
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.98/31
+!
+interface Ethernet8
+   description P2P_LINK_TO_DC1-BL2A_Ethernet2
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.114/31
+!
+interface Ethernet9
+   description P2P_LINK_TO_DC1-BL2B_Ethernet2
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.130/31
+!
+interface Ethernet14
+   description P2P_LINK_TO_DC1-CL1A_Ethernet2
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.146/31
+!
+interface Ethernet15
+   description P2P_LINK_TO_DC1-CL1B_Ethernet2
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.162/31
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 192.168.255.2/32
+!
+interface Management0
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 192.168.200.102/24
+!
+hardware tcam
+   system profile vxlan-routing
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.200.5
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+router bfd
+   multihop interval 1200 min-rx 1200 multiplier 3
+!
+router bgp 65001
+   router-id 192.168.255.2
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
+   maximum-paths 4 ecmp 4
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor UNDERLAY-PEERS peer group
+   neighbor UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor UNDERLAY-PEERS send-community
+   neighbor UNDERLAY-PEERS maximum-routes 12000
+   neighbor 172.31.255.3 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.3 remote-as 65101
+   neighbor 172.31.255.3 description DC1-LEAF1A_Ethernet2
+   neighbor 172.31.255.19 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.19 remote-as 65102
+   neighbor 172.31.255.19 description DC1-LEAF2A_Ethernet2
+   neighbor 172.31.255.35 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.35 remote-as 65102
+   neighbor 172.31.255.35 description DC1-LEAF2B_Ethernet2
+   neighbor 172.31.255.51 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.51 remote-as 65103
+   neighbor 172.31.255.51 description DC1-SVC3A_Ethernet2
+   neighbor 172.31.255.67 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.67 remote-as 65103
+   neighbor 172.31.255.67 description DC1-SVC3B_Ethernet2
+   neighbor 172.31.255.83 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.83 remote-as 65104
+   neighbor 172.31.255.83 description DC1-BL1A_Ethernet2
+   neighbor 172.31.255.99 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.99 remote-as 65105
+   neighbor 172.31.255.99 description DC1-BL1B_Ethernet2
+   neighbor 172.31.255.115 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.115 remote-as 65106
+   neighbor 172.31.255.115 description DC1-BL2A_Ethernet2
+   neighbor 172.31.255.131 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.131 remote-as 65107
+   neighbor 172.31.255.131 description DC1-BL2B_Ethernet2
+   neighbor 172.31.255.147 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.147 remote-as 65108
+   neighbor 172.31.255.147 description DC1-CL1A_Ethernet2
+   neighbor 172.31.255.163 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.163 remote-as 65109
+   neighbor 172.31.255.163 description DC1-CL1B_Ethernet2
+   neighbor 192.168.255.9 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.9 remote-as 65101
+   neighbor 192.168.255.9 description DC1-LEAF1A
+   neighbor 192.168.255.10 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.10 remote-as 65102
+   neighbor 192.168.255.10 description DC1-LEAF2A
+   neighbor 192.168.255.11 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.11 remote-as 65102
+   neighbor 192.168.255.11 description DC1-LEAF2B
+   neighbor 192.168.255.12 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.12 remote-as 65103
+   neighbor 192.168.255.12 description DC1-SVC3A
+   neighbor 192.168.255.13 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.13 remote-as 65103
+   neighbor 192.168.255.13 description DC1-SVC3B
+   neighbor 192.168.255.14 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.14 remote-as 65104
+   neighbor 192.168.255.14 description DC1-BL1A
+   neighbor 192.168.255.15 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.15 remote-as 65105
+   neighbor 192.168.255.15 description DC1-BL1B
+   neighbor 192.168.255.16 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.16 remote-as 65106
+   neighbor 192.168.255.16 description DC1-BL2A
+   neighbor 192.168.255.17 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.17 remote-as 65107
+   neighbor 192.168.255.17 description DC1-BL2B
+   neighbor 192.168.255.18 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.18 remote-as 65108
+   neighbor 192.168.255.18 description DC1-CL1A
+   neighbor 192.168.255.19 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.19 remote-as 65109
+   neighbor 192.168.255.19 description DC1-CL1B
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   address-family evpn
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor UNDERLAY-PEERS activate
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/DC1-SPINE3.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/DC1-SPINE3.cfg
@@ -1,0 +1,249 @@
+!RANCID-CONTENT-TYPE: arista
+!
+boot secret sha512 a153de6290ff1409257ade45f
+!
+daemon TerminAttr
+   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   no shutdown
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname DC1-SPINE3
+ip name-server vrf MGMT 8.8.8.8
+ip name-server vrf MGMT 192.168.200.5
+!
+ntp local-interface vrf MGMT Management1
+ntp server vrf MGMT 192.168.200.5 prefer
+!
+snmp-server contact example@example.com
+snmp-server location EOS_DESIGNS_UNIT_TESTS DC1-SPINE3
+!
+spanning-tree mode none
+!
+no enable password
+no aaa root
+!
+username admin privilege 15 role network-admin nopassword
+username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
+username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
+!
+vrf instance MGMT
+!
+interface Ethernet1
+   description P2P_LINK_TO_DC1-LEAF1A_Ethernet3
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.4/31
+!
+interface Ethernet2
+   description P2P_LINK_TO_DC1-LEAF2A_Ethernet3
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.20/31
+!
+interface Ethernet3
+   description P2P_LINK_TO_DC1-LEAF2B_Ethernet3
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.36/31
+!
+interface Ethernet4
+   description P2P_LINK_TO_DC1-SVC3A_Ethernet3
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.52/31
+!
+interface Ethernet5
+   description P2P_LINK_TO_DC1-SVC3B_Ethernet3
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.68/31
+!
+interface Ethernet6
+   description P2P_LINK_TO_DC1-BL1A_Ethernet3
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.84/31
+!
+interface Ethernet7
+   description P2P_LINK_TO_DC1-BL1B_Ethernet3
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.100/31
+!
+interface Ethernet8
+   description P2P_LINK_TO_DC1-BL2A_Ethernet3
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.116/31
+!
+interface Ethernet9
+   description P2P_LINK_TO_DC1-BL2B_Ethernet3
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.132/31
+!
+interface Ethernet14
+   description P2P_LINK_TO_DC1-CL1A_Ethernet3
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.148/31
+!
+interface Ethernet15
+   description P2P_LINK_TO_DC1-CL1B_Ethernet3
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.164/31
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 192.168.255.3/32
+!
+interface Management0
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 192.168.200.103/24
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.200.5
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+router bfd
+   multihop interval 1200 min-rx 1200 multiplier 3
+!
+router bgp 65001
+   router-id 192.168.255.3
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
+   maximum-paths 4 ecmp 4
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor UNDERLAY-PEERS peer group
+   neighbor UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor UNDERLAY-PEERS send-community
+   neighbor UNDERLAY-PEERS maximum-routes 12000
+   neighbor 172.31.255.5 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.5 remote-as 65101
+   neighbor 172.31.255.5 description DC1-LEAF1A_Ethernet3
+   neighbor 172.31.255.21 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.21 remote-as 65102
+   neighbor 172.31.255.21 description DC1-LEAF2A_Ethernet3
+   neighbor 172.31.255.37 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.37 remote-as 65102
+   neighbor 172.31.255.37 description DC1-LEAF2B_Ethernet3
+   neighbor 172.31.255.53 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.53 remote-as 65103
+   neighbor 172.31.255.53 description DC1-SVC3A_Ethernet3
+   neighbor 172.31.255.69 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.69 remote-as 65103
+   neighbor 172.31.255.69 description DC1-SVC3B_Ethernet3
+   neighbor 172.31.255.85 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.85 remote-as 65104
+   neighbor 172.31.255.85 description DC1-BL1A_Ethernet3
+   neighbor 172.31.255.101 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.101 remote-as 65105
+   neighbor 172.31.255.101 description DC1-BL1B_Ethernet3
+   neighbor 172.31.255.117 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.117 remote-as 65106
+   neighbor 172.31.255.117 description DC1-BL2A_Ethernet3
+   neighbor 172.31.255.133 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.133 remote-as 65107
+   neighbor 172.31.255.133 description DC1-BL2B_Ethernet3
+   neighbor 172.31.255.149 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.149 remote-as 65108
+   neighbor 172.31.255.149 description DC1-CL1A_Ethernet3
+   neighbor 172.31.255.165 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.165 remote-as 65109
+   neighbor 172.31.255.165 description DC1-CL1B_Ethernet3
+   neighbor 192.168.255.9 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.9 remote-as 65101
+   neighbor 192.168.255.9 description DC1-LEAF1A
+   neighbor 192.168.255.10 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.10 remote-as 65102
+   neighbor 192.168.255.10 description DC1-LEAF2A
+   neighbor 192.168.255.11 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.11 remote-as 65102
+   neighbor 192.168.255.11 description DC1-LEAF2B
+   neighbor 192.168.255.12 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.12 remote-as 65103
+   neighbor 192.168.255.12 description DC1-SVC3A
+   neighbor 192.168.255.13 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.13 remote-as 65103
+   neighbor 192.168.255.13 description DC1-SVC3B
+   neighbor 192.168.255.14 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.14 remote-as 65104
+   neighbor 192.168.255.14 description DC1-BL1A
+   neighbor 192.168.255.15 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.15 remote-as 65105
+   neighbor 192.168.255.15 description DC1-BL1B
+   neighbor 192.168.255.16 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.16 remote-as 65106
+   neighbor 192.168.255.16 description DC1-BL2A
+   neighbor 192.168.255.17 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.17 remote-as 65107
+   neighbor 192.168.255.17 description DC1-BL2B
+   neighbor 192.168.255.18 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.18 remote-as 65108
+   neighbor 192.168.255.18 description DC1-CL1A
+   neighbor 192.168.255.19 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.19 remote-as 65109
+   neighbor 192.168.255.19 description DC1-CL1B
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   address-family evpn
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor UNDERLAY-PEERS activate
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/DC1-SPINE4.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/DC1-SPINE4.cfg
@@ -1,0 +1,249 @@
+!RANCID-CONTENT-TYPE: arista
+!
+boot secret sha512 a153de6290ff1409257ade45f
+!
+daemon TerminAttr
+   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   no shutdown
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname DC1-SPINE4
+ip name-server vrf MGMT 8.8.8.8
+ip name-server vrf MGMT 192.168.200.5
+!
+ntp local-interface vrf MGMT Management1
+ntp server vrf MGMT 192.168.200.5 prefer
+!
+snmp-server contact example@example.com
+snmp-server location EOS_DESIGNS_UNIT_TESTS DC1-SPINE4
+!
+spanning-tree mode none
+!
+no enable password
+no aaa root
+!
+username admin privilege 15 role network-admin nopassword
+username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
+username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
+!
+vrf instance MGMT
+!
+interface Ethernet1
+   description P2P_LINK_TO_DC1-LEAF1A_Ethernet4
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.6/31
+!
+interface Ethernet2
+   description P2P_LINK_TO_DC1-LEAF2A_Ethernet4
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.22/31
+!
+interface Ethernet3
+   description P2P_LINK_TO_DC1-LEAF2B_Ethernet4
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.38/31
+!
+interface Ethernet4
+   description P2P_LINK_TO_DC1-SVC3A_Ethernet4
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.54/31
+!
+interface Ethernet5
+   description P2P_LINK_TO_DC1-SVC3B_Ethernet4
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.70/31
+!
+interface Ethernet6
+   description P2P_LINK_TO_DC1-BL1A_Ethernet4
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.86/31
+!
+interface Ethernet7
+   description P2P_LINK_TO_DC1-BL1B_Ethernet4
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.102/31
+!
+interface Ethernet8
+   description P2P_LINK_TO_DC1-BL2A_Ethernet4
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.118/31
+!
+interface Ethernet9
+   description P2P_LINK_TO_DC1-BL2B_Ethernet4
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.134/31
+!
+interface Ethernet14
+   description P2P_LINK_TO_DC1-CL1A_Ethernet4
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.150/31
+!
+interface Ethernet15
+   description P2P_LINK_TO_DC1-CL1B_Ethernet4
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.166/31
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 192.168.255.4/32
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 192.168.200.104/24
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.200.5
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+router bfd
+   multihop interval 1200 min-rx 1200 multiplier 3
+!
+router bgp 65001
+   router-id 192.168.255.4
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
+   maximum-paths 4 ecmp 4
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor UNDERLAY-PEERS peer group
+   neighbor UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor UNDERLAY-PEERS send-community
+   neighbor UNDERLAY-PEERS maximum-routes 12000
+   neighbor 172.31.255.7 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.7 remote-as 65101
+   neighbor 172.31.255.7 description DC1-LEAF1A_Ethernet4
+   neighbor 172.31.255.23 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.23 remote-as 65102
+   neighbor 172.31.255.23 description DC1-LEAF2A_Ethernet4
+   neighbor 172.31.255.39 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.39 remote-as 65102
+   neighbor 172.31.255.39 description DC1-LEAF2B_Ethernet4
+   neighbor 172.31.255.55 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.55 remote-as 65103
+   neighbor 172.31.255.55 description DC1-SVC3A_Ethernet4
+   neighbor 172.31.255.71 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.71 remote-as 65103
+   neighbor 172.31.255.71 description DC1-SVC3B_Ethernet4
+   neighbor 172.31.255.87 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.87 remote-as 65104
+   neighbor 172.31.255.87 description DC1-BL1A_Ethernet4
+   neighbor 172.31.255.103 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.103 remote-as 65105
+   neighbor 172.31.255.103 description DC1-BL1B_Ethernet4
+   neighbor 172.31.255.119 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.119 remote-as 65106
+   neighbor 172.31.255.119 description DC1-BL2A_Ethernet4
+   neighbor 172.31.255.135 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.135 remote-as 65107
+   neighbor 172.31.255.135 description DC1-BL2B_Ethernet4
+   neighbor 172.31.255.151 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.151 remote-as 65108
+   neighbor 172.31.255.151 description DC1-CL1A_Ethernet4
+   neighbor 172.31.255.167 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.167 remote-as 65109
+   neighbor 172.31.255.167 description DC1-CL1B_Ethernet4
+   neighbor 192.168.255.9 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.9 remote-as 65101
+   neighbor 192.168.255.9 description DC1-LEAF1A
+   neighbor 192.168.255.10 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.10 remote-as 65102
+   neighbor 192.168.255.10 description DC1-LEAF2A
+   neighbor 192.168.255.11 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.11 remote-as 65102
+   neighbor 192.168.255.11 description DC1-LEAF2B
+   neighbor 192.168.255.12 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.12 remote-as 65103
+   neighbor 192.168.255.12 description DC1-SVC3A
+   neighbor 192.168.255.13 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.13 remote-as 65103
+   neighbor 192.168.255.13 description DC1-SVC3B
+   neighbor 192.168.255.14 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.14 remote-as 65104
+   neighbor 192.168.255.14 description DC1-BL1A
+   neighbor 192.168.255.15 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.15 remote-as 65105
+   neighbor 192.168.255.15 description DC1-BL1B
+   neighbor 192.168.255.16 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.16 remote-as 65106
+   neighbor 192.168.255.16 description DC1-BL2A
+   neighbor 192.168.255.17 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.17 remote-as 65107
+   neighbor 192.168.255.17 description DC1-BL2B
+   neighbor 192.168.255.18 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.18 remote-as 65108
+   neighbor 192.168.255.18 description DC1-CL1A
+   neighbor 192.168.255.19 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.19 remote-as 65109
+   neighbor 192.168.255.19 description DC1-CL1B
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   address-family evpn
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor UNDERLAY-PEERS activate
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/DC1-SVC3A.cfg
@@ -1,0 +1,1007 @@
+!RANCID-CONTENT-TYPE: arista
+!
+boot secret sha512 a153de6290ff1409257ade45f
+!
+daemon TerminAttr
+   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   no shutdown
+!
+vlan internal order ascending range 1006 1199
+!
+no ip igmp snooping vlan 120
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname DC1-SVC3A
+ip name-server vrf MGMT 8.8.8.8
+ip name-server vrf MGMT 192.168.200.5
+!
+ntp local-interface vrf MGMT Management1
+ntp server vrf MGMT 192.168.200.5 prefer
+!
+snmp-server contact example@example.com
+snmp-server location EOS_DESIGNS_UNIT_TESTS DC1-SVC3A
+!
+spanning-tree root super
+spanning-tree mode mstp
+no spanning-tree vlan-id 4090,4092
+spanning-tree mst 0 priority 4096
+!
+no enable password
+no aaa root
+!
+username admin privilege 15 role network-admin nopassword
+username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
+username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
+!
+vlan 2
+   name MLAG_iBGP_Tenant_C_OP_Zone
+   trunk group LEAF_PEER_L3
+!
+vlan 110
+   name Tenant_A_OP_Zone_1
+!
+vlan 111
+   name Tenant_A_OP_Zone_2
+!
+vlan 112
+   name Tenant_A_OP_Zone_3
+!
+vlan 120
+   name Tenant_A_WEB_Zone_1
+!
+vlan 121
+   name Tenant_A_WEBZone_2
+!
+vlan 130
+   name Tenant_A_APP_Zone_1
+!
+vlan 131
+   name Tenant_A_APP_Zone_2
+!
+vlan 140
+   name Tenant_A_DB_BZone_1
+!
+vlan 141
+   name Tenant_A_DB_Zone_2
+!
+vlan 150
+   name Tenant_A_WAN_Zone_1
+!
+vlan 160
+   name Tenant_A_VMOTION
+!
+vlan 161
+   name Tenant_A_NFS
+!
+vlan 210
+   name Tenant_B_OP_Zone_1
+!
+vlan 211
+   name Tenant_B_OP_Zone_2
+!
+vlan 250
+   name Tenant_B_WAN_Zone_1
+!
+vlan 310
+   name Tenant_C_OP_Zone_1
+!
+vlan 311
+   name Tenant_C_OP_Zone_2
+!
+vlan 350
+   name Tenant_C_WAN_Zone_1
+!
+vlan 3008
+   name MLAG_iBGP_Tenant_A_OP_Zone
+   trunk group LEAF_PEER_L3
+!
+vlan 3010
+   name MLAG_iBGP_Tenant_A_WEB_Zone
+   trunk group LEAF_PEER_L3
+!
+vlan 3011
+   name MLAG_iBGP_Tenant_A_APP_Zone
+   trunk group LEAF_PEER_L3
+!
+vlan 3012
+   name MLAG_iBGP_Tenant_A_DB_Zone
+   trunk group LEAF_PEER_L3
+!
+vlan 3013
+   name MLAG_iBGP_Tenant_A_WAN_Zone
+   trunk group LEAF_PEER_L3
+!
+vlan 3019
+   name MLAG_iBGP_Tenant_B_OP_Zone
+   trunk group LEAF_PEER_L3
+!
+vlan 3020
+   name MLAG_iBGP_Tenant_B_WAN_Zone
+   trunk group LEAF_PEER_L3
+!
+vlan 3030
+   name MLAG_iBGP_Tenant_C_WAN_Zone
+   trunk group LEAF_PEER_L3
+!
+vlan 4090
+   name LEAF_PEER_L3
+   trunk group LEAF_PEER_L3
+!
+vlan 4092
+   name MLAG_PEER
+   trunk group MLAG
+!
+vrf instance MGMT
+!
+vrf instance Tenant_A_APP_Zone
+!
+vrf instance Tenant_A_DB_Zone
+!
+vrf instance Tenant_A_OP_Zone
+   description Tenant_A_OP_Zone
+!
+vrf instance Tenant_A_WAN_Zone
+!
+vrf instance Tenant_A_WEB_Zone
+!
+vrf instance Tenant_B_OP_Zone
+!
+vrf instance Tenant_B_WAN_Zone
+!
+vrf instance Tenant_C_OP_Zone
+!
+vrf instance Tenant_C_WAN_Zone
+!
+interface Port-Channel5
+   description MLAG_PEER_DC1-SVC3B_Po5
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 1-4094
+   switchport mode trunk
+   switchport trunk group LEAF_PEER_L3
+   switchport trunk group MLAG
+!
+interface Port-Channel7
+   description DC1_L2LEAF2_Po1
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 110-112,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350
+   switchport mode trunk
+   mlag 7
+!
+interface Port-Channel10
+   description server03_ESI_PortChanne1
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 110-111,210-211
+   switchport mode trunk
+   mlag 10
+!
+interface Port-Channel14
+   description server07_inherit_all_from_profile_port_channel_ALL_WITH_SECURITY_PORT_CHANNEL
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 1-4094
+   switchport mode trunk
+   mlag 14
+   spanning-tree portfast
+   spanning-tree bpduguard enable
+   spanning-tree bpdufilter enable
+   storm-control all level 10
+   storm-control broadcast level pps 100
+   storm-control multicast level 1
+   storm-control unknown-unicast level 2
+!
+interface Port-Channel15
+   description server08_no_profile_port_channel_server08_no_profile_port_channel
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 1-4094
+   switchport mode trunk
+   mlag 15
+   spanning-tree portfast
+   spanning-tree bpduguard disable
+   spanning-tree bpdufilter enable
+   storm-control all level 10
+   storm-control broadcast level pps 100
+   storm-control multicast level 1
+   storm-control unknown-unicast level 2
+!
+interface Port-Channel17
+   description server10_no_profile_port_channel_lacp_fallback_server10_no_profile_port_channel_lacp_fallback
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 1-4094
+   switchport mode trunk
+   port-channel lacp fallback timeout 90
+   port-channel lacp fallback static
+   mlag 17
+   spanning-tree portfast
+   spanning-tree bpduguard disable
+   spanning-tree bpdufilter enable
+   storm-control all level 10
+   storm-control broadcast level pps 100
+   storm-control multicast level 1
+   storm-control unknown-unicast level 2
+!
+interface Port-Channel18
+   description server11_inherit_profile_port_channel_lacp_fallback_ALL_WITH_SECURITY_PORT_CHANNEL
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 1-4094
+   switchport mode trunk
+   port-channel lacp fallback timeout 10
+   port-channel lacp fallback static
+   mlag 18
+   spanning-tree portfast
+   spanning-tree bpduguard enable
+   spanning-tree bpdufilter enable
+   storm-control all level 10
+   storm-control broadcast level pps 100
+   storm-control multicast level 1
+   storm-control unknown-unicast level 2
+!
+interface Port-Channel19
+   description server12_inherit_nested_profile_port_channel_lacp_fallback_NESTED_ALL_WITH_SECURITY_PORT_CHANNEL
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 1-4094
+   switchport mode trunk
+   port-channel lacp fallback timeout 10
+   port-channel lacp fallback static
+   mlag 19
+   spanning-tree portfast
+   spanning-tree bpduguard enable
+   spanning-tree bpdufilter enable
+   storm-control all level 10
+   storm-control broadcast level pps 100
+   storm-control multicast level 1
+   storm-control unknown-unicast level 2
+!
+interface Port-Channel22
+   description server15_port_channel_with_disabled_phy_interfaces_server15_port_channel_with_disabled_phy_interfaces
+   no shutdown
+   switchport
+   switchport access vlan 110
+   mlag 22
+!
+interface Port-Channel23
+   description server16_port_channel_with_disabled_port_channel_server16_port_channel_with_disabled_port_channel
+   shutdown
+   switchport
+   switchport access vlan 110
+   mlag 23
+!
+interface Port-Channel24
+   description server17_port_channel_with_disabled_phy_and_po_interfaces_server17_port_channel_with_disabled_phy_and_po_interfaces
+   shutdown
+   switchport
+   switchport access vlan 110
+   mlag 24
+!
+interface Port-Channel27
+   description server18_monitoring_session_source_po_server18_monitoring_session_source_po
+   no shutdown
+   switchport
+   switchport access vlan 110
+   mlag 27
+!
+interface Port-Channel42
+   description server21_monitoring_session_destination_po_server21_monitoring_session_destination_po
+   no shutdown
+   switchport
+   switchport access vlan 110
+   mlag 42
+!
+interface Ethernet1
+   description P2P_LINK_TO_DC1-SPINE1_Ethernet4
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.49/31
+!
+interface Ethernet2
+   description P2P_LINK_TO_DC1-SPINE2_Ethernet4
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.51/31
+!
+interface Ethernet3
+   description P2P_LINK_TO_DC1-SPINE3_Ethernet4
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.53/31
+!
+interface Ethernet4
+   description P2P_LINK_TO_DC1-SPINE4_Ethernet4
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.55/31
+!
+interface Ethernet5
+   description MLAG_PEER_DC1-SVC3B_Ethernet5
+   no shutdown
+   speed 100g
+   channel-group 5 mode active
+!
+interface Ethernet6
+   description MLAG_PEER_DC1-SVC3B_Ethernet6
+   no shutdown
+   speed 100g
+   channel-group 5 mode active
+!
+interface Ethernet7
+   description DC1-L2LEAF2A_Ethernet1
+   no shutdown
+   channel-group 7 mode active
+!
+interface Ethernet8
+   description DC1-L2LEAF2B_Ethernet1
+   no shutdown
+   channel-group 7 mode active
+!
+interface Ethernet10
+   description server03_ESI_Eth1
+   no shutdown
+   channel-group 10 mode active
+!
+interface Ethernet11
+   description server04_inherit_all_from_profile_Eth1
+   no shutdown
+   l2 mtu 8000
+   switchport trunk allowed vlan 1-4094
+   switchport mode trunk
+   switchport
+   storm-control all level 10
+   storm-control broadcast level pps 100
+   storm-control multicast level 1
+   storm-control unknown-unicast level 2
+   spanning-tree portfast
+   spanning-tree bpduguard disable
+   spanning-tree bpdufilter disable
+!
+interface Ethernet12
+   description server05_no_profile_Eth1
+   no shutdown
+   switchport trunk allowed vlan 1-4094
+   switchport mode trunk
+   switchport
+   storm-control all level 10
+   storm-control broadcast level pps 100
+   storm-control multicast level 1
+   storm-control unknown-unicast level 2
+   spanning-tree portfast
+   spanning-tree bpduguard disable
+   spanning-tree bpdufilter enable
+!
+interface Ethernet13
+   description server06_override_profile_Eth1
+   no shutdown
+   l2 mtu 8000
+   switchport access vlan 210
+   switchport mode access
+   switchport
+   storm-control all level pps 20
+   storm-control broadcast level 200
+   storm-control multicast level 1
+   storm-control unknown-unicast level 2
+   spanning-tree portfast network
+   spanning-tree bpduguard enable
+   spanning-tree bpdufilter disable
+!
+interface Ethernet14
+   description server07_inherit_all_from_profile_port_channel_Eth1
+   no shutdown
+   channel-group 14 mode active
+!
+interface Ethernet15
+   description server08_no_profile_port_channel_Eth1
+   no shutdown
+   channel-group 15 mode on
+!
+interface Ethernet16
+   description server09_override_profile_no_port_channel_Eth1
+   no shutdown
+   l2 mtu 8000
+   switchport access vlan 210
+   switchport mode access
+   switchport
+   storm-control all level pps 20
+   storm-control broadcast level 200
+   storm-control multicast level 1
+   storm-control unknown-unicast level 2
+   spanning-tree portfast network
+   spanning-tree bpduguard enable
+   spanning-tree bpdufilter disable
+!
+interface Ethernet17
+   description server10_no_profile_port_channel_lacp_fallback_Eth1
+   no shutdown
+   channel-group 17 mode active
+   lacp port-priority 8192
+!
+interface Ethernet18
+   description server11_inherit_profile_port_channel_lacp_fallback_Eth1
+   no shutdown
+   channel-group 18 mode active
+   lacp port-priority 8192
+!
+interface Ethernet19
+   description server12_inherit_nested_profile_port_channel_lacp_fallback_Eth1
+   no shutdown
+   channel-group 19 mode active
+   lacp port-priority 8192
+!
+interface Ethernet20
+   description server13_disabled_interfaces_Eth1
+   shutdown
+   switchport access vlan 110
+   switchport mode access
+   switchport
+!
+interface Ethernet21
+   description server14_explicitly_enabled_interfaces_Eth1
+   no shutdown
+   switchport access vlan 110
+   switchport mode access
+   switchport
+!
+interface Ethernet22
+   description server15_port_channel_with_disabled_phy_interfaces_Eth1
+   shutdown
+   channel-group 22 mode active
+!
+interface Ethernet23
+   description server16_port_channel_with_disabled_port_channel_Eth1
+   no shutdown
+   channel-group 23 mode active
+!
+interface Ethernet24
+   description server17_port_channel_with_disabled_phy_and_po_interfaces_Eth1
+   shutdown
+   channel-group 24 mode active
+!
+interface Ethernet25
+   description server18_monitoring_session_source_phys_interfaces_Eth1
+   no shutdown
+   switchport access vlan 110
+   switchport mode access
+   switchport
+!
+interface Ethernet26
+   description server19_monitoring_session_destination_phys_Eth1
+   no shutdown
+   switchport
+!
+interface Ethernet27
+   description server18_monitoring_session_source_po_Eth3
+   no shutdown
+   channel-group 27 mode active
+!
+interface Ethernet28
+   description server18_monitoring_session_source_phys_interface_Eth5
+   no shutdown
+   switchport access vlan 110
+   switchport mode access
+   switchport
+!
+interface Ethernet40
+   description server20_monitoring_session_destination_phys_Eth1
+   no shutdown
+   switchport
+!
+interface Ethernet42
+   description server21_monitoring_session_destination_po_Eth1
+   no shutdown
+   channel-group 42 mode active
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 192.168.255.12/32
+!
+interface Loopback1
+   description VTEP_VXLAN_Tunnel_Source
+   no shutdown
+   ip address 192.168.254.12/32
+!
+interface Loopback100
+   description Tenant_A_OP_Zone_VTEP_DIAGNOSTICS
+   no shutdown
+   vrf Tenant_A_OP_Zone
+   ip address 10.255.1.12/32
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 192.168.200.108/24
+!
+interface Vlan2
+   description MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone
+   no shutdown
+   mtu 1500
+   vrf Tenant_C_OP_Zone
+   ip address 10.255.251.6/31
+!
+interface Vlan110
+   description Tenant_A_OP_Zone_1
+   no shutdown
+   vrf Tenant_A_OP_Zone
+   ip address virtual 10.1.10.1/24
+!
+interface Vlan111
+   description Tenant_A_OP_Zone_2
+   no shutdown
+   vrf Tenant_A_OP_Zone
+   ip helper-address 1.1.1.1 vrf MGMT source-interface lo100
+   ip address virtual 10.1.11.1/24
+!
+interface Vlan112
+   description Tenant_A_OP_Zone_3
+   no shutdown
+   mtu 1560
+   vrf Tenant_A_OP_Zone
+   ip helper-address 2.2.2.2 vrf MGMT source-interface lo101
+!
+interface Vlan120
+   description Tenant_A_WEB_Zone_1
+   no shutdown
+   vrf Tenant_A_WEB_Zone
+   ip helper-address 1.1.1.1 vrf TEST source-interface lo100
+   ip address virtual 10.1.20.1/24
+   ip address virtual 10.2.20.1/24 secondary
+   ip address virtual 10.2.21.1/24 secondary
+!
+interface Vlan121
+   description Tenant_A_WEBZone_2
+   shutdown
+   mtu 1560
+   vrf Tenant_A_WEB_Zone
+   ip address virtual 10.1.10.254/24
+!
+interface Vlan130
+   description Tenant_A_APP_Zone_1
+   no shutdown
+   vrf Tenant_A_APP_Zone
+   ip address virtual 10.1.30.1/24
+!
+interface Vlan131
+   description Tenant_A_APP_Zone_2
+   no shutdown
+   vrf Tenant_A_APP_Zone
+   ip address virtual 10.1.31.1/24
+!
+interface Vlan140
+   description Tenant_A_DB_BZone_1
+   no shutdown
+   vrf Tenant_A_DB_Zone
+   ip address virtual 10.1.40.1/24
+!
+interface Vlan141
+   description Tenant_A_DB_Zone_2
+   no shutdown
+   vrf Tenant_A_DB_Zone
+   ip address virtual 10.1.41.1/24
+!
+interface Vlan150
+   description Tenant_A_WAN_Zone_1
+   no shutdown
+   vrf Tenant_A_WAN_Zone
+   ip ospf area 1
+   ip ospf cost 100
+   ip ospf authentication
+   ip ospf authentication-key 7 AQQvKeimxJu+uGQ/yYvv9w==
+   ip address virtual 10.1.40.1/24
+!
+interface Vlan210
+   description Tenant_B_OP_Zone_1
+   no shutdown
+   vrf Tenant_B_OP_Zone
+   ip address virtual 10.2.10.1/24
+!
+interface Vlan211
+   description Tenant_B_OP_Zone_2
+   no shutdown
+   vrf Tenant_B_OP_Zone
+   ip address virtual 10.2.11.1/24
+!
+interface Vlan250
+   description Tenant_B_WAN_Zone_1
+   no shutdown
+   vrf Tenant_B_WAN_Zone
+   ip address virtual 10.2.50.1/24
+!
+interface Vlan310
+   description Tenant_C_OP_Zone_1
+   no shutdown
+   vrf Tenant_C_OP_Zone
+   ip address virtual 10.3.10.1/24
+!
+interface Vlan311
+   description Tenant_C_OP_Zone_2
+   no shutdown
+   vrf Tenant_C_OP_Zone
+   ip address virtual 10.3.11.1/24
+!
+interface Vlan350
+   description Tenant_C_WAN_Zone_1
+   no shutdown
+   vrf Tenant_C_WAN_Zone
+   ip address virtual 10.3.50.1/24
+!
+interface Vlan3008
+   description MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone
+   no shutdown
+   mtu 1500
+   vrf Tenant_A_OP_Zone
+   ip address 10.255.251.6/31
+!
+interface Vlan3010
+   description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone
+   no shutdown
+   mtu 1500
+   vrf Tenant_A_WEB_Zone
+   ip address 172.31.11.6/31
+!
+interface Vlan3011
+   description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone
+   no shutdown
+   mtu 1500
+   vrf Tenant_A_APP_Zone
+   ip address 10.255.251.6/31
+!
+interface Vlan3012
+   description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone
+   no shutdown
+   mtu 1500
+   vrf Tenant_A_DB_Zone
+   ip address 10.255.251.6/31
+!
+interface Vlan3013
+   description MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone
+   no shutdown
+   mtu 1500
+   vrf Tenant_A_WAN_Zone
+   ip address 10.255.251.6/31
+!
+interface Vlan3019
+   description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone
+   no shutdown
+   mtu 1500
+   vrf Tenant_B_OP_Zone
+   ip address 10.255.251.6/31
+!
+interface Vlan3020
+   description MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone
+   no shutdown
+   mtu 1500
+   vrf Tenant_B_WAN_Zone
+   ip address 10.255.251.6/31
+!
+interface Vlan3030
+   description MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone
+   no shutdown
+   mtu 1500
+   vrf Tenant_C_WAN_Zone
+   ip address 10.255.251.6/31
+!
+interface Vlan4090
+   description MLAG_PEER_L3_PEERING
+   no shutdown
+   mtu 1500
+   ip address 10.255.251.6/31
+!
+interface Vlan4092
+   description MLAG_PEER
+   no shutdown
+   mtu 1500
+   no autostate
+   ip address 10.255.252.6/31
+!
+interface Vxlan1
+   description DC1-SVC3A_VTEP
+   vxlan source-interface Loopback1
+   vxlan virtual-router encapsulation mac-address mlag-system-id
+   vxlan udp-port 4789
+   vxlan vlan 110 vni 10110
+   vxlan vlan 111 vni 50111
+   vxlan vlan 112 vni 10112
+   vxlan vlan 120 vni 10120
+   vxlan vlan 121 vni 10121
+   vxlan vlan 130 vni 10130
+   vxlan vlan 131 vni 10131
+   vxlan vlan 140 vni 10140
+   vxlan vlan 141 vni 10141
+   vxlan vlan 150 vni 10150
+   vxlan vlan 160 vni 10160
+   vxlan vlan 161 vni 10161
+   vxlan vlan 210 vni 20210
+   vxlan vlan 211 vni 20211
+   vxlan vlan 250 vni 20250
+   vxlan vlan 310 vni 30310
+   vxlan vlan 311 vni 30311
+   vxlan vlan 350 vni 30350
+   vxlan vrf Tenant_A_APP_Zone vni 12
+   vxlan vrf Tenant_A_DB_Zone vni 13
+   vxlan vrf Tenant_A_OP_Zone vni 10
+   vxlan vrf Tenant_A_WAN_Zone vni 14
+   vxlan vrf Tenant_A_WEB_Zone vni 11
+   vxlan vrf Tenant_B_OP_Zone vni 20
+   vxlan vrf Tenant_B_WAN_Zone vni 21
+   vxlan vrf Tenant_C_OP_Zone vni 30
+   vxlan vrf Tenant_C_WAN_Zone vni 31
+!
+ip virtual-router mac-address 00:dc:00:00:00:0a
+!
+ip address virtual source-nat vrf Tenant_A_OP_Zone address 10.255.1.12
+!
+ip routing
+no ip routing vrf MGMT
+ip routing vrf Tenant_A_APP_Zone
+ip routing vrf Tenant_A_DB_Zone
+ip routing vrf Tenant_A_OP_Zone
+ip routing vrf Tenant_A_WAN_Zone
+ip routing vrf Tenant_A_WEB_Zone
+ip routing vrf Tenant_B_OP_Zone
+ip routing vrf Tenant_B_WAN_Zone
+ip routing vrf Tenant_C_OP_Zone
+ip routing vrf Tenant_C_WAN_Zone
+!
+monitor session MonitoringSessionServer18WithDest source Ethernet25 rx ip access-group MyIpACL priority 5
+monitor session MonitoringSessionServer18WithDest source Ethernet28 tx mac access-group MyMacACL priority 5
+monitor session MonitoringSessionServer18WithDest source Port-Channel27 tx mac access-group MyMacACL priority 5
+monitor session MonitoringSessionServer18WithDest destination Ethernet26
+monitor session MonitoringSessionServer18WithDest destination Ethernet40
+monitor session MonitoringSessionServer18WithDest destination Port-Channel42
+monitor session MonitoringSessionServer18WithDest header remove size 200
+monitor session MonitoringSessionServer18WithDest mac access-group mac_acl
+monitor session MonitoringSessionServer18WithDest rate-limit per-ingress-chip 30 bps
+monitor session MonitoringSessionServer18WithDest rate-limit per-egress-chip 30 bps
+monitor session MonitoringSessionServer18WithDest sample 10
+monitor session MonitoringSessionServer18WithDest truncate size 20
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+   seq 20 permit 192.168.254.0/24 eq 32
+!
+mlag configuration
+   domain-id DC1_SVC3
+   local-interface Vlan4092
+   peer-address 10.255.252.7
+   peer-link Port-Channel5
+   reload-delay mlag 300
+   reload-delay non-mlag 330
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.200.5
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+route-map RM-MLAG-PEER-IN permit 10
+   description Make routes learned over MLAG Peer-link less preferred on spines to ensure optimal routing
+   set origin incomplete
+!
+router bfd
+   multihop interval 1200 min-rx 1200 multiplier 3
+!
+router bgp 65103
+   router-id 192.168.255.12
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
+   maximum-paths 4 ecmp 4
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor MLAG-PEERS peer group
+   neighbor MLAG-PEERS remote-as 65103
+   neighbor MLAG-PEERS next-hop-self
+   neighbor MLAG-PEERS description DC1-SVC3B
+   neighbor MLAG-PEERS password 7 vnEaG8gMeQf3d3cN6PktXQ==
+   neighbor MLAG-PEERS send-community
+   neighbor MLAG-PEERS maximum-routes 12000
+   neighbor MLAG-PEERS route-map RM-MLAG-PEER-IN in
+   neighbor UNDERLAY-PEERS peer group
+   neighbor UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor UNDERLAY-PEERS send-community
+   neighbor UNDERLAY-PEERS maximum-routes 12000
+   neighbor 10.255.251.7 peer group MLAG-PEERS
+   neighbor 10.255.251.7 description DC1-SVC3B
+   neighbor 172.31.255.48 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.48 remote-as 65001
+   neighbor 172.31.255.48 description DC1-SPINE1_Ethernet4
+   neighbor 172.31.255.50 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.50 remote-as 65001
+   neighbor 172.31.255.50 description DC1-SPINE2_Ethernet4
+   neighbor 172.31.255.52 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.52 remote-as 65001
+   neighbor 172.31.255.52 description DC1-SPINE3_Ethernet4
+   neighbor 172.31.255.54 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.54 remote-as 65001
+   neighbor 172.31.255.54 description DC1-SPINE4_Ethernet4
+   neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.1 remote-as 65001
+   neighbor 192.168.255.1 description DC1-SPINE1
+   neighbor 192.168.255.2 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.2 remote-as 65001
+   neighbor 192.168.255.2 description DC1-SPINE2
+   neighbor 192.168.255.3 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.3 remote-as 65001
+   neighbor 192.168.255.3 description DC1-SPINE3
+   neighbor 192.168.255.4 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.4 remote-as 65001
+   neighbor 192.168.255.4 description DC1-SPINE4
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   vlan-aware-bundle Tenant_A_APP_Zone
+      rd 65103:12
+      route-target both 12:12
+      redistribute learned
+      vlan 130-131
+   !
+   vlan-aware-bundle Tenant_A_DB_Zone
+      rd 65103:13
+      route-target both 13:13
+      redistribute learned
+      vlan 140-141
+   !
+   vlan-aware-bundle Tenant_A_NFS
+      rd 65103:20161
+      route-target both 20161:20161
+      redistribute learned
+      vlan 161
+   !
+   vlan-aware-bundle Tenant_A_OP_Zone
+      rd 65103:9
+      route-target both 9:9
+      redistribute learned
+      vlan 110-112
+   !
+   vlan-aware-bundle Tenant_A_VMOTION
+      rd 65103:20160
+      route-target both 20160:20160
+      redistribute learned
+      vlan 160
+   !
+   vlan-aware-bundle Tenant_A_WAN_Zone
+      rd 65103:14
+      route-target both 14:14
+      redistribute learned
+      vlan 150
+   !
+   vlan-aware-bundle Tenant_A_WEB_Zone
+      rd 65103:11
+      route-target both 11:11
+      redistribute learned
+      vlan 120-121
+   !
+   vlan-aware-bundle Tenant_B_OP_Zone
+      rd 65103:20
+      route-target both 20:20
+      redistribute learned
+      vlan 210-211
+   !
+   vlan-aware-bundle Tenant_B_WAN_Zone
+      rd 65103:21
+      route-target both 21:21
+      redistribute learned
+      vlan 250
+   !
+   vlan-aware-bundle Tenant_C_OP_Zone
+      rd 65103:30
+      route-target both 30:30
+      redistribute learned
+      vlan 310-311
+   !
+   vlan-aware-bundle Tenant_C_WAN_Zone
+      rd 65103:31
+      route-target both 31:31
+      redistribute learned
+      vlan 350
+   !
+   address-family evpn
+      host-flap detection window 180 threshold 5 expiry timeout 10 seconds
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor MLAG-PEERS activate
+      neighbor UNDERLAY-PEERS activate
+   !
+   vrf Tenant_A_APP_Zone
+      rd 65103:12
+      route-target import evpn 12:12
+      route-target export evpn 12:12
+      router-id 192.168.255.12
+      neighbor 10.255.251.7 peer group MLAG-PEERS
+      redistribute connected
+   !
+   vrf Tenant_A_DB_Zone
+      rd 65103:13
+      route-target import evpn 13:13
+      route-target export evpn 13:13
+      router-id 192.168.255.12
+      neighbor 10.255.251.7 peer group MLAG-PEERS
+      redistribute connected
+   !
+   vrf Tenant_A_OP_Zone
+      rd 65103:9
+      route-target import evpn 9:9
+      route-target export evpn 9:9
+      router-id 192.168.255.12
+      neighbor 10.255.251.7 peer group MLAG-PEERS
+      redistribute connected
+   !
+   vrf Tenant_A_WAN_Zone
+      rd 65103:14
+      route-target import evpn 14:14
+      route-target import evpn 65000:456
+      route-target export evpn 14:14
+      route-target export evpn 65000:789
+      router-id 192.168.255.12
+      neighbor 10.255.251.7 peer group MLAG-PEERS
+      redistribute connected
+   !
+   vrf Tenant_A_WEB_Zone
+      rd 65103:11
+      route-target import evpn 11:11
+      route-target export evpn 11:11
+      router-id 192.168.255.12
+      neighbor 172.31.11.7 peer group MLAG-PEERS
+      redistribute connected
+   !
+   vrf Tenant_B_OP_Zone
+      rd 65103:20
+      route-target import evpn 20:20
+      route-target export evpn 20:20
+      router-id 192.168.255.12
+      neighbor 10.255.251.7 peer group MLAG-PEERS
+      redistribute connected
+   !
+   vrf Tenant_B_WAN_Zone
+      rd 65103:21
+      route-target import evpn 21:21
+      route-target export evpn 21:21
+      router-id 192.168.255.12
+      neighbor 10.255.251.7 peer group MLAG-PEERS
+      redistribute connected
+   !
+   vrf Tenant_C_OP_Zone
+      rd 65103:30
+      route-target import evpn 30:30
+      route-target export evpn 30:30
+      router-id 192.168.255.12
+      neighbor 10.255.251.7 peer group MLAG-PEERS
+      redistribute connected
+   !
+   vrf Tenant_C_WAN_Zone
+      rd 65103:31
+      route-target import evpn 31:31
+      route-target export evpn 31:31
+      router-id 192.168.255.12
+      neighbor 10.255.251.7 peer group MLAG-PEERS
+      redistribute connected
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/DC1-SVC3B.cfg
@@ -1,0 +1,981 @@
+!RANCID-CONTENT-TYPE: arista
+!
+boot secret sha512 a153de6290ff1409257ade45f
+!
+daemon TerminAttr
+   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   no shutdown
+!
+vlan internal order ascending range 1006 1199
+!
+no ip igmp snooping vlan 120
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname DC1-SVC3B
+ip name-server vrf MGMT 8.8.8.8
+ip name-server vrf MGMT 192.168.200.5
+!
+ntp local-interface vrf MGMT Management1
+ntp server vrf MGMT 192.168.200.5 prefer
+!
+snmp-server contact example@example.com
+snmp-server location EOS_DESIGNS_UNIT_TESTS DC1-SVC3B
+!
+spanning-tree root super
+spanning-tree mode mstp
+no spanning-tree vlan-id 4090,4092
+spanning-tree mst 0 priority 4096
+!
+no enable password
+no aaa root
+!
+username admin privilege 15 role network-admin nopassword
+username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
+username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
+!
+vlan 2
+   name MLAG_iBGP_Tenant_C_OP_Zone
+   trunk group LEAF_PEER_L3
+!
+vlan 110
+   name Tenant_A_OP_Zone_1
+!
+vlan 111
+   name Tenant_A_OP_Zone_2
+!
+vlan 112
+   name Tenant_A_OP_Zone_3
+!
+vlan 120
+   name Tenant_A_WEB_Zone_1
+!
+vlan 121
+   name Tenant_A_WEBZone_2
+!
+vlan 130
+   name Tenant_A_APP_Zone_1
+!
+vlan 131
+   name Tenant_A_APP_Zone_2
+!
+vlan 140
+   name Tenant_A_DB_BZone_1
+!
+vlan 141
+   name Tenant_A_DB_Zone_2
+!
+vlan 150
+   name Tenant_A_WAN_Zone_1
+!
+vlan 160
+   name Tenant_A_VMOTION
+!
+vlan 161
+   name Tenant_A_NFS
+!
+vlan 210
+   name Tenant_B_OP_Zone_1
+!
+vlan 211
+   name Tenant_B_OP_Zone_2
+!
+vlan 250
+   name Tenant_B_WAN_Zone_1
+!
+vlan 310
+   name Tenant_C_OP_Zone_1
+!
+vlan 311
+   name Tenant_C_OP_Zone_2
+!
+vlan 350
+   name Tenant_C_WAN_Zone_1
+!
+vlan 3008
+   name MLAG_iBGP_Tenant_A_OP_Zone
+   trunk group LEAF_PEER_L3
+!
+vlan 3010
+   name MLAG_iBGP_Tenant_A_WEB_Zone
+   trunk group LEAF_PEER_L3
+!
+vlan 3011
+   name MLAG_iBGP_Tenant_A_APP_Zone
+   trunk group LEAF_PEER_L3
+!
+vlan 3012
+   name MLAG_iBGP_Tenant_A_DB_Zone
+   trunk group LEAF_PEER_L3
+!
+vlan 3013
+   name MLAG_iBGP_Tenant_A_WAN_Zone
+   trunk group LEAF_PEER_L3
+!
+vlan 3019
+   name MLAG_iBGP_Tenant_B_OP_Zone
+   trunk group LEAF_PEER_L3
+!
+vlan 3020
+   name MLAG_iBGP_Tenant_B_WAN_Zone
+   trunk group LEAF_PEER_L3
+!
+vlan 3030
+   name MLAG_iBGP_Tenant_C_WAN_Zone
+   trunk group LEAF_PEER_L3
+!
+vlan 4090
+   name LEAF_PEER_L3
+   trunk group LEAF_PEER_L3
+!
+vlan 4092
+   name MLAG_PEER
+   trunk group MLAG
+!
+vrf instance MGMT
+!
+vrf instance Tenant_A_APP_Zone
+!
+vrf instance Tenant_A_DB_Zone
+!
+vrf instance Tenant_A_OP_Zone
+   description Tenant_A_OP_Zone
+!
+vrf instance Tenant_A_WAN_Zone
+!
+vrf instance Tenant_A_WEB_Zone
+!
+vrf instance Tenant_B_OP_Zone
+!
+vrf instance Tenant_B_WAN_Zone
+!
+vrf instance Tenant_C_OP_Zone
+!
+vrf instance Tenant_C_WAN_Zone
+!
+interface Port-Channel5
+   description MLAG_PEER_DC1-SVC3A_Po5
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 1-4094
+   switchport mode trunk
+   switchport trunk group LEAF_PEER_L3
+   switchport trunk group MLAG
+!
+interface Port-Channel7
+   description DC1_L2LEAF2_Po1
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 110-112,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350
+   switchport mode trunk
+   mlag 7
+!
+interface Port-Channel14
+   description server07_inherit_all_from_profile_port_channel_ALL_WITH_SECURITY_PORT_CHANNEL
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 1-4094
+   switchport mode trunk
+   mlag 14
+   spanning-tree portfast
+   spanning-tree bpduguard enable
+   spanning-tree bpdufilter enable
+   storm-control all level 10
+   storm-control broadcast level pps 100
+   storm-control multicast level 1
+   storm-control unknown-unicast level 2
+!
+interface Port-Channel15
+   description server08_no_profile_port_channel_server08_no_profile_port_channel
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 1-4094
+   switchport mode trunk
+   mlag 15
+   spanning-tree portfast
+   spanning-tree bpduguard disable
+   spanning-tree bpdufilter enable
+   storm-control all level 10
+   storm-control broadcast level pps 100
+   storm-control multicast level 1
+   storm-control unknown-unicast level 2
+!
+interface Port-Channel17
+   description server10_no_profile_port_channel_lacp_fallback_server10_no_profile_port_channel_lacp_fallback
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 1-4094
+   switchport mode trunk
+   port-channel lacp fallback timeout 90
+   port-channel lacp fallback static
+   mlag 17
+   spanning-tree portfast
+   spanning-tree bpduguard disable
+   spanning-tree bpdufilter enable
+   storm-control all level 10
+   storm-control broadcast level pps 100
+   storm-control multicast level 1
+   storm-control unknown-unicast level 2
+!
+interface Port-Channel18
+   description server11_inherit_profile_port_channel_lacp_fallback_ALL_WITH_SECURITY_PORT_CHANNEL
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 1-4094
+   switchport mode trunk
+   port-channel lacp fallback timeout 10
+   port-channel lacp fallback static
+   mlag 18
+   spanning-tree portfast
+   spanning-tree bpduguard enable
+   spanning-tree bpdufilter enable
+   storm-control all level 10
+   storm-control broadcast level pps 100
+   storm-control multicast level 1
+   storm-control unknown-unicast level 2
+!
+interface Port-Channel19
+   description server12_inherit_nested_profile_port_channel_lacp_fallback_NESTED_ALL_WITH_SECURITY_PORT_CHANNEL
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 1-4094
+   switchport mode trunk
+   port-channel lacp fallback timeout 10
+   port-channel lacp fallback static
+   mlag 19
+   spanning-tree portfast
+   spanning-tree bpduguard enable
+   spanning-tree bpdufilter enable
+   storm-control all level 10
+   storm-control broadcast level pps 100
+   storm-control multicast level 1
+   storm-control unknown-unicast level 2
+!
+interface Port-Channel22
+   description server15_port_channel_with_disabled_phy_interfaces_server15_port_channel_with_disabled_phy_interfaces
+   no shutdown
+   switchport
+   switchport access vlan 110
+   mlag 22
+!
+interface Port-Channel23
+   description server16_port_channel_with_disabled_port_channel_server16_port_channel_with_disabled_port_channel
+   shutdown
+   switchport
+   switchport access vlan 110
+   mlag 23
+!
+interface Port-Channel24
+   description server17_port_channel_with_disabled_phy_and_po_interfaces_server17_port_channel_with_disabled_phy_and_po_interfaces
+   shutdown
+   switchport
+   switchport access vlan 110
+   mlag 24
+!
+interface Port-Channel27
+   description server18_monitoring_session_source_po_server18_monitoring_session_source_po
+   no shutdown
+   switchport
+   switchport access vlan 110
+   mlag 27
+!
+interface Port-Channel42
+   description server21_monitoring_session_destination_po_server21_monitoring_session_destination_po
+   no shutdown
+   switchport
+   switchport access vlan 110
+   mlag 42
+!
+interface Ethernet1
+   description P2P_LINK_TO_DC1-SPINE1_Ethernet5
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.65/31
+!
+interface Ethernet2
+   description P2P_LINK_TO_DC1-SPINE2_Ethernet5
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.67/31
+!
+interface Ethernet3
+   description P2P_LINK_TO_DC1-SPINE3_Ethernet5
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.69/31
+!
+interface Ethernet4
+   description P2P_LINK_TO_DC1-SPINE4_Ethernet5
+   no shutdown
+   mtu 1500
+   speed forced 100gfull
+   no switchport
+   ip address 172.31.255.71/31
+!
+interface Ethernet5
+   description MLAG_PEER_DC1-SVC3A_Ethernet5
+   no shutdown
+   speed 100g
+   channel-group 5 mode active
+!
+interface Ethernet6
+   description MLAG_PEER_DC1-SVC3A_Ethernet6
+   no shutdown
+   speed 100g
+   channel-group 5 mode active
+!
+interface Ethernet7
+   description DC1-L2LEAF2A_Ethernet2
+   no shutdown
+   channel-group 7 mode active
+!
+interface Ethernet8
+   description DC1-L2LEAF2B_Ethernet2
+   no shutdown
+   channel-group 7 mode active
+!
+interface Ethernet11
+   description server04_inherit_all_from_profile_Eth2
+   no shutdown
+   l2 mtu 8000
+   switchport trunk allowed vlan 1-4094
+   switchport mode trunk
+   switchport
+   storm-control all level 10
+   storm-control broadcast level pps 100
+   storm-control multicast level 1
+   storm-control unknown-unicast level 2
+   spanning-tree portfast
+   spanning-tree bpduguard disable
+   spanning-tree bpdufilter disable
+!
+interface Ethernet12
+   description server05_no_profile_Eth2
+   no shutdown
+   switchport trunk allowed vlan 1-4094
+   switchport mode trunk
+   switchport
+   storm-control all level 10
+   storm-control broadcast level pps 100
+   storm-control multicast level 1
+   storm-control unknown-unicast level 2
+   spanning-tree portfast
+   spanning-tree bpduguard disable
+   spanning-tree bpdufilter enable
+!
+interface Ethernet13
+   description server06_override_profile_Eth2
+   no shutdown
+   l2 mtu 8000
+   switchport access vlan 210
+   switchport mode access
+   switchport
+   storm-control all level pps 20
+   storm-control broadcast level 200
+   storm-control multicast level 1
+   storm-control unknown-unicast level 2
+   spanning-tree portfast network
+   spanning-tree bpduguard enable
+   spanning-tree bpdufilter disable
+!
+interface Ethernet14
+   description server07_inherit_all_from_profile_port_channel_Eth2
+   no shutdown
+   channel-group 14 mode active
+!
+interface Ethernet15
+   description server08_no_profile_port_channel_Eth2
+   no shutdown
+   channel-group 15 mode on
+!
+interface Ethernet16
+   description server09_override_profile_no_port_channel_Eth2
+   no shutdown
+   l2 mtu 8000
+   switchport access vlan 210
+   switchport mode access
+   switchport
+   storm-control all level pps 20
+   storm-control broadcast level 200
+   storm-control multicast level 1
+   storm-control unknown-unicast level 2
+   spanning-tree portfast network
+   spanning-tree bpduguard enable
+   spanning-tree bpdufilter disable
+!
+interface Ethernet17
+   description server10_no_profile_port_channel_lacp_fallback_Eth2
+   no shutdown
+   channel-group 17 mode active
+   lacp port-priority 32768
+!
+interface Ethernet18
+   description server11_inherit_profile_port_channel_lacp_fallback_Eth2
+   no shutdown
+   channel-group 18 mode active
+   lacp port-priority 32768
+!
+interface Ethernet19
+   description server12_inherit_nested_profile_port_channel_lacp_fallback_Eth2
+   no shutdown
+   channel-group 19 mode active
+   lacp port-priority 32768
+!
+interface Ethernet20
+   description server13_disabled_interfaces_Eth2
+   shutdown
+   switchport access vlan 110
+   switchport mode access
+   switchport
+!
+interface Ethernet21
+   description server14_explicitly_enabled_interfaces_Eth2
+   no shutdown
+   switchport access vlan 110
+   switchport mode access
+   switchport
+!
+interface Ethernet22
+   description server15_port_channel_with_disabled_phy_interfaces_Eth2
+   shutdown
+   channel-group 22 mode active
+!
+interface Ethernet23
+   description server16_port_channel_with_disabled_port_channel_Eth2
+   no shutdown
+   channel-group 23 mode active
+!
+interface Ethernet24
+   description server17_port_channel_with_disabled_phy_and_po_interfaces_Eth2
+   shutdown
+   channel-group 24 mode active
+!
+interface Ethernet25
+   description server18_monitoring_session_source_phys_interfaces_Eth2
+   no shutdown
+   switchport access vlan 110
+   switchport mode access
+   switchport
+!
+interface Ethernet26
+   description server19_monitoring_session_destination_phys_Eth2
+   no shutdown
+   switchport
+!
+interface Ethernet27
+   description server18_monitoring_session_source_po_Eth4
+   no shutdown
+   channel-group 27 mode active
+!
+interface Ethernet42
+   description server21_monitoring_session_destination_po_Eth2
+   no shutdown
+   channel-group 42 mode active
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 192.168.255.13/32
+!
+interface Loopback1
+   description VTEP_VXLAN_Tunnel_Source
+   no shutdown
+   ip address 192.168.254.12/32
+!
+interface Loopback100
+   description Tenant_A_OP_Zone_VTEP_DIAGNOSTICS
+   no shutdown
+   vrf Tenant_A_OP_Zone
+   ip address 10.255.1.13/32
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 192.168.200.109/24
+!
+interface Vlan2
+   description MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone
+   no shutdown
+   mtu 1500
+   vrf Tenant_C_OP_Zone
+   ip address 10.255.251.7/31
+!
+interface Vlan110
+   description Tenant_A_OP_Zone_1
+   no shutdown
+   vrf Tenant_A_OP_Zone
+   ip address virtual 10.1.10.1/24
+!
+interface Vlan111
+   description Tenant_A_OP_Zone_2
+   no shutdown
+   vrf Tenant_A_OP_Zone
+   ip helper-address 1.1.1.1 vrf MGMT source-interface lo100
+   ip address virtual 10.1.11.1/24
+!
+interface Vlan112
+   description Tenant_A_OP_Zone_3
+   no shutdown
+   mtu 1560
+   vrf Tenant_A_OP_Zone
+   ip helper-address 2.2.2.2 vrf MGMT source-interface lo101
+!
+interface Vlan120
+   description Tenant_A_WEB_Zone_1
+   no shutdown
+   vrf Tenant_A_WEB_Zone
+   ip helper-address 1.1.1.1 vrf TEST source-interface lo100
+   ip address virtual 10.1.20.1/24
+   ip address virtual 10.2.20.1/24 secondary
+   ip address virtual 10.2.21.1/24 secondary
+!
+interface Vlan121
+   description Tenant_A_WEBZone_2
+   shutdown
+   mtu 1560
+   vrf Tenant_A_WEB_Zone
+   ip address virtual 10.1.10.254/24
+!
+interface Vlan130
+   description Tenant_A_APP_Zone_1
+   no shutdown
+   vrf Tenant_A_APP_Zone
+   ip address virtual 10.1.30.1/24
+!
+interface Vlan131
+   description Tenant_A_APP_Zone_2
+   no shutdown
+   vrf Tenant_A_APP_Zone
+   ip address virtual 10.1.31.1/24
+!
+interface Vlan140
+   description Tenant_A_DB_BZone_1
+   no shutdown
+   vrf Tenant_A_DB_Zone
+   ip address virtual 10.1.40.1/24
+!
+interface Vlan141
+   description Tenant_A_DB_Zone_2
+   no shutdown
+   vrf Tenant_A_DB_Zone
+   ip address virtual 10.1.41.1/24
+!
+interface Vlan150
+   description Tenant_A_WAN_Zone_1
+   no shutdown
+   vrf Tenant_A_WAN_Zone
+   ip ospf area 1
+   ip ospf cost 100
+   ip ospf authentication
+   ip ospf authentication-key 7 AQQvKeimxJu+uGQ/yYvv9w==
+   ip address virtual 10.1.40.1/24
+!
+interface Vlan210
+   description Tenant_B_OP_Zone_1
+   no shutdown
+   vrf Tenant_B_OP_Zone
+   ip address virtual 10.2.10.1/24
+!
+interface Vlan211
+   description Tenant_B_OP_Zone_2
+   no shutdown
+   vrf Tenant_B_OP_Zone
+   ip address virtual 10.2.11.1/24
+!
+interface Vlan250
+   description Tenant_B_WAN_Zone_1
+   no shutdown
+   vrf Tenant_B_WAN_Zone
+   ip address virtual 10.2.50.1/24
+!
+interface Vlan310
+   description Tenant_C_OP_Zone_1
+   no shutdown
+   vrf Tenant_C_OP_Zone
+   ip address virtual 10.3.10.1/24
+!
+interface Vlan311
+   description Tenant_C_OP_Zone_2
+   no shutdown
+   vrf Tenant_C_OP_Zone
+   ip address virtual 10.3.11.1/24
+!
+interface Vlan350
+   description Tenant_C_WAN_Zone_1
+   no shutdown
+   vrf Tenant_C_WAN_Zone
+   ip address virtual 10.3.50.1/24
+!
+interface Vlan3008
+   description MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone
+   no shutdown
+   mtu 1500
+   vrf Tenant_A_OP_Zone
+   ip address 10.255.251.7/31
+!
+interface Vlan3010
+   description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone
+   no shutdown
+   mtu 1500
+   vrf Tenant_A_WEB_Zone
+   ip address 172.31.11.7/31
+!
+interface Vlan3011
+   description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone
+   no shutdown
+   mtu 1500
+   vrf Tenant_A_APP_Zone
+   ip address 10.255.251.7/31
+!
+interface Vlan3012
+   description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone
+   no shutdown
+   mtu 1500
+   vrf Tenant_A_DB_Zone
+   ip address 10.255.251.7/31
+!
+interface Vlan3013
+   description MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone
+   no shutdown
+   mtu 1500
+   vrf Tenant_A_WAN_Zone
+   ip address 10.255.251.7/31
+!
+interface Vlan3019
+   description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone
+   no shutdown
+   mtu 1500
+   vrf Tenant_B_OP_Zone
+   ip address 10.255.251.7/31
+!
+interface Vlan3020
+   description MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone
+   no shutdown
+   mtu 1500
+   vrf Tenant_B_WAN_Zone
+   ip address 10.255.251.7/31
+!
+interface Vlan3030
+   description MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone
+   no shutdown
+   mtu 1500
+   vrf Tenant_C_WAN_Zone
+   ip address 10.255.251.7/31
+!
+interface Vlan4090
+   description MLAG_PEER_L3_PEERING
+   no shutdown
+   mtu 1500
+   ip address 10.255.251.7/31
+!
+interface Vlan4092
+   description MLAG_PEER
+   no shutdown
+   mtu 1500
+   no autostate
+   ip address 10.255.252.7/31
+!
+interface Vxlan1
+   description DC1-SVC3B_VTEP
+   vxlan source-interface Loopback1
+   vxlan virtual-router encapsulation mac-address mlag-system-id
+   vxlan udp-port 4789
+   vxlan vlan 110 vni 10110
+   vxlan vlan 111 vni 50111
+   vxlan vlan 112 vni 10112
+   vxlan vlan 120 vni 10120
+   vxlan vlan 121 vni 10121
+   vxlan vlan 130 vni 10130
+   vxlan vlan 131 vni 10131
+   vxlan vlan 140 vni 10140
+   vxlan vlan 141 vni 10141
+   vxlan vlan 150 vni 10150
+   vxlan vlan 160 vni 10160
+   vxlan vlan 161 vni 10161
+   vxlan vlan 210 vni 20210
+   vxlan vlan 211 vni 20211
+   vxlan vlan 250 vni 20250
+   vxlan vlan 310 vni 30310
+   vxlan vlan 311 vni 30311
+   vxlan vlan 350 vni 30350
+   vxlan vrf Tenant_A_APP_Zone vni 12
+   vxlan vrf Tenant_A_DB_Zone vni 13
+   vxlan vrf Tenant_A_OP_Zone vni 10
+   vxlan vrf Tenant_A_WAN_Zone vni 14
+   vxlan vrf Tenant_A_WEB_Zone vni 11
+   vxlan vrf Tenant_B_OP_Zone vni 20
+   vxlan vrf Tenant_B_WAN_Zone vni 21
+   vxlan vrf Tenant_C_OP_Zone vni 30
+   vxlan vrf Tenant_C_WAN_Zone vni 31
+!
+ip virtual-router mac-address 00:dc:00:00:00:0a
+!
+ip address virtual source-nat vrf Tenant_A_OP_Zone address 10.255.1.13
+!
+ip routing
+no ip routing vrf MGMT
+ip routing vrf Tenant_A_APP_Zone
+ip routing vrf Tenant_A_DB_Zone
+ip routing vrf Tenant_A_OP_Zone
+ip routing vrf Tenant_A_WAN_Zone
+ip routing vrf Tenant_A_WEB_Zone
+ip routing vrf Tenant_B_OP_Zone
+ip routing vrf Tenant_B_WAN_Zone
+ip routing vrf Tenant_C_OP_Zone
+ip routing vrf Tenant_C_WAN_Zone
+!
+monitor session MonitoringSessionServer18WithDest source Ethernet25 rx ip access-group MyIpACL priority 5
+monitor session MonitoringSessionServer18WithDest source Port-Channel27 tx mac access-group MyMacACL priority 5
+monitor session MonitoringSessionServer18WithDest destination Ethernet26
+monitor session MonitoringSessionServer18WithDest destination Port-Channel42
+monitor session MonitoringSessionServer18WithDest encapsulation gre metadata tx
+monitor session MonitoringSessionServer18WithDest header remove size 20
+monitor session MonitoringSessionServer18WithDest ip access-group ip_acl
+monitor session MonitoringSessionServer18WithDest rate-limit per-ingress-chip 30 bps
+monitor session MonitoringSessionServer18WithDest rate-limit per-egress-chip 30 bps
+monitor session MonitoringSessionServer18WithDest sample 10
+monitor session MonitoringSessionServer18WithDest truncate size 20
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+   seq 20 permit 192.168.254.0/24 eq 32
+!
+mlag configuration
+   domain-id DC1_SVC3
+   local-interface Vlan4092
+   peer-address 10.255.252.6
+   peer-link Port-Channel5
+   reload-delay mlag 300
+   reload-delay non-mlag 330
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.200.5
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+route-map RM-MLAG-PEER-IN permit 10
+   description Make routes learned over MLAG Peer-link less preferred on spines to ensure optimal routing
+   set origin incomplete
+!
+router bfd
+   multihop interval 1200 min-rx 1200 multiplier 3
+!
+router bgp 65103
+   router-id 192.168.255.13
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
+   maximum-paths 4 ecmp 4
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor MLAG-PEERS peer group
+   neighbor MLAG-PEERS remote-as 65103
+   neighbor MLAG-PEERS next-hop-self
+   neighbor MLAG-PEERS description DC1-SVC3A
+   neighbor MLAG-PEERS password 7 vnEaG8gMeQf3d3cN6PktXQ==
+   neighbor MLAG-PEERS send-community
+   neighbor MLAG-PEERS maximum-routes 12000
+   neighbor MLAG-PEERS route-map RM-MLAG-PEER-IN in
+   neighbor UNDERLAY-PEERS peer group
+   neighbor UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor UNDERLAY-PEERS send-community
+   neighbor UNDERLAY-PEERS maximum-routes 12000
+   neighbor 10.255.251.6 peer group MLAG-PEERS
+   neighbor 10.255.251.6 description DC1-SVC3A
+   neighbor 172.31.255.64 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.64 remote-as 65001
+   neighbor 172.31.255.64 description DC1-SPINE1_Ethernet5
+   neighbor 172.31.255.66 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.66 remote-as 65001
+   neighbor 172.31.255.66 description DC1-SPINE2_Ethernet5
+   neighbor 172.31.255.68 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.68 remote-as 65001
+   neighbor 172.31.255.68 description DC1-SPINE3_Ethernet5
+   neighbor 172.31.255.70 peer group UNDERLAY-PEERS
+   neighbor 172.31.255.70 remote-as 65001
+   neighbor 172.31.255.70 description DC1-SPINE4_Ethernet5
+   neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.1 remote-as 65001
+   neighbor 192.168.255.1 description DC1-SPINE1
+   neighbor 192.168.255.2 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.2 remote-as 65001
+   neighbor 192.168.255.2 description DC1-SPINE2
+   neighbor 192.168.255.3 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.3 remote-as 65001
+   neighbor 192.168.255.3 description DC1-SPINE3
+   neighbor 192.168.255.4 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.4 remote-as 65001
+   neighbor 192.168.255.4 description DC1-SPINE4
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   vlan-aware-bundle Tenant_A_APP_Zone
+      rd 65103:12
+      route-target both 12:12
+      redistribute learned
+      vlan 130-131
+   !
+   vlan-aware-bundle Tenant_A_DB_Zone
+      rd 65103:13
+      route-target both 13:13
+      redistribute learned
+      vlan 140-141
+   !
+   vlan-aware-bundle Tenant_A_NFS
+      rd 65103:20161
+      route-target both 20161:20161
+      redistribute learned
+      vlan 161
+   !
+   vlan-aware-bundle Tenant_A_OP_Zone
+      rd 65103:9
+      route-target both 9:9
+      redistribute learned
+      vlan 110-112
+   !
+   vlan-aware-bundle Tenant_A_VMOTION
+      rd 65103:20160
+      route-target both 20160:20160
+      redistribute learned
+      vlan 160
+   !
+   vlan-aware-bundle Tenant_A_WAN_Zone
+      rd 65103:14
+      route-target both 14:14
+      redistribute learned
+      vlan 150
+   !
+   vlan-aware-bundle Tenant_A_WEB_Zone
+      rd 65103:11
+      route-target both 11:11
+      redistribute learned
+      vlan 120-121
+   !
+   vlan-aware-bundle Tenant_B_OP_Zone
+      rd 65103:20
+      route-target both 20:20
+      redistribute learned
+      vlan 210-211
+   !
+   vlan-aware-bundle Tenant_B_WAN_Zone
+      rd 65103:21
+      route-target both 21:21
+      redistribute learned
+      vlan 250
+   !
+   vlan-aware-bundle Tenant_C_OP_Zone
+      rd 65103:30
+      route-target both 30:30
+      redistribute learned
+      vlan 310-311
+   !
+   vlan-aware-bundle Tenant_C_WAN_Zone
+      rd 65103:31
+      route-target both 31:31
+      redistribute learned
+      vlan 350
+   !
+   address-family evpn
+      host-flap detection window 180 threshold 5 expiry timeout 10 seconds
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor MLAG-PEERS activate
+      neighbor UNDERLAY-PEERS activate
+   !
+   vrf Tenant_A_APP_Zone
+      rd 65103:12
+      route-target import evpn 12:12
+      route-target export evpn 12:12
+      router-id 192.168.255.13
+      neighbor 10.255.251.6 peer group MLAG-PEERS
+      redistribute connected
+   !
+   vrf Tenant_A_DB_Zone
+      rd 65103:13
+      route-target import evpn 13:13
+      route-target export evpn 13:13
+      router-id 192.168.255.13
+      neighbor 10.255.251.6 peer group MLAG-PEERS
+      redistribute connected
+   !
+   vrf Tenant_A_OP_Zone
+      rd 65103:9
+      route-target import evpn 9:9
+      route-target export evpn 9:9
+      router-id 192.168.255.13
+      neighbor 10.255.251.6 peer group MLAG-PEERS
+      redistribute connected
+   !
+   vrf Tenant_A_WAN_Zone
+      rd 65103:14
+      route-target import evpn 14:14
+      route-target import evpn 65000:456
+      route-target export evpn 14:14
+      route-target export evpn 65000:789
+      router-id 192.168.255.13
+      neighbor 10.255.251.6 peer group MLAG-PEERS
+      redistribute connected
+   !
+   vrf Tenant_A_WEB_Zone
+      rd 65103:11
+      route-target import evpn 11:11
+      route-target export evpn 11:11
+      router-id 192.168.255.13
+      neighbor 172.31.11.6 peer group MLAG-PEERS
+      redistribute connected
+   !
+   vrf Tenant_B_OP_Zone
+      rd 65103:20
+      route-target import evpn 20:20
+      route-target export evpn 20:20
+      router-id 192.168.255.13
+      neighbor 10.255.251.6 peer group MLAG-PEERS
+      redistribute connected
+   !
+   vrf Tenant_B_WAN_Zone
+      rd 65103:21
+      route-target import evpn 21:21
+      route-target export evpn 21:21
+      router-id 192.168.255.13
+      neighbor 10.255.251.6 peer group MLAG-PEERS
+      redistribute connected
+   !
+   vrf Tenant_C_OP_Zone
+      rd 65103:30
+      route-target import evpn 30:30
+      route-target export evpn 30:30
+      router-id 192.168.255.13
+      neighbor 10.255.251.6 peer group MLAG-PEERS
+      redistribute connected
+   !
+   vrf Tenant_C_WAN_Zone
+      rd 65103:31
+      route-target import evpn 31:31
+      route-target export evpn 31:31
+      router-id 192.168.255.13
+      neighbor 10.255.251.6 peer group MLAG-PEERS
+      redistribute connected
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/MH-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/MH-L2LEAF1A.cfg
@@ -1,0 +1,81 @@
+!RANCID-CONTENT-TYPE: arista
+!
+boot secret sha512 a153de6290ff1409257ade45f
+!
+daemon TerminAttr
+   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   no shutdown
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname MH-L2LEAF1A
+ip name-server vrf MGMT 8.8.8.8
+ip name-server vrf MGMT 192.168.200.5
+!
+ntp local-interface vrf MGMT Management1
+ntp server vrf MGMT 192.168.200.5 prefer
+!
+snmp-server contact example@example.com
+snmp-server location EOS_DESIGNS_UNIT_TESTS MH-L2LEAF1A
+!
+spanning-tree mode mstp
+spanning-tree mst 0 priority 16384
+!
+no enable password
+no aaa root
+!
+username admin privilege 15 role network-admin nopassword
+username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
+username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
+!
+vlan 310
+   name Tenant_X_OP_Zone_1
+!
+vrf instance MGMT
+!
+link tracking group l2leaf-server02
+   recovery delay 300
+!
+interface Port-Channel1
+   description MH-LEAF2A_Po2
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 310
+   switchport mode trunk
+   link tracking group l2leaf-server02 upstream
+!
+interface Ethernet1
+   description MH-LEAF2A_Ethernet2
+   no shutdown
+   channel-group 1 mode active
+!
+interface Ethernet10
+   description server02_Eth1
+   no shutdown
+   switchport
+   link tracking group l2leaf-server02 downstream
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 192.168.201.201/24
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.200.5
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/MH-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/MH-LEAF1A.cfg
@@ -1,0 +1,232 @@
+!RANCID-CONTENT-TYPE: arista
+!
+boot secret sha512 a153de6290ff1409257ade45f
+!
+daemon TerminAttr
+   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   no shutdown
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+lacp port-id range 1 128
+!
+hostname MH-LEAF1A
+ip name-server vrf MGMT 8.8.8.8
+ip name-server vrf MGMT 192.168.200.5
+!
+ntp local-interface vrf MGMT Management1
+ntp server vrf MGMT 192.168.200.5 prefer
+!
+snmp-server contact example@example.com
+snmp-server location EOS_DESIGNS_UNIT_TESTS MH-LEAF1A
+!
+no enable password
+no aaa root
+!
+username admin privilege 15 role network-admin nopassword
+username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
+username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
+!
+vlan 310
+   name Tenant_X_OP_Zone_1
+!
+vrf instance MGMT
+!
+vrf instance Tenant_X_OP_Zone
+!
+link tracking group LT_GROUP1
+   recovery delay 300
+!
+interface Port-Channel10
+   description server01_ES1_PortChanne1
+   no shutdown
+   switchport
+   switchport access vlan 310
+   evpn ethernet-segment
+      identifier 0000:0000:0001:1010:1010
+      route-target import 00:01:10:10:10:10
+   lacp system-id 0001.1010.1010
+   link tracking group LT_GROUP1 downstream
+!
+interface Port-Channel11
+   description ROUTER02_WITH_SUBIF_Testing L2 subinterfaces
+   no shutdown
+   no switchport
+!
+interface Port-Channel11.101
+   vlan id 101
+   encapsulation vlan
+      client dot1q 101 network client
+   evpn ethernet-segment
+      identifier 0000:0000:0000:0000:0101
+      route-target import 00:00:00:00:01:01
+!
+interface Port-Channel11.102
+   vlan id 1102
+   encapsulation vlan
+      client dot1q 2102 network client
+   evpn ethernet-segment
+      identifier 0000:0000:0000:0000:0102
+      route-target import 00:00:00:00:01:02
+!
+interface Port-Channel11.103
+   vlan id 1103
+   encapsulation vlan
+      client dot1q 2103 network client
+   evpn ethernet-segment
+      identifier 0000:0000:c2c9:c85a:ed92
+      route-target import c2:c9:c8:5a:ed:92
+!
+interface Port-Channel11.104
+   vlan id 1104
+   encapsulation vlan
+      client dot1q 2104 network client
+   evpn ethernet-segment
+      identifier 0000:0000:5c8e:1f50:9fc4
+      route-target import 5c:8e:1f:50:9f:c4
+!
+interface Port-Channel12
+   description server03_AUTO_ESI_Auto-ESI PortChannel
+   no shutdown
+   switchport
+   switchport access vlan 310
+   evpn ethernet-segment
+      identifier 0000:0000:fc87:ae24:2cb3
+      route-target import fc:87:ae:24:2c:b3
+   lacp system-id fc87.ae24.2cb3
+   link tracking group LT_GROUP1 downstream
+!
+interface Ethernet1
+   description P2P_LINK_TO_DC1-SPINE1_Ethernet10
+   no shutdown
+   mtu 1500
+   no switchport
+   ip address 10.10.101.1/31
+   link tracking group LT_GROUP1 upstream
+!
+interface Ethernet10
+   description server01_ES1_Eth1
+   no shutdown
+   channel-group 10 mode active
+!
+interface Ethernet11
+   description ROUTER02_WITH_SUBIF_Eth1
+   no shutdown
+   channel-group 11 mode active
+!
+interface Ethernet12
+   description server03_AUTO_ESI_Eth1
+   no shutdown
+   channel-group 12 mode active
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 192.168.255.33/32
+!
+interface Loopback1
+   description VTEP_VXLAN_Tunnel_Source
+   no shutdown
+   ip address 192.168.254.33/32
+!
+interface Loopback100
+   description Tenant_X_OP_Zone_VTEP_DIAGNOSTICS
+   no shutdown
+   vrf Tenant_X_OP_Zone
+   ip address 10.255.1.33/32
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 192.168.201.104/24
+!
+interface Vlan310
+   description Tenant_X_OP_Zone_1
+   no shutdown
+   vrf Tenant_X_OP_Zone
+   ip address virtual 10.1.10.1/24
+!
+interface Vxlan1
+   description MH-LEAF1A_VTEP
+   vxlan source-interface Loopback1
+   vxlan udp-port 4789
+   vxlan vlan 310 vni 11310
+   vxlan vrf Tenant_X_OP_Zone vni 20
+!
+ip virtual-router mac-address 00:1c:73:00:dc:01
+!
+ip address virtual source-nat vrf Tenant_X_OP_Zone address 10.255.1.33
+!
+ip routing
+no ip routing vrf MGMT
+ip routing vrf Tenant_X_OP_Zone
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+   seq 20 permit 192.168.254.0/24 eq 32
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.200.5
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+router bfd
+   multihop interval 1200 min-rx 1200 multiplier 3
+!
+router bgp 65151
+   router-id 192.168.255.33
+   maximum-paths 4 ecmp 4
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor UNDERLAY-PEERS peer group
+   neighbor UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor UNDERLAY-PEERS send-community
+   neighbor UNDERLAY-PEERS maximum-routes 12000
+   neighbor 10.10.101.0 peer group UNDERLAY-PEERS
+   neighbor 10.10.101.0 remote-as 65001
+   neighbor 10.10.101.0 description DC1-SPINE1_Ethernet10
+   neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.1 remote-as 65001
+   neighbor 192.168.255.1 description DC1-SPINE1
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   vlan-aware-bundle Tenant_X_OP_Zone
+      rd 192.168.255.33:20
+      route-target both 20:20
+      redistribute learned
+      vlan 310
+   !
+   address-family evpn
+      host-flap detection window 180 threshold 5 expiry timeout 10 seconds
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor UNDERLAY-PEERS activate
+   !
+   vrf Tenant_X_OP_Zone
+      rd 192.168.255.33:20
+      route-target import evpn 20:20
+      route-target export evpn 20:20
+      router-id 192.168.255.33
+      redistribute connected
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/MH-LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/MH-LEAF1B.cfg
@@ -1,0 +1,232 @@
+!RANCID-CONTENT-TYPE: arista
+!
+boot secret sha512 a153de6290ff1409257ade45f
+!
+daemon TerminAttr
+   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   no shutdown
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+lacp port-id range 129 256
+!
+hostname MH-LEAF1B
+ip name-server vrf MGMT 8.8.8.8
+ip name-server vrf MGMT 192.168.200.5
+!
+ntp local-interface vrf MGMT Management1
+ntp server vrf MGMT 192.168.200.5 prefer
+!
+snmp-server contact example@example.com
+snmp-server location EOS_DESIGNS_UNIT_TESTS MH-LEAF1B
+!
+no enable password
+no aaa root
+!
+username admin privilege 15 role network-admin nopassword
+username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
+username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
+!
+vlan 310
+   name Tenant_X_OP_Zone_1
+!
+vrf instance MGMT
+!
+vrf instance Tenant_X_OP_Zone
+!
+link tracking group LT_GROUP1
+   recovery delay 300
+!
+interface Port-Channel10
+   description server01_ES1_PortChanne1
+   no shutdown
+   switchport
+   switchport access vlan 310
+   evpn ethernet-segment
+      identifier 0000:0000:0001:1010:1010
+      route-target import 00:01:10:10:10:10
+   lacp system-id 0001.1010.1010
+   link tracking group LT_GROUP1 downstream
+!
+interface Port-Channel11
+   description ROUTER02_WITH_SUBIF_Testing L2 subinterfaces
+   no shutdown
+   no switchport
+!
+interface Port-Channel11.101
+   vlan id 101
+   encapsulation vlan
+      client dot1q 101 network client
+   evpn ethernet-segment
+      identifier 0000:0000:0000:0000:0101
+      route-target import 00:00:00:00:01:01
+!
+interface Port-Channel11.102
+   vlan id 1102
+   encapsulation vlan
+      client dot1q 2102 network client
+   evpn ethernet-segment
+      identifier 0000:0000:0000:0000:0102
+      route-target import 00:00:00:00:01:02
+!
+interface Port-Channel11.103
+   vlan id 1103
+   encapsulation vlan
+      client dot1q 2103 network client
+   evpn ethernet-segment
+      identifier 0000:0000:c2c9:c85a:ed92
+      route-target import c2:c9:c8:5a:ed:92
+!
+interface Port-Channel11.104
+   vlan id 1104
+   encapsulation vlan
+      client dot1q 2104 network client
+   evpn ethernet-segment
+      identifier 0000:0000:5c8e:1f50:9fc4
+      route-target import 5c:8e:1f:50:9f:c4
+!
+interface Port-Channel12
+   description server03_AUTO_ESI_Auto-ESI PortChannel
+   no shutdown
+   switchport
+   switchport access vlan 310
+   evpn ethernet-segment
+      identifier 0000:0000:fc87:ae24:2cb3
+      route-target import fc:87:ae:24:2c:b3
+   lacp system-id fc87.ae24.2cb3
+   link tracking group LT_GROUP1 downstream
+!
+interface Ethernet1
+   description P2P_LINK_TO_DC1-SPINE1_Ethernet11
+   no shutdown
+   mtu 1500
+   no switchport
+   ip address 10.10.101.3/31
+   link tracking group LT_GROUP1 upstream
+!
+interface Ethernet10
+   description server01_ES1_Eth2
+   no shutdown
+   channel-group 10 mode active
+!
+interface Ethernet11
+   description ROUTER02_WITH_SUBIF_Eth2
+   no shutdown
+   channel-group 11 mode active
+!
+interface Ethernet12
+   description server03_AUTO_ESI_Eth2
+   no shutdown
+   channel-group 12 mode active
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 192.168.255.34/32
+!
+interface Loopback1
+   description VTEP_VXLAN_Tunnel_Source
+   no shutdown
+   ip address 192.168.254.34/32
+!
+interface Loopback100
+   description Tenant_X_OP_Zone_VTEP_DIAGNOSTICS
+   no shutdown
+   vrf Tenant_X_OP_Zone
+   ip address 10.255.1.34/32
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 192.168.201.105/24
+!
+interface Vlan310
+   description Tenant_X_OP_Zone_1
+   no shutdown
+   vrf Tenant_X_OP_Zone
+   ip address virtual 10.1.10.1/24
+!
+interface Vxlan1
+   description MH-LEAF1B_VTEP
+   vxlan source-interface Loopback1
+   vxlan udp-port 4789
+   vxlan vlan 310 vni 11310
+   vxlan vrf Tenant_X_OP_Zone vni 20
+!
+ip virtual-router mac-address 00:1c:73:00:dc:01
+!
+ip address virtual source-nat vrf Tenant_X_OP_Zone address 10.255.1.34
+!
+ip routing
+no ip routing vrf MGMT
+ip routing vrf Tenant_X_OP_Zone
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+   seq 20 permit 192.168.254.0/24 eq 32
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.200.5
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+router bfd
+   multihop interval 1200 min-rx 1200 multiplier 3
+!
+router bgp 65152
+   router-id 192.168.255.34
+   maximum-paths 4 ecmp 4
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor UNDERLAY-PEERS peer group
+   neighbor UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor UNDERLAY-PEERS send-community
+   neighbor UNDERLAY-PEERS maximum-routes 12000
+   neighbor 10.10.101.2 peer group UNDERLAY-PEERS
+   neighbor 10.10.101.2 remote-as 65001
+   neighbor 10.10.101.2 description DC1-SPINE1_Ethernet11
+   neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.1 remote-as 65001
+   neighbor 192.168.255.1 description DC1-SPINE1
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   vlan-aware-bundle Tenant_X_OP_Zone
+      rd 192.168.255.34:20
+      route-target both 20:20
+      redistribute learned
+      vlan 310
+   !
+   address-family evpn
+      host-flap detection window 180 threshold 5 expiry timeout 10 seconds
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor UNDERLAY-PEERS activate
+   !
+   vrf Tenant_X_OP_Zone
+      rd 192.168.255.34:20
+      route-target import evpn 20:20
+      route-target export evpn 20:20
+      router-id 192.168.255.34
+      redistribute connected
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/MH-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/MH-LEAF2A.cfg
@@ -1,0 +1,215 @@
+!RANCID-CONTENT-TYPE: arista
+!
+boot secret sha512 a153de6290ff1409257ade45f
+!
+daemon TerminAttr
+   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   no shutdown
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+lacp port-id range 257 768
+!
+hostname MH-LEAF2A
+ip name-server vrf MGMT 8.8.8.8
+ip name-server vrf MGMT 192.168.200.5
+!
+ntp local-interface vrf MGMT Management1
+ntp server vrf MGMT 192.168.200.5 prefer
+!
+snmp-server contact example@example.com
+snmp-server location EOS_DESIGNS_UNIT_TESTS MH-LEAF2A
+!
+no enable password
+no aaa root
+!
+username admin privilege 15 role network-admin nopassword
+username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
+username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
+!
+vlan 310
+   name Tenant_X_OP_Zone_1
+!
+vlan 311
+   name Tenant_default_vrf
+!
+vrf instance MGMT
+!
+vrf instance Tenant_X_OP_Zone
+!
+link tracking group Eth-conn-to-router
+   recovery delay 520
+!
+interface Port-Channel2
+   description MH-L2LEAF1A_Po1
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 310
+   switchport mode trunk
+!
+interface Ethernet1
+   description P2P_LINK_TO_DC1-SPINE1_Ethernet12
+   no shutdown
+   mtu 1500
+   no switchport
+   ip address 10.10.101.5/31
+   link tracking group Eth-conn-to-router upstream
+!
+interface Ethernet2
+   description MH-L2LEAF1A_Ethernet1
+   no shutdown
+   channel-group 2 mode active
+!
+interface Ethernet10
+   description ROUTER01_Eth1
+   no shutdown
+   switchport access vlan 310
+   switchport mode access
+   switchport
+   link tracking group Eth-conn-to-router downstream
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 192.168.255.35/32
+!
+interface Loopback1
+   description VTEP_VXLAN_Tunnel_Source
+   no shutdown
+   ip address 192.168.254.35/32
+!
+interface Loopback100
+   description Tenant_X_OP_Zone_VTEP_DIAGNOSTICS
+   no shutdown
+   vrf Tenant_X_OP_Zone
+   ip address 10.255.1.35/32
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 192.168.201.106/24
+!
+interface Vlan310
+   description Tenant_X_OP_Zone_1
+   no shutdown
+   vrf Tenant_X_OP_Zone
+   ip address virtual 10.1.10.1/24
+!
+interface Vlan311
+   description Tenant_default_vrf
+   no shutdown
+   ip address virtual 10.2.10.1/24
+!
+interface Vxlan1
+   description MH-LEAF2A_VTEP
+   vxlan source-interface Loopback1
+   vxlan udp-port 4789
+   vxlan vlan 310 vni 11310
+   vxlan vlan 311 vni 11311
+   vxlan vrf default vni 21
+   vxlan vrf Tenant_X_OP_Zone vni 20
+!
+ip virtual-router mac-address 00:1c:73:00:dc:01
+!
+ip address virtual source-nat vrf Tenant_X_OP_Zone address 10.255.1.35
+!
+ip routing
+no ip routing vrf MGMT
+ip routing vrf Tenant_X_OP_Zone
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+   seq 20 permit 192.168.254.0/24 eq 32
+!
+ip prefix-list PL-SVI-VRF-DEFAULT
+   seq 10 permit 10.2.10.0/24
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.200.5
+!
+route-map RM-BGP-UNDERLAY-PEERS-OUT deny 10
+   match ip address prefix-list PL-SVI-VRF-DEFAULT
+!
+route-map RM-BGP-UNDERLAY-PEERS-OUT permit 20
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+route-map RM-CONN-2-BGP permit 30
+   match ip address prefix-list PL-SVI-VRF-DEFAULT
+!
+route-map RM-EVPN-EXPORT-VRF-DEFAULT permit 10
+   match ip address prefix-list PL-SVI-VRF-DEFAULT
+!
+router bfd
+   multihop interval 1200 min-rx 1200 multiplier 3
+!
+router bgp 65153
+   router-id 192.168.255.35
+   maximum-paths 4 ecmp 4
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor UNDERLAY-PEERS peer group
+   neighbor UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor UNDERLAY-PEERS send-community
+   neighbor UNDERLAY-PEERS maximum-routes 12000
+   neighbor UNDERLAY-PEERS route-map RM-BGP-UNDERLAY-PEERS-OUT out
+   neighbor 10.10.101.4 peer group UNDERLAY-PEERS
+   neighbor 10.10.101.4 remote-as 65001
+   neighbor 10.10.101.4 description DC1-SPINE1_Ethernet12
+   neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.1 remote-as 65001
+   neighbor 192.168.255.1 description DC1-SPINE1
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   vlan-aware-bundle default
+      rd 192.168.255.35:21
+      route-target both 21:21
+      redistribute learned
+      vlan 311
+   !
+   vlan-aware-bundle Tenant_X_OP_Zone
+      rd 192.168.255.35:20
+      route-target both 20:20
+      redistribute learned
+      vlan 310
+   !
+   address-family evpn
+      host-flap detection window 180 threshold 5 expiry timeout 10 seconds
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor UNDERLAY-PEERS activate
+   !
+   vrf default
+      rd 192.168.255.35:21
+      route-target import evpn 21:21
+      route-target export evpn 21:21
+      route-target export evpn route-map RM-EVPN-EXPORT-VRF-DEFAULT
+   !
+   vrf Tenant_X_OP_Zone
+      rd 192.168.255.35:20
+      route-target import evpn 20:20
+      route-target export evpn 20:20
+      router-id 192.168.255.35
+      redistribute connected
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/core-1-isis-sr-ldp.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/core-1-isis-sr-ldp.cfg
@@ -1,0 +1,222 @@
+!RANCID-CONTENT-TYPE: arista
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname core-1-isis-sr-ldp
+!
+spanning-tree mode none
+!
+no enable password
+no aaa root
+!
+vrf instance MGMT
+!
+interface Port-Channel12
+   description P2P_LINK_TO_core-2-ospf-ldp_Port-Channel12
+   no shutdown
+   mtu 1500
+   no switchport
+   ip address 100.64.48.16/31
+   ipv6 enable
+   mpls ip
+   mpls ldp interface
+   mpls ldp igp sync
+   isis enable CORE
+   isis circuit-type level-2
+   isis metric 60
+   isis network point-to-point
+   no isis hello padding
+   isis authentication mode md5
+   isis authentication key 7 $1c$sTNAlR6rKSw=
+!
+interface Ethernet1
+   description P2P_LINK_TO_core-2-ospf-ldp_Ethernet1
+   no shutdown
+   mtu 1500
+   speed forced 1000full
+   no switchport
+   ip address unnumbered loopback0
+   ipv6 enable
+   mpls ldp igp sync
+   mpls ldp interface
+   mpls ip
+   isis enable CORE
+   isis circuit-type level-2
+   isis metric 60
+   no isis hello padding
+   isis network point-to-point
+   isis authentication mode md5
+   isis authentication key 7 $1c$sTNAlR6rKSw=
+!
+interface Ethernet2
+   description P2P_LINK_TO_core-2-ospf-ldp_Ethernet2
+   no shutdown
+   mtu 1601
+   speed 100full
+   no switchport
+   ip address 100.123.123.2/31
+   mpls ldp igp sync
+   mpls ldp interface
+   mpls ip
+   service-profile test_qos_profile
+   isis enable CORE
+   isis circuit-type level-1
+   isis metric 60
+   isis hello padding
+   isis network point-to-point
+!
+interface Ethernet3
+   description P2P_LINK_TO_core-2-ospf-ldp_Ethernet3
+   no shutdown
+   mtu 1500
+   speed forced 1000full
+   no switchport
+   ip address 100.64.48.4/31
+   ipv6 enable
+   mpls ldp igp sync
+   mpls ldp interface
+   mpls ip
+   isis enable CORE
+   isis circuit-type level-2
+   isis metric 60
+   no isis hello padding
+   isis network point-to-point
+   isis authentication mode md5
+   isis authentication key 7 $1c$sTNAlR6rKSw=
+!
+interface Ethernet4
+   description P2P_LINK_TO_core-2-ospf-ldp_Ethernet4
+   no shutdown
+   mtu 1500
+   speed forced 1000full
+   no switchport
+   ip address 100.64.48.6/31
+   ipv6 enable
+   isis enable CORE
+   isis circuit-type level-2
+   isis metric 60
+   no isis hello padding
+   isis network point-to-point
+   isis authentication mode md5
+   isis authentication key 7 $1c$sTNAlR6rKSw=
+!
+interface Ethernet5
+   description P2P_LINK_TO_core-2-ospf-ldp_Ethernet5
+   no shutdown
+   mtu 1500
+   speed forced 1000full
+   no switchport
+   ip address 100.64.48.8/31
+   ipv6 enable
+   mpls ip
+   isis enable CORE
+   isis circuit-type level-2
+   isis metric 60
+   no isis hello padding
+   isis network point-to-point
+   isis authentication mode md5
+   isis authentication key 7 $1c$sTNAlR6rKSw=
+!
+interface Ethernet6
+   description P2P_LINK_TO_core-2-ospf-ldp_Ethernet6
+   no shutdown
+   mtu 1602
+   speed 100full
+   no switchport
+   ip address unnumbered loopback0
+   ipv6 enable
+   mpls ldp igp sync
+   mpls ldp interface
+   mpls ip
+   service-profile test_qos_profile
+   isis enable CORE
+   isis circuit-type level-1-2
+   isis metric 70
+   isis hello padding
+   isis network point-to-point
+   isis authentication mode md5
+   isis authentication key 7 $1c$sTNAlR6rKSw=
+!
+interface Ethernet10
+   description P2P_LINK_TO_core-2-ospf-ldp_Ethernet10
+   no shutdown
+   mtu 1500
+   speed forced 1000full
+   no switchport
+   ip address 100.64.48.12/31
+   mpls ldp igp sync
+   mpls ldp interface
+   mpls ip
+   isis enable CORE
+   isis circuit-type level-2
+   isis metric 50
+   isis hello padding
+   isis network point-to-point
+!
+interface Ethernet12
+   description P2P_LINK_TO_core-2-ospf-ldp_Port-Channel12
+   no shutdown
+   channel-group 12 mode active
+!
+interface Ethernet13
+   description P2P_LINK_TO_core-2-ospf-ldp_Port-Channel12
+   no shutdown
+   channel-group 12 mode active
+!
+interface Loopback0
+   description LSR_Router_ID
+   no shutdown
+   ip address 10.0.0.1/32
+   ipv6 address 2000:1234:ffff:ffff::1/128
+   isis enable CORE
+   isis passive
+   mpls ldp interface
+   node-segment ipv4 index 201
+   node-segment ipv6 index 201
+!
+ip routing
+no ip routing vrf MGMT
+!
+ipv6 unicast-routing
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.0.1
+!
+router isis CORE
+   net 49.0001.0000.0001.0001.00
+   is-type level-2
+   router-id ipv4 10.0.0.1
+   log-adjacency-changes
+   mpls ldp sync default
+   timers local-convergence-delay 15000 protected-prefixes
+   advertise passive-only
+   !
+   address-family ipv4 unicast
+      maximum-paths 4
+      fast-reroute ti-lfa mode link-protection
+   address-family ipv6 unicast
+      maximum-paths 4
+      fast-reroute ti-lfa mode link-protection
+   !
+   segment-routing mpls
+      no shutdown
+!
+mpls ip
+!
+mpls ldp
+   interface disabled default
+   router-id 10.0.0.1
+   no shutdown
+   transport-address interface Loopback0
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/core-2-ospf-ldp.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/core-2-ospf-ldp.cfg
@@ -1,0 +1,178 @@
+!RANCID-CONTENT-TYPE: arista
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname core-2-ospf-ldp
+!
+spanning-tree mode none
+!
+no enable password
+no aaa root
+!
+vrf instance MGMT
+!
+interface Port-Channel12
+   description P2P_LINK_TO_core-1-isis-sr-ldp_Port-Channel12
+   no shutdown
+   mtu 1500
+   no switchport
+   ip address 100.64.48.17/31
+   ipv6 enable
+   ip ospf network point-to-point
+   ip ospf area 0.0.0.0
+   mpls ip
+   mpls ldp interface
+   mpls ldp igp sync
+!
+interface Ethernet1
+   description P2P_LINK_TO_core-1-isis-sr-ldp_Ethernet1
+   no shutdown
+   mtu 1500
+   speed forced 1000full
+   no switchport
+   ip address unnumbered loopback0
+   ipv6 enable
+   mpls ldp igp sync
+   mpls ldp interface
+   mpls ip
+   ip ospf network point-to-point
+   ip ospf area 0.0.0.0
+!
+interface Ethernet2
+   description P2P_LINK_TO_core-1-isis-sr-ldp_Ethernet2
+   no shutdown
+   mtu 1601
+   speed 100full
+   no switchport
+   ip address 100.123.123.3/31
+   mpls ldp igp sync
+   mpls ldp interface
+   mpls ip
+   ip ospf network point-to-point
+   ip ospf area 0.0.0.0
+   service-profile test_qos_profile
+!
+interface Ethernet3
+   description P2P_LINK_TO_core-1-isis-sr-ldp_Ethernet3
+   no shutdown
+   mtu 1500
+   speed forced 1000full
+   no switchport
+   ip address 100.64.48.5/31
+   ipv6 enable
+   mpls ldp igp sync
+   mpls ldp interface
+   mpls ip
+   ip ospf network point-to-point
+   ip ospf area 0.0.0.0
+!
+interface Ethernet4
+   description P2P_LINK_TO_core-1-isis-sr-ldp_Ethernet4
+   no shutdown
+   mtu 1500
+   speed forced 1000full
+   no switchport
+   ip address 100.64.48.7/31
+   ipv6 enable
+   ip ospf network point-to-point
+   ip ospf area 0.0.0.0
+!
+interface Ethernet5
+   description P2P_LINK_TO_core-1-isis-sr-ldp_Ethernet5
+   no shutdown
+   mtu 1500
+   speed forced 1000full
+   no switchport
+   ip address 100.64.48.9/31
+   ipv6 enable
+   mpls ip
+   ip ospf network point-to-point
+   ip ospf area 0.0.0.0
+!
+interface Ethernet6
+   description P2P_LINK_TO_core-1-isis-sr-ldp_Ethernet6
+   no shutdown
+   mtu 1602
+   speed 100full
+   no switchport
+   ip address unnumbered loopback0
+   ipv6 enable
+   mpls ldp igp sync
+   mpls ldp interface
+   mpls ip
+   ip ospf network point-to-point
+   ip ospf area 0.0.0.0
+   service-profile test_qos_profile
+!
+interface Ethernet10
+   description P2P_LINK_TO_core-1-isis-sr-ldp_Ethernet10
+   no shutdown
+   mtu 1500
+   speed forced 1000full
+   no switchport
+   ip address 100.64.48.13/31
+   mpls ldp igp sync
+   mpls ldp interface
+   mpls ip
+   ip ospf network point-to-point
+   ip ospf area 0.0.0.0
+!
+interface Ethernet12
+   description P2P_LINK_TO_core-1-isis-sr-ldp_Port-Channel12
+   no shutdown
+   channel-group 12 mode active
+!
+interface Ethernet13
+   description P2P_LINK_TO_core-1-isis-sr-ldp_Port-Channel12
+   no shutdown
+   channel-group 12 mode active
+!
+interface Loopback0
+   description LSR_Router_ID
+   no shutdown
+   ip address 10.0.0.2/32
+   ipv6 address 2000:1234:ffff:ffff::2/128
+   ip ospf area 0.0.0.0
+   mpls ldp interface
+!
+ip routing
+no ip routing vrf MGMT
+!
+ipv6 unicast-routing
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.0.1
+!
+router ospf 101
+   router-id 10.0.0.2
+   passive-interface default
+   no passive-interface Ethernet1
+   no passive-interface Ethernet2
+   no passive-interface Ethernet3
+   no passive-interface Ethernet4
+   no passive-interface Ethernet5
+   no passive-interface Ethernet6
+   no passive-interface Ethernet10
+   no passive-interface Port-Channel12
+   bfd default
+   max-lsa 12000
+!
+mpls ip
+!
+mpls ldp
+   interface disabled default
+   router-id 10.0.0.2
+   no shutdown
+   transport-address interface Loopback0
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/cvp-instance-ips-cvaas.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/cvp-instance-ips-cvaas.cfg
@@ -1,0 +1,70 @@
+!RANCID-CONTENT-TYPE: arista
+!
+daemon TerminAttr
+   exec /usr/bin/TerminAttr -cvaddr=cv-staging.corp.arista.io:443 -cvauth=token-secure,/tmp/cv-onboarding-token -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   no shutdown
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname cvp-instance-ips-cvaas
+!
+spanning-tree mode none
+!
+no enable password
+no aaa root
+!
+vrf instance MGMT
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 1.2.3.1/32
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 1.2.3.4/24 eq 32
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.0.1
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+router bfd
+   multihop interval 300 min-rx 300 multiplier 3
+!
+router bgp 1234
+   router-id 1.2.3.1
+   maximum-paths 4 ecmp 4
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor IPv4-UNDERLAY-PEERS peer group
+   neighbor IPv4-UNDERLAY-PEERS send-community
+   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   address-family evpn
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor IPv4-UNDERLAY-PEERS activate
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/evpn_services_l2_only_false.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/evpn_services_l2_only_false.cfg
@@ -1,0 +1,488 @@
+!RANCID-CONTENT-TYPE: arista
+!
+boot secret sha512 a153de6290ff1409257ade45f
+!
+daemon TerminAttr
+   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   no shutdown
+!
+vlan internal order ascending range 1006 1199
+!
+no ip igmp snooping vlan 120
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname evpn_services_l2_only_false
+ip name-server vrf MGMT 8.8.8.8
+ip name-server vrf MGMT 192.168.200.5
+!
+ntp local-interface vrf MGMT Management1
+ntp server vrf MGMT 192.168.200.5 prefer
+!
+snmp-server contact example@example.com
+snmp-server location EOS_DESIGNS_UNIT_TESTS evpn_services_l2_only_false
+!
+no enable password
+no aaa root
+!
+username admin privilege 15 role network-admin nopassword
+username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
+username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
+!
+vlan 110
+   name Tenant_A_OP_Zone_1
+!
+vlan 111
+   name Tenant_A_OP_Zone_2
+!
+vlan 112
+   name Tenant_A_OP_Zone_3
+!
+vlan 120
+   name Tenant_A_WEB_Zone_1
+!
+vlan 121
+   name Tenant_A_WEBZone_2
+!
+vlan 130
+   name Tenant_A_APP_Zone_1
+!
+vlan 131
+   name Tenant_A_APP_Zone_2
+!
+vlan 132
+   name Tenant_A_APP_Zone_3
+!
+vlan 140
+   name Tenant_A_DB_BZone_1
+!
+vlan 141
+   name Tenant_A_DB_Zone_2
+!
+vlan 150
+   name Tenant_A_WAN_Zone_1
+!
+vlan 151
+   name svi_with_no_tags
+!
+vlan 160
+   name Tenant_A_VMOTION
+!
+vlan 161
+   name Tenant_A_NFS
+!
+vlan 162
+   name l2vlan_with_no_tags
+!
+vlan 210
+   name Tenant_B_OP_Zone_1
+!
+vlan 211
+   name Tenant_B_OP_Zone_2
+!
+vlan 250
+   name Tenant_B_WAN_Zone_1
+!
+vlan 310
+   name Tenant_C_OP_Zone_1
+!
+vlan 311
+   name Tenant_C_OP_Zone_2
+!
+vlan 350
+   name Tenant_C_WAN_Zone_1
+!
+vrf instance MGMT
+!
+vrf instance Tenant_A_APP_Zone
+!
+vrf instance Tenant_A_DB_Zone
+!
+vrf instance Tenant_A_OP_Zone
+   description Tenant_A_OP_Zone
+!
+vrf instance Tenant_A_WAN_Zone
+!
+vrf instance Tenant_A_WEB_Zone
+!
+vrf instance Tenant_B_OP_Zone
+!
+vrf instance Tenant_B_WAN_Zone
+!
+vrf instance Tenant_C_OP_Zone
+!
+vrf instance Tenant_C_WAN_Zone
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 192.168.255.109/32
+!
+interface Loopback1
+   description VTEP_VXLAN_Tunnel_Source
+   no shutdown
+   ip address 192.168.254.109/32
+!
+interface Loopback100
+   description Tenant_A_OP_Zone_VTEP_DIAGNOSTICS
+   no shutdown
+   vrf Tenant_A_OP_Zone
+   ip address 10.255.1.109/32
+!
+interface Vlan110
+   description Tenant_A_OP_Zone_1
+   no shutdown
+   vrf Tenant_A_OP_Zone
+   ip address virtual 10.1.10.1/24
+!
+interface Vlan111
+   description Tenant_A_OP_Zone_2
+   no shutdown
+   vrf Tenant_A_OP_Zone
+   ip helper-address 1.1.1.1 vrf MGMT source-interface lo100
+   ip address virtual 10.1.11.1/24
+!
+interface Vlan112
+   description Tenant_A_OP_Zone_3
+   no shutdown
+   mtu 1560
+   vrf Tenant_A_OP_Zone
+   ip helper-address 2.2.2.2 vrf MGMT source-interface lo101
+!
+interface Vlan120
+   description Tenant_A_WEB_Zone_1
+   no shutdown
+   vrf Tenant_A_WEB_Zone
+   ip helper-address 1.1.1.1 vrf TEST source-interface lo100
+   ip address virtual 10.1.20.1/24
+   ip address virtual 10.2.20.1/24 secondary
+   ip address virtual 10.2.21.1/24 secondary
+!
+interface Vlan121
+   description Tenant_A_WEBZone_2
+   shutdown
+   mtu 1560
+   vrf Tenant_A_WEB_Zone
+   ip address virtual 10.1.10.254/24
+!
+interface Vlan130
+   description Tenant_A_APP_Zone_1
+   no shutdown
+   vrf Tenant_A_APP_Zone
+   ip address virtual 10.1.30.1/24
+!
+interface Vlan131
+   description Tenant_A_APP_Zone_2
+   no shutdown
+   vrf Tenant_A_APP_Zone
+   ip address virtual 10.1.31.1/24
+!
+interface Vlan132
+   description Tenant_A_APP_Zone_3
+   no shutdown
+   vrf Tenant_A_APP_Zone
+   ip virtual-router address 10.1.32.254
+   ip virtual-router address 10.2.32.254/24
+   ip virtual-router address 10.3.32.254/24
+!
+interface Vlan140
+   description Tenant_A_DB_BZone_1
+   no shutdown
+   vrf Tenant_A_DB_Zone
+   ip address virtual 10.1.40.1/24
+!
+interface Vlan141
+   description Tenant_A_DB_Zone_2
+   no shutdown
+   vrf Tenant_A_DB_Zone
+   ip address virtual 10.1.41.1/24
+!
+interface Vlan150
+   description Tenant_A_WAN_Zone_1
+   no shutdown
+   vrf Tenant_A_WAN_Zone
+   ip ospf area 1
+   ip ospf cost 100
+   ip ospf authentication
+   ip ospf authentication-key 7 AQQvKeimxJu+uGQ/yYvv9w==
+   ip address virtual 10.1.40.1/24
+!
+interface Vlan151
+   description svi_with_no_tags
+   no shutdown
+   vrf Tenant_A_WAN_Zone
+   ip address virtual 10.1.51.1/24
+!
+interface Vlan210
+   description Tenant_B_OP_Zone_1
+   no shutdown
+   vrf Tenant_B_OP_Zone
+   ip address virtual 10.2.10.1/24
+!
+interface Vlan211
+   description Tenant_B_OP_Zone_2
+   no shutdown
+   vrf Tenant_B_OP_Zone
+   ip address virtual 10.2.11.1/24
+!
+interface Vlan250
+   description Tenant_B_WAN_Zone_1
+   no shutdown
+   vrf Tenant_B_WAN_Zone
+   ip address virtual 10.2.50.1/24
+!
+interface Vlan310
+   description Tenant_C_OP_Zone_1
+   no shutdown
+   vrf Tenant_C_OP_Zone
+   ip address virtual 10.3.10.1/24
+!
+interface Vlan311
+   description Tenant_C_OP_Zone_2
+   no shutdown
+   vrf Tenant_C_OP_Zone
+   ip address virtual 10.3.11.1/24
+!
+interface Vlan350
+   description Tenant_C_WAN_Zone_1
+   no shutdown
+   vrf Tenant_C_WAN_Zone
+   ip address virtual 10.3.50.1/24
+!
+interface Vxlan1
+   description evpn_services_l2_only_false_VTEP
+   vxlan source-interface Loopback1
+   vxlan udp-port 4789
+   vxlan vlan 110 vni 10110
+   vxlan vlan 111 vni 50111
+   vxlan vlan 112 vni 10112
+   vxlan vlan 120 vni 10120
+   vxlan vlan 121 vni 10121
+   vxlan vlan 130 vni 10130
+   vxlan vlan 131 vni 10131
+   vxlan vlan 132 vni 10132
+   vxlan vlan 140 vni 10140
+   vxlan vlan 141 vni 10141
+   vxlan vlan 150 vni 10150
+   vxlan vlan 151 vni 10151
+   vxlan vlan 160 vni 10160
+   vxlan vlan 161 vni 10161
+   vxlan vlan 162 vni 10162
+   vxlan vlan 210 vni 20210
+   vxlan vlan 211 vni 20211
+   vxlan vlan 250 vni 20250
+   vxlan vlan 310 vni 30310
+   vxlan vlan 311 vni 30311
+   vxlan vlan 350 vni 30350
+   vxlan vrf Tenant_A_APP_Zone vni 12
+   vxlan vrf Tenant_A_DB_Zone vni 13
+   vxlan vrf Tenant_A_OP_Zone vni 10
+   vxlan vrf Tenant_A_WAN_Zone vni 14
+   vxlan vrf Tenant_A_WEB_Zone vni 11
+   vxlan vrf Tenant_B_OP_Zone vni 20
+   vxlan vrf Tenant_B_WAN_Zone vni 21
+   vxlan vrf Tenant_C_OP_Zone vni 30
+   vxlan vrf Tenant_C_WAN_Zone vni 31
+!
+ip virtual-router mac-address 00:dc:00:00:00:0a
+!
+ip address virtual source-nat vrf Tenant_A_OP_Zone address 10.255.1.109
+!
+ip routing
+no ip routing vrf MGMT
+ip routing vrf Tenant_A_APP_Zone
+ip routing vrf Tenant_A_DB_Zone
+ip routing vrf Tenant_A_OP_Zone
+ip routing vrf Tenant_A_WAN_Zone
+ip routing vrf Tenant_A_WEB_Zone
+ip routing vrf Tenant_B_OP_Zone
+ip routing vrf Tenant_B_WAN_Zone
+ip routing vrf Tenant_C_OP_Zone
+ip routing vrf Tenant_C_WAN_Zone
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+   seq 20 permit 192.168.254.0/24 eq 32
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.200.5
+ip route vrf Tenant_A_APP_Zone 10.2.32.0/24 Vlan132 name VARP
+ip route vrf Tenant_A_APP_Zone 10.3.32.0/24 Vlan132 name VARP
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+router bfd
+   multihop interval 1200 min-rx 1200 multiplier 3
+!
+router bgp 101
+   router-id 192.168.255.109
+   maximum-paths 4 ecmp 4
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor UNDERLAY-PEERS peer group
+   neighbor UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor UNDERLAY-PEERS send-community
+   neighbor UNDERLAY-PEERS maximum-routes 12000
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   vlan-aware-bundle l2vlan_with_no_tags
+      rd 192.168.255.109:20162
+      route-target both 20162:20162
+      redistribute learned
+      vlan 162
+   !
+   vlan-aware-bundle Tenant_A_APP_Zone
+      rd 192.168.255.109:12
+      route-target both 12:12
+      redistribute learned
+      vlan 130-132
+   !
+   vlan-aware-bundle Tenant_A_DB_Zone
+      rd 192.168.255.109:13
+      route-target both 13:13
+      redistribute learned
+      vlan 140-141
+   !
+   vlan-aware-bundle Tenant_A_NFS
+      rd 192.168.255.109:20161
+      route-target both 20161:20161
+      redistribute learned
+      vlan 161
+   !
+   vlan-aware-bundle Tenant_A_OP_Zone
+      rd 192.168.255.109:9
+      route-target both 9:9
+      redistribute learned
+      vlan 110-112
+   !
+   vlan-aware-bundle Tenant_A_VMOTION
+      rd 192.168.255.109:20160
+      route-target both 20160:20160
+      redistribute learned
+      vlan 160
+   !
+   vlan-aware-bundle Tenant_A_WAN_Zone
+      rd 192.168.255.109:14
+      route-target both 14:14
+      redistribute learned
+      vlan 150-151
+   !
+   vlan-aware-bundle Tenant_A_WEB_Zone
+      rd 192.168.255.109:11
+      route-target both 11:11
+      redistribute learned
+      vlan 120-121
+   !
+   vlan-aware-bundle Tenant_B_OP_Zone
+      rd 192.168.255.109:20
+      route-target both 20:20
+      redistribute learned
+      vlan 210-211
+   !
+   vlan-aware-bundle Tenant_B_WAN_Zone
+      rd 192.168.255.109:21
+      route-target both 21:21
+      redistribute learned
+      vlan 250
+   !
+   vlan-aware-bundle Tenant_C_OP_Zone
+      rd 192.168.255.109:30
+      route-target both 30:30
+      redistribute learned
+      vlan 310-311
+   !
+   vlan-aware-bundle Tenant_C_WAN_Zone
+      rd 192.168.255.109:31
+      route-target both 31:31
+      redistribute learned
+      vlan 350
+   !
+   address-family evpn
+      host-flap detection window 180 threshold 5 expiry timeout 10 seconds
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor UNDERLAY-PEERS activate
+   !
+   vrf Tenant_A_APP_Zone
+      rd 192.168.255.109:12
+      route-target import evpn 12:12
+      route-target export evpn 12:12
+      router-id 192.168.255.109
+      redistribute connected
+   !
+   vrf Tenant_A_DB_Zone
+      rd 192.168.255.109:13
+      route-target import evpn 13:13
+      route-target export evpn 13:13
+      router-id 192.168.255.109
+      redistribute connected
+   !
+   vrf Tenant_A_OP_Zone
+      rd 192.168.255.109:9
+      route-target import evpn 9:9
+      route-target export evpn 9:9
+      router-id 192.168.255.109
+      redistribute connected
+   !
+   vrf Tenant_A_WAN_Zone
+      rd 192.168.255.109:14
+      route-target import evpn 14:14
+      route-target import evpn 65000:456
+      route-target export evpn 14:14
+      route-target export evpn 65000:789
+      router-id 192.168.255.109
+      redistribute connected
+   !
+   vrf Tenant_A_WEB_Zone
+      rd 192.168.255.109:11
+      route-target import evpn 11:11
+      route-target export evpn 11:11
+      router-id 192.168.255.109
+      redistribute connected
+   !
+   vrf Tenant_B_OP_Zone
+      rd 192.168.255.109:20
+      route-target import evpn 20:20
+      route-target export evpn 20:20
+      router-id 192.168.255.109
+      redistribute connected
+   !
+   vrf Tenant_B_WAN_Zone
+      rd 192.168.255.109:21
+      route-target import evpn 21:21
+      route-target export evpn 21:21
+      router-id 192.168.255.109
+      redistribute connected
+   !
+   vrf Tenant_C_OP_Zone
+      rd 192.168.255.109:30
+      route-target import evpn 30:30
+      route-target export evpn 30:30
+      router-id 192.168.255.109
+      redistribute connected
+   !
+   vrf Tenant_C_WAN_Zone
+      rd 192.168.255.109:31
+      route-target import evpn 31:31
+      route-target export evpn 31:31
+      router-id 192.168.255.109
+      redistribute connected
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/evpn_services_l2_only_true.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/evpn_services_l2_only_true.cfg
@@ -1,0 +1,254 @@
+!RANCID-CONTENT-TYPE: arista
+!
+boot secret sha512 a153de6290ff1409257ade45f
+!
+daemon TerminAttr
+   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   no shutdown
+!
+vlan internal order ascending range 1006 1199
+!
+no ip igmp snooping vlan 120
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname evpn_services_l2_only_true
+ip name-server vrf MGMT 8.8.8.8
+ip name-server vrf MGMT 192.168.200.5
+!
+ntp local-interface vrf MGMT Management1
+ntp server vrf MGMT 192.168.200.5 prefer
+!
+snmp-server contact example@example.com
+snmp-server location EOS_DESIGNS_UNIT_TESTS evpn_services_l2_only_true
+!
+no enable password
+no aaa root
+!
+username admin privilege 15 role network-admin nopassword
+username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
+username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
+!
+vlan 110
+   name Tenant_A_OP_Zone_1
+!
+vlan 111
+   name Tenant_A_OP_Zone_2
+!
+vlan 112
+   name Tenant_A_OP_Zone_3
+!
+vlan 120
+   name Tenant_A_WEB_Zone_1
+!
+vlan 121
+   name Tenant_A_WEBZone_2
+!
+vlan 130
+   name Tenant_A_APP_Zone_1
+!
+vlan 131
+   name Tenant_A_APP_Zone_2
+!
+vlan 132
+   name Tenant_A_APP_Zone_3
+!
+vlan 140
+   name Tenant_A_DB_BZone_1
+!
+vlan 141
+   name Tenant_A_DB_Zone_2
+!
+vlan 150
+   name Tenant_A_WAN_Zone_1
+!
+vlan 151
+   name svi_with_no_tags
+!
+vlan 160
+   name Tenant_A_VMOTION
+!
+vlan 161
+   name Tenant_A_NFS
+!
+vlan 162
+   name l2vlan_with_no_tags
+!
+vlan 210
+   name Tenant_B_OP_Zone_1
+!
+vlan 211
+   name Tenant_B_OP_Zone_2
+!
+vlan 250
+   name Tenant_B_WAN_Zone_1
+!
+vlan 310
+   name Tenant_C_OP_Zone_1
+!
+vlan 311
+   name Tenant_C_OP_Zone_2
+!
+vlan 350
+   name Tenant_C_WAN_Zone_1
+!
+vrf instance MGMT
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 192.168.255.109/32
+!
+interface Loopback1
+   description VTEP_VXLAN_Tunnel_Source
+   no shutdown
+   ip address 192.168.254.109/32
+!
+interface Vxlan1
+   description evpn_services_l2_only_true_VTEP
+   vxlan source-interface Loopback1
+   vxlan udp-port 4789
+   vxlan vlan 110 vni 10110
+   vxlan vlan 111 vni 50111
+   vxlan vlan 112 vni 10112
+   vxlan vlan 120 vni 10120
+   vxlan vlan 121 vni 10121
+   vxlan vlan 130 vni 10130
+   vxlan vlan 131 vni 10131
+   vxlan vlan 132 vni 10132
+   vxlan vlan 140 vni 10140
+   vxlan vlan 141 vni 10141
+   vxlan vlan 150 vni 10150
+   vxlan vlan 151 vni 10151
+   vxlan vlan 160 vni 10160
+   vxlan vlan 161 vni 10161
+   vxlan vlan 162 vni 10162
+   vxlan vlan 210 vni 20210
+   vxlan vlan 211 vni 20211
+   vxlan vlan 250 vni 20250
+   vxlan vlan 310 vni 30310
+   vxlan vlan 311 vni 30311
+   vxlan vlan 350 vni 30350
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+   seq 20 permit 192.168.254.0/24 eq 32
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.200.5
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+router bfd
+   multihop interval 1200 min-rx 1200 multiplier 3
+!
+router bgp 101
+   router-id 192.168.255.109
+   maximum-paths 4 ecmp 4
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor UNDERLAY-PEERS peer group
+   neighbor UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor UNDERLAY-PEERS send-community
+   neighbor UNDERLAY-PEERS maximum-routes 12000
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   vlan-aware-bundle l2vlan_with_no_tags
+      rd 192.168.255.109:20162
+      route-target both 20162:20162
+      redistribute learned
+      vlan 162
+   !
+   vlan-aware-bundle Tenant_A_APP_Zone
+      rd 192.168.255.109:12
+      route-target both 12:12
+      redistribute learned
+      vlan 130-132
+   !
+   vlan-aware-bundle Tenant_A_DB_Zone
+      rd 192.168.255.109:13
+      route-target both 13:13
+      redistribute learned
+      vlan 140-141
+   !
+   vlan-aware-bundle Tenant_A_NFS
+      rd 192.168.255.109:20161
+      route-target both 20161:20161
+      redistribute learned
+      vlan 161
+   !
+   vlan-aware-bundle Tenant_A_OP_Zone
+      rd 192.168.255.109:9
+      route-target both 9:9
+      redistribute learned
+      vlan 110-112
+   !
+   vlan-aware-bundle Tenant_A_VMOTION
+      rd 192.168.255.109:20160
+      route-target both 20160:20160
+      redistribute learned
+      vlan 160
+   !
+   vlan-aware-bundle Tenant_A_WAN_Zone
+      rd 192.168.255.109:14
+      route-target both 14:14
+      redistribute learned
+      vlan 150-151
+   !
+   vlan-aware-bundle Tenant_A_WEB_Zone
+      rd 192.168.255.109:11
+      route-target both 11:11
+      redistribute learned
+      vlan 120-121
+   !
+   vlan-aware-bundle Tenant_B_OP_Zone
+      rd 192.168.255.109:20
+      route-target both 20:20
+      redistribute learned
+      vlan 210-211
+   !
+   vlan-aware-bundle Tenant_B_WAN_Zone
+      rd 192.168.255.109:21
+      route-target both 21:21
+      redistribute learned
+      vlan 250
+   !
+   vlan-aware-bundle Tenant_C_OP_Zone
+      rd 192.168.255.109:30
+      route-target both 30:30
+      redistribute learned
+      vlan 310-311
+   !
+   vlan-aware-bundle Tenant_C_WAN_Zone
+      rd 192.168.255.109:31
+      route-target both 31:31
+      redistribute learned
+      vlan 350
+   !
+   address-family evpn
+      host-flap detection window 180 threshold 5 expiry timeout 10 seconds
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor UNDERLAY-PEERS activate
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/mgmt_interface_default.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/mgmt_interface_default.cfg
@@ -1,0 +1,118 @@
+!RANCID-CONTENT-TYPE: arista
+!
+boot secret sha512 a153de6290ff1409257ade45f
+!
+daemon TerminAttr
+   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   no shutdown
+!
+vlan internal order ascending range 1006 1199
+!
+no ip igmp snooping vlan 120
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname mgmt_interface_default
+ip name-server vrf MGMT 8.8.8.8
+ip name-server vrf MGMT 192.168.200.5
+!
+ntp local-interface vrf MGMT Management1
+ntp server vrf MGMT 192.168.200.5 prefer
+!
+snmp-server contact example@example.com
+snmp-server location EOS_DESIGNS_UNIT_TESTS mgmt_interface_default
+!
+no enable password
+no aaa root
+!
+username admin privilege 15 role network-admin nopassword
+username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
+username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
+!
+vlan 110
+   name Tenant_A_OP_Zone_1
+!
+vlan 111
+   name Tenant_A_OP_Zone_2
+!
+vlan 112
+   name Tenant_A_OP_Zone_3
+!
+vlan 120
+   name Tenant_A_WEB_Zone_1
+!
+vlan 121
+   name Tenant_A_WEBZone_2
+!
+vlan 130
+   name Tenant_A_APP_Zone_1
+!
+vlan 131
+   name Tenant_A_APP_Zone_2
+!
+vlan 132
+   name Tenant_A_APP_Zone_3
+!
+vlan 140
+   name Tenant_A_DB_BZone_1
+!
+vlan 141
+   name Tenant_A_DB_Zone_2
+!
+vlan 150
+   name Tenant_A_WAN_Zone_1
+!
+vlan 151
+   name svi_with_no_tags
+!
+vlan 160
+   name Tenant_A_VMOTION
+!
+vlan 161
+   name Tenant_A_NFS
+!
+vlan 162
+   name l2vlan_with_no_tags
+!
+vlan 210
+   name Tenant_B_OP_Zone_1
+!
+vlan 211
+   name Tenant_B_OP_Zone_2
+!
+vlan 250
+   name Tenant_B_WAN_Zone_1
+!
+vlan 310
+   name Tenant_C_OP_Zone_1
+!
+vlan 311
+   name Tenant_C_OP_Zone_2
+!
+vlan 350
+   name Tenant_C_WAN_Zone_1
+!
+vrf instance MGMT
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 1.1.1.2
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.200.5
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/mgmt_interface_fabric.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/mgmt_interface_fabric.cfg
@@ -1,0 +1,118 @@
+!RANCID-CONTENT-TYPE: arista
+!
+boot secret sha512 a153de6290ff1409257ade45f
+!
+daemon TerminAttr
+   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   no shutdown
+!
+vlan internal order ascending range 1006 1199
+!
+no ip igmp snooping vlan 120
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname mgmt_interface_fabric
+ip name-server vrf MGMT 8.8.8.8
+ip name-server vrf MGMT 192.168.200.5
+!
+ntp local-interface vrf MGMT MY_INTERFACE_FABRIC
+ntp server vrf MGMT 192.168.200.5 prefer
+!
+snmp-server contact example@example.com
+snmp-server location EOS_DESIGNS_UNIT_TESTS mgmt_interface_fabric
+!
+no enable password
+no aaa root
+!
+username admin privilege 15 role network-admin nopassword
+username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
+username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
+!
+vlan 110
+   name Tenant_A_OP_Zone_1
+!
+vlan 111
+   name Tenant_A_OP_Zone_2
+!
+vlan 112
+   name Tenant_A_OP_Zone_3
+!
+vlan 120
+   name Tenant_A_WEB_Zone_1
+!
+vlan 121
+   name Tenant_A_WEBZone_2
+!
+vlan 130
+   name Tenant_A_APP_Zone_1
+!
+vlan 131
+   name Tenant_A_APP_Zone_2
+!
+vlan 132
+   name Tenant_A_APP_Zone_3
+!
+vlan 140
+   name Tenant_A_DB_BZone_1
+!
+vlan 141
+   name Tenant_A_DB_Zone_2
+!
+vlan 150
+   name Tenant_A_WAN_Zone_1
+!
+vlan 151
+   name svi_with_no_tags
+!
+vlan 160
+   name Tenant_A_VMOTION
+!
+vlan 161
+   name Tenant_A_NFS
+!
+vlan 162
+   name l2vlan_with_no_tags
+!
+vlan 210
+   name Tenant_B_OP_Zone_1
+!
+vlan 211
+   name Tenant_B_OP_Zone_2
+!
+vlan 250
+   name Tenant_B_WAN_Zone_1
+!
+vlan 310
+   name Tenant_C_OP_Zone_1
+!
+vlan 311
+   name Tenant_C_OP_Zone_2
+!
+vlan 350
+   name Tenant_C_WAN_Zone_1
+!
+vrf instance MGMT
+!
+interface MY_INTERFACE_FABRIC
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 1.1.1.2
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.200.5
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/mgmt_interface_host.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/mgmt_interface_host.cfg
@@ -1,0 +1,123 @@
+!RANCID-CONTENT-TYPE: arista
+!
+boot secret sha512 a153de6290ff1409257ade45f
+!
+daemon TerminAttr
+   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   no shutdown
+!
+vlan internal order ascending range 1006 1199
+!
+no ip igmp snooping vlan 120
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname mgmt_interface_host
+ip name-server vrf MGMT 8.8.8.8
+ip name-server vrf MGMT 192.168.200.5
+!
+ntp local-interface vrf MGMT Management1
+ntp server vrf MGMT 192.168.200.5 prefer
+!
+snmp-server contact example@example.com
+snmp-server location EOS_DESIGNS_UNIT_TESTS mgmt_interface_host
+!
+platform sand lag hardware-only
+!
+no enable password
+no aaa root
+!
+username admin privilege 15 role network-admin nopassword
+username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
+username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
+!
+vlan 110
+   name Tenant_A_OP_Zone_1
+!
+vlan 111
+   name Tenant_A_OP_Zone_2
+!
+vlan 112
+   name Tenant_A_OP_Zone_3
+!
+vlan 120
+   name Tenant_A_WEB_Zone_1
+!
+vlan 121
+   name Tenant_A_WEBZone_2
+!
+vlan 130
+   name Tenant_A_APP_Zone_1
+!
+vlan 131
+   name Tenant_A_APP_Zone_2
+!
+vlan 132
+   name Tenant_A_APP_Zone_3
+!
+vlan 140
+   name Tenant_A_DB_BZone_1
+!
+vlan 141
+   name Tenant_A_DB_Zone_2
+!
+vlan 150
+   name Tenant_A_WAN_Zone_1
+!
+vlan 151
+   name svi_with_no_tags
+!
+vlan 160
+   name Tenant_A_VMOTION
+!
+vlan 161
+   name Tenant_A_NFS
+!
+vlan 162
+   name l2vlan_with_no_tags
+!
+vlan 210
+   name Tenant_B_OP_Zone_1
+!
+vlan 211
+   name Tenant_B_OP_Zone_2
+!
+vlan 250
+   name Tenant_B_WAN_Zone_1
+!
+vlan 310
+   name Tenant_C_OP_Zone_1
+!
+vlan 311
+   name Tenant_C_OP_Zone_2
+!
+vlan 350
+   name Tenant_C_WAN_Zone_1
+!
+vrf instance MGMT
+!
+interface MY_INTERFACE_HOST
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 1.1.1.2
+!
+hardware tcam
+   system profile vxlan-routing
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.200.5
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/mgmt_interface_platform.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/configs/mgmt_interface_platform.cfg
@@ -1,0 +1,123 @@
+!RANCID-CONTENT-TYPE: arista
+!
+boot secret sha512 a153de6290ff1409257ade45f
+!
+daemon TerminAttr
+   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   no shutdown
+!
+vlan internal order ascending range 1006 1199
+!
+no ip igmp snooping vlan 120
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname mgmt_interface_platform
+ip name-server vrf MGMT 8.8.8.8
+ip name-server vrf MGMT 192.168.200.5
+!
+ntp local-interface vrf MGMT Management1
+ntp server vrf MGMT 192.168.200.5 prefer
+!
+snmp-server contact example@example.com
+snmp-server location EOS_DESIGNS_UNIT_TESTS mgmt_interface_platform
+!
+platform sand lag hardware-only
+!
+no enable password
+no aaa root
+!
+username admin privilege 15 role network-admin nopassword
+username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
+username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
+!
+vlan 110
+   name Tenant_A_OP_Zone_1
+!
+vlan 111
+   name Tenant_A_OP_Zone_2
+!
+vlan 112
+   name Tenant_A_OP_Zone_3
+!
+vlan 120
+   name Tenant_A_WEB_Zone_1
+!
+vlan 121
+   name Tenant_A_WEBZone_2
+!
+vlan 130
+   name Tenant_A_APP_Zone_1
+!
+vlan 131
+   name Tenant_A_APP_Zone_2
+!
+vlan 132
+   name Tenant_A_APP_Zone_3
+!
+vlan 140
+   name Tenant_A_DB_BZone_1
+!
+vlan 141
+   name Tenant_A_DB_Zone_2
+!
+vlan 150
+   name Tenant_A_WAN_Zone_1
+!
+vlan 151
+   name svi_with_no_tags
+!
+vlan 160
+   name Tenant_A_VMOTION
+!
+vlan 161
+   name Tenant_A_NFS
+!
+vlan 162
+   name l2vlan_with_no_tags
+!
+vlan 210
+   name Tenant_B_OP_Zone_1
+!
+vlan 211
+   name Tenant_B_OP_Zone_2
+!
+vlan 250
+   name Tenant_B_WAN_Zone_1
+!
+vlan 310
+   name Tenant_C_OP_Zone_1
+!
+vlan 311
+   name Tenant_C_OP_Zone_2
+!
+vlan 350
+   name Tenant_C_WAN_Zone_1
+!
+vrf instance MGMT
+!
+interface Management0
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 1.1.1.2
+!
+hardware tcam
+   system profile vxlan-routing
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.200.5
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/molecule.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/molecule.yml
@@ -4,13 +4,13 @@ scenario:
     - syntax
     - create
     - converge
-    #- verify       # Removed verify since it will fail with disabled convert_dicts filter
+    - verify       # Removed verify since it will fail with disabled convert_dicts filter
   test_sequence:
     - syntax
     - create
     - converge
     - idempotence
-    #- verify       # Removed verify since it will fail with disabled convert_dicts filter
+    - verify       # Removed verify since it will fail with disabled convert_dicts filter
   cleanup_sequence:
     - destroy
 dependency:
@@ -33,8 +33,8 @@ provisioner:
     defaults:
       jinja2_extensions: 'jinja2.ext.loopcontrols,jinja2.ext.do,jinja2.ext.i18n'
       gathering: explicit
-  env:
-    AVD_DISABLE_CONVERT_DICTS: "TRUE"
+  # env:
+  #   AVD_DISABLE_CONVERT_DICTS: "TRUE"
   inventory:
     links:
       hosts: 'inventory/hosts.yml'

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -100,15 +100,15 @@ keys:
     convert_types:
     - dict
     display_name: IP Community Lists
-    description: "AVD supports 2 different data models for community lists:\n\n- The
-      legacy `community_lists` data model that can be used for compatibility with
-      the existing deployments.\n- The improved `ip_community_lists` data model.\n\nBoth
-      data models can coexist without conflicts, as different keys are used: `community_lists`
-      vs `ip_community_lists`.\nCommunity list names must be unique.\n\nThe improved
-      data model has a better design documented below:\n\ncommunities and regexp MUST
-      not be configured together in the same entry\npossible community strings are
-      (case insensitive):\n - GSHUT\n - internet\n - local-as\n - no-advertise\n -
-      no-export\n - <1-4294967040>\n - aa:nn\n"
+    description: "AVD supports 2 different data models for community lists:\n\n- The\
+      \ legacy `community_lists` data model that can be used for compatibility with\
+      \ the existing deployments.\n- The improved `ip_community_lists` data model.\n\
+      \nBoth data models can coexist without conflicts, as different keys are used:\
+      \ `community_lists` vs `ip_community_lists`.\nCommunity list names must be unique.\n\
+      \nThe improved data model has a better design documented below:\n\ncommunities\
+      \ and regexp MUST not be configured together in the same entry\npossible community\
+      \ strings are (case insensitive):\n - GSHUT\n - internet\n - local-as\n - no-advertise\n\
+      \ - no-export\n - <1-4294967040>\n - aa:nn\n"
     items:
       type: dict
       keys:


### PR DESCRIPTION
## Change Summary

This PR intends to enable config generation for molecule test eos_designs_unit_tests_4.0

It was necessary to enable `convert_dict` in the molecule.yml file to generate new format eos_cli_config_gen strutcured_config (or it fails)

## Component(s) name

`arista.avd.eos_designs`

## How to test

Let the molecule test run

## Checklist


### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
