### PR TITLE
Refactor(eos_designs): Move IP and description logic to Python (step1)

### DIFF
--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_FABRIC.yml
@@ -214,8 +214,8 @@ l2leaf:
     spanning_tree_mode: mstp
     spanning_tree_priority: 16384
     rack: "rackE"
-    mlag_peer_l3_ipv4_pool: 10.255.250.0/31
-    mlag_peer_ipv4_pool: 10.255.249.0/31
+    mlag_peer_l3_ipv4_pool: 10.255.250.0/24
+    mlag_peer_ipv4_pool: 10.255.249.0/24
   node_groups:
     DC1_L2LEAF1:
       uplink_switches: [ DC1-LEAF2A, DC1-LEAF2B ]

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_facts.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_facts.py
@@ -934,10 +934,7 @@ class EosDesignsFacts(AvdFacts):
     @cached_property
     def router_id(self):
         """
-        Run template lookup to render ipv4 address for router_id
-
-        Since some templates might contain certain legacy variables (switch_*),
-        those are mapped from the switch.* model
+        Render ipv4 address for router_id using dynamically loaded python module.
         """
         if self.underlay_router is True:
             return self.avd_ip_addressing.router_id()
@@ -1181,10 +1178,7 @@ class EosDesignsFacts(AvdFacts):
     @cached_property
     def ipv6_router_id(self):
         """
-        Run template lookup to render ipv6 address for router_id
-
-        Since some templates might contain certain legacy variables (switch_*),
-        those are mapped from the switch.* model
+        Render ipv6 address for router_id using dynamically loaded python module.
         """
         if self.underlay_ipv6 is True:
             return self.avd_ip_addressing.ipv6_router_id()
@@ -1547,10 +1541,7 @@ class EosDesignsFacts(AvdFacts):
     @cached_property
     def vtep_ip(self):
         """
-        Run template lookup to render ipv4 address for vtep_ip
-
-        Since some templates might contain certain legacy variables (switch_*),
-        those are mapped from the switch.* model
+        Render ipv4 address for vtep_ip using dynamically loaded python module.
         """
         if self.vtep is True:
             if self.mlag is True:
@@ -1564,10 +1555,7 @@ class EosDesignsFacts(AvdFacts):
     @cached_property
     def mlag_ip(self):
         """
-        Run template lookup to render ipv4 address for mlag_ip
-
-        Since some templates might contain certain legacy variables (switch_*),
-        those are mapped from the switch.* model
+        Render ipv4 address for mlag_ip using dynamically loaded python module.
         """
         if self.mlag is True:
             if self.mlag_role == "primary":
@@ -1591,10 +1579,7 @@ class EosDesignsFacts(AvdFacts):
     @cached_property
     def mlag_l3_ip(self):
         """
-        Run template lookup to render ipv4 address for mlag_l3_ip
-
-        Since some templates might contain certain legacy variables (switch_*),
-        those are mapped from the switch.* model
+        Render ipv4 address for mlag_l3_ip using dynamically loaded python module.
         """
         if self.mlag_l3 is True and self.mlag_peer_l3_vlan is not None:
             if self.mlag_role == "primary":

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_facts.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_facts.py
@@ -1,6 +1,5 @@
 import ipaddress
 import re
-from collections import ChainMap
 from functools import cached_property
 from hashlib import sha256
 
@@ -12,6 +11,7 @@ from ansible_collections.arista.avd.plugins.filter.natural_sort import natural_s
 from ansible_collections.arista.avd.plugins.filter.range_expand import range_expand
 from ansible_collections.arista.avd.plugins.plugin_utils.avdfacts import AvdFacts
 from ansible_collections.arista.avd.plugins.plugin_utils.utils import AristaAvdError, AristaAvdMissingVariableError, default, get, get_item
+from ansible_collections.arista.avd.roles.eos_designs.python_modules.ip_addressing import load_ip_addressing
 
 
 class EosDesignsFacts(AvdFacts):
@@ -43,6 +43,10 @@ class EosDesignsFacts(AvdFacts):
         """
         return get(self._switch_data_combined, "foo", required=True)
     '''
+
+    def __init__(self, hostvars, templar):
+        super().__init__(hostvars, templar)
+        self.avd_ip_addressing = load_ip_addressing(self._hostvars, self._templar)
 
     @cached_property
     def type(self):
@@ -936,12 +940,7 @@ class EosDesignsFacts(AvdFacts):
         those are mapped from the switch.* model
         """
         if self.underlay_router is True:
-            template_vars = ChainMap({}, self._hostvars)
-            template_vars["switch_id"] = self.id
-            template_vars["loopback_ipv4_pool"] = self.loopback_ipv4_pool
-            template_vars["loopback_ipv4_offset"] = self.loopback_ipv4_offset
-            template_path = get(self.ip_addressing, "router_id", required=True)
-            return self.template_var(template_path, template_vars)
+            return self.avd_ip_addressing.router_id()
         return None
 
     @cached_property
