### PR TITLE
CI: Prevent automatic closure of issues when stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,7 +12,7 @@ jobs:
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         days-before-stale: 90
-        days-before-close: 15
+        days-before-close: -1
         stale-issue-message: 'This issue is stale because it has been open 90 days with no activity. Remove stale label or comment or this will be closed in 15 days'
         stale-issue-label: 'state: stale'
         exempt-issue-labels: 'state: accepted, state: in-progress'


### PR DESCRIPTION
## Change Summary

Prevent automatic closure of PRs when they have gone stale.
Closing of issues should only be done by maintainers.

## Component(s) name

GitHub Actions CI

## Proposed changes

Set `days-before-close` to -1, the issues or the pull requests will never be closed automatically.
reference: https://github.com/actions/stale
