### PR TITLE
Fix(eos_designs): Fix core_interfaces ISIS logic

### DIFF
--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1A.md
@@ -290,6 +290,7 @@ vlan 4094
 | Ethernet2 | P2P_LINK_TO_DC1-SPINE2_Ethernet6 | routed | - | 172.31.255.43/31 | default | 1500 | False | - | - |
 | Ethernet3 | P2P_LINK_TO_DC1-SPINE3_Ethernet6 | routed | - | 172.31.255.45/31 | default | 1500 | False | - | - |
 | Ethernet4 | P2P_LINK_TO_DC1-SPINE4_Ethernet6 | routed | - | 172.31.255.47/31 | default | 1500 | False | - | - |
+| Ethernet8 | P2P_LINK_TO_ROUTERX_Ethernet8 | routed | - | 100.64.0.0/31 | default | 1500 | False | - | - |
 
 #### ISIS
 
@@ -299,6 +300,7 @@ vlan 4094
 | Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point | - | - | - |
 | Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point | - | - | - |
 | Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point | - | - | - |
+| Ethernet8 | - | EVPN_UNDERLAY | 50 | point-to-point | level-2 | True | - |
 
 ### Ethernet Interfaces Device Configuration
 
@@ -353,6 +355,18 @@ interface Ethernet6
    description MLAG_PEER_DC1-BL1B_Ethernet6
    no shutdown
    channel-group 5 mode active
+!
+interface Ethernet8
+   description P2P_LINK_TO_ROUTERX_Ethernet8
+   no shutdown
+   mtu 1500
+   no switchport
+   ip address 100.64.0.0/31
+   isis enable EVPN_UNDERLAY
+   isis circuit-type level-2
+   isis metric 50
+   isis hello padding
+   isis network point-to-point
 ```
 
 ## Port-Channel Interfaces
@@ -571,6 +585,7 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | Ethernet2 | EVPN_UNDERLAY | 50 | point-to-point |
 | Ethernet3 | EVPN_UNDERLAY | 50 | point-to-point |
 | Ethernet4 | EVPN_UNDERLAY | 50 | point-to-point |
+| Ethernet8 | EVPN_UNDERLAY | 50 | point-to-point |
 | Vlan4093 | EVPN_UNDERLAY | 50 | point-to-point |
 | Loopback0 | EVPN_UNDERLAY | - | passive |
 | Loopback1 | EVPN_UNDERLAY | - | passive |

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/fabric/DC1_FABRIC-topology.csv
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/fabric/DC1_FABRIC-topology.csv
@@ -5,6 +5,7 @@ l3leaf,DC1-BL1A,Ethernet3,spine,DC1-SPINE3,Ethernet6,True
 l3leaf,DC1-BL1A,Ethernet4,spine,DC1-SPINE4,Ethernet6,True
 l3leaf,DC1-BL1A,Ethernet5,mlag_peer,DC1-BL1B,Ethernet5,True
 l3leaf,DC1-BL1A,Ethernet6,mlag_peer,DC1-BL1B,Ethernet6,True
+l3leaf,DC1-BL1A,Ethernet8,other,ROUTERX,Ethernet8,True
 l3leaf,DC1-BL1B,Ethernet1,spine,DC1-SPINE1,Ethernet7,True
 l3leaf,DC1-BL1B,Ethernet2,spine,DC1-SPINE2,Ethernet7,True
 l3leaf,DC1-BL1B,Ethernet3,spine,DC1-SPINE3,Ethernet7,True

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-BL1A.cfg
@@ -96,6 +96,18 @@ interface Ethernet6
    no shutdown
    channel-group 5 mode active
 !
+interface Ethernet8
+   description P2P_LINK_TO_ROUTERX_Ethernet8
+   no shutdown
+   mtu 1500
+   no switchport
+   ip address 100.64.0.0/31
+   isis enable EVPN_UNDERLAY
+   isis circuit-type level-2
+   isis metric 50
+   isis hello padding
+   isis network point-to-point
+!
 interface Loopback0
    description EVPN_Overlay_Peering
    no shutdown

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-BL1A.yml
@@ -193,6 +193,20 @@ ethernet_interfaces:
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
     isis_network_point_to_point: true
+  Ethernet8:
+    peer: ROUTERX
+    peer_interface: Ethernet8
+    peer_type: other
+    description: P2P_LINK_TO_ROUTERX_Ethernet8
+    type: routed
+    shutdown: false
+    mtu: 1500
+    ip_address: 100.64.0.0/31
+    isis_enable: EVPN_UNDERLAY
+    isis_metric: 50
+    isis_network_point_to_point: true
+    isis_hello_padding: true
+    isis_circuit_type: level-2
 mlag_configuration:
   domain_id: DC1_BL1
   local_interface: Vlan4094

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/inventory/group_vars/DC1_FABRIC.yml
@@ -171,3 +171,11 @@ bfd_multihop:
   interval: 1200
   min_rx: 1200
   multiplier: 3
+
+# Test core_interfaces ISIS for non-mpls fabric
+core_interfaces:
+  p2p_links:
+    - id: 1
+      ip: [ 100.64.0.0/31, 100.64.0.1/31 ]
+      nodes: [ DC1-BL1A, ROUTERX ]
+      interfaces: [ Ethernet8, Ethernet8 ]

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/core_interfaces/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/core_interfaces/ethernet-interfaces.j2
@@ -34,7 +34,7 @@ ethernet_interfaces:
     ospf_network_point_to_point: true
     ospf_area: {{ underlay_ospf_area }}
 {%         endif %}
-{%         if switch.mpls_lsr is arista.avd.defined(true) and switch.underlay_routing_protocol in ["isis", "isis-ldp", "isis-sr", "isis-sr-ldp"] %}
+{%         if switch.underlay_routing_protocol in ["isis", "isis-ldp", "isis-sr", "isis-sr-ldp"] %}
     isis_enable: {{ switch.isis_instance_name }}
     isis_metric: {{ p2p_interface.isis_metric }}
 {%             if p2p_interface.isis_network_type == "point-to-point" %}


### PR DESCRIPTION
## Change Summary

Fixed use of core_interfaces for underlay purposes for non-MPLS scenarios. This was not working before due to a requirement of switch.mpls_lsr: true to render all ISIS-related variables.


## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
Removed requirement for switch.mpls_lsr: true on core_interfaces for ISIS variables to render.

## How to test
Tested with own repo.

### Repository Checklist

- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