@@ -1188,12 +1187,7 @@ class EosDesignsFacts(AvdFacts):
         those are mapped from the switch.* model
         """
         if self.underlay_ipv6 is True:
-            template_vars = ChainMap({}, self._hostvars)
-            template_vars["switch_id"] = self.id
-            template_vars["loopback_ipv6_pool"] = self.loopback_ipv6_pool
-            template_vars["loopback_ipv6_offset"] = self.loopback_ipv6_offset
-            template_path = get(self.ip_addressing, "ipv6_router_id", required=True)
-            return self.template_var(template_path, template_vars)
+            return self.avd_ip_addressing.ipv6_router_id()
         return None
 
     @cached_property
@@ -1379,8 +1373,6 @@ class EosDesignsFacts(AvdFacts):
             uplink_switch_interfaces = default(self.uplink_switch_interfaces, [])
             fabric_name = get(self._hostvars, "fabric_name", required=True)
             inventory_group = get(self._hostvars, f"groups.{fabric_name}", required=True)
-            template_vars = ChainMap({}, self._hostvars)
-            template_vars["switch_id"] = self.id
             for uplink_index, uplink_interface in enumerate(uplink_interfaces):
                 if len(uplink_switches) <= uplink_index or len(uplink_switch_interfaces) <= uplink_index:
                     # Invalid length of input variables. Skipping
@@ -1419,11 +1411,8 @@ class EosDesignsFacts(AvdFacts):
                 if get(self._hostvars, "underlay_rfc5549") is True:
                     uplink["ipv6_enable"] = True
                 else:
-                    template_vars["uplink_switch_index"] = uplink_index
-                    template_path = get(self.ip_addressing, "p2p_uplinks_ip", required=True)
-                    uplink["ip_address"] = self.template_var(template_path, template_vars)
-                    template_path = get(self.ip_addressing, "p2p_uplinks_peer_ip", required=True)
-                    uplink["peer_ip_address"] = self.template_var(template_path, template_vars)
+                    uplink["ip_address"] = self.avd_ip_addressing.p2p_uplinks_ip(uplink_index)
+                    uplink["peer_ip_address"] = self.avd_ip_addressing.p2p_uplinks_peer_ip(uplink_index)
 
                 if self.link_tracking_groups is not None:
                     uplink["link_tracking_groups"] = []
@@ -1564,24 +1553,11 @@ class EosDesignsFacts(AvdFacts):
         those are mapped from the switch.* model
         """
         if self.vtep is True:
-            template_vars = ChainMap({}, self._hostvars)
-            template_vars["switch_id"] = self.id
-            template_vars["switch_vtep_loopback_ipv4_pool"] = self.vtep_loopback_ipv4_pool
-            template_vars["loopback_ipv4_offset"] = self.loopback_ipv4_offset
-
             if self.mlag is True:
-                if self.mlag_role == "primary":
-                    template_vars["mlag_primary_id"] = self.id
-                    template_vars["mlag_secondary_id"] = self._mlag_peer_id
-                elif self.mlag_role == "secondary":
-                    template_vars["mlag_secondary_id"] = self.id
-                    template_vars["mlag_primary_id"] = self._mlag_peer_id
+                return self.avd_ip_addressing.vtep_ip_mlag()
 
-                template_path = get(self.ip_addressing, "vtep_ip_mlag", required=True)
-                return self.template_var(template_path, template_vars)
             else:
-                template_path = get(self.ip_addressing, "vtep_ip", required=True)
-                return self.template_var(template_path, template_vars)
+                return self.avd_ip_addressing.vtep_ip()
 
         return None
 
@@ -1594,18 +1570,10 @@ class EosDesignsFacts(AvdFacts):
         those are mapped from the switch.* model
         """
         if self.mlag is True:
-            template_vars = ChainMap({}, self._hostvars)
-            template_vars["switch_id"] = self.id
-            template_vars["switch_data"] = {"combined": {"mlag_peer_ipv4_pool": self.mlag_peer_ipv4_pool}}
             if self.mlag_role == "primary":
-                template_vars["mlag_primary_id"] = self.id
-                template_vars["mlag_secondary_id"] = self._mlag_peer_id
-                template_path = get(self.ip_addressing, "mlag_ip_primary", required=True)
+                return self.avd_ip_addressing.mlag_ip_primary()
             elif self.mlag_role == "secondary":
-                template_vars["mlag_secondary_id"] = self.id
-                template_vars["mlag_primary_id"] = self._mlag_peer_id
-                template_path = get(self.ip_addressing, "mlag_ip_secondary", required=True)
-            return self.template_var(template_path, template_vars)
+                return self.avd_ip_addressing.mlag_ip_secondary()
         return None
 
     @cached_property
@@ -1629,19 +1597,10 @@ class EosDesignsFacts(AvdFacts):
         those are mapped from the switch.* model
         """
         if self.mlag_l3 is True and self.mlag_peer_l3_vlan is not None:
-            template_vars = ChainMap({}, self._hostvars)
-            template_vars["switch_id"] = self.id
-            template_vars["switch_data"] = {"combined": {"mlag_peer_l3_ipv4_pool": self.mlag_peer_l3_ipv4_pool}}
             if self.mlag_role == "primary":
-                template_vars["mlag_primary_id"] = self.id
-                template_vars["mlag_secondary_id"] = self._mlag_peer_id
-                template_path = get(self.ip_addressing, "mlag_l3_ip_primary", required=True)
+                return self.avd_ip_addressing.mlag_l3_ip_primary()
             elif self.mlag_role == "secondary":
-                template_vars["mlag_secondary_id"] = self.id
-                template_vars["mlag_primary_id"] = self._mlag_peer_id
-                template_path = get(self.ip_addressing, "mlag_l3_ip_secondary", required=True)
-
-            return self.template_var(template_path, template_vars)
+                return self.avd_ip_addressing.mlag_l3_ip_secondary()
         return None
 
     @cached_property

--- a/ansible_collections/arista/avd/roles/eos_designs/defaults/main/default-templates.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/defaults/main/default-templates.yml
@@ -30,12 +30,8 @@ default_templates:
           strip_empty_keys: false
 
     ip_addressing:
