### PR TITLE
Feat(eos_cli_config_gen): Add schema for sflow

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/group_vars/all.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/group_vars/all.yml
@@ -8,3 +8,5 @@ management_interfaces:
     vrf: MGMT
     ip_address: 10.73.255.122/24
     gateway: 10.73.255.2
+
+avd_validate_validation_mode: "error"

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/group_vars/all.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/group_vars/all.yml
@@ -8,3 +8,5 @@ management_interfaces:
     vrf: MGMT
     ip_address: 10.73.255.122/24
     gateway: 10.73.255.2
+
+avd_validate_validation_mode: "error"

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/inventory/group_vars/all.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/inventory/group_vars/all.yml
@@ -1,4 +1,3 @@
 ---
-root_dir: '{{playbook_dir}}'
 
 avd_validate_validation_mode: "error"

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/inventory/group_vars/all.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/inventory/group_vars/all.yml
@@ -1,2 +1,4 @@
 ---
 root_dir: '{{playbook_dir}}'
+
+avd_validate_validation_mode: "error"

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/all.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/all.yml
@@ -1,2 +1,4 @@
 ---
 root_dir: '{{ playbook_dir }}'
+
+avd_validate_validation_mode: "error"

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/inventory/group_vars/all.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/inventory/group_vars/all.yml
@@ -74,3 +74,5 @@ default_node_type_keys:
       default_overlay_routing_protocol: ibgp
       default_underlay_routing_protocol: isis-sr
       default_overlay_address_families: [ vpn-ipv4 ]
+
+avd_validate_validation_mode: "error"

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/all.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/all.yml
@@ -1,4 +1,3 @@
 ---
-root_dir: '{{playbook_dir}}'
 
 avd_validate_validation_mode: "error"

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/inventory/group_vars/all.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/inventory/group_vars/all.yml
@@ -1,4 +1,3 @@
 ---
-root_dir: '{{playbook_dir}}'
 
 avd_validate_validation_mode: "error"

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/inventory/group_vars/all.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/inventory/group_vars/all.yml
@@ -1,4 +1,3 @@
 ---
-root_dir: '{{playbook_dir}}'
 
 avd_validate_validation_mode: "error"

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/inventory/group_vars/all.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/inventory/group_vars/all.yml
@@ -1,4 +1,3 @@
 ---
-root_dir: '{{playbook_dir}}'
 
 avd_validate_validation_mode: "error"

--- a/ansible_collections/arista/avd/molecule/upgrade_eos_cli_config_gen/inventory/group_vars/all.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_eos_cli_config_gen/inventory/group_vars/all.yml
@@ -8,3 +8,6 @@ management_interfaces:
     vrf: MGMT
     ip_address: 10.73.255.122/24
     gateway: 10.73.255.2
+
+
+avd_validate_validation_mode: "error"

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/inventory/group_vars/all.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/inventory/group_vars/all.yml
@@ -3,3 +3,5 @@ root_dir: '{{playbook_dir}}'
 
 snmp_settings:
   location: true
+
+avd_validate_validation_mode: "error"

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/all.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/all.yml
@@ -1,4 +1,3 @@
 ---
-root_dir: '{{playbook_dir}}'
 
 avd_validate_validation_mode: "error"

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/inventory/group_vars/all.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/inventory/group_vars/all.yml
@@ -1,4 +1,3 @@
 ---
-root_dir: '{{playbook_dir}}'
 
 avd_validate_validation_mode: "error"

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/inventory/group_vars/all.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/inventory/group_vars/all.yml
@@ -1,4 +1,3 @@
 ---
-root_dir: '{{playbook_dir}}'
 
 avd_validate_validation_mode: "error"

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/inventory/group_vars/all.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/inventory/group_vars/all.yml
@@ -1,4 +1,3 @@
 ---
