### PR TITLE
Feat(eos_cli_config_gen): Add support for mtu under management interface

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-interfaces.md
@@ -47,6 +47,7 @@ interface Management1
 !
 interface Vlan123
    description inband_management
+   mtu 1500
    ip address 10.73.0.123/24
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/management-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/management-interfaces.cfg
@@ -14,6 +14,7 @@ interface Management1
 !
 interface Vlan123
    description inband_management
+   mtu 1500
    ip address 10.73.0.123/24
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/management-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/management-interfaces.yml
@@ -12,3 +12,4 @@ management_interfaces:
     ip_address: 10.73.0.123/24
     gateway: 10.73.0.1
     type: inband
+    mtu: 1500

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-L2LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-L2LEAF1A.md
@@ -60,6 +60,7 @@
 interface Vlan4085
    description L2LEAF_INBAND_MGMT
    no shutdown
+   mtu 1500
    ip address 172.21.110.4/24
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-L2LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-L2LEAF2A.md
@@ -64,6 +64,7 @@
 interface Vlan4085
    description L2LEAF_INBAND_MGMT
    no shutdown
+   mtu 1500
    ip address 172.21.110.5/24
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-L2LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-L2LEAF2B.md
@@ -72,6 +72,7 @@ interface Management1
 interface Vlan4085
    description L2LEAF_INBAND_MGMT
    no shutdown
+   mtu 1500
    ip address 172.21.110.6/24
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-L2LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-L2LEAF1A.md
@@ -68,6 +68,7 @@ interface Management1
 interface Vlan4092
    description L2LEAF_INBAND_MGMT
    no shutdown
+   mtu 1500
    ip address 172.21.210.4/24
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-L2LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-L2LEAF2A.md
@@ -68,6 +68,7 @@ interface Management1
 interface Vlan4092
    description L2LEAF_INBAND_MGMT
    no shutdown
+   mtu 1500
    ip address 172.21.210.5/24
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-L2LEAF1A.cfg
@@ -39,6 +39,7 @@ interface Ethernet1
 interface Vlan4085
    description L2LEAF_INBAND_MGMT
    no shutdown
+   mtu 1500
    ip address 172.21.110.4/24
 !
 ip routing

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-L2LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-L2LEAF2A.cfg
@@ -99,6 +99,7 @@ interface Ethernet4
 interface Vlan4085
    description L2LEAF_INBAND_MGMT
    no shutdown
+   mtu 1500
    ip address 172.21.110.5/24
 !
 interface Vlan4094

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-L2LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-L2LEAF2B.cfg
@@ -105,6 +105,7 @@ interface Management1
 interface Vlan4085
    description L2LEAF_INBAND_MGMT
    no shutdown
+   mtu 1500
    ip address 172.21.110.6/24
 !
 interface Vlan4094

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-L2LEAF1A.cfg
@@ -45,6 +45,7 @@ interface Management1
 interface Vlan4092
    description L2LEAF_INBAND_MGMT
    no shutdown
+   mtu 1500
    ip address 172.21.210.4/24
 !
 ip routing

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-L2LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-L2LEAF2A.cfg
@@ -45,6 +45,7 @@ interface Management1
 interface Vlan4092
    description L2LEAF_INBAND_MGMT
    no shutdown
+   mtu 1500
    ip address 172.21.210.5/24
 !
 ip routing

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-L2LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-L2LEAF1A.md
@@ -60,6 +60,7 @@
 interface Vlan4085
    description L2LEAF_INBAND_MGMT
    no shutdown
+   mtu 1500
    ip address 172.21.110.4/24
 ```
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-L2LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-L2LEAF2A.md
@@ -64,6 +64,7 @@
 interface Vlan4085
    description L2LEAF_INBAND_MGMT
    no shutdown
+   mtu 1500
    ip address 172.21.110.5/24
 ```
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-L2LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-L2LEAF2B.md
@@ -72,6 +72,7 @@ interface Management1
 interface Vlan4085
    description L2LEAF_INBAND_MGMT
    no shutdown
+   mtu 1500
    ip address 172.21.110.6/24
 ```
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-L2LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-L2LEAF1A.md
@@ -68,6 +68,7 @@ interface Management1
 interface Vlan4092
    description L2LEAF_INBAND_MGMT
    no shutdown
+   mtu 1500
    ip address 172.21.210.4/24
 ```
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-L2LEAF1A.cfg
@@ -39,6 +39,7 @@ interface Ethernet1
 interface Vlan4085
    description L2LEAF_INBAND_MGMT
    no shutdown
+   mtu 1500
    ip address 172.21.110.4/24
 !
 ip routing

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-L2LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-L2LEAF2A.cfg
@@ -84,6 +84,7 @@ interface Ethernet4
 interface Vlan4085
    description L2LEAF_INBAND_MGMT
    no shutdown
+   mtu 1500
    ip address 172.21.110.5/24
 !
 interface Vlan4094

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-L2LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-L2LEAF2B.cfg
@@ -90,6 +90,7 @@ interface Management1
 interface Vlan4085
    description L2LEAF_INBAND_MGMT
    no shutdown
+   mtu 1500
    ip address 172.21.110.6/24
 !
 interface Vlan4094

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-L2LEAF1A.cfg
@@ -45,6 +45,7 @@ interface Management1
 interface Vlan4092
    description L2LEAF_INBAND_MGMT
    no shutdown
+   mtu 1500
    ip address 172.21.210.4/24
 !
 ip routing

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1771,6 +1771,7 @@ management_interfaces:
   < Management_interface_1 >:
     description: < description >
     shutdown: < true | false >
+    mtu: < mtu >
     vrf: < vrf_name >
     ip_address: < IPv4_address/Mask >
     ipv6_enable: < true | false >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-interfaces.j2
@@ -10,6 +10,9 @@ interface {{ management_interface.name }}
 {%     elif management_interface.shutdown is arista.avd.defined(false) %}
    no shutdown
 {%     endif %}
+{%     if management_interface.mtu is arista.avd.defined %}
+   mtu {{ management_interface.mtu }}
+{%     endif %}
 {%     if management_interface.vrf is arista.avd.defined and management_interface.vrf is ne 'default' %}
    vrf {{ management_interface.vrf }}
 {%     endif %}


### PR DESCRIPTION
## Change Summary

Add support to define mtu for management_interfaces

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

```yaml
management_interfaces:
  < Management_interface_1 >:
    mtu: < mtu >
```

## How to test

see molecule test case

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
