### PR TITLE
Feat(eos_cli_config_gen): Add schema for bgp_groups

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -37,6 +37,32 @@ access_lists:
         action: <str>
 ```
 
+## Bgp Groups
+
+### Variables
+
+| Variable | Type | Required | Default | Value Restrictions | Description |
+| -------- | ---- | -------- | ------- | ------------------ | ----------- |
+| [<samp>bgp_groups</samp>](## "bgp_groups") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;- name</samp>](## "bgp_groups.[].name") | String | Required, Unique |  |  | Group Name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "bgp_groups.[].vrf") | String |  |  |  | VRF |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;neighbors</samp>](## "bgp_groups.[].neighbors") | List, items: String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "bgp_groups.[].neighbors.[].&lt;str&gt;") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;bgp_maintenance_profiles</samp>](## "bgp_groups.[].bgp_maintenance_profiles") | List, items: String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "bgp_groups.[].bgp_maintenance_profiles.[].&lt;str&gt;") | String |  |  |  | Profile Name |
+
+### YAML
+
+```yaml
+bgp_groups:
+  - name: <str>
+    vrf: <str>
+    neighbors:
+      - <str>
+    bgp_maintenance_profiles:
+      - <str>
+```
+
 ## QOS Class-maps
 
 ### Variables

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -55,6 +55,30 @@ keys:
                 description: 'Action as string
 
                   Example: "deny ip any any"'
+  bgp_groups:
+    type: list
+    primary_key: name
+    convert_types:
+    - dict
+    items:
+      type: dict
+      keys:
+        name:
+          type: str
+          required: true
+          display_name: Group Name
+        vrf:
+          type: str
+          display_name: VRF
+        neighbors:
+          type: list
+          items:
+            type: str
+        bgp_maintenance_profiles:
+          type: list
+          items:
+            type: str
+            display_name: Profile Name
   class_maps:
     type: dict
     display_name: QOS Class-maps

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/bgp_groups.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/bgp_groups.schema.yml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  bgp_groups:
+    type: list
+    primary_key: name
+    convert_types:
+      - dict
+    items:
+      type: dict
+      keys:
+        name:
+          type: str
+          required: true
+          display_name: Group Name
+        vrf:
+          type: str
+          display_name: VRF
+        neighbors:
+          type: list
+          items:
+            type: str
+        bgp_maintenance_profiles:
+          type: list
+          items:
+            type: str
+            display_name: Profile Name
+
+
+  

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/bgp_groups.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/bgp_groups.schema.yml
@@ -27,6 +27,3 @@ keys:
           items:
             type: str
             display_name: Profile Name
-
-
-  

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/bgp-groups.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/bgp-groups.j2
@@ -6,7 +6,7 @@
 
 | BGP group | VRF Name | Neighbors | BGP maintenance profiles |
 | --------- | -------- | --------- | ------------------------ |
-{%     for bgp_group in bgp_groups | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%     for bgp_group in bgp_groups | arista.avd.natural_sort('name') %}
 {%         set vrf = bgp_group.vrf | arista.avd.default('-') %}
 {%         if bgp_group.neighbors is arista.avd.defined %}
 {%             set neighbors = bgp_group.neighbors | arista.avd.natural_sort | join('<br>') %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/bgp-groups.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/bgp-groups.j2
@@ -1,4 +1,4 @@
-{% for bgp_group in bgp_groups | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{% for bgp_group in bgp_groups | arista.avd.natural_sort('name') %}
 !
 group bgp {{ bgp_group.name }}
 {%     if bgp_group.vrf is arista.avd.defined %}


### PR DESCRIPTION
## Add schema for data model

<!-- Use this PR Title: Feat(eos_cli_config_gen): Add schema for < data_model_key > -->

## Checklist

### Contributor Checklist

- [x] Create schema fragment matching data model described in README.md and README_v4.0.md
  - README.md is most complete with all keys. README_v4.0 includes partial data models after conversion to lists.
  - Schema fragment path is `roles/eos_cli_config_gen/schemas/schema_fragments/<data_model_key>.schema.yml`.
  - Copy line 1-5 from another schema (comments and outer type:dict).
  - Refer to [schema documentation](https://avd.sh/en/devel/docs/input-variable-validation-BETA.html) for syntax and/or use YAML Lint plugin from Redhat in VSCode.
  - Use `convert_types` on value that could be mixed type or misinterpreted like integers and numeric strings.
- [x] If the data model has been converted from wildcard dicts:
  - Add `convert_types: ['dict']` to the schema.
  - Remove `convert_dicts` from the `templates/eos/<>.j2` and `templates/documentation/<>.j2` templates.
- [x] Run `molecule converge -s build_schemas_and_docs` to update schema and documentation.
- [x] Test by running `molecule converge -s eos_cli_config_gen` and verify no errors or changes to generated configs/docs.

### Reviewer Checklist

- Reviewer 1:
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2: Tony
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
