### PR TITLE
Feat(eos_cli_config_gen): Add schema for ethernet-interfaces

### DIFF
--- a/ansible_collections/arista/avd/plugins/plugin_utils/schema/key_to_display_name.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/schema/key_to_display_name.py
@@ -17,12 +17,14 @@ WORDLIST = {
     "dr": "DR",
     "dscp": "DSCP",
     "eos": "EOS",
+    "evpn": "EVPN",
     "fcs": "FCS",
     "http": "HTTP",
     "icmp": "ICMP",
     "id": "ID",
     "ids": "IDs",
     "igmp": "IGMP",
+    "igp": "IGP",
     "ip": "IP",
     "ipv4": "IPv4",
     "ipv6": "IPv6",
@@ -45,6 +47,7 @@ WORDLIST = {
     "nd": "ND",
     "ntp": "NTP",
     "ospf": "OSPF",
+    "pae": "PAE",
     "pbr": "PBR",
     "pim": "PIM",
     "ptp": "PTP",
@@ -83,6 +86,7 @@ WORDLIST = {
     "vrfs": "VRFs",
     "vrrp": "VRRP",
     "vxlan": "VxLAN",
+    "ztp": "ZTP",
 }
 
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1030,7 +1030,7 @@ ethernet_interfaces:
       route_target: < EVPN Route Target for ESI with format xx:xx:xx:xx:xx:xx >
     snmp_trap_link_change: < true | false >
     flowcontrol:
-      received: < "received" | "send" | "on" >
+      received: < "desired" | "send" | "on" >
     mac_security:
       profile: < profile >
     channel_group:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -954,7 +954,7 @@ errdisable:
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trunk_private_vlan_secondary</samp>](## "ethernet_interfaces.[].trunk_private_vlan_secondary") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;pvlan_mapping</samp>](## "ethernet_interfaces.[].pvlan_mapping") | String |  |  |  | List of vlans as string |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vlan_translations</samp>](## "ethernet_interfaces.[].vlan_translations") | List, items: Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- from</samp>](## "ethernet_interfaces.[].vlan_translations.[].from") | Integer |  |  |  | List of vlans as string (only one vlan if direction is "both") |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- from</samp>](## "ethernet_interfaces.[].vlan_translations.[].from") | String |  |  |  | List of vlans as string (only one vlan if direction is "both") |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;to</samp>](## "ethernet_interfaces.[].vlan_translations.[].to") | Integer |  |  |  | VLAN ID |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;direction</samp>](## "ethernet_interfaces.[].vlan_translations.[].direction") | String |  | both | Valid Values:<br>- in<br>- out<br>- both |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;dot1x</samp>](## "ethernet_interfaces.[].dot1x") | Dictionary |  |  |  |  |
@@ -987,8 +987,8 @@ errdisable:
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;trust</samp>](## "ethernet_interfaces.[].qos.trust") | String |  |  | Valid Values:<br>- dscp<br>- cos<br>- disabled |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dscp</samp>](## "ethernet_interfaces.[].qos.dscp") | Integer |  |  |  | DSCP value |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;cos</samp>](## "ethernet_interfaces.[].qos.cos") | Integer |  |  |  | COS value |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;spanning_tree_bpdufilter</samp>](## "ethernet_interfaces.[].spanning_tree_bpdufilter") | String |  |  | Valid Values:<br>- enabled<br>- disabled<br>- true |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;spanning_tree_bpduguard</samp>](## "ethernet_interfaces.[].spanning_tree_bpduguard") | String |  |  | Valid Values:<br>- enabled<br>- disabled<br>- true |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;spanning_tree_bpdufilter</samp>](## "ethernet_interfaces.[].spanning_tree_bpdufilter") | String |  |  | Valid Values:<br>- enabled<br>- disabled<br>- True<br>- False<br>- true<br>- false |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;spanning_tree_bpduguard</samp>](## "ethernet_interfaces.[].spanning_tree_bpduguard") | String |  |  | Valid Values:<br>- enabled<br>- disabled<br>- True<br>- False<br>- true<br>- false |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;spanning_tree_guard</samp>](## "ethernet_interfaces.[].spanning_tree_guard") | String |  |  | Valid Values:<br>- loop<br>- root<br>- disabled |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;spanning_tree_portfast</samp>](## "ethernet_interfaces.[].spanning_tree_portfast") | String |  |  | Valid Values:<br>- edge<br>- network |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vmtracer</samp>](## "ethernet_interfaces.[].vmtracer") | Boolean |  |  |  |  |
@@ -1186,7 +1186,7 @@ ethernet_interfaces:
     trunk_private_vlan_secondary: <bool>
     pvlan_mapping: <str>
     vlan_translations:
-      - from: <int>
+      - from: <str>
         to: <int>
         direction: <str>
     dot1x:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -791,6 +791,500 @@ errdisable:
     interval: <int>
 ```
 
+## Routed Ethernet Interfaces
+
+### Variables
+
+| Variable | Type | Required | Default | Value Restrictions | Description |
+| -------- | ---- | -------- | ------- | ------------------ | ----------- |
+| [<samp>ethernet_interfaces</samp>](## "ethernet_interfaces") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;- name</samp>](## "ethernet_interfaces.[].name") | String | Required, Unique |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;peer</samp>](## "ethernet_interfaces.[].peer") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;peer_interface</samp>](## "ethernet_interfaces.[].peer_interface") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;peer_type</samp>](## "ethernet_interfaces.[].peer_type") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;description</samp>](## "ethernet_interfaces.[].description") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;shutdown</samp>](## "ethernet_interfaces.[].shutdown") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;speed</samp>](## "ethernet_interfaces.[].speed") | String |  |  |  | < interface_speed | forced interface_speed | auto interface_speed ><br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mtu</samp>](## "ethernet_interfaces.[].mtu") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;l2_mtu</samp>](## "ethernet_interfaces.[].l2_mtu") | Integer |  |  |  | l2-mtu - if defined this profile should only be used for platforms supporting the "l2 mtu" CLI<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vlans</samp>](## "ethernet_interfaces.[].vlans") | String |  |  |  | < list of vlans as string<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;native_vlan</samp>](## "ethernet_interfaces.[].native_vlan") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;native_vlan_tag</samp>](## "ethernet_interfaces.[].native_vlan_tag") | Boolean |  | False |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mode</samp>](## "ethernet_interfaces.[].mode") | String |  |  | Valid Values:<br>- access<br>- dot1q-tunnel<br>- trunk<br>- trunk phone |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;phone</samp>](## "ethernet_interfaces.[].phone") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;trunk</samp>](## "ethernet_interfaces.[].phone.trunk") | String |  |  | Valid Values:<br>- tagged<br>- untagged |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlan</samp>](## "ethernet_interfaces.[].phone.vlan") | Integer |  |  | Min: 1<br>Max: 4094 |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;l2_protocol</samp>](## "ethernet_interfaces.[].l2_protocol") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;encapsulation_dot1q_vlan</samp>](## "ethernet_interfaces.[].l2_protocol.encapsulation_dot1q_vlan") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trunk_groups</samp>](## "ethernet_interfaces.[].trunk_groups") | List, items: String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "ethernet_interfaces.[].trunk_groups.[].&lt;str&gt;") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;type</samp>](## "ethernet_interfaces.[].type") | String |  |  | Valid Values:<br>- routed<br>- switched<br>- l3dot1q<br>- l2dot1q | l3dot1q and l2dot1q are used for sub-interfaces. The parent interface should be defined as routed.<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;snmp_trap_link_change</samp>](## "ethernet_interfaces.[].snmp_trap_link_change") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;flowcontrol</samp>](## "ethernet_interfaces.[].flowcontrol") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;received</samp>](## "ethernet_interfaces.[].flowcontrol.received") | String |  |  | Valid Values:<br>- received<br>- send<br>- on |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "ethernet_interfaces.[].vrf") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;error_correction_encoding</samp>](## "ethernet_interfaces.[].error_correction_encoding") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "ethernet_interfaces.[].error_correction_encoding.enabled") | Boolean |  | True |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;fire_code</samp>](## "ethernet_interfaces.[].error_correction_encoding.fire_code") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;reed_solomon</samp>](## "ethernet_interfaces.[].error_correction_encoding.reed_solomon") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;link_tracking_groups</samp>](## "ethernet_interfaces.[].link_tracking_groups") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "ethernet_interfaces.[].link_tracking_groups.[].name") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;direction</samp>](## "ethernet_interfaces.[].link_tracking_groups.[].direction") | String |  |  | Valid Values:<br>- upstream<br>- downstream |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;evpn_ethernet_segment</samp>](## "ethernet_interfaces.[].evpn_ethernet_segment") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;identifier</samp>](## "ethernet_interfaces.[].evpn_ethernet_segment.identifier") | String |  |  |  | EVPN Ethernet Segment Identifier (Type 1 format)<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;redundancy</samp>](## "ethernet_interfaces.[].evpn_ethernet_segment.redundancy") | String |  |  | Valid Values:<br>- all-active<br>- single-active |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;designated_forwarder_election</samp>](## "ethernet_interfaces.[].evpn_ethernet_segment.designated_forwarder_election") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;algorithm</samp>](## "ethernet_interfaces.[].evpn_ethernet_segment.designated_forwarder_election.algorithm") | String |  |  | Valid Values:<br>- modulus<br>- preference |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;preference_value</samp>](## "ethernet_interfaces.[].evpn_ethernet_segment.designated_forwarder_election.preference_value") | Integer |  |  | Min: 0<br>Max: 65535 | Preference_value and dont_preempt are set for preference algorithm and are optional<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dont_preempt</samp>](## "ethernet_interfaces.[].evpn_ethernet_segment.designated_forwarder_election.dont_preempt") | Boolean |  | False |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hold_time</samp>](## "ethernet_interfaces.[].evpn_ethernet_segment.designated_forwarder_election.hold_time") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;subsequent_hold_time</samp>](## "ethernet_interfaces.[].evpn_ethernet_segment.designated_forwarder_election.subsequent_hold_time") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;candidate_reachability_required</samp>](## "ethernet_interfaces.[].evpn_ethernet_segment.designated_forwarder_election.candidate_reachability_required") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mpls</samp>](## "ethernet_interfaces.[].evpn_ethernet_segment.mpls") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;shared_index</samp>](## "ethernet_interfaces.[].evpn_ethernet_segment.mpls.shared_index") | Integer |  |  | Min: 1<br>Max: 1024 |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tunnel_flood_filter_time</samp>](## "ethernet_interfaces.[].evpn_ethernet_segment.mpls.tunnel_flood_filter_time") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_target</samp>](## "ethernet_interfaces.[].evpn_ethernet_segment.route_target") | String |  |  |  | EVPN Route Target for ESI with format xx:xx:xx:xx:xx:xx<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;encapsulation_dot1q_vlan</samp>](## "ethernet_interfaces.[].encapsulation_dot1q_vlan") | Integer |  |  |  | vlan tag to configure on sub-interface<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;encapsulation_vlan</samp>](## "ethernet_interfaces.[].encapsulation_vlan") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;client</samp>](## "ethernet_interfaces.[].encapsulation_vlan.client") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dot1q</samp>](## "ethernet_interfaces.[].encapsulation_vlan.client.dot1q") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlan</samp>](## "ethernet_interfaces.[].encapsulation_vlan.client.dot1q.vlan") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;outer</samp>](## "ethernet_interfaces.[].encapsulation_vlan.client.dot1q.outer") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;inner</samp>](## "ethernet_interfaces.[].encapsulation_vlan.client.dot1q.inner") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;outer</samp>](## "ethernet_interfaces.[].encapsulation_vlan.client.outer") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;inner</samp>](## "ethernet_interfaces.[].encapsulation_vlan.client.inner") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unmatched</samp>](## "ethernet_interfaces.[].encapsulation_vlan.client.unmatched") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;network</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network") | Dictionary |  |  |  | Network encapsulation is all optional, and skipped if using client unmatched.<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dot1q</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.dot1q") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlan</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.dot1q.vlan") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;outer</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.dot1q.outer") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;inner</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.dot1q.inner") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;outer</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.outer") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;inner</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.inner") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;client</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.client") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vlan_id</samp>](## "ethernet_interfaces.[].vlan_id") | Integer |  |  | Min: 1<br>Max: 4094 |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_address</samp>](## "ethernet_interfaces.[].ip_address") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_address_secondaries</samp>](## "ethernet_interfaces.[].ip_address_secondaries") | List, items: String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "ethernet_interfaces.[].ip_address_secondaries.[].&lt;str&gt;") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_helpers</samp>](## "ethernet_interfaces.[].ip_helpers") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- ip_helper</samp>](## "ethernet_interfaces.[].ip_helpers.[].ip_helper") | String | Required, Unique |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_interface</samp>](## "ethernet_interfaces.[].ip_helpers.[].source_interface") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "ethernet_interfaces.[].ip_helpers.[].vrf") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_enable</samp>](## "ethernet_interfaces.[].ipv6_enable") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_address</samp>](## "ethernet_interfaces.[].ipv6_address") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_address_link_local</samp>](## "ethernet_interfaces.[].ipv6_address_link_local") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_nd_ra_disabled</samp>](## "ethernet_interfaces.[].ipv6_nd_ra_disabled") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_nd_managed_config_flag</samp>](## "ethernet_interfaces.[].ipv6_nd_managed_config_flag") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_nd_prefixes</samp>](## "ethernet_interfaces.[].ipv6_nd_prefixes") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- ipv6_prefix</samp>](## "ethernet_interfaces.[].ipv6_nd_prefixes.[].ipv6_prefix") | String | Required, Unique |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;valid_lifetime</samp>](## "ethernet_interfaces.[].ipv6_nd_prefixes.[].valid_lifetime") | String |  |  |  | < infinite or lifetime in seconds ><br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;preferred_lifetime</samp>](## "ethernet_interfaces.[].ipv6_nd_prefixes.[].preferred_lifetime") | String |  |  |  | < infinite or lifetime in seconds ><br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;no_autoconfig_flag</samp>](## "ethernet_interfaces.[].ipv6_nd_prefixes.[].no_autoconfig_flag") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;access_group_in</samp>](## "ethernet_interfaces.[].access_group_in") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;access_group_out</samp>](## "ethernet_interfaces.[].access_group_out") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_access_group_in</samp>](## "ethernet_interfaces.[].ipv6_access_group_in") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_access_group_out</samp>](## "ethernet_interfaces.[].ipv6_access_group_out") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mac_access_group_in</samp>](## "ethernet_interfaces.[].mac_access_group_in") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mac_access_group_out</samp>](## "ethernet_interfaces.[].mac_access_group_out") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;multicast</samp>](## "ethernet_interfaces.[].multicast") | Dictionary |  |  |  | boundaries can be either 1 ACL or a list of multicast IP address_range(s)/prefix but not combination of both<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4</samp>](## "ethernet_interfaces.[].multicast.ipv4") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;boundaries</samp>](## "ethernet_interfaces.[].multicast.ipv4.boundaries") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- boundary</samp>](## "ethernet_interfaces.[].multicast.ipv4.boundaries.[].boundary") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;out</samp>](## "ethernet_interfaces.[].multicast.ipv4.boundaries.[].out") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;static</samp>](## "ethernet_interfaces.[].multicast.ipv4.static") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6</samp>](## "ethernet_interfaces.[].multicast.ipv6") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;boundaries</samp>](## "ethernet_interfaces.[].multicast.ipv6.boundaries") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- boundary</samp>](## "ethernet_interfaces.[].multicast.ipv6.boundaries.[].boundary") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;static</samp>](## "ethernet_interfaces.[].multicast.ipv6.static") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ospf_network_point_to_point</samp>](## "ethernet_interfaces.[].ospf_network_point_to_point") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ospf_area</samp>](## "ethernet_interfaces.[].ospf_area") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ospf_cost</samp>](## "ethernet_interfaces.[].ospf_cost") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ospf_authentication</samp>](## "ethernet_interfaces.[].ospf_authentication") | String |  |  | Valid Values:<br>- none<br>- simple<br>- message-digest |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ospf_authentication_key</samp>](## "ethernet_interfaces.[].ospf_authentication_key") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ospf_message_digest_keys</samp>](## "ethernet_interfaces.[].ospf_message_digest_keys") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- id</samp>](## "ethernet_interfaces.[].ospf_message_digest_keys.[].id") | Integer | Required, Unique |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hash_algorithm</samp>](## "ethernet_interfaces.[].ospf_message_digest_keys.[].hash_algorithm") | String |  |  | Valid Values:<br>- md5<br>- sha1<br>- sha 256<br>- sha384<br>- sha512 |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "ethernet_interfaces.[].ospf_message_digest_keys.[].key") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;pim</samp>](## "ethernet_interfaces.[].pim") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4</samp>](## "ethernet_interfaces.[].pim.ipv4") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dr_priority</samp>](## "ethernet_interfaces.[].pim.ipv4.dr_priority") | Integer |  |  | Min: 0<br>Max: 429467295 |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;sparse_mode</samp>](## "ethernet_interfaces.[].pim.ipv4.sparse_mode") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mac_security</samp>](## "ethernet_interfaces.[].mac_security") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;profile</samp>](## "ethernet_interfaces.[].mac_security.profile") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;channel_group</samp>](## "ethernet_interfaces.[].channel_group") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;id</samp>](## "ethernet_interfaces.[].channel_group.id") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mode</samp>](## "ethernet_interfaces.[].channel_group.mode") | String |  |  | Valid Values:<br>- on<br>- active<br>- passive |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;isis_enable</samp>](## "ethernet_interfaces.[].isis_enable") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;isis_passive</samp>](## "ethernet_interfaces.[].isis_passive") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;isis_metric</samp>](## "ethernet_interfaces.[].isis_metric") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;isis_network_point_to_point</samp>](## "ethernet_interfaces.[].isis_network_point_to_point") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;isis_circuit_type</samp>](## "ethernet_interfaces.[].isis_circuit_type") | String |  |  | Valid Values:<br>- level-1-2<br>- level-1<br>- level-2 |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;isis_hello_padding</samp>](## "ethernet_interfaces.[].isis_hello_padding") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;isis_authentication_mode</samp>](## "ethernet_interfaces.[].isis_authentication_mode") | String |  |  | Valid Values:<br>- text<br>- md5 |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;isis_authentication_key</samp>](## "ethernet_interfaces.[].isis_authentication_key") | String |  |  |  | type-7 encrypted password<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ptp</samp>](## "ethernet_interfaces.[].ptp") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enable</samp>](## "ethernet_interfaces.[].ptp.enable") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;announce</samp>](## "ethernet_interfaces.[].ptp.announce") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interval</samp>](## "ethernet_interfaces.[].ptp.announce.interval") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;timeout</samp>](## "ethernet_interfaces.[].ptp.announce.timeout") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;delay_req</samp>](## "ethernet_interfaces.[].ptp.delay_req") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;delay_mechanism</samp>](## "ethernet_interfaces.[].ptp.delay_mechanism") | String |  |  | Valid Values:<br>- e2e<br>- p2p |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;sync_message</samp>](## "ethernet_interfaces.[].ptp.sync_message") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interval</samp>](## "ethernet_interfaces.[].ptp.sync_message.interval") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;role</samp>](## "ethernet_interfaces.[].ptp.role") | String |  |  | Valid Values:<br>- master<br>- dynamic |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlan</samp>](## "ethernet_interfaces.[].ptp.vlan") | String |  |  |  | < all | list of vlans as string ><br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;transport</samp>](## "ethernet_interfaces.[].ptp.transport") | String |  |  | Valid Values:<br>- ipv4<br>- ipv6<br>- layer2 |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;profile</samp>](## "ethernet_interfaces.[].profile") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;storm_control</samp>](## "ethernet_interfaces.[].storm_control") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;all</samp>](## "ethernet_interfaces.[].storm_control.all") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level</samp>](## "ethernet_interfaces.[].storm_control.all.level") | Integer |  |  |  | Configure maximum storm-control level<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unit</samp>](## "ethernet_interfaces.[].storm_control.all.unit") | String |  |  |  | Percent* | pps (optional and is hardware dependant - default is percent)<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;broadcast</samp>](## "ethernet_interfaces.[].storm_control.broadcast") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level</samp>](## "ethernet_interfaces.[].storm_control.broadcast.level") | Integer |  |  |  | Configure maximum storm-control level<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unit</samp>](## "ethernet_interfaces.[].storm_control.broadcast.unit") | String |  |  |  | Percent* | pps (optional and is hardware dependant - default is percent)<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;multicast</samp>](## "ethernet_interfaces.[].storm_control.multicast") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level</samp>](## "ethernet_interfaces.[].storm_control.multicast.level") | Integer |  |  |  | Configure maximum storm-control level<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unit</samp>](## "ethernet_interfaces.[].storm_control.multicast.unit") | String |  |  |  | Percent* | pps (optional and is hardware dependant - default is percent)<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unknown_unicast</samp>](## "ethernet_interfaces.[].storm_control.unknown_unicast") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level</samp>](## "ethernet_interfaces.[].storm_control.unknown_unicast.level") | Integer |  |  |  | Configure maximum storm-control level<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unit</samp>](## "ethernet_interfaces.[].storm_control.unknown_unicast.unit") | String |  |  |  | Percent* | pps (optional and is hardware dependant - default is percent)<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;logging</samp>](## "ethernet_interfaces.[].logging") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;event</samp>](## "ethernet_interfaces.[].logging.event") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;link_status</samp>](## "ethernet_interfaces.[].logging.event.link_status") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;congestion_drops</samp>](## "ethernet_interfaces.[].logging.event.congestion_drops") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;lldp</samp>](## "ethernet_interfaces.[].lldp") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;transmit</samp>](## "ethernet_interfaces.[].lldp.transmit") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;receive</samp>](## "ethernet_interfaces.[].lldp.receive") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ztp_vlan</samp>](## "ethernet_interfaces.[].lldp.ztp_vlan") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trunk_private_vlan_secondary</samp>](## "ethernet_interfaces.[].trunk_private_vlan_secondary") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;pvlan_mapping</samp>](## "ethernet_interfaces.[].pvlan_mapping") | Integer |  |  |  | List of vlans as string<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vlan_translations</samp>](## "ethernet_interfaces.[].vlan_translations") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- from</samp>](## "ethernet_interfaces.[].vlan_translations.[].from") | String |  |  |  | List of vlans as string (only one vlan if direction is "both")<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;to</samp>](## "ethernet_interfaces.[].vlan_translations.[].to") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;direction</samp>](## "ethernet_interfaces.[].vlan_translations.[].direction") | String |  | both | Valid Values:<br>- in<br>- out<br>- both |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;dot1x</samp>](## "ethernet_interfaces.[].dot1x") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;port_control</samp>](## "ethernet_interfaces.[].dot1x.port_control") | String |  |  | Valid Values:<br>- auto<br>- force-authorized<br>- force-unauthorized |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;port_control_force_authorized_phone</samp>](## "ethernet_interfaces.[].dot1x.port_control_force_authorized_phone") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;reauthentication</samp>](## "ethernet_interfaces.[].dot1x.reauthentication") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;pae</samp>](## "ethernet_interfaces.[].dot1x.pae") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mode</samp>](## "ethernet_interfaces.[].dot1x.pae.mode") | String |  |  | Valid Values:<br>- authenticator |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;authentication_failure</samp>](## "ethernet_interfaces.[].dot1x.authentication_failure") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;action</samp>](## "ethernet_interfaces.[].dot1x.authentication_failure.action") | String |  |  | Valid Values:<br>- allow<br>- drop |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;allow_vlan</samp>](## "ethernet_interfaces.[].dot1x.authentication_failure.allow_vlan") | Integer |  |  | Min: 1<br>Max: 4094 |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;host_mode</samp>](## "ethernet_interfaces.[].dot1x.host_mode") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mode</samp>](## "ethernet_interfaces.[].dot1x.host_mode.mode") | String |  |  | Valid Values:<br>- multi-host<br>- single-host |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;multi_host_authenticated</samp>](## "ethernet_interfaces.[].dot1x.host_mode.multi_host_authenticated") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mac_based_authentication</samp>](## "ethernet_interfaces.[].dot1x.host_mode.mac_based_authentication") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "ethernet_interfaces.[].dot1x.host_mode.mac_based_authentication.enabled") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;always</samp>](## "ethernet_interfaces.[].dot1x.host_mode.mac_based_authentication.always") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;host_mode_common</samp>](## "ethernet_interfaces.[].dot1x.host_mode.mac_based_authentication.host_mode_common") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;timeout</samp>](## "ethernet_interfaces.[].dot1x.host_mode.timeout") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;idle_host</samp>](## "ethernet_interfaces.[].dot1x.host_mode.timeout.idle_host") | Integer |  |  | Min: 10<br>Max: 65535 |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;quiet_period</samp>](## "ethernet_interfaces.[].dot1x.host_mode.timeout.quiet_period") | Integer |  |  | Min: 1<br>Max: 65535 |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;reauth_period</samp>](## "ethernet_interfaces.[].dot1x.host_mode.timeout.reauth_period") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;reauth_timeout_ignore</samp>](## "ethernet_interfaces.[].dot1x.host_mode.timeout.reauth_timeout_ignore") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tx_period</samp>](## "ethernet_interfaces.[].dot1x.host_mode.timeout.tx_period") | Integer |  |  | Min: 1<br>Max: 65535 |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;reauthorization_request_limit</samp>](## "ethernet_interfaces.[].dot1x.host_mode.reauthorization_request_limit") | Integer |  |  | Min: 1<br>Max: 10 |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mac_based_authentication</samp>](## "ethernet_interfaces.[].dot1x.mac_based_authentication") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "ethernet_interfaces.[].dot1x.mac_based_authentication.enabled") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;always</samp>](## "ethernet_interfaces.[].dot1x.mac_based_authentication.always") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;host_mode_common</samp>](## "ethernet_interfaces.[].dot1x.mac_based_authentication.host_mode_common") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;timeout</samp>](## "ethernet_interfaces.[].dot1x.timeout") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;idle_host</samp>](## "ethernet_interfaces.[].dot1x.timeout.idle_host") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;quiet_period</samp>](## "ethernet_interfaces.[].dot1x.timeout.quiet_period") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;reauth_period</samp>](## "ethernet_interfaces.[].dot1x.timeout.reauth_period") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;reauth_timeout_ignore</samp>](## "ethernet_interfaces.[].dot1x.timeout.reauth_timeout_ignore") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tx_period</samp>](## "ethernet_interfaces.[].dot1x.timeout.tx_period") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;reauthorization_request_limit</samp>](## "ethernet_interfaces.[].dot1x.reauthorization_request_limit") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;service_profile</samp>](## "ethernet_interfaces.[].service_profile") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;shape</samp>](## "ethernet_interfaces.[].shape") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rate</samp>](## "ethernet_interfaces.[].shape.rate") | String |  |  |  | < "< rate > kbps" | "1-100 percent" | "< rate > pps" , supported options are platform dependent ><br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;qos</samp>](## "ethernet_interfaces.[].qos") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;trust</samp>](## "ethernet_interfaces.[].qos.trust") | String |  |  | Valid Values:<br>- dscp<br>- cos<br>- disabled |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dscp</samp>](## "ethernet_interfaces.[].qos.dscp") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;cos</samp>](## "ethernet_interfaces.[].qos.cos") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;spanning_tree_bpdufilter</samp>](## "ethernet_interfaces.[].spanning_tree_bpdufilter") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;spanning_tree_bpduguard</samp>](## "ethernet_interfaces.[].spanning_tree_bpduguard") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;spanning_tree_guard</samp>](## "ethernet_interfaces.[].spanning_tree_guard") | String |  |  | Valid Values:<br>- loop<br>- root<br>- disabled |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;spanning_tree_portfast</samp>](## "ethernet_interfaces.[].spanning_tree_portfast") | String |  |  | Valid Values:<br>- edge<br>- network |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vmtracer</samp>](## "ethernet_interfaces.[].vmtracer") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;priority_flow_control</samp>](## "ethernet_interfaces.[].priority_flow_control") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "ethernet_interfaces.[].priority_flow_control.enabled") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;priorities</samp>](## "ethernet_interfaces.[].priority_flow_control.priorities") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- priority</samp>](## "ethernet_interfaces.[].priority_flow_control.priorities.[].priority") | Integer |  |  | Min: 0<br>Max: 7 |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;no_drop</samp>](## "ethernet_interfaces.[].priority_flow_control.priorities.[].no_drop") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;bfd</samp>](## "ethernet_interfaces.[].bfd") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;echo</samp>](## "ethernet_interfaces.[].bfd.echo") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interval</samp>](## "ethernet_interfaces.[].bfd.interval") | Integer |  |  |  | Interval in milliseconds<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;min_rx</samp>](## "ethernet_interfaces.[].bfd.min_rx") | Integer |  |  |  | Rate in milliseconds<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;multiplier</samp>](## "ethernet_interfaces.[].bfd.multiplier") | Integer |  |  | Min: 3<br>Max: 50 |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;service_policy</samp>](## "ethernet_interfaces.[].service_policy") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;pbr</samp>](## "ethernet_interfaces.[].service_policy.pbr") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;input</samp>](## "ethernet_interfaces.[].service_policy.pbr.input") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mpls</samp>](## "ethernet_interfaces.[].mpls") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ip</samp>](## "ethernet_interfaces.[].mpls.ip") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ldp</samp>](## "ethernet_interfaces.[].mpls.ldp") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interface</samp>](## "ethernet_interfaces.[].mpls.ldp.interface") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;igp_sync</samp>](## "ethernet_interfaces.[].mpls.ldp.igp_sync") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;lacp_timer</samp>](## "ethernet_interfaces.[].lacp_timer") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mode</samp>](## "ethernet_interfaces.[].lacp_timer.mode") | String |  |  | Valid Values:<br>- fast<br>- normal |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;multiplier</samp>](## "ethernet_interfaces.[].lacp_timer.multiplier") | Integer |  |  | Min: 3<br>Max: 3000 |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;lacp_port_priority</samp>](## "ethernet_interfaces.[].lacp_port_priority") | Integer |  |  | Min: 0<br>Max: 65535 |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;transceiver</samp>](## "ethernet_interfaces.[].transceiver") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;media</samp>](## "ethernet_interfaces.[].transceiver.media") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;override</samp>](## "ethernet_interfaces.[].transceiver.media.override") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_proxy_arp</samp>](## "ethernet_interfaces.[].ip_proxy_arp") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;traffic_policy</samp>](## "ethernet_interfaces.[].traffic_policy") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;input</samp>](## "ethernet_interfaces.[].traffic_policy.input") | String |  |  |  | ingress traffic policy<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;output</samp>](## "ethernet_interfaces.[].traffic_policy.output") | String |  |  |  | egress traffic policy<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;eos_cli</samp>](## "ethernet_interfaces.[].eos_cli") | String |  |  |  | < multiline eos cli > |
+
+### YAML
+
+```yaml
+ethernet_interfaces:
+  - name: <str>
+    peer: <str>
+    peer_interface: <str>
+    peer_type: <str>
+    description: <str>
+    shutdown: <bool>
+    speed: <str>
+    mtu: <int>
+    l2_mtu: <int>
+    vlans: <str>
+    native_vlan: <int>
+    native_vlan_tag: <bool>
+    mode: <str>
+    phone:
+      trunk: <str>
+      vlan: <int>
+    l2_protocol:
+      encapsulation_dot1q_vlan: <int>
+    trunk_groups:
+      - <str>
+    type: <str>
+    snmp_trap_link_change: <bool>
+    flowcontrol:
+      received: <str>
+    vrf: <str>
+    error_correction_encoding:
+      enabled: <bool>
+      fire_code: <bool>
+      reed_solomon: <bool>
+    link_tracking_groups:
+      - name: <str>
+        direction: <str>
+    evpn_ethernet_segment:
+      identifier: <str>
+      redundancy: <str>
+      designated_forwarder_election:
+        algorithm: <str>
+        preference_value: <int>
+        dont_preempt: <bool>
+        hold_time: <int>
+        subsequent_hold_time: <int>
+        candidate_reachability_required: <bool>
+      mpls:
+        shared_index: <int>
+        tunnel_flood_filter_time: <int>
+      route_target: <str>
+    encapsulation_dot1q_vlan: <int>
+    encapsulation_vlan:
+      client:
+        dot1q:
+          vlan: <int>
+          outer: <int>
+          inner: <int>
+        outer: <int>
+        inner: <int>
+        unmatched: <bool>
+      network:
+        dot1q:
+          vlan: <int>
+          outer: <int>
+          inner: <int>
+        outer: <int>
+        inner: <int>
+        client: <bool>
+    vlan_id: <int>
+    ip_address: <str>
+    ip_address_secondaries:
+      - <str>
+    ip_helpers:
+      - ip_helper: <str>
+        source_interface: <str>
+        vrf: <str>
+    ipv6_enable: <bool>
+    ipv6_address: <str>
+    ipv6_address_link_local: <str>
+    ipv6_nd_ra_disabled: <bool>
+    ipv6_nd_managed_config_flag: <bool>
+    ipv6_nd_prefixes:
+      - ipv6_prefix: <str>
+        valid_lifetime: <str>
+        preferred_lifetime: <str>
+        no_autoconfig_flag: <bool>
+    access_group_in: <str>
+    access_group_out: <str>
+    ipv6_access_group_in: <str>
+    ipv6_access_group_out: <str>
+    mac_access_group_in: <str>
+    mac_access_group_out: <str>
+    multicast:
+      ipv4:
+        boundaries:
+          - boundary: <str>
+            out: <bool>
+        static: <bool>
+      ipv6:
+        boundaries:
+          - boundary: <str>
+        static: <bool>
+    ospf_network_point_to_point: <bool>
+    ospf_area: <str>
+    ospf_cost: <int>
+    ospf_authentication: <str>
+    ospf_authentication_key: <str>
+    ospf_message_digest_keys:
+      - id: <int>
+        hash_algorithm: <str>
+        key: <str>
+    pim:
+      ipv4:
+        dr_priority: <int>
+        sparse_mode: <bool>
+    mac_security:
+      profile: <str>
+    channel_group:
+      id: <int>
+      mode: <str>
+    isis_enable: <str>
+    isis_passive: <bool>
+    isis_metric: <int>
+    isis_network_point_to_point: <bool>
+    isis_circuit_type: <str>
+    isis_hello_padding: <bool>
+    isis_authentication_mode: <str>
+    isis_authentication_key: <str>
+    ptp:
+      enable: <bool>
+      announce:
+        interval: <int>
+        timeout: <int>
+      delay_req: <int>
+      delay_mechanism: <str>
+      sync_message:
+        interval: <int>
+      role: <str>
+      vlan: <str>
+      transport: <str>
+    profile: <str>
+    storm_control:
+      all:
+        level: <int>
+        unit: <str>
+      broadcast:
+        level: <int>
+        unit: <str>
+      multicast:
+        level: <int>
+        unit: <str>
+      unknown_unicast:
+        level: <int>
+        unit: <str>
+    logging:
+      event:
+        link_status: <bool>
+        congestion_drops: <bool>
+    lldp:
+      transmit: <bool>
+      receive: <bool>
+      ztp_vlan: <int>
+    trunk_private_vlan_secondary: <bool>
+    pvlan_mapping: <int>
+    vlan_translations:
+      - from: <str>
+        to: <int>
+        direction: <str>
+    dot1x:
+      port_control: <str>
+      port_control_force_authorized_phone: <bool>
+      reauthentication: <bool>
+      pae:
+        mode: <str>
+      authentication_failure:
+        action: <str>
+        allow_vlan: <int>
+      host_mode:
+        mode: <str>
+        multi_host_authenticated: <bool>
+        mac_based_authentication:
+          enabled: <bool>
+          always: <bool>
+          host_mode_common: <bool>
+        timeout:
+          idle_host: <int>
+          quiet_period: <int>
+          reauth_period: <str>
+          reauth_timeout_ignore: <bool>
+          tx_period: <int>
+        reauthorization_request_limit: <int>
+      mac_based_authentication:
+        enabled: <bool>
+        always: <bool>
+        host_mode_common: <bool>
+      timeout:
+        idle_host: <int>
+        quiet_period: <int>
+        reauth_period: <str>
+        reauth_timeout_ignore: <bool>
+        tx_period: <int>
+      reauthorization_request_limit: <int>
+    service_profile: <str>
+    shape:
+      rate: <str>
+    qos:
+      trust: <str>
+      dscp: <int>
+      cos: <int>
+    spanning_tree_bpdufilter: <str>
+    spanning_tree_bpduguard: <str>
+    spanning_tree_guard: <str>
+    spanning_tree_portfast: <str>
+    vmtracer: <bool>
+    priority_flow_control:
+      enabled: <bool>
+      priorities:
+        - priority: <int>
+          no_drop: <bool>
+    bfd:
+      echo: <bool>
+      interval: <int>
+      min_rx: <int>
+      multiplier: <int>
+    service_policy:
+      pbr:
+        input: <str>
+    mpls:
+      ip: <bool>
+      ldp:
+        interface: <bool>
+        igp_sync: <bool>
+    lacp_timer:
+      mode: <str>
+      multiplier: <int>
+    lacp_port_priority: <int>
+    transceiver:
+      media:
+        override: <str>
+    ip_proxy_arp: <bool>
+    traffic_policy:
+      input: <str>
+      output: <str>
+    eos_cli: <str>
+```
+
 ## Event Handlers
 
 ### Variables

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -793,6 +793,9 @@ errdisable:
 
 ## Ethernet Interfaces
 
+### Description
+
+Routed interfaces
 ### Variables
 
 | Variable | Type | Required | Default | Value Restrictions | Description |
@@ -804,10 +807,10 @@ errdisable:
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;peer_type</samp>](## "ethernet_interfaces.[].peer_type") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;description</samp>](## "ethernet_interfaces.[].description") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;shutdown</samp>](## "ethernet_interfaces.[].shutdown") | Boolean |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;speed</samp>](## "ethernet_interfaces.[].speed") | String |  |  |  | < interface_speed | forced interface_speed | auto interface_speed ><br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;speed</samp>](## "ethernet_interfaces.[].speed") | String |  |  |  | Speed can be interface_speed or forced interface_speed or auto interface_speed |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mtu</samp>](## "ethernet_interfaces.[].mtu") | Integer |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;l2_mtu</samp>](## "ethernet_interfaces.[].l2_mtu") | Integer |  |  |  | l2-mtu - if defined this profile should only be used for platforms supporting the "l2 mtu" CLI<br> |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vlans</samp>](## "ethernet_interfaces.[].vlans") | String |  |  |  | < list of vlans as string<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;l2_mtu</samp>](## "ethernet_interfaces.[].l2_mtu") | Integer |  |  |  | If l2_mtu defined this profile should only be used for platforms supporting the "l2 mtu" CLI |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vlans</samp>](## "ethernet_interfaces.[].vlans") | String |  |  |  | List of vlans as string |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;native_vlan</samp>](## "ethernet_interfaces.[].native_vlan") | Integer |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;native_vlan_tag</samp>](## "ethernet_interfaces.[].native_vlan_tag") | Boolean |  | False |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mode</samp>](## "ethernet_interfaces.[].mode") | String |  |  | Valid Values:<br>- access<br>- dot1q-tunnel<br>- trunk<br>- trunk phone |  |
@@ -815,27 +818,29 @@ errdisable:
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;trunk</samp>](## "ethernet_interfaces.[].phone.trunk") | String |  |  | Valid Values:<br>- tagged<br>- untagged |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlan</samp>](## "ethernet_interfaces.[].phone.vlan") | Integer |  |  | Min: 1<br>Max: 4094 |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;l2_protocol</samp>](## "ethernet_interfaces.[].l2_protocol") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;encapsulation_dot1q_vlan</samp>](## "ethernet_interfaces.[].l2_protocol.encapsulation_dot1q_vlan") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;encapsulation_dot1q_vlan</samp>](## "ethernet_interfaces.[].l2_protocol.encapsulation_dot1q_vlan") | Integer |  |  |  | Vlan tag to configure on sub-interface |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trunk_groups</samp>](## "ethernet_interfaces.[].trunk_groups") | List, items: String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "ethernet_interfaces.[].trunk_groups.[].&lt;str&gt;") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;type</samp>](## "ethernet_interfaces.[].type") | String |  |  | Valid Values:<br>- routed<br>- switched<br>- l3dot1q<br>- l2dot1q | l3dot1q and l2dot1q are used for sub-interfaces. The parent interface should be defined as routed.<br> |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;snmp_trap_link_change</samp>](## "ethernet_interfaces.[].snmp_trap_link_change") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;type</samp>](## "ethernet_interfaces.[].type") | String |  |  | Valid Values:<br>- routed<br>- switched<br>- l3dot1q<br>- l2dot1q | l3dot1q and l2dot1q are used for sub-interfaces. The parent interface should be defined as routed. |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;snmp_trap_link_change</samp>](## "ethernet_interfaces.[].snmp_trap_link_change") | Boolean |  |  |  | SNMP trap link change |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;flowcontrol</samp>](## "ethernet_interfaces.[].flowcontrol") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;received</samp>](## "ethernet_interfaces.[].flowcontrol.received") | String |  |  | Valid Values:<br>- received<br>- send<br>- on |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "ethernet_interfaces.[].vrf") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "ethernet_interfaces.[].vrf") | String |  |  |  | VRF name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;flow_tracker</samp>](## "ethernet_interfaces.[].flow_tracker") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;sampled</samp>](## "ethernet_interfaces.[].flow_tracker.sampled") | String |  |  |  | Flow tracker name |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;error_correction_encoding</samp>](## "ethernet_interfaces.[].error_correction_encoding") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "ethernet_interfaces.[].error_correction_encoding.enabled") | Boolean |  | True |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;fire_code</samp>](## "ethernet_interfaces.[].error_correction_encoding.fire_code") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;reed_solomon</samp>](## "ethernet_interfaces.[].error_correction_encoding.reed_solomon") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;link_tracking_groups</samp>](## "ethernet_interfaces.[].link_tracking_groups") | List, items: Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "ethernet_interfaces.[].link_tracking_groups.[].name") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "ethernet_interfaces.[].link_tracking_groups.[].name") | String |  |  |  | Group name |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;direction</samp>](## "ethernet_interfaces.[].link_tracking_groups.[].direction") | String |  |  | Valid Values:<br>- upstream<br>- downstream |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;evpn_ethernet_segment</samp>](## "ethernet_interfaces.[].evpn_ethernet_segment") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;identifier</samp>](## "ethernet_interfaces.[].evpn_ethernet_segment.identifier") | String |  |  |  | EVPN Ethernet Segment Identifier (Type 1 format)<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;identifier</samp>](## "ethernet_interfaces.[].evpn_ethernet_segment.identifier") | String |  |  |  | EVPN Ethernet Segment Identifier (Type 1 format) |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;redundancy</samp>](## "ethernet_interfaces.[].evpn_ethernet_segment.redundancy") | String |  |  | Valid Values:<br>- all-active<br>- single-active |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;designated_forwarder_election</samp>](## "ethernet_interfaces.[].evpn_ethernet_segment.designated_forwarder_election") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;algorithm</samp>](## "ethernet_interfaces.[].evpn_ethernet_segment.designated_forwarder_election.algorithm") | String |  |  | Valid Values:<br>- modulus<br>- preference |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;preference_value</samp>](## "ethernet_interfaces.[].evpn_ethernet_segment.designated_forwarder_election.preference_value") | Integer |  |  | Min: 0<br>Max: 65535 | Preference_value and dont_preempt are set for preference algorithm and are optional<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;preference_value</samp>](## "ethernet_interfaces.[].evpn_ethernet_segment.designated_forwarder_election.preference_value") | Integer |  |  | Min: 0<br>Max: 65535 | Preference_value and dont_preempt are set for preference algorithm and are optional |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dont_preempt</samp>](## "ethernet_interfaces.[].evpn_ethernet_segment.designated_forwarder_election.dont_preempt") | Boolean |  | False |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hold_time</samp>](## "ethernet_interfaces.[].evpn_ethernet_segment.designated_forwarder_election.hold_time") | Integer |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;subsequent_hold_time</samp>](## "ethernet_interfaces.[].evpn_ethernet_segment.designated_forwarder_election.subsequent_hold_time") | Integer |  |  |  |  |
@@ -843,18 +848,18 @@ errdisable:
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mpls</samp>](## "ethernet_interfaces.[].evpn_ethernet_segment.mpls") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;shared_index</samp>](## "ethernet_interfaces.[].evpn_ethernet_segment.mpls.shared_index") | Integer |  |  | Min: 1<br>Max: 1024 |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tunnel_flood_filter_time</samp>](## "ethernet_interfaces.[].evpn_ethernet_segment.mpls.tunnel_flood_filter_time") | Integer |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_target</samp>](## "ethernet_interfaces.[].evpn_ethernet_segment.route_target") | String |  |  |  | EVPN Route Target for ESI with format xx:xx:xx:xx:xx:xx<br> |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;encapsulation_dot1q_vlan</samp>](## "ethernet_interfaces.[].encapsulation_dot1q_vlan") | Integer |  |  |  | vlan tag to configure on sub-interface<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_target</samp>](## "ethernet_interfaces.[].evpn_ethernet_segment.route_target") | String |  |  |  | EVPN Route Target for ESI with format xx:xx:xx:xx:xx:xx |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;encapsulation_dot1q_vlan</samp>](## "ethernet_interfaces.[].encapsulation_dot1q_vlan") | Integer |  |  |  | VLAN tag to configure on sub-interface |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;encapsulation_vlan</samp>](## "ethernet_interfaces.[].encapsulation_vlan") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;client</samp>](## "ethernet_interfaces.[].encapsulation_vlan.client") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dot1q</samp>](## "ethernet_interfaces.[].encapsulation_vlan.client.dot1q") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlan</samp>](## "ethernet_interfaces.[].encapsulation_vlan.client.dot1q.vlan") | Integer |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;outer</samp>](## "ethernet_interfaces.[].encapsulation_vlan.client.dot1q.outer") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlan</samp>](## "ethernet_interfaces.[].encapsulation_vlan.client.dot1q.vlan") | Integer |  |  |  | Client VLAN ID |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;outer</samp>](## "ethernet_interfaces.[].encapsulation_vlan.client.dot1q.outer") | Integer |  |  |  | Client Outer VLAN ID |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;inner</samp>](## "ethernet_interfaces.[].encapsulation_vlan.client.dot1q.inner") | Integer |  |  |  | Client Inner VLAN ID |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;outer</samp>](## "ethernet_interfaces.[].encapsulation_vlan.client.outer") | Integer |  |  |  | Client Outer VLAN ID |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;inner</samp>](## "ethernet_interfaces.[].encapsulation_vlan.client.inner") | Integer |  |  |  | Client Inner VLAN ID |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unmatched</samp>](## "ethernet_interfaces.[].encapsulation_vlan.client.unmatched") | Boolean |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;network</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network") | Dictionary |  |  |  | Network encapsulation is all optional, and skipped if using client unmatched.<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;network</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network") | Dictionary |  |  |  | Network encapsulation is all optional, and skipped if using client unmatched. |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dot1q</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.dot1q") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlan</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.dot1q.vlan") | Integer |  |  |  | Network VLAN ID |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;outer</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.dot1q.outer") | Integer |  |  |  | Network Outer VLAN ID |
@@ -863,48 +868,48 @@ errdisable:
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;inner</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.inner") | Integer |  |  |  | Network Inner VLAN ID |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;client</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.client") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vlan_id</samp>](## "ethernet_interfaces.[].vlan_id") | Integer |  |  | Min: 1<br>Max: 4094 |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_address</samp>](## "ethernet_interfaces.[].ip_address") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_address</samp>](## "ethernet_interfaces.[].ip_address") | String |  |  |  | IPv4_address or Mask |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_address_secondaries</samp>](## "ethernet_interfaces.[].ip_address_secondaries") | List, items: String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "ethernet_interfaces.[].ip_address_secondaries.[].&lt;str&gt;") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_helpers</samp>](## "ethernet_interfaces.[].ip_helpers") | List, items: Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- ip_helper</samp>](## "ethernet_interfaces.[].ip_helpers.[].ip_helper") | String | Required, Unique |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_interface</samp>](## "ethernet_interfaces.[].ip_helpers.[].source_interface") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "ethernet_interfaces.[].ip_helpers.[].vrf") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_interface</samp>](## "ethernet_interfaces.[].ip_helpers.[].source_interface") | String |  |  |  | Source interface name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "ethernet_interfaces.[].ip_helpers.[].vrf") | String |  |  |  | VRF name |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_enable</samp>](## "ethernet_interfaces.[].ipv6_enable") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_address</samp>](## "ethernet_interfaces.[].ipv6_address") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_address_link_local</samp>](## "ethernet_interfaces.[].ipv6_address_link_local") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_nd_ra_disabled</samp>](## "ethernet_interfaces.[].ipv6_nd_ra_disabled") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_address_link_local</samp>](## "ethernet_interfaces.[].ipv6_address_link_local") | String |  |  |  | Link local IPv6 address or mask |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_nd_ra_disabled</samp>](## "ethernet_interfaces.[].ipv6_nd_ra_disabled") | Boolean |  |  |  | IPv6 ND RA disabled |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_nd_managed_config_flag</samp>](## "ethernet_interfaces.[].ipv6_nd_managed_config_flag") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_nd_prefixes</samp>](## "ethernet_interfaces.[].ipv6_nd_prefixes") | List, items: Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- ipv6_prefix</samp>](## "ethernet_interfaces.[].ipv6_nd_prefixes.[].ipv6_prefix") | String | Required, Unique |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;valid_lifetime</samp>](## "ethernet_interfaces.[].ipv6_nd_prefixes.[].valid_lifetime") | String |  |  |  | Infinite or lifetime in seconds<br> |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;preferred_lifetime</samp>](## "ethernet_interfaces.[].ipv6_nd_prefixes.[].preferred_lifetime") | String |  |  |  | Infinite or lifetime in seconds<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;valid_lifetime</samp>](## "ethernet_interfaces.[].ipv6_nd_prefixes.[].valid_lifetime") | String |  |  |  | Infinite or lifetime in seconds |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;preferred_lifetime</samp>](## "ethernet_interfaces.[].ipv6_nd_prefixes.[].preferred_lifetime") | String |  |  |  | Infinite or lifetime in seconds |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;no_autoconfig_flag</samp>](## "ethernet_interfaces.[].ipv6_nd_prefixes.[].no_autoconfig_flag") | Boolean |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;access_group_in</samp>](## "ethernet_interfaces.[].access_group_in") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;access_group_out</samp>](## "ethernet_interfaces.[].access_group_out") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_access_group_in</samp>](## "ethernet_interfaces.[].ipv6_access_group_in") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_access_group_out</samp>](## "ethernet_interfaces.[].ipv6_access_group_out") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mac_access_group_in</samp>](## "ethernet_interfaces.[].mac_access_group_in") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mac_access_group_out</samp>](## "ethernet_interfaces.[].mac_access_group_out") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;multicast</samp>](## "ethernet_interfaces.[].multicast") | Dictionary |  |  |  | boundaries can be either 1 ACL or a list of multicast IP address_range(s)/prefix but not combination of both<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;access_group_in</samp>](## "ethernet_interfaces.[].access_group_in") | String |  |  |  | Access list name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;access_group_out</samp>](## "ethernet_interfaces.[].access_group_out") | String |  |  |  | Access list name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_access_group_in</samp>](## "ethernet_interfaces.[].ipv6_access_group_in") | String |  |  |  | IPv6 access list name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_access_group_out</samp>](## "ethernet_interfaces.[].ipv6_access_group_out") | String |  |  |  | IPv6 access list name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mac_access_group_in</samp>](## "ethernet_interfaces.[].mac_access_group_in") | String |  |  |  | MAC access list name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mac_access_group_out</samp>](## "ethernet_interfaces.[].mac_access_group_out") | String |  |  |  | MAC access list name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;multicast</samp>](## "ethernet_interfaces.[].multicast") | Dictionary |  |  |  | Boundaries can be either 1 ACL or a list of multicast IP address_range(s)/prefix but not combination of both |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4</samp>](## "ethernet_interfaces.[].multicast.ipv4") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;boundaries</samp>](## "ethernet_interfaces.[].multicast.ipv4.boundaries") | List, items: Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- boundary</samp>](## "ethernet_interfaces.[].multicast.ipv4.boundaries.[].boundary") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- boundary</samp>](## "ethernet_interfaces.[].multicast.ipv4.boundaries.[].boundary") | String |  |  |  | ACL name or multicast IP subnet |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;out</samp>](## "ethernet_interfaces.[].multicast.ipv4.boundaries.[].out") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;static</samp>](## "ethernet_interfaces.[].multicast.ipv4.static") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6</samp>](## "ethernet_interfaces.[].multicast.ipv6") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;boundaries</samp>](## "ethernet_interfaces.[].multicast.ipv6.boundaries") | List, items: Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- boundary</samp>](## "ethernet_interfaces.[].multicast.ipv6.boundaries.[].boundary") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- boundary</samp>](## "ethernet_interfaces.[].multicast.ipv6.boundaries.[].boundary") | String |  |  |  | ACL name or multicast IP subnet |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;static</samp>](## "ethernet_interfaces.[].multicast.ipv6.static") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ospf_network_point_to_point</samp>](## "ethernet_interfaces.[].ospf_network_point_to_point") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ospf_area</samp>](## "ethernet_interfaces.[].ospf_area") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ospf_cost</samp>](## "ethernet_interfaces.[].ospf_cost") | Integer |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ospf_authentication</samp>](## "ethernet_interfaces.[].ospf_authentication") | String |  |  | Valid Values:<br>- none<br>- simple<br>- message-digest |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ospf_authentication_key</samp>](## "ethernet_interfaces.[].ospf_authentication_key") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ospf_authentication_key</samp>](## "ethernet_interfaces.[].ospf_authentication_key") | String |  |  |  | Encrypted password |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ospf_message_digest_keys</samp>](## "ethernet_interfaces.[].ospf_message_digest_keys") | List, items: Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- id</samp>](## "ethernet_interfaces.[].ospf_message_digest_keys.[].id") | Integer | Required, Unique |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hash_algorithm</samp>](## "ethernet_interfaces.[].ospf_message_digest_keys.[].hash_algorithm") | String |  |  | Valid Values:<br>- md5<br>- sha1<br>- sha 256<br>- sha384<br>- sha512 |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "ethernet_interfaces.[].ospf_message_digest_keys.[].key") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hash_algorithm</samp>](## "ethernet_interfaces.[].ospf_message_digest_keys.[].hash_algorithm") | String |  |  | Valid Values:<br>- md5<br>- sha1<br>- sha256<br>- sha384<br>- sha512 |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "ethernet_interfaces.[].ospf_message_digest_keys.[].key") | String |  |  |  | Encrypted password |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;pim</samp>](## "ethernet_interfaces.[].pim") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4</samp>](## "ethernet_interfaces.[].pim.ipv4") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dr_priority</samp>](## "ethernet_interfaces.[].pim.ipv4.dr_priority") | Integer |  |  | Min: 0<br>Max: 429467295 |  |
@@ -914,14 +919,14 @@ errdisable:
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;channel_group</samp>](## "ethernet_interfaces.[].channel_group") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;id</samp>](## "ethernet_interfaces.[].channel_group.id") | Integer |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mode</samp>](## "ethernet_interfaces.[].channel_group.mode") | String |  |  | Valid Values:<br>- on<br>- active<br>- passive |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;isis_enable</samp>](## "ethernet_interfaces.[].isis_enable") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;isis_enable</samp>](## "ethernet_interfaces.[].isis_enable") | String |  |  |  | ISIS instance |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;isis_passive</samp>](## "ethernet_interfaces.[].isis_passive") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;isis_metric</samp>](## "ethernet_interfaces.[].isis_metric") | Integer |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;isis_network_point_to_point</samp>](## "ethernet_interfaces.[].isis_network_point_to_point") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;isis_circuit_type</samp>](## "ethernet_interfaces.[].isis_circuit_type") | String |  |  | Valid Values:<br>- level-1-2<br>- level-1<br>- level-2 |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;isis_hello_padding</samp>](## "ethernet_interfaces.[].isis_hello_padding") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;isis_authentication_mode</samp>](## "ethernet_interfaces.[].isis_authentication_mode") | String |  |  | Valid Values:<br>- text<br>- md5 |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;isis_authentication_key</samp>](## "ethernet_interfaces.[].isis_authentication_key") | String |  |  |  | Type-7 encrypted password<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;isis_authentication_key</samp>](## "ethernet_interfaces.[].isis_authentication_key") | String |  |  |  | Type-7 encrypted password |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ptp</samp>](## "ethernet_interfaces.[].ptp") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enable</samp>](## "ethernet_interfaces.[].ptp.enable") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;announce</samp>](## "ethernet_interfaces.[].ptp.announce") | Dictionary |  |  |  |  |
@@ -932,22 +937,22 @@ errdisable:
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;sync_message</samp>](## "ethernet_interfaces.[].ptp.sync_message") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interval</samp>](## "ethernet_interfaces.[].ptp.sync_message.interval") | Integer |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;role</samp>](## "ethernet_interfaces.[].ptp.role") | String |  |  | Valid Values:<br>- master<br>- dynamic |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlan</samp>](## "ethernet_interfaces.[].ptp.vlan") | String |  |  |  | all or list of vlans as string<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlan</samp>](## "ethernet_interfaces.[].ptp.vlan") | String |  |  |  | VLAN can be 'all' or list of vlans as string |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;transport</samp>](## "ethernet_interfaces.[].ptp.transport") | String |  |  | Valid Values:<br>- ipv4<br>- ipv6<br>- layer2 |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;profile</samp>](## "ethernet_interfaces.[].profile") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;storm_control</samp>](## "ethernet_interfaces.[].storm_control") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;all</samp>](## "ethernet_interfaces.[].storm_control.all") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level</samp>](## "ethernet_interfaces.[].storm_control.all.level") | Integer |  |  |  | Configure maximum storm-control level<br> |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unit</samp>](## "ethernet_interfaces.[].storm_control.all.unit") | String |  |  |  | Percent* | pps (optional and is hardware dependant - default is percent)<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level</samp>](## "ethernet_interfaces.[].storm_control.all.level") | Integer |  |  |  | Configure maximum storm-control level |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unit</samp>](## "ethernet_interfaces.[].storm_control.all.unit") | String |  | percent | Valid Values:<br>- percent<br>- pps | Optional field and is hardware dependant |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;broadcast</samp>](## "ethernet_interfaces.[].storm_control.broadcast") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level</samp>](## "ethernet_interfaces.[].storm_control.broadcast.level") | Integer |  |  |  | Configure maximum storm-control level<br> |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unit</samp>](## "ethernet_interfaces.[].storm_control.broadcast.unit") | String |  |  |  | Percent* | pps (optional and is hardware dependant - default is percent)<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level</samp>](## "ethernet_interfaces.[].storm_control.broadcast.level") | Integer |  |  |  | Configure maximum storm-control level |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unit</samp>](## "ethernet_interfaces.[].storm_control.broadcast.unit") | String |  | percent | Valid Values:<br>- percent<br>- pps | Optional field and is hardware dependant |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;multicast</samp>](## "ethernet_interfaces.[].storm_control.multicast") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level</samp>](## "ethernet_interfaces.[].storm_control.multicast.level") | Integer |  |  |  | Configure maximum storm-control level<br> |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unit</samp>](## "ethernet_interfaces.[].storm_control.multicast.unit") | String |  |  |  | Percent* | pps (optional and is hardware dependant - default is percent)<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level</samp>](## "ethernet_interfaces.[].storm_control.multicast.level") | Integer |  |  |  | Configure maximum storm-control level |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unit</samp>](## "ethernet_interfaces.[].storm_control.multicast.unit") | String |  | percent | Valid Values:<br>- percent<br>- pps | Optional field and is hardware dependant |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unknown_unicast</samp>](## "ethernet_interfaces.[].storm_control.unknown_unicast") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level</samp>](## "ethernet_interfaces.[].storm_control.unknown_unicast.level") | Integer |  |  |  | Configure maximum storm-control level<br> |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unit</samp>](## "ethernet_interfaces.[].storm_control.unknown_unicast.unit") | String |  |  |  | Percent* | pps (optional and is hardware dependant - default is percent)<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level</samp>](## "ethernet_interfaces.[].storm_control.unknown_unicast.level") | Integer |  |  |  | Configure maximum storm-control level |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unit</samp>](## "ethernet_interfaces.[].storm_control.unknown_unicast.unit") | String |  | percent | Valid Values:<br>- percent<br>- pps | Optional field and is hardware dependant |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;logging</samp>](## "ethernet_interfaces.[].logging") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;event</samp>](## "ethernet_interfaces.[].logging.event") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;link_status</samp>](## "ethernet_interfaces.[].logging.event.link_status") | Boolean |  |  |  |  |
@@ -955,12 +960,12 @@ errdisable:
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;lldp</samp>](## "ethernet_interfaces.[].lldp") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;transmit</samp>](## "ethernet_interfaces.[].lldp.transmit") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;receive</samp>](## "ethernet_interfaces.[].lldp.receive") | Boolean |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ztp_vlan</samp>](## "ethernet_interfaces.[].lldp.ztp_vlan") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ztp_vlan</samp>](## "ethernet_interfaces.[].lldp.ztp_vlan") | Integer |  |  |  | ZTP vlan number |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trunk_private_vlan_secondary</samp>](## "ethernet_interfaces.[].trunk_private_vlan_secondary") | Boolean |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;pvlan_mapping</samp>](## "ethernet_interfaces.[].pvlan_mapping") | Integer |  |  |  | List of vlans as string<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;pvlan_mapping</samp>](## "ethernet_interfaces.[].pvlan_mapping") | Integer |  |  |  | List of vlans as string |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vlan_translations</samp>](## "ethernet_interfaces.[].vlan_translations") | List, items: Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- from</samp>](## "ethernet_interfaces.[].vlan_translations.[].from") | String |  |  |  | List of vlans as string (only one vlan if direction is "both")<br> |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;to</samp>](## "ethernet_interfaces.[].vlan_translations.[].to") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- from</samp>](## "ethernet_interfaces.[].vlan_translations.[].from") | String |  |  |  | List of vlans as string (only one vlan if direction is "both") |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;to</samp>](## "ethernet_interfaces.[].vlan_translations.[].to") | Integer |  |  |  | VLAN id |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;direction</samp>](## "ethernet_interfaces.[].vlan_translations.[].direction") | String |  | both | Valid Values:<br>- in<br>- out<br>- both |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;dot1x</samp>](## "ethernet_interfaces.[].dot1x") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;port_control</samp>](## "ethernet_interfaces.[].dot1x.port_control") | String |  |  | Valid Values:<br>- auto<br>- force-authorized<br>- force-unauthorized |  |
@@ -974,17 +979,6 @@ errdisable:
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;host_mode</samp>](## "ethernet_interfaces.[].dot1x.host_mode") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mode</samp>](## "ethernet_interfaces.[].dot1x.host_mode.mode") | String |  |  | Valid Values:<br>- multi-host<br>- single-host |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;multi_host_authenticated</samp>](## "ethernet_interfaces.[].dot1x.host_mode.multi_host_authenticated") | Boolean |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mac_based_authentication</samp>](## "ethernet_interfaces.[].dot1x.host_mode.mac_based_authentication") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "ethernet_interfaces.[].dot1x.host_mode.mac_based_authentication.enabled") | Boolean |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;always</samp>](## "ethernet_interfaces.[].dot1x.host_mode.mac_based_authentication.always") | Boolean |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;host_mode_common</samp>](## "ethernet_interfaces.[].dot1x.host_mode.mac_based_authentication.host_mode_common") | Boolean |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;timeout</samp>](## "ethernet_interfaces.[].dot1x.host_mode.timeout") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;idle_host</samp>](## "ethernet_interfaces.[].dot1x.host_mode.timeout.idle_host") | Integer |  |  | Min: 10<br>Max: 65535 |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;quiet_period</samp>](## "ethernet_interfaces.[].dot1x.host_mode.timeout.quiet_period") | Integer |  |  | Min: 1<br>Max: 65535 |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;reauth_period</samp>](## "ethernet_interfaces.[].dot1x.host_mode.timeout.reauth_period") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;reauth_timeout_ignore</samp>](## "ethernet_interfaces.[].dot1x.host_mode.timeout.reauth_timeout_ignore") | Boolean |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tx_period</samp>](## "ethernet_interfaces.[].dot1x.host_mode.timeout.tx_period") | Integer |  |  | Min: 1<br>Max: 65535 |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;reauthorization_request_limit</samp>](## "ethernet_interfaces.[].dot1x.host_mode.reauthorization_request_limit") | Integer |  |  | Min: 1<br>Max: 10 |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mac_based_authentication</samp>](## "ethernet_interfaces.[].dot1x.mac_based_authentication") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "ethernet_interfaces.[].dot1x.mac_based_authentication.enabled") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;always</samp>](## "ethernet_interfaces.[].dot1x.mac_based_authentication.always") | Boolean |  |  |  |  |
@@ -992,17 +986,17 @@ errdisable:
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;timeout</samp>](## "ethernet_interfaces.[].dot1x.timeout") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;idle_host</samp>](## "ethernet_interfaces.[].dot1x.timeout.idle_host") | Integer |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;quiet_period</samp>](## "ethernet_interfaces.[].dot1x.timeout.quiet_period") | Integer |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;reauth_period</samp>](## "ethernet_interfaces.[].dot1x.timeout.reauth_period") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;reauth_period</samp>](## "ethernet_interfaces.[].dot1x.timeout.reauth_period") | String |  |  |  | Value can be 60-4294967295 or 'server' |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;reauth_timeout_ignore</samp>](## "ethernet_interfaces.[].dot1x.timeout.reauth_timeout_ignore") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tx_period</samp>](## "ethernet_interfaces.[].dot1x.timeout.tx_period") | Integer |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;reauthorization_request_limit</samp>](## "ethernet_interfaces.[].dot1x.reauthorization_request_limit") | Integer |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;service_profile</samp>](## "ethernet_interfaces.[].service_profile") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;reauthorization_request_limit</samp>](## "ethernet_interfaces.[].dot1x.reauthorization_request_limit") | Integer |  |  | Min: 1<br>Max: 10 |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;service_profile</samp>](## "ethernet_interfaces.[].service_profile") | String |  |  |  | QOS profile |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;shape</samp>](## "ethernet_interfaces.[].shape") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rate</samp>](## "ethernet_interfaces.[].shape.rate") | String |  |  |  | rate in kbps or 1-100 percent or rate in pps, supported options are platform dependent<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rate</samp>](## "ethernet_interfaces.[].shape.rate") | String |  |  |  | Rate in kbps or pps or 1-100 percent or rate in pps, supported options are platform dependent |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;qos</samp>](## "ethernet_interfaces.[].qos") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;trust</samp>](## "ethernet_interfaces.[].qos.trust") | String |  |  | Valid Values:<br>- dscp<br>- cos<br>- disabled |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dscp</samp>](## "ethernet_interfaces.[].qos.dscp") | Integer |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;cos</samp>](## "ethernet_interfaces.[].qos.cos") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dscp</samp>](## "ethernet_interfaces.[].qos.dscp") | Integer |  |  |  | DSCP value |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;cos</samp>](## "ethernet_interfaces.[].qos.cos") | Integer |  |  |  | COS value |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;spanning_tree_bpdufilter</samp>](## "ethernet_interfaces.[].spanning_tree_bpdufilter") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;spanning_tree_bpduguard</samp>](## "ethernet_interfaces.[].spanning_tree_bpduguard") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;spanning_tree_guard</samp>](## "ethernet_interfaces.[].spanning_tree_guard") | String |  |  | Valid Values:<br>- loop<br>- root<br>- disabled |  |
@@ -1015,12 +1009,12 @@ errdisable:
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;no_drop</samp>](## "ethernet_interfaces.[].priority_flow_control.priorities.[].no_drop") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;bfd</samp>](## "ethernet_interfaces.[].bfd") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;echo</samp>](## "ethernet_interfaces.[].bfd.echo") | Boolean |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interval</samp>](## "ethernet_interfaces.[].bfd.interval") | Integer |  |  |  | Interval in milliseconds<br> |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;min_rx</samp>](## "ethernet_interfaces.[].bfd.min_rx") | Integer |  |  |  | Rate in milliseconds<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interval</samp>](## "ethernet_interfaces.[].bfd.interval") | Integer |  |  |  | Interval in milliseconds |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;min_rx</samp>](## "ethernet_interfaces.[].bfd.min_rx") | Integer |  |  |  | Rate in milliseconds |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;multiplier</samp>](## "ethernet_interfaces.[].bfd.multiplier") | Integer |  |  | Min: 3<br>Max: 50 |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;service_policy</samp>](## "ethernet_interfaces.[].service_policy") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;pbr</samp>](## "ethernet_interfaces.[].service_policy.pbr") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;input</samp>](## "ethernet_interfaces.[].service_policy.pbr.input") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;input</samp>](## "ethernet_interfaces.[].service_policy.pbr.input") | String |  |  |  | Policy-map name |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mpls</samp>](## "ethernet_interfaces.[].mpls") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ip</samp>](## "ethernet_interfaces.[].mpls.ip") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ldp</samp>](## "ethernet_interfaces.[].mpls.ldp") | Dictionary |  |  |  |  |
@@ -1035,9 +1029,10 @@ errdisable:
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;override</samp>](## "ethernet_interfaces.[].transceiver.media.override") | String |  |  |  | Transceiver Type |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_proxy_arp</samp>](## "ethernet_interfaces.[].ip_proxy_arp") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;traffic_policy</samp>](## "ethernet_interfaces.[].traffic_policy") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;input</samp>](## "ethernet_interfaces.[].traffic_policy.input") | String |  |  |  | Ingress traffic policy<br> |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;output</samp>](## "ethernet_interfaces.[].traffic_policy.output") | String |  |  |  | Egress traffic policy<br> |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;eos_cli</samp>](## "ethernet_interfaces.[].eos_cli") | String |  |  |  | Multiline eos cli |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;input</samp>](## "ethernet_interfaces.[].traffic_policy.input") | String |  |  |  | Ingress traffic policy |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;output</samp>](## "ethernet_interfaces.[].traffic_policy.output") | String |  |  |  | Egress traffic policy |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;eos_cli</samp>](## "ethernet_interfaces.[].eos_cli") | String |  |  |  | Multiline eos cli. EOS CLI rendered directly on the ethernet interface in the final EOS configuration |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;struct_cfg</samp>](## "ethernet_interfaces.[].struct_cfg") | Dictionary |  |  |  |  |
 
 ### YAML
 
@@ -1068,6 +1063,8 @@ ethernet_interfaces:
     flowcontrol:
       received: <str>
     vrf: <str>
+    flow_tracker:
+      sampled: <str>
     error_correction_encoding:
       enabled: <bool>
       fire_code: <bool>
@@ -1219,17 +1216,6 @@ ethernet_interfaces:
       host_mode:
         mode: <str>
         multi_host_authenticated: <bool>
-        mac_based_authentication:
-          enabled: <bool>
-          always: <bool>
-          host_mode_common: <bool>
-        timeout:
-          idle_host: <int>
-          quiet_period: <int>
-          reauth_period: <str>
-          reauth_timeout_ignore: <bool>
-          tx_period: <int>
-        reauthorization_request_limit: <int>
       mac_based_authentication:
         enabled: <bool>
         always: <bool>
@@ -1283,6 +1269,7 @@ ethernet_interfaces:
       input: <str>
       output: <str>
     eos_cli: <str>
+    struct_cfg:
 ```
 
 ## Event Handlers

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -793,26 +793,20 @@ errdisable:
 
 ## Ethernet Interfaces
 
-### Description
-
-Routed interfaces
 ### Variables
 
 | Variable | Type | Required | Default | Value Restrictions | Description |
 | -------- | ---- | -------- | ------- | ------------------ | ----------- |
 | [<samp>ethernet_interfaces</samp>](## "ethernet_interfaces") | List, items: Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;- name</samp>](## "ethernet_interfaces.[].name") | String | Required, Unique |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;peer</samp>](## "ethernet_interfaces.[].peer") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;peer_interface</samp>](## "ethernet_interfaces.[].peer_interface") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;peer_type</samp>](## "ethernet_interfaces.[].peer_type") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;description</samp>](## "ethernet_interfaces.[].description") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;shutdown</samp>](## "ethernet_interfaces.[].shutdown") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;speed</samp>](## "ethernet_interfaces.[].speed") | String |  |  |  | Speed can be interface_speed or forced interface_speed or auto interface_speed |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mtu</samp>](## "ethernet_interfaces.[].mtu") | Integer |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;l2_mtu</samp>](## "ethernet_interfaces.[].l2_mtu") | Integer |  |  |  | If l2_mtu defined this profile should only be used for platforms supporting the "l2 mtu" CLI |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vlans</samp>](## "ethernet_interfaces.[].vlans") | String |  |  |  | List of vlans as string |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;l2_mtu</samp>](## "ethernet_interfaces.[].l2_mtu") | Integer |  |  |  | "l2_mtu" should only be defined for platforms supporting the "l2 mtu" CLI<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vlans</samp>](## "ethernet_interfaces.[].vlans") | String |  |  |  | List of switchport vlans as string.<br>For a trunk port this would be a range like "1-200,300"<br>For an access port this would be a single vlan "123"<br> |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;native_vlan</samp>](## "ethernet_interfaces.[].native_vlan") | Integer |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;native_vlan_tag</samp>](## "ethernet_interfaces.[].native_vlan_tag") | Boolean |  | False |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;native_vlan_tag</samp>](## "ethernet_interfaces.[].native_vlan_tag") | Boolean |  |  |  | If setting both native_vlan and native_vlan_tag, native_vlan_tag takes precedence |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mode</samp>](## "ethernet_interfaces.[].mode") | String |  |  | Valid Values:<br>- access<br>- dot1q-tunnel<br>- trunk<br>- trunk phone |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;phone</samp>](## "ethernet_interfaces.[].phone") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;trunk</samp>](## "ethernet_interfaces.[].phone.trunk") | String |  |  | Valid Values:<br>- tagged<br>- untagged |  |
@@ -822,9 +816,9 @@ Routed interfaces
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trunk_groups</samp>](## "ethernet_interfaces.[].trunk_groups") | List, items: String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "ethernet_interfaces.[].trunk_groups.[].&lt;str&gt;") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;type</samp>](## "ethernet_interfaces.[].type") | String |  |  | Valid Values:<br>- routed<br>- switched<br>- l3dot1q<br>- l2dot1q | l3dot1q and l2dot1q are used for sub-interfaces. The parent interface should be defined as routed. |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;snmp_trap_link_change</samp>](## "ethernet_interfaces.[].snmp_trap_link_change") | Boolean |  |  |  | SNMP trap link change |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;snmp_trap_link_change</samp>](## "ethernet_interfaces.[].snmp_trap_link_change") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;flowcontrol</samp>](## "ethernet_interfaces.[].flowcontrol") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;received</samp>](## "ethernet_interfaces.[].flowcontrol.received") | String |  |  | Valid Values:<br>- received<br>- send<br>- on |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;received</samp>](## "ethernet_interfaces.[].flowcontrol.received") | String |  |  | Valid Values:<br>- desired<br>- on<br>- off |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "ethernet_interfaces.[].vrf") | String |  |  |  | VRF name |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;flow_tracker</samp>](## "ethernet_interfaces.[].flow_tracker") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;sampled</samp>](## "ethernet_interfaces.[].flow_tracker.sampled") | String |  |  |  | Flow tracker name |
@@ -833,15 +827,15 @@ Routed interfaces
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;fire_code</samp>](## "ethernet_interfaces.[].error_correction_encoding.fire_code") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;reed_solomon</samp>](## "ethernet_interfaces.[].error_correction_encoding.reed_solomon") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;link_tracking_groups</samp>](## "ethernet_interfaces.[].link_tracking_groups") | List, items: Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "ethernet_interfaces.[].link_tracking_groups.[].name") | String |  |  |  | Group name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "ethernet_interfaces.[].link_tracking_groups.[].name") | String | Required, Unique |  |  | Group name |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;direction</samp>](## "ethernet_interfaces.[].link_tracking_groups.[].direction") | String |  |  | Valid Values:<br>- upstream<br>- downstream |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;evpn_ethernet_segment</samp>](## "ethernet_interfaces.[].evpn_ethernet_segment") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;identifier</samp>](## "ethernet_interfaces.[].evpn_ethernet_segment.identifier") | String |  |  |  | EVPN Ethernet Segment Identifier (Type 1 format) |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;redundancy</samp>](## "ethernet_interfaces.[].evpn_ethernet_segment.redundancy") | String |  |  | Valid Values:<br>- all-active<br>- single-active |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;designated_forwarder_election</samp>](## "ethernet_interfaces.[].evpn_ethernet_segment.designated_forwarder_election") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;algorithm</samp>](## "ethernet_interfaces.[].evpn_ethernet_segment.designated_forwarder_election.algorithm") | String |  |  | Valid Values:<br>- modulus<br>- preference |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;preference_value</samp>](## "ethernet_interfaces.[].evpn_ethernet_segment.designated_forwarder_election.preference_value") | Integer |  |  | Min: 0<br>Max: 65535 | Preference_value and dont_preempt are set for preference algorithm and are optional |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dont_preempt</samp>](## "ethernet_interfaces.[].evpn_ethernet_segment.designated_forwarder_election.dont_preempt") | Boolean |  | False |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;preference_value</samp>](## "ethernet_interfaces.[].evpn_ethernet_segment.designated_forwarder_election.preference_value") | Integer |  |  | Min: 0<br>Max: 65535 | Preference_value is only used when "algorithm" is "preference" |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dont_preempt</samp>](## "ethernet_interfaces.[].evpn_ethernet_segment.designated_forwarder_election.dont_preempt") | Boolean |  |  |  | Dont_preempt is only used when "algorithm" is "preference" |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hold_time</samp>](## "ethernet_interfaces.[].evpn_ethernet_segment.designated_forwarder_election.hold_time") | Integer |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;subsequent_hold_time</samp>](## "ethernet_interfaces.[].evpn_ethernet_segment.designated_forwarder_election.subsequent_hold_time") | Integer |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;candidate_reachability_required</samp>](## "ethernet_interfaces.[].evpn_ethernet_segment.designated_forwarder_election.candidate_reachability_required") | Boolean |  |  |  |  |
@@ -856,19 +850,15 @@ Routed interfaces
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlan</samp>](## "ethernet_interfaces.[].encapsulation_vlan.client.dot1q.vlan") | Integer |  |  |  | Client VLAN ID |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;outer</samp>](## "ethernet_interfaces.[].encapsulation_vlan.client.dot1q.outer") | Integer |  |  |  | Client Outer VLAN ID |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;inner</samp>](## "ethernet_interfaces.[].encapsulation_vlan.client.dot1q.inner") | Integer |  |  |  | Client Inner VLAN ID |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;outer</samp>](## "ethernet_interfaces.[].encapsulation_vlan.client.outer") | Integer |  |  |  | Client Outer VLAN ID |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;inner</samp>](## "ethernet_interfaces.[].encapsulation_vlan.client.inner") | Integer |  |  |  | Client Inner VLAN ID |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unmatched</samp>](## "ethernet_interfaces.[].encapsulation_vlan.client.unmatched") | Boolean |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;network</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network") | Dictionary |  |  |  | Network encapsulation is all optional, and skipped if using client unmatched. |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;network</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network") | Dictionary |  |  |  | Network encapsulations are all optional, and skipped if using client unmatched. |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dot1q</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.dot1q") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlan</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.dot1q.vlan") | Integer |  |  |  | Network VLAN ID |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;outer</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.dot1q.outer") | Integer |  |  |  | Network Outer VLAN ID |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;inner</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.dot1q.inner") | Integer |  |  |  | Network Inner VLAN ID |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;outer</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.outer") | Integer |  |  |  | Network Outer VLAN ID |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;inner</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.inner") | Integer |  |  |  | Network Inner VLAN ID |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;client</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.client") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vlan_id</samp>](## "ethernet_interfaces.[].vlan_id") | Integer |  |  | Min: 1<br>Max: 4094 |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_address</samp>](## "ethernet_interfaces.[].ip_address") | String |  |  |  | IPv4_address or Mask |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_address</samp>](## "ethernet_interfaces.[].ip_address") | String |  |  |  | IPv4 address/mask |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_address_secondaries</samp>](## "ethernet_interfaces.[].ip_address_secondaries") | List, items: String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "ethernet_interfaces.[].ip_address_secondaries.[].&lt;str&gt;") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_helpers</samp>](## "ethernet_interfaces.[].ip_helpers") | List, items: Dictionary |  |  |  |  |
@@ -877,8 +867,8 @@ Routed interfaces
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "ethernet_interfaces.[].ip_helpers.[].vrf") | String |  |  |  | VRF name |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_enable</samp>](## "ethernet_interfaces.[].ipv6_enable") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_address</samp>](## "ethernet_interfaces.[].ipv6_address") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_address_link_local</samp>](## "ethernet_interfaces.[].ipv6_address_link_local") | String |  |  |  | Link local IPv6 address or mask |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_nd_ra_disabled</samp>](## "ethernet_interfaces.[].ipv6_nd_ra_disabled") | Boolean |  |  |  | IPv6 ND RA disabled |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_address_link_local</samp>](## "ethernet_interfaces.[].ipv6_address_link_local") | String |  |  |  | Link local IPv6 address/mask |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_nd_ra_disabled</samp>](## "ethernet_interfaces.[].ipv6_nd_ra_disabled") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_nd_managed_config_flag</samp>](## "ethernet_interfaces.[].ipv6_nd_managed_config_flag") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_nd_prefixes</samp>](## "ethernet_interfaces.[].ipv6_nd_prefixes") | List, items: Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- ipv6_prefix</samp>](## "ethernet_interfaces.[].ipv6_nd_prefixes.[].ipv6_prefix") | String | Required, Unique |  |  |  |
@@ -939,7 +929,7 @@ Routed interfaces
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;role</samp>](## "ethernet_interfaces.[].ptp.role") | String |  |  | Valid Values:<br>- master<br>- dynamic |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlan</samp>](## "ethernet_interfaces.[].ptp.vlan") | String |  |  |  | VLAN can be 'all' or list of vlans as string |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;transport</samp>](## "ethernet_interfaces.[].ptp.transport") | String |  |  | Valid Values:<br>- ipv4<br>- ipv6<br>- layer2 |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;profile</samp>](## "ethernet_interfaces.[].profile") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;profile</samp>](## "ethernet_interfaces.[].profile") | String |  |  |  | Interface profile |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;storm_control</samp>](## "ethernet_interfaces.[].storm_control") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;all</samp>](## "ethernet_interfaces.[].storm_control.all") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level</samp>](## "ethernet_interfaces.[].storm_control.all.level") | Integer |  |  |  | Configure maximum storm-control level |
@@ -962,10 +952,10 @@ Routed interfaces
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;receive</samp>](## "ethernet_interfaces.[].lldp.receive") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ztp_vlan</samp>](## "ethernet_interfaces.[].lldp.ztp_vlan") | Integer |  |  |  | ZTP vlan number |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trunk_private_vlan_secondary</samp>](## "ethernet_interfaces.[].trunk_private_vlan_secondary") | Boolean |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;pvlan_mapping</samp>](## "ethernet_interfaces.[].pvlan_mapping") | Integer |  |  |  | List of vlans as string |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;pvlan_mapping</samp>](## "ethernet_interfaces.[].pvlan_mapping") | String |  |  |  | List of vlans as string |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vlan_translations</samp>](## "ethernet_interfaces.[].vlan_translations") | List, items: Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- from</samp>](## "ethernet_interfaces.[].vlan_translations.[].from") | String |  |  |  | List of vlans as string (only one vlan if direction is "both") |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;to</samp>](## "ethernet_interfaces.[].vlan_translations.[].to") | Integer |  |  |  | VLAN id |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- from</samp>](## "ethernet_interfaces.[].vlan_translations.[].from") | Integer |  |  |  | List of vlans as string (only one vlan if direction is "both") |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;to</samp>](## "ethernet_interfaces.[].vlan_translations.[].to") | Integer |  |  |  | VLAN ID |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;direction</samp>](## "ethernet_interfaces.[].vlan_translations.[].direction") | String |  | both | Valid Values:<br>- in<br>- out<br>- both |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;dot1x</samp>](## "ethernet_interfaces.[].dot1x") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;port_control</samp>](## "ethernet_interfaces.[].dot1x.port_control") | String |  |  | Valid Values:<br>- auto<br>- force-authorized<br>- force-unauthorized |  |
@@ -984,28 +974,28 @@ Routed interfaces
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;always</samp>](## "ethernet_interfaces.[].dot1x.mac_based_authentication.always") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;host_mode_common</samp>](## "ethernet_interfaces.[].dot1x.mac_based_authentication.host_mode_common") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;timeout</samp>](## "ethernet_interfaces.[].dot1x.timeout") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;idle_host</samp>](## "ethernet_interfaces.[].dot1x.timeout.idle_host") | Integer |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;quiet_period</samp>](## "ethernet_interfaces.[].dot1x.timeout.quiet_period") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;idle_host</samp>](## "ethernet_interfaces.[].dot1x.timeout.idle_host") | Integer |  |  | Min: 10<br>Max: 65535 |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;quiet_period</samp>](## "ethernet_interfaces.[].dot1x.timeout.quiet_period") | Integer |  |  | Min: 1<br>Max: 65535 |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;reauth_period</samp>](## "ethernet_interfaces.[].dot1x.timeout.reauth_period") | String |  |  |  | Value can be 60-4294967295 or 'server' |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;reauth_timeout_ignore</samp>](## "ethernet_interfaces.[].dot1x.timeout.reauth_timeout_ignore") | Boolean |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tx_period</samp>](## "ethernet_interfaces.[].dot1x.timeout.tx_period") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tx_period</samp>](## "ethernet_interfaces.[].dot1x.timeout.tx_period") | Integer |  |  | Min: 1<br>Max: 65535 |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;reauthorization_request_limit</samp>](## "ethernet_interfaces.[].dot1x.reauthorization_request_limit") | Integer |  |  | Min: 1<br>Max: 10 |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;service_profile</samp>](## "ethernet_interfaces.[].service_profile") | String |  |  |  | QOS profile |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;shape</samp>](## "ethernet_interfaces.[].shape") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rate</samp>](## "ethernet_interfaces.[].shape.rate") | String |  |  |  | Rate in kbps or pps or 1-100 percent or rate in pps, supported options are platform dependent |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rate</samp>](## "ethernet_interfaces.[].shape.rate") | String |  |  |  | Rate in kbps, pps or percent. Supported options are platform dependent.<br>Examples:<br>- "5000 kbps"<br>- "1000 pps"<br>- "20 percent"<br> |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;qos</samp>](## "ethernet_interfaces.[].qos") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;trust</samp>](## "ethernet_interfaces.[].qos.trust") | String |  |  | Valid Values:<br>- dscp<br>- cos<br>- disabled |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dscp</samp>](## "ethernet_interfaces.[].qos.dscp") | Integer |  |  |  | DSCP value |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;cos</samp>](## "ethernet_interfaces.[].qos.cos") | Integer |  |  |  | COS value |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;spanning_tree_bpdufilter</samp>](## "ethernet_interfaces.[].spanning_tree_bpdufilter") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;spanning_tree_bpduguard</samp>](## "ethernet_interfaces.[].spanning_tree_bpduguard") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;spanning_tree_bpdufilter</samp>](## "ethernet_interfaces.[].spanning_tree_bpdufilter") | String |  |  | Valid Values:<br>- enabled<br>- disabled<br>- true |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;spanning_tree_bpduguard</samp>](## "ethernet_interfaces.[].spanning_tree_bpduguard") | String |  |  | Valid Values:<br>- enabled<br>- disabled<br>- true |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;spanning_tree_guard</samp>](## "ethernet_interfaces.[].spanning_tree_guard") | String |  |  | Valid Values:<br>- loop<br>- root<br>- disabled |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;spanning_tree_portfast</samp>](## "ethernet_interfaces.[].spanning_tree_portfast") | String |  |  | Valid Values:<br>- edge<br>- network |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vmtracer</samp>](## "ethernet_interfaces.[].vmtracer") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;priority_flow_control</samp>](## "ethernet_interfaces.[].priority_flow_control") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "ethernet_interfaces.[].priority_flow_control.enabled") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;priorities</samp>](## "ethernet_interfaces.[].priority_flow_control.priorities") | List, items: Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- priority</samp>](## "ethernet_interfaces.[].priority_flow_control.priorities.[].priority") | Integer |  |  | Min: 0<br>Max: 7 |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- priority</samp>](## "ethernet_interfaces.[].priority_flow_control.priorities.[].priority") | Integer | Required, Unique |  | Min: 0<br>Max: 7 |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;no_drop</samp>](## "ethernet_interfaces.[].priority_flow_control.priorities.[].no_drop") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;bfd</samp>](## "ethernet_interfaces.[].bfd") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;echo</samp>](## "ethernet_interfaces.[].bfd.echo") | Boolean |  |  |  |  |
@@ -1031,17 +1021,16 @@ Routed interfaces
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;traffic_policy</samp>](## "ethernet_interfaces.[].traffic_policy") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;input</samp>](## "ethernet_interfaces.[].traffic_policy.input") | String |  |  |  | Ingress traffic policy |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;output</samp>](## "ethernet_interfaces.[].traffic_policy.output") | String |  |  |  | Egress traffic policy |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;eos_cli</samp>](## "ethernet_interfaces.[].eos_cli") | String |  |  |  | Multiline eos cli. EOS CLI rendered directly on the ethernet interface in the final EOS configuration |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;struct_cfg</samp>](## "ethernet_interfaces.[].struct_cfg") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;eos_cli</samp>](## "ethernet_interfaces.[].eos_cli") | String |  |  |  | Multiline EOS CLI rendered directly on the ethernet interface in the final EOS configuration |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;peer</samp>](## "ethernet_interfaces.[].peer") | String |  |  |  | Key only used for documentation or validation purposes |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;peer_interface</samp>](## "ethernet_interfaces.[].peer_interface") | String |  |  |  | Key only used for documentation or validation purposes |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;peer_type</samp>](## "ethernet_interfaces.[].peer_type") | String |  |  |  | Key only used for documentation or validation purposes |
 
 ### YAML
 
 ```yaml
 ethernet_interfaces:
   - name: <str>
-    peer: <str>
-    peer_interface: <str>
-    peer_type: <str>
     description: <str>
     shutdown: <bool>
     speed: <str>
@@ -1093,16 +1082,12 @@ ethernet_interfaces:
           vlan: <int>
           outer: <int>
           inner: <int>
-        outer: <int>
-        inner: <int>
         unmatched: <bool>
       network:
         dot1q:
           vlan: <int>
           outer: <int>
           inner: <int>
-        outer: <int>
-        inner: <int>
         client: <bool>
     vlan_id: <int>
     ip_address: <str>
@@ -1199,9 +1184,9 @@ ethernet_interfaces:
       receive: <bool>
       ztp_vlan: <int>
     trunk_private_vlan_secondary: <bool>
-    pvlan_mapping: <int>
+    pvlan_mapping: <str>
     vlan_translations:
-      - from: <str>
+      - from: <int>
         to: <int>
         direction: <str>
     dot1x:
@@ -1269,7 +1254,9 @@ ethernet_interfaces:
       input: <str>
       output: <str>
     eos_cli: <str>
-    struct_cfg:
+    peer: <str>
+    peer_interface: <str>
+    peer_type: <str>
 ```
 
 ## Event Handlers

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -791,7 +791,7 @@ errdisable:
     interval: <int>
 ```
 
-## Routed Ethernet Interfaces
+## Ethernet Interfaces
 
 ### Variables
 
@@ -850,17 +850,17 @@ errdisable:
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dot1q</samp>](## "ethernet_interfaces.[].encapsulation_vlan.client.dot1q") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlan</samp>](## "ethernet_interfaces.[].encapsulation_vlan.client.dot1q.vlan") | Integer |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;outer</samp>](## "ethernet_interfaces.[].encapsulation_vlan.client.dot1q.outer") | Integer |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;inner</samp>](## "ethernet_interfaces.[].encapsulation_vlan.client.dot1q.inner") | Integer |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;outer</samp>](## "ethernet_interfaces.[].encapsulation_vlan.client.outer") | Integer |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;inner</samp>](## "ethernet_interfaces.[].encapsulation_vlan.client.inner") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;inner</samp>](## "ethernet_interfaces.[].encapsulation_vlan.client.dot1q.inner") | Integer |  |  |  | Client Inner VLAN ID |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;outer</samp>](## "ethernet_interfaces.[].encapsulation_vlan.client.outer") | Integer |  |  |  | Client Outer VLAN ID |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;inner</samp>](## "ethernet_interfaces.[].encapsulation_vlan.client.inner") | Integer |  |  |  | Client Inner VLAN ID |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unmatched</samp>](## "ethernet_interfaces.[].encapsulation_vlan.client.unmatched") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;network</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network") | Dictionary |  |  |  | Network encapsulation is all optional, and skipped if using client unmatched.<br> |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dot1q</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.dot1q") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlan</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.dot1q.vlan") | Integer |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;outer</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.dot1q.outer") | Integer |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;inner</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.dot1q.inner") | Integer |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;outer</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.outer") | Integer |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;inner</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.inner") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlan</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.dot1q.vlan") | Integer |  |  |  | Network VLAN ID |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;outer</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.dot1q.outer") | Integer |  |  |  | Network Outer VLAN ID |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;inner</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.dot1q.inner") | Integer |  |  |  | Network Inner VLAN ID |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;outer</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.outer") | Integer |  |  |  | Network Outer VLAN ID |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;inner</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.inner") | Integer |  |  |  | Network Inner VLAN ID |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;client</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.client") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vlan_id</samp>](## "ethernet_interfaces.[].vlan_id") | Integer |  |  | Min: 1<br>Max: 4094 |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_address</samp>](## "ethernet_interfaces.[].ip_address") | String |  |  |  |  |
@@ -877,8 +877,8 @@ errdisable:
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_nd_managed_config_flag</samp>](## "ethernet_interfaces.[].ipv6_nd_managed_config_flag") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_nd_prefixes</samp>](## "ethernet_interfaces.[].ipv6_nd_prefixes") | List, items: Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- ipv6_prefix</samp>](## "ethernet_interfaces.[].ipv6_nd_prefixes.[].ipv6_prefix") | String | Required, Unique |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;valid_lifetime</samp>](## "ethernet_interfaces.[].ipv6_nd_prefixes.[].valid_lifetime") | String |  |  |  | < infinite or lifetime in seconds ><br> |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;preferred_lifetime</samp>](## "ethernet_interfaces.[].ipv6_nd_prefixes.[].preferred_lifetime") | String |  |  |  | < infinite or lifetime in seconds ><br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;valid_lifetime</samp>](## "ethernet_interfaces.[].ipv6_nd_prefixes.[].valid_lifetime") | String |  |  |  | Infinite or lifetime in seconds<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;preferred_lifetime</samp>](## "ethernet_interfaces.[].ipv6_nd_prefixes.[].preferred_lifetime") | String |  |  |  | Infinite or lifetime in seconds<br> |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;no_autoconfig_flag</samp>](## "ethernet_interfaces.[].ipv6_nd_prefixes.[].no_autoconfig_flag") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;access_group_in</samp>](## "ethernet_interfaces.[].access_group_in") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;access_group_out</samp>](## "ethernet_interfaces.[].access_group_out") | String |  |  |  |  |
@@ -921,7 +921,7 @@ errdisable:
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;isis_circuit_type</samp>](## "ethernet_interfaces.[].isis_circuit_type") | String |  |  | Valid Values:<br>- level-1-2<br>- level-1<br>- level-2 |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;isis_hello_padding</samp>](## "ethernet_interfaces.[].isis_hello_padding") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;isis_authentication_mode</samp>](## "ethernet_interfaces.[].isis_authentication_mode") | String |  |  | Valid Values:<br>- text<br>- md5 |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;isis_authentication_key</samp>](## "ethernet_interfaces.[].isis_authentication_key") | String |  |  |  | type-7 encrypted password<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;isis_authentication_key</samp>](## "ethernet_interfaces.[].isis_authentication_key") | String |  |  |  | Type-7 encrypted password<br> |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ptp</samp>](## "ethernet_interfaces.[].ptp") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enable</samp>](## "ethernet_interfaces.[].ptp.enable") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;announce</samp>](## "ethernet_interfaces.[].ptp.announce") | Dictionary |  |  |  |  |
@@ -932,7 +932,7 @@ errdisable:
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;sync_message</samp>](## "ethernet_interfaces.[].ptp.sync_message") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interval</samp>](## "ethernet_interfaces.[].ptp.sync_message.interval") | Integer |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;role</samp>](## "ethernet_interfaces.[].ptp.role") | String |  |  | Valid Values:<br>- master<br>- dynamic |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlan</samp>](## "ethernet_interfaces.[].ptp.vlan") | String |  |  |  | < all | list of vlans as string ><br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlan</samp>](## "ethernet_interfaces.[].ptp.vlan") | String |  |  |  | all or list of vlans as string<br> |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;transport</samp>](## "ethernet_interfaces.[].ptp.transport") | String |  |  | Valid Values:<br>- ipv4<br>- ipv6<br>- layer2 |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;profile</samp>](## "ethernet_interfaces.[].profile") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;storm_control</samp>](## "ethernet_interfaces.[].storm_control") | Dictionary |  |  |  |  |
@@ -998,7 +998,7 @@ errdisable:
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;reauthorization_request_limit</samp>](## "ethernet_interfaces.[].dot1x.reauthorization_request_limit") | Integer |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;service_profile</samp>](## "ethernet_interfaces.[].service_profile") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;shape</samp>](## "ethernet_interfaces.[].shape") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rate</samp>](## "ethernet_interfaces.[].shape.rate") | String |  |  |  | < "< rate > kbps" | "1-100 percent" | "< rate > pps" , supported options are platform dependent ><br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rate</samp>](## "ethernet_interfaces.[].shape.rate") | String |  |  |  | rate in kbps or 1-100 percent or rate in pps, supported options are platform dependent<br> |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;qos</samp>](## "ethernet_interfaces.[].qos") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;trust</samp>](## "ethernet_interfaces.[].qos.trust") | String |  |  | Valid Values:<br>- dscp<br>- cos<br>- disabled |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dscp</samp>](## "ethernet_interfaces.[].qos.dscp") | Integer |  |  |  |  |
@@ -1032,12 +1032,12 @@ errdisable:
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;lacp_port_priority</samp>](## "ethernet_interfaces.[].lacp_port_priority") | Integer |  |  | Min: 0<br>Max: 65535 |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;transceiver</samp>](## "ethernet_interfaces.[].transceiver") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;media</samp>](## "ethernet_interfaces.[].transceiver.media") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;override</samp>](## "ethernet_interfaces.[].transceiver.media.override") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;override</samp>](## "ethernet_interfaces.[].transceiver.media.override") | String |  |  |  | Transceiver Type |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_proxy_arp</samp>](## "ethernet_interfaces.[].ip_proxy_arp") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;traffic_policy</samp>](## "ethernet_interfaces.[].traffic_policy") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;input</samp>](## "ethernet_interfaces.[].traffic_policy.input") | String |  |  |  | ingress traffic policy<br> |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;output</samp>](## "ethernet_interfaces.[].traffic_policy.output") | String |  |  |  | egress traffic policy<br> |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;eos_cli</samp>](## "ethernet_interfaces.[].eos_cli") | String |  |  |  | < multiline eos cli > |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;input</samp>](## "ethernet_interfaces.[].traffic_policy.input") | String |  |  |  | Ingress traffic policy<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;output</samp>](## "ethernet_interfaces.[].traffic_policy.output") | String |  |  |  | Egress traffic policy<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;eos_cli</samp>](## "ethernet_interfaces.[].eos_cli") | String |  |  |  | Multiline eos cli |
 
 ### YAML
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -804,7 +804,7 @@ errdisable:
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;speed</samp>](## "ethernet_interfaces.[].speed") | String |  |  |  | Speed can be interface_speed or forced interface_speed or auto interface_speed |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mtu</samp>](## "ethernet_interfaces.[].mtu") | Integer |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;l2_mtu</samp>](## "ethernet_interfaces.[].l2_mtu") | Integer |  |  |  | "l2_mtu" should only be defined for platforms supporting the "l2 mtu" CLI<br> |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vlans</samp>](## "ethernet_interfaces.[].vlans") | String |  |  |  | List of switchport vlans as string.<br>For a trunk port this would be a range like "1-200,300"<br>For an access port this would be a single vlan "123"<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vlans</samp>](## "ethernet_interfaces.[].vlans") | String |  |  |  | List of switchport vlans as string<br>For a trunk port this would be a range like "1-200,300"<br>For an access port this would be a single vlan "123"<br> |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;native_vlan</samp>](## "ethernet_interfaces.[].native_vlan") | Integer |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;native_vlan_tag</samp>](## "ethernet_interfaces.[].native_vlan_tag") | Boolean |  |  |  | If setting both native_vlan and native_vlan_tag, native_vlan_tag takes precedence |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mode</samp>](## "ethernet_interfaces.[].mode") | String |  |  | Valid Values:<br>- access<br>- dot1q-tunnel<br>- trunk<br>- trunk phone |  |
@@ -815,7 +815,7 @@ errdisable:
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;encapsulation_dot1q_vlan</samp>](## "ethernet_interfaces.[].l2_protocol.encapsulation_dot1q_vlan") | Integer |  |  |  | Vlan tag to configure on sub-interface |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trunk_groups</samp>](## "ethernet_interfaces.[].trunk_groups") | List, items: String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "ethernet_interfaces.[].trunk_groups.[].&lt;str&gt;") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;type</samp>](## "ethernet_interfaces.[].type") | String |  |  | Valid Values:<br>- routed<br>- switched<br>- l3dot1q<br>- l2dot1q | l3dot1q and l2dot1q are used for sub-interfaces. The parent interface should be defined as routed. |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;type</samp>](## "ethernet_interfaces.[].type") | String |  |  | Valid Values:<br>- routed<br>- switched<br>- l3dot1q<br>- l2dot1q | l3dot1q and l2dot1q are used for sub-interfaces<br>The parent interface should be defined as routed<br> |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;snmp_trap_link_change</samp>](## "ethernet_interfaces.[].snmp_trap_link_change") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;flowcontrol</samp>](## "ethernet_interfaces.[].flowcontrol") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;received</samp>](## "ethernet_interfaces.[].flowcontrol.received") | String |  |  | Valid Values:<br>- desired<br>- on<br>- off |  |
@@ -851,11 +851,11 @@ errdisable:
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;outer</samp>](## "ethernet_interfaces.[].encapsulation_vlan.client.dot1q.outer") | Integer |  |  |  | Client Outer VLAN ID |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;inner</samp>](## "ethernet_interfaces.[].encapsulation_vlan.client.dot1q.inner") | Integer |  |  |  | Client Inner VLAN ID |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unmatched</samp>](## "ethernet_interfaces.[].encapsulation_vlan.client.unmatched") | Boolean |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;network</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network") | Dictionary |  |  |  | Network encapsulations are all optional, and skipped if using client unmatched. |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;network</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network") | Dictionary |  |  |  | Network encapsulations are all optional and skipped if using client unmatched |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dot1q</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.dot1q") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlan</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.dot1q.vlan") | Integer |  |  |  | Network VLAN ID |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;outer</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.dot1q.outer") | Integer |  |  |  | Network Outer VLAN ID |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;inner</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.dot1q.inner") | Integer |  |  |  | Network Inner VLAN ID |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;outer</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.dot1q.outer") | Integer |  |  |  | Network outer VLAN ID |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;inner</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.dot1q.inner") | Integer |  |  |  | Network inner VLAN ID |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;client</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.client") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vlan_id</samp>](## "ethernet_interfaces.[].vlan_id") | Integer |  |  | Min: 1<br>Max: 4094 |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_address</samp>](## "ethernet_interfaces.[].ip_address") | String |  |  |  | IPv4 address/mask |
@@ -982,7 +982,7 @@ errdisable:
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;reauthorization_request_limit</samp>](## "ethernet_interfaces.[].dot1x.reauthorization_request_limit") | Integer |  |  | Min: 1<br>Max: 10 |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;service_profile</samp>](## "ethernet_interfaces.[].service_profile") | String |  |  |  | QOS profile |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;shape</samp>](## "ethernet_interfaces.[].shape") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rate</samp>](## "ethernet_interfaces.[].shape.rate") | String |  |  |  | Rate in kbps, pps or percent. Supported options are platform dependent.<br>Examples:<br>- "5000 kbps"<br>- "1000 pps"<br>- "20 percent"<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rate</samp>](## "ethernet_interfaces.[].shape.rate") | String |  |  |  | Rate in kbps, pps or percent<br>Supported options are platform dependent<br>Examples:<br>- "5000 kbps"<br>- "1000 pps"<br>- "20 percent"<br> |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;qos</samp>](## "ethernet_interfaces.[].qos") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;trust</samp>](## "ethernet_interfaces.[].qos.trust") | String |  |  | Valid Values:<br>- dscp<br>- cos<br>- disabled |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dscp</samp>](## "ethernet_interfaces.[].qos.dscp") | Integer |  |  |  | DSCP value |
@@ -1016,15 +1016,15 @@ errdisable:
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;lacp_port_priority</samp>](## "ethernet_interfaces.[].lacp_port_priority") | Integer |  |  | Min: 0<br>Max: 65535 |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;transceiver</samp>](## "ethernet_interfaces.[].transceiver") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;media</samp>](## "ethernet_interfaces.[].transceiver.media") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;override</samp>](## "ethernet_interfaces.[].transceiver.media.override") | String |  |  |  | Transceiver Type |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;override</samp>](## "ethernet_interfaces.[].transceiver.media.override") | String |  |  |  | Transceiver type |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_proxy_arp</samp>](## "ethernet_interfaces.[].ip_proxy_arp") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;traffic_policy</samp>](## "ethernet_interfaces.[].traffic_policy") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;input</samp>](## "ethernet_interfaces.[].traffic_policy.input") | String |  |  |  | Ingress traffic policy |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;output</samp>](## "ethernet_interfaces.[].traffic_policy.output") | String |  |  |  | Egress traffic policy |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;eos_cli</samp>](## "ethernet_interfaces.[].eos_cli") | String |  |  |  | Multiline EOS CLI rendered directly on the ethernet interface in the final EOS configuration |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;peer</samp>](## "ethernet_interfaces.[].peer") | String |  |  |  | Key only used for documentation or validation purposes |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;peer_interface</samp>](## "ethernet_interfaces.[].peer_interface") | String |  |  |  | Key only used for documentation or validation purposes |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;peer_type</samp>](## "ethernet_interfaces.[].peer_type") | String |  |  |  | Key only used for documentation or validation purposes |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;eos_cli</samp>](## "ethernet_interfaces.[].eos_cli") | String |  |  |  | Multiline EOS CLI rendered directly on the ethernet interface in the final EOS configuration |
 
 ### YAML
 
@@ -1253,10 +1253,10 @@ ethernet_interfaces:
     traffic_policy:
       input: <str>
       output: <str>
-    eos_cli: <str>
     peer: <str>
     peer_interface: <str>
     peer_type: <str>
+    eos_cli: <str>
 ```
 
 ## Event Handlers

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -1520,7 +1520,7 @@
               }
             },
             "additionalProperties": false,
-            "title": "Evpn Ethernet Segment"
+            "title": "EVPN Ethernet Segment"
           },
           "encapsulation_dot1q_vlan": {
             "type": "integer",
@@ -2039,7 +2039,7 @@
               }
             },
             "additionalProperties": false,
-            "title": "Ptp"
+            "title": "PTP"
           },
           "profile": {
             "type": "string",
@@ -2176,7 +2176,7 @@
               "ztp_vlan": {
                 "type": "integer",
                 "description": "ZTP vlan number",
-                "title": "Ztp VLAN"
+                "title": "ZTP VLAN"
               }
             },
             "additionalProperties": false,
@@ -2253,7 +2253,7 @@
                   }
                 },
                 "additionalProperties": false,
-                "title": "Pae"
+                "title": "PAE"
               },
               "authentication_failure": {
                 "type": "object",
@@ -2517,7 +2517,7 @@
                   },
                   "igp_sync": {
                     "type": "boolean",
-                    "title": "Igp Sync"
+                    "title": "IGP Sync"
                   }
                 },
                 "additionalProperties": false,
@@ -2546,13 +2546,13 @@
               }
             },
             "additionalProperties": false,
-            "title": "Lacp Timer"
+            "title": "LACP Timer"
           },
           "lacp_port_priority": {
             "type": "integer",
             "minimum": 0,
             "maximum": 65535,
-            "title": "Lacp Port Priority"
+            "title": "LACP Port Priority"
           },
           "transceiver": {
             "type": "object",
@@ -7954,7 +7954,7 @@
                   }
                 },
                 "additionalProperties": false,
-                "title": "Rd Evpn Domain"
+                "title": "Rd EVPN Domain"
               },
               "route_targets": {
                 "type": "object",
@@ -8000,7 +8000,7 @@
                       },
                       "additionalProperties": false
                     },
-                    "title": "Import Evpn Domains"
+                    "title": "Import EVPN Domains"
                   },
                   "export_evpn_domains": {
                     "type": "array",
@@ -8022,7 +8022,7 @@
                       },
                       "additionalProperties": false
                     },
-                    "title": "Export Evpn Domains"
+                    "title": "Export EVPN Domains"
                   },
                   "import_export_evpn_domains": {
                     "type": "array",
@@ -8044,7 +8044,7 @@
                       },
                       "additionalProperties": false
                     },
-                    "title": "Import Export Evpn Domains"
+                    "title": "Import Export EVPN Domains"
                   }
                 },
                 "additionalProperties": false,
@@ -8114,7 +8114,7 @@
                   }
                 },
                 "additionalProperties": false,
-                "title": "Rd Evpn Domain"
+                "title": "Rd EVPN Domain"
               },
               "eos_cli": {
                 "type": "string",
@@ -8165,7 +8165,7 @@
                       },
                       "additionalProperties": false
                     },
-                    "title": "Import Evpn Domains"
+                    "title": "Import EVPN Domains"
                   },
                   "export_evpn_domains": {
                     "type": "array",
@@ -8187,7 +8187,7 @@
                       },
                       "additionalProperties": false
                     },
-                    "title": "Export Evpn Domains"
+                    "title": "Export EVPN Domains"
                   },
                   "import_export_evpn_domains": {
                     "type": "array",
@@ -8209,7 +8209,7 @@
                       },
                       "additionalProperties": false
                     },
-                    "title": "Import Export Evpn Domains"
+                    "title": "Import Export EVPN Domains"
                   }
                 },
                 "additionalProperties": false,
@@ -8348,7 +8348,7 @@
                     }
                   },
                   "additionalProperties": false,
-                  "title": "Next Hop Self Received Evpn Routes"
+                  "title": "Next Hop Self Received EVPN Routes"
                 }
               },
               "additionalProperties": false,
@@ -8420,7 +8420,7 @@
                 }
               },
               "additionalProperties": false,
-              "title": "Evpn Hostflap Detection"
+              "title": "EVPN Hostflap Detection"
             },
             "route": {
               "type": "object",
@@ -8438,7 +8438,7 @@
             }
           },
           "additionalProperties": false,
-          "title": "Address Family Evpn"
+          "title": "Address Family EVPN"
         },
         "address_family_rtc": {
           "type": "object",
@@ -9079,7 +9079,7 @@
               },
               "evpn_multicast": {
                 "type": "boolean",
-                "title": "Evpn Multicast"
+                "title": "EVPN Multicast"
               },
               "evpn_multicast_address_family": {
                 "type": "object",
@@ -13624,7 +13624,7 @@
                     }
                   },
                   "additionalProperties": false,
-                  "title": "BFD Vtep Evpn"
+                  "title": "BFD Vtep EVPN"
                 },
                 "qos": {
                   "type": "object",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -1243,6 +1243,7 @@
     },
     "ethernet_interfaces": {
       "type": "array",
+      "description": "Routed interfaces",
       "items": {
         "type": "object",
         "properties": {
@@ -1272,7 +1273,7 @@
           },
           "speed": {
             "type": "string",
-            "description": "< interface_speed | forced interface_speed | auto interface_speed >\n",
+            "description": "Speed can be interface_speed or forced interface_speed or auto interface_speed",
             "title": "Speed"
           },
           "mtu": {
@@ -1281,12 +1282,12 @@
           },
           "l2_mtu": {
             "type": "integer",
-            "description": "l2-mtu - if defined this profile should only be used for platforms supporting the \"l2 mtu\" CLI\n",
+            "description": "If l2_mtu defined this profile should only be used for platforms supporting the \"l2 mtu\" CLI",
             "title": "L2 MTU"
           },
           "vlans": {
             "type": "string",
-            "description": "< list of vlans as string\n",
+            "description": "List of vlans as string",
             "title": "VLANs"
           },
           "native_vlan": {
@@ -1334,6 +1335,7 @@
             "properties": {
               "encapsulation_dot1q_vlan": {
                 "type": "integer",
+                "description": "Vlan tag to configure on sub-interface",
                 "title": "Encapsulation Dot1Q VLAN"
               }
             },
@@ -1355,12 +1357,13 @@
               "l3dot1q",
               "l2dot1q"
             ],
-            "description": "l3dot1q and l2dot1q are used for sub-interfaces. The parent interface should be defined as routed.\n",
+            "description": "l3dot1q and l2dot1q are used for sub-interfaces. The parent interface should be defined as routed.",
             "title": "Type"
           },
           "snmp_trap_link_change": {
-            "title": "SNMP Trap Link Change",
-            "type": "boolean"
+            "type": "boolean",
+            "description": "SNMP trap link change",
+            "title": "Snmp Trap Link Change"
           },
           "flowcontrol": {
             "type": "object",
@@ -1379,8 +1382,21 @@
             "title": "Flowcontrol"
           },
           "vrf": {
-            "title": "VRF Name",
-            "type": "string"
+            "type": "string",
+            "description": "VRF name",
+            "title": "VRF"
+          },
+          "flow_tracker": {
+            "type": "object",
+            "properties": {
+              "sampled": {
+                "type": "string",
+                "description": "Flow tracker name",
+                "title": "Sampled"
+              }
+            },
+            "additionalProperties": false,
+            "title": "Flow Tracker"
           },
           "error_correction_encoding": {
             "type": "object",
@@ -1409,6 +1425,7 @@
               "properties": {
                 "name": {
                   "type": "string",
+                  "description": "Group name",
                   "title": "Name"
                 },
                 "direction": {
@@ -1429,7 +1446,7 @@
             "properties": {
               "identifier": {
                 "type": "string",
-                "description": "EVPN Ethernet Segment Identifier (Type 1 format)\n",
+                "description": "EVPN Ethernet Segment Identifier (Type 1 format)",
                 "title": "Identifier"
               },
               "redundancy": {
@@ -1455,7 +1472,7 @@
                     "type": "integer",
                     "minimum": 0,
                     "maximum": 65535,
-                    "description": "Preference_value and dont_preempt are set for preference algorithm and are optional\n",
+                    "description": "Preference_value and dont_preempt are set for preference algorithm and are optional",
                     "title": "Preference Value"
                   },
                   "dont_preempt": {
@@ -1498,7 +1515,7 @@
               },
               "route_target": {
                 "type": "string",
-                "description": "EVPN Route Target for ESI with format xx:xx:xx:xx:xx:xx\n",
+                "description": "EVPN Route Target for ESI with format xx:xx:xx:xx:xx:xx",
                 "title": "Route Target"
               }
             },
@@ -1507,7 +1524,7 @@
           },
           "encapsulation_dot1q_vlan": {
             "type": "integer",
-            "description": "vlan tag to configure on sub-interface\n",
+            "description": "VLAN tag to configure on sub-interface",
             "title": "Encapsulation Dot1Q VLAN"
           },
           "encapsulation_vlan": {
@@ -1521,11 +1538,13 @@
                     "properties": {
                       "vlan": {
                         "type": "integer",
+                        "description": "Client VLAN ID",
                         "title": "VLAN"
                       },
                       "outer": {
-                        "title": "Client Outer VLAN ID",
-                        "type": "integer"
+                        "type": "integer",
+                        "description": "Client Outer VLAN ID",
+                        "title": "Outer"
                       },
                       "inner": {
                         "type": "integer",
@@ -1556,7 +1575,7 @@
               },
               "network": {
                 "type": "object",
-                "description": "Network encapsulation is all optional, and skipped if using client unmatched.\n",
+                "description": "Network encapsulation is all optional, and skipped if using client unmatched.",
                 "properties": {
                   "dot1q": {
                     "type": "object",
@@ -1610,6 +1629,7 @@
           },
           "ip_address": {
             "type": "string",
+            "description": "IPv4_address or Mask",
             "title": "IP Address"
           },
           "ip_address_secondaries": {
@@ -1630,10 +1650,12 @@
                 },
                 "source_interface": {
                   "type": "string",
+                  "description": "Source interface name",
                   "title": "Source Interface"
                 },
                 "vrf": {
                   "type": "string",
+                  "description": "VRF name",
                   "title": "VRF"
                 }
               },
@@ -1654,11 +1676,13 @@
           },
           "ipv6_address_link_local": {
             "type": "string",
+            "description": "Link local IPv6 address or mask",
             "title": "IPv6 Address Link Local"
           },
           "ipv6_nd_ra_disabled": {
-            "title": "IPv6 ND RA Disabled",
-            "type": "boolean"
+            "type": "boolean",
+            "description": "IPv6 ND RA disabled",
+            "title": "IPv6 ND RA Disabled"
           },
           "ipv6_nd_managed_config_flag": {
             "type": "boolean",
@@ -1675,12 +1699,12 @@
                 },
                 "valid_lifetime": {
                   "type": "string",
-                  "description": "Infinite or lifetime in seconds\n",
+                  "description": "Infinite or lifetime in seconds",
                   "title": "Valid Lifetime"
                 },
                 "preferred_lifetime": {
                   "type": "string",
-                  "description": "Infinite or lifetime in seconds\n",
+                  "description": "Infinite or lifetime in seconds",
                   "title": "Preferred Lifetime"
                 },
                 "no_autoconfig_flag": {
@@ -1697,31 +1721,37 @@
           },
           "access_group_in": {
             "type": "string",
+            "description": "Access list name",
             "title": "Access Group In"
           },
           "access_group_out": {
             "type": "string",
+            "description": "Access list name",
             "title": "Access Group Out"
           },
           "ipv6_access_group_in": {
             "type": "string",
+            "description": "IPv6 access list name",
             "title": "IPv6 Access Group In"
           },
           "ipv6_access_group_out": {
             "type": "string",
+            "description": "IPv6 access list name",
             "title": "IPv6 Access Group Out"
           },
           "mac_access_group_in": {
             "type": "string",
+            "description": "MAC access list name",
             "title": "MAC Access Group In"
           },
           "mac_access_group_out": {
             "type": "string",
+            "description": "MAC access list name",
             "title": "MAC Access Group Out"
           },
           "multicast": {
             "type": "object",
-            "description": "boundaries can be either 1 ACL or a list of multicast IP address_range(s)/prefix but not combination of both\n",
+            "description": "Boundaries can be either 1 ACL or a list of multicast IP address_range(s)/prefix but not combination of both",
             "properties": {
               "ipv4": {
                 "type": "object",
@@ -1733,6 +1763,7 @@
                       "properties": {
                         "boundary": {
                           "type": "string",
+                          "description": "ACL name or multicast IP subnet",
                           "title": "Boundary"
                         },
                         "out": {
@@ -1762,6 +1793,7 @@
                       "properties": {
                         "boundary": {
                           "type": "string",
+                          "description": "ACL name or multicast IP subnet",
                           "title": "Boundary"
                         }
                       },
@@ -1804,6 +1836,7 @@
           },
           "ospf_authentication_key": {
             "type": "string",
+            "description": "Encrypted password",
             "title": "OSPF Authentication Key"
           },
           "ospf_message_digest_keys": {
@@ -1812,15 +1845,15 @@
               "type": "object",
               "properties": {
                 "id": {
-                  "title": "ID",
-                  "type": "integer"
+                  "type": "integer",
+                  "title": "ID"
                 },
                 "hash_algorithm": {
                   "type": "string",
                   "enum": [
                     "md5",
                     "sha1",
-                    "sha 256",
+                    "sha256",
                     "sha384",
                     "sha512"
                   ],
@@ -1828,6 +1861,7 @@
                 },
                 "key": {
                   "type": "string",
+                  "description": "Encrypted password",
                   "title": "Key"
                 }
               },
@@ -1895,6 +1929,7 @@
           },
           "isis_enable": {
             "type": "string",
+            "description": "ISIS instance",
             "title": "ISIS Enable"
           },
           "isis_passive": {
@@ -1932,7 +1967,7 @@
           },
           "isis_authentication_key": {
             "type": "string",
-            "description": "Type-7 encrypted password\n",
+            "description": "Type-7 encrypted password",
             "title": "ISIS Authentication Key"
           },
           "ptp": {
@@ -1990,7 +2025,7 @@
               },
               "vlan": {
                 "type": "string",
-                "description": "all or list of vlans as string\n",
+                "description": "VLAN can be 'all' or list of vlans as string",
                 "title": "VLAN"
               },
               "transport": {
@@ -2018,12 +2053,17 @@
                 "properties": {
                   "level": {
                     "type": "integer",
-                    "description": "Configure maximum storm-control level\n",
+                    "description": "Configure maximum storm-control level",
                     "title": "Level"
                   },
                   "unit": {
                     "type": "string",
-                    "description": "Percent* | pps (optional and is hardware dependant - default is percent)\n",
+                    "default": "percent",
+                    "enum": [
+                      "percent",
+                      "pps"
+                    ],
+                    "description": "Optional field and is hardware dependant",
                     "title": "Unit"
                   }
                 },
@@ -2035,12 +2075,17 @@
                 "properties": {
                   "level": {
                     "type": "integer",
-                    "description": "Configure maximum storm-control level\n",
+                    "description": "Configure maximum storm-control level",
                     "title": "Level"
                   },
                   "unit": {
                     "type": "string",
-                    "description": "Percent* | pps (optional and is hardware dependant - default is percent)\n",
+                    "default": "percent",
+                    "enum": [
+                      "percent",
+                      "pps"
+                    ],
+                    "description": "Optional field and is hardware dependant",
                     "title": "Unit"
                   }
                 },
@@ -2052,12 +2097,17 @@
                 "properties": {
                   "level": {
                     "type": "integer",
-                    "description": "Configure maximum storm-control level\n",
+                    "description": "Configure maximum storm-control level",
                     "title": "Level"
                   },
                   "unit": {
                     "type": "string",
-                    "description": "Percent* | pps (optional and is hardware dependant - default is percent)\n",
+                    "default": "percent",
+                    "enum": [
+                      "percent",
+                      "pps"
+                    ],
+                    "description": "Optional field and is hardware dependant",
                     "title": "Unit"
                   }
                 },
@@ -2069,12 +2119,17 @@
                 "properties": {
                   "level": {
                     "type": "integer",
-                    "description": "Configure maximum storm-control level\n",
+                    "description": "Configure maximum storm-control level",
                     "title": "Level"
                   },
                   "unit": {
                     "type": "string",
-                    "description": "Percent* | pps (optional and is hardware dependant - default is percent)\n",
+                    "default": "percent",
+                    "enum": [
+                      "percent",
+                      "pps"
+                    ],
+                    "description": "Optional field and is hardware dependant",
                     "title": "Unit"
                   }
                 },
@@ -2120,6 +2175,7 @@
               },
               "ztp_vlan": {
                 "type": "integer",
+                "description": "ZTP vlan number",
                 "title": "Ztp VLAN"
               }
             },
@@ -2132,7 +2188,7 @@
           },
           "pvlan_mapping": {
             "type": "integer",
-            "description": "List of vlans as string\n",
+            "description": "List of vlans as string",
             "title": "PVLAN Mapping"
           },
           "vlan_translations": {
@@ -2142,11 +2198,12 @@
               "properties": {
                 "from": {
                   "type": "string",
-                  "description": "List of vlans as string (only one vlan if direction is \"both\")\n",
+                  "description": "List of vlans as string (only one vlan if direction is \"both\")",
                   "title": "From"
                 },
                 "to": {
                   "type": "integer",
+                  "description": "VLAN id",
                   "title": "To"
                 },
                 "direction": {
@@ -2233,64 +2290,6 @@
                   "multi_host_authenticated": {
                     "type": "boolean",
                     "title": "Multi Host Authenticated"
-                  },
-                  "mac_based_authentication": {
-                    "type": "object",
-                    "properties": {
-                      "enabled": {
-                        "type": "boolean",
-                        "title": "Enabled"
-                      },
-                      "always": {
-                        "type": "boolean",
-                        "title": "Always"
-                      },
-                      "host_mode_common": {
-                        "type": "boolean",
-                        "title": "Host Mode Common"
-                      }
-                    },
-                    "additionalProperties": false,
-                    "title": "MAC Based Authentication"
-                  },
-                  "timeout": {
-                    "type": "object",
-                    "properties": {
-                      "idle_host": {
-                        "type": "integer",
-                        "minimum": 10,
-                        "maximum": 65535,
-                        "title": "Idle Host"
-                      },
-                      "quiet_period": {
-                        "type": "integer",
-                        "minimum": 1,
-                        "maximum": 65535,
-                        "title": "Quiet Period"
-                      },
-                      "reauth_period": {
-                        "type": "string",
-                        "title": "Reauth Period"
-                      },
-                      "reauth_timeout_ignore": {
-                        "type": "boolean",
-                        "title": "Reauth Timeout Ignore"
-                      },
-                      "tx_period": {
-                        "title": "Transmit Period",
-                        "type": "integer",
-                        "minimum": 1,
-                        "maximum": 65535
-                      }
-                    },
-                    "additionalProperties": false,
-                    "title": "Timeout"
-                  },
-                  "reauthorization_request_limit": {
-                    "type": "integer",
-                    "minimum": 1,
-                    "maximum": 10,
-                    "title": "Reauthorization Request Limit"
                   }
                 },
                 "additionalProperties": false,
@@ -2328,6 +2327,7 @@
                   },
                   "reauth_period": {
                     "type": "string",
+                    "description": "Value can be 60-4294967295 or 'server'",
                     "title": "Reauth Period"
                   },
                   "reauth_timeout_ignore": {
@@ -2344,6 +2344,8 @@
               },
               "reauthorization_request_limit": {
                 "type": "integer",
+                "minimum": 1,
+                "maximum": 10,
                 "title": "Reauthorization Request Limit"
               }
             },
@@ -2352,6 +2354,7 @@
           },
           "service_profile": {
             "type": "string",
+            "description": "QOS profile",
             "title": "Service Profile"
           },
           "shape": {
@@ -2359,7 +2362,7 @@
             "properties": {
               "rate": {
                 "type": "string",
-                "description": "rate in kbps or 1-100 percent or rate in pps, supported options are platform dependent\n",
+                "description": "Rate in kbps or pps or 1-100 percent or rate in pps, supported options are platform dependent",
                 "title": "Rate"
               }
             },
@@ -2380,10 +2383,12 @@
               },
               "dscp": {
                 "type": "integer",
+                "description": "DSCP value",
                 "title": "DSCP"
               },
               "cos": {
                 "type": "integer",
+                "description": "COS value",
                 "title": "COS"
               }
             },
@@ -2459,12 +2464,12 @@
               },
               "interval": {
                 "type": "integer",
-                "description": "Interval in milliseconds\n",
+                "description": "Interval in milliseconds",
                 "title": "Interval"
               },
               "min_rx": {
                 "type": "integer",
-                "description": "Rate in milliseconds\n",
+                "description": "Rate in milliseconds",
                 "title": "Min RX"
               },
               "multiplier": {
@@ -2485,6 +2490,7 @@
                 "properties": {
                   "input": {
                     "type": "string",
+                    "description": "Policy-map name",
                     "title": "Input"
                   }
                 },
@@ -2510,8 +2516,8 @@
                     "title": "Interface"
                   },
                   "igp_sync": {
-                    "title": "IGP Sync",
-                    "type": "boolean"
+                    "type": "boolean",
+                    "title": "Igp Sync"
                   }
                 },
                 "additionalProperties": false,
@@ -2576,12 +2582,12 @@
             "properties": {
               "input": {
                 "type": "string",
-                "description": "Ingress traffic policy\n",
+                "description": "Ingress traffic policy",
                 "title": "Input"
               },
               "output": {
                 "type": "string",
-                "description": "Egress traffic policy\n",
+                "description": "Egress traffic policy",
                 "title": "Output"
               }
             },
@@ -2590,8 +2596,12 @@
           },
           "eos_cli": {
             "type": "string",
-            "description": "Multiline eos cli",
+            "description": "Multiline eos cli. EOS CLI rendered directly on the ethernet interface in the final EOS configuration",
             "title": "EOS CLI"
+          },
+          "struct_cfg": {
+            "type": "object",
+            "title": "Struct Cfg"
           }
         },
         "required": [

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -1241,6 +1241,1357 @@
       "additionalProperties": false,
       "title": "Errdisable"
     },
+    "ethernet_interfaces": {
+      "type": "array",
+      "title": "Routed Ethernet Interfaces",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Ethernet Interface"
+          },
+          "peer": {
+            "type": "string",
+            "title": "Peer"
+          },
+          "peer_interface": {
+            "type": "string",
+            "title": "Peer Interface"
+          },
+          "peer_type": {
+            "type": "string",
+            "title": "Peer Type"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
+          "shutdown": {
+            "type": "boolean",
+            "title": "Shutdown"
+          },
+          "speed": {
+            "type": "string",
+            "description": "< interface_speed | forced interface_speed | auto interface_speed >\n",
+            "title": "Speed"
+          },
+          "mtu": {
+            "title": "MTU",
+            "type": "integer"
+          },
+          "l2_mtu": {
+            "title": "L2 MTU",
+            "type": "integer",
+            "description": "l2-mtu - if defined this profile should only be used for platforms supporting the \"l2 mtu\" CLI\n"
+          },
+          "vlans": {
+            "title": "VLANs",
+            "type": "string",
+            "description": "< list of vlans as string\n"
+          },
+          "native_vlan": {
+            "title": "Native VLAN",
+            "type": "integer"
+          },
+          "native_vlan_tag": {
+            "title": "Native VLAN Tag",
+            "type": "boolean",
+            "default": false
+          },
+          "mode": {
+            "type": "string",
+            "enum": [
+              "access",
+              "dot1q-tunnel",
+              "trunk",
+              "trunk phone"
+            ],
+            "title": "Mode"
+          },
+          "phone": {
+            "type": "object",
+            "properties": {
+              "trunk": {
+                "type": "string",
+                "enum": [
+                  "tagged",
+                  "untagged"
+                ],
+                "title": "Trunk"
+              },
+              "vlan": {
+                "title": "VLAN",
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 4094
+              }
+            },
+            "additionalProperties": false,
+            "title": "Phone"
+          },
+          "l2_protocol": {
+            "title": "L2 Protocol",
+            "type": "object",
+            "properties": {
+              "encapsulation_dot1q_vlan": {
+                "title": "Encapsulation dot1q VLAN",
+                "type": "integer"
+              }
+            },
+            "additionalProperties": false
+          },
+          "trunk_groups": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "title": "Trunk Groups"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "routed",
+              "switched",
+              "l3dot1q",
+              "l2dot1q"
+            ],
+            "description": "l3dot1q and l2dot1q are used for sub-interfaces. The parent interface should be defined as routed.\n",
+            "title": "Type"
+          },
+          "snmp_trap_link_change": {
+            "title": "SNMP Trap Link Change",
+            "type": "boolean"
+          },
+          "flowcontrol": {
+            "type": "object",
+            "properties": {
+              "received": {
+                "type": "string",
+                "enum": [
+                  "received",
+                  "send",
+                  "on"
+                ],
+                "title": "Received"
+              }
+            },
+            "additionalProperties": false,
+            "title": "Flowcontrol"
+          },
+          "vrf": {
+            "title": "VRF Name",
+            "type": "string"
+          },
+          "error_correction_encoding": {
+            "type": "object",
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "default": true,
+                "title": "Enabled"
+              },
+              "fire_code": {
+                "type": "boolean",
+                "title": "Fire Code"
+              },
+              "reed_solomon": {
+                "type": "boolean",
+                "title": "Reed Solomon"
+              }
+            },
+            "additionalProperties": false,
+            "title": "Error Correction Encoding"
+          },
+          "link_tracking_groups": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "title": "Group Name",
+                  "type": "string"
+                },
+                "direction": {
+                  "type": "string",
+                  "enum": [
+                    "upstream",
+                    "downstream"
+                  ],
+                  "title": "Direction"
+                }
+              },
+              "additionalProperties": false
+            },
+            "title": "Link Tracking Groups"
+          },
+          "evpn_ethernet_segment": {
+            "title": "EVPN Ethernet Segment",
+            "type": "object",
+            "properties": {
+              "identifier": {
+                "type": "string",
+                "description": "EVPN Ethernet Segment Identifier (Type 1 format)\n",
+                "title": "Identifier"
+              },
+              "redundancy": {
+                "type": "string",
+                "enum": [
+                  "all-active",
+                  "single-active"
+                ],
+                "title": "Redundancy"
+              },
+              "designated_forwarder_election": {
+                "type": "object",
+                "properties": {
+                  "algorithm": {
+                    "type": "string",
+                    "enum": [
+                      "modulus",
+                      "preference"
+                    ],
+                    "title": "Algorithm"
+                  },
+                  "preference_value": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 65535,
+                    "description": "Preference_value and dont_preempt are set for preference algorithm and are optional\n",
+                    "title": "Preference Value"
+                  },
+                  "dont_preempt": {
+                    "type": "boolean",
+                    "default": false,
+                    "title": "Dont Preempt"
+                  },
+                  "hold_time": {
+                    "type": "integer",
+                    "title": "Hold Time"
+                  },
+                  "subsequent_hold_time": {
+                    "type": "integer",
+                    "title": "Subsequent Hold Time"
+                  },
+                  "candidate_reachability_required": {
+                    "type": "boolean",
+                    "title": "Candidate Reachability Required"
+                  }
+                },
+                "additionalProperties": false,
+                "title": "Designated Forwarder Election"
+              },
+              "mpls": {
+                "title": "MPLS",
+                "type": "object",
+                "properties": {
+                  "shared_index": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 1024,
+                    "title": "Shared Index"
+                  },
+                  "tunnel_flood_filter_time": {
+                    "type": "integer",
+                    "title": "Tunnel Flood Filter Time"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "route_target": {
+                "type": "string",
+                "description": "EVPN Route Target for ESI with format xx:xx:xx:xx:xx:xx\n",
+                "title": "Route Target"
+              }
+            },
+            "additionalProperties": false
+          },
+          "encapsulation_dot1q_vlan": {
+            "title": "Encapsulation dot1q VLAN",
+            "type": "integer",
+            "description": "vlan tag to configure on sub-interface\n"
+          },
+          "encapsulation_vlan": {
+            "title": "Encapsulation VLAN",
+            "type": "object",
+            "properties": {
+              "client": {
+                "type": "object",
+                "properties": {
+                  "dot1q": {
+                    "type": "object",
+                    "properties": {
+                      "vlan": {
+                        "title": "Client VLAN ID",
+                        "type": "integer"
+                      },
+                      "outer": {
+                        "title": "Client Outer VLAN ID",
+                        "type": "integer"
+                      },
+                      "inner": {
+                        "title": "Client Inner VLAN ID",
+                        "type": "integer"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "title": "Dot1Q"
+                  },
+                  "outer": {
+                    "title": "Client Outer VLAN ID",
+                    "type": "integer"
+                  },
+                  "inner": {
+                    "title": "Client Inner VLAN ID",
+                    "type": "integer"
+                  },
+                  "unmatched": {
+                    "type": "boolean",
+                    "title": "Unmatched"
+                  }
+                },
+                "additionalProperties": false,
+                "title": "Client"
+              },
+              "network": {
+                "type": "object",
+                "description": "Network encapsulation is all optional, and skipped if using client unmatched.\n",
+                "properties": {
+                  "dot1q": {
+                    "type": "object",
+                    "properties": {
+                      "vlan": {
+                        "title": "Network VLAN ID",
+                        "type": "integer"
+                      },
+                      "outer": {
+                        "title": "Network Outer VLAN ID",
+                        "type": "integer"
+                      },
+                      "inner": {
+                        "title": "Network Inner VLAN ID",
+                        "type": "integer"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "title": "Dot1Q"
+                  },
+                  "outer": {
+                    "title": "Network Outer VLAN ID",
+                    "type": "integer"
+                  },
+                  "inner": {
+                    "title": "Network Inner VLAN ID",
+                    "type": "integer"
+                  },
+                  "client": {
+                    "type": "boolean",
+                    "title": "Client"
+                  }
+                },
+                "additionalProperties": false,
+                "title": "Network"
+              }
+            },
+            "additionalProperties": false
+          },
+          "vlan_id": {
+            "title": "VLAN ID",
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 4094
+          },
+          "ip_address": {
+            "title": "IP Address",
+            "type": "string"
+          },
+          "ip_address_secondaries": {
+            "title": "IP Address Secondaries",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "ip_helpers": {
+            "title": "IP Helpers",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "ip_helper": {
+                  "title": "IP Helper",
+                  "type": "string"
+                },
+                "source_interface": {
+                  "type": "string",
+                  "title": "Source Interface Name"
+                },
+                "vrf": {
+                  "title": "VRF Name",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "ip_helper"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "ipv6_enable": {
+            "title": "IPv6 Enable",
+            "type": "boolean"
+          },
+          "ipv6_address": {
+            "title": "IPv6 Address",
+            "type": "string"
+          },
+          "ipv6_address_link_local": {
+            "title": "IPv6 Address Link Local",
+            "type": "string"
+          },
+          "ipv6_nd_ra_disabled": {
+            "title": "IPv6 ND RA Disabled",
+            "type": "boolean"
+          },
+          "ipv6_nd_managed_config_flag": {
+            "title": "IPv6 ND Managed Config Flag",
+            "type": "boolean"
+          },
+          "ipv6_nd_prefixes": {
+            "title": "IPv6 ND Prefixes",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "ipv6_prefix": {
+                  "title": "IPv6 Prefix",
+                  "type": "string"
+                },
+                "valid_lifetime": {
+                  "type": "string",
+                  "description": "< infinite or lifetime in seconds >\n",
+                  "title": "Valid Lifetime"
+                },
+                "preferred_lifetime": {
+                  "type": "string",
+                  "description": "< infinite or lifetime in seconds >\n",
+                  "title": "Preferred Lifetime"
+                },
+                "no_autoconfig_flag": {
+                  "type": "boolean",
+                  "title": "No Autoconfig Flag"
+                }
+              },
+              "required": [
+                "ipv6_prefix"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "access_group_in": {
+            "title": "Access Group IN",
+            "type": "string"
+          },
+          "access_group_out": {
+            "title": "Access Group OUT",
+            "type": "string"
+          },
+          "ipv6_access_group_in": {
+            "title": "IPv6 Access Group IN",
+            "type": "string"
+          },
+          "ipv6_access_group_out": {
+            "title": "IPV6 Access Group OUT",
+            "type": "string"
+          },
+          "mac_access_group_in": {
+            "title": "MAC Access Group IN",
+            "type": "string"
+          },
+          "mac_access_group_out": {
+            "title": "MAC Access Group OUT",
+            "type": "string"
+          },
+          "multicast": {
+            "type": "object",
+            "description": "boundaries can be either 1 ACL or a list of multicast IP address_range(s)/prefix but not combination of both\n",
+            "properties": {
+              "ipv4": {
+                "title": "IPv4",
+                "type": "object",
+                "properties": {
+                  "boundaries": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "boundary": {
+                          "type": "string",
+                          "title": "Boundary"
+                        },
+                        "out": {
+                          "type": "boolean",
+                          "title": "Out"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "title": "Boundaries"
+                  },
+                  "static": {
+                    "type": "boolean",
+                    "title": "Static"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "ipv6": {
+                "title": "IPv6",
+                "type": "object",
+                "properties": {
+                  "boundaries": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "boundary": {
+                          "type": "string",
+                          "title": "Boundary"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "title": "Boundaries"
+                  },
+                  "static": {
+                    "type": "boolean",
+                    "title": "Static"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false,
+            "title": "Multicast"
+          },
+          "ospf_network_point_to_point": {
+            "title": "OSPF Network Point To Point",
+            "type": "boolean"
+          },
+          "ospf_area": {
+            "title": "OSPF Area",
+            "type": "string"
+          },
+          "ospf_cost": {
+            "title": "OSPF Cost",
+            "type": "integer"
+          },
+          "ospf_authentication": {
+            "title": "OSPF Authentication",
+            "type": "string",
+            "enum": [
+              "none",
+              "simple",
+              "message-digest"
+            ]
+          },
+          "ospf_authentication_key": {
+            "title": "OSPF Authentication Key",
+            "type": "string"
+          },
+          "ospf_message_digest_keys": {
+            "title": "OSPF Message Digest Keys",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "title": "ID",
+                  "type": "integer"
+                },
+                "hash_algorithm": {
+                  "type": "string",
+                  "enum": [
+                    "md5",
+                    "sha1",
+                    "sha 256",
+                    "sha384",
+                    "sha512"
+                  ],
+                  "title": "Hash Algorithm"
+                },
+                "key": {
+                  "type": "string",
+                  "title": "Key"
+                }
+              },
+              "required": [
+                "id"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "pim": {
+            "title": "PIM",
+            "type": "object",
+            "properties": {
+              "ipv4": {
+                "title": "IPv4",
+                "type": "object",
+                "properties": {
+                  "dr_priority": {
+                    "title": "DR Priority",
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 429467295
+                  },
+                  "sparse_mode": {
+                    "type": "boolean",
+                    "title": "Sparse Mode"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          "mac_security": {
+            "title": "MAC Security",
+            "type": "object",
+            "properties": {
+              "profile": {
+                "type": "string",
+                "title": "Profile"
+              }
+            },
+            "additionalProperties": false
+          },
+          "channel_group": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "title": "Port-Channel ID",
+                "type": "integer"
+              },
+              "mode": {
+                "type": "string",
+                "enum": [
+                  "on",
+                  "active",
+                  "passive"
+                ],
+                "title": "Mode"
+              }
+            },
+            "additionalProperties": false,
+            "title": "Channel Group"
+          },
+          "isis_enable": {
+            "title": "ISIS Enable",
+            "type": "string"
+          },
+          "isis_passive": {
+            "title": "ISIS Passive",
+            "type": "boolean"
+          },
+          "isis_metric": {
+            "title": "ISIS Metric",
+            "type": "integer"
+          },
+          "isis_network_point_to_point": {
+            "title": "ISIS Network Point To Point",
+            "type": "boolean"
+          },
+          "isis_circuit_type": {
+            "title": "ISIS Circuit Type",
+            "type": "string",
+            "enum": [
+              "level-1-2",
+              "level-1",
+              "level-2"
+            ]
+          },
+          "isis_hello_padding": {
+            "title": "ISIS Hello Padding",
+            "type": "boolean"
+          },
+          "isis_authentication_mode": {
+            "title": "ISIS Authentication Mode",
+            "type": "string",
+            "enum": [
+              "text",
+              "md5"
+            ]
+          },
+          "isis_authentication_key": {
+            "title": "ISIS Authentication Key",
+            "type": "string",
+            "description": "type-7 encrypted password\n"
+          },
+          "ptp": {
+            "title": "PTP",
+            "type": "object",
+            "properties": {
+              "enable": {
+                "type": "boolean",
+                "title": "Enable"
+              },
+              "announce": {
+                "type": "object",
+                "properties": {
+                  "interval": {
+                    "type": "integer",
+                    "title": "Interval"
+                  },
+                  "timeout": {
+                    "type": "integer",
+                    "title": "Timeout"
+                  }
+                },
+                "additionalProperties": false,
+                "title": "Announce"
+              },
+              "delay_req": {
+                "type": "integer",
+                "title": "Delay Req"
+              },
+              "delay_mechanism": {
+                "type": "string",
+                "enum": [
+                  "e2e",
+                  "p2p"
+                ],
+                "title": "Delay Mechanism"
+              },
+              "sync_message": {
+                "type": "object",
+                "properties": {
+                  "interval": {
+                    "type": "integer",
+                    "title": "Interval"
+                  }
+                },
+                "additionalProperties": false,
+                "title": "Sync Message"
+              },
+              "role": {
+                "type": "string",
+                "enum": [
+                  "master",
+                  "dynamic"
+                ],
+                "title": "Role"
+              },
+              "vlan": {
+                "title": "VLAN",
+                "type": "string",
+                "description": "< all | list of vlans as string >\n"
+              },
+              "transport": {
+                "type": "string",
+                "enum": [
+                  "ipv4",
+                  "ipv6",
+                  "layer2"
+                ],
+                "title": "Transport"
+              }
+            },
+            "additionalProperties": false
+          },
+          "profile": {
+            "title": "Interface Profile",
+            "type": "string"
+          },
+          "storm_control": {
+            "type": "object",
+            "properties": {
+              "all": {
+                "type": "object",
+                "properties": {
+                  "level": {
+                    "type": "integer",
+                    "description": "Configure maximum storm-control level\n",
+                    "title": "Level"
+                  },
+                  "unit": {
+                    "type": "string",
+                    "description": "Percent* | pps (optional and is hardware dependant - default is percent)\n",
+                    "title": "Unit"
+                  }
+                },
+                "additionalProperties": false,
+                "title": "All"
+              },
+              "broadcast": {
+                "type": "object",
+                "properties": {
+                  "level": {
+                    "type": "integer",
+                    "description": "Configure maximum storm-control level\n",
+                    "title": "Level"
+                  },
+                  "unit": {
+                    "type": "string",
+                    "description": "Percent* | pps (optional and is hardware dependant - default is percent)\n",
+                    "title": "Unit"
+                  }
+                },
+                "additionalProperties": false,
+                "title": "Broadcast"
+              },
+              "multicast": {
+                "type": "object",
+                "properties": {
+                  "level": {
+                    "type": "integer",
+                    "description": "Configure maximum storm-control level\n",
+                    "title": "Level"
+                  },
+                  "unit": {
+                    "type": "string",
+                    "description": "Percent* | pps (optional and is hardware dependant - default is percent)\n",
+                    "title": "Unit"
+                  }
+                },
+                "additionalProperties": false,
+                "title": "Multicast"
+              },
+              "unknown_unicast": {
+                "type": "object",
+                "properties": {
+                  "level": {
+                    "type": "integer",
+                    "description": "Configure maximum storm-control level\n",
+                    "title": "Level"
+                  },
+                  "unit": {
+                    "type": "string",
+                    "description": "Percent* | pps (optional and is hardware dependant - default is percent)\n",
+                    "title": "Unit"
+                  }
+                },
+                "additionalProperties": false,
+                "title": "Unknown Unicast"
+              }
+            },
+            "additionalProperties": false,
+            "title": "Storm Control"
+          },
+          "logging": {
+            "type": "object",
+            "properties": {
+              "event": {
+                "type": "object",
+                "properties": {
+                  "link_status": {
+                    "type": "boolean",
+                    "title": "Link Status"
+                  },
+                  "congestion_drops": {
+                    "type": "boolean",
+                    "title": "Congestion Drops"
+                  }
+                },
+                "additionalProperties": false,
+                "title": "Event"
+              }
+            },
+            "additionalProperties": false,
+            "title": "Logging"
+          },
+          "lldp": {
+            "title": "LLDP",
+            "type": "object",
+            "properties": {
+              "transmit": {
+                "type": "boolean",
+                "title": "Transmit"
+              },
+              "receive": {
+                "type": "boolean",
+                "title": "Receive"
+              },
+              "ztp_vlan": {
+                "title": "ZTP VLAN",
+                "type": "integer"
+              }
+            },
+            "additionalProperties": false
+          },
+          "trunk_private_vlan_secondary": {
+            "title": "Trunk Private VLAN Secondary",
+            "type": "boolean"
+          },
+          "pvlan_mapping": {
+            "title": "PVLAN Mapping",
+            "type": "integer",
+            "description": "List of vlans as string\n"
+          },
+          "vlan_translations": {
+            "title": "VLAN Translations",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "from": {
+                  "type": "string",
+                  "description": "List of vlans as string (only one vlan if direction is \"both\")\n",
+                  "title": "From"
+                },
+                "to": {
+                  "title": "To",
+                  "type": "integer"
+                },
+                "direction": {
+                  "type": "string",
+                  "enum": [
+                    "in",
+                    "out",
+                    "both"
+                  ],
+                  "default": "both",
+                  "title": "Direction"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "dot1x": {
+            "type": "object",
+            "properties": {
+              "port_control": {
+                "type": "string",
+                "enum": [
+                  "auto",
+                  "force-authorized",
+                  "force-unauthorized"
+                ],
+                "title": "Port Control"
+              },
+              "port_control_force_authorized_phone": {
+                "type": "boolean",
+                "title": "Port Control Force Authorized Phone"
+              },
+              "reauthentication": {
+                "type": "boolean",
+                "title": "Reauthentication"
+              },
+              "pae": {
+                "title": "PAE",
+                "type": "object",
+                "properties": {
+                  "mode": {
+                    "type": "string",
+                    "enum": [
+                      "authenticator"
+                    ],
+                    "title": "Mode"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "authentication_failure": {
+                "type": "object",
+                "properties": {
+                  "action": {
+                    "type": "string",
+                    "enum": [
+                      "allow",
+                      "drop"
+                    ],
+                    "title": "Action"
+                  },
+                  "allow_vlan": {
+                    "title": "Allow VLAN",
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 4094
+                  }
+                },
+                "additionalProperties": false,
+                "title": "Authentication Failure"
+              },
+              "host_mode": {
+                "type": "object",
+                "properties": {
+                  "mode": {
+                    "type": "string",
+                    "enum": [
+                      "multi-host",
+                      "single-host"
+                    ],
+                    "title": "Mode"
+                  },
+                  "multi_host_authenticated": {
+                    "type": "boolean",
+                    "title": "Multi Host Authenticated"
+                  },
+                  "mac_based_authentication": {
+                    "title": "MAC Based Authentication",
+                    "type": "object",
+                    "properties": {
+                      "enabled": {
+                        "type": "boolean",
+                        "title": "Enabled"
+                      },
+                      "always": {
+                        "type": "boolean",
+                        "title": "Always"
+                      },
+                      "host_mode_common": {
+                        "type": "boolean",
+                        "title": "Host Mode Common"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "timeout": {
+                    "type": "object",
+                    "properties": {
+                      "idle_host": {
+                        "type": "integer",
+                        "minimum": 10,
+                        "maximum": 65535,
+                        "title": "Idle Host"
+                      },
+                      "quiet_period": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 65535,
+                        "title": "Quiet Period"
+                      },
+                      "reauth_period": {
+                        "type": "string",
+                        "title": "Reauth Period"
+                      },
+                      "reauth_timeout_ignore": {
+                        "type": "boolean",
+                        "title": "Reauth Timeout Ignore"
+                      },
+                      "tx_period": {
+                        "title": "Transmit Period",
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 65535
+                      }
+                    },
+                    "additionalProperties": false,
+                    "title": "Timeout"
+                  },
+                  "reauthorization_request_limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 10,
+                    "title": "Reauthorization Request Limit"
+                  }
+                },
+                "additionalProperties": false,
+                "title": "Host Mode"
+              },
+              "mac_based_authentication": {
+                "title": "MAC Based Authentication",
+                "type": "object",
+                "properties": {
+                  "enabled": {
+                    "type": "boolean",
+                    "title": "Enabled"
+                  },
+                  "always": {
+                    "type": "boolean",
+                    "title": "Always"
+                  },
+                  "host_mode_common": {
+                    "type": "boolean",
+                    "title": "Host Mode Common"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "timeout": {
+                "type": "object",
+                "properties": {
+                  "idle_host": {
+                    "type": "integer",
+                    "title": "Idle Host"
+                  },
+                  "quiet_period": {
+                    "type": "integer",
+                    "title": "Quiet Period"
+                  },
+                  "reauth_period": {
+                    "type": "string",
+                    "title": "Reauth Period"
+                  },
+                  "reauth_timeout_ignore": {
+                    "type": "boolean",
+                    "title": "Reauth Timeout Ignore"
+                  },
+                  "tx_period": {
+                    "title": "Transmit Period",
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false,
+                "title": "Timeout"
+              },
+              "reauthorization_request_limit": {
+                "type": "integer",
+                "title": "Reauthorization Request Limit"
+              }
+            },
+            "additionalProperties": false,
+            "title": "dot1x"
+          },
+          "service_profile": {
+            "type": "string",
+            "title": "Service Profile"
+          },
+          "shape": {
+            "type": "object",
+            "properties": {
+              "rate": {
+                "type": "string",
+                "description": "< \"< rate > kbps\" | \"1-100 percent\" | \"< rate > pps\" , supported options are platform dependent >\n",
+                "title": "Rate"
+              }
+            },
+            "additionalProperties": false,
+            "title": "Shape"
+          },
+          "qos": {
+            "title": "QOS",
+            "type": "object",
+            "properties": {
+              "trust": {
+                "type": "string",
+                "enum": [
+                  "dscp",
+                  "cos",
+                  "disabled"
+                ],
+                "title": "Trust"
+              },
+              "dscp": {
+                "title": "DSCP",
+                "type": "integer"
+              },
+              "cos": {
+                "title": "COS",
+                "type": "integer"
+              }
+            },
+            "additionalProperties": false
+          },
+          "spanning_tree_bpdufilter": {
+            "type": "string",
+            "title": "Spanning Tree Bpdufilter"
+          },
+          "spanning_tree_bpduguard": {
+            "type": "string",
+            "title": "Spanning Tree Bpduguard"
+          },
+          "spanning_tree_guard": {
+            "type": "string",
+            "enum": [
+              "loop",
+              "root",
+              "disabled"
+            ],
+            "title": "Spanning Tree Guard"
+          },
+          "spanning_tree_portfast": {
+            "type": "string",
+            "enum": [
+              "edge",
+              "network"
+            ],
+            "title": "Spanning Tree Portfast"
+          },
+          "vmtracer": {
+            "title": "VM Tracer",
+            "type": "boolean"
+          },
+          "priority_flow_control": {
+            "type": "object",
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "title": "Enabled"
+              },
+              "priorities": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "priority": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 7,
+                      "title": "Priority"
+                    },
+                    "no_drop": {
+                      "type": "boolean",
+                      "title": "No Drop"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "title": "Priorities"
+              }
+            },
+            "additionalProperties": false,
+            "title": "Priority Flow Control"
+          },
+          "bfd": {
+            "title": "BFD",
+            "type": "object",
+            "properties": {
+              "echo": {
+                "type": "boolean",
+                "title": "Echo"
+              },
+              "interval": {
+                "type": "integer",
+                "description": "Interval in milliseconds\n",
+                "title": "Interval"
+              },
+              "min_rx": {
+                "title": "Min RX",
+                "type": "integer",
+                "description": "Rate in milliseconds\n"
+              },
+              "multiplier": {
+                "type": "integer",
+                "minimum": 3,
+                "maximum": 50,
+                "title": "Multiplier"
+              }
+            },
+            "additionalProperties": false
+          },
+          "service_policy": {
+            "type": "object",
+            "properties": {
+              "pbr": {
+                "title": "PBR",
+                "type": "object",
+                "properties": {
+                  "input": {
+                    "type": "string",
+                    "title": "Policy Map Name"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false,
+            "title": "Service Policy"
+          },
+          "mpls": {
+            "title": "MPLS",
+            "type": "object",
+            "properties": {
+              "ip": {
+                "title": "IP",
+                "type": "boolean"
+              },
+              "ldp": {
+                "title": "LDP",
+                "type": "object",
+                "properties": {
+                  "interface": {
+                    "type": "boolean",
+                    "title": "Interface"
+                  },
+                  "igp_sync": {
+                    "title": "IGP Sync",
+                    "type": "boolean"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          "lacp_timer": {
+            "title": "LACP Timer",
+            "type": "object",
+            "properties": {
+              "mode": {
+                "type": "string",
+                "enum": [
+                  "fast",
+                  "normal"
+                ],
+                "title": "Mode"
+              },
+              "multiplier": {
+                "type": "integer",
+                "minimum": 3,
+                "maximum": 3000,
+                "title": "Multiplier"
+              }
+            },
+            "additionalProperties": false
+          },
+          "lacp_port_priority": {
+            "title": "LACP Port Priority",
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 65535
+          },
+          "transceiver": {
+            "type": "object",
+            "properties": {
+              "media": {
+                "type": "object",
+                "properties": {
+                  "override": {
+                    "title": "Transceiver Type",
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false,
+                "title": "Media"
+              }
+            },
+            "additionalProperties": false,
+            "title": "Transceiver"
+          },
+          "ip_proxy_arp": {
+            "title": "IP Proxy ARP",
+            "type": "boolean"
+          },
+          "traffic_policy": {
+            "type": "object",
+            "properties": {
+              "input": {
+                "type": "string",
+                "description": "ingress traffic policy\n",
+                "title": "Input"
+              },
+              "output": {
+                "type": "string",
+                "description": "egress traffic policy\n",
+                "title": "Output"
+              }
+            },
+            "additionalProperties": false,
+            "title": "Traffic Policy"
+          },
+          "eos_cli": {
+            "title": "EOS CLI",
+            "type": "string",
+            "description": "< multiline eos cli >"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false
+      }
+    },
     "event_handlers": {
       "type": "array",
       "items": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -2166,7 +2166,7 @@
               "type": "object",
               "properties": {
                 "from": {
-                  "type": "integer",
+                  "type": "string",
                   "description": "List of vlans as string (only one vlan if direction is \"both\")",
                   "title": "From"
                 },
@@ -2375,7 +2375,10 @@
             "enum": [
               "enabled",
               "disabled",
-              "true"
+              "True",
+              "False",
+              "true",
+              "false"
             ],
             "title": "Spanning Tree Bpdufilter"
           },
@@ -2384,7 +2387,10 @@
             "enum": [
               "enabled",
               "disabled",
-              "true"
+              "True",
+              "False",
+              "true",
+              "false"
             ],
             "title": "Spanning Tree Bpduguard"
           },

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -1243,25 +1243,12 @@
     },
     "ethernet_interfaces": {
       "type": "array",
-      "description": "Routed interfaces",
       "items": {
         "type": "object",
         "properties": {
           "name": {
             "type": "string",
             "title": "Name"
-          },
-          "peer": {
-            "type": "string",
-            "title": "Peer"
-          },
-          "peer_interface": {
-            "type": "string",
-            "title": "Peer Interface"
-          },
-          "peer_type": {
-            "type": "string",
-            "title": "Peer Type"
           },
           "description": {
             "type": "string",
@@ -1282,12 +1269,12 @@
           },
           "l2_mtu": {
             "type": "integer",
-            "description": "If l2_mtu defined this profile should only be used for platforms supporting the \"l2 mtu\" CLI",
+            "description": "\"l2_mtu\" should only be defined for platforms supporting the \"l2 mtu\" CLI\n",
             "title": "L2 MTU"
           },
           "vlans": {
             "type": "string",
-            "description": "List of vlans as string",
+            "description": "List of switchport vlans as string.\nFor a trunk port this would be a range like \"1-200,300\"\nFor an access port this would be a single vlan \"123\"\n",
             "title": "VLANs"
           },
           "native_vlan": {
@@ -1296,7 +1283,7 @@
           },
           "native_vlan_tag": {
             "type": "boolean",
-            "default": false,
+            "description": "If setting both native_vlan and native_vlan_tag, native_vlan_tag takes precedence",
             "title": "Native VLAN Tag"
           },
           "mode": {
@@ -1362,7 +1349,6 @@
           },
           "snmp_trap_link_change": {
             "type": "boolean",
-            "description": "SNMP trap link change",
             "title": "Snmp Trap Link Change"
           },
           "flowcontrol": {
@@ -1371,9 +1357,9 @@
               "received": {
                 "type": "string",
                 "enum": [
-                  "received",
-                  "send",
-                  "on"
+                  "desired",
+                  "on",
+                  "off"
                 ],
                 "title": "Received"
               }
@@ -1437,7 +1423,10 @@
                   "title": "Direction"
                 }
               },
-              "additionalProperties": false
+              "additionalProperties": false,
+              "required": [
+                "name"
+              ]
             },
             "title": "Link Tracking Groups"
           },
@@ -1472,12 +1461,12 @@
                     "type": "integer",
                     "minimum": 0,
                     "maximum": 65535,
-                    "description": "Preference_value and dont_preempt are set for preference algorithm and are optional",
+                    "description": "Preference_value is only used when \"algorithm\" is \"preference\"",
                     "title": "Preference Value"
                   },
                   "dont_preempt": {
                     "type": "boolean",
-                    "default": false,
+                    "description": "Dont_preempt is only used when \"algorithm\" is \"preference\"",
                     "title": "Dont Preempt"
                   },
                   "hold_time": {
@@ -1555,16 +1544,6 @@
                     "additionalProperties": false,
                     "title": "Dot1Q"
                   },
-                  "outer": {
-                    "type": "integer",
-                    "description": "Client Outer VLAN ID",
-                    "title": "Outer"
-                  },
-                  "inner": {
-                    "type": "integer",
-                    "description": "Client Inner VLAN ID",
-                    "title": "Inner"
-                  },
                   "unmatched": {
                     "type": "boolean",
                     "title": "Unmatched"
@@ -1575,7 +1554,7 @@
               },
               "network": {
                 "type": "object",
-                "description": "Network encapsulation is all optional, and skipped if using client unmatched.",
+                "description": "Network encapsulations are all optional, and skipped if using client unmatched.",
                 "properties": {
                   "dot1q": {
                     "type": "object",
@@ -1599,16 +1578,6 @@
                     "additionalProperties": false,
                     "title": "Dot1Q"
                   },
-                  "outer": {
-                    "type": "integer",
-                    "description": "Network Outer VLAN ID",
-                    "title": "Outer"
-                  },
-                  "inner": {
-                    "type": "integer",
-                    "description": "Network Inner VLAN ID",
-                    "title": "Inner"
-                  },
                   "client": {
                     "type": "boolean",
                     "title": "Client"
@@ -1629,7 +1598,7 @@
           },
           "ip_address": {
             "type": "string",
-            "description": "IPv4_address or Mask",
+            "description": "IPv4 address/mask",
             "title": "IP Address"
           },
           "ip_address_secondaries": {
@@ -1676,12 +1645,11 @@
           },
           "ipv6_address_link_local": {
             "type": "string",
-            "description": "Link local IPv6 address or mask",
+            "description": "Link local IPv6 address/mask",
             "title": "IPv6 Address Link Local"
           },
           "ipv6_nd_ra_disabled": {
             "type": "boolean",
-            "description": "IPv6 ND RA disabled",
             "title": "IPv6 ND RA Disabled"
           },
           "ipv6_nd_managed_config_flag": {
@@ -2043,6 +2011,7 @@
           },
           "profile": {
             "type": "string",
+            "description": "Interface profile",
             "title": "Profile"
           },
           "storm_control": {
@@ -2187,7 +2156,7 @@
             "title": "Trunk Private VLAN Secondary"
           },
           "pvlan_mapping": {
-            "type": "integer",
+            "type": "string",
             "description": "List of vlans as string",
             "title": "PVLAN Mapping"
           },
@@ -2197,13 +2166,13 @@
               "type": "object",
               "properties": {
                 "from": {
-                  "type": "string",
+                  "type": "integer",
                   "description": "List of vlans as string (only one vlan if direction is \"both\")",
                   "title": "From"
                 },
                 "to": {
                   "type": "integer",
-                  "description": "VLAN id",
+                  "description": "VLAN ID",
                   "title": "To"
                 },
                 "direction": {
@@ -2319,10 +2288,14 @@
                 "properties": {
                   "idle_host": {
                     "type": "integer",
+                    "minimum": 10,
+                    "maximum": 65535,
                     "title": "Idle Host"
                   },
                   "quiet_period": {
                     "type": "integer",
+                    "minimum": 1,
+                    "maximum": 65535,
                     "title": "Quiet Period"
                   },
                   "reauth_period": {
@@ -2336,6 +2309,8 @@
                   },
                   "tx_period": {
                     "type": "integer",
+                    "minimum": 1,
+                    "maximum": 65535,
                     "title": "TX Period"
                   }
                 },
@@ -2362,7 +2337,7 @@
             "properties": {
               "rate": {
                 "type": "string",
-                "description": "Rate in kbps or pps or 1-100 percent or rate in pps, supported options are platform dependent",
+                "description": "Rate in kbps, pps or percent. Supported options are platform dependent.\nExamples:\n- \"5000 kbps\"\n- \"1000 pps\"\n- \"20 percent\"\n",
                 "title": "Rate"
               }
             },
@@ -2397,10 +2372,20 @@
           },
           "spanning_tree_bpdufilter": {
             "type": "string",
+            "enum": [
+              "enabled",
+              "disabled",
+              "true"
+            ],
             "title": "Spanning Tree Bpdufilter"
           },
           "spanning_tree_bpduguard": {
             "type": "string",
+            "enum": [
+              "enabled",
+              "disabled",
+              "true"
+            ],
             "title": "Spanning Tree Bpduguard"
           },
           "spanning_tree_guard": {
@@ -2447,7 +2432,10 @@
                       "title": "No Drop"
                     }
                   },
-                  "additionalProperties": false
+                  "additionalProperties": false,
+                  "required": [
+                    "priority"
+                  ]
                 },
                 "title": "Priorities"
               }
@@ -2596,12 +2584,23 @@
           },
           "eos_cli": {
             "type": "string",
-            "description": "Multiline eos cli. EOS CLI rendered directly on the ethernet interface in the final EOS configuration",
+            "description": "Multiline EOS CLI rendered directly on the ethernet interface in the final EOS configuration",
             "title": "EOS CLI"
           },
-          "struct_cfg": {
-            "type": "object",
-            "title": "Struct Cfg"
+          "peer": {
+            "type": "string",
+            "description": "Key only used for documentation or validation purposes",
+            "title": "Peer"
+          },
+          "peer_interface": {
+            "type": "string",
+            "description": "Key only used for documentation or validation purposes",
+            "title": "Peer Interface"
+          },
+          "peer_type": {
+            "type": "string",
+            "description": "Key only used for documentation or validation purposes",
+            "title": "Peer Type"
           }
         },
         "required": [
@@ -9099,7 +9098,7 @@
                   }
                 },
                 "additionalProperties": false,
-                "title": "Evpn Multicast Address Family"
+                "title": "EVPN Multicast Address Family"
               },
               "route_targets": {
                 "type": "object",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -1274,7 +1274,7 @@
           },
           "vlans": {
             "type": "string",
-            "description": "List of switchport vlans as string.\nFor a trunk port this would be a range like \"1-200,300\"\nFor an access port this would be a single vlan \"123\"\n",
+            "description": "List of switchport vlans as string\nFor a trunk port this would be a range like \"1-200,300\"\nFor an access port this would be a single vlan \"123\"\n",
             "title": "VLANs"
           },
           "native_vlan": {
@@ -1344,7 +1344,7 @@
               "l3dot1q",
               "l2dot1q"
             ],
-            "description": "l3dot1q and l2dot1q are used for sub-interfaces. The parent interface should be defined as routed.",
+            "description": "l3dot1q and l2dot1q are used for sub-interfaces\nThe parent interface should be defined as routed\n",
             "title": "Type"
           },
           "snmp_trap_link_change": {
@@ -1554,7 +1554,7 @@
               },
               "network": {
                 "type": "object",
-                "description": "Network encapsulations are all optional, and skipped if using client unmatched.",
+                "description": "Network encapsulations are all optional and skipped if using client unmatched",
                 "properties": {
                   "dot1q": {
                     "type": "object",
@@ -1566,12 +1566,12 @@
                       },
                       "outer": {
                         "type": "integer",
-                        "description": "Network Outer VLAN ID",
+                        "description": "Network outer VLAN ID",
                         "title": "Outer"
                       },
                       "inner": {
                         "type": "integer",
-                        "description": "Network Inner VLAN ID",
+                        "description": "Network inner VLAN ID",
                         "title": "Inner"
                       }
                     },
@@ -2337,7 +2337,7 @@
             "properties": {
               "rate": {
                 "type": "string",
-                "description": "Rate in kbps, pps or percent. Supported options are platform dependent.\nExamples:\n- \"5000 kbps\"\n- \"1000 pps\"\n- \"20 percent\"\n",
+                "description": "Rate in kbps, pps or percent\nSupported options are platform dependent\nExamples:\n- \"5000 kbps\"\n- \"1000 pps\"\n- \"20 percent\"\n",
                 "title": "Rate"
               }
             },
@@ -2556,7 +2556,7 @@
                 "properties": {
                   "override": {
                     "type": "string",
-                    "description": "Transceiver Type",
+                    "description": "Transceiver type",
                     "title": "Override"
                   }
                 },
@@ -2588,11 +2588,6 @@
             "additionalProperties": false,
             "title": "Traffic Policy"
           },
-          "eos_cli": {
-            "type": "string",
-            "description": "Multiline EOS CLI rendered directly on the ethernet interface in the final EOS configuration",
-            "title": "EOS CLI"
-          },
           "peer": {
             "type": "string",
             "description": "Key only used for documentation or validation purposes",
@@ -2607,6 +2602,11 @@
             "type": "string",
             "description": "Key only used for documentation or validation purposes",
             "title": "Peer Type"
+          },
+          "eos_cli": {
+            "type": "string",
+            "description": "Multiline EOS CLI rendered directly on the ethernet interface in the final EOS configuration",
+            "title": "EOS CLI"
           }
         },
         "required": [

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -1243,13 +1243,12 @@
     },
     "ethernet_interfaces": {
       "type": "array",
-      "title": "Routed Ethernet Interfaces",
       "items": {
         "type": "object",
         "properties": {
           "name": {
             "type": "string",
-            "title": "Ethernet Interface"
+            "title": "Name"
           },
           "peer": {
             "type": "string",
@@ -1277,27 +1276,27 @@
             "title": "Speed"
           },
           "mtu": {
-            "title": "MTU",
-            "type": "integer"
+            "type": "integer",
+            "title": "MTU"
           },
           "l2_mtu": {
-            "title": "L2 MTU",
             "type": "integer",
-            "description": "l2-mtu - if defined this profile should only be used for platforms supporting the \"l2 mtu\" CLI\n"
+            "description": "l2-mtu - if defined this profile should only be used for platforms supporting the \"l2 mtu\" CLI\n",
+            "title": "L2 MTU"
           },
           "vlans": {
-            "title": "VLANs",
             "type": "string",
-            "description": "< list of vlans as string\n"
+            "description": "< list of vlans as string\n",
+            "title": "VLANs"
           },
           "native_vlan": {
-            "title": "Native VLAN",
-            "type": "integer"
+            "type": "integer",
+            "title": "Native VLAN"
           },
           "native_vlan_tag": {
-            "title": "Native VLAN Tag",
             "type": "boolean",
-            "default": false
+            "default": false,
+            "title": "Native VLAN Tag"
           },
           "mode": {
             "type": "string",
@@ -1321,25 +1320,25 @@
                 "title": "Trunk"
               },
               "vlan": {
-                "title": "VLAN",
                 "type": "integer",
                 "minimum": 1,
-                "maximum": 4094
+                "maximum": 4094,
+                "title": "VLAN"
               }
             },
             "additionalProperties": false,
             "title": "Phone"
           },
           "l2_protocol": {
-            "title": "L2 Protocol",
             "type": "object",
             "properties": {
               "encapsulation_dot1q_vlan": {
-                "title": "Encapsulation dot1q VLAN",
-                "type": "integer"
+                "type": "integer",
+                "title": "Encapsulation Dot1Q VLAN"
               }
             },
-            "additionalProperties": false
+            "additionalProperties": false,
+            "title": "L2 Protocol"
           },
           "trunk_groups": {
             "type": "array",
@@ -1409,8 +1408,8 @@
               "type": "object",
               "properties": {
                 "name": {
-                  "title": "Group Name",
-                  "type": "string"
+                  "type": "string",
+                  "title": "Name"
                 },
                 "direction": {
                   "type": "string",
@@ -1426,7 +1425,6 @@
             "title": "Link Tracking Groups"
           },
           "evpn_ethernet_segment": {
-            "title": "EVPN Ethernet Segment",
             "type": "object",
             "properties": {
               "identifier": {
@@ -1482,7 +1480,6 @@
                 "title": "Designated Forwarder Election"
               },
               "mpls": {
-                "title": "MPLS",
                 "type": "object",
                 "properties": {
                   "shared_index": {
@@ -1496,7 +1493,8 @@
                     "title": "Tunnel Flood Filter Time"
                   }
                 },
-                "additionalProperties": false
+                "additionalProperties": false,
+                "title": "MPLS"
               },
               "route_target": {
                 "type": "string",
@@ -1504,15 +1502,15 @@
                 "title": "Route Target"
               }
             },
-            "additionalProperties": false
+            "additionalProperties": false,
+            "title": "Evpn Ethernet Segment"
           },
           "encapsulation_dot1q_vlan": {
-            "title": "Encapsulation dot1q VLAN",
             "type": "integer",
-            "description": "vlan tag to configure on sub-interface\n"
+            "description": "vlan tag to configure on sub-interface\n",
+            "title": "Encapsulation Dot1Q VLAN"
           },
           "encapsulation_vlan": {
-            "title": "Encapsulation VLAN",
             "type": "object",
             "properties": {
               "client": {
@@ -1522,28 +1520,31 @@
                     "type": "object",
                     "properties": {
                       "vlan": {
-                        "title": "Client VLAN ID",
-                        "type": "integer"
+                        "type": "integer",
+                        "title": "VLAN"
                       },
                       "outer": {
                         "title": "Client Outer VLAN ID",
                         "type": "integer"
                       },
                       "inner": {
-                        "title": "Client Inner VLAN ID",
-                        "type": "integer"
+                        "type": "integer",
+                        "description": "Client Inner VLAN ID",
+                        "title": "Inner"
                       }
                     },
                     "additionalProperties": false,
                     "title": "Dot1Q"
                   },
                   "outer": {
-                    "title": "Client Outer VLAN ID",
-                    "type": "integer"
+                    "type": "integer",
+                    "description": "Client Outer VLAN ID",
+                    "title": "Outer"
                   },
                   "inner": {
-                    "title": "Client Inner VLAN ID",
-                    "type": "integer"
+                    "type": "integer",
+                    "description": "Client Inner VLAN ID",
+                    "title": "Inner"
                   },
                   "unmatched": {
                     "type": "boolean",
@@ -1561,28 +1562,33 @@
                     "type": "object",
                     "properties": {
                       "vlan": {
-                        "title": "Network VLAN ID",
-                        "type": "integer"
+                        "type": "integer",
+                        "description": "Network VLAN ID",
+                        "title": "VLAN"
                       },
                       "outer": {
-                        "title": "Network Outer VLAN ID",
-                        "type": "integer"
+                        "type": "integer",
+                        "description": "Network Outer VLAN ID",
+                        "title": "Outer"
                       },
                       "inner": {
-                        "title": "Network Inner VLAN ID",
-                        "type": "integer"
+                        "type": "integer",
+                        "description": "Network Inner VLAN ID",
+                        "title": "Inner"
                       }
                     },
                     "additionalProperties": false,
                     "title": "Dot1Q"
                   },
                   "outer": {
-                    "title": "Network Outer VLAN ID",
-                    "type": "integer"
+                    "type": "integer",
+                    "description": "Network Outer VLAN ID",
+                    "title": "Outer"
                   },
                   "inner": {
-                    "title": "Network Inner VLAN ID",
-                    "type": "integer"
+                    "type": "integer",
+                    "description": "Network Inner VLAN ID",
+                    "title": "Inner"
                   },
                   "client": {
                     "type": "boolean",
@@ -1593,88 +1599,88 @@
                 "title": "Network"
               }
             },
-            "additionalProperties": false
+            "additionalProperties": false,
+            "title": "Encapsulation VLAN"
           },
           "vlan_id": {
-            "title": "VLAN ID",
             "type": "integer",
             "minimum": 1,
-            "maximum": 4094
+            "maximum": 4094,
+            "title": "VLAN ID"
           },
           "ip_address": {
-            "title": "IP Address",
-            "type": "string"
+            "type": "string",
+            "title": "IP Address"
           },
           "ip_address_secondaries": {
-            "title": "IP Address Secondaries",
             "type": "array",
             "items": {
               "type": "string"
-            }
+            },
+            "title": "IP Address Secondaries"
           },
           "ip_helpers": {
-            "title": "IP Helpers",
             "type": "array",
             "items": {
               "type": "object",
               "properties": {
                 "ip_helper": {
-                  "title": "IP Helper",
-                  "type": "string"
+                  "type": "string",
+                  "title": "IP Helper"
                 },
                 "source_interface": {
                   "type": "string",
-                  "title": "Source Interface Name"
+                  "title": "Source Interface"
                 },
                 "vrf": {
-                  "title": "VRF Name",
-                  "type": "string"
+                  "type": "string",
+                  "title": "VRF"
                 }
               },
               "required": [
                 "ip_helper"
               ],
               "additionalProperties": false
-            }
+            },
+            "title": "IP Helpers"
           },
           "ipv6_enable": {
-            "title": "IPv6 Enable",
-            "type": "boolean"
+            "type": "boolean",
+            "title": "IPv6 Enable"
           },
           "ipv6_address": {
-            "title": "IPv6 Address",
-            "type": "string"
+            "type": "string",
+            "title": "IPv6 Address"
           },
           "ipv6_address_link_local": {
-            "title": "IPv6 Address Link Local",
-            "type": "string"
+            "type": "string",
+            "title": "IPv6 Address Link Local"
           },
           "ipv6_nd_ra_disabled": {
             "title": "IPv6 ND RA Disabled",
             "type": "boolean"
           },
           "ipv6_nd_managed_config_flag": {
-            "title": "IPv6 ND Managed Config Flag",
-            "type": "boolean"
+            "type": "boolean",
+            "title": "IPv6 ND Managed Config Flag"
           },
           "ipv6_nd_prefixes": {
-            "title": "IPv6 ND Prefixes",
             "type": "array",
             "items": {
               "type": "object",
               "properties": {
                 "ipv6_prefix": {
-                  "title": "IPv6 Prefix",
-                  "type": "string"
+                  "type": "string",
+                  "title": "IPv6 Prefix"
                 },
                 "valid_lifetime": {
                   "type": "string",
-                  "description": "< infinite or lifetime in seconds >\n",
+                  "description": "Infinite or lifetime in seconds\n",
                   "title": "Valid Lifetime"
                 },
                 "preferred_lifetime": {
                   "type": "string",
-                  "description": "< infinite or lifetime in seconds >\n",
+                  "description": "Infinite or lifetime in seconds\n",
                   "title": "Preferred Lifetime"
                 },
                 "no_autoconfig_flag": {
@@ -1686,38 +1692,38 @@
                 "ipv6_prefix"
               ],
               "additionalProperties": false
-            }
+            },
+            "title": "IPv6 ND Prefixes"
           },
           "access_group_in": {
-            "title": "Access Group IN",
-            "type": "string"
+            "type": "string",
+            "title": "Access Group In"
           },
           "access_group_out": {
-            "title": "Access Group OUT",
-            "type": "string"
+            "type": "string",
+            "title": "Access Group Out"
           },
           "ipv6_access_group_in": {
-            "title": "IPv6 Access Group IN",
-            "type": "string"
+            "type": "string",
+            "title": "IPv6 Access Group In"
           },
           "ipv6_access_group_out": {
-            "title": "IPV6 Access Group OUT",
-            "type": "string"
+            "type": "string",
+            "title": "IPv6 Access Group Out"
           },
           "mac_access_group_in": {
-            "title": "MAC Access Group IN",
-            "type": "string"
+            "type": "string",
+            "title": "MAC Access Group In"
           },
           "mac_access_group_out": {
-            "title": "MAC Access Group OUT",
-            "type": "string"
+            "type": "string",
+            "title": "MAC Access Group Out"
           },
           "multicast": {
             "type": "object",
             "description": "boundaries can be either 1 ACL or a list of multicast IP address_range(s)/prefix but not combination of both\n",
             "properties": {
               "ipv4": {
-                "title": "IPv4",
                 "type": "object",
                 "properties": {
                   "boundaries": {
@@ -1743,10 +1749,10 @@
                     "title": "Static"
                   }
                 },
-                "additionalProperties": false
+                "additionalProperties": false,
+                "title": "IPv4"
               },
               "ipv6": {
-                "title": "IPv6",
                 "type": "object",
                 "properties": {
                   "boundaries": {
@@ -1768,39 +1774,39 @@
                     "title": "Static"
                   }
                 },
-                "additionalProperties": false
+                "additionalProperties": false,
+                "title": "IPv6"
               }
             },
             "additionalProperties": false,
             "title": "Multicast"
           },
           "ospf_network_point_to_point": {
-            "title": "OSPF Network Point To Point",
-            "type": "boolean"
+            "type": "boolean",
+            "title": "OSPF Network Point To Point"
           },
           "ospf_area": {
-            "title": "OSPF Area",
-            "type": "string"
+            "type": "string",
+            "title": "OSPF Area"
           },
           "ospf_cost": {
-            "title": "OSPF Cost",
-            "type": "integer"
+            "type": "integer",
+            "title": "OSPF Cost"
           },
           "ospf_authentication": {
-            "title": "OSPF Authentication",
             "type": "string",
             "enum": [
               "none",
               "simple",
               "message-digest"
-            ]
+            ],
+            "title": "OSPF Authentication"
           },
           "ospf_authentication_key": {
-            "title": "OSPF Authentication Key",
-            "type": "string"
+            "type": "string",
+            "title": "OSPF Authentication Key"
           },
           "ospf_message_digest_keys": {
-            "title": "OSPF Message Digest Keys",
             "type": "array",
             "items": {
               "type": "object",
@@ -1829,34 +1835,34 @@
                 "id"
               ],
               "additionalProperties": false
-            }
+            },
+            "title": "OSPF Message Digest Keys"
           },
           "pim": {
-            "title": "PIM",
             "type": "object",
             "properties": {
               "ipv4": {
-                "title": "IPv4",
                 "type": "object",
                 "properties": {
                   "dr_priority": {
-                    "title": "DR Priority",
                     "type": "integer",
                     "minimum": 0,
-                    "maximum": 429467295
+                    "maximum": 429467295,
+                    "title": "DR Priority"
                   },
                   "sparse_mode": {
                     "type": "boolean",
                     "title": "Sparse Mode"
                   }
                 },
-                "additionalProperties": false
+                "additionalProperties": false,
+                "title": "IPv4"
               }
             },
-            "additionalProperties": false
+            "additionalProperties": false,
+            "title": "PIM"
           },
           "mac_security": {
-            "title": "MAC Security",
             "type": "object",
             "properties": {
               "profile": {
@@ -1864,14 +1870,15 @@
                 "title": "Profile"
               }
             },
-            "additionalProperties": false
+            "additionalProperties": false,
+            "title": "MAC Security"
           },
           "channel_group": {
             "type": "object",
             "properties": {
               "id": {
-                "title": "Port-Channel ID",
-                "type": "integer"
+                "type": "integer",
+                "title": "ID"
               },
               "mode": {
                 "type": "string",
@@ -1887,49 +1894,48 @@
             "title": "Channel Group"
           },
           "isis_enable": {
-            "title": "ISIS Enable",
-            "type": "string"
+            "type": "string",
+            "title": "ISIS Enable"
           },
           "isis_passive": {
-            "title": "ISIS Passive",
-            "type": "boolean"
+            "type": "boolean",
+            "title": "ISIS Passive"
           },
           "isis_metric": {
-            "title": "ISIS Metric",
-            "type": "integer"
+            "type": "integer",
+            "title": "ISIS Metric"
           },
           "isis_network_point_to_point": {
-            "title": "ISIS Network Point To Point",
-            "type": "boolean"
+            "type": "boolean",
+            "title": "ISIS Network Point To Point"
           },
           "isis_circuit_type": {
-            "title": "ISIS Circuit Type",
             "type": "string",
             "enum": [
               "level-1-2",
               "level-1",
               "level-2"
-            ]
+            ],
+            "title": "ISIS Circuit Type"
           },
           "isis_hello_padding": {
-            "title": "ISIS Hello Padding",
-            "type": "boolean"
+            "type": "boolean",
+            "title": "ISIS Hello Padding"
           },
           "isis_authentication_mode": {
-            "title": "ISIS Authentication Mode",
             "type": "string",
             "enum": [
               "text",
               "md5"
-            ]
+            ],
+            "title": "ISIS Authentication Mode"
           },
           "isis_authentication_key": {
-            "title": "ISIS Authentication Key",
             "type": "string",
-            "description": "type-7 encrypted password\n"
+            "description": "Type-7 encrypted password\n",
+            "title": "ISIS Authentication Key"
           },
           "ptp": {
-            "title": "PTP",
             "type": "object",
             "properties": {
               "enable": {
@@ -1983,9 +1989,9 @@
                 "title": "Role"
               },
               "vlan": {
-                "title": "VLAN",
                 "type": "string",
-                "description": "< all | list of vlans as string >\n"
+                "description": "all or list of vlans as string\n",
+                "title": "VLAN"
               },
               "transport": {
                 "type": "string",
@@ -1997,11 +2003,12 @@
                 "title": "Transport"
               }
             },
-            "additionalProperties": false
+            "additionalProperties": false,
+            "title": "Ptp"
           },
           "profile": {
-            "title": "Interface Profile",
-            "type": "string"
+            "type": "string",
+            "title": "Profile"
           },
           "storm_control": {
             "type": "object",
@@ -2101,7 +2108,6 @@
             "title": "Logging"
           },
           "lldp": {
-            "title": "LLDP",
             "type": "object",
             "properties": {
               "transmit": {
@@ -2113,23 +2119,23 @@
                 "title": "Receive"
               },
               "ztp_vlan": {
-                "title": "ZTP VLAN",
-                "type": "integer"
+                "type": "integer",
+                "title": "Ztp VLAN"
               }
             },
-            "additionalProperties": false
+            "additionalProperties": false,
+            "title": "LLDP"
           },
           "trunk_private_vlan_secondary": {
-            "title": "Trunk Private VLAN Secondary",
-            "type": "boolean"
+            "type": "boolean",
+            "title": "Trunk Private VLAN Secondary"
           },
           "pvlan_mapping": {
-            "title": "PVLAN Mapping",
             "type": "integer",
-            "description": "List of vlans as string\n"
+            "description": "List of vlans as string\n",
+            "title": "PVLAN Mapping"
           },
           "vlan_translations": {
-            "title": "VLAN Translations",
             "type": "array",
             "items": {
               "type": "object",
@@ -2140,8 +2146,8 @@
                   "title": "From"
                 },
                 "to": {
-                  "title": "To",
-                  "type": "integer"
+                  "type": "integer",
+                  "title": "To"
                 },
                 "direction": {
                   "type": "string",
@@ -2155,7 +2161,8 @@
                 }
               },
               "additionalProperties": false
-            }
+            },
+            "title": "VLAN Translations"
           },
           "dot1x": {
             "type": "object",
@@ -2178,7 +2185,6 @@
                 "title": "Reauthentication"
               },
               "pae": {
-                "title": "PAE",
                 "type": "object",
                 "properties": {
                   "mode": {
@@ -2189,7 +2195,8 @@
                     "title": "Mode"
                   }
                 },
-                "additionalProperties": false
+                "additionalProperties": false,
+                "title": "Pae"
               },
               "authentication_failure": {
                 "type": "object",
@@ -2203,10 +2210,10 @@
                     "title": "Action"
                   },
                   "allow_vlan": {
-                    "title": "Allow VLAN",
                     "type": "integer",
                     "minimum": 1,
-                    "maximum": 4094
+                    "maximum": 4094,
+                    "title": "Allow VLAN"
                   }
                 },
                 "additionalProperties": false,
@@ -2228,7 +2235,6 @@
                     "title": "Multi Host Authenticated"
                   },
                   "mac_based_authentication": {
-                    "title": "MAC Based Authentication",
                     "type": "object",
                     "properties": {
                       "enabled": {
@@ -2244,7 +2250,8 @@
                         "title": "Host Mode Common"
                       }
                     },
-                    "additionalProperties": false
+                    "additionalProperties": false,
+                    "title": "MAC Based Authentication"
                   },
                   "timeout": {
                     "type": "object",
@@ -2290,7 +2297,6 @@
                 "title": "Host Mode"
               },
               "mac_based_authentication": {
-                "title": "MAC Based Authentication",
                 "type": "object",
                 "properties": {
                   "enabled": {
@@ -2306,7 +2312,8 @@
                     "title": "Host Mode Common"
                   }
                 },
-                "additionalProperties": false
+                "additionalProperties": false,
+                "title": "MAC Based Authentication"
               },
               "timeout": {
                 "type": "object",
@@ -2328,8 +2335,8 @@
                     "title": "Reauth Timeout Ignore"
                   },
                   "tx_period": {
-                    "title": "Transmit Period",
-                    "type": "integer"
+                    "type": "integer",
+                    "title": "TX Period"
                   }
                 },
                 "additionalProperties": false,
@@ -2352,7 +2359,7 @@
             "properties": {
               "rate": {
                 "type": "string",
-                "description": "< \"< rate > kbps\" | \"1-100 percent\" | \"< rate > pps\" , supported options are platform dependent >\n",
+                "description": "rate in kbps or 1-100 percent or rate in pps, supported options are platform dependent\n",
                 "title": "Rate"
               }
             },
@@ -2360,7 +2367,6 @@
             "title": "Shape"
           },
           "qos": {
-            "title": "QOS",
             "type": "object",
             "properties": {
               "trust": {
@@ -2373,15 +2379,16 @@
                 "title": "Trust"
               },
               "dscp": {
-                "title": "DSCP",
-                "type": "integer"
+                "type": "integer",
+                "title": "DSCP"
               },
               "cos": {
-                "title": "COS",
-                "type": "integer"
+                "type": "integer",
+                "title": "COS"
               }
             },
-            "additionalProperties": false
+            "additionalProperties": false,
+            "title": "QOS"
           },
           "spanning_tree_bpdufilter": {
             "type": "string",
@@ -2409,8 +2416,8 @@
             "title": "Spanning Tree Portfast"
           },
           "vmtracer": {
-            "title": "VM Tracer",
-            "type": "boolean"
+            "type": "boolean",
+            "title": "VMTracer"
           },
           "priority_flow_control": {
             "type": "object",
@@ -2444,7 +2451,6 @@
             "title": "Priority Flow Control"
           },
           "bfd": {
-            "title": "BFD",
             "type": "object",
             "properties": {
               "echo": {
@@ -2457,9 +2463,9 @@
                 "title": "Interval"
               },
               "min_rx": {
-                "title": "Min RX",
                 "type": "integer",
-                "description": "Rate in milliseconds\n"
+                "description": "Rate in milliseconds\n",
+                "title": "Min RX"
               },
               "multiplier": {
                 "type": "integer",
@@ -2468,36 +2474,35 @@
                 "title": "Multiplier"
               }
             },
-            "additionalProperties": false
+            "additionalProperties": false,
+            "title": "BFD"
           },
           "service_policy": {
             "type": "object",
             "properties": {
               "pbr": {
-                "title": "PBR",
                 "type": "object",
                 "properties": {
                   "input": {
                     "type": "string",
-                    "title": "Policy Map Name"
+                    "title": "Input"
                   }
                 },
-                "additionalProperties": false
+                "additionalProperties": false,
+                "title": "PBR"
               }
             },
             "additionalProperties": false,
             "title": "Service Policy"
           },
           "mpls": {
-            "title": "MPLS",
             "type": "object",
             "properties": {
               "ip": {
-                "title": "IP",
-                "type": "boolean"
+                "type": "boolean",
+                "title": "IP"
               },
               "ldp": {
-                "title": "LDP",
                 "type": "object",
                 "properties": {
                   "interface": {
@@ -2509,13 +2514,14 @@
                     "type": "boolean"
                   }
                 },
-                "additionalProperties": false
+                "additionalProperties": false,
+                "title": "LDP"
               }
             },
-            "additionalProperties": false
+            "additionalProperties": false,
+            "title": "MPLS"
           },
           "lacp_timer": {
-            "title": "LACP Timer",
             "type": "object",
             "properties": {
               "mode": {
@@ -2533,13 +2539,14 @@
                 "title": "Multiplier"
               }
             },
-            "additionalProperties": false
+            "additionalProperties": false,
+            "title": "Lacp Timer"
           },
           "lacp_port_priority": {
-            "title": "LACP Port Priority",
             "type": "integer",
             "minimum": 0,
-            "maximum": 65535
+            "maximum": 65535,
+            "title": "Lacp Port Priority"
           },
           "transceiver": {
             "type": "object",
@@ -2548,8 +2555,9 @@
                 "type": "object",
                 "properties": {
                   "override": {
-                    "title": "Transceiver Type",
-                    "type": "string"
+                    "type": "string",
+                    "description": "Transceiver Type",
+                    "title": "Override"
                   }
                 },
                 "additionalProperties": false,
@@ -2560,20 +2568,20 @@
             "title": "Transceiver"
           },
           "ip_proxy_arp": {
-            "title": "IP Proxy ARP",
-            "type": "boolean"
+            "type": "boolean",
+            "title": "IP Proxy ARP"
           },
           "traffic_policy": {
             "type": "object",
             "properties": {
               "input": {
                 "type": "string",
-                "description": "ingress traffic policy\n",
+                "description": "Ingress traffic policy\n",
                 "title": "Input"
               },
               "output": {
                 "type": "string",
-                "description": "egress traffic policy\n",
+                "description": "Egress traffic policy\n",
                 "title": "Output"
               }
             },
@@ -2581,16 +2589,17 @@
             "title": "Traffic Policy"
           },
           "eos_cli": {
-            "title": "EOS CLI",
             "type": "string",
-            "description": "< multiline eos cli >"
+            "description": "Multiline eos cli",
+            "title": "EOS CLI"
           }
         },
         "required": [
           "name"
         ],
         "additionalProperties": false
-      }
+      },
+      "title": "Ethernet Interfaces"
     },
     "event_handlers": {
       "type": "array",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -982,14 +982,12 @@ keys:
     primary_key: name
     convert_types:
     - dict
-    display_name: Routed Ethernet Interfaces
     items:
       type: dict
       keys:
         name:
           type: str
           required: true
-          display_name: Ethernet Interface
         peer:
           type: str
         peer_interface:
@@ -1007,12 +1005,10 @@ keys:
 
             '
         mtu:
-          display_name: MTU
           type: int
           convert_types:
           - str
         l2_mtu:
-          display_name: L2 MTU
           type: int
           convert_types:
           - str
@@ -1021,7 +1017,6 @@ keys:
 
             '
         vlans:
-          display_name: VLANs
           type: str
           convert_types:
           - int
@@ -1029,12 +1024,10 @@ keys:
 
             '
         native_vlan:
-          display_name: Native VLAN
           type: int
           convert_types:
           - str
         native_vlan_tag:
-          display_name: Native VLAN Tag
           type: bool
           default: false
         mode:
@@ -1053,18 +1046,15 @@ keys:
               - tagged
               - untagged
             vlan:
-              display_name: VLAN
               type: int
               min: 1
               max: 4094
               convert_types:
               - str
         l2_protocol:
-          display_name: L2 Protocol
           type: dict
           keys:
             encapsulation_dot1q_vlan:
-              display_name: Encapsulation dot1q VLAN
               type: int
               convert_types:
               - str
@@ -1114,7 +1104,6 @@ keys:
             type: dict
             keys:
               name:
-                display_name: Group Name
                 type: str
               direction:
                 type: str
@@ -1122,7 +1111,6 @@ keys:
                 - upstream
                 - downstream
         evpn_ethernet_segment:
-          display_name: EVPN Ethernet Segment
           type: dict
           keys:
             identifier:
@@ -1165,7 +1153,6 @@ keys:
                 candidate_reachability_required:
                   type: bool
             mpls:
-              display_name: MPLS
               type: dict
               keys:
                 shared_index:
@@ -1184,7 +1171,6 @@ keys:
 
                 '
         encapsulation_dot1q_vlan:
-          display_name: Encapsulation dot1q VLAN
           type: int
           convert_types:
           - str
@@ -1192,7 +1178,6 @@ keys:
 
             '
         encapsulation_vlan:
-          display_name: Encapsulation VLAN
           type: dict
           keys:
             client:
@@ -1202,7 +1187,6 @@ keys:
                   type: dict
                   keys:
                     vlan:
-                      display_name: Client VLAN ID
                       type: int
                       convert_types:
                       - str
@@ -1212,20 +1196,20 @@ keys:
                       convert_types:
                       - str
                     inner:
-                      display_name: Client Inner VLAN ID
                       type: int
                       convert_types:
                       - str
+                      description: Client Inner VLAN ID
                 outer:
-                  display_name: Client Outer VLAN ID
                   type: int
                   convert_types:
                   - str
+                  description: Client Outer VLAN ID
                 inner:
-                  display_name: Client Inner VLAN ID
                   type: int
                   convert_types:
                   - str
+                  description: Client Inner VLAN ID
                 unmatched:
                   type: bool
             network:
@@ -1239,49 +1223,45 @@ keys:
                   type: dict
                   keys:
                     vlan:
-                      display_name: Network VLAN ID
                       type: int
                       convert_types:
                       - str
+                      description: Network VLAN ID
                     outer:
-                      display_name: Network Outer VLAN ID
                       type: int
                       convert_types:
                       - str
+                      description: Network Outer VLAN ID
                     inner:
-                      display_name: Network Inner VLAN ID
                       type: int
                       convert_types:
                       - str
+                      description: Network Inner VLAN ID
                 outer:
-                  display_name: Network Outer VLAN ID
                   type: int
                   convert_types:
                   - str
+                  description: Network Outer VLAN ID
                 inner:
-                  display_name: Network Inner VLAN ID
                   type: int
                   convert_types:
                   - str
+                  description: Network Inner VLAN ID
                 client:
                   type: bool
         vlan_id:
-          display_name: VLAN ID
           type: int
           min: 1
           max: 4094
           convert_types:
           - str
         ip_address:
-          display_name: IP Address
           type: str
         ip_address_secondaries:
-          display_name: IP Address Secondaries
           type: list
           items:
             type: str
         ip_helpers:
-          display_name: IP Helpers
           type: list
           primary_key: ip_helper
           convert_types:
@@ -1290,32 +1270,24 @@ keys:
             type: dict
             keys:
               ip_helper:
-                display_name: IP Helper
                 type: str
                 required: true
               source_interface:
                 type: str
-                display_name: Source Interface Name
               vrf:
-                display_name: VRF Name
                 type: str
         ipv6_enable:
-          display_name: IPv6 Enable
           type: bool
         ipv6_address:
-          display_name: IPv6 Address
           type: str
         ipv6_address_link_local:
-          display_name: IPv6 Address Link Local
           type: str
         ipv6_nd_ra_disabled:
           display_name: IPv6 ND RA Disabled
           type: bool
         ipv6_nd_managed_config_flag:
-          display_name: IPv6 ND Managed Config Flag
           type: bool
         ipv6_nd_prefixes:
-          display_name: IPv6 ND Prefixes
           type: list
           primary_key: ipv6_prefix
           convert_types:
@@ -1324,42 +1296,35 @@ keys:
             type: dict
             keys:
               ipv6_prefix:
-                display_name: IPv6 Prefix
                 type: str
                 required: true
               valid_lifetime:
                 type: str
                 convert_types:
                 - int
-                description: '< infinite or lifetime in seconds >
+                description: 'Infinite or lifetime in seconds
 
                   '
               preferred_lifetime:
                 type: str
                 convert_types:
                 - int
-                description: '< infinite or lifetime in seconds >
+                description: 'Infinite or lifetime in seconds
 
                   '
               no_autoconfig_flag:
                 type: bool
         access_group_in:
-          display_name: Access Group IN
           type: str
         access_group_out:
-          display_name: Access Group OUT
           type: str
         ipv6_access_group_in:
-          display_name: IPv6 Access Group IN
           type: str
         ipv6_access_group_out:
-          display_name: IPV6 Access Group OUT
           type: str
         mac_access_group_in:
-          display_name: MAC Access Group IN
           type: str
         mac_access_group_out:
-          display_name: MAC Access Group OUT
           type: str
         multicast:
           type: dict
@@ -1369,7 +1334,6 @@ keys:
             '
           keys:
             ipv4:
-              display_name: IPv4
               type: dict
               keys:
                 boundaries:
@@ -1384,7 +1348,6 @@ keys:
                 static:
                   type: bool
             ipv6:
-              display_name: IPv6
               type: dict
               keys:
                 boundaries:
@@ -1397,30 +1360,24 @@ keys:
                 static:
                   type: bool
         ospf_network_point_to_point:
-          display_name: OSPF Network Point To Point
           type: bool
         ospf_area:
-          display_name: OSPF Area
           type: str
           convert_types:
           - int
         ospf_cost:
-          display_name: OSPF Cost
           type: int
           convert_types:
           - str
         ospf_authentication:
-          display_name: OSPF Authentication
           type: str
           valid_values:
           - none
           - simple
           - message-digest
         ospf_authentication_key:
-          display_name: OSPF Authentication Key
           type: str
         ospf_message_digest_keys:
-          display_name: OSPF Message Digest Keys
           type: list
           primary_key: id
           convert_types:
@@ -1445,15 +1402,12 @@ keys:
               key:
                 type: str
         pim:
-          display_name: PIM
           type: dict
           keys:
             ipv4:
-              display_name: IPv4
               type: dict
               keys:
                 dr_priority:
-                  display_name: DR Priority
                   type: int
                   convert_types:
                   - str
@@ -1462,7 +1416,6 @@ keys:
                 sparse_mode:
                   type: bool
         mac_security:
-          display_name: MAC Security
           type: dict
           keys:
             profile:
@@ -1471,7 +1424,6 @@ keys:
           type: dict
           keys:
             id:
-              display_name: Port-Channel ID
               type: int
               convert_types:
               - str
@@ -1482,43 +1434,34 @@ keys:
               - active
               - passive
         isis_enable:
-          display_name: ISIS Enable
           type: str
         isis_passive:
-          display_name: ISIS Passive
           type: bool
         isis_metric:
-          display_name: ISIS Metric
           type: int
           convert_types:
           - str
         isis_network_point_to_point:
-          display_name: ISIS Network Point To Point
           type: bool
         isis_circuit_type:
-          display_name: ISIS Circuit Type
           type: str
           valid_values:
           - level-1-2
           - level-1
           - level-2
         isis_hello_padding:
-          display_name: ISIS Hello Padding
           type: bool
         isis_authentication_mode:
-          display_name: ISIS Authentication Mode
           type: str
           valid_values:
           - text
           - md5
         isis_authentication_key:
-          display_name: ISIS Authentication Key
           type: str
-          description: 'type-7 encrypted password
+          description: 'Type-7 encrypted password
 
             '
         ptp:
-          display_name: PTP
           type: dict
           keys:
             enable:
@@ -1556,11 +1499,10 @@ keys:
               - master
               - dynamic
             vlan:
-              display_name: VLAN
               type: str
               convert_types:
               - int
-              description: '< all | list of vlans as string >
+              description: 'all or list of vlans as string
 
                 '
             transport:
@@ -1570,7 +1512,6 @@ keys:
               - ipv6
               - layer2
         profile:
-          display_name: Interface Profile
           type: str
         storm_control:
           type: dict
@@ -1650,7 +1591,6 @@ keys:
                 congestion_drops:
                   type: bool
         lldp:
-          display_name: LLDP
           type: dict
           keys:
             transmit:
@@ -1658,15 +1598,12 @@ keys:
             receive:
               type: bool
             ztp_vlan:
-              display_name: ZTP VLAN
               type: int
               convert_types:
               - str
         trunk_private_vlan_secondary:
-          display_name: Trunk Private VLAN Secondary
           type: bool
         pvlan_mapping:
-          display_name: PVLAN Mapping
           type: int
           convert_types:
           - str
@@ -1674,7 +1611,6 @@ keys:
 
             '
         vlan_translations:
-          display_name: VLAN Translations
           type: list
           items:
             type: dict
@@ -1686,7 +1622,6 @@ keys:
 
                   '
               to:
-                display_name: To
                 type: int
                 convert_types:
                 - str
@@ -1711,7 +1646,6 @@ keys:
             reauthentication:
               type: bool
             pae:
-              display_name: PAE
               type: dict
               keys:
                 mode:
@@ -1727,7 +1661,6 @@ keys:
                   - allow
                   - drop
                 allow_vlan:
-                  display_name: Allow VLAN
                   type: int
                   min: 1
                   max: 4094
@@ -1744,7 +1677,6 @@ keys:
                 multi_host_authenticated:
                   type: bool
                 mac_based_authentication:
-                  display_name: MAC Based Authentication
                   type: dict
                   keys:
                     enabled:
@@ -1786,7 +1718,6 @@ keys:
                   convert_types:
                   - str
             mac_based_authentication:
-              display_name: MAC Based Authentication
               type: dict
               keys:
                 enabled:
@@ -1811,7 +1742,6 @@ keys:
                 reauth_timeout_ignore:
                   type: bool
                 tx_period:
-                  display_name: Transmit Period
                   type: int
                   convert_types:
                   - str
@@ -1826,12 +1756,11 @@ keys:
           keys:
             rate:
               type: str
-              description: '< "< rate > kbps" | "1-100 percent" | "< rate > pps" ,
-                supported options are platform dependent >
+              description: 'rate in kbps or 1-100 percent or rate in pps, supported
+                options are platform dependent
 
                 '
         qos:
-          display_name: QOS
           type: dict
           keys:
             trust:
@@ -1841,12 +1770,10 @@ keys:
               - cos
               - disabled
             dscp:
-              display_name: DSCP
               type: int
               convert_types:
               - str
             cos:
-              display_name: COS
               type: int
               convert_types:
               - str
@@ -1870,7 +1797,6 @@ keys:
           - edge
           - network
         vmtracer:
-          display_name: VM Tracer
           type: bool
         priority_flow_control:
           type: dict
@@ -1891,7 +1817,6 @@ keys:
                   no_drop:
                     type: bool
         bfd:
-          display_name: BFD
           type: dict
           keys:
             echo:
@@ -1904,7 +1829,6 @@ keys:
 
                 '
             min_rx:
-              display_name: Min RX
               type: int
               convert_types:
               - str
@@ -1921,21 +1845,16 @@ keys:
           type: dict
           keys:
             pbr:
-              display_name: PBR
               type: dict
               keys:
                 input:
                   type: str
-                  display_name: Policy Map Name
         mpls:
-          display_name: MPLS
           type: dict
           keys:
             ip:
-              display_name: IP
               type: bool
             ldp:
-              display_name: LDP
               type: dict
               keys:
                 interface:
@@ -1944,7 +1863,6 @@ keys:
                   display_name: IGP Sync
                   type: bool
         lacp_timer:
-          display_name: LACP Timer
           type: dict
           keys:
             mode:
@@ -1959,7 +1877,6 @@ keys:
               convert_types:
               - str
         lacp_port_priority:
-          display_name: LACP Port Priority
           type: int
           min: 0
           max: 65535
@@ -1972,28 +1889,26 @@ keys:
               type: dict
               keys:
                 override:
-                  display_name: Transceiver Type
                   type: str
+                  description: Transceiver Type
         ip_proxy_arp:
-          display_name: IP Proxy ARP
           type: bool
         traffic_policy:
           type: dict
           keys:
             input:
               type: str
-              description: 'ingress traffic policy
+              description: 'Ingress traffic policy
 
                 '
             output:
               type: str
-              description: 'egress traffic policy
+              description: 'Egress traffic policy
 
                 '
         eos_cli:
-          display_name: EOS CLI
           type: str
-          description: < multiline eos cli >
+          description: Multiline eos cli
   event_handlers:
     type: list
     primary_key: name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -982,19 +982,12 @@ keys:
     primary_key: name
     convert_types:
     - dict
-    description: Routed interfaces
     items:
       type: dict
       keys:
         name:
           type: str
           required: true
-        peer:
-          type: str
-        peer_interface:
-          type: str
-        peer_type:
-          type: str
         description:
           type: str
         shutdown:
@@ -1011,20 +1004,29 @@ keys:
           type: int
           convert_types:
           - str
-          description: If l2_mtu defined this profile should only be used for platforms
-            supporting the "l2 mtu" CLI
+          description: '"l2_mtu" should only be defined for platforms supporting the
+            "l2 mtu" CLI
+
+            '
         vlans:
           type: str
           convert_types:
           - int
-          description: List of vlans as string
+          description: 'List of switchport vlans as string.
+
+            For a trunk port this would be a range like "1-200,300"
+
+            For an access port this would be a single vlan "123"
+
+            '
         native_vlan:
           type: int
           convert_types:
           - str
         native_vlan_tag:
           type: bool
-          default: false
+          description: If setting both native_vlan and native_vlan_tag, native_vlan_tag
+            takes precedence
         mode:
           type: str
           valid_values:
@@ -1069,16 +1071,15 @@ keys:
             interface should be defined as routed.
         snmp_trap_link_change:
           type: bool
-          description: SNMP trap link change
         flowcontrol:
           type: dict
           keys:
             received:
               type: str
               valid_values:
-              - received
-              - send
+              - desired
               - 'on'
+              - 'off'
         vrf:
           type: str
           description: VRF name
@@ -1100,6 +1101,7 @@ keys:
               type: bool
         link_tracking_groups:
           type: list
+          primary_key: name
           items:
             type: dict
             keys:
@@ -1134,11 +1136,12 @@ keys:
                   type: int
                   min: 0
                   max: 65535
-                  description: Preference_value and dont_preempt are set for preference
-                    algorithm and are optional
+                  convert_types:
+                  - str
+                  description: Preference_value is only used when "algorithm" is "preference"
                 dont_preempt:
                   type: bool
-                  default: false
+                  description: Dont_preempt is only used when "algorithm" is "preference"
                 hold_time:
                   type: int
                   convert_types:
@@ -1194,22 +1197,12 @@ keys:
                       convert_types:
                       - str
                       description: Client Inner VLAN ID
-                outer:
-                  type: int
-                  convert_types:
-                  - str
-                  description: Client Outer VLAN ID
-                inner:
-                  type: int
-                  convert_types:
-                  - str
-                  description: Client Inner VLAN ID
                 unmatched:
                   type: bool
             network:
               type: dict
-              description: Network encapsulation is all optional, and skipped if using
-                client unmatched.
+              description: Network encapsulations are all optional, and skipped if
+                using client unmatched.
               keys:
                 dot1q:
                   type: dict
@@ -1229,16 +1222,6 @@ keys:
                       convert_types:
                       - str
                       description: Network Inner VLAN ID
-                outer:
-                  type: int
-                  convert_types:
-                  - str
-                  description: Network Outer VLAN ID
-                inner:
-                  type: int
-                  convert_types:
-                  - str
-                  description: Network Inner VLAN ID
                 client:
                   type: bool
         vlan_id:
@@ -1249,7 +1232,7 @@ keys:
           - str
         ip_address:
           type: str
-          description: IPv4_address or Mask
+          description: IPv4 address/mask
         ip_address_secondaries:
           type: list
           items:
@@ -1277,10 +1260,9 @@ keys:
           type: str
         ipv6_address_link_local:
           type: str
-          description: Link local IPv6 address or mask
+          description: Link local IPv6 address/mask
         ipv6_nd_ra_disabled:
           type: bool
-          description: IPv6 ND RA disabled
         ipv6_nd_managed_config_flag:
           type: bool
         ipv6_nd_prefixes:
@@ -1509,6 +1491,7 @@ keys:
               - layer2
         profile:
           type: str
+          description: Interface profile
         storm_control:
           type: dict
           keys:
@@ -1597,9 +1580,9 @@ keys:
         trunk_private_vlan_secondary:
           type: bool
         pvlan_mapping:
-          type: int
+          type: str
           convert_types:
-          - str
+          - int
           description: List of vlans as string
         vlan_translations:
           type: list
@@ -1607,14 +1590,16 @@ keys:
             type: dict
             keys:
               from:
-                type: str
+                type: int
+                convert_types:
+                - str
                 description: List of vlans as string (only one vlan if direction is
                   "both")
               to:
                 type: int
                 convert_types:
                 - str
-                description: VLAN id
+                description: VLAN ID
               direction:
                 type: str
                 valid_values:
@@ -1680,10 +1665,14 @@ keys:
               keys:
                 idle_host:
                   type: int
+                  min: 10
+                  max: 65535
                   convert_types:
                   - str
                 quiet_period:
                   type: int
+                  min: 1
+                  max: 65535
                   convert_types:
                   - str
                 reauth_period:
@@ -1695,6 +1684,8 @@ keys:
                   type: bool
                 tx_period:
                   type: int
+                  min: 1
+                  max: 65535
                   convert_types:
                   - str
             reauthorization_request_limit:
@@ -1711,8 +1702,18 @@ keys:
           keys:
             rate:
               type: str
-              description: Rate in kbps or pps or 1-100 percent or rate in pps, supported
-                options are platform dependent
+              description: 'Rate in kbps, pps or percent. Supported options are platform
+                dependent.
+
+                Examples:
+
+                - "5000 kbps"
+
+                - "1000 pps"
+
+                - "20 percent"
+
+                '
         qos:
           type: dict
           keys:
@@ -1736,10 +1737,18 @@ keys:
           type: str
           convert_types:
           - bool
+          valid_values:
+          - enabled
+          - disabled
+          - 'true'
         spanning_tree_bpduguard:
           type: str
           convert_types:
           - bool
+          valid_values:
+          - enabled
+          - disabled
+          - 'true'
         spanning_tree_guard:
           type: str
           valid_values:
@@ -1760,6 +1769,7 @@ keys:
               type: bool
             priorities:
               type: list
+              primary_key: priority
               items:
                 type: dict
                 keys:
@@ -1855,10 +1865,17 @@ keys:
               description: Egress traffic policy
         eos_cli:
           type: str
-          description: Multiline eos cli. EOS CLI rendered directly on the ethernet
-            interface in the final EOS configuration
-        struct_cfg:
-          type: dict
+          description: Multiline EOS CLI rendered directly on the ethernet interface
+            in the final EOS configuration
+        peer:
+          type: str
+          description: Key only used for documentation or validation purposes
+        peer_interface:
+          type: str
+          description: Key only used for documentation or validation purposes
+        peer_type:
+          type: str
+          description: Key only used for documentation or validation purposes
   event_handlers:
     type: list
     primary_key: name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -982,6 +982,7 @@ keys:
     primary_key: name
     convert_types:
     - dict
+    description: Routed interfaces
     items:
       type: dict
       keys:
@@ -1000,10 +1001,8 @@ keys:
           type: bool
         speed:
           type: str
-          description: '< interface_speed | forced interface_speed | auto interface_speed
-            >
-
-            '
+          description: Speed can be interface_speed or forced interface_speed or auto
+            interface_speed
         mtu:
           type: int
           convert_types:
@@ -1012,17 +1011,13 @@ keys:
           type: int
           convert_types:
           - str
-          description: 'l2-mtu - if defined this profile should only be used for platforms
+          description: If l2_mtu defined this profile should only be used for platforms
             supporting the "l2 mtu" CLI
-
-            '
         vlans:
           type: str
           convert_types:
           - int
-          description: '< list of vlans as string
-
-            '
+          description: List of vlans as string
         native_vlan:
           type: int
           convert_types:
@@ -1058,6 +1053,7 @@ keys:
               type: int
               convert_types:
               - str
+              description: Vlan tag to configure on sub-interface
         trunk_groups:
           type: list
           items:
@@ -1069,13 +1065,11 @@ keys:
           - switched
           - l3dot1q
           - l2dot1q
-          description: 'l3dot1q and l2dot1q are used for sub-interfaces. The parent
+          description: l3dot1q and l2dot1q are used for sub-interfaces. The parent
             interface should be defined as routed.
-
-            '
         snmp_trap_link_change:
-          display_name: SNMP Trap Link Change
           type: bool
+          description: SNMP trap link change
         flowcontrol:
           type: dict
           keys:
@@ -1086,8 +1080,14 @@ keys:
               - send
               - 'on'
         vrf:
-          display_name: VRF Name
           type: str
+          description: VRF name
+        flow_tracker:
+          type: dict
+          keys:
+            sampled:
+              type: str
+              description: Flow tracker name
         error_correction_encoding:
           type: dict
           keys:
@@ -1105,6 +1105,7 @@ keys:
             keys:
               name:
                 type: str
+                description: Group name
               direction:
                 type: str
                 valid_values:
@@ -1115,9 +1116,7 @@ keys:
           keys:
             identifier:
               type: str
-              description: 'EVPN Ethernet Segment Identifier (Type 1 format)
-
-                '
+              description: EVPN Ethernet Segment Identifier (Type 1 format)
             redundancy:
               type: str
               valid_values:
@@ -1135,10 +1134,8 @@ keys:
                   type: int
                   min: 0
                   max: 65535
-                  description: 'Preference_value and dont_preempt are set for preference
+                  description: Preference_value and dont_preempt are set for preference
                     algorithm and are optional
-
-                    '
                 dont_preempt:
                   type: bool
                   default: false
@@ -1167,16 +1164,12 @@ keys:
                   - str
             route_target:
               type: str
-              description: 'EVPN Route Target for ESI with format xx:xx:xx:xx:xx:xx
-
-                '
+              description: EVPN Route Target for ESI with format xx:xx:xx:xx:xx:xx
         encapsulation_dot1q_vlan:
           type: int
           convert_types:
           - str
-          description: 'vlan tag to configure on sub-interface
-
-            '
+          description: VLAN tag to configure on sub-interface
         encapsulation_vlan:
           type: dict
           keys:
@@ -1190,11 +1183,12 @@ keys:
                       type: int
                       convert_types:
                       - str
+                      description: Client VLAN ID
                     outer:
-                      display_name: Client Outer VLAN ID
                       type: int
                       convert_types:
                       - str
+                      description: Client Outer VLAN ID
                     inner:
                       type: int
                       convert_types:
@@ -1214,10 +1208,8 @@ keys:
                   type: bool
             network:
               type: dict
-              description: 'Network encapsulation is all optional, and skipped if
-                using client unmatched.
-
-                '
+              description: Network encapsulation is all optional, and skipped if using
+                client unmatched.
               keys:
                 dot1q:
                   type: dict
@@ -1257,6 +1249,7 @@ keys:
           - str
         ip_address:
           type: str
+          description: IPv4_address or Mask
         ip_address_secondaries:
           type: list
           items:
@@ -1274,17 +1267,20 @@ keys:
                 required: true
               source_interface:
                 type: str
+                description: Source interface name
               vrf:
                 type: str
+                description: VRF name
         ipv6_enable:
           type: bool
         ipv6_address:
           type: str
         ipv6_address_link_local:
           type: str
+          description: Link local IPv6 address or mask
         ipv6_nd_ra_disabled:
-          display_name: IPv6 ND RA Disabled
           type: bool
+          description: IPv6 ND RA disabled
         ipv6_nd_managed_config_flag:
           type: bool
         ipv6_nd_prefixes:
@@ -1302,36 +1298,36 @@ keys:
                 type: str
                 convert_types:
                 - int
-                description: 'Infinite or lifetime in seconds
-
-                  '
+                description: Infinite or lifetime in seconds
               preferred_lifetime:
                 type: str
                 convert_types:
                 - int
-                description: 'Infinite or lifetime in seconds
-
-                  '
+                description: Infinite or lifetime in seconds
               no_autoconfig_flag:
                 type: bool
         access_group_in:
           type: str
+          description: Access list name
         access_group_out:
           type: str
+          description: Access list name
         ipv6_access_group_in:
           type: str
+          description: IPv6 access list name
         ipv6_access_group_out:
           type: str
+          description: IPv6 access list name
         mac_access_group_in:
           type: str
+          description: MAC access list name
         mac_access_group_out:
           type: str
+          description: MAC access list name
         multicast:
           type: dict
-          description: 'boundaries can be either 1 ACL or a list of multicast IP address_range(s)/prefix
+          description: Boundaries can be either 1 ACL or a list of multicast IP address_range(s)/prefix
             but not combination of both
-
-            '
           keys:
             ipv4:
               type: dict
@@ -1343,6 +1339,7 @@ keys:
                     keys:
                       boundary:
                         type: str
+                        description: ACL name or multicast IP subnet
                       out:
                         type: bool
                 static:
@@ -1357,6 +1354,7 @@ keys:
                     keys:
                       boundary:
                         type: str
+                        description: ACL name or multicast IP subnet
                 static:
                   type: bool
         ospf_network_point_to_point:
@@ -1377,6 +1375,7 @@ keys:
           - message-digest
         ospf_authentication_key:
           type: str
+          description: Encrypted password
         ospf_message_digest_keys:
           type: list
           primary_key: id
@@ -1386,7 +1385,6 @@ keys:
             type: dict
             keys:
               id:
-                display_name: ID
                 type: int
                 convert_types:
                 - str
@@ -1396,11 +1394,12 @@ keys:
                 valid_values:
                 - md5
                 - sha1
-                - sha 256
+                - sha256
                 - sha384
                 - sha512
               key:
                 type: str
+                description: Encrypted password
         pim:
           type: dict
           keys:
@@ -1435,6 +1434,7 @@ keys:
               - passive
         isis_enable:
           type: str
+          description: ISIS instance
         isis_passive:
           type: bool
         isis_metric:
@@ -1458,9 +1458,7 @@ keys:
           - md5
         isis_authentication_key:
           type: str
-          description: 'Type-7 encrypted password
-
-            '
+          description: Type-7 encrypted password
         ptp:
           type: dict
           keys:
@@ -1502,9 +1500,7 @@ keys:
               type: str
               convert_types:
               - int
-              description: 'all or list of vlans as string
-
-                '
+              description: VLAN can be 'all' or list of vlans as string
             transport:
               type: str
               valid_values:
@@ -1523,15 +1519,14 @@ keys:
                   type: int
                   convert_types:
                   - str
-                  description: 'Configure maximum storm-control level
-
-                    '
+                  description: Configure maximum storm-control level
                 unit:
                   type: str
-                  description: 'Percent* | pps (optional and is hardware dependant
-                    - default is percent)
-
-                    '
+                  default: percent
+                  valid_values:
+                  - percent
+                  - pps
+                  description: Optional field and is hardware dependant
             broadcast:
               type: dict
               keys:
@@ -1539,15 +1534,14 @@ keys:
                   type: int
                   convert_types:
                   - str
-                  description: 'Configure maximum storm-control level
-
-                    '
+                  description: Configure maximum storm-control level
                 unit:
                   type: str
-                  description: 'Percent* | pps (optional and is hardware dependant
-                    - default is percent)
-
-                    '
+                  default: percent
+                  valid_values:
+                  - percent
+                  - pps
+                  description: Optional field and is hardware dependant
             multicast:
               type: dict
               keys:
@@ -1555,15 +1549,14 @@ keys:
                   type: int
                   convert_types:
                   - str
-                  description: 'Configure maximum storm-control level
-
-                    '
+                  description: Configure maximum storm-control level
                 unit:
                   type: str
-                  description: 'Percent* | pps (optional and is hardware dependant
-                    - default is percent)
-
-                    '
+                  default: percent
+                  valid_values:
+                  - percent
+                  - pps
+                  description: Optional field and is hardware dependant
             unknown_unicast:
               type: dict
               keys:
@@ -1571,15 +1564,14 @@ keys:
                   type: int
                   convert_types:
                   - str
-                  description: 'Configure maximum storm-control level
-
-                    '
+                  description: Configure maximum storm-control level
                 unit:
                   type: str
-                  description: 'Percent* | pps (optional and is hardware dependant
-                    - default is percent)
-
-                    '
+                  default: percent
+                  valid_values:
+                  - percent
+                  - pps
+                  description: Optional field and is hardware dependant
         logging:
           type: dict
           keys:
@@ -1601,15 +1593,14 @@ keys:
               type: int
               convert_types:
               - str
+              description: ZTP vlan number
         trunk_private_vlan_secondary:
           type: bool
         pvlan_mapping:
           type: int
           convert_types:
           - str
-          description: 'List of vlans as string
-
-            '
+          description: List of vlans as string
         vlan_translations:
           type: list
           items:
@@ -1617,14 +1608,13 @@ keys:
             keys:
               from:
                 type: str
-                description: 'List of vlans as string (only one vlan if direction
-                  is "both")
-
-                  '
+                description: List of vlans as string (only one vlan if direction is
+                  "both")
               to:
                 type: int
                 convert_types:
                 - str
+                description: VLAN id
               direction:
                 type: str
                 valid_values:
@@ -1676,47 +1666,6 @@ keys:
                   - single-host
                 multi_host_authenticated:
                   type: bool
-                mac_based_authentication:
-                  type: dict
-                  keys:
-                    enabled:
-                      type: bool
-                    always:
-                      type: bool
-                    host_mode_common:
-                      type: bool
-                timeout:
-                  type: dict
-                  keys:
-                    idle_host:
-                      type: int
-                      min: 10
-                      max: 65535
-                      convert_types:
-                      - str
-                    quiet_period:
-                      type: int
-                      min: 1
-                      max: 65535
-                      convert_types:
-                      - str
-                    reauth_period:
-                      type: str
-                    reauth_timeout_ignore:
-                      type: bool
-                    tx_period:
-                      display_name: Transmit Period
-                      type: int
-                      min: 1
-                      max: 65535
-                      convert_types:
-                      - str
-                reauthorization_request_limit:
-                  type: int
-                  min: 1
-                  max: 10
-                  convert_types:
-                  - str
             mac_based_authentication:
               type: dict
               keys:
@@ -1739,6 +1688,9 @@ keys:
                   - str
                 reauth_period:
                   type: str
+                  convert_types:
+                  - int
+                  description: Value can be 60-4294967295 or 'server'
                 reauth_timeout_ignore:
                   type: bool
                 tx_period:
@@ -1747,19 +1699,20 @@ keys:
                   - str
             reauthorization_request_limit:
               type: int
+              min: 1
+              max: 10
               convert_types:
               - str
         service_profile:
           type: str
+          description: QOS profile
         shape:
           type: dict
           keys:
             rate:
               type: str
-              description: 'rate in kbps or 1-100 percent or rate in pps, supported
+              description: Rate in kbps or pps or 1-100 percent or rate in pps, supported
                 options are platform dependent
-
-                '
         qos:
           type: dict
           keys:
@@ -1773,10 +1726,12 @@ keys:
               type: int
               convert_types:
               - str
+              description: DSCP value
             cos:
               type: int
               convert_types:
               - str
+              description: COS value
         spanning_tree_bpdufilter:
           type: str
           convert_types:
@@ -1825,16 +1780,12 @@ keys:
               type: int
               convert_types:
               - str
-              description: 'Interval in milliseconds
-
-                '
+              description: Interval in milliseconds
             min_rx:
               type: int
               convert_types:
               - str
-              description: 'Rate in milliseconds
-
-                '
+              description: Rate in milliseconds
             multiplier:
               type: int
               min: 3
@@ -1849,6 +1800,7 @@ keys:
               keys:
                 input:
                   type: str
+                  description: Policy-map name
         mpls:
           type: dict
           keys:
@@ -1860,7 +1812,6 @@ keys:
                 interface:
                   type: bool
                 igp_sync:
-                  display_name: IGP Sync
                   type: bool
         lacp_timer:
           type: dict
@@ -1898,17 +1849,16 @@ keys:
           keys:
             input:
               type: str
-              description: 'Ingress traffic policy
-
-                '
+              description: Ingress traffic policy
             output:
               type: str
-              description: 'Egress traffic policy
-
-                '
+              description: Egress traffic policy
         eos_cli:
           type: str
-          description: Multiline eos cli
+          description: Multiline eos cli. EOS CLI rendered directly on the ethernet
+            interface in the final EOS configuration
+        struct_cfg:
+          type: dict
   event_handlers:
     type: list
     primary_key: name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -1590,9 +1590,9 @@ keys:
             type: dict
             keys:
               from:
-                type: int
+                type: str
                 convert_types:
-                - str
+                - int
                 description: List of vlans as string (only one vlan if direction is
                   "both")
               to:
@@ -1740,7 +1740,10 @@ keys:
           valid_values:
           - enabled
           - disabled
+          - 'True'
+          - 'False'
           - 'true'
+          - 'false'
         spanning_tree_bpduguard:
           type: str
           convert_types:
@@ -1748,7 +1751,10 @@ keys:
           valid_values:
           - enabled
           - disabled
+          - 'True'
+          - 'False'
           - 'true'
+          - 'false'
         spanning_tree_guard:
           type: str
           valid_values:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -977,6 +977,1023 @@ keys:
             default: 300
             min: 30
             max: 86400
+  ethernet_interfaces:
+    type: list
+    primary_key: name
+    convert_types:
+    - dict
+    display_name: Routed Ethernet Interfaces
+    items:
+      type: dict
+      keys:
+        name:
+          type: str
+          required: true
+          display_name: Ethernet Interface
+        peer:
+          type: str
+        peer_interface:
+          type: str
+        peer_type:
+          type: str
+        description:
+          type: str
+        shutdown:
+          type: bool
+        speed:
+          type: str
+          description: '< interface_speed | forced interface_speed | auto interface_speed
+            >
+
+            '
+        mtu:
+          display_name: MTU
+          type: int
+          convert_types:
+          - str
+        l2_mtu:
+          display_name: L2 MTU
+          type: int
+          convert_types:
+          - str
+          description: 'l2-mtu - if defined this profile should only be used for platforms
+            supporting the "l2 mtu" CLI
+
+            '
+        vlans:
+          display_name: VLANs
+          type: str
+          convert_types:
+          - int
+          description: '< list of vlans as string
+
+            '
+        native_vlan:
+          display_name: Native VLAN
+          type: int
+          convert_types:
+          - str
+        native_vlan_tag:
+          display_name: Native VLAN Tag
+          type: bool
+          default: false
+        mode:
+          type: str
+          valid_values:
+          - access
+          - dot1q-tunnel
+          - trunk
+          - trunk phone
+        phone:
+          type: dict
+          keys:
+            trunk:
+              type: str
+              valid_values:
+              - tagged
+              - untagged
+            vlan:
+              display_name: VLAN
+              type: int
+              min: 1
+              max: 4094
+              convert_types:
+              - str
+        l2_protocol:
+          display_name: L2 Protocol
+          type: dict
+          keys:
+            encapsulation_dot1q_vlan:
+              display_name: Encapsulation dot1q VLAN
+              type: int
+              convert_types:
+              - str
+        trunk_groups:
+          type: list
+          items:
+            type: str
+        type:
+          type: str
+          valid_values:
+          - routed
+          - switched
+          - l3dot1q
+          - l2dot1q
+          description: 'l3dot1q and l2dot1q are used for sub-interfaces. The parent
+            interface should be defined as routed.
+
+            '
+        snmp_trap_link_change:
+          display_name: SNMP Trap Link Change
+          type: bool
+        flowcontrol:
+          type: dict
+          keys:
+            received:
+              type: str
+              valid_values:
+              - received
+              - send
+              - 'on'
+        vrf:
+          display_name: VRF Name
+          type: str
+        error_correction_encoding:
+          type: dict
+          keys:
+            enabled:
+              type: bool
+              default: true
+            fire_code:
+              type: bool
+            reed_solomon:
+              type: bool
+        link_tracking_groups:
+          type: list
+          items:
+            type: dict
+            keys:
+              name:
+                display_name: Group Name
+                type: str
+              direction:
+                type: str
+                valid_values:
+                - upstream
+                - downstream
+        evpn_ethernet_segment:
+          display_name: EVPN Ethernet Segment
+          type: dict
+          keys:
+            identifier:
+              type: str
+              description: 'EVPN Ethernet Segment Identifier (Type 1 format)
+
+                '
+            redundancy:
+              type: str
+              valid_values:
+              - all-active
+              - single-active
+            designated_forwarder_election:
+              type: dict
+              keys:
+                algorithm:
+                  type: str
+                  valid_values:
+                  - modulus
+                  - preference
+                preference_value:
+                  type: int
+                  min: 0
+                  max: 65535
+                  description: 'Preference_value and dont_preempt are set for preference
+                    algorithm and are optional
+
+                    '
+                dont_preempt:
+                  type: bool
+                  default: false
+                hold_time:
+                  type: int
+                  convert_types:
+                  - str
+                subsequent_hold_time:
+                  type: int
+                  convert_types:
+                  - str
+                candidate_reachability_required:
+                  type: bool
+            mpls:
+              display_name: MPLS
+              type: dict
+              keys:
+                shared_index:
+                  type: int
+                  min: 1
+                  max: 1024
+                  convert_types:
+                  - str
+                tunnel_flood_filter_time:
+                  type: int
+                  convert_types:
+                  - str
+            route_target:
+              type: str
+              description: 'EVPN Route Target for ESI with format xx:xx:xx:xx:xx:xx
+
+                '
+        encapsulation_dot1q_vlan:
+          display_name: Encapsulation dot1q VLAN
+          type: int
+          convert_types:
+          - str
+          description: 'vlan tag to configure on sub-interface
+
+            '
+        encapsulation_vlan:
+          display_name: Encapsulation VLAN
+          type: dict
+          keys:
+            client:
+              type: dict
+              keys:
+                dot1q:
+                  type: dict
+                  keys:
+                    vlan:
+                      display_name: Client VLAN ID
+                      type: int
+                      convert_types:
+                      - str
+                    outer:
+                      display_name: Client Outer VLAN ID
+                      type: int
+                      convert_types:
+                      - str
+                    inner:
+                      display_name: Client Inner VLAN ID
+                      type: int
+                      convert_types:
+                      - str
+                outer:
+                  display_name: Client Outer VLAN ID
+                  type: int
+                  convert_types:
+                  - str
+                inner:
+                  display_name: Client Inner VLAN ID
+                  type: int
+                  convert_types:
+                  - str
+                unmatched:
+                  type: bool
+            network:
+              type: dict
+              description: 'Network encapsulation is all optional, and skipped if
+                using client unmatched.
+
+                '
+              keys:
+                dot1q:
+                  type: dict
+                  keys:
+                    vlan:
+                      display_name: Network VLAN ID
+                      type: int
+                      convert_types:
+                      - str
+                    outer:
+                      display_name: Network Outer VLAN ID
+                      type: int
+                      convert_types:
+                      - str
+                    inner:
+                      display_name: Network Inner VLAN ID
+                      type: int
+                      convert_types:
+                      - str
+                outer:
+                  display_name: Network Outer VLAN ID
+                  type: int
+                  convert_types:
+                  - str
+                inner:
+                  display_name: Network Inner VLAN ID
+                  type: int
+                  convert_types:
+                  - str
+                client:
+                  type: bool
+        vlan_id:
+          display_name: VLAN ID
+          type: int
+          min: 1
+          max: 4094
+          convert_types:
+          - str
+        ip_address:
+          display_name: IP Address
+          type: str
+        ip_address_secondaries:
+          display_name: IP Address Secondaries
+          type: list
+          items:
+            type: str
+        ip_helpers:
+          display_name: IP Helpers
+          type: list
+          primary_key: ip_helper
+          convert_types:
+          - dict
+          items:
+            type: dict
+            keys:
+              ip_helper:
+                display_name: IP Helper
+                type: str
+                required: true
+              source_interface:
+                type: str
+                display_name: Source Interface Name
+              vrf:
+                display_name: VRF Name
+                type: str
+        ipv6_enable:
+          display_name: IPv6 Enable
+          type: bool
+        ipv6_address:
+          display_name: IPv6 Address
+          type: str
+        ipv6_address_link_local:
+          display_name: IPv6 Address Link Local
+          type: str
+        ipv6_nd_ra_disabled:
+          display_name: IPv6 ND RA Disabled
+          type: bool
+        ipv6_nd_managed_config_flag:
+          display_name: IPv6 ND Managed Config Flag
+          type: bool
+        ipv6_nd_prefixes:
+          display_name: IPv6 ND Prefixes
+          type: list
+          primary_key: ipv6_prefix
+          convert_types:
+          - dict
+          items:
+            type: dict
+            keys:
+              ipv6_prefix:
+                display_name: IPv6 Prefix
+                type: str
+                required: true
+              valid_lifetime:
+                type: str
+                convert_types:
+                - int
+                description: '< infinite or lifetime in seconds >
+
+                  '
+              preferred_lifetime:
+                type: str
+                convert_types:
+                - int
+                description: '< infinite or lifetime in seconds >
+
+                  '
+              no_autoconfig_flag:
+                type: bool
+        access_group_in:
+          display_name: Access Group IN
+          type: str
+        access_group_out:
+          display_name: Access Group OUT
+          type: str
+        ipv6_access_group_in:
+          display_name: IPv6 Access Group IN
+          type: str
+        ipv6_access_group_out:
+          display_name: IPV6 Access Group OUT
+          type: str
+        mac_access_group_in:
+          display_name: MAC Access Group IN
+          type: str
+        mac_access_group_out:
+          display_name: MAC Access Group OUT
+          type: str
+        multicast:
+          type: dict
+          description: 'boundaries can be either 1 ACL or a list of multicast IP address_range(s)/prefix
+            but not combination of both
+
+            '
+          keys:
+            ipv4:
+              display_name: IPv4
+              type: dict
+              keys:
+                boundaries:
+                  type: list
+                  items:
+                    type: dict
+                    keys:
+                      boundary:
+                        type: str
+                      out:
+                        type: bool
+                static:
+                  type: bool
+            ipv6:
+              display_name: IPv6
+              type: dict
+              keys:
+                boundaries:
+                  type: list
+                  items:
+                    type: dict
+                    keys:
+                      boundary:
+                        type: str
+                static:
+                  type: bool
+        ospf_network_point_to_point:
+          display_name: OSPF Network Point To Point
+          type: bool
+        ospf_area:
+          display_name: OSPF Area
+          type: str
+          convert_types:
+          - int
+        ospf_cost:
+          display_name: OSPF Cost
+          type: int
+          convert_types:
+          - str
+        ospf_authentication:
+          display_name: OSPF Authentication
+          type: str
+          valid_values:
+          - none
+          - simple
+          - message-digest
+        ospf_authentication_key:
+          display_name: OSPF Authentication Key
+          type: str
+        ospf_message_digest_keys:
+          display_name: OSPF Message Digest Keys
+          type: list
+          primary_key: id
+          convert_types:
+          - dict
+          items:
+            type: dict
+            keys:
+              id:
+                display_name: ID
+                type: int
+                convert_types:
+                - str
+                required: true
+              hash_algorithm:
+                type: str
+                valid_values:
+                - md5
+                - sha1
+                - sha 256
+                - sha384
+                - sha512
+              key:
+                type: str
+        pim:
+          display_name: PIM
+          type: dict
+          keys:
+            ipv4:
+              display_name: IPv4
+              type: dict
+              keys:
+                dr_priority:
+                  display_name: DR Priority
+                  type: int
+                  convert_types:
+                  - str
+                  min: 0
+                  max: 429467295
+                sparse_mode:
+                  type: bool
+        mac_security:
+          display_name: MAC Security
+          type: dict
+          keys:
+            profile:
+              type: str
+        channel_group:
+          type: dict
+          keys:
+            id:
+              display_name: Port-Channel ID
+              type: int
+              convert_types:
+              - str
+            mode:
+              type: str
+              valid_values:
+              - 'on'
+              - active
+              - passive
+        isis_enable:
+          display_name: ISIS Enable
+          type: str
+        isis_passive:
+          display_name: ISIS Passive
+          type: bool
+        isis_metric:
+          display_name: ISIS Metric
+          type: int
+          convert_types:
+          - str
+        isis_network_point_to_point:
+          display_name: ISIS Network Point To Point
+          type: bool
+        isis_circuit_type:
+          display_name: ISIS Circuit Type
+          type: str
+          valid_values:
+          - level-1-2
+          - level-1
+          - level-2
+        isis_hello_padding:
+          display_name: ISIS Hello Padding
+          type: bool
+        isis_authentication_mode:
+          display_name: ISIS Authentication Mode
+          type: str
+          valid_values:
+          - text
+          - md5
+        isis_authentication_key:
+          display_name: ISIS Authentication Key
+          type: str
+          description: 'type-7 encrypted password
+
+            '
+        ptp:
+          display_name: PTP
+          type: dict
+          keys:
+            enable:
+              type: bool
+            announce:
+              type: dict
+              keys:
+                interval:
+                  type: int
+                  convert_types:
+                  - str
+                timeout:
+                  type: int
+                  convert_types:
+                  - str
+            delay_req:
+              type: int
+              convert_types:
+              - str
+            delay_mechanism:
+              type: str
+              valid_values:
+              - e2e
+              - p2p
+            sync_message:
+              type: dict
+              keys:
+                interval:
+                  type: int
+                  convert_types:
+                  - str
+            role:
+              type: str
+              valid_values:
+              - master
+              - dynamic
+            vlan:
+              display_name: VLAN
+              type: str
+              convert_types:
+              - int
+              description: '< all | list of vlans as string >
+
+                '
+            transport:
+              type: str
+              valid_values:
+              - ipv4
+              - ipv6
+              - layer2
+        profile:
+          display_name: Interface Profile
+          type: str
+        storm_control:
+          type: dict
+          keys:
+            all:
+              type: dict
+              keys:
+                level:
+                  type: int
+                  convert_types:
+                  - str
+                  description: 'Configure maximum storm-control level
+
+                    '
+                unit:
+                  type: str
+                  description: 'Percent* | pps (optional and is hardware dependant
+                    - default is percent)
+
+                    '
+            broadcast:
+              type: dict
+              keys:
+                level:
+                  type: int
+                  convert_types:
+                  - str
+                  description: 'Configure maximum storm-control level
+
+                    '
+                unit:
+                  type: str
+                  description: 'Percent* | pps (optional and is hardware dependant
+                    - default is percent)
+
+                    '
+            multicast:
+              type: dict
+              keys:
+                level:
+                  type: int
+                  convert_types:
+                  - str
+                  description: 'Configure maximum storm-control level
+
+                    '
+                unit:
+                  type: str
+                  description: 'Percent* | pps (optional and is hardware dependant
+                    - default is percent)
+
+                    '
+            unknown_unicast:
+              type: dict
+              keys:
+                level:
+                  type: int
+                  convert_types:
+                  - str
+                  description: 'Configure maximum storm-control level
+
+                    '
+                unit:
+                  type: str
+                  description: 'Percent* | pps (optional and is hardware dependant
+                    - default is percent)
+
+                    '
+        logging:
+          type: dict
+          keys:
+            event:
+              type: dict
+              keys:
+                link_status:
+                  type: bool
+                congestion_drops:
+                  type: bool
+        lldp:
+          display_name: LLDP
+          type: dict
+          keys:
+            transmit:
+              type: bool
+            receive:
+              type: bool
+            ztp_vlan:
+              display_name: ZTP VLAN
+              type: int
+              convert_types:
+              - str
+        trunk_private_vlan_secondary:
+          display_name: Trunk Private VLAN Secondary
+          type: bool
+        pvlan_mapping:
+          display_name: PVLAN Mapping
+          type: int
+          convert_types:
+          - str
+          description: 'List of vlans as string
+
+            '
+        vlan_translations:
+          display_name: VLAN Translations
+          type: list
+          items:
+            type: dict
+            keys:
+              from:
+                type: str
+                description: 'List of vlans as string (only one vlan if direction
+                  is "both")
+
+                  '
+              to:
+                display_name: To
+                type: int
+                convert_types:
+                - str
+              direction:
+                type: str
+                valid_values:
+                - in
+                - out
+                - both
+                default: both
+        dot1x:
+          type: dict
+          keys:
+            port_control:
+              type: str
+              valid_values:
+              - auto
+              - force-authorized
+              - force-unauthorized
+            port_control_force_authorized_phone:
+              type: bool
+            reauthentication:
+              type: bool
+            pae:
+              display_name: PAE
+              type: dict
+              keys:
+                mode:
+                  type: str
+                  valid_values:
+                  - authenticator
+            authentication_failure:
+              type: dict
+              keys:
+                action:
+                  type: str
+                  valid_values:
+                  - allow
+                  - drop
+                allow_vlan:
+                  display_name: Allow VLAN
+                  type: int
+                  min: 1
+                  max: 4094
+                  convert_types:
+                  - str
+            host_mode:
+              type: dict
+              keys:
+                mode:
+                  type: str
+                  valid_values:
+                  - multi-host
+                  - single-host
+                multi_host_authenticated:
+                  type: bool
+                mac_based_authentication:
+                  display_name: MAC Based Authentication
+                  type: dict
+                  keys:
+                    enabled:
+                      type: bool
+                    always:
+                      type: bool
+                    host_mode_common:
+                      type: bool
+                timeout:
+                  type: dict
+                  keys:
+                    idle_host:
+                      type: int
+                      min: 10
+                      max: 65535
+                      convert_types:
+                      - str
+                    quiet_period:
+                      type: int
+                      min: 1
+                      max: 65535
+                      convert_types:
+                      - str
+                    reauth_period:
+                      type: str
+                    reauth_timeout_ignore:
+                      type: bool
+                    tx_period:
+                      display_name: Transmit Period
+                      type: int
+                      min: 1
+                      max: 65535
+                      convert_types:
+                      - str
+                reauthorization_request_limit:
+                  type: int
+                  min: 1
+                  max: 10
+                  convert_types:
+                  - str
+            mac_based_authentication:
+              display_name: MAC Based Authentication
+              type: dict
+              keys:
+                enabled:
+                  type: bool
+                always:
+                  type: bool
+                host_mode_common:
+                  type: bool
+            timeout:
+              type: dict
+              keys:
+                idle_host:
+                  type: int
+                  convert_types:
+                  - str
+                quiet_period:
+                  type: int
+                  convert_types:
+                  - str
+                reauth_period:
+                  type: str
+                reauth_timeout_ignore:
+                  type: bool
+                tx_period:
+                  display_name: Transmit Period
+                  type: int
+                  convert_types:
+                  - str
+            reauthorization_request_limit:
+              type: int
+              convert_types:
+              - str
+        service_profile:
+          type: str
+        shape:
+          type: dict
+          keys:
+            rate:
+              type: str
+              description: '< "< rate > kbps" | "1-100 percent" | "< rate > pps" ,
+                supported options are platform dependent >
+
+                '
+        qos:
+          display_name: QOS
+          type: dict
+          keys:
+            trust:
+              type: str
+              valid_values:
+              - dscp
+              - cos
+              - disabled
+            dscp:
+              display_name: DSCP
+              type: int
+              convert_types:
+              - str
+            cos:
+              display_name: COS
+              type: int
+              convert_types:
+              - str
+        spanning_tree_bpdufilter:
+          type: str
+          convert_types:
+          - bool
+        spanning_tree_bpduguard:
+          type: str
+          convert_types:
+          - bool
+        spanning_tree_guard:
+          type: str
+          valid_values:
+          - loop
+          - root
+          - disabled
+        spanning_tree_portfast:
+          type: str
+          valid_values:
+          - edge
+          - network
+        vmtracer:
+          display_name: VM Tracer
+          type: bool
+        priority_flow_control:
+          type: dict
+          keys:
+            enabled:
+              type: bool
+            priorities:
+              type: list
+              items:
+                type: dict
+                keys:
+                  priority:
+                    type: int
+                    min: 0
+                    max: 7
+                    convert_types:
+                    - str
+                  no_drop:
+                    type: bool
+        bfd:
+          display_name: BFD
+          type: dict
+          keys:
+            echo:
+              type: bool
+            interval:
+              type: int
+              convert_types:
+              - str
+              description: 'Interval in milliseconds
+
+                '
+            min_rx:
+              display_name: Min RX
+              type: int
+              convert_types:
+              - str
+              description: 'Rate in milliseconds
+
+                '
+            multiplier:
+              type: int
+              min: 3
+              max: 50
+              convert_types:
+              - str
+        service_policy:
+          type: dict
+          keys:
+            pbr:
+              display_name: PBR
+              type: dict
+              keys:
+                input:
+                  type: str
+                  display_name: Policy Map Name
+        mpls:
+          display_name: MPLS
+          type: dict
+          keys:
+            ip:
+              display_name: IP
+              type: bool
+            ldp:
+              display_name: LDP
+              type: dict
+              keys:
+                interface:
+                  type: bool
+                igp_sync:
+                  display_name: IGP Sync
+                  type: bool
+        lacp_timer:
+          display_name: LACP Timer
+          type: dict
+          keys:
+            mode:
+              type: str
+              valid_values:
+              - fast
+              - normal
+            multiplier:
+              type: int
+              min: 3
+              max: 3000
+              convert_types:
+              - str
+        lacp_port_priority:
+          display_name: LACP Port Priority
+          type: int
+          min: 0
+          max: 65535
+          convert_types:
+          - str
+        transceiver:
+          type: dict
+          keys:
+            media:
+              type: dict
+              keys:
+                override:
+                  display_name: Transceiver Type
+                  type: str
+        ip_proxy_arp:
+          display_name: IP Proxy ARP
+          type: bool
+        traffic_policy:
+          type: dict
+          keys:
+            input:
+              type: str
+              description: 'ingress traffic policy
+
+                '
+            output:
+              type: str
+              description: 'egress traffic policy
+
+                '
+        eos_cli:
+          display_name: EOS CLI
+          type: str
+          description: < multiline eos cli >
   event_handlers:
     type: list
     primary_key: name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -1012,7 +1012,7 @@ keys:
           type: str
           convert_types:
           - int
-          description: 'List of switchport vlans as string.
+          description: 'List of switchport vlans as string
 
             For a trunk port this would be a range like "1-200,300"
 
@@ -1067,8 +1067,11 @@ keys:
           - switched
           - l3dot1q
           - l2dot1q
-          description: l3dot1q and l2dot1q are used for sub-interfaces. The parent
-            interface should be defined as routed.
+          description: 'l3dot1q and l2dot1q are used for sub-interfaces
+
+            The parent interface should be defined as routed
+
+            '
         snmp_trap_link_change:
           type: bool
         flowcontrol:
@@ -1201,8 +1204,8 @@ keys:
                   type: bool
             network:
               type: dict
-              description: Network encapsulations are all optional, and skipped if
-                using client unmatched.
+              description: Network encapsulations are all optional and skipped if
+                using client unmatched
               keys:
                 dot1q:
                   type: dict
@@ -1216,12 +1219,12 @@ keys:
                       type: int
                       convert_types:
                       - str
-                      description: Network Outer VLAN ID
+                      description: Network outer VLAN ID
                     inner:
                       type: int
                       convert_types:
                       - str
-                      description: Network Inner VLAN ID
+                      description: Network inner VLAN ID
                 client:
                   type: bool
         vlan_id:
@@ -1702,8 +1705,9 @@ keys:
           keys:
             rate:
               type: str
-              description: 'Rate in kbps, pps or percent. Supported options are platform
-                dependent.
+              description: 'Rate in kbps, pps or percent
+
+                Supported options are platform dependent
 
                 Examples:
 
@@ -1857,7 +1861,7 @@ keys:
               keys:
                 override:
                   type: str
-                  description: Transceiver Type
+                  description: Transceiver type
         ip_proxy_arp:
           type: bool
         traffic_policy:
@@ -1869,10 +1873,6 @@ keys:
             output:
               type: str
               description: Egress traffic policy
-        eos_cli:
-          type: str
-          description: Multiline EOS CLI rendered directly on the ethernet interface
-            in the final EOS configuration
         peer:
           type: str
           description: Key only used for documentation or validation purposes
@@ -1882,6 +1882,10 @@ keys:
         peer_type:
           type: str
           description: Key only used for documentation or validation purposes
+        eos_cli:
+          type: str
+          description: Multiline EOS CLI rendered directly on the ethernet interface
+            in the final EOS configuration
   event_handlers:
     type: list
     primary_key: name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ethernet_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ethernet_interfaces.schema.yml
@@ -36,7 +36,7 @@ keys:
           convert_types:
           - int
           description: |
-            List of switchport vlans as string.
+            List of switchport vlans as string
             For a trunk port this would be a range like "1-200,300"
             For an access port this would be a single vlan "123"
         native_vlan:
@@ -76,7 +76,9 @@ keys:
         type:
           type: str
           valid_values: ["routed", "switched", "l3dot1q", "l2dot1q"]
-          description: l3dot1q and l2dot1q are used for sub-interfaces. The parent interface should be defined as routed.
+          description: |
+            l3dot1q and l2dot1q are used for sub-interfaces
+            The parent interface should be defined as routed
         snmp_trap_link_change:
           type: bool
         flowcontrol:
@@ -200,7 +202,7 @@ keys:
                   type: bool
             network:
               type: dict
-              description: Network encapsulations are all optional, and skipped if using client unmatched.
+              description: Network encapsulations are all optional and skipped if using client unmatched
               keys:
                 dot1q:
                   type: dict
@@ -214,12 +216,12 @@ keys:
                       type: int
                       convert_types:
                       - str
-                      description: Network Outer VLAN ID
+                      description: Network outer VLAN ID
                     inner:
                       type: int
                       convert_types:
                       - str
-                      description: Network Inner VLAN ID
+                      description: Network inner VLAN ID
                 client:
                   type: bool
         vlan_id:
@@ -657,7 +659,8 @@ keys:
             rate:
               type: str
               description: |
-                Rate in kbps, pps or percent. Supported options are platform dependent.
+                Rate in kbps, pps or percent
+                Supported options are platform dependent
                 Examples:
                 - "5000 kbps"
                 - "1000 pps"
@@ -783,7 +786,7 @@ keys:
               keys:
                 override:
                   type: str
-                  description: Transceiver Type
+                  description: Transceiver type
         ip_proxy_arp:
           type: bool
         traffic_policy:
@@ -795,9 +798,6 @@ keys:
             output:
               type: str
               description: Egress traffic policy
-        eos_cli:
-          type: str
-          description: Multiline EOS CLI rendered directly on the ethernet interface in the final EOS configuration
         peer:
           type: str
           description: Key only used for documentation or validation purposes
@@ -807,3 +807,6 @@ keys:
         peer_type:
           type: str
           description: Key only used for documentation or validation purposes
+        eos_cli:
+          type: str
+          description: Multiline EOS CLI rendered directly on the ethernet interface in the final EOS configuration

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ethernet_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ethernet_interfaces.schema.yml
@@ -8,19 +8,12 @@ keys:
     primary_key: name
     convert_types:
     - dict
-    description: Routed interfaces
     items:
       type: dict
       keys:
         name:
           type: str
           required: true
-        peer:
-          type: str
-        peer_interface:
-          type: str
-        peer_type:
-          type: str
         description:
           type: str
         shutdown:
@@ -36,19 +29,23 @@ keys:
           type: int
           convert_types:
           - str
-          description: If l2_mtu defined this profile should only be used for platforms supporting the "l2 mtu" CLI
+          description: |
+            "l2_mtu" should only be defined for platforms supporting the "l2 mtu" CLI
         vlans:
           type: str
           convert_types:
           - int
-          description: List of vlans as string
+          description: |
+            List of switchport vlans as string.
+            For a trunk port this would be a range like "1-200,300"
+            For an access port this would be a single vlan "123"
         native_vlan:
           type: int
           convert_types:
           - str
         native_vlan_tag:
           type: bool
-          default: false
+          description: If setting both native_vlan and native_vlan_tag, native_vlan_tag takes precedence
         mode:
           type: str
           valid_values: ["access", "dot1q-tunnel", "trunk", "trunk phone"]
@@ -82,13 +79,12 @@ keys:
           description: l3dot1q and l2dot1q are used for sub-interfaces. The parent interface should be defined as routed.
         snmp_trap_link_change:
           type: bool
-          description: SNMP trap link change
         flowcontrol:
           type: dict
           keys:
             received:
               type: str
-              valid_values: ["received", "send", "on"]
+              valid_values: ["desired", "on", "off"]
         vrf:
           type: str
           description: VRF name
@@ -110,6 +106,7 @@ keys:
               type: bool
         link_tracking_groups:
           type: list
+          primary_key: name
           items:
             type: dict
             keys:
@@ -138,10 +135,12 @@ keys:
                   type: int
                   min: 0
                   max: 65535
-                  description: Preference_value and dont_preempt are set for preference algorithm and are optional
+                  convert_types:
+                  - str
+                  description: Preference_value is only used when "algorithm" is "preference"
                 dont_preempt:
                   type: bool
-                  default: false
+                  description: Dont_preempt is only used when "algorithm" is "preference"
                 hold_time:
                   type: int
                   convert_types:
@@ -197,21 +196,11 @@ keys:
                       convert_types:
                       - str
                       description: Client Inner VLAN ID
-                outer:
-                  type: int
-                  convert_types:
-                  - str
-                  description: Client Outer VLAN ID
-                inner:
-                  type: int
-                  convert_types:
-                  - str
-                  description: Client Inner VLAN ID
                 unmatched:
                   type: bool
             network:
               type: dict
-              description: Network encapsulation is all optional, and skipped if using client unmatched.
+              description: Network encapsulations are all optional, and skipped if using client unmatched.
               keys:
                 dot1q:
                   type: dict
@@ -231,16 +220,6 @@ keys:
                       convert_types:
                       - str
                       description: Network Inner VLAN ID
-                outer:
-                  type: int
-                  convert_types:
-                  - str
-                  description: Network Outer VLAN ID
-                inner:
-                  type: int
-                  convert_types:
-                  - str
-                  description: Network Inner VLAN ID
                 client:
                   type: bool
         vlan_id:
@@ -251,7 +230,7 @@ keys:
           - str
         ip_address:
           type: str
-          description: IPv4_address or Mask
+          description: IPv4 address/mask
         ip_address_secondaries:
           type: list
           items:
@@ -279,10 +258,9 @@ keys:
           type: str
         ipv6_address_link_local:
           type: str
-          description: Link local IPv6 address or mask
+          description: Link local IPv6 address/mask
         ipv6_nd_ra_disabled:
           type: bool
-          description: IPv6 ND RA disabled
         ipv6_nd_managed_config_flag:
           type: bool
         ipv6_nd_prefixes:
@@ -487,6 +465,7 @@ keys:
               valid_values: ["ipv4", "ipv6", "layer2"]
         profile:
           type: str
+          description: Interface profile
         storm_control:
           type: dict
           keys:
@@ -567,9 +546,9 @@ keys:
         trunk_private_vlan_secondary:
           type: bool
         pvlan_mapping:
-          type: int
+          type: str
           convert_types:
-          - str
+          - int
           description: List of vlans as string
         vlan_translations:
           type: list
@@ -577,13 +556,15 @@ keys:
             type: dict
             keys:
               from:
-                type: str
+                type: int
+                convert_types:
+                - str
                 description: List of vlans as string (only one vlan if direction is "both")
               to:
                 type: int
                 convert_types:
                 - str
-                description: VLAN id
+                description: VLAN ID
               direction:
                 type: str
                 valid_values: ["in", "out", "both"]
@@ -638,10 +619,14 @@ keys:
               keys:
                 idle_host:
                   type: int
+                  min: 10
+                  max: 65535
                   convert_types:
                   - str
                 quiet_period:
                   type: int
+                  min: 1
+                  max: 65535
                   convert_types:
                   - str
                 reauth_period:
@@ -653,6 +638,8 @@ keys:
                   type: bool
                 tx_period:
                   type: int
+                  min: 1
+                  max: 65535
                   convert_types:
                   - str
             reauthorization_request_limit:
@@ -669,7 +656,12 @@ keys:
           keys:
             rate:
               type: str
-              description: Rate in kbps or pps or 1-100 percent or rate in pps, supported options are platform dependent
+              description: |
+                Rate in kbps, pps or percent. Supported options are platform dependent.
+                Examples:
+                - "5000 kbps"
+                - "1000 pps"
+                - "20 percent"
         qos:
           type: dict
           keys:
@@ -690,10 +682,12 @@ keys:
           type: str
           convert_types:
           - bool
+          valid_values: ["enabled", "disabled", "true"]
         spanning_tree_bpduguard:
           type: str
           convert_types:
           - bool
+          valid_values: ["enabled", "disabled", "true"]
         spanning_tree_guard:
           type: str
           valid_values: ["loop", "root", "disabled"]
@@ -709,6 +703,7 @@ keys:
               type: bool
             priorities:
               type: list
+              primary_key: priority
               items:
                 type: dict
                 keys:
@@ -802,6 +797,13 @@ keys:
               description: Egress traffic policy
         eos_cli:
           type: str
-          description: Multiline eos cli. EOS CLI rendered directly on the ethernet interface in the final EOS configuration
-        struct_cfg:
-          type: dict
+          description: Multiline EOS CLI rendered directly on the ethernet interface in the final EOS configuration
+        peer:
+          type: str
+          description: Key only used for documentation or validation purposes
+        peer_interface:
+          type: str
+          description: Key only used for documentation or validation purposes
+        peer_type:
+          type: str
+          description: Key only used for documentation or validation purposes

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ethernet_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ethernet_interfaces.schema.yml
@@ -1,0 +1,919 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  ethernet_interfaces:
+    type: list
+    primary_key: name
+    convert_types:
+    - dict
+    display_name: Routed Ethernet Interfaces
+    items:
+      type: dict
+      keys:
+        name:
+          type: str
+          required: true
+          display_name: Ethernet Interface
+        peer:
+          type: str
+        peer_interface:
+          type: str
+        peer_type:
+          type: str
+        description:
+          type: str
+        shutdown:
+          type: bool
+        speed:
+          type: str
+          description: |
+            < interface_speed | forced interface_speed | auto interface_speed >
+        mtu:
+          display_name: MTU
+          type: int
+          convert_types:
+          - str
+        l2_mtu:
+          display_name: L2 MTU
+          type: int
+          convert_types:
+          - str
+          description: |
+            l2-mtu - if defined this profile should only be used for platforms supporting the "l2 mtu" CLI
+        vlans:
+          display_name: VLANs
+          type: str
+          convert_types:
+          - int
+          description: |
+            < list of vlans as string
+        native_vlan:
+          display_name: Native VLAN
+          type: int
+          convert_types:
+          - str
+        native_vlan_tag:
+          display_name: Native VLAN Tag
+          type: bool
+          default: false
+        mode:
+          type: str
+          valid_values: ["access", "dot1q-tunnel", "trunk", "trunk phone"]
+        phone:
+          type: dict
+          keys:
+            trunk:
+              type: str
+              valid_values: ["tagged", "untagged"]
+            vlan:
+              display_name: VLAN
+              type: int
+              min: 1
+              max: 4094
+              convert_types:
+              - str
+        l2_protocol:
+          display_name: L2 Protocol
+          type: dict
+          keys:
+            encapsulation_dot1q_vlan:
+              display_name: Encapsulation dot1q VLAN
+              type: int
+              convert_types:
+              - str
+        trunk_groups:
+          type: list
+          items:
+            type: str
+        type:
+          type: str
+          valid_values: ["routed", "switched", "l3dot1q", "l2dot1q"]
+          description: |
+            l3dot1q and l2dot1q are used for sub-interfaces. The parent interface should be defined as routed.
+        snmp_trap_link_change:
+          display_name: SNMP Trap Link Change
+          type: bool
+        flowcontrol:
+          type: dict
+          keys:
+            received:
+              type: str
+              valid_values: ["received", "send", "on"]
+        vrf:
+          display_name: VRF Name
+          type: str
+        error_correction_encoding:
+          type: dict
+          keys:
+            enabled:
+              type: bool
+              default: true
+            fire_code:
+              type: bool
+            reed_solomon:
+              type: bool
+        link_tracking_groups:
+          type: list
+          items:
+            type: dict
+            keys:
+              name:
+                display_name: Group Name
+                type: str
+              direction:
+                type: str
+                valid_values: ["upstream", "downstream"]
+        evpn_ethernet_segment:
+          display_name: EVPN Ethernet Segment
+          type: dict
+          keys:
+            identifier:
+              type: str
+              description: |
+                EVPN Ethernet Segment Identifier (Type 1 format)
+            redundancy:
+              type: str
+              valid_values: ["all-active", "single-active"]
+            designated_forwarder_election:
+              type: dict
+              keys:
+                algorithm:
+                  type: str
+                  valid_values: ["modulus", "preference"]
+                preference_value:
+                  type: int
+                  min: 0
+                  max: 65535
+                  description: |
+                    Preference_value and dont_preempt are set for preference algorithm and are optional
+                dont_preempt:
+                  type: bool
+                  default: false
+                hold_time:
+                  type: int
+                  convert_types:
+                  - str
+                subsequent_hold_time:
+                  type: int
+                  convert_types:
+                  - str
+                candidate_reachability_required:
+                  type: bool
+            mpls:
+              display_name: MPLS
+              type: dict
+              keys:
+                shared_index:
+                  type: int
+                  min: 1
+                  max: 1024
+                  convert_types:
+                  - str
+                tunnel_flood_filter_time:
+                  type: int
+                  convert_types:
+                  - str
+            route_target:
+              type: str
+              description: |
+                EVPN Route Target for ESI with format xx:xx:xx:xx:xx:xx
+        encapsulation_dot1q_vlan:
+          display_name: Encapsulation dot1q VLAN
+          type: int
+          convert_types:
+          - str
+          description: |
+            vlan tag to configure on sub-interface
+        encapsulation_vlan:
+          display_name: Encapsulation VLAN
+          type: dict
+          keys:
+            client:
+              type: dict
+              keys:
+                dot1q:
+                  type: dict
+                  keys:
+                    vlan:
+                      display_name: Client VLAN ID
+                      type: int
+                      convert_types:
+                      - str
+                    outer:
+                      display_name: Client Outer VLAN ID
+                      type: int
+                      convert_types:
+                      - str
+                    inner:
+                      display_name: Client Inner VLAN ID
+                      type: int
+                      convert_types:
+                      - str
+                outer:
+                  display_name: Client Outer VLAN ID
+                  type: int
+                  convert_types:
+                  - str
+                inner:
+                  display_name: Client Inner VLAN ID
+                  type: int
+                  convert_types:
+                  - str
+                unmatched:
+                  type: bool
+            network:
+              type: dict
+              description: |
+                Network encapsulation is all optional, and skipped if using client unmatched.
+              keys:
+                dot1q:
+                  type: dict
+                  keys:
+                    vlan:
+                      display_name: Network VLAN ID
+                      type: int
+                      convert_types:
+                      - str
+                    outer:
+                      display_name: Network Outer VLAN ID
+                      type: int
+                      convert_types:
+                      - str
+                    inner:
+                      display_name: Network Inner VLAN ID
+                      type: int
+                      convert_types:
+                      - str
+                outer:
+                  display_name: Network Outer VLAN ID
+                  type: int
+                  convert_types:
+                  - str
+                inner:
+                  display_name: Network Inner VLAN ID
+                  type: int
+                  convert_types:
+                  - str
+                client:
+                  type: bool
+        vlan_id:
+          display_name: VLAN ID
+          type: int
+          min: 1
+          max: 4094
+          convert_types:
+          - str
+        ip_address:
+          display_name: IP Address
+          type: str
+        ip_address_secondaries:
+          display_name: IP Address Secondaries
+          type: list
+          items:
+            type: str
+        ip_helpers:
+          display_name: IP Helpers
+          type: list
+          primary_key: ip_helper
+          convert_types:
+          - dict
+          items:
+            type: dict
+            keys:
+              ip_helper:
+                display_name: IP Helper
+                type: str
+                required: true
+              source_interface:
+                type: str
+                display_name: Source Interface Name
+              vrf:
+                display_name: VRF Name
+                type: str
+        ipv6_enable:
+          display_name: IPv6 Enable
+          type: bool
+        ipv6_address:
+          display_name: IPv6 Address
+          type: str
+        ipv6_address_link_local:
+          display_name: IPv6 Address Link Local
+          type: str
+        ipv6_nd_ra_disabled:
+          display_name: IPv6 ND RA Disabled
+          type: bool
+        ipv6_nd_managed_config_flag:
+          display_name: IPv6 ND Managed Config Flag
+          type: bool
+        ipv6_nd_prefixes:
+          display_name: IPv6 ND Prefixes
+          type: list
+          primary_key: ipv6_prefix
+          convert_types:
+          - dict
+          items:
+            type: dict
+            keys:
+              ipv6_prefix:
+                display_name: IPv6 Prefix
+                type: str
+                required: true
+              valid_lifetime:
+                type: str
+                convert_types:
+                - int
+                description: |
+                  < infinite or lifetime in seconds >
+              preferred_lifetime:
+                type: str
+                convert_types:
+                - int
+                description: |
+                  < infinite or lifetime in seconds >
+              no_autoconfig_flag:
+                type: bool
+        access_group_in:
+          display_name: Access Group IN
+          type: str
+        access_group_out:
+          display_name: Access Group OUT
+          type: str
+        ipv6_access_group_in:
+          display_name: IPv6 Access Group IN
+          type: str
+        ipv6_access_group_out:
+          display_name: IPV6 Access Group OUT
+          type: str
+        mac_access_group_in:
+          display_name: MAC Access Group IN
+          type: str
+        mac_access_group_out:
+          display_name: MAC Access Group OUT
+          type: str
+        multicast:
+          type: dict
+          description: |
+            boundaries can be either 1 ACL or a list of multicast IP address_range(s)/prefix but not combination of both
+          keys:
+            ipv4:
+              display_name: IPv4
+              type: dict
+              keys:
+                boundaries:
+                  type: list
+                  items:
+                    type: dict
+                    keys:
+                      boundary:
+                        type: str
+                      out:
+                        type: bool
+                static:
+                  type: bool
+            ipv6:
+              display_name: IPv6
+              type: dict
+              keys:
+                boundaries:
+                  type: list
+                  items:
+                    type: dict
+                    keys:
+                      boundary:
+                        type: str
+                static:
+                  type: bool
+        ospf_network_point_to_point:
+          display_name: OSPF Network Point To Point
+          type: bool
+        ospf_area:
+          display_name: OSPF Area
+          type: str
+          convert_types:
+          - int
+        ospf_cost:
+          display_name: OSPF Cost
+          type: int
+          convert_types:
+          - str
+        ospf_authentication:
+          display_name: OSPF Authentication
+          type: str
+          valid_values: ["none", "simple", "message-digest"]
+        ospf_authentication_key:
+          display_name: OSPF Authentication Key
+          type: str
+        ospf_message_digest_keys:
+          display_name: OSPF Message Digest Keys
+          type: list
+          primary_key: id
+          convert_types:
+          - dict
+          items:
+            type: dict
+            keys:
+              id:
+                display_name: ID
+                type: int
+                convert_types:
+                - str
+                required: true
+              hash_algorithm:
+                type: str
+                valid_values: ["md5", "sha1", "sha 256", "sha384", "sha512"]
+              key:
+                type: str
+        pim:
+          display_name: PIM
+          type: dict
+          keys:
+            ipv4:
+              display_name: IPv4
+              type: dict
+              keys:
+                dr_priority:
+                  display_name: DR Priority
+                  type: int
+                  convert_types:
+                  - str
+                  min: 0
+                  max: 429467295
+                sparse_mode:
+                  type: bool
+        mac_security:
+          display_name: MAC Security
+          type: dict
+          keys:
+            profile:
+              type: str
+        channel_group:
+          type: dict
+          keys:
+            id:
+              display_name: Port-Channel ID
+              type: int
+              convert_types:
+              - str
+            mode:
+              type: str
+              valid_values: ["on", "active", "passive"]
+        isis_enable:
+          display_name: ISIS Enable
+          type: str
+        isis_passive:
+          display_name: ISIS Passive
+          type: bool
+        isis_metric:
+          display_name: ISIS Metric
+          type: int
+          convert_types:
+          - str
+        isis_network_point_to_point:
+          display_name: ISIS Network Point To Point
+          type: bool
+        isis_circuit_type:
+          display_name: ISIS Circuit Type
+          type: str
+          valid_values: ["level-1-2", "level-1", "level-2"]
+        isis_hello_padding:
+          display_name: ISIS Hello Padding
+          type: bool
+        isis_authentication_mode:
+          display_name: ISIS Authentication Mode
+          type: str
+          valid_values: ["text", "md5"]
+        isis_authentication_key:
+          display_name: ISIS Authentication Key
+          type: str
+          description: |
+            type-7 encrypted password
+        ptp:
+          display_name: PTP
+          type: dict
+          keys:
+            enable:
+              type: bool
+            announce:
+              type: dict
+              keys:
+                interval:
+                  type: int
+                  convert_types:
+                  - str
+                timeout:
+                  type: int
+                  convert_types:
+                  - str
+            delay_req:
+              type: int
+              convert_types:
+              - str
+            delay_mechanism:
+              type: str
+              valid_values: ["e2e", "p2p"]
+            sync_message:
+              type: dict
+              keys:
+                interval:
+                  type: int
+                  convert_types:
+                  - str
+            role:
+              type: str
+              valid_values: ["master", "dynamic"]
+            vlan:
+              display_name: VLAN
+              type: str
+              convert_types:
+              - int
+              description: |
+                < all | list of vlans as string >
+            transport:
+              type: str
+              valid_values: ["ipv4", "ipv6", "layer2"]
+        profile:
+          display_name: Interface Profile
+          type: str
+        storm_control:
+          type: dict
+          keys:
+            all:
+              type: dict
+              keys:
+                level:
+                  type: int
+                  convert_types:
+                  - str
+                  description: |
+                    Configure maximum storm-control level
+                unit:
+                  type: str
+                  description: |
+                    Percent* | pps (optional and is hardware dependant - default is percent)
+            broadcast:
+              type: dict
+              keys:
+                level:
+                  type: int
+                  convert_types:
+                  - str
+                  description: |
+                    Configure maximum storm-control level
+                unit:
+                  type: str
+                  description: |
+                    Percent* | pps (optional and is hardware dependant - default is percent)
+            multicast:
+              type: dict
+              keys:
+                level:
+                  type: int
+                  convert_types:
+                  - str
+                  description: |
+                    Configure maximum storm-control level
+                unit:
+                  type: str
+                  description: |
+                    Percent* | pps (optional and is hardware dependant - default is percent)
+            unknown_unicast:
+              type: dict
+              keys:
+                level:
+                  type: int
+                  convert_types:
+                  - str
+                  description: |
+                    Configure maximum storm-control level
+                unit:
+                  type: str
+                  description: |
+                    Percent* | pps (optional and is hardware dependant - default is percent)
+        logging:
+          type: dict
+          keys:
+            event:
+              type: dict
+              keys:
+                link_status:
+                  type: bool
+                congestion_drops:
+                  type: bool
+        lldp:
+          display_name: LLDP
+          type: dict
+          keys:
+            transmit:
+              type: bool
+            receive:
+              type: bool
+            ztp_vlan:
+              display_name: ZTP VLAN
+              type: int
+              convert_types:
+              - str
+        trunk_private_vlan_secondary:
+          display_name: Trunk Private VLAN Secondary
+          type: bool
+        pvlan_mapping:
+          display_name: PVLAN Mapping
+          type: int
+          convert_types:
+          - str
+          description: |
+            List of vlans as string
+        vlan_translations:
+          display_name: VLAN Translations
+          type: list
+          items:
+            type: dict
+            keys:
+              from:
+                type: str
+                description: |
+                  List of vlans as string (only one vlan if direction is "both")
+              to:
+                display_name: To
+                type: int
+                convert_types:
+                - str
+              direction:
+                type: str
+                valid_values: ["in", "out", "both"]
+                default: "both"
+        dot1x:
+          type: dict
+          keys:
+            port_control:
+              type: str
+              valid_values: ["auto", "force-authorized", "force-unauthorized"]
+            port_control_force_authorized_phone:
+              type: bool
+            reauthentication:
+              type: bool
+            pae:
+              display_name: PAE
+              type: dict
+              keys:
+                mode:
+                  type: str
+                  valid_values: ["authenticator"]
+            authentication_failure:
+              type: dict
+              keys:
+                action:
+                  type: str
+                  valid_values: ["allow", "drop"]
+                allow_vlan:
+                  display_name: Allow VLAN
+                  type: int
+                  min: 1
+                  max: 4094
+                  convert_types:
+                  - str
+            host_mode:
+              type: dict
+              keys:
+                mode:
+                  type: str
+                  valid_values: ["multi-host", "single-host"]
+                multi_host_authenticated:
+                  type: bool
+                mac_based_authentication:
+                  display_name: MAC Based Authentication
+                  type: dict
+                  keys:
+                    enabled:
+                      type: bool
+                    always:
+                      type: bool
+                    host_mode_common:
+                      type: bool
+                timeout:
+                  type: dict
+                  keys:
+                    idle_host:
+                      type: int
+                      min: 10
+                      max: 65535
+                      convert_types:
+                      - str
+                    quiet_period:
+                      type: int
+                      min: 1
+                      max: 65535
+                      convert_types:
+                      - str
+                    reauth_period:
+                      type: str
+                    reauth_timeout_ignore:
+                      type: bool
+                    tx_period:
+                      display_name: Transmit Period
+                      type: int
+                      min: 1
+                      max: 65535
+                      convert_types:
+                      - str
+                reauthorization_request_limit:
+                  type: int
+                  min: 1
+                  max: 10
+                  convert_types:
+                  - str
+            mac_based_authentication:
+              display_name: MAC Based Authentication
+              type: dict
+              keys:
+                enabled:
+                  type: bool
+                always:
+                  type: bool
+                host_mode_common:
+                  type: bool
+            timeout:
+              type: dict
+              keys:
+                idle_host:
+                  type: int
+                  convert_types:
+                  - str
+                quiet_period:
+                  type: int
+                  convert_types:
+                  - str
+                reauth_period:
+                  type: str
+                reauth_timeout_ignore:
+                  type: bool
+                tx_period:
+                  display_name: Transmit Period
+                  type: int
+                  convert_types:
+                  - str
+            reauthorization_request_limit:
+              type: int
+              convert_types:
+              - str
+        service_profile:
+          type: str
+        shape:
+          type: dict
+          keys:
+            rate:
+              type: str
+              description: |
+                < "< rate > kbps" | "1-100 percent" | "< rate > pps" , supported options are platform dependent >
+        qos:
+          display_name: QOS
+          type: dict
+          keys:
+            trust:
+              type: str
+              valid_values: ["dscp", "cos", "disabled"]
+            dscp:
+              display_name: DSCP
+              type: int
+              convert_types:
+              - str
+            cos:
+              display_name: COS
+              type: int
+              convert_types:
+              - str
+        spanning_tree_bpdufilter:
+          type: str
+          convert_types:
+          - bool
+        spanning_tree_bpduguard:
+          type: str
+          convert_types:
+          - bool
+        spanning_tree_guard:
+          type: str
+          valid_values: ["loop", "root", "disabled"]
+        spanning_tree_portfast:
+          type: str
+          valid_values: ["edge", "network"]
+        vmtracer:
+          display_name: VM Tracer
+          type: bool
+        priority_flow_control:
+          type: dict
+          keys:
+            enabled:
+              type: bool
+            priorities:
+              type: list
+              items:
+                type: dict
+                keys:
+                  priority:
+                    type: int
+                    min: 0
+                    max: 7
+                    convert_types:
+                    - str
+                  no_drop:
+                    type: bool
+        bfd:
+          display_name: BFD
+          type: dict
+          keys:
+            echo:
+              type: bool
+            interval:
+              type: int
+              convert_types:
+              - str
+              description: |
+                Interval in milliseconds
+            min_rx:
+              display_name: Min RX
+              type: int
+              convert_types:
+              - str
+              description: |
+                Rate in milliseconds
+            multiplier:
+              type: int
+              min: 3
+              max: 50
+              convert_types:
+              - str
+        service_policy:
+          type: dict
+          keys:
+            pbr:
+              display_name: PBR
+              type: dict
+              keys:
+                input:
+                  type: str
+                  display_name: Policy Map Name
+        mpls:
+          display_name: MPLS
+          type: dict
+          keys:
+            ip:
+              display_name: IP
+              type: bool
+            ldp:
+              display_name: LDP
+              type: dict
+              keys:
+                interface:
+                  type: bool
+                igp_sync:
+                  display_name: IGP Sync
+                  type: bool
+        lacp_timer:
+          display_name: LACP Timer
+          type: dict
+          keys:
+            mode:
+              type: str
+              valid_values: ["fast", "normal"]
+            multiplier:
+              type: int
+              min: 3
+              max: 3000
+              convert_types:
+              - str
+        lacp_port_priority:
+          display_name: LACP Port Priority
+          type: int
+          min: 0
+          max: 65535
+          convert_types:
+          - str
+        transceiver:
+          type: dict
+          keys:
+            media:
+              type: dict
+              keys:
+                override:
+                  display_name: Transceiver Type
+                  type: str
+        ip_proxy_arp:
+          display_name: IP Proxy ARP
+          type: bool
+        traffic_policy:
+          type: dict
+          keys:
+            input:
+              type: str
+              description: |
+                ingress traffic policy
+            output:
+              type: str
+              description: |
+                egress traffic policy
+        eos_cli:
+          display_name: EOS CLI
+          type: str
+          description: |
+            < multiline eos cli >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ethernet_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ethernet_interfaces.schema.yml
@@ -8,6 +8,7 @@ keys:
     primary_key: name
     convert_types:
     - dict
+    description: Routed interfaces
     items:
       type: dict
       keys:
@@ -26,8 +27,7 @@ keys:
           type: bool
         speed:
           type: str
-          description: |
-            < interface_speed | forced interface_speed | auto interface_speed >
+          description: Speed can be interface_speed or forced interface_speed or auto interface_speed
         mtu:
           type: int
           convert_types:
@@ -36,14 +36,12 @@ keys:
           type: int
           convert_types:
           - str
-          description: |
-            l2-mtu - if defined this profile should only be used for platforms supporting the "l2 mtu" CLI
+          description: If l2_mtu defined this profile should only be used for platforms supporting the "l2 mtu" CLI
         vlans:
           type: str
           convert_types:
           - int
-          description: |
-            < list of vlans as string
+          description: List of vlans as string
         native_vlan:
           type: int
           convert_types:
@@ -73,6 +71,7 @@ keys:
               type: int
               convert_types:
               - str
+              description: Vlan tag to configure on sub-interface
         trunk_groups:
           type: list
           items:
@@ -80,11 +79,10 @@ keys:
         type:
           type: str
           valid_values: ["routed", "switched", "l3dot1q", "l2dot1q"]
-          description: |
-            l3dot1q and l2dot1q are used for sub-interfaces. The parent interface should be defined as routed.
+          description: l3dot1q and l2dot1q are used for sub-interfaces. The parent interface should be defined as routed.
         snmp_trap_link_change:
-          display_name: SNMP Trap Link Change
           type: bool
+          description: SNMP trap link change
         flowcontrol:
           type: dict
           keys:
@@ -92,8 +90,14 @@ keys:
               type: str
               valid_values: ["received", "send", "on"]
         vrf:
-          display_name: VRF Name
           type: str
+          description: VRF name
+        flow_tracker:
+          type: dict
+          keys:
+            sampled:
+              type: str
+              description: Flow tracker name
         error_correction_encoding:
           type: dict
           keys:
@@ -111,6 +115,7 @@ keys:
             keys:
               name:
                 type: str
+                description: Group name
               direction:
                 type: str
                 valid_values: ["upstream", "downstream"]
@@ -119,8 +124,7 @@ keys:
           keys:
             identifier:
               type: str
-              description: |
-                EVPN Ethernet Segment Identifier (Type 1 format)
+              description: EVPN Ethernet Segment Identifier (Type 1 format)
             redundancy:
               type: str
               valid_values: ["all-active", "single-active"]
@@ -134,8 +138,7 @@ keys:
                   type: int
                   min: 0
                   max: 65535
-                  description: |
-                    Preference_value and dont_preempt are set for preference algorithm and are optional
+                  description: Preference_value and dont_preempt are set for preference algorithm and are optional
                 dont_preempt:
                   type: bool
                   default: false
@@ -164,14 +167,12 @@ keys:
                   - str
             route_target:
               type: str
-              description: |
-                EVPN Route Target for ESI with format xx:xx:xx:xx:xx:xx
+              description: EVPN Route Target for ESI with format xx:xx:xx:xx:xx:xx
         encapsulation_dot1q_vlan:
           type: int
           convert_types:
           - str
-          description: |
-            vlan tag to configure on sub-interface
+          description: VLAN tag to configure on sub-interface
         encapsulation_vlan:
           type: dict
           keys:
@@ -185,11 +186,12 @@ keys:
                       type: int
                       convert_types:
                       - str
+                      description: Client VLAN ID
                     outer:
-                      display_name: Client Outer VLAN ID
                       type: int
                       convert_types:
                       - str
+                      description: Client Outer VLAN ID
                     inner:
                       type: int
                       convert_types:
@@ -209,8 +211,7 @@ keys:
                   type: bool
             network:
               type: dict
-              description: |
-                Network encapsulation is all optional, and skipped if using client unmatched.
+              description: Network encapsulation is all optional, and skipped if using client unmatched.
               keys:
                 dot1q:
                   type: dict
@@ -250,6 +251,7 @@ keys:
           - str
         ip_address:
           type: str
+          description: IPv4_address or Mask
         ip_address_secondaries:
           type: list
           items:
@@ -267,17 +269,20 @@ keys:
                 required: true
               source_interface:
                 type: str
+                description: Source interface name
               vrf:
                 type: str
+                description: VRF name
         ipv6_enable:
           type: bool
         ipv6_address:
           type: str
         ipv6_address_link_local:
           type: str
+          description: Link local IPv6 address or mask
         ipv6_nd_ra_disabled:
-          display_name: IPv6 ND RA Disabled
           type: bool
+          description: IPv6 ND RA disabled
         ipv6_nd_managed_config_flag:
           type: bool
         ipv6_nd_prefixes:
@@ -295,32 +300,35 @@ keys:
                 type: str
                 convert_types:
                 - int
-                description: |
-                  Infinite or lifetime in seconds
+                description: Infinite or lifetime in seconds
               preferred_lifetime:
                 type: str
                 convert_types:
                 - int
-                description: |
-                  Infinite or lifetime in seconds
+                description: Infinite or lifetime in seconds
               no_autoconfig_flag:
                 type: bool
         access_group_in:
           type: str
+          description: Access list name
         access_group_out:
           type: str
+          description: Access list name
         ipv6_access_group_in:
           type: str
+          description: IPv6 access list name
         ipv6_access_group_out:
           type: str
+          description: IPv6 access list name
         mac_access_group_in:
           type: str
+          description: MAC access list name
         mac_access_group_out:
           type: str
+          description: MAC access list name
         multicast:
           type: dict
-          description: |
-            boundaries can be either 1 ACL or a list of multicast IP address_range(s)/prefix but not combination of both
+          description: Boundaries can be either 1 ACL or a list of multicast IP address_range(s)/prefix but not combination of both
           keys:
             ipv4:
               type: dict
@@ -332,6 +340,7 @@ keys:
                     keys:
                       boundary:
                         type: str
+                        description: ACL name or multicast IP subnet
                       out:
                         type: bool
                 static:
@@ -346,6 +355,7 @@ keys:
                     keys:
                       boundary:
                         type: str
+                        description: ACL name or multicast IP subnet
                 static:
                   type: bool
         ospf_network_point_to_point:
@@ -363,6 +373,7 @@ keys:
           valid_values: ["none", "simple", "message-digest"]
         ospf_authentication_key:
           type: str
+          description: Encrypted password
         ospf_message_digest_keys:
           type: list
           primary_key: id
@@ -372,16 +383,16 @@ keys:
             type: dict
             keys:
               id:
-                display_name: ID
                 type: int
                 convert_types:
                 - str
                 required: true
               hash_algorithm:
                 type: str
-                valid_values: ["md5", "sha1", "sha 256", "sha384", "sha512"]
+                valid_values: ["md5", "sha1", "sha256", "sha384", "sha512"]
               key:
                 type: str
+                description: Encrypted password
         pim:
           type: dict
           keys:
@@ -413,6 +424,7 @@ keys:
               valid_values: ["on", "active", "passive"]
         isis_enable:
           type: str
+          description: ISIS instance
         isis_passive:
           type: bool
         isis_metric:
@@ -431,8 +443,7 @@ keys:
           valid_values: ["text", "md5"]
         isis_authentication_key:
           type: str
-          description: |
-            Type-7 encrypted password
+          description: Type-7 encrypted password
         ptp:
           type: dict
           keys:
@@ -470,8 +481,7 @@ keys:
               type: str
               convert_types:
               - int
-              description: |
-                all or list of vlans as string
+              description: VLAN can be 'all' or list of vlans as string
             transport:
               type: str
               valid_values: ["ipv4", "ipv6", "layer2"]
@@ -487,12 +497,12 @@ keys:
                   type: int
                   convert_types:
                   - str
-                  description: |
-                    Configure maximum storm-control level
+                  description: Configure maximum storm-control level
                 unit:
                   type: str
-                  description: |
-                    Percent* | pps (optional and is hardware dependant - default is percent)
+                  default: "percent"
+                  valid_values: [ "percent", "pps" ]
+                  description: Optional field and is hardware dependant
             broadcast:
               type: dict
               keys:
@@ -500,12 +510,12 @@ keys:
                   type: int
                   convert_types:
                   - str
-                  description: |
-                    Configure maximum storm-control level
+                  description: Configure maximum storm-control level
                 unit:
                   type: str
-                  description: |
-                    Percent* | pps (optional and is hardware dependant - default is percent)
+                  default: "percent"
+                  valid_values: ["percent", "pps"]
+                  description: Optional field and is hardware dependant
             multicast:
               type: dict
               keys:
@@ -513,12 +523,12 @@ keys:
                   type: int
                   convert_types:
                   - str
-                  description: |
-                    Configure maximum storm-control level
+                  description: Configure maximum storm-control level
                 unit:
                   type: str
-                  description: |
-                    Percent* | pps (optional and is hardware dependant - default is percent)
+                  default: "percent"
+                  valid_values: ["percent", "pps"]
+                  description: Optional field and is hardware dependant
             unknown_unicast:
               type: dict
               keys:
@@ -526,12 +536,12 @@ keys:
                   type: int
                   convert_types:
                   - str
-                  description: |
-                    Configure maximum storm-control level
+                  description: Configure maximum storm-control level
                 unit:
                   type: str
-                  description: |
-                    Percent* | pps (optional and is hardware dependant - default is percent)
+                  default: "percent"
+                  valid_values: [ "percent", "pps" ]
+                  description: Optional field and is hardware dependant
         logging:
           type: dict
           keys:
@@ -553,14 +563,14 @@ keys:
               type: int
               convert_types:
               - str
+              description: ZTP vlan number
         trunk_private_vlan_secondary:
           type: bool
         pvlan_mapping:
           type: int
           convert_types:
           - str
-          description: |
-            List of vlans as string
+          description: List of vlans as string
         vlan_translations:
           type: list
           items:
@@ -568,12 +578,12 @@ keys:
             keys:
               from:
                 type: str
-                description: |
-                  List of vlans as string (only one vlan if direction is "both")
+                description: List of vlans as string (only one vlan if direction is "both")
               to:
                 type: int
                 convert_types:
                 - str
+                description: VLAN id
               direction:
                 type: str
                 valid_values: ["in", "out", "both"]
@@ -614,47 +624,6 @@ keys:
                   valid_values: ["multi-host", "single-host"]
                 multi_host_authenticated:
                   type: bool
-                mac_based_authentication:
-                  type: dict
-                  keys:
-                    enabled:
-                      type: bool
-                    always:
-                      type: bool
-                    host_mode_common:
-                      type: bool
-                timeout:
-                  type: dict
-                  keys:
-                    idle_host:
-                      type: int
-                      min: 10
-                      max: 65535
-                      convert_types:
-                      - str
-                    quiet_period:
-                      type: int
-                      min: 1
-                      max: 65535
-                      convert_types:
-                      - str
-                    reauth_period:
-                      type: str
-                    reauth_timeout_ignore:
-                      type: bool
-                    tx_period:
-                      display_name: Transmit Period
-                      type: int
-                      min: 1
-                      max: 65535
-                      convert_types:
-                      - str
-                reauthorization_request_limit:
-                  type: int
-                  min: 1
-                  max: 10
-                  convert_types:
-                  - str
             mac_based_authentication:
               type: dict
               keys:
@@ -677,6 +646,9 @@ keys:
                   - str
                 reauth_period:
                   type: str
+                  convert_types:
+                  - int
+                  description: Value can be 60-4294967295 or 'server'
                 reauth_timeout_ignore:
                   type: bool
                 tx_period:
@@ -685,17 +657,19 @@ keys:
                   - str
             reauthorization_request_limit:
               type: int
+              min: 1
+              max: 10
               convert_types:
               - str
         service_profile:
           type: str
+          description: QOS profile
         shape:
           type: dict
           keys:
             rate:
               type: str
-              description: |
-                rate in kbps or 1-100 percent or rate in pps, supported options are platform dependent
+              description: Rate in kbps or pps or 1-100 percent or rate in pps, supported options are platform dependent
         qos:
           type: dict
           keys:
@@ -706,10 +680,12 @@ keys:
               type: int
               convert_types:
               - str
+              description: DSCP value
             cos:
               type: int
               convert_types:
               - str
+              description: COS value
         spanning_tree_bpdufilter:
           type: str
           convert_types:
@@ -753,14 +729,12 @@ keys:
               type: int
               convert_types:
               - str
-              description: |
-                Interval in milliseconds
+              description: Interval in milliseconds
             min_rx:
               type: int
               convert_types:
               - str
-              description: |
-                Rate in milliseconds
+              description: Rate in milliseconds
             multiplier:
               type: int
               min: 3
@@ -775,6 +749,7 @@ keys:
               keys:
                 input:
                   type: str
+                  description: Policy-map name
         mpls:
           type: dict
           keys:
@@ -786,7 +761,6 @@ keys:
                 interface:
                   type: bool
                 igp_sync:
-                  display_name: IGP Sync
                   type: bool
         lacp_timer:
           type: dict
@@ -822,13 +796,12 @@ keys:
           keys:
             input:
               type: str
-              description: |
-                Ingress traffic policy
+              description: Ingress traffic policy
             output:
               type: str
-              description: |
-                Egress traffic policy
+              description: Egress traffic policy
         eos_cli:
           type: str
-          description: |
-            Multiline eos cli
+          description: Multiline eos cli. EOS CLI rendered directly on the ethernet interface in the final EOS configuration
+        struct_cfg:
+          type: dict

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ethernet_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ethernet_interfaces.schema.yml
@@ -556,9 +556,9 @@ keys:
             type: dict
             keys:
               from:
-                type: int
+                type: str
                 convert_types:
-                - str
+                - int
                 description: List of vlans as string (only one vlan if direction is "both")
               to:
                 type: int
@@ -682,12 +682,12 @@ keys:
           type: str
           convert_types:
           - bool
-          valid_values: ["enabled", "disabled", "true"]
+          valid_values: ["enabled", "disabled", "True", "False", "true", "false"]
         spanning_tree_bpduguard:
           type: str
           convert_types:
           - bool
-          valid_values: ["enabled", "disabled", "true"]
+          valid_values: ["enabled", "disabled", "True", "False", "true", "false"]
         spanning_tree_guard:
           type: str
           valid_values: ["loop", "root", "disabled"]

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ethernet_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ethernet_interfaces.schema.yml
@@ -8,14 +8,12 @@ keys:
     primary_key: name
     convert_types:
     - dict
-    display_name: Routed Ethernet Interfaces
     items:
       type: dict
       keys:
         name:
           type: str
           required: true
-          display_name: Ethernet Interface
         peer:
           type: str
         peer_interface:
@@ -31,31 +29,26 @@ keys:
           description: |
             < interface_speed | forced interface_speed | auto interface_speed >
         mtu:
-          display_name: MTU
           type: int
           convert_types:
           - str
         l2_mtu:
-          display_name: L2 MTU
           type: int
           convert_types:
           - str
           description: |
             l2-mtu - if defined this profile should only be used for platforms supporting the "l2 mtu" CLI
         vlans:
-          display_name: VLANs
           type: str
           convert_types:
           - int
           description: |
             < list of vlans as string
         native_vlan:
-          display_name: Native VLAN
           type: int
           convert_types:
           - str
         native_vlan_tag:
-          display_name: Native VLAN Tag
           type: bool
           default: false
         mode:
@@ -68,18 +61,15 @@ keys:
               type: str
               valid_values: ["tagged", "untagged"]
             vlan:
-              display_name: VLAN
               type: int
               min: 1
               max: 4094
               convert_types:
               - str
         l2_protocol:
-          display_name: L2 Protocol
           type: dict
           keys:
             encapsulation_dot1q_vlan:
-              display_name: Encapsulation dot1q VLAN
               type: int
               convert_types:
               - str
@@ -120,13 +110,11 @@ keys:
             type: dict
             keys:
               name:
-                display_name: Group Name
                 type: str
               direction:
                 type: str
                 valid_values: ["upstream", "downstream"]
         evpn_ethernet_segment:
-          display_name: EVPN Ethernet Segment
           type: dict
           keys:
             identifier:
@@ -162,7 +150,6 @@ keys:
                 candidate_reachability_required:
                   type: bool
             mpls:
-              display_name: MPLS
               type: dict
               keys:
                 shared_index:
@@ -180,14 +167,12 @@ keys:
               description: |
                 EVPN Route Target for ESI with format xx:xx:xx:xx:xx:xx
         encapsulation_dot1q_vlan:
-          display_name: Encapsulation dot1q VLAN
           type: int
           convert_types:
           - str
           description: |
             vlan tag to configure on sub-interface
         encapsulation_vlan:
-          display_name: Encapsulation VLAN
           type: dict
           keys:
             client:
@@ -197,7 +182,6 @@ keys:
                   type: dict
                   keys:
                     vlan:
-                      display_name: Client VLAN ID
                       type: int
                       convert_types:
                       - str
@@ -207,20 +191,20 @@ keys:
                       convert_types:
                       - str
                     inner:
-                      display_name: Client Inner VLAN ID
                       type: int
                       convert_types:
                       - str
+                      description: Client Inner VLAN ID
                 outer:
-                  display_name: Client Outer VLAN ID
                   type: int
                   convert_types:
                   - str
+                  description: Client Outer VLAN ID
                 inner:
-                  display_name: Client Inner VLAN ID
                   type: int
                   convert_types:
                   - str
+                  description: Client Inner VLAN ID
                 unmatched:
                   type: bool
             network:
@@ -232,49 +216,45 @@ keys:
                   type: dict
                   keys:
                     vlan:
-                      display_name: Network VLAN ID
                       type: int
                       convert_types:
                       - str
+                      description: Network VLAN ID
                     outer:
-                      display_name: Network Outer VLAN ID
                       type: int
                       convert_types:
                       - str
+                      description: Network Outer VLAN ID
                     inner:
-                      display_name: Network Inner VLAN ID
                       type: int
                       convert_types:
                       - str
+                      description: Network Inner VLAN ID
                 outer:
-                  display_name: Network Outer VLAN ID
                   type: int
                   convert_types:
                   - str
+                  description: Network Outer VLAN ID
                 inner:
-                  display_name: Network Inner VLAN ID
                   type: int
                   convert_types:
                   - str
+                  description: Network Inner VLAN ID
                 client:
                   type: bool
         vlan_id:
-          display_name: VLAN ID
           type: int
           min: 1
           max: 4094
           convert_types:
           - str
         ip_address:
-          display_name: IP Address
           type: str
         ip_address_secondaries:
-          display_name: IP Address Secondaries
           type: list
           items:
             type: str
         ip_helpers:
-          display_name: IP Helpers
           type: list
           primary_key: ip_helper
           convert_types:
@@ -283,32 +263,24 @@ keys:
             type: dict
             keys:
               ip_helper:
-                display_name: IP Helper
                 type: str
                 required: true
               source_interface:
                 type: str
-                display_name: Source Interface Name
               vrf:
-                display_name: VRF Name
                 type: str
         ipv6_enable:
-          display_name: IPv6 Enable
           type: bool
         ipv6_address:
-          display_name: IPv6 Address
           type: str
         ipv6_address_link_local:
-          display_name: IPv6 Address Link Local
           type: str
         ipv6_nd_ra_disabled:
           display_name: IPv6 ND RA Disabled
           type: bool
         ipv6_nd_managed_config_flag:
-          display_name: IPv6 ND Managed Config Flag
           type: bool
         ipv6_nd_prefixes:
-          display_name: IPv6 ND Prefixes
           type: list
           primary_key: ipv6_prefix
           convert_types:
@@ -317,7 +289,6 @@ keys:
             type: dict
             keys:
               ipv6_prefix:
-                display_name: IPv6 Prefix
                 type: str
                 required: true
               valid_lifetime:
@@ -325,32 +296,26 @@ keys:
                 convert_types:
                 - int
                 description: |
-                  < infinite or lifetime in seconds >
+                  Infinite or lifetime in seconds
               preferred_lifetime:
                 type: str
                 convert_types:
                 - int
                 description: |
-                  < infinite or lifetime in seconds >
+                  Infinite or lifetime in seconds
               no_autoconfig_flag:
                 type: bool
         access_group_in:
-          display_name: Access Group IN
           type: str
         access_group_out:
-          display_name: Access Group OUT
           type: str
         ipv6_access_group_in:
-          display_name: IPv6 Access Group IN
           type: str
         ipv6_access_group_out:
-          display_name: IPV6 Access Group OUT
           type: str
         mac_access_group_in:
-          display_name: MAC Access Group IN
           type: str
         mac_access_group_out:
-          display_name: MAC Access Group OUT
           type: str
         multicast:
           type: dict
@@ -358,7 +323,6 @@ keys:
             boundaries can be either 1 ACL or a list of multicast IP address_range(s)/prefix but not combination of both
           keys:
             ipv4:
-              display_name: IPv4
               type: dict
               keys:
                 boundaries:
@@ -373,7 +337,6 @@ keys:
                 static:
                   type: bool
             ipv6:
-              display_name: IPv6
               type: dict
               keys:
                 boundaries:
@@ -386,27 +349,21 @@ keys:
                 static:
                   type: bool
         ospf_network_point_to_point:
-          display_name: OSPF Network Point To Point
           type: bool
         ospf_area:
-          display_name: OSPF Area
           type: str
           convert_types:
           - int
         ospf_cost:
-          display_name: OSPF Cost
           type: int
           convert_types:
           - str
         ospf_authentication:
-          display_name: OSPF Authentication
           type: str
           valid_values: ["none", "simple", "message-digest"]
         ospf_authentication_key:
-          display_name: OSPF Authentication Key
           type: str
         ospf_message_digest_keys:
-          display_name: OSPF Message Digest Keys
           type: list
           primary_key: id
           convert_types:
@@ -426,15 +383,12 @@ keys:
               key:
                 type: str
         pim:
-          display_name: PIM
           type: dict
           keys:
             ipv4:
-              display_name: IPv4
               type: dict
               keys:
                 dr_priority:
-                  display_name: DR Priority
                   type: int
                   convert_types:
                   - str
@@ -443,7 +397,6 @@ keys:
                 sparse_mode:
                   type: bool
         mac_security:
-          display_name: MAC Security
           type: dict
           keys:
             profile:
@@ -452,7 +405,6 @@ keys:
           type: dict
           keys:
             id:
-              display_name: Port-Channel ID
               type: int
               convert_types:
               - str
@@ -460,37 +412,28 @@ keys:
               type: str
               valid_values: ["on", "active", "passive"]
         isis_enable:
-          display_name: ISIS Enable
           type: str
         isis_passive:
-          display_name: ISIS Passive
           type: bool
         isis_metric:
-          display_name: ISIS Metric
           type: int
           convert_types:
           - str
         isis_network_point_to_point:
-          display_name: ISIS Network Point To Point
           type: bool
         isis_circuit_type:
-          display_name: ISIS Circuit Type
           type: str
           valid_values: ["level-1-2", "level-1", "level-2"]
         isis_hello_padding:
-          display_name: ISIS Hello Padding
           type: bool
         isis_authentication_mode:
-          display_name: ISIS Authentication Mode
           type: str
           valid_values: ["text", "md5"]
         isis_authentication_key:
-          display_name: ISIS Authentication Key
           type: str
           description: |
-            type-7 encrypted password
+            Type-7 encrypted password
         ptp:
-          display_name: PTP
           type: dict
           keys:
             enable:
@@ -524,17 +467,15 @@ keys:
               type: str
               valid_values: ["master", "dynamic"]
             vlan:
-              display_name: VLAN
               type: str
               convert_types:
               - int
               description: |
-                < all | list of vlans as string >
+                all or list of vlans as string
             transport:
               type: str
               valid_values: ["ipv4", "ipv6", "layer2"]
         profile:
-          display_name: Interface Profile
           type: str
         storm_control:
           type: dict
@@ -602,7 +543,6 @@ keys:
                 congestion_drops:
                   type: bool
         lldp:
-          display_name: LLDP
           type: dict
           keys:
             transmit:
@@ -610,22 +550,18 @@ keys:
             receive:
               type: bool
             ztp_vlan:
-              display_name: ZTP VLAN
               type: int
               convert_types:
               - str
         trunk_private_vlan_secondary:
-          display_name: Trunk Private VLAN Secondary
           type: bool
         pvlan_mapping:
-          display_name: PVLAN Mapping
           type: int
           convert_types:
           - str
           description: |
             List of vlans as string
         vlan_translations:
-          display_name: VLAN Translations
           type: list
           items:
             type: dict
@@ -635,7 +571,6 @@ keys:
                 description: |
                   List of vlans as string (only one vlan if direction is "both")
               to:
-                display_name: To
                 type: int
                 convert_types:
                 - str
@@ -654,7 +589,6 @@ keys:
             reauthentication:
               type: bool
             pae:
-              display_name: PAE
               type: dict
               keys:
                 mode:
@@ -667,7 +601,6 @@ keys:
                   type: str
                   valid_values: ["allow", "drop"]
                 allow_vlan:
-                  display_name: Allow VLAN
                   type: int
                   min: 1
                   max: 4094
@@ -682,7 +615,6 @@ keys:
                 multi_host_authenticated:
                   type: bool
                 mac_based_authentication:
-                  display_name: MAC Based Authentication
                   type: dict
                   keys:
                     enabled:
@@ -724,7 +656,6 @@ keys:
                   convert_types:
                   - str
             mac_based_authentication:
-              display_name: MAC Based Authentication
               type: dict
               keys:
                 enabled:
@@ -749,7 +680,6 @@ keys:
                 reauth_timeout_ignore:
                   type: bool
                 tx_period:
-                  display_name: Transmit Period
                   type: int
                   convert_types:
                   - str
@@ -765,21 +695,18 @@ keys:
             rate:
               type: str
               description: |
-                < "< rate > kbps" | "1-100 percent" | "< rate > pps" , supported options are platform dependent >
+                rate in kbps or 1-100 percent or rate in pps, supported options are platform dependent
         qos:
-          display_name: QOS
           type: dict
           keys:
             trust:
               type: str
               valid_values: ["dscp", "cos", "disabled"]
             dscp:
-              display_name: DSCP
               type: int
               convert_types:
               - str
             cos:
-              display_name: COS
               type: int
               convert_types:
               - str
@@ -798,7 +725,6 @@ keys:
           type: str
           valid_values: ["edge", "network"]
         vmtracer:
-          display_name: VM Tracer
           type: bool
         priority_flow_control:
           type: dict
@@ -819,7 +745,6 @@ keys:
                   no_drop:
                     type: bool
         bfd:
-          display_name: BFD
           type: dict
           keys:
             echo:
@@ -831,7 +756,6 @@ keys:
               description: |
                 Interval in milliseconds
             min_rx:
-              display_name: Min RX
               type: int
               convert_types:
               - str
@@ -847,21 +771,16 @@ keys:
           type: dict
           keys:
             pbr:
-              display_name: PBR
               type: dict
               keys:
                 input:
                   type: str
-                  display_name: Policy Map Name
         mpls:
-          display_name: MPLS
           type: dict
           keys:
             ip:
-              display_name: IP
               type: bool
             ldp:
-              display_name: LDP
               type: dict
               keys:
                 interface:
@@ -870,7 +789,6 @@ keys:
                   display_name: IGP Sync
                   type: bool
         lacp_timer:
-          display_name: LACP Timer
           type: dict
           keys:
             mode:
@@ -883,7 +801,6 @@ keys:
               convert_types:
               - str
         lacp_port_priority:
-          display_name: LACP Port Priority
           type: int
           min: 0
           max: 65535
@@ -896,10 +813,9 @@ keys:
               type: dict
               keys:
                 override:
-                  display_name: Transceiver Type
                   type: str
+                  description: Transceiver Type
         ip_proxy_arp:
-          display_name: IP Proxy ARP
           type: bool
         traffic_policy:
           type: dict
@@ -907,13 +823,12 @@ keys:
             input:
               type: str
               description: |
-                ingress traffic policy
+                Ingress traffic policy
             output:
               type: str
               description: |
-                egress traffic policy
+                Egress traffic policy
         eos_cli:
-          display_name: EOS CLI
           type: str
           description: |
-            < multiline eos cli >
+            Multiline eos cli

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ethernet-interfaces.j2
@@ -8,7 +8,7 @@
 
 | Interface | Description | Mode | VLANs | Native VLAN | Trunk Group | Channel-Group |
 | --------- | ----------- | ---- | ----- | ----------- | ----------- | ------------- |
-{%     for ethernet_interface in ethernet_interfaces | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%     for ethernet_interface in ethernet_interfaces | arista.avd.natural_sort('name') %}
 {%         if ethernet_interface.channel_group.id is arista.avd.defined %}
 {%             set port_channel_interface_name = 'Port-Channel' ~ ethernet_interface.channel_group.id %}
 {%             set port_channel_interface = port_channel_interfaces | arista.avd.default([]) |
@@ -64,7 +64,7 @@
 {# Encapsulation #}
 {%     set encapsulation_dot1q_interfaces = [] %}
 {%     set flexencap_interfaces = [] %}
-{%     for ethernet_interface in ethernet_interfaces | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%     for ethernet_interface in ethernet_interfaces | arista.avd.natural_sort('name') %}
 {%         if ethernet_interface.type | arista.avd.default in ['l3dot1q', 'l2dot1q'] %}
 {%             if ethernet_interface.encapsulation_dot1q_vlan is arista.avd.defined %}
 {%                 do encapsulation_dot1q_interfaces.append(ethernet_interface) %}
@@ -111,7 +111,7 @@
 {# PVLAN #}
 {%     set ethernet_interface_pvlan = namespace() %}
 {%     set ethernet_interface_pvlan.configured = false %}
-{%     for ethernet_interface in ethernet_interfaces | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%     for ethernet_interface in ethernet_interfaces | arista.avd.natural_sort('name') %}
 {%         if ethernet_interface.pvlan_mapping is arista.avd.defined or
               ethernet_interface.trunk_private_vlan_secondary is arista.avd.defined %}
 {%             set ethernet_interface_pvlan.configured = true %}
@@ -124,7 +124,7 @@
 
 | Interface | PVLAN Mapping | Secondary Trunk |
 | --------- | ------------- | ----------------|
-{%         for ethernet_interface in ethernet_interfaces | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%         for ethernet_interface in ethernet_interfaces | arista.avd.natural_sort('name') %}
 {%             if ethernet_interface.pvlan_mapping is arista.avd.defined or
                ethernet_interface.trunk_private_vlan_secondary is arista.avd.defined %}
 {%                 set row_pvlan_mapping = ethernet_interface.pvlan_mapping | arista.avd.default('-') %}
@@ -136,7 +136,7 @@
 {# VLAN Translations #}
 {%     set ethernet_interface_vlan_xlate = namespace() %}
 {%     set ethernet_interface_vlan_xlate.configured = false %}
-{%     for ethernet_interface in ethernet_interfaces | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%     for ethernet_interface in ethernet_interfaces | arista.avd.natural_sort('name') %}
 {%         if ethernet_interface.vlan_translations is arista.avd.defined %}
 {%             set ethernet_interface_vlan_xlate.configured = true %}
 {%             break %}
@@ -148,7 +148,7 @@
 
 | Interface | From VLAN ID(s) | To VLAN ID | Direction |
 | --------- | --------------- | -----------| --------- |
-{%         for ethernet_interface in ethernet_interfaces | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%         for ethernet_interface in ethernet_interfaces | arista.avd.natural_sort('name') %}
 {%             if ethernet_interface.vlan_translations is arista.avd.defined %}
 {%                 for vlan_translation in ethernet_interface.vlan_translations | arista.avd.natural_sort %}
 {%                     if vlan_translation.from is arista.avd.defined and vlan_translation.to is arista.avd.defined %}
@@ -161,7 +161,7 @@
 {%     endif %}
 {# Link Tracking Groups #}
 {%     set link_tracking_interfaces = [] %}
-{%     for ethernet_interface in ethernet_interfaces | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%     for ethernet_interface in ethernet_interfaces | arista.avd.natural_sort('name') %}
 {%         if ethernet_interface.link_tracking_groups is arista.avd.defined %}
 {%             do link_tracking_interfaces.append(ethernet_interface) %}
 {%         endif %}
@@ -182,7 +182,7 @@
 {%     endif %}
 {# Multicast Routing #}
 {%     set multicast_interfaces = [] %}
-{%     for ethernet_interface in ethernet_interfaces | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%     for ethernet_interface in ethernet_interfaces | arista.avd.natural_sort('name') %}
 {%         if ethernet_interface.multicast is arista.avd.defined %}
 {%             do multicast_interfaces.append(ethernet_interface) %}
 {%         endif %}
@@ -221,7 +221,7 @@
 {# IPv4 #}
 {%     set ethernet_interface_ipv4 = namespace() %}
 {%     set ethernet_interface_ipv4.configured = false %}
-{%     for ethernet_interface in ethernet_interfaces | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%     for ethernet_interface in ethernet_interfaces | arista.avd.natural_sort('name') %}
 {%         if ethernet_interface.type is arista.avd.defined
             and ethernet_interface.type in ['routed', 'l3dot1q']
             and ethernet_interface.ip_address is arista.avd.defined %}
@@ -245,7 +245,7 @@
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-{%         for ethernet_interface in ethernet_interfaces | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%         for ethernet_interface in ethernet_interfaces | arista.avd.natural_sort('name') %}
 {%             if ethernet_interface.channel_group.id is arista.avd.defined %}
 {%                 set port_channel_interface_name = 'Port-Channel' ~ ethernet_interface.channel_group.id %}
 {%                 set port_channel_interface = port_channel_interfaces | arista.avd.default([]) |
@@ -285,7 +285,7 @@
 {# IPv6 #}
 {%     set ethernet_interface_ipv6 = namespace() %}
 {%     set ethernet_interface_ipv6.configured = false %}
-{%     for ethernet_interface in ethernet_interfaces | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%     for ethernet_interface in ethernet_interfaces | arista.avd.natural_sort('name') %}
 {%         if ethernet_interface.type is arista.avd.defined
               and ethernet_interface.type in ['routed', 'l3dot1q']
               and (ethernet_interface.ipv6_address is arista.avd.defined or ethernet_interface.ipv6_enable is arista.avd.defined(true)) %}
@@ -309,7 +309,7 @@
 
 | Interface | Description | Type | Channel Group | IPv6 Address | VRF | MTU | Shutdown | ND RA Disabled | Managed Config Flag | IPv6 ACL In | IPv6 ACL Out |
 | --------- | ----------- | ---- | --------------| ------------ | --- | --- | -------- | -------------- | -------------------| ----------- | ------------ |
-{%         for ethernet_interface in ethernet_interfaces | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%         for ethernet_interface in ethernet_interfaces | arista.avd.natural_sort('name') %}
 {%             if ethernet_interface.channel_group.id is arista.avd.defined %}
 {%                 set port_channel_interface_name = 'Port-Channel' ~ ethernet_interface.channel_group.id %}
 {%                 set port_channel_interface = port_channel_interfaces | arista.avd.default([]) |
@@ -352,7 +352,7 @@
 {%     endif %}
 {# ISIS #}
 {%     set ethernet_interfaces_isis = [] %}
-{%     for ethernet_interface in ethernet_interfaces | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%     for ethernet_interface in ethernet_interfaces | arista.avd.natural_sort('name') %}
 {%         if ethernet_interface.isis_enable is arista.avd.defined or
                ethernet_interface.isis_metric is arista.avd.defined or
                ethernet_interface.isis_circuit_type is arista.avd.defined or
@@ -381,7 +381,7 @@
 
 | Interface | Channel Group | ISIS Instance | ISIS Metric | Mode | ISIS Circuit Type | Hello Padding | Authentication Mode |
 | --------- | ------------- | ------------- | ----------- | ---- | ----------------- | ------------- | ------------------- |
-{%         for ethernet_interface in ethernet_interfaces | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%         for ethernet_interface in ethernet_interfaces | arista.avd.natural_sort('name') %}
 {%             if ethernet_interface.channel_group.id is arista.avd.defined %}
 {%                 set port_channel_interface_name = 'Port-Channel' ~ ethernet_interface.channel_group.id %}
 {%                 set port_channel_interface = port_channel_interfaces_isis | selectattr('name', 'arista.avd.defined', port_channel_interface_name) |
@@ -429,7 +429,7 @@
 {%     set evpn_es_ethernet_interfaces = [] %}
 {%     set evpn_dfe_ethernet_interfaces = [] %}
 {%     set evpn_mpls_ethernet_interfaces = [] %}
-{%     for ethernet_interface in ethernet_interfaces | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%     for ethernet_interface in ethernet_interfaces | arista.avd.natural_sort('name') %}
 {%         if ethernet_interface.evpn_ethernet_segment is arista.avd.defined %}
 {%             do evpn_es_ethernet_interfaces.append(ethernet_interface) %}
 {%             if ethernet_interface.evpn_ethernet_segment.designated_forwarder_election is arista.avd.defined %}
@@ -485,7 +485,7 @@
 {%         endif %}
 {%     endif %}
 {%     set err_cor_enc_intfs = [] %}
-{%     for ethernet_interface in ethernet_interfaces | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%     for ethernet_interface in ethernet_interfaces | arista.avd.natural_sort('name') %}
 {%         if ethernet_interface.error_correction_encoding is arista.avd.defined %}
 {%             do err_cor_enc_intfs.append(ethernet_interface) %}
 {%         endif %}
@@ -512,7 +512,7 @@
 {%         endfor %}
 {%     endif %}
 {%     set priority_intfs = [] %}
-{%     for ethernet_interface in ethernet_interfaces | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%     for ethernet_interface in ethernet_interfaces | arista.avd.natural_sort('name') %}
 {%         if ethernet_interface.priority_flow_control.enabled is arista.avd.defined %}
 {%             do priority_intfs.append(ethernet_interface) %}
 {%         endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -549,12 +549,12 @@ interface {{ ethernet_interface.name }}
 {%         elif ethernet_interface.spanning_tree_portfast is arista.avd.defined('network') %}
    spanning-tree portfast network
 {%         endif %}
-{%         if ethernet_interface.spanning_tree_bpduguard is arista.avd.defined(true) or ethernet_interface.spanning_tree_bpduguard is arista.avd.defined("enabled") %}
+{%         if ethernet_interface.spanning_tree_bpduguard is arista.avd.defined and ethernet_interface.spanning_tree_bpduguard in [True, "True", "enabled"] %}
    spanning-tree bpduguard enable
 {%         elif ethernet_interface.spanning_tree_bpduguard is arista.avd.defined("disabled") %}
    spanning-tree bpduguard disable
 {%         endif %}
-{%         if ethernet_interface.spanning_tree_bpdufilter is arista.avd.defined(true) or ethernet_interface.spanning_tree_bpdufilter is arista.avd.defined("enabled") %}
+{%         if ethernet_interface.spanning_tree_bpdufilter is arista.avd.defined and ethernet_interface.spanning_tree_bpdufilter in [True, "True", "enabled"] %}
    spanning-tree bpdufilter enable
 {%         elif ethernet_interface.spanning_tree_bpdufilter is arista.avd.defined("disabled") %}
    spanning-tree bpdufilter disable

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -1,5 +1,5 @@
 {# eos - Ethernet Interfaces #}
-{% for ethernet_interface in ethernet_interfaces | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{% for ethernet_interface in ethernet_interfaces | arista.avd.natural_sort('name') %}
 {%     if ethernet_interface.channel_group.id is arista.avd.defined and ethernet_interface.channel_group.mode is arista.avd.defined %}
 {%         set port_channel_interface_name = 'Port-Channel' ~ ethernet_interface.channel_group.id %}
 {%         if port_channel_interfaces | arista.avd.default([]) |
@@ -290,7 +290,7 @@ interface {{ ethernet_interface.name }}
    ip address {{ ip_address_secondary }} secondary
 {%                 endfor %}
 {%             endif %}
-{%             for ip_helper in ethernet_interface.ip_helpers | arista.avd.convert_dicts('ip_helper') | arista.avd.natural_sort('ip_helper') %}
+{%             for ip_helper in ethernet_interface.ip_helpers | arista.avd.natural_sort('ip_helper') %}
 {%                 set ip_helper_cli = "ip helper-address " ~ ip_helper.ip_helper %}
 {%                 if ip_helper.vrf is arista.avd.defined %}
 {%                     set ip_helper_cli = ip_helper_cli ~ " vrf " ~ ip_helper.vrf %}
@@ -327,7 +327,7 @@ interface {{ ethernet_interface.name }}
    ipv6 nd managed-config-flag
 {%         endif %}
 {%         if ethernet_interface.ipv6_nd_prefixes is arista.avd.defined %}
-{%             for prefix in ethernet_interface.ipv6_nd_prefixes | arista.avd.convert_dicts('ipv6_prefix') %}
+{%             for prefix in ethernet_interface.ipv6_nd_prefixes %}
 {%                 set ipv6_nd_prefix_cli = "ipv6 nd prefix " ~ prefix.ipv6_prefix %}
 {%                 if prefix.valid_lifetime is arista.avd.defined %}
 {%                     set ipv6_nd_prefix_cli = ipv6_nd_prefix_cli ~ " " ~ prefix.valid_lifetime %}
@@ -434,7 +434,7 @@ interface {{ ethernet_interface.name }}
 {%         if ethernet_interface.ospf_area is arista.avd.defined %}
    ip ospf area {{ ethernet_interface.ospf_area }}
 {%         endif %}
-{%         for ospf_message_digest_key in ethernet_interface.ospf_message_digest_keys | arista.avd.convert_dicts('id') | arista.avd.natural_sort('id') %}
+{%         for ospf_message_digest_key in ethernet_interface.ospf_message_digest_keys | arista.avd.natural_sort('id') %}
 {%             if ospf_message_digest_key.hash_algorithm is arista.avd.defined and ospf_message_digest_key.key is arista.avd.defined %}
    ip ospf message-digest-key {{ ospf_message_digest_key.id }} {{ ospf_message_digest_key.hash_algorithm }} 7 {{ ospf_message_digest_key.key }}
 {%             endif %}


### PR DESCRIPTION
## Add schema for data model

<!-- Use this PR Title: Feat(eos_cli_config_gen): Add schema for < data_model_key > -->

## Checklist

### Contributor Checklist

- [x] Create schema fragment matching data model described in README.md and README_v4.0.md
  - README.md is most complete with all keys. README_v4.0 includes partial data models after conversion to lists.
  - Schema fragment path is `roles/eos_cli_config_gen/schemas/schema_fragments/<data_model_key>.schema.yml`.
  - Copy line 1-5 from another schema (comments and outer type:dict).
  - Refer to [schema documentation](https://avd.sh/en/devel/docs/input-variable-validation-BETA.html) for syntax and/or use YAML Lint plugin from Redhat in VSCode.
  - Use `convert_types` on value that could be mixed type or misinterpreted like integers and numeric strings.
- [x] If the data model has been converted from wildcard dicts:
  - Add `convert_types: ['dict']` to the schema.
  - Remove `convert_dicts` from the `templates/eos/<>.j2` and `templates/documentation/<>.j2` templates.
- [x] Run `molecule converge -s build_schemas_and_docs` to update schema and documentation.
- [x] Test by running `molecule converge -s eos_cli_config_gen` and verify no errors or changes to generated configs/docs.

### Reviewer Checklist

- Reviewer 1 (Emil):
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2: Claus
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
