### PR TITLE
Feat(eos_cli_config_gen): Add schema for interface_groups

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -87,6 +87,34 @@ daemons:
     enabled: <bool>
 ```
 
+## Maintenance Interface Groups
+
+### Variables
+
+| Variable | Type | Required | Default | Value Restrictions | Description |
+| -------- | ---- | -------- | ------- | ------------------ | ----------- |
+| [<samp>interface_groups</samp>](## "interface_groups") | List, items: Dictionary |  |  |  | Maintenance Interface Groups |
+| [<samp>&nbsp;&nbsp;- name</samp>](## "interface_groups.[].name") | String | Required, Unique |  |  | Interface-Group name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;interfaces</samp>](## "interface_groups.[].interfaces") | List, items: String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "interface_groups.[].interfaces.[].&lt;str&gt;") | String |  |  |  | Interface Name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;bgp_maintenance_profiles</samp>](## "interface_groups.[].bgp_maintenance_profiles") | List, items: String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "interface_groups.[].bgp_maintenance_profiles.[].&lt;str&gt;") | String |  |  |  | Name of BGP Maintenance Profile |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;interface_maintenance_profiles</samp>](## "interface_groups.[].interface_maintenance_profiles") | List, items: String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "interface_groups.[].interface_maintenance_profiles.[].&lt;str&gt;") | String |  |  |  | Name of Interface Maintenance Profile |
+
+### YAML
+
+```yaml
+interface_groups:
+  - name: <str>
+    interfaces:
+      - <str>
+    bgp_maintenance_profiles:
+      - <str>
+    interface_maintenance_profiles:
+      - <str>
+```
+
 ## Interface Profiles
 
 ### Variables

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -142,15 +142,15 @@ keys:
     convert_types:
     - dict
     display_name: IP Community Lists
-    description: "AVD supports 2 different data models for community lists:\n\n- The
-      legacy `community_lists` data model that can be used for compatibility with
-      the existing deployments.\n- The improved `ip_community_lists` data model.\n\nBoth
-      data models can coexist without conflicts, as different keys are used: `community_lists`
-      vs `ip_community_lists`.\nCommunity list names must be unique.\n\nThe improved
-      data model has a better design documented below:\n\ncommunities and regexp MUST
-      not be configured together in the same entry\npossible community strings are
-      (case insensitive):\n - GSHUT\n - internet\n - local-as\n - no-advertise\n -
-      no-export\n - <1-4294967040>\n - aa:nn\n"
+    description: "AVD supports 2 different data models for community lists:\n\n- The\
+      \ legacy `community_lists` data model that can be used for compatibility with\
+      \ the existing deployments.\n- The improved `ip_community_lists` data model.\n\
+      \nBoth data models can coexist without conflicts, as different keys are used:\
+      \ `community_lists` vs `ip_community_lists`.\nCommunity list names must be unique.\n\
+      \nThe improved data model has a better design documented below:\n\ncommunities\
+      \ and regexp MUST not be configured together in the same entry\npossible community\
+      \ strings are (case insensitive):\n - GSHUT\n - internet\n - local-as\n - no-advertise\n\
+      \ - no-export\n - <1-4294967040>\n - aa:nn\n"
     items:
       type: dict
       keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -95,6 +95,7 @@ keys:
             Example: "permit GSHUT 65123:123"'
   daemons:
     type: list
+    display_name: Maintenance Interface Groups
     primary_key: name
     convert_types:
     - dict

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -143,15 +143,15 @@ keys:
     convert_types:
     - dict
     display_name: IP Community Lists
-    description: "AVD supports 2 different data models for community lists:\n\n- The\
-      \ legacy `community_lists` data model that can be used for compatibility with\
-      \ the existing deployments.\n- The improved `ip_community_lists` data model.\n\
-      \nBoth data models can coexist without conflicts, as different keys are used:\
-      \ `community_lists` vs `ip_community_lists`.\nCommunity list names must be unique.\n\
-      \nThe improved data model has a better design documented below:\n\ncommunities\
-      \ and regexp MUST not be configured together in the same entry\npossible community\
-      \ strings are (case insensitive):\n - GSHUT\n - internet\n - local-as\n - no-advertise\n\
-      \ - no-export\n - <1-4294967040>\n - aa:nn\n"
+    description: "AVD supports 2 different data models for community lists:\n\n- The
+      legacy `community_lists` data model that can be used for compatibility with
+      the existing deployments.\n- The improved `ip_community_lists` data model.\n\nBoth
+      data models can coexist without conflicts, as different keys are used: `community_lists`
+      vs `ip_community_lists`.\nCommunity list names must be unique.\n\nThe improved
+      data model has a better design documented below:\n\ncommunities and regexp MUST
+      not be configured together in the same entry\npossible community strings are
+      (case insensitive):\n - GSHUT\n - internet\n - local-as\n - no-advertise\n -
+      no-export\n - <1-4294967040>\n - aa:nn\n"
     items:
       type: dict
       keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -95,7 +95,6 @@ keys:
             Example: "permit GSHUT 65123:123"'
   daemons:
     type: list
-    display_name: Maintenance Interface Groups
     primary_key: name
     convert_types:
     - dict
@@ -116,6 +115,34 @@ keys:
         enabled:
           type: bool
           default: true
+  interface_groups:
+    type: list
+    display_name: Maintenance Interface Groups
+    primary_key: name
+    convert_types:
+    - dict
+    items:
+      type: dict
+      keys:
+        name:
+          type: str
+          required: true
+          display_name: Interface-Group name
+        interfaces:
+          type: list
+          items:
+            type: str
+            description: Interface Name
+        bgp_maintenance_profiles:
+          type: list
+          items:
+            type: str
+            description: Name of BGP Maintenance Profile
+        interface_maintenance_profiles:
+          type: list
+          items:
+            type: str
+            description: Name of Interface Maintenance Profile
   interface_profiles:
     type: list
     primary_key: name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/interface_groups.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/interface_groups.schema.yml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  interface_groups:
+    type: list
+    primary_key: name
+    convert_types:
+      - dict
+    display_name: Interface Groups
+    items:
+      type: dict
+      keys:
+        name:
+          type: str
+          required: true
+          display_name: Group-name
+        interfaces:
+          type: list
+          items:
+            type: str
+        bgp_maintenance_profiles:
+          type: list
+          items:
+            type: str
+        interface_maintenance_profiles:
+          type: list
+          items:
+            type: str

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/interface_groups.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/interface_groups.schema.yml
@@ -5,6 +5,7 @@ type: dict
 keys:
   interface_groups:
     type: list
+    display_name: Maintenance Interface Groups
     primary_key: name
     convert_types:
       - dict
@@ -19,11 +20,14 @@ keys:
           type: list
           items:
             type: str
+            description: Interface Name
         bgp_maintenance_profiles:
           type: list
           items:
             type: str
+            description: Name of BGP Maintenance Profile
         interface_maintenance_profiles:
           type: list
           items:
             type: str
+            description: Name of Interface Maintenance Profile

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/interface_groups.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/interface_groups.schema.yml
@@ -8,14 +8,13 @@ keys:
     primary_key: name
     convert_types:
       - dict
-    display_name: Interface Groups
     items:
       type: dict
       keys:
         name:
           type: str
           required: true
-          display_name: Group-name
+          display_name: Interface-Group name
         interfaces:
           type: list
           items:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/interface-groups.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/interface-groups.j2
@@ -6,7 +6,7 @@
 
 | Interface Group | Interfaces | Interface maintenance profile | BGP maintenance profiles |
 | --------------- | ---------- | ----------------------------- | ------------------------ |
-{%     for interface_group in interface_groups | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%     for interface_group in interface_groups | arista.avd.natural_sort('name') %}
 {%         set interfaces = interface_group.interfaces | arista.avd.natural_sort | join('<br>') %}
 {%         if interface_group.interface_maintenance_profiles is arista.avd.defined %}
 {%             set interface_profile = interface_group.interface_maintenance_profiles | arista.avd.natural_sort | join('<br>') %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/interface-groups.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/interface-groups.j2
@@ -1,4 +1,4 @@
-{% for interface_group in interface_groups | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{% for interface_group in interface_groups | arista.avd.natural_sort('name') %}
 !
 group interface {{ interface_group.name }}
 {%     for interface in interface_group.interfaces | arista.avd.natural_sort %}


### PR DESCRIPTION
## Add schema for data model

<!-- Use this PR Title: Feat(eos_cli_config_gen): Add schema for interface_groups -->

## Checklist

### Contributor Checklist

- [x] Create schema fragment matching data model described in README.md and README_v4.0.md
  - README.md is most complete with all keys. README_v4.0 includes partial data models after conversion to lists.
  - Schema fragment path is `roles/eos_cli_config_gen/schemas/schema_fragments/<data_model_key>.schema.yml`.
  - Copy line 1-5 from another schema (comments and outer type:dict).
  - Refer to [schema documentation](https://avd.sh/en/devel/docs/input-variable-validation-BETA.html) for syntax and/or use YAML Lint plugin from Redhat in VSCode.
  - Use `convert_types` on value that could be mixed type or misinterpreted like integers and numeric strings.
- [x] If the data model has been converted from wildcard dicts:
  - Add `convert_types: ['dict']` to the schema.
  - Remove `convert_dicts` from the `templates/eos/<>.j2` and `templates/documentation/<>.j2` templates.
- [x] Run `molecule converge -s build_schemas_and_docs` to update schema and documentation.
- [x] Test by running `molecule converge -s eos_cli_config_gen` and verify no errors or changes to generated configs/docs.

### Reviewer Checklist

- Reviewer 1:
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2:
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
