### PR TITLE
Feat(eos_cli_config_gen): Add schema for management-api-http

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -411,6 +411,42 @@ maintenance:
           - <str>
 ```
 
+## Management HTTP
+
+### Variables
+
+| Variable | Type | Required | Default | Value Restrictions | Description |
+| -------- | ---- | -------- | ------- | ------------------ | ----------- |
+| [<samp>management_api_http</samp>](## "management_api_http") | Dictionary |  |  |  | Management HTTP |
+| [<samp>&nbsp;&nbsp;enable_http</samp>](## "management_api_http.enable_http") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;enable_https</samp>](## "management_api_http.enable_https") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;https_ssl_profile</samp>](## "management_api_http.https_ssl_profile") | String |  |  |  | SSL Profile Name |
+| [<samp>&nbsp;&nbsp;default_services</samp>](## "management_api_http.default_services") | Boolean |  |  |  | Enable default services: capi-doc and tapagg |
+| [<samp>&nbsp;&nbsp;enable_vrfs</samp>](## "management_api_http.enable_vrfs") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "management_api_http.enable_vrfs.[].name") | String | Required, Unique |  |  | VRF Name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;access_group</samp>](## "management_api_http.enable_vrfs.[].access_group") | String |  |  |  | Standard IPv4 ACL name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_access_group</samp>](## "management_api_http.enable_vrfs.[].ipv6_access_group") | String |  |  |  | Standard IPv6 ACL name |
+| [<samp>&nbsp;&nbsp;protocol_https_certificate</samp>](## "management_api_http.protocol_https_certificate") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;certificate</samp>](## "management_api_http.protocol_https_certificate.certificate") | String |  |  |  | Name of certificate; private key must also be specified |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;private_key</samp>](## "management_api_http.protocol_https_certificate.private_key") | String |  |  |  | Name of private key; certificate must also be specified |
+
+### YAML
+
+```yaml
+management_api_http:
+  enable_http: <bool>
+  enable_https: <bool>
+  https_ssl_profile: <str>
+  default_services: <bool>
+  enable_vrfs:
+    - name: <str>
+      access_group: <str>
+      ipv6_access_group: <str>
+  protocol_https_certificate:
+    certificate: <str>
+    private_key: <str>
+```
+
 ## Management Interfaces
 
 ### Variables

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -576,6 +576,47 @@ keys:
                   items:
                     type: str
                     description: Name of Interface Group
+  management_api_http:
+    display_name: Management HTTP
+    type: dict
+    keys:
+      enable_http:
+        type: bool
+      enable_https:
+        type: bool
+      https_ssl_profile:
+        display_name: SSL Profile Name
+        type: str
+      default_services:
+        type: bool
+        description: 'Enable default services: capi-doc and tapagg'
+      enable_vrfs:
+        type: list
+        primary_key: name
+        convert_types:
+        - dict
+        items:
+          type: dict
+          keys:
+            name:
+              display_name: VRF Name
+              type: str
+              required: true
+            access_group:
+              display_name: Standard IPv4 ACL name
+              type: str
+            ipv6_access_group:
+              display_name: Standard IPv6 ACL name
+              type: str
+      protocol_https_certificate:
+        type: dict
+        keys:
+          certificate:
+            type: str
+            description: Name of certificate; private key must also be specified
+          private_key:
+            type: str
+            description: Name of private key; certificate must also be specified
   management_interfaces:
     type: list
     primary_key: name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_api_http.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_api_http.schema.yml
@@ -12,9 +12,11 @@ keys:
       enable_https:
         type: bool
       https_ssl_profile:
+        display_name: SSL Profile Name
         type: str
       default_services:
         type: bool
+        description: "Enable default services: capi-doc and tapagg"
       enable_vrfs:
         type: list
         primary_key: name
@@ -38,5 +40,7 @@ keys:
         keys:
           certificate:
             type: str
+            description: Name of certificate; private key must also be specified
           private_key:
             type: str
+            description: Name of private key; certificate must also be specified

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_api_http.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_api_http.schema.yml
@@ -1,0 +1,42 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  management_api_http:
+    display_name: Management HTTP
+    type: dict
+    keys:
+      enable_http:
+        type: bool
+      enable_https:
+        type: bool
+      https_ssl_profile:
+        type: str
+      default_services:
+        type: bool
+      enable_vrfs:
+        type: list
+        primary_key: name
+        convert_types:
+        - dict
+        items:
+          type: dict
+          keys:
+            name:
+              display_name: VRF Name
+              type: str
+              required: true
+            access_group:
+              display_name: Standard IPv4 ACL name
+              type: str
+            ipv6_access_group:
+              display_name: Standard IPv6 ACL name
+              type: str
+      protocol_https_certificate:
+        type: dict
+        keys:
+          certificate:
+            type: str
+          private_key:
+            type: str

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-api-http.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-api-http.j2
@@ -18,7 +18,7 @@ Management HTTPS is using the SSL profile {{ management_api_http.https_ssl_profi
 
 | VRF Name | IPv4 ACL | IPv6 ACL |
 | -------- | -------- | -------- |
-{%         for vrf in management_api_http.enable_vrfs | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%         for vrf in management_api_http.enable_vrfs | arista.avd.natural_sort('name') %}
 | {{ vrf.name }} | {{ vrf.access_group | arista.avd.default('-') }} | {{ vrf.ipv6_access_group | arista.avd.default('-') }} |
 {%         endfor %}
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-api-http.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-api-http.j2
@@ -21,7 +21,7 @@ management api http-commands
    no default-services
 {%     endif %}
    no shutdown
-{%     for vrf in management_api_http.enable_vrfs | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%     for vrf in management_api_http.enable_vrfs | arista.avd.natural_sort('name') %}
    !
    vrf {{ vrf.name }}
       no shutdown


### PR DESCRIPTION
## Add schema for data model

<!-- Use this PR Title: Feat(eos_cli_config_gen): Add schema for < data_model_key > -->

## Checklist

### Contributor Checklist

- [x] Create schema fragment matching data model described in README.md and README_v4.0.md
  - README.md is most complete with all keys. README_v4.0 includes partial data models after conversion to lists.
  - Schema fragment path is `roles/eos_cli_config_gen/schemas/schema_fragments/<data_model_key>.schema.yml`.
  - Copy line 1-5 from another schema (comments and outer type:dict).
  - Refer to [schema documentation](https://avd.sh/en/devel/docs/input-variable-validation-BETA.html) for syntax and/or use YAML Lint plugin from Redhat in VSCode.
  - Use `convert_types` on value that could be mixed type or misinterpreted like integers and numeric strings.
- [x] If the data model has been converted from wildcard dicts:
  - Add `convert_types: ['dict']` to the schema.
  - Remove `convert_dicts` from the `templates/eos/<>.j2` and `templates/documentation/<>.j2` templates.
- [x] Run `molecule converge -s build_schemas_and_docs` to update schema and documentation.
- [x] Test by running `molecule converge -s eos_cli_config_gen` and verify no errors or changes to generated configs/docs.

### Reviewer Checklist

- Reviewer 1: jonxstill
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2: Carl
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