-      router_id: 'ip_addressing/router-id.j2'
-      ipv6_router_id: 'ip_addressing/router-id-ipv6.j2'
-      mlag_ip_primary: 'ip_addressing/mlag-ip-primary.j2'
-      mlag_ip_secondary: 'ip_addressing/mlag-ip-secondary.j2'
-      mlag_l3_ip_primary: 'ip_addressing/mlag-l3-ip-primary.j2'
-      mlag_l3_ip_secondary: 'ip_addressing/mlag-l3-ip-secondary.j2'
+      python_module: 'ansible_collections.arista.avd.roles.eos_designs.python_modules.ip_addressing'
+      python_class_name: 'AvdIpAddressing'
       mlag_ibgp_peering_ip_primary: 'ip_addressing/mlag-ibgp-peering-ip-primary.j2'
       mlag_ibgp_peering_ip_secondary: 'ip_addressing/mlag-ibgp-peering-ip-secondary.j2'
       p2p_uplinks_ip: 'ip_addressing/p2p-uplinks-ip.j2'
@@ -44,6 +40,8 @@ default_templates:
       vtep_ip: 'ip_addressing/vtep-ip.j2'
 
     interface_descriptions:
+      python_module: 'ansible_collections.arista.avd.roles.eos_designs.python_modules.interface_descriptions'
+      python_class_name: 'AvdInterfaceDescriptions'
       underlay_ethernet_interfaces: 'interface_descriptions/underlay/ethernet-interfaces.j2'
       underlay_port_channel_interfaces: 'interface_descriptions/underlay/port-channel-interfaces.j2'
       mlag_ethernet_interfaces: 'interface_descriptions/mlag/ethernet-interfaces.j2'
@@ -77,11 +75,11 @@ default_templates:
           list_merge: "{{ custom_structured_configuration_list_merge }}"
           strip_empty_keys: false
     ip_addressing:
-      router_id: 'ip_addressing/router-id.j2'
-      p2p_uplinks_ip: 'ip_addressing/p2p-uplinks-ip.j2'
-      p2p_uplinks_peer_ip: 'ip_addressing/p2p-uplinks-peer-ip.j2'
-      ipv6_router_id: 'ip_addressing/router-id-ipv6.j2'
+      python_module: 'ansible_collections.arista.avd.roles.eos_designs.python_modules.ip_addressing'
+      python_class_name: 'AvdIpAddressing'
     interface_descriptions:
+      python_module: 'ansible_collections.arista.avd.roles.eos_designs.python_modules.interface_descriptions'
+      python_class_name: 'AvdInterfaceDescriptions'
       underlay_ethernet_interfaces: 'interface_descriptions/underlay/ethernet-interfaces.j2'
       underlay_port_channel_interfaces: 'interface_descriptions/underlay/port-channel-interfaces.j2'
       connected_endpoints_ethernet_interfaces: 'interface_descriptions/connected_endpoints/ethernet-interfaces.j2'
@@ -116,16 +114,12 @@ default_templates:
           list_merge: "{{ custom_structured_configuration_list_merge }}"
           strip_empty_keys: false
     ip_addressing:
-      router_id: 'ip_addressing/router-id.j2'
-      ipv6_router_id: 'ip_addressing/router-id-ipv6.j2'
-      mlag_ip_primary: 'ip_addressing/mlag-ip-primary.j2'
-      mlag_ip_secondary: 'ip_addressing/mlag-ip-secondary.j2'
-      mlag_l3_ip_primary: 'ip_addressing/mlag-l3-ip-primary.j2'
-      mlag_l3_ip_secondary: 'ip_addressing/mlag-l3-ip-secondary.j2'
-      p2p_uplinks_ip: 'ip_addressing/p2p-uplinks-ip.j2'
-      p2p_uplinks_peer_ip: 'ip_addressing/p2p-uplinks-peer-ip.j2'
+      python_module: 'ansible_collections.arista.avd.roles.eos_designs.python_modules.ip_addressing'
+      python_class_name: 'AvdIpAddressing'
 
     interface_descriptions:
+      python_module: 'ansible_collections.arista.avd.roles.eos_designs.python_modules.interface_descriptions'
+      python_class_name: 'AvdInterfaceDescriptions'
       underlay_ethernet_interfaces: 'interface_descriptions/underlay/ethernet-interfaces.j2'
       underlay_port_channel_interfaces: 'interface_descriptions/underlay/port-channel-interfaces.j2'
       mlag_ethernet_interfaces: 'interface_descriptions/mlag/ethernet-interfaces.j2'

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/interface_descriptions/__init__.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/interface_descriptions/__init__.py
@@ -104,9 +104,7 @@ class AvdInterfaceDescriptions(AvdFacts):
             self._hostvars,
             "switch.interface_descriptions.connected_endpoints_ethernet_interfaces",
         ):
-            return self._template(
-                template_path, peer=peer, peer_interface=peer_interface
-            )
+            return self._template(template_path, peer=peer, peer_interface=peer_interface)
 
         elements = [peer, peer_interface]
         return "_".join([str(element) for element in elements if element is not None])
@@ -169,8 +167,6 @@ def load_interfacedescriptions(hostvars, templar) -> AvdInterfaceDescriptions:
 
     # if not isinstance(cls, AvdInterfaceDescriptions):
     if not issubclass(cls, AvdInterfaceDescriptions):
-        raise AristaAvdError(
-            f"{cls} is not a subclass of AvdInterfaceDescriptions class"
-        )
+        raise AristaAvdError(f"{cls} is not a subclass of AvdInterfaceDescriptions class")
 
     return cls(hostvars=hostvars, templar=templar)

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/interface_descriptions/__init__.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/interface_descriptions/__init__.py
@@ -104,14 +104,12 @@ class AvdInterfaceDescriptions(AvdFacts):
             self._hostvars,
             "switch.interface_descriptions.connected_endpoints_ethernet_interfaces",
         ):
