### PR TITLE
Fix(eos_designs): fix wrong type being returned for mac_address_table aging-time

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1A.cfg
@@ -188,6 +188,8 @@ interface Vxlan1
 hardware tcam
    system profile vxlan-routing
 !
+mac address-table aging-time 42
+!
 ip virtual-router mac-address 00:dc:00:00:00:0a
 !
 event-handler evpn-blacklist-recovery

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1A.yml
@@ -359,6 +359,8 @@ platform:
   sand:
     lag:
       hardware_only: true
+mac_address_table:
+  aging_time: 42
 management_api_http:
   enable_vrfs:
     MGMT: {}

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/DC1-BL1A.yml
@@ -32,3 +32,7 @@ event_handlers:
 # Since base.py is not performing any templating, the vars must be templated before handed over to the python class.
 template_timezone: "correctly_templated_timezone"
 timezone: "{{ template_timezone }}"
+
+# Test Mac address table variables
+mac_address_table:
+  aging_time: 42

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-BL1A.yml
@@ -351,6 +351,8 @@ platform:
   sand:
     lag:
       hardware_only: true
+mac_address_table:
+  aging_time: 42
 management_api_http:
   enable_vrfs:
     MGMT: {}

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/inventory/host_vars/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/inventory/host_vars/DC1-BL1A.yml
@@ -27,3 +27,7 @@ event_handlers:
   trigger: on-logging
   regex: EVPN-3-BLACKLISTED_DUPLICATE_MAC
   asynchronous: true
+
+# Test Mac address table variables
+mac_address_table:
+  aging_time: 42

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/base/base.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/base/base.py
@@ -505,7 +505,7 @@ class AvdStructuredConfig(AvdFacts):
         """
         mac_address_table set based on mac_address_table data-model
         """
-        if aging_time := get(self._hostvars, "mac_address_table.aging_time") is not None:
+        if (aging_time := get(self._hostvars, "mac_address_table.aging_time")) is not None:
             return {"aging_time": aging_time}
         return None
 


### PR DESCRIPTION
## Change Summary

* Add parenthesis around walrus operator for mac_address_table aging-time to get the correct value assigned (int and not boolean)
* Also checked that all other walrus assignment in `eos_designs` looked correct (did not verify if they are covered by tests)
* Add test in eos_designs molecule scenario

## Related Issue(s)

Fixes #2101

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

cf summary

## How to test

molecule scenario for eos_designs_unit_tests. Chose an existing device to avoid adding unnecessary config

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
