### PR TITLE
Feat(eos_cli_config_gen): Add schema for logging

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/logging.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/logging.md
@@ -55,7 +55,7 @@ interface Management1
 
 | Type | Level |
 | -----| ----- |
-| Console | error |
+| Console | errors |
 | Buffer | warnings |
 | Trap | disabled |
 | Synchronous | critical |
@@ -87,7 +87,7 @@ interface Management1
 !
 logging buffered 1000000 warnings
 no logging trap
-logging console error
+logging console errors
 logging synchronous level critical
 logging host 20.20.20.7
 logging host 50.50.50.7 100 200 protocol tcp

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/logging.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/logging.cfg
@@ -4,7 +4,7 @@ transceiver qsfp default-mode 4x10G
 !
 logging buffered 1000000 warnings
 no logging trap
-logging console error
+logging console errors
 logging synchronous level critical
 logging host 20.20.20.7
 logging host 50.50.50.7 100 200 protocol tcp

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/logging.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/logging.yml
@@ -1,6 +1,6 @@
 ### Logging ###
 logging:
-  console: error
+  console: errors
   buffered:
     size: 1000000
     level: warnings

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/logging.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/logging.md
@@ -55,7 +55,7 @@ interface Management1
 
 | Type | Level |
 | -----| ----- |
-| Console | error |
+| Console | errors |
 | Buffer | warnings |
 | Trap | disabled |
 | Synchronous | critical |
@@ -80,7 +80,7 @@ interface Management1
 !
 logging buffered 1000000 warnings
 no logging trap
-logging console error
+logging console errors
 logging synchronous level critical
 logging host 20.20.20.7
 logging host 50.50.50.7 100 200 protocol tcp

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/logging.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/logging.cfg
@@ -4,7 +4,7 @@ transceiver qsfp default-mode 4x10G
 !
 logging buffered 1000000 warnings
 no logging trap
-logging console error
+logging console errors
 logging synchronous level critical
 logging host 20.20.20.7
 logging host 50.50.50.7 100 200 protocol tcp

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/logging.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/logging.yml
@@ -1,6 +1,6 @@
 ### Logging ###
 logging:
-  console: error
+  console: errors
   buffered:
     size: 1000000
     level: warnings

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -1534,19 +1534,19 @@ local_users:
 | Variable | Type | Required | Default | Value Restrictions | Description |
 | -------- | ---- | -------- | ------- | ------------------ | ----------- |
 | [<samp>logging</samp>](## "logging") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;console</samp>](## "logging.console") | String |  |  |  | "<severity_level>" | "disabled"<br>e.g. console: error<br> |
-| [<samp>&nbsp;&nbsp;monitor</samp>](## "logging.monitor") | String |  |  |  | "<severity_level>" | "disabled"<br>e.g. monitor: debugging<br> |
+| [<samp>&nbsp;&nbsp;console</samp>](## "logging.console") | String |  |  | Valid Values:<br>- debugging<br>- informational<br>- notifications<br>- warnings<br>- errors<br>- critical<br>- alerts<br>- emergencies<br>- disabled | Console logging severity level<br> |
+| [<samp>&nbsp;&nbsp;monitor</samp>](## "logging.monitor") | String |  |  | Valid Values:<br>- debugging<br>- informational<br>- notifications<br>- warnings<br>- errors<br>- critical<br>- alerts<br>- emergencies<br>- disabled | Monitor logging severity level<br> |
 | [<samp>&nbsp;&nbsp;buffered</samp>](## "logging.buffered") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;size</samp>](## "logging.buffered.size") | Integer |  |  | Min: 10 |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;level</samp>](## "logging.buffered.level") | String |  |  |  | "<severity_level>" | "disabled"<br>e.g. monitor: warnings<br> |
-| [<samp>&nbsp;&nbsp;trap</samp>](## "logging.trap") | String |  |  |  | "<severity_level>" | "disabled"<br>e.g. trap: disabled<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;size</samp>](## "logging.buffered.size") | Integer |  |  | Min: 10<br>Max: 2147483647 |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;level</samp>](## "logging.buffered.level") | String |  |  | Valid Values:<br>- debugging<br>- informational<br>- notifications<br>- warnings<br>- errors<br>- critical<br>- alerts<br>- emergencies<br>- disabled | Buffer logging severity level<br> |
+| [<samp>&nbsp;&nbsp;trap</samp>](## "logging.trap") | String |  |  | Valid Values:<br>- debugging<br>- informational<br>- notifications<br>- warnings<br>- errors<br>- critical<br>- alerts<br>- emergencies<br>- disabled | Trap logging severity level<br> |
 | [<samp>&nbsp;&nbsp;synchronous</samp>](## "logging.synchronous") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;level</samp>](## "logging.synchronous.level") | String |  | critical |  | "<severity_level>" | "disabled"<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;level</samp>](## "logging.synchronous.level") | String |  | critical | Valid Values:<br>- debugging<br>- informational<br>- notifications<br>- warnings<br>- errors<br>- critical<br>- alerts<br>- emergencies<br>- disabled | Synchronous logging severity level<br> |
 | [<samp>&nbsp;&nbsp;format</samp>](## "logging.format") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;timestamp</samp>](## "logging.format.timestamp") | String |  |  |  | < high-resolution | traditional ><br> |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;hostname</samp>](## "logging.format.hostname") | String |  |  |  | < fqdn | ipv4 ><br> |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;sequence_numbers</samp>](## "logging.format.sequence_numbers") | Boolean |  |  |  |  |
-| [<samp>&nbsp;&nbsp;facility</samp>](## "logging.facility") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;timestamp</samp>](## "logging.format.timestamp") | String |  |  | Valid Values:<br>- high-resolution<br>- traditional | Timestamp format |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;hostname</samp>](## "logging.format.hostname") | String |  |  | Valid Values:<br>- fqdn<br>- ipv4 | Hostname format |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;sequence_numbers</samp>](## "logging.format.sequence_numbers") | Boolean |  |  |  | Add sequence numbers to log messages<br> |
+| [<samp>&nbsp;&nbsp;facility</samp>](## "logging.facility") | String |  |  | Valid Values:<br>- auth<br>- cron<br>- daemon<br>- kern<br>- local0<br>- local1<br>- local2<br>- local3<br>- local4<br>- local5<br>- local6<br>- local7<br>- lpr<br>- mail<br>- news<br>- sys9<br>- sys10<br>- sys11<br>- sys12<br>- sys13<br>- sys14<br>- syslog<br>- user<br>- uucp |  |
 | [<samp>&nbsp;&nbsp;source_interface</samp>](## "logging.source_interface") | String |  |  |  | Source Interface Name |
 | [<samp>&nbsp;&nbsp;vrfs</samp>](## "logging.vrfs") | List, items: Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "logging.vrfs.[].name") | String | Required, Unique |  |  | VRF Name |
@@ -1560,7 +1560,7 @@ local_users:
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;match</samp>](## "logging.policy.match") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;match_lists</samp>](## "logging.policy.match.match_lists") | List, items: Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "logging.policy.match.match_lists.[].name") | String | Required, Unique |  |  | Match list |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;action</samp>](## "logging.policy.match.match_lists.[].action") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;action</samp>](## "logging.policy.match.match_lists.[].action") | String |  |  | Valid Values:<br>- discard |  |
 
 ### YAML
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -1548,7 +1548,7 @@ local_users:
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;sequence_numbers</samp>](## "logging.format.sequence_numbers") | Boolean |  |  |  | Add sequence numbers to log messages<br> |
 | [<samp>&nbsp;&nbsp;facility</samp>](## "logging.facility") | String |  |  | Valid Values:<br>- auth<br>- cron<br>- daemon<br>- kern<br>- local0<br>- local1<br>- local2<br>- local3<br>- local4<br>- local5<br>- local6<br>- local7<br>- lpr<br>- mail<br>- news<br>- sys9<br>- sys10<br>- sys11<br>- sys12<br>- sys13<br>- sys14<br>- syslog<br>- user<br>- uucp |  |
 | [<samp>&nbsp;&nbsp;source_interface</samp>](## "logging.source_interface") | String |  |  |  | Source Interface Name |
-| [<samp>&nbsp;&nbsp;vrfs</samp>](## "logging.vrfs") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;vrfs</samp>](## "logging.vrfs") | List, items: Dictionary |  |  |  | VRFs |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "logging.vrfs.[].name") | String | Required, Unique |  |  | VRF Name |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_interface</samp>](## "logging.vrfs.[].source_interface") | String |  |  |  | Source Interface Name |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hosts</samp>](## "logging.vrfs.[].hosts") | List, items: Dictionary |  |  |  |  |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -1527,6 +1527,74 @@ local_users:
     ssh_key: <str>
 ```
 
+## Logging
+
+### Variables
+
+| Variable | Type | Required | Default | Value Restrictions | Description |
+| -------- | ---- | -------- | ------- | ------------------ | ----------- |
+| [<samp>logging</samp>](## "logging") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;console</samp>](## "logging.console") | String |  |  |  | "<severity_level>" | "disabled"<br>e.g. console: error<br> |
+| [<samp>&nbsp;&nbsp;monitor</samp>](## "logging.monitor") | String |  |  |  | "<severity_level>" | "disabled"<br>e.g. monitor: debugging<br> |
+| [<samp>&nbsp;&nbsp;buffered</samp>](## "logging.buffered") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;size</samp>](## "logging.buffered.size") | Integer |  |  | Min: 10 |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;level</samp>](## "logging.buffered.level") | String |  |  |  | "<severity_level>" | "disabled"<br>e.g. monitor: warnings<br> |
+| [<samp>&nbsp;&nbsp;trap</samp>](## "logging.trap") | String |  |  |  | "<severity_level>" | "disabled"<br>e.g. trap: disabled<br> |
+| [<samp>&nbsp;&nbsp;synchronous</samp>](## "logging.synchronous") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;level</samp>](## "logging.synchronous.level") | String |  | critical |  | "<severity_level>" | "disabled"<br> |
+| [<samp>&nbsp;&nbsp;format</samp>](## "logging.format") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;timestamp</samp>](## "logging.format.timestamp") | String |  |  |  | < high-resolution | traditional ><br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;hostname</samp>](## "logging.format.hostname") | String |  |  |  | < fqdn | ipv4 ><br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;sequence_numbers</samp>](## "logging.format.sequence_numbers") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;facility</samp>](## "logging.facility") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;source_interface</samp>](## "logging.source_interface") | String |  |  |  | Source Interface Name |
+| [<samp>&nbsp;&nbsp;vrfs</samp>](## "logging.vrfs") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "logging.vrfs.[].name") | String | Required, Unique |  |  | VRF Name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_interface</samp>](## "logging.vrfs.[].source_interface") | String |  |  |  | Source Interface Name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hosts</samp>](## "logging.vrfs.[].hosts") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "logging.vrfs.[].hosts.[].name") | String | Required, Unique |  |  | Syslog Server Name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;protocol</samp>](## "logging.vrfs.[].hosts.[].protocol") | String |  | udp | Valid Values:<br>- tcp<br>- udp |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ports</samp>](## "logging.vrfs.[].hosts.[].ports") | List, items: Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;int&gt;</samp>](## "logging.vrfs.[].hosts.[].ports.[].&lt;int&gt;") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;policy</samp>](## "logging.policy") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;match</samp>](## "logging.policy.match") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;match_lists</samp>](## "logging.policy.match.match_lists") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "logging.policy.match.match_lists.[].name") | String | Required, Unique |  |  | Match list |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;action</samp>](## "logging.policy.match.match_lists.[].action") | String |  |  |  |  |
+
+### YAML
+
+```yaml
+logging:
+  console: <str>
+  monitor: <str>
+  buffered:
+    size: <int>
+    level: <str>
+  trap: <str>
+  synchronous:
+    level: <str>
+  format:
+    timestamp: <str>
+    hostname: <str>
+    sequence_numbers: <bool>
+  facility: <str>
+  source_interface: <str>
+  vrfs:
+    - name: <str>
+      source_interface: <str>
+      hosts:
+        - name: <str>
+          protocol: <str>
+          ports:
+            - <int>
+  policy:
+    match:
+      match_lists:
+        - name: <str>
+          action: <str>
+```
+
 ## Mac Access Lists
 
 ### Variables

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -1543,7 +1543,7 @@ local_users:
 | [<samp>&nbsp;&nbsp;synchronous</samp>](## "logging.synchronous") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;level</samp>](## "logging.synchronous.level") | String |  | critical | Valid Values:<br>- debugging<br>- informational<br>- notifications<br>- warnings<br>- errors<br>- critical<br>- alerts<br>- emergencies<br>- disabled | Synchronous logging severity level<br> |
 | [<samp>&nbsp;&nbsp;format</samp>](## "logging.format") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;timestamp</samp>](## "logging.format.timestamp") | String |  |  | Valid Values:<br>- high-resolution<br>- traditional | Timestamp format |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;timestamp</samp>](## "logging.format.timestamp") | String |  |  | Valid Values:<br>- high-resolution<br>- traditional<br>- traditional timezone<br>- traditional year<br>- traditional timezone year<br>- traditional year timezone | Timestamp format |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;hostname</samp>](## "logging.format.hostname") | String |  |  | Valid Values:<br>- fqdn<br>- ipv4 | Hostname format |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;sequence_numbers</samp>](## "logging.format.sequence_numbers") | Boolean |  |  |  | Add sequence numbers to log messages<br> |
 | [<samp>&nbsp;&nbsp;facility</samp>](## "logging.facility") | String |  |  | Valid Values:<br>- auth<br>- cron<br>- daemon<br>- kern<br>- local0<br>- local1<br>- local2<br>- local3<br>- local4<br>- local5<br>- local6<br>- local7<br>- lpr<br>- mail<br>- news<br>- sys9<br>- sys10<br>- sys11<br>- sys12<br>- sys13<br>- sys14<br>- syslog<br>- user<br>- uucp |  |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -1549,10 +1549,10 @@ local_users:
 | [<samp>&nbsp;&nbsp;facility</samp>](## "logging.facility") | String |  |  | Valid Values:<br>- auth<br>- cron<br>- daemon<br>- kern<br>- local0<br>- local1<br>- local2<br>- local3<br>- local4<br>- local5<br>- local6<br>- local7<br>- lpr<br>- mail<br>- news<br>- sys9<br>- sys10<br>- sys11<br>- sys12<br>- sys13<br>- sys14<br>- syslog<br>- user<br>- uucp |  |
 | [<samp>&nbsp;&nbsp;source_interface</samp>](## "logging.source_interface") | String |  |  |  | Source Interface Name |
 | [<samp>&nbsp;&nbsp;vrfs</samp>](## "logging.vrfs") | List, items: Dictionary |  |  |  | VRFs |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "logging.vrfs.[].name") | String | Required, Unique |  |  | VRF Name |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_interface</samp>](## "logging.vrfs.[].source_interface") | String |  |  |  | Source Interface Name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "logging.vrfs.[].name") | String | Required, Unique |  |  | VRF name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_interface</samp>](## "logging.vrfs.[].source_interface") | String |  |  |  | Source interface name |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hosts</samp>](## "logging.vrfs.[].hosts") | List, items: Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "logging.vrfs.[].hosts.[].name") | String | Required, Unique |  |  | Syslog Server Name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "logging.vrfs.[].hosts.[].name") | String | Required, Unique |  |  | Syslog server name |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;protocol</samp>](## "logging.vrfs.[].hosts.[].protocol") | String |  | udp | Valid Values:<br>- tcp<br>- udp |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ports</samp>](## "logging.vrfs.[].hosts.[].ports") | List, items: Integer |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;int&gt;</samp>](## "logging.vrfs.[].hosts.[].ports.[].&lt;int&gt;") | Integer |  |  |  |  |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -2383,7 +2383,8 @@
                 "traditional timezone year",
                 "traditional year timezone"
               ],
-              "title": "Timestamp format"
+              "description": "Timestamp format",
+              "title": "Timestamp"
             },
             "hostname": {
               "type": "string",
@@ -2391,7 +2392,8 @@
                 "fqdn",
                 "ipv4"
               ],
-              "title": "Hostname format"
+              "description": "Hostname format",
+              "title": "Hostname"
             },
             "sequence_numbers": {
               "type": "boolean",
@@ -2434,7 +2436,8 @@
         },
         "source_interface": {
           "type": "string",
-          "title": "Source Interface Name"
+          "description": "Source Interface Name",
+          "title": "Source Interface"
         },
         "vrfs": {
           "title": "VRFs",
@@ -2444,11 +2447,13 @@
             "properties": {
               "name": {
                 "type": "string",
-                "title": "VRF Name"
+                "description": "VRF name",
+                "title": "Name"
               },
               "source_interface": {
                 "type": "string",
-                "title": "Source Interface Name"
+                "description": "Source interface name",
+                "title": "Source Interface"
               },
               "hosts": {
                 "type": "array",
@@ -2457,7 +2462,8 @@
                   "properties": {
                     "name": {
                       "type": "string",
-                      "title": "Syslog Server Name"
+                      "description": "Syslog server name",
+                      "title": "Name"
                     },
                     "protocol": {
                       "type": "string",
@@ -2503,7 +2509,8 @@
                     "properties": {
                       "name": {
                         "type": "string",
-                        "title": "Match list"
+                        "description": "Match list",
+                        "title": "Name"
                       },
                       "action": {
                         "type": "string",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -2271,12 +2271,34 @@
       "properties": {
         "console": {
           "type": "string",
-          "description": "\"<severity_level>\" | \"disabled\"\ne.g. console: error\n",
+          "enum": [
+            "debugging",
+            "informational",
+            "notifications",
+            "warnings",
+            "errors",
+            "critical",
+            "alerts",
+            "emergencies",
+            "disabled"
+          ],
+          "description": "Console logging severity level\n",
           "title": "Console"
         },
         "monitor": {
           "type": "string",
-          "description": "\"<severity_level>\" | \"disabled\"\ne.g. monitor: debugging\n",
+          "enum": [
+            "debugging",
+            "informational",
+            "notifications",
+            "warnings",
+            "errors",
+            "critical",
+            "alerts",
+            "emergencies",
+            "disabled"
+          ],
+          "description": "Monitor logging severity level\n",
           "title": "Monitor"
         },
         "buffered": {
@@ -2285,11 +2307,23 @@
             "size": {
               "type": "integer",
               "minimum": 10,
+              "maximum": 2147483647,
               "title": "Size"
             },
             "level": {
               "type": "string",
-              "description": "\"<severity_level>\" | \"disabled\"\ne.g. monitor: warnings\n",
+              "enum": [
+                "debugging",
+                "informational",
+                "notifications",
+                "warnings",
+                "errors",
+                "critical",
+                "alerts",
+                "emergencies",
+                "disabled"
+              ],
+              "description": "Buffer logging severity level\n",
               "title": "Level"
             }
           },
@@ -2298,7 +2332,18 @@
         },
         "trap": {
           "type": "string",
-          "description": "\"<severity_level>\" | \"disabled\"\ne.g. trap: disabled\n",
+          "enum": [
+            "debugging",
+            "informational",
+            "notifications",
+            "warnings",
+            "errors",
+            "critical",
+            "alerts",
+            "emergencies",
+            "disabled"
+          ],
+          "description": "Trap logging severity level\n",
           "title": "Trap"
         },
         "synchronous": {
@@ -2306,7 +2351,18 @@
           "properties": {
             "level": {
               "type": "string",
-              "description": "\"<severity_level>\" | \"disabled\"\n",
+              "enum": [
+                "debugging",
+                "informational",
+                "notifications",
+                "warnings",
+                "errors",
+                "critical",
+                "alerts",
+                "emergencies",
+                "disabled"
+              ],
+              "description": "Synchronous logging severity level\n",
               "default": "critical",
               "title": "Level"
             }
@@ -2319,16 +2375,23 @@
           "properties": {
             "timestamp": {
               "type": "string",
-              "description": "< high-resolution | traditional >\n",
-              "title": "Timestamp"
+              "enum": [
+                "high-resolution",
+                "traditional"
+              ],
+              "title": "Timestamp format"
             },
             "hostname": {
               "type": "string",
-              "description": "< fqdn | ipv4 >\n",
-              "title": "Hostname"
+              "enum": [
+                "fqdn",
+                "ipv4"
+              ],
+              "title": "Hostname format"
             },
             "sequence_numbers": {
               "type": "boolean",
+              "description": "Add sequence numbers to log messages\n",
               "title": "Sequence Numbers"
             }
           },
@@ -2337,6 +2400,32 @@
         },
         "facility": {
           "type": "string",
+          "enum": [
+            "auth",
+            "cron",
+            "daemon",
+            "kern",
+            "local0",
+            "local1",
+            "local2",
+            "local3",
+            "local4",
+            "local5",
+            "local6",
+            "local7",
+            "lpr",
+            "mail",
+            "news",
+            "sys9",
+            "sys10",
+            "sys11",
+            "sys12",
+            "sys13",
+            "sys14",
+            "syslog",
+            "user",
+            "uucp"
+          ],
           "title": "Facility"
         },
         "source_interface": {
@@ -2414,6 +2503,9 @@
                       },
                       "action": {
                         "type": "string",
+                        "enum": [
+                          "discard"
+                        ],
                         "title": "Action"
                       }
                     },

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -2266,6 +2266,176 @@
       },
       "title": "Local Users"
     },
+    "logging": {
+      "type": "object",
+      "properties": {
+        "console": {
+          "type": "string",
+          "description": "\"<severity_level>\" | \"disabled\"\ne.g. console: error\n",
+          "title": "Console"
+        },
+        "monitor": {
+          "type": "string",
+          "description": "\"<severity_level>\" | \"disabled\"\ne.g. monitor: debugging\n",
+          "title": "Monitor"
+        },
+        "buffered": {
+          "type": "object",
+          "properties": {
+            "size": {
+              "type": "integer",
+              "minimum": 10,
+              "title": "Size"
+            },
+            "level": {
+              "type": "string",
+              "description": "\"<severity_level>\" | \"disabled\"\ne.g. monitor: warnings\n",
+              "title": "Level"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Buffered"
+        },
+        "trap": {
+          "type": "string",
+          "description": "\"<severity_level>\" | \"disabled\"\ne.g. trap: disabled\n",
+          "title": "Trap"
+        },
+        "synchronous": {
+          "type": "object",
+          "properties": {
+            "level": {
+              "type": "string",
+              "description": "\"<severity_level>\" | \"disabled\"\n",
+              "default": "critical",
+              "title": "Level"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Synchronous"
+        },
+        "format": {
+          "type": "object",
+          "properties": {
+            "timestamp": {
+              "type": "string",
+              "description": "< high-resolution | traditional >\n",
+              "title": "Timestamp"
+            },
+            "hostname": {
+              "type": "string",
+              "description": "< fqdn | ipv4 >\n",
+              "title": "Hostname"
+            },
+            "sequence_numbers": {
+              "type": "boolean",
+              "title": "Sequence Numbers"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Format"
+        },
+        "facility": {
+          "type": "string",
+          "title": "Facility"
+        },
+        "source_interface": {
+          "type": "string",
+          "title": "Source Interface Name"
+        },
+        "vrfs": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "VRF Name"
+              },
+              "source_interface": {
+                "type": "string",
+                "title": "Source Interface Name"
+              },
+              "hosts": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "title": "Syslog Server Name"
+                    },
+                    "protocol": {
+                      "type": "string",
+                      "enum": [
+                        "tcp",
+                        "udp"
+                      ],
+                      "default": "udp",
+                      "title": "Protocol"
+                    },
+                    "ports": {
+                      "type": "array",
+                      "items": {
+                        "type": "integer"
+                      },
+                      "title": "Ports"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "additionalProperties": false
+                },
+                "title": "Hosts"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "additionalProperties": false
+          },
+          "title": "Vrfs"
+        },
+        "policy": {
+          "type": "object",
+          "properties": {
+            "match": {
+              "type": "object",
+              "properties": {
+                "match_lists": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "title": "Match list"
+                      },
+                      "action": {
+                        "type": "string",
+                        "title": "Action"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "additionalProperties": false
+                  },
+                  "title": "Match Lists"
+                }
+              },
+              "additionalProperties": false,
+              "title": "Match"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Policy"
+        }
+      },
+      "additionalProperties": false,
+      "title": "Logging"
+    },
     "mac_access_lists": {
       "type": "array",
       "items": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -2377,7 +2377,11 @@
               "type": "string",
               "enum": [
                 "high-resolution",
-                "traditional"
+                "traditional",
+                "traditional timezone",
+                "traditional year",
+                "traditional timezone year",
+                "traditional year timezone"
               ],
               "title": "Timestamp format"
             },

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -2437,6 +2437,7 @@
           "title": "Source Interface Name"
         },
         "vrfs": {
+          "title": "VRFs",
           "type": "array",
           "items": {
             "type": "object",
@@ -2487,8 +2488,7 @@
               "name"
             ],
             "additionalProperties": false
-          },
-          "title": "Vrfs"
+          }
         },
         "policy": {
           "type": "object",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -1986,6 +1986,7 @@ keys:
         type: str
         display_name: Source Interface Name
       vrfs:
+        display_name: VRFs
         type: list
         primary_key: name
         convert_types:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -1939,6 +1939,10 @@ keys:
             valid_values:
             - high-resolution
             - traditional
+            - traditional timezone
+            - traditional year
+            - traditional timezone year
+            - traditional year timezone
             display_name: Timestamp format
           hostname:
             type: str

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -1845,16 +1845,32 @@ keys:
     keys:
       console:
         type: str
-        description: '"<severity_level>" | "disabled"
-
-          e.g. console: error
+        valid_values:
+        - debugging
+        - informational
+        - notifications
+        - warnings
+        - errors
+        - critical
+        - alerts
+        - emergencies
+        - disabled
+        description: 'Console logging severity level
 
           '
       monitor:
         type: str
-        description: '"<severity_level>" | "disabled"
-
-          e.g. monitor: debugging
+        valid_values:
+        - debugging
+        - informational
+        - notifications
+        - warnings
+        - errors
+        - critical
+        - alerts
+        - emergencies
+        - disabled
+        description: 'Monitor logging severity level
 
           '
       buffered:
@@ -1865,18 +1881,35 @@ keys:
             convert_types:
             - str
             min: 10
+            max: 2147483647
           level:
             type: str
-            description: '"<severity_level>" | "disabled"
-
-              e.g. monitor: warnings
+            valid_values:
+            - debugging
+            - informational
+            - notifications
+            - warnings
+            - errors
+            - critical
+            - alerts
+            - emergencies
+            - disabled
+            description: 'Buffer logging severity level
 
               '
       trap:
         type: str
-        description: '"<severity_level>" | "disabled"
-
-          e.g. trap: disabled
+        valid_values:
+        - debugging
+        - informational
+        - notifications
+        - warnings
+        - errors
+        - critical
+        - alerts
+        - emergencies
+        - disabled
+        description: 'Trap logging severity level
 
           '
       synchronous:
@@ -1884,7 +1917,17 @@ keys:
         keys:
           level:
             type: str
-            description: '"<severity_level>" | "disabled"
+            valid_values:
+            - debugging
+            - informational
+            - notifications
+            - warnings
+            - errors
+            - critical
+            - alerts
+            - emergencies
+            - disabled
+            description: 'Synchronous logging severity level
 
               '
             default: critical
@@ -1893,18 +1936,48 @@ keys:
         keys:
           timestamp:
             type: str
-            description: '< high-resolution | traditional >
-
-              '
+            valid_values:
+            - high-resolution
+            - traditional
+            display_name: Timestamp format
           hostname:
             type: str
-            description: '< fqdn | ipv4 >
-
-              '
+            valid_values:
+            - fqdn
+            - ipv4
+            display_name: Hostname format
           sequence_numbers:
             type: bool
+            description: 'Add sequence numbers to log messages
+
+              '
       facility:
         type: str
+        valid_values:
+        - auth
+        - cron
+        - daemon
+        - kern
+        - local0
+        - local1
+        - local2
+        - local3
+        - local4
+        - local5
+        - local6
+        - local7
+        - lpr
+        - mail
+        - news
+        - sys9
+        - sys10
+        - sys11
+        - sys12
+        - sys13
+        - sys14
+        - syslog
+        - user
+        - uucp
       source_interface:
         type: str
         display_name: Source Interface Name
@@ -1967,6 +2040,8 @@ keys:
                       display_name: Match list
                     action:
                       type: str
+                      valid_values:
+                      - discard
   mac_access_lists:
     type: list
     primary_key: name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -1943,13 +1943,13 @@ keys:
             - traditional year
             - traditional timezone year
             - traditional year timezone
-            display_name: Timestamp format
+            description: Timestamp format
           hostname:
             type: str
             valid_values:
             - fqdn
             - ipv4
-            display_name: Hostname format
+            description: Hostname format
           sequence_numbers:
             type: bool
             description: 'Add sequence numbers to log messages
@@ -1984,7 +1984,7 @@ keys:
         - uucp
       source_interface:
         type: str
-        display_name: Source Interface Name
+        description: Source Interface Name
       vrfs:
         display_name: VRFs
         type: list
@@ -1997,10 +1997,10 @@ keys:
             name:
               type: str
               required: true
-              display_name: VRF Name
+              description: VRF name
             source_interface:
               type: str
-              display_name: Source Interface Name
+              description: Source interface name
             hosts:
               type: list
               primary_key: name
@@ -2012,7 +2012,7 @@ keys:
                   name:
                     type: str
                     required: true
-                    display_name: Syslog Server Name
+                    description: Syslog server name
                   protocol:
                     type: str
                     valid_values:
@@ -2042,7 +2042,7 @@ keys:
                     name:
                       type: str
                       required: true
-                      display_name: Match list
+                      description: Match list
                     action:
                       type: str
                       valid_values:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -1840,6 +1840,133 @@ keys:
         ssh_key:
           display_name: SSH Key
           type: str
+  logging:
+    type: dict
+    keys:
+      console:
+        type: str
+        description: '"<severity_level>" | "disabled"
+
+          e.g. console: error
+
+          '
+      monitor:
+        type: str
+        description: '"<severity_level>" | "disabled"
+
+          e.g. monitor: debugging
+
+          '
+      buffered:
+        type: dict
+        keys:
+          size:
+            type: int
+            convert_types:
+            - str
+            min: 10
+          level:
+            type: str
+            description: '"<severity_level>" | "disabled"
+
+              e.g. monitor: warnings
+
+              '
+      trap:
+        type: str
+        description: '"<severity_level>" | "disabled"
+
+          e.g. trap: disabled
+
+          '
+      synchronous:
+        type: dict
+        keys:
+          level:
+            type: str
+            description: '"<severity_level>" | "disabled"
+
+              '
+            default: critical
+      format:
+        type: dict
+        keys:
+          timestamp:
+            type: str
+            description: '< high-resolution | traditional >
+
+              '
+          hostname:
+            type: str
+            description: '< fqdn | ipv4 >
+
+              '
+          sequence_numbers:
+            type: bool
+      facility:
+        type: str
+      source_interface:
+        type: str
+        display_name: Source Interface Name
+      vrfs:
+        type: list
+        primary_key: name
+        convert_types:
+        - dict
+        items:
+          type: dict
+          keys:
+            name:
+              type: str
+              required: true
+              display_name: VRF Name
+            source_interface:
+              type: str
+              display_name: Source Interface Name
+            hosts:
+              type: list
+              primary_key: name
+              convert_types:
+              - dict
+              items:
+                type: dict
+                keys:
+                  name:
+                    type: str
+                    required: true
+                    display_name: Syslog Server Name
+                  protocol:
+                    type: str
+                    valid_values:
+                    - tcp
+                    - udp
+                    default: udp
+                  ports:
+                    type: list
+                    items:
+                      type: int
+                      convert_types:
+                      - str
+      policy:
+        type: dict
+        keys:
+          match:
+            type: dict
+            keys:
+              match_lists:
+                type: list
+                primary_key: name
+                convert_types:
+                - dict
+                items:
+                  type: dict
+                  keys:
+                    name:
+                      type: str
+                      required: true
+                      display_name: Match list
+                    action:
+                      type: str
   mac_access_lists:
     type: list
     primary_key: name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/logging.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/logging.schema.yml
@@ -8,14 +8,14 @@ keys:
     keys:
       console:
         type: str
+        valid_values: ["debugging", "informational", "notifications", "warnings", "errors", "critical", "alerts", "emergencies", "disabled"]
         description: |
-          "<severity_level>" | "disabled"
-          e.g. console: error
+          Console logging severity level
       monitor:
         type: str
+        valid_values: ["debugging", "informational", "notifications", "warnings", "errors", "critical", "alerts", "emergencies", "disabled"]
         description: |
-          "<severity_level>" | "disabled"
-          e.g. monitor: debugging
+          Monitor logging severity level
       buffered:
         type: dict
         keys:
@@ -24,39 +24,46 @@ keys:
             convert_types:
             - str
             min: 10
+            max: 2147483647
           level:
             type: str
+            valid_values: ["debugging", "informational", "notifications", "warnings", "errors", "critical", "alerts", "emergencies", "disabled"]
             description: |
-              "<severity_level>" | "disabled"
-              e.g. monitor: warnings
+              Buffer logging severity level
       trap:
         type: str
+        valid_values: ["debugging", "informational", "notifications", "warnings", "errors", "critical", "alerts", "emergencies", "disabled"]
         description: |
-          "<severity_level>" | "disabled"
-          e.g. trap: disabled
+          Trap logging severity level
       synchronous:
         type: dict
         keys:
           level:
             type: str
+            valid_values: ["debugging", "informational", "notifications", "warnings", "errors", "critical", "alerts", "emergencies", "disabled"]
             description: |
-              "<severity_level>" | "disabled"
-            default: critical
+              Synchronous logging severity level
+            default: "critical"
       format:
         type: dict
         keys:
           timestamp:
             type: str
-            description: |
-              < high-resolution | traditional >
+            valid_values: ["high-resolution", "traditional"]
+            display_name: Timestamp format
           hostname:
             type: str
-            description: |
-              < fqdn | ipv4 >
+            valid_values: ["fqdn", "ipv4"]
+            display_name: Hostname format
           sequence_numbers:
             type: bool
+            description: |
+              Add sequence numbers to log messages
       facility:
         type: str
+        valid_values: ["auth", "cron", "daemon", "kern", "local0", "local1", "local2", "local3", "local4",
+                       "local5", "local6", "local7", "lpr", "mail", "news", "sys9", "sys10", "sys11", "sys12",
+                       "sys13", "sys14", "syslog", "user", "uucp"]
       source_interface:
         type: str
         display_name: Source Interface Name
@@ -117,3 +124,4 @@ keys:
                       display_name: Match list
                     action:
                       type: str
+                      valid_values: ["discard"]

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/logging.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/logging.schema.yml
@@ -1,0 +1,119 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  logging:
+    type: dict
+    keys:
+      console:
+        type: str
+        description: |
+          "<severity_level>" | "disabled"
+          e.g. console: error
+      monitor:
+        type: str
+        description: |
+          "<severity_level>" | "disabled"
+          e.g. monitor: debugging
+      buffered:
+        type: dict
+        keys:
+          size:
+            type: int
+            convert_types:
+            - str
+            min: 10
+          level:
+            type: str
+            description: |
+              "<severity_level>" | "disabled"
+              e.g. monitor: warnings
+      trap:
+        type: str
+        description: |
+          "<severity_level>" | "disabled"
+          e.g. trap: disabled
+      synchronous:
+        type: dict
+        keys:
+          level:
+            type: str
+            description: |
+              "<severity_level>" | "disabled"
+            default: critical
+      format:
+        type: dict
+        keys:
+          timestamp:
+            type: str
+            description: |
+              < high-resolution | traditional >
+          hostname:
+            type: str
+            description: |
+              < fqdn | ipv4 >
+          sequence_numbers:
+            type: bool
+      facility:
+        type: str
+      source_interface:
+        type: str
+        display_name: Source Interface Name
+      vrfs:
+        type: list
+        primary_key: name
+        convert_types:
+        - dict
+        items:
+          type: dict
+          keys:
+            name:
+              type: str
+              required: true
+              display_name: VRF Name
+            source_interface:
+              type: str
+              display_name: Source Interface Name
+            hosts:
+              type: list
+              primary_key: name
+              convert_types:
+              - dict
+              items:
+                type: dict
+                keys:
+                  name:
+                    type: str
+                    required: true
+                    display_name: Syslog Server Name
+                  protocol:
+                    type: str
+                    valid_values: ["tcp", "udp"]
+                    default: udp
+                  ports:
+                    type: list
+                    items:
+                      type: int
+                      convert_types:
+                      - str
+      policy:
+        type: dict
+        keys:
+          match:
+            type: dict
+            keys:
+              match_lists:
+                type: list
+                primary_key: name
+                convert_types:
+                - dict
+                items:
+                  type: dict
+                  keys:
+                    name:
+                      type: str
+                      required: true
+                      display_name: Match list
+                    action:
+                      type: str

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/logging.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/logging.schema.yml
@@ -49,7 +49,7 @@ keys:
         keys:
           timestamp:
             type: str
-            valid_values: ["high-resolution", "traditional"]
+            valid_values: ["high-resolution", "traditional", "traditional timezone", "traditional year", "traditional timezone year", "traditional year timezone"]
             display_name: Timestamp format
           hostname:
             type: str

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/logging.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/logging.schema.yml
@@ -50,11 +50,11 @@ keys:
           timestamp:
             type: str
             valid_values: ["high-resolution", "traditional", "traditional timezone", "traditional year", "traditional timezone year", "traditional year timezone"]
-            display_name: Timestamp format
+            description: Timestamp format
           hostname:
             type: str
             valid_values: ["fqdn", "ipv4"]
-            display_name: Hostname format
+            description: Hostname format
           sequence_numbers:
             type: bool
             description: |
@@ -66,7 +66,7 @@ keys:
                        "sys13", "sys14", "syslog", "user", "uucp"]
       source_interface:
         type: str
-        display_name: Source Interface Name
+        description: Source Interface Name
       vrfs:
         display_name: VRFs
         type: list
@@ -79,10 +79,10 @@ keys:
             name:
               type: str
               required: true
-              display_name: VRF Name
+              description: VRF name
             source_interface:
               type: str
-              display_name: Source Interface Name
+              description: Source interface name
             hosts:
               type: list
               primary_key: name
@@ -94,7 +94,7 @@ keys:
                   name:
                     type: str
                     required: true
-                    display_name: Syslog Server Name
+                    description: Syslog server name
                   protocol:
                     type: str
                     valid_values: ["tcp", "udp"]
@@ -122,7 +122,7 @@ keys:
                     name:
                       type: str
                       required: true
-                      display_name: Match list
+                      description: Match list
                     action:
                       type: str
                       valid_values: ["discard"]

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/logging.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/logging.schema.yml
@@ -68,6 +68,7 @@ keys:
         type: str
         display_name: Source Interface Name
       vrfs:
+        display_name: VRFs
         type: list
         primary_key: name
         convert_types:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/logging.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/logging.j2
@@ -46,7 +46,7 @@
 {%         if logging.source_interface is arista.avd.defined %}
 | - | {{ logging.source_interface }} |
 {%         endif %}
-{%         for vrf in logging.vrfs | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%         for vrf in logging.vrfs | arista.avd.natural_sort('name') %}
 {%             if vrf.source_interface is arista.avd.defined %}
 | {{ vrf.name }} | {{ vrf.source_interface }} |
 {%             endif %}
@@ -54,9 +54,9 @@
 
 | VRF | Hosts | Ports | Protocol |
 | --- | ----- | ----- | -------- |
-{%         for vrf in logging.vrfs | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%         for vrf in logging.vrfs | arista.avd.natural_sort('name') %}
 {%             if vrf.hosts is arista.avd.defined %}
-{%                 for host in vrf.hosts | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%                 for host in vrf.hosts | arista.avd.natural_sort('name') %}
 | {{ vrf.name }} | {{ host.name }} | {{ host.ports | arista.avd.default(['Default']) | join(', ') }} | {{ host.protocol | arista.avd.default('UDP') | upper }} |
 {%                 endfor %}
 {%             endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/logging.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/logging.j2
@@ -31,8 +31,8 @@ no logging synchronous
 {%     elif logging.synchronous is arista.avd.defined %}
 logging synchronous level {{ logging.synchronous.level | arista.avd.default("critical") }}
 {%     endif %}
-{%     for vrf in logging.vrfs | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
-{%         for host in vrf.hosts | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%     for vrf in logging.vrfs | arista.avd.natural_sort('name') %}
+{%         for host in vrf.hosts | arista.avd.natural_sort('name') %}
 {%             set logging_host_cli = "logging" %}
 {%             if vrf.name != "default" %}
 {%                 set logging_host_cli = logging_host_cli ~ " vrf " ~ vrf.name %}
@@ -64,7 +64,7 @@ logging facility {{ logging.facility }}
 {%     if logging.source_interface is arista.avd.defined %}
 logging source-interface {{ logging.source_interface }}
 {%     endif %}
-{%     for vrf in logging.vrfs | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%     for vrf in logging.vrfs | arista.avd.natural_sort('name') %}
 {%         set logging_cli = "logging" %}
 {%         if vrf.source_interface is arista.avd.defined %}
 {%             if vrf.name != "default" %}
@@ -74,7 +74,7 @@ logging source-interface {{ logging.source_interface }}
 {{ logging_cli }}
 {%         endif %}
 {%     endfor %}
-{%     for match_list in logging.policy.match.match_lists | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%     for match_list in logging.policy.match.match_lists | arista.avd.natural_sort('name') %}
 logging policy match match-list {{ match_list.name }} {{ match_list.action }}
 {%     endfor %}
 {% endif %}


### PR DESCRIPTION
## Add schema for data model

<!-- Use this PR Title: Feat(eos_cli_config_gen): Add schema for < data_model_key > -->

## Checklist

### Contributor Checklist

- [x] Create schema fragment matching data model described in README.md and README_v4.0.md
  - README.md is most complete with all keys. README_v4.0 includes partial data models after conversion to lists.
  - Schema fragment path is `roles/eos_cli_config_gen/schemas/schema_fragments/<data_model_key>.schema.yml`.
  - Copy line 1-5 from another schema (comments and outer type:dict).
  - Refer to [schema documentation](https://avd.sh/en/devel/docs/input-variable-validation-BETA.html) for syntax and/or use YAML Lint plugin from Redhat in VSCode.
  - Use `convert_types` on value that could be mixed type or misinterpreted like integers and numeric strings.
- [x] If the data model has been converted from wildcard dicts:
  - Add `convert_types: ['dict']` to the schema.
  - Remove `convert_dicts` from the `templates/eos/<>.j2` and `templates/documentation/<>.j2` templates.
- [x] Run `molecule converge -s build_schemas_and_docs` to update schema and documentation.
- [x] Test by running `molecule converge -s eos_cli_config_gen` and verify no errors or changes to generated configs/docs.

### Reviewer Checklist

- Reviewer 1: Carl
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2: Claus
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