-            template_vars = ChainMap({}, self._hostvars)
-            template_vars["peer"] = peer
-            template_vars["peer_interface"] = peer_interface
-            return self.template_var(template_path, template_vars)
+            return self._template(
+                template_path, peer=peer, peer_interface=peer_interface
+            )
 
         elements = [peer, peer_interface]
-        elements = [str(element) for element in elements if element is not None]
-        return "_".join(elements)
+        return "_".join([str(element) for element in elements if element is not None])
 
     def connected_endpoints_port_channel_interfaces(self, peer: str = None, adapter_port_channel_description: str = None) -> str:
         if template_path := get(
@@ -125,8 +123,7 @@ class AvdInterfaceDescriptions(AvdFacts):
             )
 
         elements = [peer, adapter_port_channel_description]
-        elements = [str(element) for element in elements if element is not None]
-        return "_".join(elements)
+        return "_".join([str(element) for element in elements if element is not None])
 
     def overlay_loopback_interface(self, overlay_loopback_description) -> str:
         if template_path := get(self._hostvars, "switch.interface_descriptions.overlay_loopback_interface"):
@@ -172,6 +169,8 @@ def load_interfacedescriptions(hostvars, templar) -> AvdInterfaceDescriptions:
 
     # if not isinstance(cls, AvdInterfaceDescriptions):
     if not issubclass(cls, AvdInterfaceDescriptions):
-        raise AristaAvdError(f"{cls} is not an instance of AvdFacts class")
+        raise AristaAvdError(
+            f"{cls} is not a subclass of AvdInterfaceDescriptions class"
+        )
 
     return cls(hostvars=hostvars, templar=templar)

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/interface_descriptions/__init__.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/interface_descriptions/__init__.py
@@ -60,7 +60,7 @@ class AvdInterfaceDescriptions(AvdFacts):
         self,
         link_peer: str,
         link_peer_channel_group_id: int,
