### PR TITLE
Feat(eos_cli_config_gen): Add schema for vxlan-interfaces

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -4070,32 +4070,32 @@ vrfs:
 | [<samp>&nbsp;&nbsp;Vxlan1</samp>](## "vxlan_interface.Vxlan1") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;description</samp>](## "vxlan_interface.Vxlan1.description") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vxlan</samp>](## "vxlan_interface.Vxlan1.vxlan") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_interface</samp>](## "vxlan_interface.Vxlan1.vxlan.source_interface") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_interface</samp>](## "vxlan_interface.Vxlan1.vxlan.source_interface") | String |  |  |  | Source Interface Name |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_source_interface</samp>](## "vxlan_interface.Vxlan1.vxlan.mlag_source_interface") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;udp_port</samp>](## "vxlan_interface.Vxlan1.vxlan.udp_port") | Integer |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;virtual_router_encapsulation_mac_address</samp>](## "vxlan_interface.Vxlan1.vxlan.virtual_router_encapsulation_mac_address") | String |  |  |  | mlag-system-id or ethernet_address (H.H.H)<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;virtual_router_encapsulation_mac_address</samp>](## "vxlan_interface.Vxlan1.vxlan.virtual_router_encapsulation_mac_address") | String |  |  |  | "mlag-system-id" or ethernet_address (H.H.H)<br> |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bfd_vtep_evpn</samp>](## "vxlan_interface.Vxlan1.vxlan.bfd_vtep_evpn") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interval</samp>](## "vxlan_interface.Vxlan1.vxlan.bfd_vtep_evpn.interval") | Integer |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;min_rx</samp>](## "vxlan_interface.Vxlan1.vxlan.bfd_vtep_evpn.min_rx") | Integer |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;multiplier</samp>](## "vxlan_interface.Vxlan1.vxlan.bfd_vtep_evpn.multiplier") | Integer |  |  | Min: 3<br>Max: 50 |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;prefix_list</samp>](## "vxlan_interface.Vxlan1.vxlan.bfd_vtep_evpn.prefix_list") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;qos</samp>](## "vxlan_interface.Vxlan1.vxlan.qos") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dscp_propagation_encapsulation</samp>](## "vxlan_interface.Vxlan1.vxlan.qos.dscp_propagation_encapsulation") | Boolean |  |  |  | For the Traffic Class to be derived based on the outer DSCP field of the incoming VxLan packet, the core ports must be in "DSCP Trust" mode.<br>!!!Warning, only few hardware types with software version >= 4.26.0 support the below knobs to configure Vxlan DSCP mapping.<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;qos</samp>](## "vxlan_interface.Vxlan1.vxlan.qos") | Dictionary |  |  |  | For the Traffic Class to be derived based on the outer DSCP field of the incoming VxLan packet, the core ports must be in "DSCP Trust" mode.<br>!!!Warning, only few hardware types with software version >= 4.26.0 support the below knobs to configure Vxlan DSCP mapping.<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dscp_propagation_encapsulation</samp>](## "vxlan_interface.Vxlan1.vxlan.qos.dscp_propagation_encapsulation") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;map_dscp_to_traffic_class_decapsulation</samp>](## "vxlan_interface.Vxlan1.vxlan.qos.map_dscp_to_traffic_class_decapsulation") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlans</samp>](## "vxlan_interface.Vxlan1.vxlan.vlans") | List, items: Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- id</samp>](## "vxlan_interface.Vxlan1.vxlan.vlans.[].id") | Integer | Required, Unique |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- id</samp>](## "vxlan_interface.Vxlan1.vxlan.vlans.[].id") | Integer | Required, Unique |  |  | VLAN ID |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vni</samp>](## "vxlan_interface.Vxlan1.vxlan.vlans.[].vni") | Integer |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;multicast_group</samp>](## "vxlan_interface.Vxlan1.vxlan.vlans.[].multicast_group") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;multicast_group</samp>](## "vxlan_interface.Vxlan1.vxlan.vlans.[].multicast_group") | String |  |  |  | IP Multicast Group Address |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;flood_vteps</samp>](## "vxlan_interface.Vxlan1.vxlan.vlans.[].flood_vteps") | List, items: String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "vxlan_interface.Vxlan1.vxlan.vlans.[].flood_vteps.[].&lt;str&gt;") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "vxlan_interface.Vxlan1.vxlan.vlans.[].flood_vteps.[].&lt;str&gt;") | String |  |  |  | Remote VTEP IP Address |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrfs</samp>](## "vxlan_interface.Vxlan1.vxlan.vrfs") | List, items: Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "vxlan_interface.Vxlan1.vxlan.vrfs.[].name") | String | Required, Unique |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "vxlan_interface.Vxlan1.vxlan.vrfs.[].name") | String | Required, Unique |  |  | VRF Name |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vni</samp>](## "vxlan_interface.Vxlan1.vxlan.vrfs.[].vni") | Integer |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;multicast_group</samp>](## "vxlan_interface.Vxlan1.vxlan.vrfs.[].multicast_group") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;multicast_group</samp>](## "vxlan_interface.Vxlan1.vxlan.vrfs.[].multicast_group") | String |  |  |  | IP Multicast Group Address |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;flood_vteps</samp>](## "vxlan_interface.Vxlan1.vxlan.flood_vteps") | List, items: String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "vxlan_interface.Vxlan1.vxlan.flood_vteps.[].&lt;str&gt;") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "vxlan_interface.Vxlan1.vxlan.flood_vteps.[].&lt;str&gt;") | String |  |  |  | Remote VTEP IP Address |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;flood_vtep_learned_data_plane</samp>](## "vxlan_interface.Vxlan1.vxlan.flood_vtep_learned_data_plane") | Boolean |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;eos_cli</samp>](## "vxlan_interface.Vxlan1.eos_cli") | String |  |  |  | EOS CLI rendered directly on the Vxlan interface in the final EOS configuration. |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;eos_cli</samp>](## "vxlan_interface.Vxlan1.eos_cli") | String |  |  |  | Multiline String with EOS CLI rendered directly on the Vxlan interface in the final EOS configuration. |
 
 ### YAML
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -4059,3 +4059,75 @@ vrfs:
     ipv6_routing: <bool>
     tenant: <str>
 ```
+
+## VxLAN Interface
+
+### Variables
+
+| Variable | Type | Required | Default | Value Restrictions | Description |
+| -------- | ---- | -------- | ------- | ------------------ | ----------- |
+| [<samp>vxlan_interface</samp>](## "vxlan_interface") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;Vxlan1</samp>](## "vxlan_interface.Vxlan1") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;description</samp>](## "vxlan_interface.Vxlan1.description") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vxlan</samp>](## "vxlan_interface.Vxlan1.vxlan") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_interface</samp>](## "vxlan_interface.Vxlan1.vxlan.source_interface") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_source_interface</samp>](## "vxlan_interface.Vxlan1.vxlan.mlag_source_interface") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;udp_port</samp>](## "vxlan_interface.Vxlan1.vxlan.udp_port") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;virtual_router_encapsulation_mac_address</samp>](## "vxlan_interface.Vxlan1.vxlan.virtual_router_encapsulation_mac_address") | String |  |  |  | mlag-system-id or ethernet_address (H.H.H)<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bfd_vtep_evpn</samp>](## "vxlan_interface.Vxlan1.vxlan.bfd_vtep_evpn") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interval</samp>](## "vxlan_interface.Vxlan1.vxlan.bfd_vtep_evpn.interval") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;min_rx</samp>](## "vxlan_interface.Vxlan1.vxlan.bfd_vtep_evpn.min_rx") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;multiplier</samp>](## "vxlan_interface.Vxlan1.vxlan.bfd_vtep_evpn.multiplier") | Integer |  |  | Min: 3<br>Max: 50 |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;prefix_list</samp>](## "vxlan_interface.Vxlan1.vxlan.bfd_vtep_evpn.prefix_list") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;qos</samp>](## "vxlan_interface.Vxlan1.vxlan.qos") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dscp_propagation_encapsulation</samp>](## "vxlan_interface.Vxlan1.vxlan.qos.dscp_propagation_encapsulation") | Boolean |  |  |  | For the Traffic Class to be derived based on the outer DSCP field of the incoming VxLan packet, the core ports must be in "DSCP Trust" mode.<br>!!!Warning, only few hardware types with software version >= 4.26.0 support the below knobs to configure Vxlan DSCP mapping.<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;map_dscp_to_traffic_class_decapsulation</samp>](## "vxlan_interface.Vxlan1.vxlan.qos.map_dscp_to_traffic_class_decapsulation") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlans</samp>](## "vxlan_interface.Vxlan1.vxlan.vlans") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- id</samp>](## "vxlan_interface.Vxlan1.vxlan.vlans.[].id") | Integer | Required, Unique |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vni</samp>](## "vxlan_interface.Vxlan1.vxlan.vlans.[].vni") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;multicast_group</samp>](## "vxlan_interface.Vxlan1.vxlan.vlans.[].multicast_group") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;flood_vteps</samp>](## "vxlan_interface.Vxlan1.vxlan.vlans.[].flood_vteps") | List, items: String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "vxlan_interface.Vxlan1.vxlan.vlans.[].flood_vteps.[].&lt;str&gt;") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrfs</samp>](## "vxlan_interface.Vxlan1.vxlan.vrfs") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "vxlan_interface.Vxlan1.vxlan.vrfs.[].name") | String | Required, Unique |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vni</samp>](## "vxlan_interface.Vxlan1.vxlan.vrfs.[].vni") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;multicast_group</samp>](## "vxlan_interface.Vxlan1.vxlan.vrfs.[].multicast_group") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;flood_vteps</samp>](## "vxlan_interface.Vxlan1.vxlan.flood_vteps") | List, items: String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "vxlan_interface.Vxlan1.vxlan.flood_vteps.[].&lt;str&gt;") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;flood_vtep_learned_data_plane</samp>](## "vxlan_interface.Vxlan1.vxlan.flood_vtep_learned_data_plane") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;eos_cli</samp>](## "vxlan_interface.Vxlan1.eos_cli") | String |  |  |  | EOS CLI rendered directly on the Vxlan interface in the final EOS configuration. |
+
+### YAML
+
+```yaml
+vxlan_interface:
+  Vxlan1:
+    description: <str>
+    vxlan:
+      source_interface: <str>
+      mlag_source_interface: <str>
+      udp_port: <int>
+      virtual_router_encapsulation_mac_address: <str>
+      bfd_vtep_evpn:
+        interval: <int>
+        min_rx: <int>
+        multiplier: <int>
+        prefix_list: <str>
+      qos:
+        dscp_propagation_encapsulation: <bool>
+        map_dscp_to_traffic_class_decapsulation: <bool>
+      vlans:
+        - id: <int>
+          vni: <int>
+          multicast_group: <str>
+          flood_vteps:
+            - <str>
+      vrfs:
+        - name: <str>
+          vni: <int>
+          multicast_group: <str>
+      flood_vteps:
+        - <str>
+      flood_vtep_learned_data_plane: <bool>
+    eos_cli: <str>
+```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -7745,7 +7745,8 @@
               "properties": {
                 "source_interface": {
                   "type": "string",
-                  "title": "Source Interface Name"
+                  "description": "Source Interface Name",
+                  "title": "Source Interface"
                 },
                 "mlag_source_interface": {
                   "title": "MLAG Source Interface",
@@ -7758,7 +7759,7 @@
                 "virtual_router_encapsulation_mac_address": {
                   "title": "Virtual Router Encapsulation MAC Address",
                   "type": "string",
-                  "description": "mlag-system-id or ethernet_address (H.H.H)\n"
+                  "description": "\"mlag-system-id\" or ethernet_address (H.H.H)\n"
                 },
                 "bfd_vtep_evpn": {
                   "title": "BFD VTEP EVPN",
@@ -7769,7 +7770,7 @@
                       "title": "Interval"
                     },
                     "min_rx": {
-                      "title": "MIN RX",
+                      "title": "Min RX",
                       "type": "integer"
                     },
                     "multiplier": {
@@ -7788,11 +7789,11 @@
                 "qos": {
                   "title": "QOS",
                   "type": "object",
+                  "description": "For the Traffic Class to be derived based on the outer DSCP field of the incoming VxLan packet, the core ports must be in \"DSCP Trust\" mode.\n!!!Warning, only few hardware types with software version >= 4.26.0 support the below knobs to configure Vxlan DSCP mapping.\n",
                   "properties": {
                     "dscp_propagation_encapsulation": {
                       "title": "DSCP Propagation Encapsulation",
-                      "type": "boolean",
-                      "description": "For the Traffic Class to be derived based on the outer DSCP field of the incoming VxLan packet, the core ports must be in \"DSCP Trust\" mode.\n!!!Warning, only few hardware types with software version >= 4.26.0 support the below knobs to configure Vxlan DSCP mapping.\n"
+                      "type": "boolean"
                     },
                     "map_dscp_to_traffic_class_decapsulation": {
                       "title": "Map DSCP To Traffic Class Decapsulation",
@@ -7809,7 +7810,8 @@
                     "properties": {
                       "id": {
                         "type": "integer",
-                        "title": "VLAN ID"
+                        "title": "ID",
+                        "description": "VLAN ID"
                       },
                       "vni": {
                         "title": "VNI",
@@ -7817,13 +7819,15 @@
                       },
                       "multicast_group": {
                         "type": "string",
-                        "title": "IP Multicast Group Address"
+                        "description": "IP Multicast Group Address",
+                        "title": "Multicast Group"
                       },
                       "flood_vteps": {
                         "title": "Flood VTEPs",
                         "type": "array",
                         "items": {
-                          "type": "string"
+                          "type": "string",
+                          "description": "Remote VTEP IP Address"
                         }
                       }
                     },
@@ -7841,7 +7845,8 @@
                     "properties": {
                       "name": {
                         "type": "string",
-                        "title": "VRF Name"
+                        "description": "VRF Name",
+                        "title": "Name"
                       },
                       "vni": {
                         "title": "VNI",
@@ -7849,7 +7854,8 @@
                       },
                       "multicast_group": {
                         "type": "string",
-                        "title": "IP Multicast Group Address"
+                        "description": "IP Multicast Group Address",
+                        "title": "Multicast Group"
                       }
                     },
                     "required": [
@@ -7862,7 +7868,8 @@
                   "title": "Flood VTEPs",
                   "type": "array",
                   "items": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Remote VTEP IP Address"
                   }
                 },
                 "flood_vtep_learned_data_plane": {
@@ -7874,8 +7881,8 @@
             },
             "eos_cli": {
               "type": "string",
-              "title": "Multiline EOS CLI",
-              "description": "EOS CLI rendered directly on the Vxlan interface in the final EOS configuration."
+              "title": "EOS CLI",
+              "description": "Multiline String with EOS CLI rendered directly on the Vxlan interface in the final EOS configuration."
             }
           },
           "additionalProperties": false,

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -7729,7 +7729,6 @@
       "title": "VRFs"
     },
     "vxlan_interface": {
-      "title": "VxLAN Interface",
       "type": "object",
       "properties": {
         "Vxlan1": {
@@ -7740,7 +7739,6 @@
               "title": "Description"
             },
             "vxlan": {
-              "title": "VxLAN",
               "type": "object",
               "properties": {
                 "source_interface": {
@@ -7749,20 +7747,19 @@
                   "title": "Source Interface"
                 },
                 "mlag_source_interface": {
-                  "title": "MLAG Source Interface",
-                  "type": "string"
+                  "type": "string",
+                  "title": "MLAG Source Interface"
                 },
                 "udp_port": {
-                  "title": "UDP Port",
-                  "type": "integer"
+                  "type": "integer",
+                  "title": "UDP Port"
                 },
                 "virtual_router_encapsulation_mac_address": {
-                  "title": "Virtual Router Encapsulation MAC Address",
                   "type": "string",
-                  "description": "\"mlag-system-id\" or ethernet_address (H.H.H)\n"
+                  "description": "\"mlag-system-id\" or ethernet_address (H.H.H)\n",
+                  "title": "Virtual Router Encapsulation MAC Address"
                 },
                 "bfd_vtep_evpn": {
-                  "title": "BFD VTEP EVPN",
                   "type": "object",
                   "properties": {
                     "interval": {
@@ -7770,8 +7767,8 @@
                       "title": "Interval"
                     },
                     "min_rx": {
-                      "title": "Min RX",
-                      "type": "integer"
+                      "type": "integer",
+                      "title": "Min RX"
                     },
                     "multiplier": {
                       "type": "integer",
@@ -7784,38 +7781,38 @@
                       "title": "Prefix List"
                     }
                   },
-                  "additionalProperties": false
+                  "additionalProperties": false,
+                  "title": "BFD Vtep Evpn"
                 },
                 "qos": {
-                  "title": "QOS",
                   "type": "object",
                   "description": "For the Traffic Class to be derived based on the outer DSCP field of the incoming VxLan packet, the core ports must be in \"DSCP Trust\" mode.\n!!!Warning, only few hardware types with software version >= 4.26.0 support the below knobs to configure Vxlan DSCP mapping.\n",
                   "properties": {
                     "dscp_propagation_encapsulation": {
-                      "title": "DSCP Propagation Encapsulation",
-                      "type": "boolean"
+                      "type": "boolean",
+                      "title": "DSCP Propagation Encapsulation"
                     },
                     "map_dscp_to_traffic_class_decapsulation": {
-                      "title": "Map DSCP To Traffic Class Decapsulation",
-                      "type": "boolean"
+                      "type": "boolean",
+                      "title": "Map DSCP To Traffic Class Decapsulation"
                     }
                   },
-                  "additionalProperties": false
+                  "additionalProperties": false,
+                  "title": "QOS"
                 },
                 "vlans": {
-                  "title": "VLANs",
                   "type": "array",
                   "items": {
                     "type": "object",
                     "properties": {
                       "id": {
                         "type": "integer",
-                        "title": "ID",
-                        "description": "VLAN ID"
+                        "description": "VLAN ID",
+                        "title": "ID"
                       },
                       "vni": {
-                        "title": "VNI",
-                        "type": "integer"
+                        "type": "integer",
+                        "title": "Vni"
                       },
                       "multicast_group": {
                         "type": "string",
@@ -7823,22 +7820,22 @@
                         "title": "Multicast Group"
                       },
                       "flood_vteps": {
-                        "title": "Flood VTEPs",
                         "type": "array",
                         "items": {
                           "type": "string",
                           "description": "Remote VTEP IP Address"
-                        }
+                        },
+                        "title": "Flood Vteps"
                       }
                     },
                     "required": [
                       "id"
                     ],
                     "additionalProperties": false
-                  }
+                  },
+                  "title": "VLANs"
                 },
                 "vrfs": {
-                  "title": "VRFs",
                   "type": "array",
                   "items": {
                     "type": "object",
@@ -7849,8 +7846,8 @@
                         "title": "Name"
                       },
                       "vni": {
-                        "title": "VNI",
-                        "type": "integer"
+                        "type": "integer",
+                        "title": "Vni"
                       },
                       "multicast_group": {
                         "type": "string",
@@ -7862,34 +7859,37 @@
                       "name"
                     ],
                     "additionalProperties": false
-                  }
+                  },
+                  "title": "VRFs"
                 },
                 "flood_vteps": {
-                  "title": "Flood VTEPs",
                   "type": "array",
                   "items": {
                     "type": "string",
                     "description": "Remote VTEP IP Address"
-                  }
+                  },
+                  "title": "Flood Vteps"
                 },
                 "flood_vtep_learned_data_plane": {
-                  "title": "Flood VTEP Learned Data Plane",
-                  "type": "boolean"
+                  "type": "boolean",
+                  "title": "Flood Vtep Learned Data Plane"
                 }
               },
-              "additionalProperties": false
+              "additionalProperties": false,
+              "title": "VxLAN"
             },
             "eos_cli": {
               "type": "string",
-              "title": "EOS CLI",
-              "description": "Multiline String with EOS CLI rendered directly on the Vxlan interface in the final EOS configuration."
+              "description": "Multiline String with EOS CLI rendered directly on the Vxlan interface in the final EOS configuration.",
+              "title": "EOS CLI"
             }
           },
           "additionalProperties": false,
           "title": "Vxlan1"
         }
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "title": "VxLAN Interface"
     }
   },
   "additionalProperties": true

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -7727,6 +7727,162 @@
         ]
       },
       "title": "VRFs"
+    },
+    "vxlan_interface": {
+      "title": "VxLAN Interface",
+      "type": "object",
+      "properties": {
+        "Vxlan1": {
+          "type": "object",
+          "properties": {
+            "description": {
+              "type": "string",
+              "title": "Description"
+            },
+            "vxlan": {
+              "title": "VxLAN",
+              "type": "object",
+              "properties": {
+                "source_interface": {
+                  "type": "string",
+                  "title": "Source Interface Name"
+                },
+                "mlag_source_interface": {
+                  "title": "MLAG Source Interface",
+                  "type": "string"
+                },
+                "udp_port": {
+                  "title": "UDP Port",
+                  "type": "integer"
+                },
+                "virtual_router_encapsulation_mac_address": {
+                  "title": "Virtual Router Encapsulation MAC Address",
+                  "type": "string",
+                  "description": "mlag-system-id or ethernet_address (H.H.H)\n"
+                },
+                "bfd_vtep_evpn": {
+                  "title": "BFD VTEP EVPN",
+                  "type": "object",
+                  "properties": {
+                    "interval": {
+                      "type": "integer",
+                      "title": "Interval"
+                    },
+                    "min_rx": {
+                      "title": "MIN RX",
+                      "type": "integer"
+                    },
+                    "multiplier": {
+                      "type": "integer",
+                      "minimum": 3,
+                      "maximum": 50,
+                      "title": "Multiplier"
+                    },
+                    "prefix_list": {
+                      "type": "string",
+                      "title": "Prefix List"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "qos": {
+                  "title": "QOS",
+                  "type": "object",
+                  "properties": {
+                    "dscp_propagation_encapsulation": {
+                      "title": "DSCP Propagation Encapsulation",
+                      "type": "boolean",
+                      "description": "For the Traffic Class to be derived based on the outer DSCP field of the incoming VxLan packet, the core ports must be in \"DSCP Trust\" mode.\n!!!Warning, only few hardware types with software version >= 4.26.0 support the below knobs to configure Vxlan DSCP mapping.\n"
+                    },
+                    "map_dscp_to_traffic_class_decapsulation": {
+                      "title": "Map DSCP To Traffic Class Decapsulation",
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "vlans": {
+                  "title": "VLANs",
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "integer",
+                        "title": "VLAN ID"
+                      },
+                      "vni": {
+                        "title": "VNI",
+                        "type": "integer"
+                      },
+                      "multicast_group": {
+                        "type": "string",
+                        "title": "IP Multicast Group Address"
+                      },
+                      "flood_vteps": {
+                        "title": "Flood VTEPs",
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "required": [
+                      "id"
+                    ],
+                    "additionalProperties": false
+                  }
+                },
+                "vrfs": {
+                  "title": "VRFs",
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "title": "VRF Name"
+                      },
+                      "vni": {
+                        "title": "VNI",
+                        "type": "integer"
+                      },
+                      "multicast_group": {
+                        "type": "string",
+                        "title": "IP Multicast Group Address"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "additionalProperties": false
+                  }
+                },
+                "flood_vteps": {
+                  "title": "Flood VTEPs",
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "flood_vtep_learned_data_plane": {
+                  "title": "Flood VTEP Learned Data Plane",
+                  "type": "boolean"
+                }
+              },
+              "additionalProperties": false
+            },
+            "eos_cli": {
+              "type": "string",
+              "title": "Multiline EOS CLI",
+              "description": "EOS CLI rendered directly on the Vxlan interface in the final EOS configuration."
+            }
+          },
+          "additionalProperties": false,
+          "title": "Vxlan1"
+        }
+      },
+      "additionalProperties": false
     }
   },
   "additionalProperties": true

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -5299,7 +5299,6 @@ keys:
           type: str
           description: Key only used for documentation or validation purposes
   vxlan_interface:
-    display_name: VxLAN Interface
     type: dict
     keys:
       Vxlan1:
@@ -5308,28 +5307,23 @@ keys:
           description:
             type: str
           vxlan:
-            display_name: VxLAN
             type: dict
             keys:
               source_interface:
                 type: str
                 description: Source Interface Name
               mlag_source_interface:
-                display_name: MLAG Source Interface
                 type: str
               udp_port:
-                display_name: UDP Port
                 type: int
                 convert_types:
                 - str
               virtual_router_encapsulation_mac_address:
-                display_name: Virtual Router Encapsulation MAC Address
                 type: str
                 description: '"mlag-system-id" or ethernet_address (H.H.H)
 
                   '
               bfd_vtep_evpn:
-                display_name: BFD VTEP EVPN
                 type: dict
                 keys:
                   interval:
@@ -5337,7 +5331,6 @@ keys:
                     convert_types:
                     - str
                   min_rx:
-                    display_name: Min RX
                     type: int
                     convert_types:
                     - str
@@ -5350,7 +5343,6 @@ keys:
                   prefix_list:
                     type: str
               qos:
-                display_name: QOS
                 type: dict
                 description: 'For the Traffic Class to be derived based on the outer
                   DSCP field of the incoming VxLan packet, the core ports must be
@@ -5362,13 +5354,10 @@ keys:
                   '
                 keys:
                   dscp_propagation_encapsulation:
-                    display_name: DSCP Propagation Encapsulation
                     type: bool
                   map_dscp_to_traffic_class_decapsulation:
-                    display_name: Map DSCP To Traffic Class Decapsulation
                     type: bool
               vlans:
-                display_name: VLANs
                 type: list
                 primary_key: id
                 convert_types:
@@ -5381,10 +5370,8 @@ keys:
                       convert_types:
                       - str
                       required: true
-                      display_name: ID
                       description: VLAN ID
                     vni:
-                      display_name: VNI
                       type: int
                       convert_types:
                       - str
@@ -5392,13 +5379,11 @@ keys:
                       type: str
                       description: IP Multicast Group Address
                     flood_vteps:
-                      display_name: Flood VTEPs
                       type: list
                       items:
                         type: str
                         description: Remote VTEP IP Address
               vrfs:
-                display_name: VRFs
                 type: list
                 primary_key: name
                 convert_types:
@@ -5411,7 +5396,6 @@ keys:
                       required: true
                       description: VRF Name
                     vni:
-                      display_name: VNI
                       type: int
                       convert_types:
                       - str
@@ -5419,16 +5403,13 @@ keys:
                       type: str
                       description: IP Multicast Group Address
               flood_vteps:
-                display_name: Flood VTEPs
                 type: list
                 items:
                   type: str
                   description: Remote VTEP IP Address
               flood_vtep_learned_data_plane:
-                display_name: Flood VTEP Learned Data Plane
                 type: bool
           eos_cli:
             type: str
-            display_name: EOS CLI
             description: Multiline String with EOS CLI rendered directly on the Vxlan
               interface in the final EOS configuration.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -5298,3 +5298,134 @@ keys:
         tenant:
           type: str
           description: Key only used for documentation or validation purposes
+  vxlan_interface:
+    display_name: VxLAN Interface
+    type: dict
+    keys:
+      Vxlan1:
+        type: dict
+        keys:
+          description:
+            type: str
+          vxlan:
+            display_name: VxLAN
+            type: dict
+            keys:
+              source_interface:
+                type: str
+                display_name: Source Interface Name
+              mlag_source_interface:
+                display_name: MLAG Source Interface
+                type: str
+              udp_port:
+                display_name: UDP Port
+                type: int
+                convert_types:
+                - str
+              virtual_router_encapsulation_mac_address:
+                display_name: Virtual Router Encapsulation MAC Address
+                type: str
+                description: 'mlag-system-id or ethernet_address (H.H.H)
+
+                  '
+              bfd_vtep_evpn:
+                display_name: BFD VTEP EVPN
+                type: dict
+                keys:
+                  interval:
+                    type: int
+                    convert_types:
+                    - str
+                  min_rx:
+                    display_name: MIN RX
+                    type: int
+                    convert_types:
+                    - str
+                  multiplier:
+                    type: int
+                    convert_types:
+                    - str
+                    min: 3
+                    max: 50
+                  prefix_list:
+                    type: str
+              qos:
+                display_name: QOS
+                type: dict
+                keys:
+                  dscp_propagation_encapsulation:
+                    display_name: DSCP Propagation Encapsulation
+                    type: bool
+                    description: 'For the Traffic Class to be derived based on the
+                      outer DSCP field of the incoming VxLan packet, the core ports
+                      must be in "DSCP Trust" mode.
+
+                      !!!Warning, only few hardware types with software version >=
+                      4.26.0 support the below knobs to configure Vxlan DSCP mapping.
+
+                      '
+                  map_dscp_to_traffic_class_decapsulation:
+                    display_name: Map DSCP To Traffic Class Decapsulation
+                    type: bool
+              vlans:
+                display_name: VLANs
+                type: list
+                primary_key: id
+                convert_types:
+                - dict
+                items:
+                  type: dict
+                  keys:
+                    id:
+                      type: int
+                      convert_types:
+                      - str
+                      required: true
+                      display_name: VLAN ID
+                    vni:
+                      display_name: VNI
+                      type: int
+                      convert_types:
+                      - str
+                    multicast_group:
+                      type: str
+                      display_name: IP Multicast Group Address
+                    flood_vteps:
+                      display_name: Flood VTEPs
+                      type: list
+                      items:
+                        type: str
+              vrfs:
+                display_name: VRFs
+                type: list
+                primary_key: name
+                convert_types:
+                - dict
+                items:
+                  type: dict
+                  keys:
+                    name:
+                      type: str
+                      required: true
+                      display_name: VRF Name
+                    vni:
+                      display_name: VNI
+                      type: int
+                      convert_types:
+                      - str
+                    multicast_group:
+                      type: str
+                      display_name: IP Multicast Group Address
+              flood_vteps:
+                display_name: Flood VTEPs
+                type: list
+                items:
+                  type: str
+              flood_vtep_learned_data_plane:
+                display_name: Flood VTEP Learned Data Plane
+                type: bool
+          eos_cli:
+            type: str
+            display_name: Multiline EOS CLI
+            description: EOS CLI rendered directly on the Vxlan interface in the final
+              EOS configuration.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -5313,7 +5313,7 @@ keys:
             keys:
               source_interface:
                 type: str
-                display_name: Source Interface Name
+                description: Source Interface Name
               mlag_source_interface:
                 display_name: MLAG Source Interface
                 type: str
@@ -5325,7 +5325,7 @@ keys:
               virtual_router_encapsulation_mac_address:
                 display_name: Virtual Router Encapsulation MAC Address
                 type: str
-                description: 'mlag-system-id or ethernet_address (H.H.H)
+                description: '"mlag-system-id" or ethernet_address (H.H.H)
 
                   '
               bfd_vtep_evpn:
@@ -5337,7 +5337,7 @@ keys:
                     convert_types:
                     - str
                   min_rx:
-                    display_name: MIN RX
+                    display_name: Min RX
                     type: int
                     convert_types:
                     - str
@@ -5352,18 +5352,18 @@ keys:
               qos:
                 display_name: QOS
                 type: dict
+                description: 'For the Traffic Class to be derived based on the outer
+                  DSCP field of the incoming VxLan packet, the core ports must be
+                  in "DSCP Trust" mode.
+
+                  !!!Warning, only few hardware types with software version >= 4.26.0
+                  support the below knobs to configure Vxlan DSCP mapping.
+
+                  '
                 keys:
                   dscp_propagation_encapsulation:
                     display_name: DSCP Propagation Encapsulation
                     type: bool
-                    description: 'For the Traffic Class to be derived based on the
-                      outer DSCP field of the incoming VxLan packet, the core ports
-                      must be in "DSCP Trust" mode.
-
-                      !!!Warning, only few hardware types with software version >=
-                      4.26.0 support the below knobs to configure Vxlan DSCP mapping.
-
-                      '
                   map_dscp_to_traffic_class_decapsulation:
                     display_name: Map DSCP To Traffic Class Decapsulation
                     type: bool
@@ -5381,7 +5381,8 @@ keys:
                       convert_types:
                       - str
                       required: true
-                      display_name: VLAN ID
+                      display_name: ID
+                      description: VLAN ID
                     vni:
                       display_name: VNI
                       type: int
@@ -5389,12 +5390,13 @@ keys:
                       - str
                     multicast_group:
                       type: str
-                      display_name: IP Multicast Group Address
+                      description: IP Multicast Group Address
                     flood_vteps:
                       display_name: Flood VTEPs
                       type: list
                       items:
                         type: str
+                        description: Remote VTEP IP Address
               vrfs:
                 display_name: VRFs
                 type: list
@@ -5407,7 +5409,7 @@ keys:
                     name:
                       type: str
                       required: true
-                      display_name: VRF Name
+                      description: VRF Name
                     vni:
                       display_name: VNI
                       type: int
@@ -5415,17 +5417,18 @@ keys:
                       - str
                     multicast_group:
                       type: str
-                      display_name: IP Multicast Group Address
+                      description: IP Multicast Group Address
               flood_vteps:
                 display_name: Flood VTEPs
                 type: list
                 items:
                   type: str
+                  description: Remote VTEP IP Address
               flood_vtep_learned_data_plane:
                 display_name: Flood VTEP Learned Data Plane
                 type: bool
           eos_cli:
             type: str
-            display_name: Multiline EOS CLI
-            description: EOS CLI rendered directly on the Vxlan interface in the final
-              EOS configuration.
+            display_name: EOS CLI
+            description: Multiline String with EOS CLI rendered directly on the Vxlan
+              interface in the final EOS configuration.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/vxlan_interface.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/vxlan_interface.schema.yml
@@ -4,7 +4,6 @@
 type: dict
 keys:
   vxlan_interface:
-    display_name: VxLAN Interface
     type: dict
     keys:
       Vxlan1:
@@ -13,27 +12,22 @@ keys:
           description:
             type: str
           vxlan:
-            display_name: VxLAN
             type: dict
             keys:
               source_interface:
                 type: str
                 description: Source Interface Name
               mlag_source_interface:
-                display_name: MLAG Source Interface
                 type: str
               udp_port:
-                display_name: UDP Port
                 type: int
                 convert_types:
                 - str
               virtual_router_encapsulation_mac_address:
-                display_name: Virtual Router Encapsulation MAC Address
                 type: str
                 description: |
                   "mlag-system-id" or ethernet_address (H.H.H)
               bfd_vtep_evpn:
-                display_name: BFD VTEP EVPN
                 type: dict
                 keys:
                   interval:
@@ -41,7 +35,6 @@ keys:
                     convert_types:
                     - str
                   min_rx:
-                    display_name: Min RX
                     type: int
                     convert_types:
                     - str
@@ -54,20 +47,16 @@ keys:
                   prefix_list:
                     type: str
               qos:
-                display_name: QOS
                 type: dict
                 description: |
                   For the Traffic Class to be derived based on the outer DSCP field of the incoming VxLan packet, the core ports must be in "DSCP Trust" mode.
                   !!!Warning, only few hardware types with software version >= 4.26.0 support the below knobs to configure Vxlan DSCP mapping.
                 keys:
                   dscp_propagation_encapsulation:
-                    display_name: DSCP Propagation Encapsulation
                     type: bool
                   map_dscp_to_traffic_class_decapsulation:
-                    display_name: Map DSCP To Traffic Class Decapsulation
                     type: bool
               vlans:
-                display_name: VLANs
                 type: list
                 primary_key: id
                 convert_types:
@@ -80,10 +69,8 @@ keys:
                       convert_types:
                       - str
                       required: true
-                      display_name: ID
                       description: VLAN ID
                     vni:
-                      display_name: VNI
                       type: int
                       convert_types:
                       - str
@@ -91,13 +78,11 @@ keys:
                       type: str
                       description: IP Multicast Group Address
                     flood_vteps:
-                      display_name: Flood VTEPs
                       type: list
                       items:
                         type: str
                         description: Remote VTEP IP Address
               vrfs:
-                display_name: VRFs
                 type: list
                 primary_key: name
                 convert_types:
@@ -110,7 +95,6 @@ keys:
                       required: true
                       description: VRF Name
                     vni:
-                      display_name: VNI
                       type: int
                       convert_types:
                       - str
@@ -118,16 +102,13 @@ keys:
                       type: str
                       description: IP Multicast Group Address
               flood_vteps:
-                display_name: Flood VTEPs
                 type: list
                 items:
                   type: str
                   description: Remote VTEP IP Address
               flood_vtep_learned_data_plane:
-                display_name: Flood VTEP Learned Data Plane
                 type: bool
           eos_cli:
             type: str
-            display_name: EOS CLI
             description: |
               Multiline String with EOS CLI rendered directly on the Vxlan interface in the final EOS configuration.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/vxlan_interface.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/vxlan_interface.schema.yml
@@ -1,0 +1,130 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  vxlan_interface:
+    display_name: VxLAN Interface
+    type: dict
+    keys:
+      Vxlan1:
+        type: dict
+        keys:
+          description:
+            type: str
+          vxlan:
+            display_name: VxLAN
+            type: dict
+            keys:
+              source_interface:
+                type: str
+                display_name: Source Interface Name
+              mlag_source_interface:
+                display_name: MLAG Source Interface
+                type: str
+              udp_port:
+                display_name: UDP Port
+                type: int
+                convert_types:
+                - str
+              virtual_router_encapsulation_mac_address:
+                display_name: Virtual Router Encapsulation MAC Address
+                type: str
+                description: |
+                  mlag-system-id or ethernet_address (H.H.H)
+              bfd_vtep_evpn:
+                display_name: BFD VTEP EVPN
+                type: dict
+                keys:
+                  interval:
+                    type: int
+                    convert_types:
+                    - str
+                  min_rx:
+                    display_name: MIN RX
+                    type: int
+                    convert_types:
+                    - str
+                  multiplier:
+                    type: int
+                    convert_types:
+                    - str
+                    min: 3
+                    max: 50
+                  prefix_list:
+                    type: str
+              qos:
+                display_name: QOS
+                type: dict
+                keys:
+                  dscp_propagation_encapsulation:
+                    display_name: DSCP Propagation Encapsulation
+                    type: bool
+                    description: |
+                      For the Traffic Class to be derived based on the outer DSCP field of the incoming VxLan packet, the core ports must be in "DSCP Trust" mode.
+                      !!!Warning, only few hardware types with software version >= 4.26.0 support the below knobs to configure Vxlan DSCP mapping.
+                  map_dscp_to_traffic_class_decapsulation:
+                    display_name: Map DSCP To Traffic Class Decapsulation
+                    type: bool
+              vlans:
+                display_name: VLANs
+                type: list
+                primary_key: id
+                convert_types:
+                - dict
+                items:
+                  type: dict
+                  keys:
+                    id:
+                      type: int
+                      convert_types:
+                      - str
+                      required: true
+                      display_name: VLAN ID
+                    vni:
+                      display_name: VNI
+                      type: int
+                      convert_types:
+                      - str
+                    multicast_group:
+                      type: str
+                      display_name: IP Multicast Group Address
+                    flood_vteps:
+                      display_name: Flood VTEPs
+                      type: list
+                      items:
+                        type: str
+              vrfs:
+                display_name: VRFs
+                type: list
+                primary_key: name
+                convert_types:
+                - dict
+                items:
+                  type: dict
+                  keys:
+                    name:
+                      type: str
+                      required: true
+                      display_name: VRF Name
+                    vni:
+                      display_name: VNI
+                      type: int
+                      convert_types:
+                      - str
+                    multicast_group:
+                      type: str
+                      display_name: IP Multicast Group Address
+              flood_vteps:
+                display_name: Flood VTEPs
+                type: list
+                items:
+                  type: str
+              flood_vtep_learned_data_plane:
+                display_name: Flood VTEP Learned Data Plane
+                type: bool
+          eos_cli:
+            type: str
+            display_name: Multiline EOS CLI
+            description: |
+              EOS CLI rendered directly on the Vxlan interface in the final EOS configuration.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/vxlan_interface.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/vxlan_interface.schema.yml
@@ -18,7 +18,7 @@ keys:
             keys:
               source_interface:
                 type: str
-                display_name: Source Interface Name
+                description: Source Interface Name
               mlag_source_interface:
                 display_name: MLAG Source Interface
                 type: str
@@ -31,7 +31,7 @@ keys:
                 display_name: Virtual Router Encapsulation MAC Address
                 type: str
                 description: |
-                  mlag-system-id or ethernet_address (H.H.H)
+                  "mlag-system-id" or ethernet_address (H.H.H)
               bfd_vtep_evpn:
                 display_name: BFD VTEP EVPN
                 type: dict
@@ -41,7 +41,7 @@ keys:
                     convert_types:
                     - str
                   min_rx:
-                    display_name: MIN RX
+                    display_name: Min RX
                     type: int
                     convert_types:
                     - str
@@ -56,13 +56,13 @@ keys:
               qos:
                 display_name: QOS
                 type: dict
+                description: |
+                  For the Traffic Class to be derived based on the outer DSCP field of the incoming VxLan packet, the core ports must be in "DSCP Trust" mode.
+                  !!!Warning, only few hardware types with software version >= 4.26.0 support the below knobs to configure Vxlan DSCP mapping.
                 keys:
                   dscp_propagation_encapsulation:
                     display_name: DSCP Propagation Encapsulation
                     type: bool
-                    description: |
-                      For the Traffic Class to be derived based on the outer DSCP field of the incoming VxLan packet, the core ports must be in "DSCP Trust" mode.
-                      !!!Warning, only few hardware types with software version >= 4.26.0 support the below knobs to configure Vxlan DSCP mapping.
                   map_dscp_to_traffic_class_decapsulation:
                     display_name: Map DSCP To Traffic Class Decapsulation
                     type: bool
@@ -80,7 +80,8 @@ keys:
                       convert_types:
                       - str
                       required: true
-                      display_name: VLAN ID
+                      display_name: ID
+                      description: VLAN ID
                     vni:
                       display_name: VNI
                       type: int
@@ -88,12 +89,13 @@ keys:
                       - str
                     multicast_group:
                       type: str
-                      display_name: IP Multicast Group Address
+                      description: IP Multicast Group Address
                     flood_vteps:
                       display_name: Flood VTEPs
                       type: list
                       items:
                         type: str
+                        description: Remote VTEP IP Address
               vrfs:
                 display_name: VRFs
                 type: list
@@ -106,7 +108,7 @@ keys:
                     name:
                       type: str
                       required: true
-                      display_name: VRF Name
+                      description: VRF Name
                     vni:
                       display_name: VNI
                       type: int
@@ -114,17 +116,18 @@ keys:
                       - str
                     multicast_group:
                       type: str
-                      display_name: IP Multicast Group Address
+                      description: IP Multicast Group Address
               flood_vteps:
                 display_name: Flood VTEPs
                 type: list
                 items:
                   type: str
+                  description: Remote VTEP IP Address
               flood_vtep_learned_data_plane:
                 display_name: Flood VTEP Learned Data Plane
                 type: bool
           eos_cli:
             type: str
-            display_name: Multiline EOS CLI
+            display_name: EOS CLI
             description: |
-              EOS CLI rendered directly on the Vxlan interface in the final EOS configuration.
+              Multiline String with EOS CLI rendered directly on the Vxlan interface in the final EOS configuration.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vxlan-interface.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vxlan-interface.j2
@@ -52,7 +52,7 @@
 
 | VLAN | VNI | Flood List | Multicast Group |
 | ---- | --- | ---------- | --------------- |
-{%         for vlan in vxlan_interface.Vxlan1.vxlan.vlans | arista.avd.convert_dicts('id') | arista.avd.natural_sort('id') %}
+{%         for vlan in vxlan_interface.Vxlan1.vxlan.vlans | arista.avd.natural_sort('id') %}
 {%             set vlan_vni = vlan.vni | arista.avd.default('-') %}
 {%             set multicast_group = vlan.multicast_group | arista.avd.default('-') %}
 {%             if vlan.flood_vteps is arista.avd.defined %}
@@ -69,7 +69,7 @@
 
 | VRF | VNI | Multicast Group |
 | ---- | --- | --------------- |
-{%         for vrf in vxlan_interface.Vxlan1.vxlan.vrfs | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%         for vrf in vxlan_interface.Vxlan1.vxlan.vrfs | arista.avd.natural_sort('name') %}
 {%             set vrf_vni = vrf.vni | arista.avd.default('-') %}
 {%             set multicast_group = vrf.multicast_group | arista.avd.default('-') %}
 | {{ vrf.name }} | {{ vrf_vni }} | {{ multicast_group }} |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vxlan-interface.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vxlan-interface.j2
@@ -18,7 +18,7 @@ interface Vxlan1
 {%     if vxlan_interface.Vxlan1.vxlan.flood_vtep_learned_data_plane is arista.avd.defined(true) %}
    vxlan flood vtep learned data-plane
 {%     endif %}
-{%     for vlan in vxlan_interface.Vxlan1.vxlan.vlans | arista.avd.convert_dicts('id') | arista.avd.natural_sort('id') %}
+{%     for vlan in vxlan_interface.Vxlan1.vxlan.vlans | arista.avd.natural_sort('id') %}
 {%         if vlan.vni is arista.avd.defined %}
    vxlan vlan {{ vlan.id }} vni {{ vlan.vni }}
 {%         endif %}
@@ -26,7 +26,7 @@ interface Vxlan1
    vxlan vlan {{ vlan.id }} flood vtep {{ vlan.flood_vteps | join(' ') }}
 {%         endif %}
 {%     endfor %}
-{%     for vrf in vxlan_interface.Vxlan1.vxlan.vrfs | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%     for vrf in vxlan_interface.Vxlan1.vxlan.vrfs | arista.avd.natural_sort('name') %}
 {%         if vrf.vni is arista.avd.defined %}
    vxlan vrf {{ vrf.name }} vni {{ vrf.vni }}
 {%         endif %}
@@ -57,10 +57,10 @@ interface Vxlan1
 {%     elif vxlan_interface.Vxlan1.vxlan.qos.map_dscp_to_traffic_class_decapsulation is arista.avd.defined(false) %}
    no vxlan qos map dscp to traffic-class decapsulation
 {%     endif %}
-{%     for vlan in vxlan_interface.Vxlan1.vxlan.vlans | arista.avd.convert_dicts('id') | arista.avd.natural_sort('id') if vlan.multicast_group is arista.avd.defined %}
+{%     for vlan in vxlan_interface.Vxlan1.vxlan.vlans | arista.avd.natural_sort('id') if vlan.multicast_group is arista.avd.defined %}
    vxlan vlan {{ vlan.id }} multicast group {{ vlan.multicast_group }}
 {%     endfor %}
-{%     for vrf in vxlan_interface.Vxlan1.vxlan.vrfs | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') if vrf.multicast_group is arista.avd.defined %}
+{%     for vrf in vxlan_interface.Vxlan1.vxlan.vrfs | arista.avd.natural_sort('name') if vrf.multicast_group is arista.avd.defined %}
    vxlan vrf {{ vrf.name }} multicast group {{ vrf.multicast_group }}
 {%     endfor %}
 {%     if  vxlan_interface.Vxlan1.eos_cli is arista.avd.defined %}


### PR DESCRIPTION
## Add schema for data model

<!-- Use this PR Title: Feat(eos_cli_config_gen): Add schema for < data_model_key > -->

## Checklist

### Contributor Checklist

- [x] Create schema fragment matching data model described in README.md and README_v4.0.md
  - README.md is most complete with all keys. README_v4.0 includes partial data models after conversion to lists.
  - Schema fragment path is `roles/eos_cli_config_gen/schemas/schema_fragments/<data_model_key>.schema.yml`.
  - Copy line 1-5 from another schema (comments and outer type:dict).
  - Refer to [schema documentation](https://avd.sh/en/devel/docs/input-variable-validation-BETA.html) for syntax and/or use YAML Lint plugin from Redhat in VSCode.
  - Use `convert_types` on value that could be mixed type or misinterpreted like integers and numeric strings.
- [x] If the data model has been converted from wildcard dicts:
  - Add `convert_types: ['dict']` to the schema.
  - Remove `convert_dicts` from the `templates/eos/<>.j2` and `templates/documentation/<>.j2` templates.
- [x] Run `molecule converge -s build_schemas_and_docs` to update schema and documentation.
- [x] Test by running `molecule converge -s eos_cli_config_gen` and verify no errors or changes to generated configs/docs.

### Reviewer Checklist

- Reviewer 1: Claus
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2: Carl
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
