### PR TITLE
CI: fix the release.yml generation script

### DIFF
--- a/.github/generate_release.py
+++ b/.github/generate_release.py
@@ -74,7 +74,7 @@ if __name__ == "__main__":
     categories_list.append(
         {
             "title": "Fixed issues in eos_cli_config_gen",
-            "labels": "rn: Fix(eos_cli_config_gen)",
+            "labels": ["rn: Fix(eos_cli_config_gen)"],
         }
     )
 
@@ -82,7 +82,7 @@ if __name__ == "__main__":
     categories_list.append(
         {
             "title": "Fixed issues in eos_designs",
-            "labels": "rn: Fix(eos_designs)",
+            "labels": ["rn: Fix(eos_designs)"],
         }
     )
 
@@ -112,7 +112,7 @@ if __name__ == "__main__":
     categories_list.append(
         {
             "title": "New features and enhancements in eos_cli_config_gen",
-            "labels": "rn: Feat(eos_cli_config_gen)",
+            "labels": ["rn: Feat(eos_cli_config_gen)"],
         }
     )
 
@@ -120,7 +120,7 @@ if __name__ == "__main__":
     categories_list.append(
         {
             "title": "New features and enhancements in eos_designs",
-            "labels": "rn: Feat(eos_designs)",
+            "labels": ["rn: Feat(eos_designs)"],
         }
     )
 

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -101,9 +101,11 @@ changelog:
         - 'rn: Refactor!'
         - 'rn: Bump!'
     - title: Fixed issues in eos_cli_config_gen
-      labels: 'rn: Fix(eos_cli_config_gen)'
+      labels:
+        - 'rn: Fix(eos_cli_config_gen)'
     - title: Fixed issues in eos_designs
-      labels: 'rn: Fix(eos_designs)'
+      labels:
+        - 'rn: Fix(eos_designs)'
     - title: Other Fixed issues
       labels:
         - 'rn: Fix(build_output_folders)'
@@ -131,9 +133,11 @@ changelog:
         - 'rn: Doc(requirements)'
         - 'rn: Doc'
     - title: New features and enhancements in eos_cli_config_gen
-      labels: 'rn: Feat(eos_cli_config_gen)'
+      labels:
+        - 'rn: Feat(eos_cli_config_gen)'
     - title: New features and enhancements in eos_designs
-      labels: 'rn: Feat(eos_designs)'
+      labels:
+        - 'rn: Feat(eos_designs)'
     - title: Other new features and enhancements
       labels:
         - 'rn: Feat(build_output_folders)'


### PR DESCRIPTION
## Change Summary

With the latest refactoring of `.github/generate_release.py` there was an issue introduced where the format of some of the section does not follow the expected format from Github. This is fixed in this PR

## Related Issue(s)

Issue not opened

## Component(s) name

`ci:w`

## Proposed changes

Whererever label was not a list, it is not a list (YAML array)

## How to test

Generate release notes

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