-        link_channel_description: str | None,
+        link_channel_description: str,
     ) -> str:
         if template_path := get(self._hostvars, "switch.interface_descriptions.underlay_port_channel_interfaces"):
             template_vars = ChainMap({}, self._hostvars)

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/interface_descriptions/__init__.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/interface_descriptions/__init__.py
@@ -1,0 +1,159 @@
+import importlib
+from collections import ChainMap
+from functools import cached_property
+
+from ansible_collections.arista.avd.plugins.plugin_utils.avdfacts import AvdFacts
+from ansible_collections.arista.avd.plugins.plugin_utils.utils import AristaAvdError, get
+
+DEFAULT_AVD_INTERFACE_DESCRIPTIONS_PYTHON_MODULE = "ansible_collections.arista.avd.roles.eos_designs.python_modules.interface_descriptions"
+DEFAULT_AVD_INTERFACE_DESCRIPTIONS_PYTHON_CLASS_NAME = "AvdInterfaceDescriptions"
+
+
+class AvdInterfaceDescriptions(AvdFacts):
+
+    """
+    Class used to render Interface Descriptions either from custom Jinja2 templates or using default Python Logic
+
+    Since some templates might contain certain legacy variables (switch_*),
+    those are mapped from the switch.* model
+
+    This class is imported adhoc based on the variable `templates.interface_descriptions.python_module` so it can
+    be overridden by a custom python class.
+    """
+
+    @cached_property
+    def _default_mpls_overlay_role(self) -> str:
+        return get(self._hostvars, "switch.default_mpls_overlay_role")
+
+    @cached_property
+    def _mpls_lsr(self) -> str:
+        return get(self._hostvars, "switch.mpls_lsr")
+
+    @cached_property
+    def _mlag_peer(self) -> str:
+        return get(self._hostvars, "switch.mlag_peer", required=True)
+
+    @cached_property
+    def _mlag_port_channel_id(self) -> str:
+        return get(self._hostvars, "switch.mlag_port_channel_id", required=True)
+
+    def underlay_ethernet_interfaces(self, link_type: str, link_peer: str, link_peer_interface: str) -> str:
+        if template_path := get(self._hostvars, "switch.interface_descriptions.underlay_ethernet_interfaces"):
+            template_vars = ChainMap({}, self._hostvars)
+            template_vars["link"] = {
+                "type": link_type,
+                "peer": link_peer,
+                "peer_interface": link_peer_interface,
+            }
+            return self.template_var(template_path, template_vars)
+
+        link_peer = str(link_peer).upper()
+        if link_type == "underlay_p2p":
+            return f"P2P_LINK_TO_{link_peer}_{link_peer_interface}"
+
+        if link_type == "underlay_l2":
+            return f"{link_peer}_{link_peer_interface}"
+
+        return ""
+
+    def underlay_port_channel_interfaces(
+        self,
+        link_peer: str,
+        link_peer_channel_group_id: int,
+        link_channel_description: str | None,
+    ) -> str:
+        if template_path := get(self._hostvars, "switch.interface_descriptions.underlay_port_channel_interfaces"):
+            template_vars = ChainMap({}, self._hostvars)
+            template_vars["link"] = {
+                "peer": link_peer,
+                "peer_channel_group_id": link_peer_channel_group_id,
+                "channel_description": link_channel_description,
+            }
+            return self.template_var(template_path, template_vars)
+
+        if link_channel_description is not None:
+            link_channel_description = str(link_channel_description).upper()
+            return f"{link_channel_description}_Po{link_peer_channel_group_id}"
+
+        link_peer = str(link_peer).upper()
+        return f"{link_peer}_Po{link_peer_channel_group_id}"
+
+    def mlag_ethernet_interfaces(self, mlag_interface: str) -> str:
+        if template_path := get(self._hostvars, "switch.interface_descriptions.mlag_ethernet_interfaces"):
+            template_vars = ChainMap({}, self._hostvars)
+            template_vars["mlag_interface"] = mlag_interface
+            return self.template_var(template_path, template_vars)
+
+        return f"MLAG_PEER_{self._mlag_peer}_{mlag_interface}"
+
+    def mlag_port_channel_interfaces(self) -> str:
+        if template_path := get(self._hostvars, "switch.interface_descriptions.mlag_port_channel_interfaces"):
+            template_vars = ChainMap({}, self._hostvars)
+            return self.template_var(template_path, template_vars)
+
+        return f"MLAG_PEER_{self._mlag_peer}_Po{self._mlag_port_channel_id}"
+
+    def connected_endpoints_ethernet_interfaces(self, peer: str = None, peer_interface: str = None) -> str:
+        if template_path := get(self._hostvars, "switch.interface_descriptions.connected_endpoints_ethernet_interfaces"):
+            template_vars = ChainMap({}, self._hostvars)
+            template_vars["peer"] = peer
+            template_vars["peer_interface"] = peer_interface
+            return self.template_var(template_path, template_vars)
+
+        elements = [peer, peer_interface]
+        elements = [str(element) for element in elements if element is not None]
+        return "_".join(elements)
+
+    def connected_endpoints_port_channel_interfaces(self, peer: str = None, adapter_port_channel_description: str = None) -> str:
+        if template_path := get(self._hostvars, "switch.interface_descriptions.connected_endpoints_port_channel_interfaces"):
+            template_vars = ChainMap({}, self._hostvars)
+            template_vars["peer"] = peer
+            template_vars["adapter_port_channel_description"] = adapter_port_channel_description
+            return self.template_var(template_path, template_vars)
+
+        elements = [peer, adapter_port_channel_description]
+        elements = [str(element) for element in elements if element is not None]
+        return "_".join(elements)
+
+    def overlay_loopback_interface(self, overlay_loopback_description) -> str:
+        if template_path := get(self._hostvars, "switch.interface_descriptions.overlay_loopback_interface"):
+            template_vars = ChainMap({}, self._hostvars)
+            template_vars["overlay_loopback_description"] = overlay_loopback_description
+            return self.template_var(template_path, template_vars)
+
+        if overlay_loopback_description is not None:
+            return overlay_loopback_description
+
+        if self._default_mpls_overlay_role in ["server", "client"]:
+            return "MPLS_Overlay_peering"
+
+        if self._mpls_lsr is True:
+            return "LSR_Router_ID"
+
+        return "EVPN_Overlay_Peering"
+
+    def vtep_loopback_interface(self) -> str:
+        if template_path := get(self._hostvars, "switch.interface_descriptions.vtep_loopback_interface"):
+            template_vars = ChainMap({}, self._hostvars)
+            return self.template_var(template_path, template_vars)
+
+        return "VTEP_VXLAN_Tunnel_Source"
+
+
+def load_interfacedescriptions(hostvars, templar) -> AvdInterfaceDescriptions:
+    """
+    Load the python_module defined in `templates.interface_descriptions.python_module`
+    Return the class defined by `templates.interface_descriptions.python_class_name`
+    """
+    module_path = get(hostvars, "switch.interface_descriptions.python_module", default=DEFAULT_AVD_INTERFACE_DESCRIPTIONS_PYTHON_MODULE)
+    class_name = get(hostvars, "switch.interface_descriptions.python_class_name", default=DEFAULT_AVD_INTERFACE_DESCRIPTIONS_PYTHON_CLASS_NAME)
+    try:
+        cls = getattr(importlib.import_module(module_path), class_name)
+    except ImportError as imp_exc:
+        raise AristaAvdError(imp_exc) from imp_exc
+
+    # if not isinstance(cls, AvdInterfaceDescriptions):
+    if not issubclass(cls, AvdInterfaceDescriptions):
+        raise AristaAvdError(f"{cls} is not an instance of AvdFacts class")
+
+    return cls(hostvars=hostvars, templar=templar)

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/ip_addressing/__init__.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/ip_addressing/__init__.py
@@ -1,0 +1,317 @@
+import importlib
+import ipaddress
+from collections import ChainMap
+from functools import cached_property
+
+from ansible_collections.arista.avd.plugins.plugin_utils.avdfacts import AvdFacts
+from ansible_collections.arista.avd.plugins.plugin_utils.utils import AristaAvdError, get
+
+DEFAULT_AVD_IP_ADDRESSING_PYTHON_MODULE = "ansible_collections.arista.avd.roles.eos_designs.python_modules.ip_addressing"
+DEFAULT_AVD_IP_ADDRESSING_PYTHON_CLASS_NAME = "AvdIpAddressing"
+
+
+class AvdIpAddressing(AvdFacts):
+
+    """
+    Class used to render IP addresses either from custom Jinja2 templates or using default Python Logic
+
+    Since some templates might contain certain legacy variables (switch_*),
+    those are mapped from the switch.* model
+
+    This class is imported adhoc based on the variable `templates.ip_addressing.python_module` so it can
+    be overridden by a custom python class.
+    """
+
+    def _ip(self, pool: str, prefixlen: int, subnet_offset: int, ip_offset: int) -> str:
+        network = ipaddress.ip_network(pool, strict=False)
+        subnets = network.subnets(new_prefix=prefixlen)
+        if isinstance(subnets, list):
+            # It seems that some versions of python return a list instead of the documented iterator
+            subnets = iter(subnets)
+        subnet_index = 0
+        try:
+            while subnet_index <= subnet_offset:
+                subnet = next(subnets)
+                subnet_index += 1
+        except StopIteration as e:
+            raise AristaAvdError(f"Unable to get {subnet_offset+1} /{prefixlen} subnets from pool {pool}") from e
+        ips = subnet.hosts()
+        if isinstance(ips, list):
+            # It seems that some versions of python return a list instead of the documented iterator
+            ips = iter(ips)
+        ip_index = 0
+        try:
+            while ip_index <= ip_offset:
+                ip = next(ips)
+                ip_index += 1
+        except StopIteration as e:
+            raise AristaAvdError(f"Unable to get {ip_offset+1} hosts in subnet {subnet} taken from pool {pool}") from e
+        return str(ip)
+
+    @cached_property
+    def _mlag_primary_id(self) -> int:
+        return int(get(self._hostvars, "switch.mlag_switch_ids.primary", required=True))
+
+    @cached_property
+    def _mlag_secondary_id(self) -> int:
+        return int(get(self._hostvars, "switch.mlag_switch_ids.secondary", required=True))
+
+    @cached_property
+    def _mlag_peer_ipv4_pool(self) -> str:
+        return get(self._hostvars, "switch.mlag_peer_ipv4_pool", required=True)
+
+    @cached_property
+    def _mlag_peer_l3_ipv4_pool(self) -> str:
+        return get(self._hostvars, "switch.mlag_peer_l3_ipv4_pool", required=True)
+
+    @cached_property
+    def _uplink_ipv4_pool(self) -> str:
+        return get(self._hostvars, "switch.uplink_ipv4_pool", required=True)
+
+    @cached_property
+    def _id(self) -> int:
+        return int(get(self._hostvars, "switch.id", required=True))
+
+    @cached_property
+    def _max_uplink_switches(self) -> int:
+        return int(get(self._hostvars, "switch.max_uplink_switches", required=True))
+
+    @cached_property
+    def _max_parallel_uplinks(self) -> int:
+        return int(get(self._hostvars, "switch.max_parallel_uplinks", required=True))
+
+    @cached_property
+    def _loopback_ipv4_pool(self) -> str:
+        return get(self._hostvars, "switch.loopback_ipv4_pool", required=True)
+
+    @cached_property
+    def _loopback_ipv4_offset(self) -> int:
+        return get(self._hostvars, "switch.loopback_ipv4_offset", required=True)
+
+    @cached_property
+    def _loopback_ipv6_pool(self) -> str:
+        return get(self._hostvars, "switch.loopback_ipv6_pool", required=True)
+
+    @cached_property
+    def _loopback_ipv6_offset(self) -> int:
+        return get(self._hostvars, "switch.loopback_ipv6_offset", required=True)
+
+    @cached_property
+    def _vtep_loopback_ipv4_pool(self) -> str:
+        return get(self._hostvars, "switch.vtep_loopback_ipv4_pool", required=True)
+
+    def mlag_ibgp_peering_ip_primary(self, mlag_ibgp_peering_ipv4_pool: str) -> str:
+        """
+        Return IP for L3 Peerings in VRFs for MLAG Primary
+
+        Default offset from pool is `(mlag_primary_id - 1) * 2`
+        """
+        if template_path := get(self._hostvars, "switch.ip_addressing.mlag_ibgp_peering_ip_primary"):
+            template_vars = ChainMap({}, self._hostvars)
+            template_vars["vrf"] = {"mlag_ibgp_peering_ipv4_pool": mlag_ibgp_peering_ipv4_pool}
+            return self.template_var(template_path, template_vars)
+
+        offset = self._mlag_primary_id - 1
+        return self._ip(mlag_ibgp_peering_ipv4_pool, 31, offset, 0)
+
+    def mlag_ibgp_peering_ip_secondary(self, mlag_ibgp_peering_ipv4_pool: str) -> str:
+        """
+        Return IP for L3 Peerings in VRFs for MLAG Secondary
+
+        Default offset from pool is `((mlag_primary_id - 1) * 2) + 1`
+        """
+        if template_path := get(self._hostvars, "switch.ip_addressing.mlag_ibgp_peering_ip_secondary"):
+            template_vars = ChainMap({}, self._hostvars)
+            template_vars["vrf"] = {"mlag_ibgp_peering_ipv4_pool": mlag_ibgp_peering_ipv4_pool}
+            return self.template_var(template_path, template_vars)
+
+        offset = self._mlag_primary_id - 1
+        return self._ip(mlag_ibgp_peering_ipv4_pool, 31, offset, 1)
+
+    def mlag_ip_primary(self) -> str:
+        """
+        Return IP for MLAG Primary
+
+        Default pool is "switch.mlag_peer_ipv4_pool"
+        Default offset from pool is `(mlag_primary_id - 1) * 2`
+        """
+        if template_path := get(self._hostvars, "switch.ip_addressing.mlag_ip_primary"):
+            template_vars = ChainMap({}, self._hostvars)
+            template_vars["mlag_primary_id"] = self._mlag_primary_id
+            template_vars["mlag_secondary_id"] = self._mlag_secondary_id
+            template_vars["switch_data"] = {"combined": {"mlag_peer_ipv4_pool": self._mlag_peer_ipv4_pool}}
+            return self.template_var(template_path, template_vars)
+
+        offset = self._mlag_primary_id - 1
+        return self._ip(self._mlag_peer_ipv4_pool, 31, offset, 0)
+
+    def mlag_ip_secondary(self) -> str:
+        """
+        Return IP for MLAG Secondary
+
+        Default pool is "switch.mlag_peer_ipv4_pool"
+        Default offset from pool is `((mlag_primary_id - 1) * 2) + 1`
+        """
+        if template_path := get(self._hostvars, "switch.ip_addressing.mlag_ip_secondary"):
+            template_vars = ChainMap({}, self._hostvars)
+            template_vars["mlag_primary_id"] = self._mlag_primary_id
+            template_vars["mlag_secondary_id"] = self._mlag_secondary_id
+            template_vars["switch_data"] = {"combined": {"mlag_peer_ipv4_pool": self._mlag_peer_ipv4_pool}}
+            return self.template_var(template_path, template_vars)
+
+        offset = self._mlag_primary_id - 1
+        return self._ip(self._mlag_peer_ipv4_pool, 31, offset, 1)
+
+    def mlag_l3_ip_primary(self) -> str:
+        """
+        Return IP for L3 Peerings for MLAG Primary
+
+        Default pool is "switch.mlag_peer_l3_ipv4_pool"
+        Default offset from pool is `(mlag_primary_id - 1) * 2`
+        """
+        if template_path := get(self._hostvars, "switch.ip_addressing.mlag_l3_ip_primary"):
+            template_vars = ChainMap({}, self._hostvars)
+            template_vars["mlag_primary_id"] = self._mlag_primary_id
+            template_vars["mlag_secondary_id"] = self._mlag_secondary_id
+            template_vars["switch_data"] = {"combined": {"mlag_peer_l3_ipv4_pool": self._mlag_peer_l3_ipv4_pool}}
+            return self.template_var(template_path, template_vars)
+
+        offset = self._mlag_primary_id - 1
+        return self._ip(self._mlag_peer_l3_ipv4_pool, 31, offset, 0)
+
+    def mlag_l3_ip_secondary(self) -> str:
+        """
+        Return IP for L3 Peerings for MLAG Secondary
+
+        Default pool is "switch.mlag_peer_l3_ipv4_pool"
+        Default offset from pool is `((mlag_primary_id - 1) * 2) + 1`
+        """
+        if template_path := get(self._hostvars, "switch.ip_addressing.mlag_l3_ip_secondary"):
+            template_vars = ChainMap({}, self._hostvars)
+            template_vars["mlag_primary_id"] = self._mlag_primary_id
+            template_vars["mlag_secondary_id"] = self._mlag_secondary_id
+            template_vars["switch_data"] = {"combined": {"mlag_peer_l3_ipv4_pool": self._mlag_peer_l3_ipv4_pool}}
+            return self.template_var(template_path, template_vars)
+
+        offset = self._mlag_primary_id - 1
+        return self._ip(self._mlag_peer_l3_ipv4_pool, 31, offset, 1)
+
+    def p2p_uplinks_ip(self, uplink_switch_index: int) -> str:
+        """
+        Return Child IP for P2P Uplinks
+
+        Default pool is "switch.uplink_ipv4_pool"
+        Default offset from pool is `((switch.id - 1) * 2 * switch.max_uplink_switches * switch.max_parallel_uplinks) + (uplink_switch_index * 2) + 1`
+        """
+        uplink_switch_index = int(uplink_switch_index)
+        if template_path := get(self._hostvars, "switch.ip_addressing.p2p_uplinks_ip"):
+            template_vars = ChainMap({}, self._hostvars)
+            template_vars["uplink_switch_index"] = uplink_switch_index
+            return self.template_var(template_path, template_vars)
+
+        offset = ((self._id - 1) * self._max_uplink_switches * self._max_parallel_uplinks) + uplink_switch_index
+        return self._ip(self._uplink_ipv4_pool, 31, offset, 1)
+
+    def p2p_uplinks_peer_ip(self, uplink_switch_index: int) -> str:
+        """
+        Return Parent IP for P2P Uplinks
+
+        Default pool is "switch.uplink_ipv4_pool"
+        Default offset from pool is `((switch.id - 1) * 2 * switch.max_uplink_switches * switch.max_parallel_uplinks) + (uplink_switch_index * 2)`
+        """
+        uplink_switch_index = int(uplink_switch_index)
+        if template_path := get(self._hostvars, "switch.ip_addressing.p2p_uplinks_peer_ip"):
+            template_vars = ChainMap({}, self._hostvars)
+            template_vars["uplink_switch_index"] = uplink_switch_index
+            return self.template_var(template_path, template_vars)
+
+        offset = ((self._id - 1) * self._max_uplink_switches * self._max_parallel_uplinks) + uplink_switch_index
+        return self._ip(self._uplink_ipv4_pool, 31, offset, 0)
+
+    def router_id(self) -> str:
+        """
+        Return IP address for Router ID
+
+        Default pool is "switch.loopback_ipv4_pool"
+        Default offset from pool is `switch.id + switch.loopback_ipv4_offset`
+        """
+        if template_path := get(self._hostvars, "switch.ip_addressing.router_id"):
+            template_vars = ChainMap({}, self._hostvars)
+            template_vars["switch_id"] = self._id
+            template_vars["loopback_ipv4_pool"] = self._loopback_ipv4_pool
+            template_vars["loopback_ipv4_offset"] = self._loopback_ipv4_offset
+            return self.template_var(template_path, template_vars)
+
+        offset = self._id + self._loopback_ipv4_offset
+        return self._ip(self._loopback_ipv4_pool, 32, offset, 0)
+
+    def ipv6_router_id(self) -> str:
+        """
+        Return IPv6 address for Router ID
+
+        Default pool is "switch.loopback_ipv6_pool"
+        Default offset from pool is `switch.id + switch.loopback_ipv6_offset`
+        """
+        if template_path := get(self._hostvars, "switch.ip_addressing.ipv6_router_id"):
+            template_vars = ChainMap({}, self._hostvars)
+            template_vars["switch_id"] = self._id
+            template_vars["loopback_ipv6_pool"] = self._loopback_ipv6_pool
+            template_vars["loopback_ipv6_offset"] = self._loopback_ipv6_offset
+            return self.template_var(template_path, template_vars)
+
+        offset = self._id + self._loopback_ipv6_offset
+        return self._ip(self._loopback_ipv6_pool, 128, offset, 0)
+
+    def vtep_ip_mlag(self) -> str:
+        """
+        Return IP address for VTEP for MLAG Leaf
+
+        Default pool is "switch.vtep_loopback_ipv4_pool"
+        Default offset from pool is `mlag_primary_id + switch.loopback_ipv4_offset`
+        """
+        if template_path := get(self._hostvars, "switch.ip_addressing.vtep_ip_mlag"):
+            template_vars = ChainMap({}, self._hostvars)
+            template_vars["switch_id"] = self._id
+            template_vars["switch_vtep_loopback_ipv4_pool"] = self._vtep_loopback_ipv4_pool
+            template_vars["loopback_ipv4_offset"] = self._loopback_ipv4_offset
+            template_vars["mlag_primary_id"] = self._mlag_primary_id
+            template_vars["mlag_secondary_id"] = self._mlag_secondary_id
+            return self.template_var(template_path, template_vars)
+
+        offset = self._mlag_primary_id + self._loopback_ipv4_offset
+        return self._ip(self._vtep_loopback_ipv4_pool, 32, offset, 0)
+
+    def vtep_ip(self) -> str:
+        """
+        Return IP address for VTEP for MLAG Leaf
+
+        Default pool is "switch.vtep_loopback_ipv4_pool"
+        Default offset from pool is `switch.id + switch.loopback_ipv4_offset`
+        """
+        if template_path := get(self._hostvars, "switch.ip_addressing.vtep_ip"):
+            template_vars = ChainMap({}, self._hostvars)
+            template_vars["switch_id"] = self._id
+            template_vars["switch_vtep_loopback_ipv4_pool"] = self._vtep_loopback_ipv4_pool
+            template_vars["loopback_ipv4_offset"] = self._loopback_ipv4_offset
+            return self.template_var(template_path, template_vars)
+
+        offset = self._id + self._loopback_ipv4_offset
+        return self._ip(self._vtep_loopback_ipv4_pool, 32, offset, 0)
+
+
+def load_ip_addressing(hostvars, templar) -> AvdIpAddressing:
+    """
+    Load the python_module defined in `templates.ip_addressing.python_module`
+    Return the class defined by `templates.ip_addressing.python_class_name`
+    """
+    module_path = get(hostvars, "switch.ip_addressing.python_module", default=DEFAULT_AVD_IP_ADDRESSING_PYTHON_MODULE)
+    class_name = get(hostvars, "switch.ip_addressing.python_class_name", default=DEFAULT_AVD_IP_ADDRESSING_PYTHON_CLASS_NAME)
+    try:
+        cls = getattr(importlib.import_module(module_path), class_name)
+    except ImportError as imp_exc:
+        raise AristaAvdError(imp_exc) from imp_exc
+
+    if not issubclass(cls, AvdFacts):
+        raise AristaAvdError(f"{cls} is not an instance of AvdFacts class")
+
+    return cls(hostvars=hostvars, templar=templar)

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/ip_addressing/__init__.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/ip_addressing/__init__.py
@@ -322,7 +322,7 @@ def load_ip_addressing(hostvars, templar) -> AvdIpAddressing:
     except ImportError as imp_exc:
         raise AristaAvdError(imp_exc) from imp_exc
 
