### PR TITLE
Feat(eos_cli_config_gen): Add schema for daemon terminattr

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -163,56 +163,57 @@ community_lists:
 
 ### Description
 
-Address of the gRPC server on CloudVision
-- TCP 9910 is used on on-prem
-- TCP 443 is used on CV as a Service
+You can either provide a list of IPs/FQDNs to target on-premise Cloudvision cluster or use DNS name for your Cloudvision as a Service instance.
+Streaming to multiple clusters both on-prem and cloud service is supported.
+> Note For TerminAttr version recommendation and EOS compatibility matrix, please refer to the latest TerminAttr Release Notes
+  which always contain the latest recommended versions and minimum required versions per EOS release.
 
 ### Variables
 
 | Variable | Type | Required | Default | Value Restrictions | Description |
 | -------- | ---- | -------- | ------- | ------------------ | ----------- |
 | [<samp>daemon_terminattr</samp>](## "daemon_terminattr") | Dictionary |  |  |  | Daemon TerminAttr |
-| [<samp>&nbsp;&nbsp;cvaddrs</samp>](## "daemon_terminattr.cvaddrs") | List, items: String |  |  |  | Address for single cluster<br> |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "daemon_terminattr.cvaddrs.[].&lt;str&gt;") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;clusters</samp>](## "daemon_terminattr.clusters") | List, items: Dictionary |  |  |  | For multiple cluster support<br> |
+| [<samp>&nbsp;&nbsp;cvaddrs</samp>](## "daemon_terminattr.cvaddrs") | List, items: String |  |  |  | Streaming address(es) for CloudVision single cluster<br>- TCP 9910 is used for CV on-prem<br>- TCP 443 is used for CV as a Service<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "daemon_terminattr.cvaddrs.[].&lt;str&gt;") | String |  |  |  | Server address in the format `<ip/fqdn>:<port>` |
+| [<samp>&nbsp;&nbsp;clusters</samp>](## "daemon_terminattr.clusters") | List, items: Dictionary |  |  |  | Multiple CloudVision clusters<br> |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "daemon_terminattr.clusters.[].name") | String | Required, Unique |  |  | Cluster Name |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;cvaddrs</samp>](## "daemon_terminattr.clusters.[].cvaddrs") | List, items: String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "daemon_terminattr.clusters.[].cvaddrs.[].&lt;str&gt;") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;cvauth</samp>](## "daemon_terminattr.clusters.[].cvauth") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;cvaddrs</samp>](## "daemon_terminattr.clusters.[].cvaddrs") | List, items: String |  |  |  | Streaming address(es) for CloudVision cluster<br>- TCP 9910 is used for CV on-prem<br>- TCP 443 is used for CV as a Service<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "daemon_terminattr.clusters.[].cvaddrs.[].&lt;str&gt;") | String |  |  |  | Server address in the format `<ip/fqdn>:<port>` |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;cvauth</samp>](## "daemon_terminattr.clusters.[].cvauth") | Dictionary |  |  |  | Authentication scheme used to connect to CloudVision<br> |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;method</samp>](## "daemon_terminattr.clusters.[].cvauth.method") | String |  |  | Valid Values:<br>- token<br>- token-secure<br>- key |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "daemon_terminattr.clusters.[].cvauth.key") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;token_file</samp>](## "daemon_terminattr.clusters.[].cvauth.token_file") | String |  |  |  | Path<br>Token file path<br>e.g. "/tmp/token"<br> |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;cvobscurekeyfile</samp>](## "daemon_terminattr.clusters.[].cvobscurekeyfile") | Boolean |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;cvproxy</samp>](## "daemon_terminattr.clusters.[].cvproxy") | String |  |  |  | URL |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;cvsourceip</samp>](## "daemon_terminattr.clusters.[].cvsourceip") | String |  |  |  | IP Address |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;cvvrf</samp>](## "daemon_terminattr.clusters.[].cvvrf") | String |  |  |  | VRF |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;token_file</samp>](## "daemon_terminattr.clusters.[].cvauth.token_file") | String |  |  |  | Token file path<br>e.g. "/tmp/token"<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;cvobscurekeyfile</samp>](## "daemon_terminattr.clusters.[].cvobscurekeyfile") | Boolean |  |  |  | Obscure Key File<br>Encrypt the private key used for authentication to CloudVision<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;cvproxy</samp>](## "daemon_terminattr.clusters.[].cvproxy") | String |  |  |  | Proxy URL<br>Proxy server through which CloudVision is reachable. Useful when the CloudVision server is hosted in the cloud.<br>The expected form is http://[user:password@]ip:port, e.g.: 'http://arista:arista@10.83.12.78:3128'. Available as of TerminAttr v1.13.0<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;cvsourceip</samp>](## "daemon_terminattr.clusters.[].cvsourceip") | String |  |  |  | Source IP Address<br>Set source IP address in case of in-band managament<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;cvvrf</samp>](## "daemon_terminattr.clusters.[].cvvrf") | String |  |  |  | VRF<br>The VRF to use to connect to CloudVision<br> |
 | [<samp>&nbsp;&nbsp;cvauth</samp>](## "daemon_terminattr.cvauth") | Dictionary |  |  |  | Authentication scheme used to connect to CloudVision<br> |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;method</samp>](## "daemon_terminattr.cvauth.method") | String |  |  | Valid Values:<br>- token<br>- token-secure<br>- key |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "daemon_terminattr.cvauth.key") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;token_file</samp>](## "daemon_terminattr.cvauth.token_file") | String |  |  |  | Path<br>Token file path<br>e.g. "/tmp/token"<br> |
-| [<samp>&nbsp;&nbsp;cvobscurekeyfile</samp>](## "daemon_terminattr.cvobscurekeyfile") | Boolean |  |  |  | The default compression scheme when streaming to CloudVision is gzip since TerminAttr 1.6.1 and CVP 2019.1.0. There is no need to change the compression scheme.<br>Encrypt the private key used for authentication to CloudVision<br> |
-| [<samp>&nbsp;&nbsp;cvproxy</samp>](## "daemon_terminattr.cvproxy") | String |  |  |  | URL<br>Proxy server through which CloudVision is reachable. Useful when the CloudVision server is hosted in the cloud.<br>The expected form is http://[user:password@]ip:port, e.g.: 'http://arista:arista@10.83.12.78:3128'. Available as of TerminAttr v1.13.0<br> |
-| [<samp>&nbsp;&nbsp;cvsourceip</samp>](## "daemon_terminattr.cvsourceip") | String |  |  |  | IP Address<br>Set source IP address in case of in-band managament<br> |
-| [<samp>&nbsp;&nbsp;cvvrf</samp>](## "daemon_terminattr.cvvrf") | String |  |  |  | VRF<br>Name of the VRF to use to connect to CloudVision<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;token_file</samp>](## "daemon_terminattr.cvauth.token_file") | String |  |  |  | Token file path<br>e.g. "/tmp/token"<br> |
+| [<samp>&nbsp;&nbsp;cvobscurekeyfile</samp>](## "daemon_terminattr.cvobscurekeyfile") | Boolean |  |  |  | Obscure Key File<br>Encrypt the private key used for authentication to CloudVision<br> |
+| [<samp>&nbsp;&nbsp;cvproxy</samp>](## "daemon_terminattr.cvproxy") | String |  |  |  | Proxy URL<br>Proxy server through which CloudVision is reachable. Useful when the CloudVision server is hosted in the cloud.<br>The expected form is http://[user:password@]ip:port, e.g.: 'http://arista:arista@10.83.12.78:3128'. Available as of TerminAttr v1.13.0<br> |
+| [<samp>&nbsp;&nbsp;cvsourceip</samp>](## "daemon_terminattr.cvsourceip") | String |  |  |  | Source IP Address<br>Set source IP address in case of in-band managament<br> |
+| [<samp>&nbsp;&nbsp;cvvrf</samp>](## "daemon_terminattr.cvvrf") | String |  |  |  | VRF<br>The VRF to use to connect to CloudVision<br> |
 | [<samp>&nbsp;&nbsp;cvgnmi</samp>](## "daemon_terminattr.cvgnmi") | Boolean |  |  |  | Stream states from EOS GNMI servers (Openconfig) to CloudVision. Available as of TerminAttr v1.13.1<br> |
 | [<samp>&nbsp;&nbsp;disable_aaa</samp>](## "daemon_terminattr.disable_aaa") | Boolean |  |  |  | Disable AAA authorization and accounting.<br>When setting this flag, all commands pushed from CloudVision are applied directly to the CLI without authorization<br> |
 | [<samp>&nbsp;&nbsp;grpcaddr</samp>](## "daemon_terminattr.grpcaddr") | String |  |  |  | Set the gRPC server address, the default is 127.0.0.1:6042<br>e.g. "MGMT/0.0.0.0:6042"<br> |
-| [<samp>&nbsp;&nbsp;grpcreadonly</samp>](## "daemon_terminattr.grpcreadonly") | Boolean |  |  |  | gNMI read-only mode – Disable gnmi.Set()<br> |
+| [<samp>&nbsp;&nbsp;grpcreadonly</samp>](## "daemon_terminattr.grpcreadonly") | Boolean |  |  |  | gNMI read-only mode - Disable gnmi.Set()<br> |
 | [<samp>&nbsp;&nbsp;ingestexclude</samp>](## "daemon_terminattr.ingestexclude") | String |  |  |  | Exclude paths from Sysdb on the ingest side.<br>e.g. "/Sysdb/cell/1/agent,/Sysdb/cell/2/agent"<br> |
 | [<samp>&nbsp;&nbsp;smashexcludes</samp>](## "daemon_terminattr.smashexcludes") | String |  |  |  | Exclude paths from the shared memory table.<br>e.g. "ale,flexCounter,hardware,kni,pulse,strata"<br> |
 | [<samp>&nbsp;&nbsp;taillogs</samp>](## "daemon_terminattr.taillogs") | String |  |  |  | Enable log file collection; /var/log/messages is streamed by default if no path is set.<br>e.g. "/var/log/messages"<br> |
-| [<samp>&nbsp;&nbsp;ecodhcpaddr</samp>](## "daemon_terminattr.ecodhcpaddr") | String |  |  |  | ECO DHCP Collector address or ECO DHCP Fingerprint listening addressin standalone mode (default "127.0.0.1:67")<br> |
-| [<samp>&nbsp;&nbsp;ipfix</samp>](## "daemon_terminattr.ipfix") | Boolean |  |  |  | Enable IPFIX provider (default true).<br>This flag is enabled by default and does not have to be added to the daemon configuration.<br> |
-| [<samp>&nbsp;&nbsp;ipfixaddr</samp>](## "daemon_terminattr.ipfixaddr") | String |  |  |  | ECO IPFIX Collector address to listen on to receive IPFIX packets (default "127.0.0.1:4739").<br>This flag is enabled by default and does not have to be added to the daemon configuration<br> |
-| [<samp>&nbsp;&nbsp;sflow</samp>](## "daemon_terminattr.sflow") | Boolean |  |  |  | Enable sFlow provider (default true).<br>This flag is enabled by default and does not have to be added to the daemon configuration<br> |
-| [<samp>&nbsp;&nbsp;sflowaddr</samp>](## "daemon_terminattr.sflowaddr") | String |  |  |  | ECO sFlow Collector address to listen on to receive sFlow packets (default "127.0.0.1:6343").<br>This flag is enabled by default and does not have to be added to the daemon configuration.<br> |
-| [<samp>&nbsp;&nbsp;cvcompression</samp>](## "daemon_terminattr.cvcompression") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;ingestauth_key</samp>](## "daemon_terminattr.ingestauth_key") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;ingestgrpcurl</samp>](## "daemon_terminattr.ingestgrpcurl") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;ecodhcpaddr</samp>](## "daemon_terminattr.ecodhcpaddr") | String |  |  |  | ECO DHCP Collector address or ECO DHCP Fingerprint listening address in standalone mode (default "127.0.0.1:67")<br> |
+| [<samp>&nbsp;&nbsp;ipfix</samp>](## "daemon_terminattr.ipfix") | Boolean |  |  |  | Enable IPFIX provider (TerminAttr default is true).<br>This flag is enabled by default and does not have to be added to the daemon configuration.<br> |
+| [<samp>&nbsp;&nbsp;ipfixaddr</samp>](## "daemon_terminattr.ipfixaddr") | String |  |  |  | ECO IPFIX Collector address to listen on to receive IPFIX packets (TerminAttr default "127.0.0.1:4739").<br> |
+| [<samp>&nbsp;&nbsp;sflow</samp>](## "daemon_terminattr.sflow") | Boolean |  |  |  | Enable sFlow provider (TerminAttr default is true).<br> |
+| [<samp>&nbsp;&nbsp;sflowaddr</samp>](## "daemon_terminattr.sflowaddr") | String |  |  |  | ECO sFlow Collector address to listen on to receive sFlow packets (TerminAttr default "127.0.0.1:6343").<br> |
+| [<samp>&nbsp;&nbsp;cvcompression</samp>](## "daemon_terminattr.cvcompression") | String |  |  |  | The default compression scheme when streaming to CloudVision is gzip since TerminAttr 1.6.1 and CVP 2019.1.0.<br>There is no need to change the compression scheme.<br> |
+| [<samp>&nbsp;&nbsp;ingestauth_key</samp>](## "daemon_terminattr.ingestauth_key") | String |  |  |  | Deprecated key. Use `cvauth` instead.<br> |
+| [<samp>&nbsp;&nbsp;ingestgrpcurl</samp>](## "daemon_terminattr.ingestgrpcurl") | Dictionary |  |  |  | Deprecated key. Use `cvaddrs` instead.<br> |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ips</samp>](## "daemon_terminattr.ingestgrpcurl.ips") | List, items: String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "daemon_terminattr.ingestgrpcurl.ips.[].&lt;str&gt;") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;port</samp>](## "daemon_terminattr.ingestgrpcurl.port") | Integer |  |  |  |  |
-| [<samp>&nbsp;&nbsp;ingestvrf</samp>](## "daemon_terminattr.ingestvrf") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;ingestvrf</samp>](## "daemon_terminattr.ingestvrf") | String |  |  |  | Deprecated key. Use `cvvrf` instead.<br> |
 
 ### YAML
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -205,7 +205,11 @@ Address of the gRPC server on CloudVision
 | [<samp>&nbsp;&nbsp;ipfix</samp>](## "daemon_terminattr.ipfix") | Boolean |  |  |  | Enable IPFIX provider (default true).<br>This flag is enabled by default and does not have to be added to the daemon configuration.<br> |
 | [<samp>&nbsp;&nbsp;ipfixaddr</samp>](## "daemon_terminattr.ipfixaddr") | String |  |  |  | ECO IPFIX Collector address to listen on to receive IPFIX packets (default "127.0.0.1:4739").<br>This flag is enabled by default and does not have to be added to the daemon configuration<br> |
 | [<samp>&nbsp;&nbsp;sflow</samp>](## "daemon_terminattr.sflow") | Boolean |  |  |  | Enable sFlow provider (default true).<br>This flag is enabled by default and does not have to be added to the daemon configuration<br> |
-| [<samp>&nbsp;&nbsp;sflowaddr</samp>](## "daemon_terminattr.sflowaddr") | String |  |  |  | ECO sFlow Collector address to listen on to receive sFlow packets (default "127.0.0.1:6343").<br>This flag is enabled by default and does not have to be added to the daemon configuration. |
+| [<samp>&nbsp;&nbsp;sflowaddr</samp>](## "daemon_terminattr.sflowaddr") | String |  |  |  | ECO sFlow Collector address to listen on to receive sFlow packets (default "127.0.0.1:6343").<br>This flag is enabled by default and does not have to be added to the daemon configuration.<br> |
+| [<samp>&nbsp;&nbsp;cvcompression</samp>](## "daemon_terminattr.cvcompression") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;ingestauth_key</samp>](## "daemon_terminattr.ingestauth_key") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;ingestgrpcurl</samp>](## "daemon_terminattr.ingestgrpcurl") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;ingestvrf</samp>](## "daemon_terminattr.ingestvrf") | String |  |  |  |  |
 
 ### YAML
 
@@ -245,6 +249,10 @@ daemon_terminattr:
   ipfixaddr: <str>
   sflow: <bool>
   sflowaddr: <str>
+  cvcompression: <str>
+  ingestauth_key: <str>
+  ingestgrpcurl: <str>
+  ingestvrf: <str>
 ```
 
 ## Custom Daemons

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -208,7 +208,10 @@ Address of the gRPC server on CloudVision
 | [<samp>&nbsp;&nbsp;sflowaddr</samp>](## "daemon_terminattr.sflowaddr") | String |  |  |  | ECO sFlow Collector address to listen on to receive sFlow packets (default "127.0.0.1:6343").<br>This flag is enabled by default and does not have to be added to the daemon configuration.<br> |
 | [<samp>&nbsp;&nbsp;cvcompression</samp>](## "daemon_terminattr.cvcompression") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;ingestauth_key</samp>](## "daemon_terminattr.ingestauth_key") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;ingestgrpcurl</samp>](## "daemon_terminattr.ingestgrpcurl") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;ingestgrpcurl</samp>](## "daemon_terminattr.ingestgrpcurl") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ips</samp>](## "daemon_terminattr.ingestgrpcurl.ips") | List, items: String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "daemon_terminattr.ingestgrpcurl.ips.[].&lt;str&gt;") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;port</samp>](## "daemon_terminattr.ingestgrpcurl.port") | Integer |  |  |  |  |
 | [<samp>&nbsp;&nbsp;ingestvrf</samp>](## "daemon_terminattr.ingestvrf") | String |  |  |  |  |
 
 ### YAML
@@ -251,7 +254,10 @@ daemon_terminattr:
   sflowaddr: <str>
   cvcompression: <str>
   ingestauth_key: <str>
-  ingestgrpcurl: <str>
+  ingestgrpcurl:
+    ips:
+      - <str>
+    port: <int>
   ingestvrf: <str>
 ```
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -159,6 +159,94 @@ community_lists:
     action: <str>
 ```
 
+## Daemon TerminAttr
+
+### Description
+
+Address of the gRPC server on CloudVision
+- TCP 9910 is used on on-prem
+- TCP 443 is used on CV as a Service
+
+### Variables
+
+| Variable | Type | Required | Default | Value Restrictions | Description |
+| -------- | ---- | -------- | ------- | ------------------ | ----------- |
+| [<samp>daemon_terminattr</samp>](## "daemon_terminattr") | Dictionary |  |  |  | Daemon TerminAttr |
+| [<samp>&nbsp;&nbsp;cvaddrs</samp>](## "daemon_terminattr.cvaddrs") | List, items: String |  |  |  | Address for single cluster<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "daemon_terminattr.cvaddrs.[].&lt;str&gt;") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;clusters</samp>](## "daemon_terminattr.clusters") | List, items: Dictionary |  |  |  | For multiple cluster support<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "daemon_terminattr.clusters.[].name") | String | Required, Unique |  |  | Cluster Name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;cvaddrs</samp>](## "daemon_terminattr.clusters.[].cvaddrs") | List, items: String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "daemon_terminattr.clusters.[].cvaddrs.[].&lt;str&gt;") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;cvauth</samp>](## "daemon_terminattr.clusters.[].cvauth") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;method</samp>](## "daemon_terminattr.clusters.[].cvauth.method") | String |  |  | Valid Values:<br>- token<br>- token-secure<br>- key |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "daemon_terminattr.clusters.[].cvauth.key") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;token_file</samp>](## "daemon_terminattr.clusters.[].cvauth.token_file") | String |  |  |  | Path<br>Token file path<br>e.g. "/tmp/token"<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;cvobscurekeyfile</samp>](## "daemon_terminattr.clusters.[].cvobscurekeyfile") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;cvproxy</samp>](## "daemon_terminattr.clusters.[].cvproxy") | String |  |  |  | URL |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;cvsourceip</samp>](## "daemon_terminattr.clusters.[].cvsourceip") | String |  |  |  | IP Address |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;cvvrf</samp>](## "daemon_terminattr.clusters.[].cvvrf") | String |  |  |  | VRF |
+| [<samp>&nbsp;&nbsp;cvauth</samp>](## "daemon_terminattr.cvauth") | Dictionary |  |  |  | Authentication scheme used to connect to CloudVision<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;method</samp>](## "daemon_terminattr.cvauth.method") | String |  |  | Valid Values:<br>- token<br>- token-secure<br>- key |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "daemon_terminattr.cvauth.key") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;token_file</samp>](## "daemon_terminattr.cvauth.token_file") | String |  |  |  | Path<br>Token file path<br>e.g. "/tmp/token"<br> |
+| [<samp>&nbsp;&nbsp;cvobscurekeyfile</samp>](## "daemon_terminattr.cvobscurekeyfile") | Boolean |  |  |  | The default compression scheme when streaming to CloudVision is gzip since TerminAttr 1.6.1 and CVP 2019.1.0. There is no need to change the compression scheme.<br>Encrypt the private key used for authentication to CloudVision<br> |
+| [<samp>&nbsp;&nbsp;cvproxy</samp>](## "daemon_terminattr.cvproxy") | String |  |  |  | URL<br>Proxy server through which CloudVision is reachable. Useful when the CloudVision server is hosted in the cloud.<br>The expected form is http://[user:password@]ip:port, e.g.: 'http://arista:arista@10.83.12.78:3128'. Available as of TerminAttr v1.13.0<br> |
+| [<samp>&nbsp;&nbsp;cvsourceip</samp>](## "daemon_terminattr.cvsourceip") | String |  |  |  | IP Address<br>Set source IP address in case of in-band managament<br> |
+| [<samp>&nbsp;&nbsp;cvvrf</samp>](## "daemon_terminattr.cvvrf") | String |  |  |  | VRF<br>Name of the VRF to use to connect to CloudVision<br> |
+| [<samp>&nbsp;&nbsp;cvgnmi</samp>](## "daemon_terminattr.cvgnmi") | Boolean |  |  |  | Stream states from EOS GNMI servers (Openconfig) to CloudVision. Available as of TerminAttr v1.13.1<br> |
+| [<samp>&nbsp;&nbsp;disable_aaa</samp>](## "daemon_terminattr.disable_aaa") | Boolean |  |  |  | Disable AAA authorization and accounting.<br>When setting this flag, all commands pushed from CloudVision are applied directly to the CLI without authorization<br> |
+| [<samp>&nbsp;&nbsp;grpcaddr</samp>](## "daemon_terminattr.grpcaddr") | String |  |  |  | Set the gRPC server address, the default is 127.0.0.1:6042<br>e.g. "MGMT/0.0.0.0:6042"<br> |
+| [<samp>&nbsp;&nbsp;grpcreadonly</samp>](## "daemon_terminattr.grpcreadonly") | Boolean |  |  |  | gNMI read-only mode – Disable gnmi.Set()<br> |
+| [<samp>&nbsp;&nbsp;ingestexclude</samp>](## "daemon_terminattr.ingestexclude") | String |  |  |  | Exclude paths from Sysdb on the ingest side.<br>e.g. "/Sysdb/cell/1/agent,/Sysdb/cell/2/agent"<br> |
+| [<samp>&nbsp;&nbsp;smashexcludes</samp>](## "daemon_terminattr.smashexcludes") | String |  |  |  | Exclude paths from the shared memory table.<br>e.g. "ale,flexCounter,hardware,kni,pulse,strata"<br> |
+| [<samp>&nbsp;&nbsp;taillogs</samp>](## "daemon_terminattr.taillogs") | String |  |  |  | Enable log file collection; /var/log/messages is streamed by default if no path is set.<br>e.g. "/var/log/messages"<br> |
+| [<samp>&nbsp;&nbsp;ecodhcpaddr</samp>](## "daemon_terminattr.ecodhcpaddr") | String |  |  |  | ECO DHCP Collector address or ECO DHCP Fingerprint listening addressin standalone mode (default "127.0.0.1:67")<br> |
+| [<samp>&nbsp;&nbsp;ipfix</samp>](## "daemon_terminattr.ipfix") | Boolean |  |  |  | Enable IPFIX provider (default true).<br>This flag is enabled by default and does not have to be added to the daemon configuration.<br> |
+| [<samp>&nbsp;&nbsp;ipfixaddr</samp>](## "daemon_terminattr.ipfixaddr") | String |  |  |  | ECO IPFIX Collector address to listen on to receive IPFIX packets (default "127.0.0.1:4739").<br>This flag is enabled by default and does not have to be added to the daemon configuration<br> |
+| [<samp>&nbsp;&nbsp;sflow</samp>](## "daemon_terminattr.sflow") | Boolean |  |  |  | Enable sFlow provider (default true).<br>This flag is enabled by default and does not have to be added to the daemon configuration<br> |
+| [<samp>&nbsp;&nbsp;sflowaddr</samp>](## "daemon_terminattr.sflowaddr") | String |  |  |  | ECO sFlow Collector address to listen on to receive sFlow packets (default "127.0.0.1:6343").<br>This flag is enabled by default and does not have to be added to the daemon configuration. |
+
+### YAML
+
+```yaml
+daemon_terminattr:
+  cvaddrs:
+    - <str>
+  clusters:
+    - name: <str>
+      cvaddrs:
+        - <str>
+      cvauth:
+        method: <str>
+        key: <str>
+        token_file: <str>
+      cvobscurekeyfile: <bool>
+      cvproxy: <str>
+      cvsourceip: <str>
+      cvvrf: <str>
+  cvauth:
+    method: <str>
+    key: <str>
+    token_file: <str>
+  cvobscurekeyfile: <bool>
+  cvproxy: <str>
+  cvsourceip: <str>
+  cvvrf: <str>
+  cvgnmi: <bool>
+  disable_aaa: <bool>
+  grpcaddr: <str>
+  grpcreadonly: <bool>
+  ingestexclude: <str>
+  smashexcludes: <str>
+  taillogs: <str>
+  ecodhcpaddr: <str>
+  ipfix: <bool>
+  ipfixaddr: <str>
+  sflow: <bool>
+  sflowaddr: <str>
+```
+
 ## Custom Daemons
 
 ### Variables

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -247,6 +247,236 @@
         "additionalProperties": false
       }
     },
+    "daemon_terminattr": {
+      "type": "object",
+      "title": "Daemon TerminAttr",
+      "description": "You can either provide a list of IPs/FQDNs to target on-premise Cloudvision cluster or use DNS name for your Cloudvision as a Service instance.\nStreaming to multiple clusters both on-prem and cloud service is supported.\n> Note For TerminAttr version recommendation and EOS compatibility matrix, please refer to the latest TerminAttr Release Notes\n  which always contain the latest recommended versions and minimum required versions per EOS release.\n",
+      "properties": {
+        "cvaddrs": {
+          "type": "array",
+          "description": "Streaming address(es) for CloudVision single cluster\n- TCP 9910 is used for CV on-prem\n- TCP 443 is used for CV as a Service\n",
+          "items": {
+            "type": "string",
+            "description": "Server address in the format `<ip/fqdn>:<port>`"
+          },
+          "title": "Cvaddrs"
+        },
+        "clusters": {
+          "type": "array",
+          "description": "Multiple CloudVision clusters\n",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "Cluster Name"
+              },
+              "cvaddrs": {
+                "type": "array",
+                "description": "Streaming address(es) for CloudVision cluster\n- TCP 9910 is used for CV on-prem\n- TCP 443 is used for CV as a Service\n",
+                "items": {
+                  "type": "string",
+                  "description": "Server address in the format `<ip/fqdn>:<port>`"
+                },
+                "title": "Cvaddrs"
+              },
+              "cvauth": {
+                "type": "object",
+                "description": "Authentication scheme used to connect to CloudVision\n",
+                "properties": {
+                  "method": {
+                    "type": "string",
+                    "enum": [
+                      "token",
+                      "token-secure",
+                      "key"
+                    ],
+                    "title": "Method"
+                  },
+                  "key": {
+                    "type": "string",
+                    "title": "Key"
+                  },
+                  "token_file": {
+                    "type": "string",
+                    "description": "Token file path\ne.g. \"/tmp/token\"\n",
+                    "title": "Token File"
+                  }
+                },
+                "additionalProperties": false,
+                "title": "Cvauth"
+              },
+              "cvobscurekeyfile": {
+                "type": "boolean",
+                "title": "Obscure Key File",
+                "description": "Encrypt the private key used for authentication to CloudVision\n"
+              },
+              "cvproxy": {
+                "type": "string",
+                "title": "Proxy URL",
+                "description": "Proxy server through which CloudVision is reachable. Useful when the CloudVision server is hosted in the cloud.\nThe expected form is http://[user:password@]ip:port, e.g.: 'http://arista:arista@10.83.12.78:3128'. Available as of TerminAttr v1.13.0\n"
+              },
+              "cvsourceip": {
+                "type": "string",
+                "title": "Source IP Address",
+                "description": "Set source IP address in case of in-band managament\n"
+              },
+              "cvvrf": {
+                "type": "string",
+                "title": "VRF",
+                "description": "The VRF to use to connect to CloudVision\n"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "additionalProperties": false
+          },
+          "title": "Clusters"
+        },
+        "cvauth": {
+          "type": "object",
+          "description": "Authentication scheme used to connect to CloudVision\n",
+          "properties": {
+            "method": {
+              "type": "string",
+              "enum": [
+                "token",
+                "token-secure",
+                "key"
+              ],
+              "title": "Method"
+            },
+            "key": {
+              "type": "string",
+              "title": "Key"
+            },
+            "token_file": {
+              "type": "string",
+              "description": "Token file path\ne.g. \"/tmp/token\"\n",
+              "title": "Token File"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Cvauth"
+        },
+        "cvobscurekeyfile": {
+          "type": "boolean",
+          "title": "Obscure Key File",
+          "description": "Encrypt the private key used for authentication to CloudVision\n"
+        },
+        "cvproxy": {
+          "type": "string",
+          "title": "Proxy URL",
+          "description": "Proxy server through which CloudVision is reachable. Useful when the CloudVision server is hosted in the cloud.\nThe expected form is http://[user:password@]ip:port, e.g.: 'http://arista:arista@10.83.12.78:3128'. Available as of TerminAttr v1.13.0\n"
+        },
+        "cvsourceip": {
+          "type": "string",
+          "title": "Source IP Address",
+          "description": "Set source IP address in case of in-band managament\n"
+        },
+        "cvvrf": {
+          "type": "string",
+          "title": "VRF",
+          "description": "The VRF to use to connect to CloudVision\n"
+        },
+        "cvgnmi": {
+          "type": "boolean",
+          "description": "Stream states from EOS GNMI servers (Openconfig) to CloudVision. Available as of TerminAttr v1.13.1\n",
+          "title": "Cvgnmi"
+        },
+        "disable_aaa": {
+          "type": "boolean",
+          "description": "Disable AAA authorization and accounting.\nWhen setting this flag, all commands pushed from CloudVision are applied directly to the CLI without authorization\n",
+          "title": "Disable Aaa"
+        },
+        "grpcaddr": {
+          "type": "string",
+          "description": "Set the gRPC server address, the default is 127.0.0.1:6042\ne.g. \"MGMT/0.0.0.0:6042\"\n",
+          "title": "Grpcaddr"
+        },
+        "grpcreadonly": {
+          "type": "boolean",
+          "description": "gNMI read-only mode - Disable gnmi.Set()\n",
+          "title": "Grpcreadonly"
+        },
+        "ingestexclude": {
+          "type": "string",
+          "description": "Exclude paths from Sysdb on the ingest side.\ne.g. \"/Sysdb/cell/1/agent,/Sysdb/cell/2/agent\"\n",
+          "title": "Ingestexclude"
+        },
+        "smashexcludes": {
+          "type": "string",
+          "description": "Exclude paths from the shared memory table.\ne.g. \"ale,flexCounter,hardware,kni,pulse,strata\"\n",
+          "title": "Smashexcludes"
+        },
+        "taillogs": {
+          "type": "string",
+          "description": "Enable log file collection; /var/log/messages is streamed by default if no path is set.\ne.g. \"/var/log/messages\"\n",
+          "title": "Taillogs"
+        },
+        "ecodhcpaddr": {
+          "type": "string",
+          "description": "ECO DHCP Collector address or ECO DHCP Fingerprint listening address in standalone mode (default \"127.0.0.1:67\")\n",
+          "title": "Ecodhcpaddr"
+        },
+        "ipfix": {
+          "type": "boolean",
+          "description": "Enable IPFIX provider (TerminAttr default is true).\nThis flag is enabled by default and does not have to be added to the daemon configuration.\n",
+          "title": "Ipfix"
+        },
+        "ipfixaddr": {
+          "type": "string",
+          "description": "ECO IPFIX Collector address to listen on to receive IPFIX packets (TerminAttr default \"127.0.0.1:4739\").\n",
+          "title": "Ipfixaddr"
+        },
+        "sflow": {
+          "type": "boolean",
+          "description": "Enable sFlow provider (TerminAttr default is true).\n",
+          "title": "Sflow"
+        },
+        "sflowaddr": {
+          "type": "string",
+          "description": "ECO sFlow Collector address to listen on to receive sFlow packets (TerminAttr default \"127.0.0.1:6343\").\n",
+          "title": "Sflowaddr"
+        },
+        "cvcompression": {
+          "type": "string",
+          "description": "The default compression scheme when streaming to CloudVision is gzip since TerminAttr 1.6.1 and CVP 2019.1.0.\nThere is no need to change the compression scheme.\n",
+          "title": "Cvcompression"
+        },
+        "ingestauth_key": {
+          "type": "string",
+          "description": "Deprecated key. Use `cvauth` instead.\n",
+          "title": "Ingestauth Key"
+        },
+        "ingestgrpcurl": {
+          "type": "object",
+          "description": "Deprecated key. Use `cvaddrs` instead.\n",
+          "properties": {
+            "ips": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "title": "Ips"
+            },
+            "port": {
+              "type": "integer",
+              "title": "Port"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Ingestgrpcurl"
+        },
+        "ingestvrf": {
+          "description": "Deprecated key. Use `cvvrf` instead.\n",
+          "type": "string",
+          "title": "Ingestvrf"
+        }
+      },
+      "additionalProperties": false
+    },
     "daemons": {
       "type": "array",
       "title": "Custom Daemons",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -211,24 +211,28 @@ keys:
   daemon_terminattr:
     type: dict
     display_name: Daemon TerminAttr
-    description: 'Address of the gRPC server on CloudVision
-
-      - TCP 9910 is used on on-prem
-
-      - TCP 443 is used on CV as a Service
-
-      '
+    description: "You can either provide a list of IPs/FQDNs to target on-premise
+      Cloudvision cluster or use DNS name for your Cloudvision as a Service instance.\nStreaming
+      to multiple clusters both on-prem and cloud service is supported.\n> Note For
+      TerminAttr version recommendation and EOS compatibility matrix, please refer
+      to the latest TerminAttr Release Notes\n  which always contain the latest recommended
+      versions and minimum required versions per EOS release.\n"
     keys:
       cvaddrs:
         type: list
-        description: 'Address for single cluster
+        description: 'Streaming address(es) for CloudVision single cluster
+
+          - TCP 9910 is used for CV on-prem
+
+          - TCP 443 is used for CV as a Service
 
           '
         items:
           type: str
+          description: Server address in the format `<ip/fqdn>:<port>`
       clusters:
         type: list
-        description: 'For multiple cluster support
+        description: 'Multiple CloudVision clusters
 
           '
         primary_key: name
@@ -243,10 +247,21 @@ keys:
               display_name: Cluster Name
             cvaddrs:
               type: list
+              description: 'Streaming address(es) for CloudVision cluster
+
+                - TCP 9910 is used for CV on-prem
+
+                - TCP 443 is used for CV as a Service
+
+                '
               items:
                 type: str
+                description: Server address in the format `<ip/fqdn>:<port>`
             cvauth:
               type: dict
+              description: 'Authentication scheme used to connect to CloudVision
+
+                '
               keys:
                 method:
                   type: str
@@ -258,7 +273,6 @@ keys:
                   type: str
                 token_file:
                   type: str
-                  display_name: Path
                   description: 'Token file path
 
                     e.g. "/tmp/token"
@@ -266,15 +280,32 @@ keys:
                     '
             cvobscurekeyfile:
               type: bool
+              display_name: Obscure Key File
+              description: 'Encrypt the private key used for authentication to CloudVision
+
+                '
             cvproxy:
               type: str
-              display_name: URL
+              display_name: Proxy URL
+              description: 'Proxy server through which CloudVision is reachable. Useful
+                when the CloudVision server is hosted in the cloud.
+
+                The expected form is http://[user:password@]ip:port, e.g.: ''http://arista:arista@10.83.12.78:3128''.
+                Available as of TerminAttr v1.13.0
+
+                '
             cvsourceip:
               type: str
-              display_name: IP Address
+              display_name: Source IP Address
+              description: 'Set source IP address in case of in-band managament
+
+                '
             cvvrf:
               type: str
               display_name: VRF
+              description: 'The VRF to use to connect to CloudVision
+
+                '
       cvauth:
         type: dict
         description: 'Authentication scheme used to connect to CloudVision
@@ -291,7 +322,6 @@ keys:
             type: str
           token_file:
             type: str
-            display_name: Path
             description: 'Token file path
 
               e.g. "/tmp/token"
@@ -299,16 +329,13 @@ keys:
               '
       cvobscurekeyfile:
         type: bool
-        description: 'The default compression scheme when streaming to CloudVision
-          is gzip since TerminAttr 1.6.1 and CVP 2019.1.0. There is no need to change
-          the compression scheme.
-
-          Encrypt the private key used for authentication to CloudVision
+        display_name: Obscure Key File
+        description: 'Encrypt the private key used for authentication to CloudVision
 
           '
       cvproxy:
         type: str
-        display_name: URL
+        display_name: Proxy URL
         description: 'Proxy server through which CloudVision is reachable. Useful
           when the CloudVision server is hosted in the cloud.
 
@@ -318,14 +345,14 @@ keys:
           '
       cvsourceip:
         type: str
-        display_name: IP Address
+        display_name: Source IP Address
         description: 'Set source IP address in case of in-band managament
 
           '
       cvvrf:
         type: str
         display_name: VRF
-        description: 'Name of the VRF to use to connect to CloudVision
+        description: 'The VRF to use to connect to CloudVision
 
           '
       cvgnmi:
@@ -351,7 +378,7 @@ keys:
           '
       grpcreadonly:
         type: bool
-        description: 'gNMI read-only mode – Disable gnmi.Set()
+        description: 'gNMI read-only mode - Disable gnmi.Set()
 
           '
       ingestexclude:
@@ -379,12 +406,12 @@ keys:
       ecodhcpaddr:
         type: str
         description: 'ECO DHCP Collector address or ECO DHCP Fingerprint listening
-          addressin standalone mode (default "127.0.0.1:67")
+          address in standalone mode (default "127.0.0.1:67")
 
           '
       ipfix:
         type: bool
-        description: 'Enable IPFIX provider (default true).
+        description: 'Enable IPFIX provider (TerminAttr default is true).
 
           This flag is enabled by default and does not have to be added to the daemon
           configuration.
@@ -393,35 +420,38 @@ keys:
       ipfixaddr:
         type: str
         description: 'ECO IPFIX Collector address to listen on to receive IPFIX packets
-          (default "127.0.0.1:4739").
-
-          This flag is enabled by default and does not have to be added to the daemon
-          configuration
+          (TerminAttr default "127.0.0.1:4739").
 
           '
       sflow:
         type: bool
-        description: 'Enable sFlow provider (default true).
-
-          This flag is enabled by default and does not have to be added to the daemon
-          configuration
+        description: 'Enable sFlow provider (TerminAttr default is true).
 
           '
       sflowaddr:
         type: str
         description: 'ECO sFlow Collector address to listen on to receive sFlow packets
-          (default "127.0.0.1:6343").
-
-          This flag is enabled by default and does not have to be added to the daemon
-          configuration.
+          (TerminAttr default "127.0.0.1:6343").
 
           '
       cvcompression:
         type: str
+        description: 'The default compression scheme when streaming to CloudVision
+          is gzip since TerminAttr 1.6.1 and CVP 2019.1.0.
+
+          There is no need to change the compression scheme.
+
+          '
       ingestauth_key:
         type: str
+        description: 'Deprecated key. Use `cvauth` instead.
+
+          '
       ingestgrpcurl:
         type: dict
+        description: 'Deprecated key. Use `cvaddrs` instead.
+
+          '
         keys:
           ips:
             type: list
@@ -432,6 +462,9 @@ keys:
             convert_types:
             - str
       ingestvrf:
+        description: 'Deprecated key. Use `cvvrf` instead.
+
+          '
         type: str
   daemons:
     type: list

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -413,7 +413,17 @@ keys:
           (default "127.0.0.1:6343").
 
           This flag is enabled by default and does not have to be added to the daemon
-          configuration.'
+          configuration.
+
+          '
+      cvcompression:
+        type: str
+      ingestauth_key:
+        type: str
+      ingestgrpcurl:
+        type: str
+      ingestvrf:
+        type: str
   daemons:
     type: list
     primary_key: name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -421,7 +421,16 @@ keys:
       ingestauth_key:
         type: str
       ingestgrpcurl:
-        type: str
+        type: dict
+        keys:
+          ips:
+            type: list
+            items:
+              type: str
+          port:
+            type: int
+            convert_types:
+            - str
       ingestvrf:
         type: str
   daemons:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -208,6 +208,212 @@ keys:
           description: 'Action as string
 
             Example: "permit GSHUT 65123:123"'
+  daemon_terminattr:
+    type: dict
+    display_name: Daemon TerminAttr
+    description: 'Address of the gRPC server on CloudVision
+
+      - TCP 9910 is used on on-prem
+
+      - TCP 443 is used on CV as a Service
+
+      '
+    keys:
+      cvaddrs:
+        type: list
+        description: 'Address for single cluster
+
+          '
+        items:
+          type: str
+      clusters:
+        type: list
+        description: 'For multiple cluster support
+
+          '
+        primary_key: name
+        convert_types:
+        - dict
+        items:
+          type: dict
+          keys:
+            name:
+              type: str
+              required: true
+              display_name: Cluster Name
+            cvaddrs:
+              type: list
+              items:
+                type: str
+            cvauth:
+              type: dict
+              keys:
+                method:
+                  type: str
+                  valid_values:
+                  - token
+                  - token-secure
+                  - key
+                key:
+                  type: str
+                token_file:
+                  type: str
+                  display_name: Path
+                  description: 'Token file path
+
+                    e.g. "/tmp/token"
+
+                    '
+            cvobscurekeyfile:
+              type: bool
+            cvproxy:
+              type: str
+              display_name: URL
+            cvsourceip:
+              type: str
+              display_name: IP Address
+            cvvrf:
+              type: str
+              display_name: VRF
+      cvauth:
+        type: dict
+        description: 'Authentication scheme used to connect to CloudVision
+
+          '
+        keys:
+          method:
+            type: str
+            valid_values:
+            - token
+            - token-secure
+            - key
+          key:
+            type: str
+          token_file:
+            type: str
+            display_name: Path
+            description: 'Token file path
+
+              e.g. "/tmp/token"
+
+              '
+      cvobscurekeyfile:
+        type: bool
+        description: 'The default compression scheme when streaming to CloudVision
+          is gzip since TerminAttr 1.6.1 and CVP 2019.1.0. There is no need to change
+          the compression scheme.
+
+          Encrypt the private key used for authentication to CloudVision
+
+          '
+      cvproxy:
+        type: str
+        display_name: URL
+        description: 'Proxy server through which CloudVision is reachable. Useful
+          when the CloudVision server is hosted in the cloud.
+
+          The expected form is http://[user:password@]ip:port, e.g.: ''http://arista:arista@10.83.12.78:3128''.
+          Available as of TerminAttr v1.13.0
+
+          '
+      cvsourceip:
+        type: str
+        display_name: IP Address
+        description: 'Set source IP address in case of in-band managament
+
+          '
+      cvvrf:
+        type: str
+        display_name: VRF
+        description: 'Name of the VRF to use to connect to CloudVision
+
+          '
+      cvgnmi:
+        type: bool
+        description: 'Stream states from EOS GNMI servers (Openconfig) to CloudVision.
+          Available as of TerminAttr v1.13.1
+
+          '
+      disable_aaa:
+        type: bool
+        description: 'Disable AAA authorization and accounting.
+
+          When setting this flag, all commands pushed from CloudVision are applied
+          directly to the CLI without authorization
+
+          '
+      grpcaddr:
+        type: str
+        description: 'Set the gRPC server address, the default is 127.0.0.1:6042
+
+          e.g. "MGMT/0.0.0.0:6042"
+
+          '
+      grpcreadonly:
+        type: bool
+        description: 'gNMI read-only mode – Disable gnmi.Set()
+
+          '
+      ingestexclude:
+        type: str
+        description: 'Exclude paths from Sysdb on the ingest side.
+
+          e.g. "/Sysdb/cell/1/agent,/Sysdb/cell/2/agent"
+
+          '
+      smashexcludes:
+        type: str
+        description: 'Exclude paths from the shared memory table.
+
+          e.g. "ale,flexCounter,hardware,kni,pulse,strata"
+
+          '
+      taillogs:
+        type: str
+        description: 'Enable log file collection; /var/log/messages is streamed by
+          default if no path is set.
+
+          e.g. "/var/log/messages"
+
+          '
+      ecodhcpaddr:
+        type: str
+        description: 'ECO DHCP Collector address or ECO DHCP Fingerprint listening
+          addressin standalone mode (default "127.0.0.1:67")
+
+          '
+      ipfix:
+        type: bool
+        description: 'Enable IPFIX provider (default true).
+
+          This flag is enabled by default and does not have to be added to the daemon
+          configuration.
+
+          '
+      ipfixaddr:
+        type: str
+        description: 'ECO IPFIX Collector address to listen on to receive IPFIX packets
+          (default "127.0.0.1:4739").
+
+          This flag is enabled by default and does not have to be added to the daemon
+          configuration
+
+          '
+      sflow:
+        type: bool
+        description: 'Enable sFlow provider (default true).
+
+          This flag is enabled by default and does not have to be added to the daemon
+          configuration
+
+          '
+      sflowaddr:
+        type: str
+        description: 'ECO sFlow Collector address to listen on to receive sFlow packets
+          (default "127.0.0.1:6343").
+
+          This flag is enabled by default and does not have to be added to the daemon
+          configuration.'
   daemons:
     type: list
     primary_key: name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/daemon_terminattr.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/daemon_terminattr.schema.yml
@@ -160,6 +160,15 @@ keys:
       ingestauth_key:
         type: str
       ingestgrpcurl:
-        type: str
+        type: dict
+        keys:
+          ips:
+            type: list
+            items:
+              type: str
+          port:
+            type: int
+            convert_types:
+            - str
       ingestvrf:
         type: str

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/daemon_terminattr.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/daemon_terminattr.schema.yml
@@ -1,0 +1,164 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  daemon_terminattr:
+    type: dict
+    display_name: Daemon TerminAttr
+    description: |
+      Address of the gRPC server on CloudVision
+      - TCP 9910 is used on on-prem
+      - TCP 443 is used on CV as a Service
+    keys:
+      cvaddrs:
+        type: list
+        description: |
+          Address for single cluster
+        items:
+          type: str
+      clusters:
+        type: list
+        description: |
+          For multiple cluster support
+        primary_key: name
+        convert_types:
+        - dict
+        items:
+          type: dict
+          keys:
+            name:
+              type: str
+              required: true
+              display_name: Cluster Name
+            cvaddrs:
+              type: list
+              items:
+                type: str
+            cvauth:
+              type: dict
+              keys:
+                method:
+                  type: str
+                  valid_values: ["token", "token-secure", "key"]
+                key:
+                  type: str
+                token_file:
+                  type: str
+                  display_name: Path
+                  description: |
+                    Token file path
+                    e.g. "/tmp/token"
+            cvobscurekeyfile:
+              type: bool
+            cvproxy:
+              type: str
+              display_name: URL
+            cvsourceip:
+              type: str
+              display_name: IP Address
+            cvvrf:
+              type: str
+              display_name: VRF
+      cvauth:
+        type: dict
+        description: |
+          Authentication scheme used to connect to CloudVision
+        keys:
+          method:
+            type: str
+            valid_values: ["token", "token-secure", "key"]
+          key:
+            type: str
+          token_file:
+            type: str
+            display_name: Path
+            description: |
+              Token file path
+              e.g. "/tmp/token"
+
+
+
+
+
+
+
+
+      cvobscurekeyfile:
+        type: bool
+        description: |
+          The default compression scheme when streaming to CloudVision is gzip since TerminAttr 1.6.1 and CVP 2019.1.0. There is no need to change the compression scheme.
+          Encrypt the private key used for authentication to CloudVision
+      cvproxy:
+        type: str
+        display_name: URL
+        description: |
+          Proxy server through which CloudVision is reachable. Useful when the CloudVision server is hosted in the cloud.
+          The expected form is http://[user:password@]ip:port, e.g.: 'http://arista:arista@10.83.12.78:3128'. Available as of TerminAttr v1.13.0
+      cvsourceip:
+        type: str
+        display_name: IP Address
+        description: |
+          Set source IP address in case of in-band managament
+      cvvrf:
+        type: str
+        display_name: VRF
+        description: |
+          Name of the VRF to use to connect to CloudVision
+      cvgnmi:
+        type: bool
+        description: |
+          Stream states from EOS GNMI servers (Openconfig) to CloudVision. Available as of TerminAttr v1.13.1
+      disable_aaa:
+        type: bool
+        description: |
+          Disable AAA authorization and accounting.
+          When setting this flag, all commands pushed from CloudVision are applied directly to the CLI without authorization
+      grpcaddr:
+        type: str
+        description: |
+          Set the gRPC server address, the default is 127.0.0.1:6042
+          e.g. "MGMT/0.0.0.0:6042"
+      grpcreadonly:
+        type: bool
+        description: |
+          gNMI read-only mode – Disable gnmi.Set()
+      ingestexclude:
+        type: str
+        description: |
+          Exclude paths from Sysdb on the ingest side.
+          e.g. "/Sysdb/cell/1/agent,/Sysdb/cell/2/agent"
+      smashexcludes:
+        type: str
+        description: |
+          Exclude paths from the shared memory table.
+          e.g. "ale,flexCounter,hardware,kni,pulse,strata"
+      taillogs:
+        type: str
+        description: |
+          Enable log file collection; /var/log/messages is streamed by default if no path is set.
+          e.g. "/var/log/messages"
+      ecodhcpaddr:
+        type: str
+        description: |
+          ECO DHCP Collector address or ECO DHCP Fingerprint listening addressin standalone mode (default "127.0.0.1:67")
+      ipfix:
+        type: bool
+        description: |
+          Enable IPFIX provider (default true).
+          This flag is enabled by default and does not have to be added to the daemon configuration.
+      ipfixaddr:
+        type: str
+        description: |
+          ECO IPFIX Collector address to listen on to receive IPFIX packets (default "127.0.0.1:4739").
+          This flag is enabled by default and does not have to be added to the daemon configuration
+      sflow:
+        type: bool
+        description: |
+          Enable sFlow provider (default true).
+          This flag is enabled by default and does not have to be added to the daemon configuration
+      sflowaddr:
+        type: str
+        description: |
+          ECO sFlow Collector address to listen on to receive sFlow packets (default "127.0.0.1:6343").
+          This flag is enabled by default and does not have to be added to the daemon configuration.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/daemon_terminattr.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/daemon_terminattr.schema.yml
@@ -154,3 +154,12 @@ keys:
         description: |
           ECO sFlow Collector address to listen on to receive sFlow packets (default "127.0.0.1:6343").
           This flag is enabled by default and does not have to be added to the daemon configuration.
+
+      cvcompression:
+        type: str
+      ingestauth_key:
+        type: str
+      ingestgrpcurl:
+        type: str
+      ingestvrf:
+        type: str

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/daemon_terminattr.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/daemon_terminattr.schema.yml
@@ -7,20 +7,24 @@ keys:
     type: dict
     display_name: Daemon TerminAttr
     description: |
-      Address of the gRPC server on CloudVision
-      - TCP 9910 is used on on-prem
-      - TCP 443 is used on CV as a Service
+      You can either provide a list of IPs/FQDNs to target on-premise Cloudvision cluster or use DNS name for your Cloudvision as a Service instance.
+      Streaming to multiple clusters both on-prem and cloud service is supported.
+      > Note For TerminAttr version recommendation and EOS compatibility matrix, please refer to the latest TerminAttr Release Notes
+        which always contain the latest recommended versions and minimum required versions per EOS release.
     keys:
       cvaddrs:
         type: list
         description: |
-          Address for single cluster
+          Streaming address(es) for CloudVision single cluster
+          - TCP 9910 is used for CV on-prem
+          - TCP 443 is used for CV as a Service
         items:
           type: str
+          description: "Server address in the format `<ip/fqdn>:<port>`"
       clusters:
         type: list
         description: |
-          For multiple cluster support
+          Multiple CloudVision clusters
         primary_key: name
         convert_types:
         - dict
@@ -33,10 +37,17 @@ keys:
               display_name: Cluster Name
             cvaddrs:
               type: list
+              description: |
+                Streaming address(es) for CloudVision cluster
+                - TCP 9910 is used for CV on-prem
+                - TCP 443 is used for CV as a Service
               items:
                 type: str
+                description: "Server address in the format `<ip/fqdn>:<port>`"
             cvauth:
               type: dict
+              description: |
+                Authentication scheme used to connect to CloudVision
               keys:
                 method:
                   type: str
@@ -45,21 +56,30 @@ keys:
                   type: str
                 token_file:
                   type: str
-                  display_name: Path
                   description: |
                     Token file path
                     e.g. "/tmp/token"
             cvobscurekeyfile:
               type: bool
+              display_name: Obscure Key File
+              description: |
+                Encrypt the private key used for authentication to CloudVision
             cvproxy:
               type: str
-              display_name: URL
+              display_name: Proxy URL
+              description: |
+                Proxy server through which CloudVision is reachable. Useful when the CloudVision server is hosted in the cloud.
+                The expected form is http://[user:password@]ip:port, e.g.: 'http://arista:arista@10.83.12.78:3128'. Available as of TerminAttr v1.13.0
             cvsourceip:
               type: str
-              display_name: IP Address
+              display_name: Source IP Address
+              description: |
+                Set source IP address in case of in-band managament
             cvvrf:
               type: str
               display_name: VRF
+              description: |
+                The VRF to use to connect to CloudVision
       cvauth:
         type: dict
         description: |
@@ -72,31 +92,30 @@ keys:
             type: str
           token_file:
             type: str
-            display_name: Path
             description: |
               Token file path
               e.g. "/tmp/token"
       cvobscurekeyfile:
         type: bool
+        display_name: Obscure Key File
         description: |
-          The default compression scheme when streaming to CloudVision is gzip since TerminAttr 1.6.1 and CVP 2019.1.0. There is no need to change the compression scheme.
           Encrypt the private key used for authentication to CloudVision
       cvproxy:
         type: str
-        display_name: URL
+        display_name: Proxy URL
         description: |
           Proxy server through which CloudVision is reachable. Useful when the CloudVision server is hosted in the cloud.
           The expected form is http://[user:password@]ip:port, e.g.: 'http://arista:arista@10.83.12.78:3128'. Available as of TerminAttr v1.13.0
       cvsourceip:
         type: str
-        display_name: IP Address
+        display_name: Source IP Address
         description: |
           Set source IP address in case of in-band managament
       cvvrf:
         type: str
         display_name: VRF
         description: |
-          Name of the VRF to use to connect to CloudVision
+          The VRF to use to connect to CloudVision
       cvgnmi:
         type: bool
         description: |
@@ -114,7 +133,7 @@ keys:
       grpcreadonly:
         type: bool
         description: |
-          gNMI read-only mode – Disable gnmi.Set()
+          gNMI read-only mode - Disable gnmi.Set()
       ingestexclude:
         type: str
         description: |
@@ -133,34 +152,37 @@ keys:
       ecodhcpaddr:
         type: str
         description: |
-          ECO DHCP Collector address or ECO DHCP Fingerprint listening addressin standalone mode (default "127.0.0.1:67")
+          ECO DHCP Collector address or ECO DHCP Fingerprint listening address in standalone mode (default "127.0.0.1:67")
       ipfix:
         type: bool
         description: |
-          Enable IPFIX provider (default true).
+          Enable IPFIX provider (TerminAttr default is true).
           This flag is enabled by default and does not have to be added to the daemon configuration.
       ipfixaddr:
         type: str
         description: |
-          ECO IPFIX Collector address to listen on to receive IPFIX packets (default "127.0.0.1:4739").
-          This flag is enabled by default and does not have to be added to the daemon configuration
+          ECO IPFIX Collector address to listen on to receive IPFIX packets (TerminAttr default "127.0.0.1:4739").
       sflow:
         type: bool
         description: |
-          Enable sFlow provider (default true).
-          This flag is enabled by default and does not have to be added to the daemon configuration
+          Enable sFlow provider (TerminAttr default is true).
       sflowaddr:
         type: str
         description: |
-          ECO sFlow Collector address to listen on to receive sFlow packets (default "127.0.0.1:6343").
-          This flag is enabled by default and does not have to be added to the daemon configuration.
-
+          ECO sFlow Collector address to listen on to receive sFlow packets (TerminAttr default "127.0.0.1:6343").
       cvcompression:
         type: str
+        description: |
+          The default compression scheme when streaming to CloudVision is gzip since TerminAttr 1.6.1 and CVP 2019.1.0.
+          There is no need to change the compression scheme.
       ingestauth_key:
         type: str
+        description: |
+          Deprecated key. Use `cvauth` instead.
       ingestgrpcurl:
         type: dict
+        description: |
+          Deprecated key. Use `cvaddrs` instead.
         keys:
           ips:
             type: list
@@ -171,4 +193,6 @@ keys:
             convert_types:
             - str
       ingestvrf:
+        description: |
+          Deprecated key. Use `cvvrf` instead.
         type: str

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/daemon_terminattr.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/daemon_terminattr.schema.yml
@@ -76,14 +76,6 @@ keys:
             description: |
               Token file path
               e.g. "/tmp/token"
-
-
-
-
-
-
-
-
       cvobscurekeyfile:
         type: bool
         description: |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/daemon-terminattr.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/daemon-terminattr.j2
@@ -6,7 +6,7 @@
 
 | CV Compression | CloudVision Servers | VRF | Authentication | Smash Excludes | Ingest Exclude | Bypass AAA |
 | -------------- | ------------------- | --- | -------------- | -------------- | -------------- | ---------- |
-{%     for cluster in daemon_terminattr.clusters | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%     for cluster in daemon_terminattr.clusters | arista.avd.natural_sort('name') %}
 {%         set url = cluster.cvaddrs | arista.avd.default([]) | join(',') %}
 {%         if cluster.cvauth.method is arista.avd.defined('key') %}
 {%             set auth = 'key,' ~ cluster.cvauth.key | arista.avd.default('') %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/daemon-terminattr.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/daemon-terminattr.j2
@@ -4,7 +4,7 @@
 !
 daemon TerminAttr
 {%     set cvp_config.cli = "exec /usr/bin/TerminAttr" %}
-{%     for cluster in daemon_terminattr.clusters | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%     for cluster in daemon_terminattr.clusters | arista.avd.natural_sort('name') %}
 {%         set cvp_config.cli = cvp_config.cli ~  " -cvopt " ~ cluster.name ~ ".addr=" ~ cluster.cvaddrs | join(',') %}
 {%         if cluster.cvauth.method is arista.avd.defined('key') %}
 {%             set cvp_config.cli = cvp_config.cli ~ " -cvopt " ~ cluster.name ~ ".auth=key," ~ cluster.cvauth.key | arista.avd.default('') %}


### PR DESCRIPTION
## Add schema for data model

<!-- Use this PR Title: Feat(eos_cli_config_gen): Add schema for < data_model_key > -->

## Checklist

### Contributor Checklist

- [x] Create schema fragment matching data model described in README.md and README_v4.0.md
  - README.md is most complete with all keys. README_v4.0 includes partial data models after conversion to lists.
  - Schema fragment path is `roles/eos_cli_config_gen/schemas/schema_fragments/<data_model_key>.schema.yml`.
  - Copy line 1-5 from another schema (comments and outer type:dict).
  - Refer to [schema documentation](https://avd.sh/en/devel/docs/input-variable-validation-BETA.html) for syntax and/or use YAML Lint plugin from Redhat in VSCode.
  - Use `convert_types` on value that could be mixed type or misinterpreted like integers and numeric strings.
- [x] If the data model has been converted from wildcard dicts:
  - Add `convert_types: ['dict']` to the schema.
  - Remove `convert_dicts` from the `templates/eos/<>.j2` and `templates/documentation/<>.j2` templates.
- [x] Run `molecule converge -s build_schemas_and_docs` to update schema and documentation.
- [x] Test by running `molecule converge -s eos_cli_config_gen` and verify no errors or changes to generated configs/docs.

### Reviewer Checklist

- Reviewer 1: Claus
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2: Carl
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
