### PR TITLE
Feat(eos_cli_config_gen): Add schema for snmp_server

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -4442,6 +4442,9 @@ sflow:
 
 ## Snmp Server
 
+### Description
+
+SNMP settings
 ### Variables
 
 | Variable | Type | Required | Default | Value Restrictions | Description |
@@ -4495,7 +4498,7 @@ sflow:
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;priv</samp>](## "snmp_server.users.[].priv") | String |  |  |  | Encryption algorithm<br> |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;priv_passphrase</samp>](## "snmp_server.users.[].priv_passphrase") | String |  |  |  | Hashed privacy passphrase if localized is used else cleartext privacy passphrase<br> |
 | [<samp>&nbsp;&nbsp;hosts</samp>](## "snmp_server.hosts") | List, items: Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- host</samp>](## "snmp_server.hosts.[].host") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- host</samp>](## "snmp_server.hosts.[].host") | String |  |  |  | Host IP address or name |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "snmp_server.hosts.[].vrf") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;version</samp>](## "snmp_server.hosts.[].version") | String |  |  | Valid Values:<br>- 1<br>- 2c<br>- 3 |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;community</samp>](## "snmp_server.hosts.[].community") | String |  |  |  | Community name |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -4450,65 +4450,65 @@ sflow:
 | [<samp>&nbsp;&nbsp;engine_ids</samp>](## "snmp_server.engine_ids") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;local</samp>](## "snmp_server.engine_ids.local") | String |  |  |  | Engine ID in hexadecimal<br> |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;remotes</samp>](## "snmp_server.engine_ids.remotes") | List, items: Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- id</samp>](## "snmp_server.engine_ids.remotes.[].id") | String |  |  |  | Remote Engine ID In Hexadecimal<br> |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;address</samp>](## "snmp_server.engine_ids.remotes.[].address") | String |  |  |  | Hostname or IP Of Remote Engine<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- id</samp>](## "snmp_server.engine_ids.remotes.[].id") | String |  |  |  | Remote engine ID in hexadecimal<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;address</samp>](## "snmp_server.engine_ids.remotes.[].address") | String |  |  |  | Hostname or IP of remote engine<br> |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;udp_port</samp>](## "snmp_server.engine_ids.remotes.[].udp_port") | Integer |  |  |  |  |
-| [<samp>&nbsp;&nbsp;contact</samp>](## "snmp_server.contact") | String |  |  |  | SNMP Contact |
-| [<samp>&nbsp;&nbsp;location</samp>](## "snmp_server.location") | String |  |  |  | SNMP Location |
+| [<samp>&nbsp;&nbsp;contact</samp>](## "snmp_server.contact") | String |  |  |  | SNMP contact |
+| [<samp>&nbsp;&nbsp;location</samp>](## "snmp_server.location") | String |  |  |  | SNMP location |
 | [<samp>&nbsp;&nbsp;communities</samp>](## "snmp_server.communities") | List, items: Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "snmp_server.communities.[].name") | String | Required, Unique |  |  | Community Name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "snmp_server.communities.[].name") | String | Required, Unique |  |  | Community name |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;access</samp>](## "snmp_server.communities.[].access") | String |  |  | Valid Values:<br>- ro<br>- rw |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;access_list_ipv4</samp>](## "snmp_server.communities.[].access_list_ipv4") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "snmp_server.communities.[].access_list_ipv4.name") | String |  |  |  | IPv4 Access List Name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "snmp_server.communities.[].access_list_ipv4.name") | String |  |  |  | IPv4 access list name |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;access_list_ipv6</samp>](## "snmp_server.communities.[].access_list_ipv6") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "snmp_server.communities.[].access_list_ipv6.name") | String |  |  |  | IPv6 Access List Name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "snmp_server.communities.[].access_list_ipv6.name") | String |  |  |  | IPv6 access list name |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;view</samp>](## "snmp_server.communities.[].view") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;ipv4_acls</samp>](## "snmp_server.ipv4_acls") | List, items: Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "snmp_server.ipv4_acls.[].name") | String |  |  |  | IPv4 Access List Name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "snmp_server.ipv4_acls.[].name") | String |  |  |  | IPv4 access list name |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "snmp_server.ipv4_acls.[].vrf") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;ipv6_acls</samp>](## "snmp_server.ipv6_acls") | List, items: Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "snmp_server.ipv6_acls.[].name") | String |  |  |  | IPv6 Access List Name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "snmp_server.ipv6_acls.[].name") | String |  |  |  | IPv6 access list name |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "snmp_server.ipv6_acls.[].vrf") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;local_interfaces</samp>](## "snmp_server.local_interfaces") | List, items: Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "snmp_server.local_interfaces.[].name") | String | Required, Unique |  |  | Interface Name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "snmp_server.local_interfaces.[].name") | String | Required, Unique |  |  | Interface name |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "snmp_server.local_interfaces.[].vrf") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;views</samp>](## "snmp_server.views") | List, items: Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "snmp_server.views.[].name") | String |  |  |  | SNMP View Name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "snmp_server.views.[].name") | String |  |  |  | SNMP view name |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;MIB_family_name</samp>](## "snmp_server.views.[].MIB_family_name") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;included</samp>](## "snmp_server.views.[].included") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;groups</samp>](## "snmp_server.groups") | List, items: Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "snmp_server.groups.[].name") | String |  |  |  | Group name |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;version</samp>](## "snmp_server.groups.[].version") | String |  |  | Valid Values:<br>- v1<br>- v2c<br>- v3 |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;authentication</samp>](## "snmp_server.groups.[].authentication") | String |  |  | Valid Values:<br>- auth<br>- noauth<br>- priv |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;read</samp>](## "snmp_server.groups.[].read") | String |  |  |  | Read View |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;write</samp>](## "snmp_server.groups.[].write") | String |  |  |  | Write View |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;notify</samp>](## "snmp_server.groups.[].notify") | String |  |  |  | Notify View |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;read</samp>](## "snmp_server.groups.[].read") | String |  |  |  | Read view |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;write</samp>](## "snmp_server.groups.[].write") | String |  |  |  | Write view |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;notify</samp>](## "snmp_server.groups.[].notify") | String |  |  |  | Notify view |
 | [<samp>&nbsp;&nbsp;users</samp>](## "snmp_server.users") | List, items: Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "snmp_server.users.[].name") | String |  |  |  | Username |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;group</samp>](## "snmp_server.users.[].group") | String |  |  |  | Group Name |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;remote_address</samp>](## "snmp_server.users.[].remote_address") | String |  |  |  | Hostname or ip of remote engine. The remote_address and udp_port are used for remote users.<br> |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;udp_port</samp>](## "snmp_server.users.[].udp_port") | Integer |  |  |  | udp_port will not be used if no remote_address is configured.<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;group</samp>](## "snmp_server.users.[].group") | String |  |  |  | Group name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;remote_address</samp>](## "snmp_server.users.[].remote_address") | String |  |  |  | Hostname or ip of remote engine<br>The remote_address and udp_port are used for remote users<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;udp_port</samp>](## "snmp_server.users.[].udp_port") | Integer |  |  |  | udp_port will not be used if no remote_address is configured<br> |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;version</samp>](## "snmp_server.users.[].version") | String |  |  | Valid Values:<br>- v1<br>- v2c<br>- v3 |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;localized</samp>](## "snmp_server.users.[].localized") | String |  |  |  | Engine ID in hexadecimal for localizing auth and/or priv<br> |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;auth</samp>](## "snmp_server.users.[].auth") | String |  |  |  | Hash Algorithm<br> |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;auth_passphrase</samp>](## "snmp_server.users.[].auth_passphrase") | String |  |  |  | hashed_auth_passphrase if localized is used else cleartext auth_passphrase.<br> |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;priv</samp>](## "snmp_server.users.[].priv") | String |  |  |  | Encryption Algorithm<br> |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;priv_passphrase</samp>](## "snmp_server.users.[].priv_passphrase") | String |  |  |  | hashed_priv_passphrase if localized is used else cleartext priv_passphrase.<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;auth</samp>](## "snmp_server.users.[].auth") | String |  |  |  | Hash algorithm<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;auth_passphrase</samp>](## "snmp_server.users.[].auth_passphrase") | String |  |  |  | Hashed authentication passphrase if localized is used else cleartext authentication passphrase<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;priv</samp>](## "snmp_server.users.[].priv") | String |  |  |  | Encryption algorithm<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;priv_passphrase</samp>](## "snmp_server.users.[].priv_passphrase") | String |  |  |  | Hashed privacy passphrase if localized is used else cleartext privacy passphrase<br> |
 | [<samp>&nbsp;&nbsp;hosts</samp>](## "snmp_server.hosts") | List, items: Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- host</samp>](## "snmp_server.hosts.[].host") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "snmp_server.hosts.[].vrf") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;version</samp>](## "snmp_server.hosts.[].version") | String |  |  | Valid Values:<br>- 1<br>- 2c<br>- 3 |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;community</samp>](## "snmp_server.hosts.[].community") | String |  |  |  | Community Name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;community</samp>](## "snmp_server.hosts.[].community") | String |  |  |  | Community name |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;users</samp>](## "snmp_server.hosts.[].users") | List, items: Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- username</samp>](## "snmp_server.hosts.[].users.[].username") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;authentication_level</samp>](## "snmp_server.hosts.[].users.[].authentication_level") | String |  |  | Valid Values:<br>- auth<br>- noauth<br>- priv |  |
 | [<samp>&nbsp;&nbsp;traps</samp>](## "snmp_server.traps") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;enable</samp>](## "snmp_server.traps.enable") | Boolean |  | False |  | Enable or disable all snmp-traps<br> |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;snmp_traps</samp>](## "snmp_server.traps.snmp_traps") | List, items: Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "snmp_server.traps.snmp_traps.[].name") | String |  |  |  | Enable or disable specific snmp-traps and their sub_traps.<br>Examples:<br>- "bgp"<br>- "bgp established"<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "snmp_server.traps.snmp_traps.[].name") | String |  |  |  | Enable or disable specific snmp-traps and their sub_traps<br>Examples:<br>- "bgp"<br>- "bgp established"<br> |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "snmp_server.traps.snmp_traps.[].enabled") | Boolean |  | True |  |  |
 | [<samp>&nbsp;&nbsp;vrfs</samp>](## "snmp_server.vrfs") | List, items: Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "snmp_server.vrfs.[].name") | String |  |  |  | VRF Name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "snmp_server.vrfs.[].name") | String |  |  |  | VRF name |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enable</samp>](## "snmp_server.vrfs.[].enable") | Boolean |  |  |  |  |
 
 ### YAML

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -4440,79 +4440,52 @@ sflow:
         enabled: <bool>
 ```
 
-## SNMP Server
+## Snmp Server
 
 ### Variables
 
 | Variable | Type | Required | Default | Value Restrictions | Description |
 | -------- | ---- | -------- | ------- | ------------------ | ----------- |
-<<<<<<< HEAD
 | [<samp>snmp_server</samp>](## "snmp_server") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;engine_ids</samp>](## "snmp_server.engine_ids") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;local</samp>](## "snmp_server.engine_ids.local") | String |  |  |  | Engine id in hexadecimal<br> |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;remotes</samp>](## "snmp_server.engine_ids.remotes") | List, items: Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- id</samp>](## "snmp_server.engine_ids.remotes.[].id") | String |  |  |  | Engine ID In Hexadecimal<br> |
-=======
-| [<samp>snmp_server</samp>](## "snmp_server") | Dictionary |  |  |  | SNMP Server |
-| [<samp>&nbsp;&nbsp;engine_ids</samp>](## "snmp_server.engine_ids") | Dictionary |  |  |  | Engine IDs |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;local</samp>](## "snmp_server.engine_ids.local") | String |  |  |  | Engine ID in hexadecimal<br> |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;remotes</samp>](## "snmp_server.engine_ids.remotes") | List, items: Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- id</samp>](## "snmp_server.engine_ids.remotes.[].id") | String |  |  |  | ID<br>Remote Engine ID In Hexadecimal<br> |
->>>>>>> 4474817d (Update descriptions etc.)
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- id</samp>](## "snmp_server.engine_ids.remotes.[].id") | String |  |  |  | Remote Engine ID In Hexadecimal<br> |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;address</samp>](## "snmp_server.engine_ids.remotes.[].address") | String |  |  |  | Hostname or IP Of Remote Engine<br> |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;udp_port</samp>](## "snmp_server.engine_ids.remotes.[].udp_port") | Integer |  |  |  |  |
-| [<samp>&nbsp;&nbsp;contact</samp>](## "snmp_server.contact") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;contact</samp>](## "snmp_server.contact") | String |  |  |  | Contact Name |
 | [<samp>&nbsp;&nbsp;location</samp>](## "snmp_server.location") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;communities</samp>](## "snmp_server.communities") | List, items: Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "snmp_server.communities.[].name") | String | Required, Unique |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "snmp_server.communities.[].name") | String | Required, Unique |  |  | Community Name |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;access</samp>](## "snmp_server.communities.[].access") | String |  |  | Valid Values:<br>- ro<br>- rw |  |
-<<<<<<< HEAD
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;access_list_ipv4</samp>](## "snmp_server.communities.[].access_list_ipv4") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "snmp_server.communities.[].access_list_ipv4.name") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;access_list_ipv6</samp>](## "snmp_server.communities.[].access_list_ipv6") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "snmp_server.communities.[].access_list_ipv6.name") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;view</samp>](## "snmp_server.communities.[].view") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;ipv4_acls</samp>](## "snmp_server.ipv4_acls") | List, items: Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "snmp_server.ipv4_acls.[].name") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "snmp_server.ipv4_acls.[].name") | String |  |  |  | IPv4 Access List Name |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "snmp_server.ipv4_acls.[].vrf") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;ipv6_acls</samp>](## "snmp_server.ipv6_acls") | List, items: Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "snmp_server.ipv6_acls.[].name") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "snmp_server.ipv6_acls.[].vrf") | String |  |  |  |  |
-=======
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;access_list_ipv4</samp>](## "snmp_server.communities.[].access_list_ipv4") | Dictionary |  |  |  | Access List IPv4 |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "snmp_server.communities.[].access_list_ipv4.name") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;access_list_ipv6</samp>](## "snmp_server.communities.[].access_list_ipv6") | Dictionary |  |  |  | Access List IPv6 |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "snmp_server.communities.[].access_list_ipv6.name") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;view</samp>](## "snmp_server.communities.[].view") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;ipv4_acls</samp>](## "snmp_server.ipv4_acls") | List, items: Dictionary |  |  |  | IPv4 ACLs |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "snmp_server.ipv4_acls.[].name") | String |  |  |  | IPv4 Access List Name |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "snmp_server.ipv4_acls.[].vrf") | String |  |  |  | VRF |
-| [<samp>&nbsp;&nbsp;ipv6_acls</samp>](## "snmp_server.ipv6_acls") | List, items: Dictionary |  |  |  | IPv6 ACLs |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "snmp_server.ipv6_acls.[].name") | String |  |  |  | IPv6 Access List Name |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "snmp_server.ipv6_acls.[].vrf") | String |  |  |  | VRF |
->>>>>>> 4474817d (Update descriptions etc.)
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "snmp_server.ipv6_acls.[].vrf") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;local_interfaces</samp>](## "snmp_server.local_interfaces") | List, items: Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "snmp_server.local_interfaces.[].name") | String | Required, Unique |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "snmp_server.local_interfaces.[].name") | String | Required, Unique |  |  | Interface Name |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "snmp_server.local_interfaces.[].vrf") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;views</samp>](## "snmp_server.views") | List, items: Dictionary |  |  |  |  |
-<<<<<<< HEAD
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "snmp_server.views.[].name") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;MIB_family_name</samp>](## "snmp_server.views.[].MIB_family_name") | String |  |  |  |  |
-=======
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "snmp_server.views.[].name") | String |  |  |  | SNMP View Name |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;MIB_family_name</samp>](## "snmp_server.views.[].MIB_family_name") | String |  |  |  | MIB Family Name |
->>>>>>> 4474817d (Update descriptions etc.)
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;MIB_family_name</samp>](## "snmp_server.views.[].MIB_family_name") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;included</samp>](## "snmp_server.views.[].included") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;groups</samp>](## "snmp_server.groups") | List, items: Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "snmp_server.groups.[].name") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "snmp_server.groups.[].name") | String |  |  |  | Group name |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;version</samp>](## "snmp_server.groups.[].version") | String |  |  | Valid Values:<br>- v1<br>- v2c<br>- v3 |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;authentication</samp>](## "snmp_server.groups.[].authentication") | String |  |  | Valid Values:<br>- auth<br>- noauth<br>- priv |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;read</samp>](## "snmp_server.groups.[].read") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;write</samp>](## "snmp_server.groups.[].write") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;notify</samp>](## "snmp_server.groups.[].notify") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;read</samp>](## "snmp_server.groups.[].read") | String |  |  |  | Read View |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;write</samp>](## "snmp_server.groups.[].write") | String |  |  |  | Write View |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;notify</samp>](## "snmp_server.groups.[].notify") | String |  |  |  | Notify View |
 | [<samp>&nbsp;&nbsp;users</samp>](## "snmp_server.users") | List, items: Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "snmp_server.users.[].name") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;group</samp>](## "snmp_server.users.[].group") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "snmp_server.users.[].name") | String |  |  |  | Username |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;group</samp>](## "snmp_server.users.[].group") | String |  |  |  | Group Name |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;remote_address</samp>](## "snmp_server.users.[].remote_address") | String |  |  |  | Hostname or ip of remote engine. The remote_address and udp_port are used for remote users.<br> |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;udp_port</samp>](## "snmp_server.users.[].udp_port") | Integer |  |  |  | udp_port will not be used if no remote_address is configured.<br> |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;version</samp>](## "snmp_server.users.[].version") | String |  |  | Valid Values:<br>- v1<br>- v2c<br>- v3 |  |
@@ -4523,28 +4496,19 @@ sflow:
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;priv_passphrase</samp>](## "snmp_server.users.[].priv_passphrase") | String |  |  |  | hashed_priv_passphrase if localized is used else cleartext priv_passphrase.<br> |
 | [<samp>&nbsp;&nbsp;hosts</samp>](## "snmp_server.hosts") | List, items: Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- host</samp>](## "snmp_server.hosts.[].host") | String |  |  |  |  |
-<<<<<<< HEAD
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "snmp_server.hosts.[].vrf") | String |  |  |  |  |
-=======
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "snmp_server.hosts.[].vrf") | String |  |  |  | VRF |
->>>>>>> 4474817d (Update descriptions etc.)
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;version</samp>](## "snmp_server.hosts.[].version") | String |  |  | Valid Values:<br>- 1<br>- 2c<br>- 3 |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;community</samp>](## "snmp_server.hosts.[].community") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;community</samp>](## "snmp_server.hosts.[].community") | String |  |  |  | Community Name |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;users</samp>](## "snmp_server.hosts.[].users") | List, items: Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- username</samp>](## "snmp_server.hosts.[].users.[].username") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;authentication_level</samp>](## "snmp_server.hosts.[].users.[].authentication_level") | String |  |  | Valid Values:<br>- auth<br>- noauth<br>- priv |  |
 | [<samp>&nbsp;&nbsp;traps</samp>](## "snmp_server.traps") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;enable</samp>](## "snmp_server.traps.enable") | Boolean |  | False |  | Enable or disable all snmp-traps<br> |
-<<<<<<< HEAD
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;snmp_traps</samp>](## "snmp_server.traps.snmp_traps") | List, items: Dictionary |  |  |  | Enable or disable specific snmp-traps and their sub_traps<br> |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "snmp_server.traps.snmp_traps.[].name") | String |  |  |  | snmp_trap_type | snmp_trap_type snmp_sub_trap_type<br> |
-=======
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;snmp_traps</samp>](## "snmp_server.traps.snmp_traps") | List, items: Dictionary |  |  |  | SNMP Traps |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;snmp_traps</samp>](## "snmp_server.traps.snmp_traps") | List, items: Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "snmp_server.traps.snmp_traps.[].name") | String |  |  |  | Enable or disable specific snmp-traps and their sub_traps.<br>Examples:<br>- "bgp"<br>- "bgp established"<br> |
->>>>>>> 4474817d (Update descriptions etc.)
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "snmp_server.traps.snmp_traps.[].enabled") | Boolean |  | True |  |  |
 | [<samp>&nbsp;&nbsp;vrfs</samp>](## "snmp_server.vrfs") | List, items: Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "snmp_server.vrfs.[].name") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "snmp_server.vrfs.[].name") | String |  |  |  | VRF Name |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enable</samp>](## "snmp_server.vrfs.[].enable") | Boolean |  |  |  |  |
 
 ### YAML

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -4440,6 +4440,146 @@ sflow:
         enabled: <bool>
 ```
 
+## SNMP Server
+
+### Variables
+
+| Variable | Type | Required | Default | Value Restrictions | Description |
+| -------- | ---- | -------- | ------- | ------------------ | ----------- |
+| [<samp>snmp_server</samp>](## "snmp_server") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;engine_ids</samp>](## "snmp_server.engine_ids") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;local</samp>](## "snmp_server.engine_ids.local") | String |  |  |  | Engine id in hexadecimal<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;remotes</samp>](## "snmp_server.engine_ids.remotes") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- id</samp>](## "snmp_server.engine_ids.remotes.[].id") | String |  |  |  | Engine ID In Hexadecimal<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;address</samp>](## "snmp_server.engine_ids.remotes.[].address") | String |  |  |  | Hostname or IP Of Remote Engine<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;udp_port</samp>](## "snmp_server.engine_ids.remotes.[].udp_port") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;contact</samp>](## "snmp_server.contact") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;location</samp>](## "snmp_server.location") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;communities</samp>](## "snmp_server.communities") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "snmp_server.communities.[].name") | String | Required, Unique |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;access</samp>](## "snmp_server.communities.[].access") | String |  |  | Valid Values:<br>- ro<br>- rw |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;access_list_ipv4</samp>](## "snmp_server.communities.[].access_list_ipv4") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "snmp_server.communities.[].access_list_ipv4.name") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;access_list_ipv6</samp>](## "snmp_server.communities.[].access_list_ipv6") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "snmp_server.communities.[].access_list_ipv6.name") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;view</samp>](## "snmp_server.communities.[].view") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;ipv4_acls</samp>](## "snmp_server.ipv4_acls") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "snmp_server.ipv4_acls.[].name") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "snmp_server.ipv4_acls.[].vrf") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;ipv6_acls</samp>](## "snmp_server.ipv6_acls") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "snmp_server.ipv6_acls.[].name") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "snmp_server.ipv6_acls.[].vrf") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;local_interfaces</samp>](## "snmp_server.local_interfaces") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "snmp_server.local_interfaces.[].name") | String | Required, Unique |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "snmp_server.local_interfaces.[].vrf") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;views</samp>](## "snmp_server.views") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "snmp_server.views.[].name") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;MIB_family_name</samp>](## "snmp_server.views.[].MIB_family_name") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;included</samp>](## "snmp_server.views.[].included") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;groups</samp>](## "snmp_server.groups") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "snmp_server.groups.[].name") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;version</samp>](## "snmp_server.groups.[].version") | String |  |  | Valid Values:<br>- v1<br>- v2c<br>- v3 |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;authentication</samp>](## "snmp_server.groups.[].authentication") | String |  |  | Valid Values:<br>- auth<br>- noauth<br>- priv |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;read</samp>](## "snmp_server.groups.[].read") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;write</samp>](## "snmp_server.groups.[].write") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;notify</samp>](## "snmp_server.groups.[].notify") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;users</samp>](## "snmp_server.users") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "snmp_server.users.[].name") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;group</samp>](## "snmp_server.users.[].group") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;remote_address</samp>](## "snmp_server.users.[].remote_address") | String |  |  |  | Hostname or ip of remote engine. The remote_address and udp_port are used for remote users.<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;udp_port</samp>](## "snmp_server.users.[].udp_port") | Integer |  |  |  | udp_port will not be used if no remote_address is configured.<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;version</samp>](## "snmp_server.users.[].version") | String |  |  | Valid Values:<br>- v1<br>- v2c<br>- v3 |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;localized</samp>](## "snmp_server.users.[].localized") | String |  |  |  | Engine ID in hexadecimal<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;auth</samp>](## "snmp_server.users.[].auth") | String |  |  |  | Hash Algorithm<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;auth_passphrase</samp>](## "snmp_server.users.[].auth_passphrase") | String |  |  |  | hashed_auth_passphrase if localized is used else cleartext auth_passphrase.<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;priv</samp>](## "snmp_server.users.[].priv") | String |  |  |  | Encryption Algorithm<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;priv_passphrase</samp>](## "snmp_server.users.[].priv_passphrase") | String |  |  |  | hashed_priv_passphrase if localized is used else cleartext priv_passphrase.<br> |
+| [<samp>&nbsp;&nbsp;hosts</samp>](## "snmp_server.hosts") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- host</samp>](## "snmp_server.hosts.[].host") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "snmp_server.hosts.[].vrf") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;version</samp>](## "snmp_server.hosts.[].version") | String |  |  | Valid Values:<br>- 1<br>- 2c<br>- 3 |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;community</samp>](## "snmp_server.hosts.[].community") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;users</samp>](## "snmp_server.hosts.[].users") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- username</samp>](## "snmp_server.hosts.[].users.[].username") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;authentication_level</samp>](## "snmp_server.hosts.[].users.[].authentication_level") | String |  |  | Valid Values:<br>- auth<br>- noauth<br>- priv |  |
+| [<samp>&nbsp;&nbsp;traps</samp>](## "snmp_server.traps") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;enable</samp>](## "snmp_server.traps.enable") | Boolean |  | False |  | Enable or disable all snmp-traps<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;snmp_traps</samp>](## "snmp_server.traps.snmp_traps") | List, items: Dictionary |  |  |  | Enable or disable specific snmp-traps and their sub_traps<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "snmp_server.traps.snmp_traps.[].name") | String |  |  |  | snmp_trap_type | snmp_trap_type snmp_sub_trap_type<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "snmp_server.traps.snmp_traps.[].enabled") | Boolean |  | True |  |  |
+| [<samp>&nbsp;&nbsp;vrfs</samp>](## "snmp_server.vrfs") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "snmp_server.vrfs.[].name") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enable</samp>](## "snmp_server.vrfs.[].enable") | Boolean |  |  |  |  |
+
+### YAML
+
+```yaml
+snmp_server:
+  engine_ids:
+    local: <str>
+    remotes:
+      - id: <str>
+        address: <str>
+        udp_port: <int>
+  contact: <str>
+  location: <str>
+  communities:
+    - name: <str>
+      access: <str>
+      access_list_ipv4:
+        name: <str>
+      access_list_ipv6:
+        name: <str>
+      view: <str>
+  ipv4_acls:
+    - name: <str>
+      vrf: <str>
+  ipv6_acls:
+    - name: <str>
+      vrf: <str>
+  local_interfaces:
+    - name: <str>
+      vrf: <str>
+  views:
+    - name: <str>
+      MIB_family_name: <str>
+      included: <bool>
+  groups:
+    - name: <str>
+      version: <str>
+      authentication: <str>
+      read: <str>
+      write: <str>
+      notify: <str>
+  users:
+    - name: <str>
+      group: <str>
+      remote_address: <str>
+      udp_port: <int>
+      version: <str>
+      localized: <str>
+      auth: <str>
+      auth_passphrase: <str>
+      priv: <str>
+      priv_passphrase: <str>
+  hosts:
+    - host: <str>
+      vrf: <str>
+      version: <str>
+      community: <str>
+      users:
+        - username: <str>
+          authentication_level: <str>
+  traps:
+    enable: <bool>
+    snmp_traps:
+      - name: <str>
+        enabled: <bool>
+  vrfs:
+    - name: <str>
+      enable: <bool>
+```
+
 ## Spanning Tree
 
 ### Variables

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -4446,11 +4446,19 @@ sflow:
 
 | Variable | Type | Required | Default | Value Restrictions | Description |
 | -------- | ---- | -------- | ------- | ------------------ | ----------- |
+<<<<<<< HEAD
 | [<samp>snmp_server</samp>](## "snmp_server") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;engine_ids</samp>](## "snmp_server.engine_ids") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;local</samp>](## "snmp_server.engine_ids.local") | String |  |  |  | Engine id in hexadecimal<br> |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;remotes</samp>](## "snmp_server.engine_ids.remotes") | List, items: Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- id</samp>](## "snmp_server.engine_ids.remotes.[].id") | String |  |  |  | Engine ID In Hexadecimal<br> |
+=======
+| [<samp>snmp_server</samp>](## "snmp_server") | Dictionary |  |  |  | SNMP Server |
+| [<samp>&nbsp;&nbsp;engine_ids</samp>](## "snmp_server.engine_ids") | Dictionary |  |  |  | Engine IDs |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;local</samp>](## "snmp_server.engine_ids.local") | String |  |  |  | Engine ID in hexadecimal<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;remotes</samp>](## "snmp_server.engine_ids.remotes") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- id</samp>](## "snmp_server.engine_ids.remotes.[].id") | String |  |  |  | ID<br>Remote Engine ID In Hexadecimal<br> |
+>>>>>>> 4474817d (Update descriptions etc.)
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;address</samp>](## "snmp_server.engine_ids.remotes.[].address") | String |  |  |  | Hostname or IP Of Remote Engine<br> |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;udp_port</samp>](## "snmp_server.engine_ids.remotes.[].udp_port") | Integer |  |  |  |  |
 | [<samp>&nbsp;&nbsp;contact</samp>](## "snmp_server.contact") | String |  |  |  |  |
@@ -4458,6 +4466,7 @@ sflow:
 | [<samp>&nbsp;&nbsp;communities</samp>](## "snmp_server.communities") | List, items: Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "snmp_server.communities.[].name") | String | Required, Unique |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;access</samp>](## "snmp_server.communities.[].access") | String |  |  | Valid Values:<br>- ro<br>- rw |  |
+<<<<<<< HEAD
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;access_list_ipv4</samp>](## "snmp_server.communities.[].access_list_ipv4") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "snmp_server.communities.[].access_list_ipv4.name") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;access_list_ipv6</samp>](## "snmp_server.communities.[].access_list_ipv6") | Dictionary |  |  |  |  |
@@ -4469,12 +4478,30 @@ sflow:
 | [<samp>&nbsp;&nbsp;ipv6_acls</samp>](## "snmp_server.ipv6_acls") | List, items: Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "snmp_server.ipv6_acls.[].name") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "snmp_server.ipv6_acls.[].vrf") | String |  |  |  |  |
+=======
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;access_list_ipv4</samp>](## "snmp_server.communities.[].access_list_ipv4") | Dictionary |  |  |  | Access List IPv4 |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "snmp_server.communities.[].access_list_ipv4.name") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;access_list_ipv6</samp>](## "snmp_server.communities.[].access_list_ipv6") | Dictionary |  |  |  | Access List IPv6 |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "snmp_server.communities.[].access_list_ipv6.name") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;view</samp>](## "snmp_server.communities.[].view") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;ipv4_acls</samp>](## "snmp_server.ipv4_acls") | List, items: Dictionary |  |  |  | IPv4 ACLs |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "snmp_server.ipv4_acls.[].name") | String |  |  |  | IPv4 Access List Name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "snmp_server.ipv4_acls.[].vrf") | String |  |  |  | VRF |
+| [<samp>&nbsp;&nbsp;ipv6_acls</samp>](## "snmp_server.ipv6_acls") | List, items: Dictionary |  |  |  | IPv6 ACLs |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "snmp_server.ipv6_acls.[].name") | String |  |  |  | IPv6 Access List Name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "snmp_server.ipv6_acls.[].vrf") | String |  |  |  | VRF |
+>>>>>>> 4474817d (Update descriptions etc.)
 | [<samp>&nbsp;&nbsp;local_interfaces</samp>](## "snmp_server.local_interfaces") | List, items: Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "snmp_server.local_interfaces.[].name") | String | Required, Unique |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "snmp_server.local_interfaces.[].vrf") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;views</samp>](## "snmp_server.views") | List, items: Dictionary |  |  |  |  |
+<<<<<<< HEAD
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "snmp_server.views.[].name") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;MIB_family_name</samp>](## "snmp_server.views.[].MIB_family_name") | String |  |  |  |  |
+=======
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "snmp_server.views.[].name") | String |  |  |  | SNMP View Name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;MIB_family_name</samp>](## "snmp_server.views.[].MIB_family_name") | String |  |  |  | MIB Family Name |
+>>>>>>> 4474817d (Update descriptions etc.)
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;included</samp>](## "snmp_server.views.[].included") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;groups</samp>](## "snmp_server.groups") | List, items: Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "snmp_server.groups.[].name") | String |  |  |  |  |
@@ -4489,14 +4516,18 @@ sflow:
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;remote_address</samp>](## "snmp_server.users.[].remote_address") | String |  |  |  | Hostname or ip of remote engine. The remote_address and udp_port are used for remote users.<br> |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;udp_port</samp>](## "snmp_server.users.[].udp_port") | Integer |  |  |  | udp_port will not be used if no remote_address is configured.<br> |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;version</samp>](## "snmp_server.users.[].version") | String |  |  | Valid Values:<br>- v1<br>- v2c<br>- v3 |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;localized</samp>](## "snmp_server.users.[].localized") | String |  |  |  | Engine ID in hexadecimal<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;localized</samp>](## "snmp_server.users.[].localized") | String |  |  |  | Engine ID in hexadecimal for localizing auth and/or priv<br> |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;auth</samp>](## "snmp_server.users.[].auth") | String |  |  |  | Hash Algorithm<br> |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;auth_passphrase</samp>](## "snmp_server.users.[].auth_passphrase") | String |  |  |  | hashed_auth_passphrase if localized is used else cleartext auth_passphrase.<br> |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;priv</samp>](## "snmp_server.users.[].priv") | String |  |  |  | Encryption Algorithm<br> |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;priv_passphrase</samp>](## "snmp_server.users.[].priv_passphrase") | String |  |  |  | hashed_priv_passphrase if localized is used else cleartext priv_passphrase.<br> |
 | [<samp>&nbsp;&nbsp;hosts</samp>](## "snmp_server.hosts") | List, items: Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- host</samp>](## "snmp_server.hosts.[].host") | String |  |  |  |  |
+<<<<<<< HEAD
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "snmp_server.hosts.[].vrf") | String |  |  |  |  |
+=======
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "snmp_server.hosts.[].vrf") | String |  |  |  | VRF |
+>>>>>>> 4474817d (Update descriptions etc.)
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;version</samp>](## "snmp_server.hosts.[].version") | String |  |  | Valid Values:<br>- 1<br>- 2c<br>- 3 |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;community</samp>](## "snmp_server.hosts.[].community") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;users</samp>](## "snmp_server.hosts.[].users") | List, items: Dictionary |  |  |  |  |
@@ -4504,8 +4535,13 @@ sflow:
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;authentication_level</samp>](## "snmp_server.hosts.[].users.[].authentication_level") | String |  |  | Valid Values:<br>- auth<br>- noauth<br>- priv |  |
 | [<samp>&nbsp;&nbsp;traps</samp>](## "snmp_server.traps") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;enable</samp>](## "snmp_server.traps.enable") | Boolean |  | False |  | Enable or disable all snmp-traps<br> |
+<<<<<<< HEAD
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;snmp_traps</samp>](## "snmp_server.traps.snmp_traps") | List, items: Dictionary |  |  |  | Enable or disable specific snmp-traps and their sub_traps<br> |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "snmp_server.traps.snmp_traps.[].name") | String |  |  |  | snmp_trap_type | snmp_trap_type snmp_sub_trap_type<br> |
+=======
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;snmp_traps</samp>](## "snmp_server.traps.snmp_traps") | List, items: Dictionary |  |  |  | SNMP Traps |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "snmp_server.traps.snmp_traps.[].name") | String |  |  |  | Enable or disable specific snmp-traps and their sub_traps.<br>Examples:<br>- "bgp"<br>- "bgp established"<br> |
+>>>>>>> 4474817d (Update descriptions etc.)
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "snmp_server.traps.snmp_traps.[].enabled") | Boolean |  | True |  |  |
 | [<samp>&nbsp;&nbsp;vrfs</samp>](## "snmp_server.vrfs") | List, items: Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "snmp_server.vrfs.[].name") | String |  |  |  |  |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -4453,15 +4453,15 @@ sflow:
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- id</samp>](## "snmp_server.engine_ids.remotes.[].id") | String |  |  |  | Remote Engine ID In Hexadecimal<br> |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;address</samp>](## "snmp_server.engine_ids.remotes.[].address") | String |  |  |  | Hostname or IP Of Remote Engine<br> |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;udp_port</samp>](## "snmp_server.engine_ids.remotes.[].udp_port") | Integer |  |  |  |  |
-| [<samp>&nbsp;&nbsp;contact</samp>](## "snmp_server.contact") | String |  |  |  | Contact Name |
-| [<samp>&nbsp;&nbsp;location</samp>](## "snmp_server.location") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;contact</samp>](## "snmp_server.contact") | String |  |  |  | SNMP Contact |
+| [<samp>&nbsp;&nbsp;location</samp>](## "snmp_server.location") | String |  |  |  | SNMP Location |
 | [<samp>&nbsp;&nbsp;communities</samp>](## "snmp_server.communities") | List, items: Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "snmp_server.communities.[].name") | String | Required, Unique |  |  | Community Name |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;access</samp>](## "snmp_server.communities.[].access") | String |  |  | Valid Values:<br>- ro<br>- rw |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;access_list_ipv4</samp>](## "snmp_server.communities.[].access_list_ipv4") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "snmp_server.communities.[].access_list_ipv4.name") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "snmp_server.communities.[].access_list_ipv4.name") | String |  |  |  | IPv4 Access List Name |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;access_list_ipv6</samp>](## "snmp_server.communities.[].access_list_ipv6") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "snmp_server.communities.[].access_list_ipv6.name") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "snmp_server.communities.[].access_list_ipv6.name") | String |  |  |  | IPv6 Access List Name |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;view</samp>](## "snmp_server.communities.[].view") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;ipv4_acls</samp>](## "snmp_server.ipv4_acls") | List, items: Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "snmp_server.ipv4_acls.[].name") | String |  |  |  | IPv4 Access List Name |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -9222,6 +9222,7 @@
     },
     "snmp_server": {
       "type": "object",
+      "description": "SNMP settings",
       "properties": {
         "engine_ids": {
           "type": "object",
@@ -9525,6 +9526,7 @@
             "properties": {
               "host": {
                 "type": "string",
+                "description": "Host IP address or name",
                 "title": "Host"
               },
               "vrf": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -9222,11 +9222,9 @@
     },
     "snmp_server": {
       "type": "object",
-      "title": "SNMP Server",
       "properties": {
         "engine_ids": {
           "type": "object",
-          "title": "Engine IDs",
           "properties": {
             "local": {
               "type": "string",
@@ -9240,8 +9238,8 @@
                 "properties": {
                   "id": {
                     "type": "string",
-                    "title": "ID",
-                    "description": "Remote Engine ID In Hexadecimal\n"
+                    "description": "Remote Engine ID In Hexadecimal\n",
+                    "title": "ID"
                   },
                   "address": {
                     "type": "string",
@@ -9258,7 +9256,8 @@
               "title": "Remotes"
             }
           },
-          "additionalProperties": false
+          "additionalProperties": false,
+          "title": "Engine IDs"
         },
         "contact": {
           "type": "string",
@@ -9289,25 +9288,25 @@
               },
               "access_list_ipv4": {
                 "type": "object",
-                "title": "Access List IPv4",
                 "properties": {
                   "name": {
                     "type": "string",
                     "title": "Name"
                   }
                 },
-                "additionalProperties": false
+                "additionalProperties": false,
+                "title": "Access List IPv4"
               },
               "access_list_ipv6": {
                 "type": "object",
-                "title": "Access List IPv6",
                 "properties": {
                   "name": {
                     "type": "string",
                     "title": "Name"
                   }
                 },
-                "additionalProperties": false
+                "additionalProperties": false,
+                "title": "Access List IPv6"
               },
               "view": {
                 "type": "string",
@@ -9323,7 +9322,6 @@
         },
         "ipv4_acls": {
           "type": "array",
-          "title": "IPv4 ACLs",
           "items": {
             "type": "object",
             "properties": {
@@ -9338,10 +9336,10 @@
               }
             },
             "additionalProperties": false
-          }
+          },
+          "title": "IPv4 Acls"
         },
         "ipv6_acls": {
-          "title": "IPv6 ACLs",
           "type": "array",
           "items": {
             "type": "object",
@@ -9352,12 +9350,13 @@
                 "title": "Name"
               },
               "vrf": {
-                "title": "VRF",
-                "type": "string"
+                "type": "string",
+                "title": "VRF"
               }
             },
             "additionalProperties": false
-          }
+          },
+          "title": "IPv6 Acls"
         },
         "local_interfaces": {
           "type": "array",
@@ -9473,9 +9472,9 @@
                 "title": "Remote Address"
               },
               "udp_port": {
-                "title": "UDP Port",
                 "type": "integer",
-                "description": "udp_port will not be used if no remote_address is configured.\n"
+                "description": "udp_port will not be used if no remote_address is configured.\n",
+                "title": "UDP Port"
               },
               "version": {
                 "type": "string",
@@ -9581,7 +9580,6 @@
               "title": "Enable"
             },
             "snmp_traps": {
-              "title": "SNMP Traps",
               "type": "array",
               "items": {
                 "type": "object",
@@ -9598,14 +9596,14 @@
                   }
                 },
                 "additionalProperties": false
-              }
+              },
+              "title": "Snmp Traps"
             }
           },
           "additionalProperties": false,
           "title": "Traps"
         },
         "vrfs": {
-          "title": "VRFs",
           "type": "array",
           "items": {
             "type": "object",
@@ -9621,10 +9619,12 @@
               }
             },
             "additionalProperties": false
-          }
+          },
+          "title": "VRFs"
         }
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "title": "Snmp Server"
     },
     "spanning_tree": {
       "type": "object",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -9261,11 +9261,12 @@
         },
         "contact": {
           "type": "string",
-          "description": "Contact Name",
+          "description": "SNMP Contact",
           "title": "Contact"
         },
         "location": {
           "type": "string",
+          "description": "SNMP Location",
           "title": "Location"
         },
         "communities": {
@@ -9291,6 +9292,7 @@
                 "properties": {
                   "name": {
                     "type": "string",
+                    "description": "IPv4 Access List Name",
                     "title": "Name"
                   }
                 },
@@ -9302,6 +9304,7 @@
                 "properties": {
                   "name": {
                     "type": "string",
+                    "description": "IPv6 Access List Name",
                     "title": "Name"
                   }
                 },

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -9238,12 +9238,12 @@
                 "properties": {
                   "id": {
                     "type": "string",
-                    "description": "Remote Engine ID In Hexadecimal\n",
+                    "description": "Remote engine ID in hexadecimal\n",
                     "title": "ID"
                   },
                   "address": {
                     "type": "string",
-                    "description": "Hostname or IP Of Remote Engine\n",
+                    "description": "Hostname or IP of remote engine\n",
                     "title": "Address"
                   },
                   "udp_port": {
@@ -9261,12 +9261,12 @@
         },
         "contact": {
           "type": "string",
-          "description": "SNMP Contact",
+          "description": "SNMP contact",
           "title": "Contact"
         },
         "location": {
           "type": "string",
-          "description": "SNMP Location",
+          "description": "SNMP location",
           "title": "Location"
         },
         "communities": {
@@ -9276,7 +9276,7 @@
             "properties": {
               "name": {
                 "type": "string",
-                "description": "Community Name",
+                "description": "Community name",
                 "title": "Name"
               },
               "access": {
@@ -9292,7 +9292,7 @@
                 "properties": {
                   "name": {
                     "type": "string",
-                    "description": "IPv4 Access List Name",
+                    "description": "IPv4 access list name",
                     "title": "Name"
                   }
                 },
@@ -9304,7 +9304,7 @@
                 "properties": {
                   "name": {
                     "type": "string",
-                    "description": "IPv6 Access List Name",
+                    "description": "IPv6 access list name",
                     "title": "Name"
                   }
                 },
@@ -9330,7 +9330,7 @@
             "properties": {
               "name": {
                 "type": "string",
-                "description": "IPv4 Access List Name",
+                "description": "IPv4 access list name",
                 "title": "Name"
               },
               "vrf": {
@@ -9349,7 +9349,7 @@
             "properties": {
               "name": {
                 "type": "string",
-                "description": "IPv6 Access List Name",
+                "description": "IPv6 access list name",
                 "title": "Name"
               },
               "vrf": {
@@ -9368,7 +9368,7 @@
             "properties": {
               "name": {
                 "type": "string",
-                "description": "Interface Name",
+                "description": "Interface name",
                 "title": "Name"
               },
               "vrf": {
@@ -9390,7 +9390,7 @@
             "properties": {
               "name": {
                 "type": "string",
-                "description": "SNMP View Name",
+                "description": "SNMP view name",
                 "title": "Name"
               },
               "MIB_family_name": {
@@ -9436,17 +9436,17 @@
               },
               "read": {
                 "type": "string",
-                "description": "Read View",
+                "description": "Read view",
                 "title": "Read"
               },
               "write": {
                 "type": "string",
-                "description": "Write View",
+                "description": "Write view",
                 "title": "Write"
               },
               "notify": {
                 "type": "string",
-                "description": "Notify View",
+                "description": "Notify view",
                 "title": "Notify"
               }
             },
@@ -9466,17 +9466,17 @@
               },
               "group": {
                 "type": "string",
-                "description": "Group Name",
+                "description": "Group name",
                 "title": "Group"
               },
               "remote_address": {
                 "type": "string",
-                "description": "Hostname or ip of remote engine. The remote_address and udp_port are used for remote users.\n",
+                "description": "Hostname or ip of remote engine\nThe remote_address and udp_port are used for remote users\n",
                 "title": "Remote Address"
               },
               "udp_port": {
                 "type": "integer",
-                "description": "udp_port will not be used if no remote_address is configured.\n",
+                "description": "udp_port will not be used if no remote_address is configured\n",
                 "title": "UDP Port"
               },
               "version": {
@@ -9495,22 +9495,22 @@
               },
               "auth": {
                 "type": "string",
-                "description": "Hash Algorithm\n",
+                "description": "Hash algorithm\n",
                 "title": "Auth"
               },
               "auth_passphrase": {
                 "type": "string",
-                "description": "hashed_auth_passphrase if localized is used else cleartext auth_passphrase.\n",
+                "description": "Hashed authentication passphrase if localized is used else cleartext authentication passphrase\n",
                 "title": "Auth Passphrase"
               },
               "priv": {
                 "type": "string",
-                "description": "Encryption Algorithm\n",
+                "description": "Encryption algorithm\n",
                 "title": "Priv"
               },
               "priv_passphrase": {
                 "type": "string",
-                "description": "hashed_priv_passphrase if localized is used else cleartext priv_passphrase.\n",
+                "description": "Hashed privacy passphrase if localized is used else cleartext privacy passphrase\n",
                 "title": "Priv Passphrase"
               }
             },
@@ -9542,7 +9542,7 @@
               },
               "community": {
                 "type": "string",
-                "description": "Community Name",
+                "description": "Community name",
                 "title": "Community"
               },
               "users": {
@@ -9589,7 +9589,7 @@
                 "properties": {
                   "name": {
                     "type": "string",
-                    "description": "Enable or disable specific snmp-traps and their sub_traps.\nExamples:\n- \"bgp\"\n- \"bgp established\"\n",
+                    "description": "Enable or disable specific snmp-traps and their sub_traps\nExamples:\n- \"bgp\"\n- \"bgp established\"\n",
                     "title": "Name"
                   },
                   "enabled": {
@@ -9613,7 +9613,7 @@
             "properties": {
               "name": {
                 "type": "string",
-                "description": "VRF Name",
+                "description": "VRF name",
                 "title": "Name"
               },
               "enable": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -9221,16 +9221,16 @@
       "title": "Sflow"
     },
     "snmp_server": {
-      "title": "SNMP Server",
       "type": "object",
+      "title": "SNMP Server",
       "properties": {
         "engine_ids": {
-          "title": "Engine IDs",
           "type": "object",
+          "title": "Engine IDs",
           "properties": {
             "local": {
               "type": "string",
-              "description": "Engine id in hexadecimal\n",
+              "description": "Engine ID in hexadecimal\n",
               "title": "Local"
             },
             "remotes": {
@@ -9239,9 +9239,9 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "title": "ID",
                     "type": "string",
-                    "description": "Engine ID In Hexadecimal\n"
+                    "title": "ID",
+                    "description": "Remote Engine ID In Hexadecimal\n"
                   },
                   "address": {
                     "type": "string",
@@ -9249,8 +9249,8 @@
                     "title": "Address"
                   },
                   "udp_port": {
-                    "title": "UDP Port",
-                    "type": "integer"
+                    "type": "integer",
+                    "title": "UDP Port"
                   }
                 },
                 "additionalProperties": false
@@ -9262,7 +9262,8 @@
         },
         "contact": {
           "type": "string",
-          "title": "Contact Name"
+          "description": "Contact Name",
+          "title": "Contact"
         },
         "location": {
           "type": "string",
@@ -9275,7 +9276,8 @@
             "properties": {
               "name": {
                 "type": "string",
-                "title": "Community Name"
+                "description": "Community Name",
+                "title": "Name"
               },
               "access": {
                 "type": "string",
@@ -9286,30 +9288,30 @@
                 "title": "Access"
               },
               "access_list_ipv4": {
-                "title": "Access List IPv4",
                 "type": "object",
+                "title": "Access List IPv4",
                 "properties": {
                   "name": {
                     "type": "string",
-                    "title": "ACL IPv4 Name"
+                    "title": "Name"
                   }
                 },
                 "additionalProperties": false
               },
               "access_list_ipv6": {
-                "title": "Access List IPv6",
                 "type": "object",
+                "title": "Access List IPv6",
                 "properties": {
                   "name": {
                     "type": "string",
-                    "title": "ACL IPv6 Name"
+                    "title": "Name"
                   }
                 },
                 "additionalProperties": false
               },
               "view": {
                 "type": "string",
-                "title": "View Name"
+                "title": "View"
               }
             },
             "additionalProperties": false,
@@ -9320,18 +9322,19 @@
           "title": "Communities"
         },
         "ipv4_acls": {
-          "title": "IPv4 ACLs",
           "type": "array",
+          "title": "IPv4 ACLs",
           "items": {
             "type": "object",
             "properties": {
               "name": {
                 "type": "string",
-                "title": "IPv4 Access List"
+                "description": "IPv4 Access List Name",
+                "title": "Name"
               },
               "vrf": {
-                "title": "VRF",
-                "type": "string"
+                "type": "string",
+                "title": "VRF"
               }
             },
             "additionalProperties": false
@@ -9345,7 +9348,8 @@
             "properties": {
               "name": {
                 "type": "string",
-                "title": "IPv4 Access List"
+                "description": "IPv6 Access List Name",
+                "title": "Name"
               },
               "vrf": {
                 "title": "VRF",
@@ -9362,11 +9366,12 @@
             "properties": {
               "name": {
                 "type": "string",
-                "title": "Interface Name"
+                "description": "Interface Name",
+                "title": "Name"
               },
               "vrf": {
-                "title": "VRF",
-                "type": "string"
+                "type": "string",
+                "title": "VRF"
               }
             },
             "required": [
@@ -9383,11 +9388,12 @@
             "properties": {
               "name": {
                 "type": "string",
-                "title": "View Name"
+                "description": "SNMP View Name",
+                "title": "Name"
               },
               "MIB_family_name": {
-                "title": "MIB Family Name",
-                "type": "string"
+                "type": "string",
+                "title": "MIB Family Name"
               },
               "included": {
                 "type": "boolean",
@@ -9405,7 +9411,8 @@
             "properties": {
               "name": {
                 "type": "string",
-                "title": "Group name"
+                "description": "Group name",
+                "title": "Name"
               },
               "version": {
                 "type": "string",
@@ -9427,15 +9434,18 @@
               },
               "read": {
                 "type": "string",
-                "title": "Read View"
+                "description": "Read View",
+                "title": "Read"
               },
               "write": {
                 "type": "string",
-                "title": "Write View"
+                "description": "Write View",
+                "title": "Write"
               },
               "notify": {
                 "type": "string",
-                "title": "Notify View"
+                "description": "Notify View",
+                "title": "Notify"
               }
             },
             "additionalProperties": false
@@ -9449,11 +9459,13 @@
             "properties": {
               "name": {
                 "type": "string",
-                "title": "Username"
+                "description": "Username",
+                "title": "Name"
               },
               "group": {
                 "type": "string",
-                "title": "Group Name"
+                "description": "Group Name",
+                "title": "Group"
               },
               "remote_address": {
                 "type": "string",
@@ -9476,7 +9488,7 @@
               },
               "localized": {
                 "type": "string",
-                "description": "Engine ID in hexadecimal\n",
+                "description": "Engine ID in hexadecimal for localizing auth and/or priv\n",
                 "title": "Localized"
               },
               "auth": {
@@ -9515,7 +9527,7 @@
               },
               "vrf": {
                 "type": "string",
-                "title": "VRF Name"
+                "title": "VRF"
               },
               "version": {
                 "type": "string",
@@ -9528,7 +9540,8 @@
               },
               "community": {
                 "type": "string",
-                "title": "Community Name"
+                "description": "Community Name",
+                "title": "Community"
               },
               "users": {
                 "type": "array",
@@ -9570,13 +9583,12 @@
             "snmp_traps": {
               "title": "SNMP Traps",
               "type": "array",
-              "description": "Enable or disable specific snmp-traps and their sub_traps\n",
               "items": {
                 "type": "object",
                 "properties": {
                   "name": {
                     "type": "string",
-                    "description": "snmp_trap_type | snmp_trap_type snmp_sub_trap_type\n",
+                    "description": "Enable or disable specific snmp-traps and their sub_traps.\nExamples:\n- \"bgp\"\n- \"bgp established\"\n",
                     "title": "Name"
                   },
                   "enabled": {
@@ -9600,7 +9612,8 @@
             "properties": {
               "name": {
                 "type": "string",
-                "title": "VRF Name"
+                "description": "VRF Name",
+                "title": "Name"
               },
               "enable": {
                 "type": "boolean",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -9220,6 +9220,399 @@
       "additionalProperties": false,
       "title": "Sflow"
     },
+    "snmp_server": {
+      "title": "SNMP Server",
+      "type": "object",
+      "properties": {
+        "engine_ids": {
+          "title": "Engine IDs",
+          "type": "object",
+          "properties": {
+            "local": {
+              "type": "string",
+              "description": "Engine id in hexadecimal\n",
+              "title": "Local"
+            },
+            "remotes": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "title": "ID",
+                    "type": "string",
+                    "description": "Engine ID In Hexadecimal\n"
+                  },
+                  "address": {
+                    "type": "string",
+                    "description": "Hostname or IP Of Remote Engine\n",
+                    "title": "Address"
+                  },
+                  "udp_port": {
+                    "title": "UDP Port",
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "title": "Remotes"
+            }
+          },
+          "additionalProperties": false
+        },
+        "contact": {
+          "type": "string",
+          "title": "Contact Name"
+        },
+        "location": {
+          "type": "string",
+          "title": "Location"
+        },
+        "communities": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "Community Name"
+              },
+              "access": {
+                "type": "string",
+                "enum": [
+                  "ro",
+                  "rw"
+                ],
+                "title": "Access"
+              },
+              "access_list_ipv4": {
+                "title": "Access List IPv4",
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "title": "ACL IPv4 Name"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "access_list_ipv6": {
+                "title": "Access List IPv6",
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "title": "ACL IPv6 Name"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "view": {
+                "type": "string",
+                "title": "View Name"
+              }
+            },
+            "additionalProperties": false,
+            "required": [
+              "name"
+            ]
+          },
+          "title": "Communities"
+        },
+        "ipv4_acls": {
+          "title": "IPv4 ACLs",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "IPv4 Access List"
+              },
+              "vrf": {
+                "title": "VRF",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "ipv6_acls": {
+          "title": "IPv6 ACLs",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "IPv4 Access List"
+              },
+              "vrf": {
+                "title": "VRF",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "local_interfaces": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "Interface Name"
+              },
+              "vrf": {
+                "title": "VRF",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "additionalProperties": false
+          },
+          "title": "Local Interfaces"
+        },
+        "views": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "View Name"
+              },
+              "MIB_family_name": {
+                "title": "MIB Family Name",
+                "type": "string"
+              },
+              "included": {
+                "type": "boolean",
+                "title": "Included"
+              }
+            },
+            "additionalProperties": false
+          },
+          "title": "Views"
+        },
+        "groups": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "Group name"
+              },
+              "version": {
+                "type": "string",
+                "enum": [
+                  "v1",
+                  "v2c",
+                  "v3"
+                ],
+                "title": "Version"
+              },
+              "authentication": {
+                "type": "string",
+                "enum": [
+                  "auth",
+                  "noauth",
+                  "priv"
+                ],
+                "title": "Authentication"
+              },
+              "read": {
+                "type": "string",
+                "title": "Read View"
+              },
+              "write": {
+                "type": "string",
+                "title": "Write View"
+              },
+              "notify": {
+                "type": "string",
+                "title": "Notify View"
+              }
+            },
+            "additionalProperties": false
+          },
+          "title": "Groups"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "Username"
+              },
+              "group": {
+                "type": "string",
+                "title": "Group Name"
+              },
+              "remote_address": {
+                "type": "string",
+                "description": "Hostname or ip of remote engine. The remote_address and udp_port are used for remote users.\n",
+                "title": "Remote Address"
+              },
+              "udp_port": {
+                "title": "UDP Port",
+                "type": "integer",
+                "description": "udp_port will not be used if no remote_address is configured.\n"
+              },
+              "version": {
+                "type": "string",
+                "enum": [
+                  "v1",
+                  "v2c",
+                  "v3"
+                ],
+                "title": "Version"
+              },
+              "localized": {
+                "type": "string",
+                "description": "Engine ID in hexadecimal\n",
+                "title": "Localized"
+              },
+              "auth": {
+                "type": "string",
+                "description": "Hash Algorithm\n",
+                "title": "Auth"
+              },
+              "auth_passphrase": {
+                "type": "string",
+                "description": "hashed_auth_passphrase if localized is used else cleartext auth_passphrase.\n",
+                "title": "Auth Passphrase"
+              },
+              "priv": {
+                "type": "string",
+                "description": "Encryption Algorithm\n",
+                "title": "Priv"
+              },
+              "priv_passphrase": {
+                "type": "string",
+                "description": "hashed_priv_passphrase if localized is used else cleartext priv_passphrase.\n",
+                "title": "Priv Passphrase"
+              }
+            },
+            "additionalProperties": false
+          },
+          "title": "Users"
+        },
+        "hosts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "host": {
+                "type": "string",
+                "title": "Host"
+              },
+              "vrf": {
+                "type": "string",
+                "title": "VRF Name"
+              },
+              "version": {
+                "type": "string",
+                "enum": [
+                  "1",
+                  "2c",
+                  "3"
+                ],
+                "title": "Version"
+              },
+              "community": {
+                "type": "string",
+                "title": "Community Name"
+              },
+              "users": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "username": {
+                      "type": "string",
+                      "title": "Username"
+                    },
+                    "authentication_level": {
+                      "type": "string",
+                      "enum": [
+                        "auth",
+                        "noauth",
+                        "priv"
+                      ],
+                      "title": "Authentication Level"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "title": "Users"
+              }
+            },
+            "additionalProperties": false
+          },
+          "title": "Hosts"
+        },
+        "traps": {
+          "type": "object",
+          "properties": {
+            "enable": {
+              "type": "boolean",
+              "default": false,
+              "description": "Enable or disable all snmp-traps\n",
+              "title": "Enable"
+            },
+            "snmp_traps": {
+              "title": "SNMP Traps",
+              "type": "array",
+              "description": "Enable or disable specific snmp-traps and their sub_traps\n",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "snmp_trap_type | snmp_trap_type snmp_sub_trap_type\n",
+                    "title": "Name"
+                  },
+                  "enabled": {
+                    "type": "boolean",
+                    "default": true,
+                    "title": "Enabled"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          },
+          "additionalProperties": false,
+          "title": "Traps"
+        },
+        "vrfs": {
+          "title": "VRFs",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "VRF Name"
+              },
+              "enable": {
+                "type": "boolean",
+                "title": "Enable"
+              }
+            },
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    },
     "spanning_tree": {
       "type": "object",
       "properties": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -6209,18 +6209,18 @@ keys:
                   type: bool
                   default: true
   snmp_server:
-    display_name: SNMP Server
     type: dict
+    display_name: SNMP Server
     keys:
       engine_ids:
-        display_name: Engine IDs
         type: dict
+        display_name: Engine IDs
         keys:
           local:
             type: str
             convert_types:
             - int
-            description: 'Engine id in hexadecimal
+            description: 'Engine ID in hexadecimal
 
               '
           remotes:
@@ -6229,11 +6229,11 @@ keys:
               type: dict
               keys:
                 id:
-                  display_name: ID
                   type: str
+                  display_name: ID
                   convert_types:
                   - int
-                  description: 'Engine ID In Hexadecimal
+                  description: 'Remote Engine ID In Hexadecimal
 
                     '
                 address:
@@ -6242,13 +6242,13 @@ keys:
 
                     '
                 udp_port:
-                  display_name: UDP Port
                   type: int
+                  display_name: UDP Port
                   convert_types:
                   - str
       contact:
         type: str
-        display_name: Contact Name
+        description: Contact Name
       location:
         type: str
       communities:
@@ -6261,41 +6261,38 @@ keys:
           keys:
             name:
               type: str
-              display_name: Community Name
+              description: Community Name
             access:
               type: str
               valid_values:
               - ro
               - rw
             access_list_ipv4:
+              type: dict
               display_name: Access List IPv4
-              type: dict
               keys:
                 name:
                   type: str
-                  display_name: ACL IPv4 Name
             access_list_ipv6:
-              display_name: Access List IPv6
               type: dict
+              display_name: Access List IPv6
               keys:
                 name:
                   type: str
-                  display_name: ACL IPv6 Name
             view:
               type: str
-              display_name: View Name
       ipv4_acls:
-        display_name: IPv4 ACLs
         type: list
+        display_name: IPv4 ACLs
         items:
           type: dict
           keys:
             name:
               type: str
-              display_name: IPv4 Access List
+              description: IPv4 Access List Name
             vrf:
-              display_name: VRF
               type: str
+              display_name: VRF
       ipv6_acls:
         display_name: IPv6 ACLs
         type: list
@@ -6304,7 +6301,7 @@ keys:
           keys:
             name:
               type: str
-              display_name: IPv4 Access List
+              description: IPv6 Access List Name
             vrf:
               display_name: VRF
               type: str
@@ -6319,10 +6316,10 @@ keys:
             name:
               type: str
               required: true
-              display_name: Interface Name
+              description: Interface Name
             vrf:
-              display_name: VRF
               type: str
+              display_name: VRF
       views:
         type: list
         items:
@@ -6330,10 +6327,10 @@ keys:
           keys:
             name:
               type: str
-              display_name: View Name
+              description: SNMP View Name
             MIB_family_name:
-              display_name: MIB Family Name
               type: str
+              display_name: MIB Family Name
             included:
               type: bool
       groups:
@@ -6343,7 +6340,7 @@ keys:
           keys:
             name:
               type: str
-              display_name: Group name
+              description: Group name
             version:
               type: str
               valid_values:
@@ -6358,13 +6355,13 @@ keys:
               - priv
             read:
               type: str
-              display_name: Read View
+              description: Read View
             write:
               type: str
-              display_name: Write View
+              description: Write View
             notify:
               type: str
-              display_name: Notify View
+              description: Notify View
       users:
         type: list
         items:
@@ -6372,10 +6369,10 @@ keys:
           keys:
             name:
               type: str
-              display_name: Username
+              description: Username
             group:
               type: str
-              display_name: Group Name
+              description: Group Name
             remote_address:
               type: str
               description: 'Hostname or ip of remote engine. The remote_address and
@@ -6400,7 +6397,7 @@ keys:
               type: str
               convert_types:
               - int
-              description: 'Engine ID in hexadecimal
+              description: 'Engine ID in hexadecimal for localizing auth and/or priv
 
                 '
             auth:
@@ -6434,7 +6431,7 @@ keys:
               type: str
             vrf:
               type: str
-              display_name: VRF Name
+              display_name: VRF
             version:
               type: str
               convert_types:
@@ -6445,7 +6442,7 @@ keys:
               - '3'
             community:
               type: str
-              display_name: Community Name
+              description: Community Name
             users:
               type: list
               items:
@@ -6471,15 +6468,18 @@ keys:
           snmp_traps:
             display_name: SNMP Traps
             type: list
-            description: 'Enable or disable specific snmp-traps and their sub_traps
-
-              '
             items:
               type: dict
               keys:
                 name:
                   type: str
-                  description: 'snmp_trap_type | snmp_trap_type snmp_sub_trap_type
+                  description: 'Enable or disable specific snmp-traps and their sub_traps.
+
+                    Examples:
+
+                    - "bgp"
+
+                    - "bgp established"
 
                     '
                 enabled:
@@ -6493,7 +6493,7 @@ keys:
           keys:
             name:
               type: str
-              display_name: VRF Name
+              description: VRF Name
             enable:
               type: bool
   spanning_tree:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -6210,11 +6210,9 @@ keys:
                   default: true
   snmp_server:
     type: dict
-    display_name: SNMP Server
     keys:
       engine_ids:
         type: dict
-        display_name: Engine IDs
         keys:
           local:
             type: str
@@ -6230,7 +6228,6 @@ keys:
               keys:
                 id:
                   type: str
-                  display_name: ID
                   convert_types:
                   - int
                   description: 'Remote Engine ID In Hexadecimal
@@ -6243,7 +6240,6 @@ keys:
                     '
                 udp_port:
                   type: int
-                  display_name: UDP Port
                   convert_types:
                   - str
       contact:
@@ -6269,13 +6265,11 @@ keys:
               - rw
             access_list_ipv4:
               type: dict
-              display_name: Access List IPv4
               keys:
                 name:
                   type: str
             access_list_ipv6:
               type: dict
-              display_name: Access List IPv6
               keys:
                 name:
                   type: str
@@ -6283,7 +6277,6 @@ keys:
               type: str
       ipv4_acls:
         type: list
-        display_name: IPv4 ACLs
         items:
           type: dict
           keys:
@@ -6292,9 +6285,7 @@ keys:
               description: IPv4 Access List Name
             vrf:
               type: str
-              display_name: VRF
       ipv6_acls:
-        display_name: IPv6 ACLs
         type: list
         items:
           type: dict
@@ -6303,7 +6294,6 @@ keys:
               type: str
               description: IPv6 Access List Name
             vrf:
-              display_name: VRF
               type: str
       local_interfaces:
         type: list
@@ -6319,7 +6309,6 @@ keys:
               description: Interface Name
             vrf:
               type: str
-              display_name: VRF
       views:
         type: list
         items:
@@ -6330,7 +6319,6 @@ keys:
               description: SNMP View Name
             MIB_family_name:
               type: str
-              display_name: MIB Family Name
             included:
               type: bool
       groups:
@@ -6380,7 +6368,6 @@ keys:
 
                 '
             udp_port:
-              display_name: UDP Port
               type: int
               convert_types:
               - str
@@ -6431,7 +6418,6 @@ keys:
               type: str
             vrf:
               type: str
-              display_name: VRF
             version:
               type: str
               convert_types:
@@ -6466,7 +6452,6 @@ keys:
 
               '
           snmp_traps:
-            display_name: SNMP Traps
             type: list
             items:
               type: dict
@@ -6486,7 +6471,6 @@ keys:
                   type: bool
                   default: true
       vrfs:
-        display_name: VRFs
         type: list
         items:
           type: dict

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -6244,9 +6244,10 @@ keys:
                   - str
       contact:
         type: str
-        description: Contact Name
+        description: SNMP Contact
       location:
         type: str
+        description: SNMP Location
       communities:
         type: list
         primary_key: name
@@ -6268,11 +6269,13 @@ keys:
               keys:
                 name:
                   type: str
+                  description: IPv4 Access List Name
             access_list_ipv6:
               type: dict
               keys:
                 name:
                   type: str
+                  description: IPv6 Access List Name
             view:
               type: str
       ipv4_acls:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -6230,12 +6230,12 @@ keys:
                   type: str
                   convert_types:
                   - int
-                  description: 'Remote Engine ID In Hexadecimal
+                  description: 'Remote engine ID in hexadecimal
 
                     '
                 address:
                   type: str
-                  description: 'Hostname or IP Of Remote Engine
+                  description: 'Hostname or IP of remote engine
 
                     '
                 udp_port:
@@ -6244,10 +6244,10 @@ keys:
                   - str
       contact:
         type: str
-        description: SNMP Contact
+        description: SNMP contact
       location:
         type: str
-        description: SNMP Location
+        description: SNMP location
       communities:
         type: list
         primary_key: name
@@ -6258,7 +6258,7 @@ keys:
           keys:
             name:
               type: str
-              description: Community Name
+              description: Community name
             access:
               type: str
               valid_values:
@@ -6269,13 +6269,13 @@ keys:
               keys:
                 name:
                   type: str
-                  description: IPv4 Access List Name
+                  description: IPv4 access list name
             access_list_ipv6:
               type: dict
               keys:
                 name:
                   type: str
-                  description: IPv6 Access List Name
+                  description: IPv6 access list name
             view:
               type: str
       ipv4_acls:
@@ -6285,7 +6285,7 @@ keys:
           keys:
             name:
               type: str
-              description: IPv4 Access List Name
+              description: IPv4 access list name
             vrf:
               type: str
       ipv6_acls:
@@ -6295,7 +6295,7 @@ keys:
           keys:
             name:
               type: str
-              description: IPv6 Access List Name
+              description: IPv6 access list name
             vrf:
               type: str
       local_interfaces:
@@ -6309,7 +6309,7 @@ keys:
             name:
               type: str
               required: true
-              description: Interface Name
+              description: Interface name
             vrf:
               type: str
       views:
@@ -6319,7 +6319,7 @@ keys:
           keys:
             name:
               type: str
-              description: SNMP View Name
+              description: SNMP view name
             MIB_family_name:
               type: str
             included:
@@ -6346,13 +6346,13 @@ keys:
               - priv
             read:
               type: str
-              description: Read View
+              description: Read view
             write:
               type: str
-              description: Write View
+              description: Write view
             notify:
               type: str
-              description: Notify View
+              description: Notify view
       users:
         type: list
         items:
@@ -6363,18 +6363,19 @@ keys:
               description: Username
             group:
               type: str
-              description: Group Name
+              description: Group name
             remote_address:
               type: str
-              description: 'Hostname or ip of remote engine. The remote_address and
-                udp_port are used for remote users.
+              description: 'Hostname or ip of remote engine
+
+                The remote_address and udp_port are used for remote users
 
                 '
             udp_port:
               type: int
               convert_types:
               - str
-              description: 'udp_port will not be used if no remote_address is configured.
+              description: 'udp_port will not be used if no remote_address is configured
 
                 '
             version:
@@ -6392,24 +6393,24 @@ keys:
                 '
             auth:
               type: str
-              description: 'Hash Algorithm
+              description: 'Hash algorithm
 
                 '
             auth_passphrase:
               type: str
-              description: 'hashed_auth_passphrase if localized is used else cleartext
-                auth_passphrase.
+              description: 'Hashed authentication passphrase if localized is used
+                else cleartext authentication passphrase
 
                 '
             priv:
               type: str
-              description: 'Encryption Algorithm
+              description: 'Encryption algorithm
 
                 '
             priv_passphrase:
               type: str
-              description: 'hashed_priv_passphrase if localized is used else cleartext
-                priv_passphrase.
+              description: 'Hashed privacy passphrase if localized is used else cleartext
+                privacy passphrase
 
                 '
       hosts:
@@ -6431,7 +6432,7 @@ keys:
               - '3'
             community:
               type: str
-              description: Community Name
+              description: Community name
             users:
               type: list
               items:
@@ -6461,7 +6462,7 @@ keys:
               keys:
                 name:
                   type: str
-                  description: 'Enable or disable specific snmp-traps and their sub_traps.
+                  description: 'Enable or disable specific snmp-traps and their sub_traps
 
                     Examples:
 
@@ -6480,7 +6481,7 @@ keys:
           keys:
             name:
               type: str
-              description: VRF Name
+              description: VRF name
             enable:
               type: bool
   spanning_tree:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -6210,6 +6210,7 @@ keys:
                   default: true
   snmp_server:
     type: dict
+    description: SNMP settings
     keys:
       engine_ids:
         type: dict
@@ -6420,6 +6421,7 @@ keys:
           keys:
             host:
               type: str
+              description: Host IP address or name
             vrf:
               type: str
             version:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -6208,6 +6208,294 @@ keys:
                 enabled:
                   type: bool
                   default: true
+  snmp_server:
+    display_name: SNMP Server
+    type: dict
+    keys:
+      engine_ids:
+        display_name: Engine IDs
+        type: dict
+        keys:
+          local:
+            type: str
+            convert_types:
+            - int
+            description: 'Engine id in hexadecimal
+
+              '
+          remotes:
+            type: list
+            items:
+              type: dict
+              keys:
+                id:
+                  display_name: ID
+                  type: str
+                  convert_types:
+                  - int
+                  description: 'Engine ID In Hexadecimal
+
+                    '
+                address:
+                  type: str
+                  description: 'Hostname or IP Of Remote Engine
+
+                    '
+                udp_port:
+                  display_name: UDP Port
+                  type: int
+                  convert_types:
+                  - str
+      contact:
+        type: str
+        display_name: Contact Name
+      location:
+        type: str
+      communities:
+        type: list
+        primary_key: name
+        convert_types:
+        - dict
+        items:
+          type: dict
+          keys:
+            name:
+              type: str
+              display_name: Community Name
+            access:
+              type: str
+              valid_values:
+              - ro
+              - rw
+            access_list_ipv4:
+              display_name: Access List IPv4
+              type: dict
+              keys:
+                name:
+                  type: str
+                  display_name: ACL IPv4 Name
+            access_list_ipv6:
+              display_name: Access List IPv6
+              type: dict
+              keys:
+                name:
+                  type: str
+                  display_name: ACL IPv6 Name
+            view:
+              type: str
+              display_name: View Name
+      ipv4_acls:
+        display_name: IPv4 ACLs
+        type: list
+        items:
+          type: dict
+          keys:
+            name:
+              type: str
+              display_name: IPv4 Access List
+            vrf:
+              display_name: VRF
+              type: str
+      ipv6_acls:
+        display_name: IPv6 ACLs
+        type: list
+        items:
+          type: dict
+          keys:
+            name:
+              type: str
+              display_name: IPv4 Access List
+            vrf:
+              display_name: VRF
+              type: str
+      local_interfaces:
+        type: list
+        primary_key: name
+        convert_types:
+        - dict
+        items:
+          type: dict
+          keys:
+            name:
+              type: str
+              required: true
+              display_name: Interface Name
+            vrf:
+              display_name: VRF
+              type: str
+      views:
+        type: list
+        items:
+          type: dict
+          keys:
+            name:
+              type: str
+              display_name: View Name
+            MIB_family_name:
+              display_name: MIB Family Name
+              type: str
+            included:
+              type: bool
+      groups:
+        type: list
+        items:
+          type: dict
+          keys:
+            name:
+              type: str
+              display_name: Group name
+            version:
+              type: str
+              valid_values:
+              - v1
+              - v2c
+              - v3
+            authentication:
+              type: str
+              valid_values:
+              - auth
+              - noauth
+              - priv
+            read:
+              type: str
+              display_name: Read View
+            write:
+              type: str
+              display_name: Write View
+            notify:
+              type: str
+              display_name: Notify View
+      users:
+        type: list
+        items:
+          type: dict
+          keys:
+            name:
+              type: str
+              display_name: Username
+            group:
+              type: str
+              display_name: Group Name
+            remote_address:
+              type: str
+              description: 'Hostname or ip of remote engine. The remote_address and
+                udp_port are used for remote users.
+
+                '
+            udp_port:
+              display_name: UDP Port
+              type: int
+              convert_types:
+              - str
+              description: 'udp_port will not be used if no remote_address is configured.
+
+                '
+            version:
+              type: str
+              valid_values:
+              - v1
+              - v2c
+              - v3
+            localized:
+              type: str
+              convert_types:
+              - int
+              description: 'Engine ID in hexadecimal
+
+                '
+            auth:
+              type: str
+              description: 'Hash Algorithm
+
+                '
+            auth_passphrase:
+              type: str
+              description: 'hashed_auth_passphrase if localized is used else cleartext
+                auth_passphrase.
+
+                '
+            priv:
+              type: str
+              description: 'Encryption Algorithm
+
+                '
+            priv_passphrase:
+              type: str
+              description: 'hashed_priv_passphrase if localized is used else cleartext
+                priv_passphrase.
+
+                '
+      hosts:
+        type: list
+        items:
+          type: dict
+          keys:
+            host:
+              type: str
+            vrf:
+              type: str
+              display_name: VRF Name
+            version:
+              type: str
+              convert_types:
+              - int
+              valid_values:
+              - '1'
+              - 2c
+              - '3'
+            community:
+              type: str
+              display_name: Community Name
+            users:
+              type: list
+              items:
+                type: dict
+                keys:
+                  username:
+                    type: str
+                  authentication_level:
+                    type: str
+                    valid_values:
+                    - auth
+                    - noauth
+                    - priv
+      traps:
+        type: dict
+        keys:
+          enable:
+            type: bool
+            default: false
+            description: 'Enable or disable all snmp-traps
+
+              '
+          snmp_traps:
+            display_name: SNMP Traps
+            type: list
+            description: 'Enable or disable specific snmp-traps and their sub_traps
+
+              '
+            items:
+              type: dict
+              keys:
+                name:
+                  type: str
+                  description: 'snmp_trap_type | snmp_trap_type snmp_sub_trap_type
+
+                    '
+                enabled:
+                  type: bool
+                  default: true
+      vrfs:
+        display_name: VRFs
+        type: list
+        items:
+          type: dict
+          keys:
+            name:
+              type: str
+              display_name: VRF Name
+            enable:
+              type: bool
   spanning_tree:
     type: dict
     keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/snmp_server.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/snmp_server.schema.yml
@@ -5,6 +5,7 @@ type: dict
 keys:
   snmp_server:
     type: dict
+    description: SNMP settings
     keys:
       engine_ids:
         type: dict
@@ -191,6 +192,7 @@ keys:
           keys:
             host:
               type: str
+              description: Host IP address or name
             vrf:
               type: str
             version:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/snmp_server.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/snmp_server.schema.yml
@@ -4,43 +4,43 @@
 type: dict
 keys:
   snmp_server:
-    display_name: SNMP Server
     type: dict
+    display_name: SNMP Server
     keys:
       engine_ids:
-        display_name: Engine IDs
         type: dict
+        display_name: Engine IDs
         keys:
           local:
             type: str
             convert_types:
             - int
             description: |
-              Engine id in hexadecimal
+              Engine ID in hexadecimal
           remotes:
             type: list
             items:
               type: dict
               keys:
                 id:
-                  display_name: ID
                   type: str
+                  display_name: ID
                   convert_types:
                   - int
                   description: |
-                    Engine ID In Hexadecimal
+                    Remote Engine ID In Hexadecimal
                 address:
                   type: str
                   description: |
                     Hostname or IP Of Remote Engine
                 udp_port:
-                  display_name: UDP Port
                   type: int
+                  display_name: UDP Port
                   convert_types:
                   - str
       contact:
         type: str
-        display_name: Contact Name
+        description: Contact Name
       location:
         type: str
       communities:
@@ -53,39 +53,36 @@ keys:
           keys:
             name:
               type: str
-              display_name: Community Name
+              description: Community Name
             access:
               type: str
               valid_values: ["ro", "rw"]
             access_list_ipv4:
+              type: dict
               display_name: Access List IPv4
-              type: dict
               keys:
                 name:
                   type: str
-                  display_name: ACL IPv4 Name
             access_list_ipv6:
-              display_name: Access List IPv6
               type: dict
+              display_name: Access List IPv6
               keys:
                 name:
                   type: str
-                  display_name: ACL IPv6 Name
             view:
               type: str
-              display_name: View Name
       ipv4_acls:
-        display_name: IPv4 ACLs
         type: list
+        display_name: IPv4 ACLs
         items:
           type: dict
           keys:
             name:
               type: str
-              display_name: IPv4 Access List
+              description: IPv4 Access List Name
             vrf:
-              display_name: VRF
               type: str
+              display_name: VRF
       ipv6_acls:
         display_name: IPv6 ACLs
         type: list
@@ -94,7 +91,7 @@ keys:
           keys:
             name:
               type: str
-              display_name: IPv4 Access List
+              description: IPv6 Access List Name
             vrf:
               display_name: VRF
               type: str
@@ -109,10 +106,10 @@ keys:
             name:
               type: str
               required: true
-              display_name: Interface Name
+              description: Interface Name
             vrf:
-              display_name: VRF
               type: str
+              display_name: VRF
       views:
         type: list
         items:
@@ -120,10 +117,10 @@ keys:
           keys:
             name:
               type: str
-              display_name: View Name
+              description: SNMP View Name
             MIB_family_name:
-              display_name: MIB Family Name
               type: str
+              display_name: MIB Family Name
             included:
               type: bool
       groups:
@@ -133,7 +130,7 @@ keys:
           keys:
             name:
               type: str
-              display_name: Group name
+              description: Group name
             version:
               type: str
               valid_values: ["v1", "v2c", "v3"]
@@ -142,13 +139,13 @@ keys:
               valid_values: ["auth", "noauth", "priv"]
             read:
               type: str
-              display_name: Read View
+              description: Read View
             write:
               type: str
-              display_name: Write View
+              description: Write View
             notify:
               type: str
-              display_name: Notify View
+              description: Notify View
       users:
         type: list
         items:
@@ -156,10 +153,10 @@ keys:
           keys:
             name:
               type: str
-              display_name: Username
+              description: Username
             group:
               type: str
-              display_name: Group Name
+              description: Group Name
             remote_address:
               type: str
               description: |
@@ -179,7 +176,7 @@ keys:
               convert_types:
               - int
               description: |
-                Engine ID in hexadecimal
+                Engine ID in hexadecimal for localizing auth and/or priv
             auth:
               type: str
               description: |
@@ -205,7 +202,7 @@ keys:
               type: str
             vrf:
               type: str
-              display_name: VRF Name
+              display_name: VRF
             version:
               type: str
               convert_types:
@@ -213,7 +210,7 @@ keys:
               valid_values: ["1", "2c", "3"]
             community:
               type: str
-              display_name: Community Name
+              description: Community Name
             users:
               type: list
               items:
@@ -235,15 +232,16 @@ keys:
           snmp_traps:
             display_name: SNMP Traps
             type: list
-            description: |
-              Enable or disable specific snmp-traps and their sub_traps
             items:
               type: dict
               keys:
                 name:
                   type: str
                   description: |
-                    snmp_trap_type | snmp_trap_type snmp_sub_trap_type
+                    Enable or disable specific snmp-traps and their sub_traps.
+                    Examples:
+                    - "bgp"
+                    - "bgp established"
                 enabled:
                   type: bool
                   default: true
@@ -255,6 +253,6 @@ keys:
           keys:
             name:
               type: str
-              display_name: VRF Name
+              description: VRF Name
             enable:
               type: bool

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/snmp_server.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/snmp_server.schema.yml
@@ -59,11 +59,13 @@ keys:
               keys:
                 name:
                   type: str
+                  description: IPv4 Access List Name
             access_list_ipv6:
               type: dict
               keys:
                 name:
                   type: str
+                  description: IPv6 Access List Name
             view:
               type: str
       ipv4_acls:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/snmp_server.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/snmp_server.schema.yml
@@ -36,9 +36,10 @@ keys:
                   - str
       contact:
         type: str
-        description: Contact Name
+        description: SNMP Contact
       location:
         type: str
+        description: SNMP Location
       communities:
         type: list
         primary_key: name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/snmp_server.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/snmp_server.schema.yml
@@ -5,11 +5,9 @@ type: dict
 keys:
   snmp_server:
     type: dict
-    display_name: SNMP Server
     keys:
       engine_ids:
         type: dict
-        display_name: Engine IDs
         keys:
           local:
             type: str
@@ -24,7 +22,6 @@ keys:
               keys:
                 id:
                   type: str
-                  display_name: ID
                   convert_types:
                   - int
                   description: |
@@ -35,7 +32,6 @@ keys:
                     Hostname or IP Of Remote Engine
                 udp_port:
                   type: int
-                  display_name: UDP Port
                   convert_types:
                   - str
       contact:
@@ -59,13 +55,11 @@ keys:
               valid_values: ["ro", "rw"]
             access_list_ipv4:
               type: dict
-              display_name: Access List IPv4
               keys:
                 name:
                   type: str
             access_list_ipv6:
               type: dict
-              display_name: Access List IPv6
               keys:
                 name:
                   type: str
@@ -73,7 +67,6 @@ keys:
               type: str
       ipv4_acls:
         type: list
-        display_name: IPv4 ACLs
         items:
           type: dict
           keys:
@@ -82,9 +75,7 @@ keys:
               description: IPv4 Access List Name
             vrf:
               type: str
-              display_name: VRF
       ipv6_acls:
-        display_name: IPv6 ACLs
         type: list
         items:
           type: dict
@@ -93,7 +84,6 @@ keys:
               type: str
               description: IPv6 Access List Name
             vrf:
-              display_name: VRF
               type: str
       local_interfaces:
         type: list
@@ -109,7 +99,6 @@ keys:
               description: Interface Name
             vrf:
               type: str
-              display_name: VRF
       views:
         type: list
         items:
@@ -120,7 +109,6 @@ keys:
               description: SNMP View Name
             MIB_family_name:
               type: str
-              display_name: MIB Family Name
             included:
               type: bool
       groups:
@@ -162,7 +150,6 @@ keys:
               description: |
                 Hostname or ip of remote engine. The remote_address and udp_port are used for remote users.
             udp_port:
-              display_name: UDP Port
               type: int
               convert_types:
               - str
@@ -202,7 +189,6 @@ keys:
               type: str
             vrf:
               type: str
-              display_name: VRF
             version:
               type: str
               convert_types:
@@ -230,7 +216,6 @@ keys:
             description: |
               Enable or disable all snmp-traps
           snmp_traps:
-            display_name: SNMP Traps
             type: list
             items:
               type: dict
@@ -246,7 +231,6 @@ keys:
                   type: bool
                   default: true
       vrfs:
-        display_name: VRFs
         type: list
         items:
           type: dict

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/snmp_server.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/snmp_server.schema.yml
@@ -25,21 +25,21 @@ keys:
                   convert_types:
                   - int
                   description: |
-                    Remote Engine ID In Hexadecimal
+                    Remote engine ID in hexadecimal
                 address:
                   type: str
                   description: |
-                    Hostname or IP Of Remote Engine
+                    Hostname or IP of remote engine
                 udp_port:
                   type: int
                   convert_types:
                   - str
       contact:
         type: str
-        description: SNMP Contact
+        description: SNMP contact
       location:
         type: str
-        description: SNMP Location
+        description: SNMP location
       communities:
         type: list
         primary_key: name
@@ -50,7 +50,7 @@ keys:
           keys:
             name:
               type: str
-              description: Community Name
+              description: Community name
             access:
               type: str
               valid_values: ["ro", "rw"]
@@ -59,13 +59,13 @@ keys:
               keys:
                 name:
                   type: str
-                  description: IPv4 Access List Name
+                  description: IPv4 access list name
             access_list_ipv6:
               type: dict
               keys:
                 name:
                   type: str
-                  description: IPv6 Access List Name
+                  description: IPv6 access list name
             view:
               type: str
       ipv4_acls:
@@ -75,7 +75,7 @@ keys:
           keys:
             name:
               type: str
-              description: IPv4 Access List Name
+              description: IPv4 access list name
             vrf:
               type: str
       ipv6_acls:
@@ -85,7 +85,7 @@ keys:
           keys:
             name:
               type: str
-              description: IPv6 Access List Name
+              description: IPv6 access list name
             vrf:
               type: str
       local_interfaces:
@@ -99,7 +99,7 @@ keys:
             name:
               type: str
               required: true
-              description: Interface Name
+              description: Interface name
             vrf:
               type: str
       views:
@@ -109,7 +109,7 @@ keys:
           keys:
             name:
               type: str
-              description: SNMP View Name
+              description: SNMP view name
             MIB_family_name:
               type: str
             included:
@@ -130,13 +130,13 @@ keys:
               valid_values: ["auth", "noauth", "priv"]
             read:
               type: str
-              description: Read View
+              description: Read view
             write:
               type: str
-              description: Write View
+              description: Write view
             notify:
               type: str
-              description: Notify View
+              description: Notify view
       users:
         type: list
         items:
@@ -147,17 +147,18 @@ keys:
               description: Username
             group:
               type: str
-              description: Group Name
+              description: Group name
             remote_address:
               type: str
               description: |
-                Hostname or ip of remote engine. The remote_address and udp_port are used for remote users.
+                Hostname or ip of remote engine
+                The remote_address and udp_port are used for remote users
             udp_port:
               type: int
               convert_types:
               - str
               description: |
-                udp_port will not be used if no remote_address is configured.
+                udp_port will not be used if no remote_address is configured
             version:
               type: str
               valid_values: ["v1", "v2c", "v3"]
@@ -170,19 +171,19 @@ keys:
             auth:
               type: str
               description: |
-                Hash Algorithm
+                Hash algorithm
             auth_passphrase:
               type: str
               description: |
-                hashed_auth_passphrase if localized is used else cleartext auth_passphrase.
+                Hashed authentication passphrase if localized is used else cleartext authentication passphrase
             priv:
               type: str
               description: |
-                Encryption Algorithm
+                Encryption algorithm
             priv_passphrase:
               type: str
               description: |
-                hashed_priv_passphrase if localized is used else cleartext priv_passphrase.
+                Hashed privacy passphrase if localized is used else cleartext privacy passphrase
       hosts:
         type: list
         items:
@@ -199,7 +200,7 @@ keys:
               valid_values: ["1", "2c", "3"]
             community:
               type: str
-              description: Community Name
+              description: Community name
             users:
               type: list
               items:
@@ -226,7 +227,7 @@ keys:
                 name:
                   type: str
                   description: |
-                    Enable or disable specific snmp-traps and their sub_traps.
+                    Enable or disable specific snmp-traps and their sub_traps
                     Examples:
                     - "bgp"
                     - "bgp established"
@@ -240,6 +241,6 @@ keys:
           keys:
             name:
               type: str
-              description: VRF Name
+              description: VRF name
             enable:
               type: bool

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/snmp_server.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/snmp_server.schema.yml
@@ -1,0 +1,260 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  snmp_server:
+    display_name: SNMP Server
+    type: dict
+    keys:
+      engine_ids:
+        display_name: Engine IDs
+        type: dict
+        keys:
+          local:
+            type: str
+            convert_types:
+            - int
+            description: |
+              Engine id in hexadecimal
+          remotes:
+            type: list
+            items:
+              type: dict
+              keys:
+                id:
+                  display_name: ID
+                  type: str
+                  convert_types:
+                  - int
+                  description: |
+                    Engine ID In Hexadecimal
+                address:
+                  type: str
+                  description: |
+                    Hostname or IP Of Remote Engine
+                udp_port:
+                  display_name: UDP Port
+                  type: int
+                  convert_types:
+                  - str
+      contact:
+        type: str
+        display_name: Contact Name
+      location:
+        type: str
+      communities:
+        type: list
+        primary_key: name
+        convert_types:
+        - dict
+        items:
+          type: dict
+          keys:
+            name:
+              type: str
+              display_name: Community Name
+            access:
+              type: str
+              valid_values: ["ro", "rw"]
+            access_list_ipv4:
+              display_name: Access List IPv4
+              type: dict
+              keys:
+                name:
+                  type: str
+                  display_name: ACL IPv4 Name
+            access_list_ipv6:
+              display_name: Access List IPv6
+              type: dict
+              keys:
+                name:
+                  type: str
+                  display_name: ACL IPv6 Name
+            view:
+              type: str
+              display_name: View Name
+      ipv4_acls:
+        display_name: IPv4 ACLs
+        type: list
+        items:
+          type: dict
+          keys:
+            name:
+              type: str
+              display_name: IPv4 Access List
+            vrf:
+              display_name: VRF
+              type: str
+      ipv6_acls:
+        display_name: IPv6 ACLs
+        type: list
+        items:
+          type: dict
+          keys:
+            name:
+              type: str
+              display_name: IPv4 Access List
+            vrf:
+              display_name: VRF
+              type: str
+      local_interfaces:
+        type: list
+        primary_key: name
+        convert_types:
+        - dict
+        items:
+          type: dict
+          keys:
+            name:
+              type: str
+              required: true
+              display_name: Interface Name
+            vrf:
+              display_name: VRF
+              type: str
+      views:
+        type: list
+        items:
+          type: dict
+          keys:
+            name:
+              type: str
+              display_name: View Name
+            MIB_family_name:
+              display_name: MIB Family Name
+              type: str
+            included:
+              type: bool
+      groups:
+        type: list
+        items:
+          type: dict
+          keys:
+            name:
+              type: str
+              display_name: Group name
+            version:
+              type: str
+              valid_values: ["v1", "v2c", "v3"]
+            authentication:
+              type: str
+              valid_values: ["auth", "noauth", "priv"]
+            read:
+              type: str
+              display_name: Read View
+            write:
+              type: str
+              display_name: Write View
+            notify:
+              type: str
+              display_name: Notify View
+      users:
+        type: list
+        items:
+          type: dict
+          keys:
+            name:
+              type: str
+              display_name: Username
+            group:
+              type: str
+              display_name: Group Name
+            remote_address:
+              type: str
+              description: |
+                Hostname or ip of remote engine. The remote_address and udp_port are used for remote users.
+            udp_port:
+              display_name: UDP Port
+              type: int
+              convert_types:
+              - str
+              description: |
+                udp_port will not be used if no remote_address is configured.
+            version:
+              type: str
+              valid_values: ["v1", "v2c", "v3"]
+            localized:
+              type: str
+              convert_types:
+              - int
+              description: |
+                Engine ID in hexadecimal
+            auth:
+              type: str
+              description: |
+                Hash Algorithm
+            auth_passphrase:
+              type: str
+              description: |
+                hashed_auth_passphrase if localized is used else cleartext auth_passphrase.
+            priv:
+              type: str
+              description: |
+                Encryption Algorithm
+            priv_passphrase:
+              type: str
+              description: |
+                hashed_priv_passphrase if localized is used else cleartext priv_passphrase.
+      hosts:
+        type: list
+        items:
+          type: dict
+          keys:
+            host:
+              type: str
+            vrf:
+              type: str
+              display_name: VRF Name
+            version:
+              type: str
+              convert_types:
+              - int
+              valid_values: ["1", "2c", "3"]
+            community:
+              type: str
+              display_name: Community Name
+            users:
+              type: list
+              items:
+                type: dict
+                keys:
+                  username:
+                    type: str
+                  authentication_level:
+                    type: str
+                    valid_values: ["auth", "noauth", "priv"]
+      traps:
+        type: dict
+        keys:
+          enable:
+            type: bool
+            default: false
+            description: |
+              Enable or disable all snmp-traps
+          snmp_traps:
+            display_name: SNMP Traps
+            type: list
+            description: |
+              Enable or disable specific snmp-traps and their sub_traps
+            items:
+              type: dict
+              keys:
+                name:
+                  type: str
+                  description: |
+                    snmp_trap_type | snmp_trap_type snmp_sub_trap_type
+                enabled:
+                  type: bool
+                  default: true
+      vrfs:
+        display_name: VRFs
+        type: list
+        items:
+          type: dict
+          keys:
+            name:
+              type: str
+              display_name: VRF Name
+            enable:
+              type: bool

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/snmp-settings.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/snmp-settings.j2
@@ -60,7 +60,7 @@
 
 | Local Interface | VRF |
 | --------------- | --- |
-{%         for interface in snmp_server.local_interfaces | arista.avd.convert_dicts('name') %}
+{%         for interface in snmp_server.local_interfaces %}
 | {{ interface.name }} | {{ interface.vrf | arista.avd.default('default') }} |
 {%         endfor %}
 {%     endif %}
@@ -127,7 +127,7 @@
 
 | Community | Access | Access List IPv4 | Access List IPv6 | View |
 | --------- | ------ | ---------------- | ---------------- | ---- |
-{%         for community in snmp_server.communities | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%         for community in snmp_server.communities | arista.avd.natural_sort('name') %}
 {%             set access = community.access | arista.avd.default("ro") %}
 {%             set access_list_ipv4 = community.access_list_ipv4.name | arista.avd.default("-") %}
 {%             set access_list_ipv6 = community.access_list_ipv6.name | arista.avd.default("-") %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/snmp-settings.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/snmp-settings.j2
@@ -41,7 +41,7 @@ snmp-server location {{ snmp_server.location }}
 {%         endfor %}
 {%     endif %}
 {%     if snmp_server.local_interfaces is arista.avd.defined %}
-{%         for local_interface in snmp_server.local_interfaces | arista.avd.convert_dicts('name') %}
+{%         for local_interface in snmp_server.local_interfaces %}
 {%             set interface_snmp_cli = "snmp-server" %}
 {%             if local_interface.vrf is arista.avd.defined %}
 {%                 set interface_snmp_cli = interface_snmp_cli ~ " vrf " ~ local_interface.vrf %}
@@ -67,7 +67,7 @@ snmp-server location {{ snmp_server.location }}
 {%         endfor %}
 {%     endif %}
 {%     if snmp_server.communities is arista.avd.defined %}
-{%         for community in snmp_server.communities | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%         for community in snmp_server.communities | arista.avd.natural_sort('name') %}
 {%             set communities_cli = "snmp-server community " ~ community.name %}
 {%             if community.view is arista.avd.defined %}
 {%                 set communities_cli = communities_cli ~ " view " ~ community.view %}


### PR DESCRIPTION
## Add schema for data model

<!-- Use this PR Title: Feat(eos_cli_config_gen): Add schema for < data_model_key > -->

## Checklist

### Contributor Checklist

- [x] Create schema fragment matching data model described in README.md and README_v4.0.md
  - README.md is most complete with all keys. README_v4.0 includes partial data models after conversion to lists.
  - Schema fragment path is `roles/eos_cli_config_gen/schemas/schema_fragments/<data_model_key>.schema.yml`.
  - Copy line 1-5 from another schema (comments and outer type:dict).
  - Refer to [schema documentation](https://avd.sh/en/devel/docs/input-variable-validation-BETA.html) for syntax and/or use YAML Lint plugin from Redhat in VSCode.
  - Use `convert_types` on value that could be mixed type or misinterpreted like integers and numeric strings.
- [x] If the data model has been converted from wildcard dicts:
  - Add `convert_types: ['dict']` to the schema.
  - Remove `convert_dicts` from the `templates/eos/<>.j2` and `templates/documentation/<>.j2` templates.
- [x] Run `molecule converge -s build_schemas_and_docs` to update schema and documentation.
- [x] Test by running `molecule converge -s eos_cli_config_gen` and verify no errors or changes to generated configs/docs.

### Reviewer Checklist

- Reviewer 1: Claus
  - [ ] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2: Carl
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