-    if not issubclass(cls, AvdFacts):
-        raise AristaAvdError(f"{cls} is not an instance of AvdFacts class")
+    if not issubclass(cls, AvdIpAddressing):
+        raise AristaAvdError(f"{cls} is not a subclass of AvdIpAddressing class")
 
     return cls(hostvars=hostvars, templar=templar)


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Refactor(eos_designs): Move IP and description logic to Python (step1)

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

- Add support for loading configurable python modules with IP addressing and Interface Description logic:
```
templates:
  ip_addressing:
    python_module: 'ansible_collections.arista.avd.roles.eos_designs.python_modules.ip_addressing'
    python_class_name: 'AvdIpAddressing'
  interface_descriptions:
    python_module: 'ansible_collections.arista.avd.roles.eos_designs.python_modules.interface_descriptions'
    python_class_name: 'AvdInterfaceDescriptions'
```

- Refactor `eos_designs_facts` to leverage these new python modules.
  - The new logic uses python builtin `ipaddress` and enforces correct sizing of pools.
  - Errors will be raised if we try to fetch IPs outside the pool. Historically we just ignored the pool mask and assigned outside it.
- The default python modules still respect any custom templates, and since these take precedence, the python modules will not have any effect, until we remove the default templates.
- In this PR we remove the default IP templates that are only leveraged inside `eos_designs_facts`

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
No changes to molecule. Tested locally with some refactored code.

- had to change a bad mask on an IP pool, since we now enforce taking from the pool instead of overflowing.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