-root_dir: '{{playbook_dir}}'
 
 avd_validate_validation_mode: "error"

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -254,7 +254,7 @@ match_list_input:
 | Variable | Type | Required | Default | Value Restrictions | Description |
 | -------- | ---- | -------- | ------- | ------------------ | ----------- |
 | [<samp>sflow</samp>](## "sflow") | Dictionary |  |  |  | Sflow |
-| [<samp>&nbsp;&nbsp;sample</samp>](## "sflow.sample") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;sample</samp>](## "sflow.sample") | Integer |  |  |  |  |
 | [<samp>&nbsp;&nbsp;dangerous</samp>](## "sflow.dangerous") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;vrfs</samp>](## "sflow.vrfs") | List, items: Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "sflow.vrfs.[].name") | String |  |  |  | VRF |
@@ -270,12 +270,18 @@ match_list_input:
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;disable</samp>](## "sflow.interface.disable") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;default</samp>](## "sflow.interface.disable.default") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;run</samp>](## "sflow.run") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;hardware_acceleration</samp>](## "sflow.hardware_acceleration") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "sflow.hardware_acceleration.enabled") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;sample</samp>](## "sflow.hardware_acceleration.sample") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;modules</samp>](## "sflow.hardware_acceleration.modules") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "sflow.hardware_acceleration.modules.[].name") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "sflow.hardware_acceleration.modules.[].enabled") | Boolean |  | True |  |  |
 
 ### YAML
 
 ```yaml
 sflow:
-  sample: <str>
+  sample: <int>
   dangerous: <bool>
   vrfs:
     - name: <str>
@@ -291,6 +297,12 @@ sflow:
     disable:
       default: <bool>
   run: <bool>
+  hardware_acceleration:
+    enabled: <bool>
+    sample: <int>
+    modules:
+      - name: <str>
+        enabled: <bool>
 ```
 
 ## Standard Access-Lists

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -318,7 +318,9 @@ keys:
     display_name: Sflow
     keys:
       sample:
-        type: str
+        type: int
+        convert_types:
+        - str
       dangerous:
         type: bool
       vrfs:
@@ -380,6 +382,26 @@ keys:
                 type: bool
       run:
         type: bool
+      hardware_acceleration:
+        type: dict
+        keys:
+          enabled:
+            type: bool
+          sample:
+            type: int
+            convert_types:
+            - str
+          modules:
+            type: list
+            primary_key: name
+            items:
+              type: dict
+              keys:
+                name:
+                  type: str
+                enabled:
+                  type: bool
+                  default: true
   standard_access_lists:
     type: list
     primary_key: name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/sflow.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/sflow.schema.yml
@@ -73,3 +73,23 @@ keys:
                 type: bool
       run:
         type: bool
+      hardware_acceleration:
+        type: dict
+        keys:
+          enabled:
+            type: bool
+          sample:
+            type: int
+            convert_types:
+            - str
+          modules:
+            type: list
+            primary_key: name
+            items:
+              type: dict
+              keys:
+                name:
+                  type: str
+                enabled:
+                  type: bool
+                  default: true

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/sflow.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/sflow.schema.yml
@@ -9,7 +9,9 @@ keys:
     display_name: Sflow
     keys:
       sample:
-        type: str
+        type: int
+        convert_types:
+        - str
       dangerous:
         type: bool
       vrfs:


### PR DESCRIPTION
## Add schema for data model

<!-- Use this PR Title: Feat(eos_cli_config_gen): Add schema for hardware_counters -->

Fix issue with `sflow.sample` type/auto conversion, and adding `sflow.hardware_accelleration` key missed in PR #2036 

Additionally, now enforcing validation on the `eos_cli_config_gen` molecule scenario to trigger CI failure.
See commit [d3a41fd](https://github.com/aristanetworks/ansible-avd/pull/2056/commits/d3a41fdb048280efeabc1e2f5c7a1d5043149846) which triggered CI failure.

## Checklist

### Contributor Checklist

- [x] Create schema fragment matching data model described in README.md and README_v4.0.md
  - README.md is most complete with all keys. README_v4.0 includes partial data models after conversion to lists.
  - Schema fragment path is `roles/eos_cli_config_gen/schemas/schema_fragments/<data_model_key>.schema.yml`.
  - Copy line 1-5 from another schema (comments and outer type:dict).
  - Refer to [schema documentation](https://avd.sh/en/devel/docs/input-variable-validation-BETA.html) for syntax and/or use YAML Lint plugin from Redhat in VSCode.
  - Use `convert_types` on value that could be mixed type or misinterpreted like integers and numeric strings.
- [x] If the data model has been converted from wildcard dicts:
  - Add `convert_types: ['dict']` to the schema.
  - Remove `convert_dicts` from the `templates/eos/<>.j2` and `templates/documentation/<>.j2` templates.
- [x] Run `molecule converge -s build_schemas_and_docs` to update schema and documentation.
- [x] Test by running `molecule converge -s eos_cli_config_gen` and verify no errors or changes to generated configs/docs.

### Reviewer Checklist

- Reviewer 1:
  - [ ] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [ ] Verify that `convert_dicts` has been removed from templates as applicable.
  - [ ] Verify no changes to configs/docs on any molecule scenario
  - [ ] Verify that CI pass

- Reviewer 2:
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
