### PR TITLE
Fix(eos_cli_config_gen): documentation failure when enable isis on vlan-interface

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
@@ -157,6 +157,12 @@ interface Management1
 | Vlan667 | 1 | 105 | 2 | Enabled | - | - | 192.0.2.1 | 2 | - |
 | Vlan667 | 2 | - | - | Enabled | - | - | - | 2 | 2001:db8::1 |
 
+#### ISIS
+
+| Interface | ISIS Instance | ISIS Metric | Mode |
+| --------- | ------------- | ----------- | ---- |
+| Vlan2002 | EVPN_UNDERLAY | - | - |
+
 #### Multicast Routing
 
 | Interface | IP Version | Static Routes Allowed | Multicast Boundaries | Export Host Routes For Multicast Sources |
@@ -384,6 +390,7 @@ interface Vlan2002
    description SVI Description
    no autostate
    vrf Tenant_B
+   isis enable EVPN_UNDERLAY
    ip address virtual 10.2.2.1/24
 !
 interface Vlan4094

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
@@ -224,6 +224,7 @@ interface Vlan2002
    description SVI Description
    no autostate
    vrf Tenant_B
+   isis enable EVPN_UNDERLAY
    ip address virtual 10.2.2.1/24
 !
 interface Vlan4094

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
@@ -15,6 +15,7 @@ vlan_interfaces:
     vrf: Tenant_B
     ip_address_virtual: 10.2.2.1/24
     no_autostate: true
+    isis_enable: "EVPN_UNDERLAY"
 
   Vlan81:
     description: IPv6 Virtual Address

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/vlan-interfaces.md
@@ -136,6 +136,12 @@ interface Management1
 | Vlan1001 | Tenant_A | a1::1/64 | - | - | - | - | True | - | - |
 | Vlan1002 | Tenant_A | a2::1/64 | - | - | - | True | True | - | - |
 
+#### ISIS
+
+| Interface | ISIS Instance | ISIS Metric | Mode |
+| --------- | ------------- | ----------- | ---- |
+| Vlan2002 | EVPN_UNDERLAY | - | - |
+
 #### Multicast Routing
 
 | Interface | IP Version | Static Routes Allowed | Multicast Boundaries | Export Host Routes For Multicast Sources |
@@ -297,6 +303,7 @@ interface Vlan2002
    description SVI Description
    no autostate
    vrf Tenant_B
+   isis enable EVPN_UNDERLAY
    ip address virtual 10.2.2.1/24
 !
 interface Vlan4094

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/vlan-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/vlan-interfaces.cfg
@@ -163,6 +163,7 @@ interface Vlan2002
    description SVI Description
    no autostate
    vrf Tenant_B
+   isis enable EVPN_UNDERLAY
    ip address virtual 10.2.2.1/24
 !
 interface Vlan4094

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/vlan-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/vlan-interfaces.yml
@@ -15,6 +15,7 @@ vlan_interfaces:
     vrf: Tenant_B
     ip_address_virtual: 10.2.2.1/24
     no_autostate: true
+    isis_enable: "EVPN_UNDERLAY"
 
   - name: Vlan81
     description: IPv6 Virtual Address

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vlan-interfaces.j2
@@ -146,9 +146,11 @@
 {%             if vlan_interface.isis_enable is arista.avd.defined %}
 {%                 set isis_metric = vlan_interface.isis_metric | arista.avd.default('-') %}
 {%                 if vlan_interface.isis_network_point_to_point is arista.avd.defined %}
-{%                     set mode = 'point-to-point' | arista.avd.default('-') %}
+{%                     set mode = "point-to-point" %}
 {%                 elif vlan_interface.isis_passive is arista.avd.defined %}
-{%                     set mode = 'passive' | arista.avd.default('-') %}
+{%                     set mode = "passive" %}
+{%                 else %}
+{%                     set mode = "-" %}
 {%                 endif %}
 | {{ vlan_interface.name }} | {{ vlan_interface.isis_enable }} | {{ isis_metric }} | {{ mode }} |
 {%             endif %}


### PR DESCRIPTION
## Change Summary

When a vlan-interface is configured with enabling isis without isis_network_point_to_point or passive, the documentation template would fail

## Related Issue(s)

Fixes #2071

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Adjust the template in the documentation template to always give a value to `mode`:

```diff
 {%                 if vlan_interface.isis_network_point_to_point is arista.avd.defined %}
-{%                     set mode = 'point-to-point' | arista.avd.default('-') %}
+{%                     set mode = "point-to-point" %}
 {%                 elif vlan_interface.isis_passive is arista.avd.defined %}
-{%                     set mode = 'passive' | arista.avd.default('-') %}
+{%                     set mode = "passive" %}
+{%                 else %}
+{%                     set mode = "-" %}
``` 
## How to test

Added a test in molecule to validate this behavior - the test was failing before the change and works now.

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
