### PR TITLE
Feat(eos_cli_config_gen): Add schema for router-pim-sparse-mode

### DIFF
--- a/ansible_collections/arista/avd/plugins/plugin_utils/schema/avd_meta_schema.json
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/schema/avd_meta_schema.json
@@ -170,7 +170,7 @@
                         },
                         "convert_types": {
                             "type": "array",
-                            "description": "List of types to auto-convert from.\nFor 'list' auto-conversion is supported from 'dict' if 'primary_key' is set on the list schema",
+                            "description": "List of types to auto-convert from.\nFor 'list of dicts' auto-conversion is supported from 'dict' if 'primary_key' is set on the list schema\nFor other list item types conversion from dict will use the keys as list items.",
                             "items": {
                                 "type": "string",
                                 "enum": [

--- a/ansible_collections/arista/avd/plugins/plugin_utils/schema/avddataconverter.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/schema/avddataconverter.py
@@ -185,6 +185,14 @@ def _convert_types(validator, convert_types: list, instance, schema: dict):
                     converted_instance = instance
                     pass
                 return converted_instance
+            elif convert_type == "dict" and schema_type == "list":
+                try:
+                    converted_instance = list(instance)
+                except Exception:
+                    # Ignore errors and return original
+                    converted_instance = instance
+                    pass
+                return converted_instance
     return instance
 
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -1941,6 +1941,56 @@ router_igmp:
   ssm_aware: <bool>
 ```
 
+## Routing PIM Sparse Mode
+
+### Variables
+
+| Variable | Type | Required | Default | Value Restrictions | Description |
+| -------- | ---- | -------- | ------- | ------------------ | ----------- |
+| [<samp>router_pim_sparse_mode</samp>](## "router_pim_sparse_mode") | Dictionary |  |  |  | Routing PIM Sparse Mode |
+| [<samp>&nbsp;&nbsp;ipv4</samp>](## "router_pim_sparse_mode.ipv4") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ssm_range</samp>](## "router_pim_sparse_mode.ipv4.ssm_range") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;rp_addresses</samp>](## "router_pim_sparse_mode.ipv4.rp_addresses") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- address</samp>](## "router_pim_sparse_mode.ipv4.rp_addresses.[].address") | String | Required, Unique |  |  | RP Address |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;groups</samp>](## "router_pim_sparse_mode.ipv4.rp_addresses.[].groups") | List, items: String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "router_pim_sparse_mode.ipv4.rp_addresses.[].groups.[].&lt;str&gt;") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;anycast_rps</samp>](## "router_pim_sparse_mode.ipv4.anycast_rps") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- address</samp>](## "router_pim_sparse_mode.ipv4.anycast_rps.[].address") | String | Required, Unique |  |  | Anycast RP Address |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;other_anycast_rp_addresses</samp>](## "router_pim_sparse_mode.ipv4.anycast_rps.[].other_anycast_rp_addresses") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- address</samp>](## "router_pim_sparse_mode.ipv4.anycast_rps.[].other_anycast_rp_addresses.[].address") | String | Required, Unique |  |  | Other Anycast RP Address |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;register_count</samp>](## "router_pim_sparse_mode.ipv4.anycast_rps.[].other_anycast_rp_addresses.[].register_count") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;vrfs</samp>](## "router_pim_sparse_mode.vrfs") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "router_pim_sparse_mode.vrfs.[].name") | String |  |  |  | VRF Name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4</samp>](## "router_pim_sparse_mode.vrfs.[].ipv4") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rp_addresses</samp>](## "router_pim_sparse_mode.vrfs.[].ipv4.rp_addresses") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- address</samp>](## "router_pim_sparse_mode.vrfs.[].ipv4.rp_addresses.[].address") | String |  |  |  | RP Address |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;groups</samp>](## "router_pim_sparse_mode.vrfs.[].ipv4.rp_addresses.[].groups") | List, items: String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "router_pim_sparse_mode.vrfs.[].ipv4.rp_addresses.[].groups.[].&lt;str&gt;") | String |  |  |  |  |
+
+### YAML
+
+```yaml
+router_pim_sparse_mode:
+  ipv4:
+    ssm_range: <str>
+    rp_addresses:
+      - address: <str>
+        groups:
+          - <str>
+    anycast_rps:
+      - address: <str>
+        other_anycast_rp_addresses:
+          - address: <str>
+            register_count: <int>
+  vrfs:
+    - name: <str>
+      ipv4:
+        rp_addresses:
+          - address: <str>
+            groups:
+              - <str>
+```
+
 ## Service Routing Protocols Model
 
 ### Variables

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -1948,21 +1948,21 @@ router_igmp:
 | Variable | Type | Required | Default | Value Restrictions | Description |
 | -------- | ---- | -------- | ------- | ------------------ | ----------- |
 | [<samp>router_pim_sparse_mode</samp>](## "router_pim_sparse_mode") | Dictionary |  |  |  | Routing PIM Sparse Mode |
-| [<samp>&nbsp;&nbsp;ipv4</samp>](## "router_pim_sparse_mode.ipv4") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ssm_range</samp>](## "router_pim_sparse_mode.ipv4.ssm_range") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;rp_addresses</samp>](## "router_pim_sparse_mode.ipv4.rp_addresses") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;ipv4</samp>](## "router_pim_sparse_mode.ipv4") | Dictionary |  |  |  | IPv4 |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ssm_range</samp>](## "router_pim_sparse_mode.ipv4.ssm_range") | String |  |  |  | IPv4 Prefix associated with SSM |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;rp_addresses</samp>](## "router_pim_sparse_mode.ipv4.rp_addresses") | List, items: Dictionary |  |  |  | RP Addresses |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- address</samp>](## "router_pim_sparse_mode.ipv4.rp_addresses.[].address") | String | Required, Unique |  |  | RP Address |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;groups</samp>](## "router_pim_sparse_mode.ipv4.rp_addresses.[].groups") | List, items: String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "router_pim_sparse_mode.ipv4.rp_addresses.[].groups.[].&lt;str&gt;") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;anycast_rps</samp>](## "router_pim_sparse_mode.ipv4.anycast_rps") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;anycast_rps</samp>](## "router_pim_sparse_mode.ipv4.anycast_rps") | List, items: Dictionary |  |  |  | Anycast RPs |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- address</samp>](## "router_pim_sparse_mode.ipv4.anycast_rps.[].address") | String | Required, Unique |  |  | Anycast RP Address |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;other_anycast_rp_addresses</samp>](## "router_pim_sparse_mode.ipv4.anycast_rps.[].other_anycast_rp_addresses") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;other_anycast_rp_addresses</samp>](## "router_pim_sparse_mode.ipv4.anycast_rps.[].other_anycast_rp_addresses") | List, items: Dictionary |  |  |  | Other Anycast RP Addresses |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- address</samp>](## "router_pim_sparse_mode.ipv4.anycast_rps.[].other_anycast_rp_addresses.[].address") | String | Required, Unique |  |  | Other Anycast RP Address |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;register_count</samp>](## "router_pim_sparse_mode.ipv4.anycast_rps.[].other_anycast_rp_addresses.[].register_count") | Integer |  |  |  |  |
-| [<samp>&nbsp;&nbsp;vrfs</samp>](## "router_pim_sparse_mode.vrfs") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;vrfs</samp>](## "router_pim_sparse_mode.vrfs") | List, items: Dictionary |  |  |  | VRFs |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "router_pim_sparse_mode.vrfs.[].name") | String |  |  |  | VRF Name |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4</samp>](## "router_pim_sparse_mode.vrfs.[].ipv4") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rp_addresses</samp>](## "router_pim_sparse_mode.vrfs.[].ipv4.rp_addresses") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rp_addresses</samp>](## "router_pim_sparse_mode.vrfs.[].ipv4.rp_addresses") | List, items: Dictionary |  |  |  | RP Addresses |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- address</samp>](## "router_pim_sparse_mode.vrfs.[].ipv4.rp_addresses.[].address") | String |  |  |  | RP Address |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;groups</samp>](## "router_pim_sparse_mode.vrfs.[].ipv4.rp_addresses.[].groups") | List, items: String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "router_pim_sparse_mode.vrfs.[].ipv4.rp_addresses.[].groups.[].&lt;str&gt;") | String |  |  |  |  |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -3178,6 +3178,128 @@
       },
       "additionalProperties": false
     },
+    "router_pim_sparse_mode": {
+      "type": "object",
+      "title": "Routing PIM Sparse Mode",
+      "properties": {
+        "ipv4": {
+          "type": "object",
+          "properties": {
+            "ssm_range": {
+              "type": "string",
+              "title": "Ssm Range"
+            },
+            "rp_addresses": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "address": {
+                    "type": "string",
+                    "title": "RP Address"
+                  },
+                  "groups": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Groups"
+                  }
+                },
+                "required": [
+                  "address"
+                ],
+                "additionalProperties": false
+              },
+              "title": "Rp Addresses"
+            },
+            "anycast_rps": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "address": {
+                    "type": "string",
+                    "title": "Anycast RP Address"
+                  },
+                  "other_anycast_rp_addresses": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "address": {
+                          "type": "string",
+                          "title": "Other Anycast RP Address"
+                        },
+                        "register_count": {
+                          "type": "integer",
+                          "title": "Register Count"
+                        }
+                      },
+                      "required": [
+                        "address"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "title": "Other Anycast Rp Addresses"
+                  }
+                },
+                "required": [
+                  "address"
+                ],
+                "additionalProperties": false
+              },
+              "title": "Anycast Rps"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Ipv4"
+        },
+        "vrfs": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "VRF Name"
+              },
+              "ipv4": {
+                "type": "object",
+                "properties": {
+                  "rp_addresses": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "address": {
+                          "type": "string",
+                          "title": "RP Address"
+                        },
+                        "groups": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "title": "Groups"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "title": "Rp Addresses"
+                  }
+                },
+                "additionalProperties": false,
+                "title": "Ipv4"
+              }
+            },
+            "additionalProperties": false
+          },
+          "title": "Vrfs"
+        }
+      },
+      "additionalProperties": false
+    },
     "service_routing_protocols_model": {
       "type": "string",
       "enum": [

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -3184,13 +3184,16 @@
       "properties": {
         "ipv4": {
           "type": "object",
+          "title": "IPv4",
           "properties": {
             "ssm_range": {
               "type": "string",
+              "description": "IPv4 Prefix associated with SSM",
               "title": "Ssm Range"
             },
             "rp_addresses": {
               "type": "array",
+              "title": "RP Addresses",
               "items": {
                 "type": "object",
                 "properties": {
@@ -3210,11 +3213,11 @@
                   "address"
                 ],
                 "additionalProperties": false
-              },
-              "title": "Rp Addresses"
+              }
             },
             "anycast_rps": {
               "type": "array",
+              "title": "Anycast RPs",
               "items": {
                 "type": "object",
                 "properties": {
@@ -3224,6 +3227,7 @@
                   },
                   "other_anycast_rp_addresses": {
                     "type": "array",
+                    "title": "Other Anycast RP Addresses",
                     "items": {
                       "type": "object",
                       "properties": {
@@ -3240,23 +3244,21 @@
                         "address"
                       ],
                       "additionalProperties": false
-                    },
-                    "title": "Other Anycast Rp Addresses"
+                    }
                   }
                 },
                 "required": [
                   "address"
                 ],
                 "additionalProperties": false
-              },
-              "title": "Anycast Rps"
+              }
             }
           },
-          "additionalProperties": false,
-          "title": "Ipv4"
+          "additionalProperties": false
         },
         "vrfs": {
           "type": "array",
+          "title": "VRFs",
           "items": {
             "type": "object",
             "properties": {
@@ -3269,6 +3271,7 @@
                 "properties": {
                   "rp_addresses": {
                     "type": "array",
+                    "title": "RP Addresses",
                     "items": {
                       "type": "object",
                       "properties": {
@@ -3285,8 +3288,7 @@
                         }
                       },
                       "additionalProperties": false
-                    },
-                    "title": "Rp Addresses"
+                    }
                   }
                 },
                 "additionalProperties": false,
@@ -3294,8 +3296,7 @@
               }
             },
             "additionalProperties": false
-          },
-          "title": "Vrfs"
+          }
         }
       },
       "additionalProperties": false

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -2493,11 +2493,14 @@ keys:
     keys:
       ipv4:
         type: dict
+        display_name: IPv4
         keys:
           ssm_range:
             type: str
+            description: IPv4 Prefix associated with SSM
           rp_addresses:
             type: list
+            display_name: RP Addresses
             primary_key: address
             convert_types:
             - dict
@@ -2510,10 +2513,13 @@ keys:
                   display_name: RP Address
                 groups:
                   type: list
+                  convert_types:
+                  - dict
                   items:
                     type: str
           anycast_rps:
             type: list
+            display_name: Anycast RPs
             primary_key: address
             convert_types:
             - dict
@@ -2526,6 +2532,7 @@ keys:
                   display_name: Anycast RP Address
                 other_anycast_rp_addresses:
                   type: list
+                  display_name: Other Anycast RP Addresses
                   primary_key: address
                   convert_types:
                   - dict
@@ -2542,6 +2549,7 @@ keys:
                         - str
       vrfs:
         type: list
+        display_name: VRFs
         items:
           type: dict
           keys:
@@ -2553,6 +2561,7 @@ keys:
               keys:
                 rp_addresses:
                   type: list
+                  display_name: RP Addresses
                   items:
                     type: dict
                     keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -2487,6 +2487,82 @@ keys:
     keys:
       ssm_aware:
         type: bool
+  router_pim_sparse_mode:
+    type: dict
+    display_name: Routing PIM Sparse Mode
+    keys:
+      ipv4:
+        type: dict
+        keys:
+          ssm_range:
+            type: str
+          rp_addresses:
+            type: list
+            primary_key: address
+            convert_types:
+            - dict
+            items:
+              type: dict
+              keys:
+                address:
+                  type: str
+                  required: true
+                  display_name: RP Address
+                groups:
+                  type: list
+                  items:
+                    type: str
+          anycast_rps:
+            type: list
+            primary_key: address
+            convert_types:
+            - dict
+            items:
+              type: dict
+              keys:
+                address:
+                  type: str
+                  required: true
+                  display_name: Anycast RP Address
+                other_anycast_rp_addresses:
+                  type: list
+                  primary_key: address
+                  convert_types:
+                  - dict
+                  items:
+                    type: dict
+                    keys:
+                      address:
+                        type: str
+                        required: true
+                        display_name: Other Anycast RP Address
+                      register_count:
+                        type: int
+                        convert_types:
+                        - str
+      vrfs:
+        type: list
+        items:
+          type: dict
+          keys:
+            name:
+              type: str
+              display_name: VRF Name
+            ipv4:
+              type: dict
+              keys:
+                rp_addresses:
+                  type: list
+                  items:
+                    type: dict
+                    keys:
+                      address:
+                        type: str
+                        display_name: RP Address
+                      groups:
+                        type: list
+                        items:
+                          type: str
   service_routing_protocols_model:
     type: str
     valid_values:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_pim_sparse_mode.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_pim_sparse_mode.schema.yml
@@ -1,0 +1,81 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  router_pim_sparse_mode:
+    type: dict
+    display_name: Routing PIM Sparse Mode
+    keys:
+      ipv4:
+        type: dict
+        keys:
+          ssm_range:
+            type: str
+          rp_addresses:
+            type: list
+            primary_key: address
+            convert_types:
+            - dict
+            items:
+              type: dict
+              keys:
+                address:
+                  type: str
+                  required: true
+                  display_name: RP Address
+                groups:
+                  type: list
+                  items:
+                    type: str
+          anycast_rps:
+            type: list
+            primary_key: address
+            convert_types:
+            - dict
+            items:
+              type: dict
+              keys:
+                address:
+                  type: str
+                  required: true
+                  display_name: Anycast RP Address
+                other_anycast_rp_addresses:
+                  type: list
+                  primary_key: address
+                  convert_types:
+                  - dict
+                  items:
+                    type: dict
+                    keys:
+                      address:
+                        type: str
+                        required: true
+                        display_name: Other Anycast RP Address
+                      register_count:
+                        type: int
+                        convert_types:
+                        - str
+      vrfs:
+        type: list
+        items:
+          type: dict
+          keys:
+            name:
+              type: str
+              display_name: VRF Name
+            ipv4:
+              type: dict
+              keys:
+                rp_addresses:
+                  type: list
+                  items:
+                    type: dict
+                    keys:
+                      address:
+                        type: str
+                        display_name: RP Address
+                      groups:
+                        type: list
+                        items:
+                          type: str

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_pim_sparse_mode.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_pim_sparse_mode.schema.yml
@@ -9,11 +9,14 @@ keys:
     keys:
       ipv4:
         type: dict
+        display_name: IPv4
         keys:
           ssm_range:
             type: str
+            description: IPv4 Prefix associated with SSM
           rp_addresses:
             type: list
+            display_name: RP Addresses
             primary_key: address
             convert_types:
             - dict
@@ -26,10 +29,13 @@ keys:
                   display_name: RP Address
                 groups:
                   type: list
+                  convert_types:
+                  - dict
                   items:
                     type: str
           anycast_rps:
             type: list
+            display_name: Anycast RPs
             primary_key: address
             convert_types:
             - dict
@@ -42,6 +48,7 @@ keys:
                   display_name: Anycast RP Address
                 other_anycast_rp_addresses:
                   type: list
+                  display_name: Other Anycast RP Addresses
                   primary_key: address
                   convert_types:
                   - dict
@@ -58,6 +65,7 @@ keys:
                         - str
       vrfs:
         type: list
+        display_name: VRFs
         items:
           type: dict
           keys:
@@ -69,6 +77,7 @@ keys:
               keys:
                 rp_addresses:
                   type: list
+                  display_name: RP Addresses
                   items:
                     type: dict
                     keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-pim-sparse-mode.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-pim-sparse-mode.j2
@@ -11,7 +11,7 @@
 
 | Rendezvous Point Address | Group Address |
 | ------------------------ | ------------- |
-{%             for rp_address in router_pim_sparse_mode.ipv4.rp_addresses | arista.avd.convert_dicts('address') | arista.avd.natural_sort('address') %}
+{%             for rp_address in router_pim_sparse_mode.ipv4.rp_addresses | arista.avd.natural_sort('address') %}
 {%                 set rp_groups = rp_address.groups | arista.avd.default(['-']) | join(', ') %}
 | {{ rp_address.address }} | {{ rp_groups }} |
 {%             endfor %}
@@ -22,8 +22,8 @@
 
 | IP Anycast Address | Other Rendezvous Point Address | Register Count |
 | ------------------ | ------------------------------ | -------------- |
-{%             for anycast_rp in router_pim_sparse_mode.ipv4.anycast_rps | arista.avd.convert_dicts('address') | arista.avd.natural_sort('address') %}
-{%                 for other_anycast_rp_address in anycast_rp.other_anycast_rp_addresses | arista.avd.convert_dicts('address') | arista.avd.natural_sort('address') %}
+{%             for anycast_rp in router_pim_sparse_mode.ipv4.anycast_rps | arista.avd.natural_sort('address') %}
+{%                 for other_anycast_rp_address in anycast_rp.other_anycast_rp_addresses | arista.avd.natural_sort('address') %}
 {%                     set register_count = other_anycast_rp_address.register_count | arista.avd.default('-') %}
 | {{ anycast_rp.address }} | {{ other_anycast_rp_address.address }} | {{ register_count }} |
 {%                 endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-pim-sparse-mode.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-pim-sparse-mode.j2
@@ -4,7 +4,7 @@
 router pim sparse-mode
 {%     if router_pim_sparse_mode.ipv4 is arista.avd.defined %}
    ipv4
-{%         for rp_address in router_pim_sparse_mode.ipv4.rp_addresses | arista.avd.convert_dicts('address') | arista.avd.natural_sort('address') %}
+{%         for rp_address in router_pim_sparse_mode.ipv4.rp_addresses | arista.avd.natural_sort('address') %}
 {%             if rp_address.groups is arista.avd.defined %}
 {%                 for group in rp_address.groups | arista.avd.natural_sort %}
       rp address {{ rp_address.address }} {{ group }}
@@ -13,8 +13,8 @@ router pim sparse-mode
       rp address {{ rp_address.address }}
 {%             endif %}
 {%         endfor %}
-{%         for anycast_rp in router_pim_sparse_mode.ipv4.anycast_rps | arista.avd.convert_dicts('address') | arista.avd.natural_sort('address') %}
-{%             for other_anycast_rp_address in anycast_rp.other_anycast_rp_addresses | arista.avd.convert_dicts('address') | arista.avd.natural_sort('address') %}
+{%         for anycast_rp in router_pim_sparse_mode.ipv4.anycast_rps | arista.avd.natural_sort('address') %}
+{%             for other_anycast_rp_address in anycast_rp.other_anycast_rp_addresses | arista.avd.natural_sort('address') %}
 {%                 set other_anycast_rp_addresses_cli = "anycast-rp " ~ anycast_rp.address ~ " " ~ other_anycast_rp_address.address %}
 {%                 if other_anycast_rp_address.register_count is arista.avd.defined %}
 {%                     set other_anycast_rp_addresses_cli = other_anycast_rp_addresses_cli ~ " register-count " ~ other_anycast_rp_address.register_count %}


### PR DESCRIPTION
## Add schema for data model

<!-- Use this PR Title: Feat(eos_cli_config_gen): Add schema for < data_model_key > -->

## Checklist

### Contributor Checklist

- [x] Create schema fragment matching data model described in README.md and README_v4.0.md
  - README.md is most complete with all keys. README_v4.0 includes partial data models after conversion to lists.
  - Schema fragment path is `roles/eos_cli_config_gen/schemas/schema_fragments/<data_model_key>.schema.yml`.
  - Copy line 1-5 from another schema (comments and outer type:dict).
  - Refer to [schema documentation](https://avd.sh/en/devel/docs/input-variable-validation-BETA.html) for syntax and/or use YAML Lint plugin from Redhat in VSCode.
  - Use `convert_types` on value that could be mixed type or misinterpreted like integers and numeric strings.
- [x] If the data model has been converted from wildcard dicts:
  - Add `convert_types: ['dict']` to the schema.
  - Remove `convert_dicts` from the `templates/eos/<>.j2` and `templates/documentation/<>.j2` templates.
- [x] Run `molecule converge -s build_schemas_and_docs` to update schema and documentation.
- [x] Test by running `molecule converge -s eos_cli_config_gen` and verify no errors or changes to generated configs/docs.

### Reviewer Checklist

- Reviewer 1:
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2:
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
