### PR TITLE
Feat(eos_cli_config_gen): Add schema for ip_access_lists

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -603,42 +603,54 @@ interface_profiles:
       - <str>
 ```
 
-## Ip Access Lists
+## IP Extended Access-Lists (improved model)
+
+### Description
+
+AVD currently supports 2 different data models for extended ACLs:
+
+- The legacy `access_lists` data model, for compatibility with existing deployments
+- The improved `ip_access_lists` data model, for access to more EOS features
+
+Both data models can coexists without conflicts, as different keys are used: `access_lists` vs `ip_access_lists`.
+Access list names must be unique.
+
+The improved data model has a more sophisticated design documented below:
 
 ### Variables
 
 | Variable | Type | Required | Default | Value Restrictions | Description |
 | -------- | ---- | -------- | ------- | ------------------ | ----------- |
-| [<samp>ip_access_lists</samp>](## "ip_access_lists") | List, items: Dictionary |  |  |  |  |
+| [<samp>ip_access_lists</samp>](## "ip_access_lists") | List, items: Dictionary |  |  |  | IP Extended Access-Lists (improved model) |
 | [<samp>&nbsp;&nbsp;- name</samp>](## "ip_access_lists.[].name") | String | Required, Unique |  |  | Access-list Name |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;counters_per_entry</samp>](## "ip_access_lists.[].counters_per_entry") | Boolean |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;entries</samp>](## "ip_access_lists.[].entries") | List, items: Dictionary |  |  |  | Remark Entry |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- sequence</samp>](## "ip_access_lists.[].entries.[].sequence") | Integer |  |  |  | ACL entry sequence number<br> |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;remark</samp>](## "ip_access_lists.[].entries.[].remark") | String |  |  |  | Comment up to 100 characters<br> |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;action</samp>](## "ip_access_lists.[].entries.[].action") | String |  |  | Valid Values:<br>- permit<br>- deny |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;protocol</samp>](## "ip_access_lists.[].entries.[].protocol") | String |  |  |  | ip | tcp | udp | icmp | other protocol name or number.<br> |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source</samp>](## "ip_access_lists.[].entries.[].source") | String |  |  |  | NOTE: A.B.C.D without a mask means host<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;entries</samp>](## "ip_access_lists.[].entries") | List, items: Dictionary |  |  |  | ACL Entries |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- sequence</samp>](## "ip_access_lists.[].entries.[].sequence") | Integer |  |  |  | ACL entry sequence number.<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;remark</samp>](## "ip_access_lists.[].entries.[].remark") | String |  |  |  | Comment up to 100 characters.<br>If remark is defined, other keys in acl entry will be ignored.<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;action</samp>](## "ip_access_lists.[].entries.[].action") | String |  |  | Valid Values:<br>- permit<br>- deny | ACL action.<br>Required for standard entry.<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;protocol</samp>](## "ip_access_lists.[].entries.[].protocol") | String |  |  |  | ip, tcp, udp, icmp or other protocol name or number.<br>Required for standard entry.<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source</samp>](## "ip_access_lists.[].entries.[].source") | String |  |  |  | any, A.B.C.D/E or A.B.C.D.<br>A.B.C.D without a mask means host.<br>Required for standard entry.<br> |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_ports_match</samp>](## "ip_access_lists.[].entries.[].source_ports_match") | String |  | eq | Valid Values:<br>- eq<br>- gt<br>- lt<br>- neq<br>- range |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_ports</samp>](## "ip_access_lists.[].entries.[].source_ports") | List, items: Integer |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;int&gt;</samp>](## "ip_access_lists.[].entries.[].source_ports.[].&lt;int&gt;") | Integer |  |  |  | tcp/udp port name or number<br> |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;destination</samp>](## "ip_access_lists.[].entries.[].destination") | String |  |  |  | NOTE: A.B.C.D without a mask means host<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_ports</samp>](## "ip_access_lists.[].entries.[].source_ports") | List, items: String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "ip_access_lists.[].entries.[].source_ports.[].&lt;str&gt;") | String |  |  |  | TCP/UDP source port name or number. |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;destination</samp>](## "ip_access_lists.[].entries.[].destination") | String |  |  |  | any, A.B.C.D/E or A.B.C.D.<br>A.B.C.D without a mask means host.<br>Required for standard entry.<br> |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;destination_ports_match</samp>](## "ip_access_lists.[].entries.[].destination_ports_match") | String |  | eq | Valid Values:<br>- eq<br>- gt<br>- lt<br>- neq<br>- range |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;destination_ports</samp>](## "ip_access_lists.[].entries.[].destination_ports") | List, items: Integer |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;int&gt;</samp>](## "ip_access_lists.[].entries.[].destination_ports.[].&lt;int&gt;") | Integer |  |  |  | TCP/UDP port name or number<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;destination_ports</samp>](## "ip_access_lists.[].entries.[].destination_ports") | List, items: String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "ip_access_lists.[].entries.[].destination_ports.[].&lt;str&gt;") | String |  |  |  | TCP/UDP destination port name or number. |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tcp_flags</samp>](## "ip_access_lists.[].entries.[].tcp_flags") | List, items: String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "ip_access_lists.[].entries.[].tcp_flags.[].&lt;str&gt;") | String |  |  |  | TCP Flag Name |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;fragments</samp>](## "ip_access_lists.[].entries.[].fragments") | Boolean |  |  |  | Match non-head fragment packets<br> |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;log</samp>](## "ip_access_lists.[].entries.[].log") | Boolean |  |  |  | Log matches against this rule<br> |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ttl</samp>](## "ip_access_lists.[].entries.[].ttl") | Integer |  |  |  | TTL value |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;fragments</samp>](## "ip_access_lists.[].entries.[].fragments") | Boolean |  |  |  | Match non-head fragment packets. |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;log</samp>](## "ip_access_lists.[].entries.[].log") | Boolean |  |  |  | Log matches against this rule. |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ttl</samp>](## "ip_access_lists.[].entries.[].ttl") | Integer |  |  | Min: 0<br>Max: 254 | TTL value |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ttl_match</samp>](## "ip_access_lists.[].entries.[].ttl_match") | String |  | eq | Valid Values:<br>- eq<br>- gt<br>- lt<br>- neq |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;icmp_type</samp>](## "ip_access_lists.[].entries.[].icmp_type") | String |  |  |  | Message type name/number for ICMP packets.<br> |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;icmp_code</samp>](## "ip_access_lists.[].entries.[].icmp_code") | String |  |  |  | Message code for ICMP packets<br> |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;nexthop_group</samp>](## "ip_access_lists.[].entries.[].nexthop_group") | String |  |  |  | Nexthop-Group Name |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tracked</samp>](## "ip_access_lists.[].entries.[].tracked") | Boolean |  |  |  | Match packets in existing ICMP/UDP/TCP connections.<br> |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dscp</samp>](## "ip_access_lists.[].entries.[].dscp") | String |  |  |  | DSCP Name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;icmp_type</samp>](## "ip_access_lists.[].entries.[].icmp_type") | String |  |  |  | Message type name/number for ICMP packets. |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;icmp_code</samp>](## "ip_access_lists.[].entries.[].icmp_code") | String |  |  |  | Message code for ICMP packets. |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;nexthop_group</samp>](## "ip_access_lists.[].entries.[].nexthop_group") | String |  |  |  | nexthop-group name. |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tracked</samp>](## "ip_access_lists.[].entries.[].tracked") | Boolean |  |  |  | Match packets in existing ICMP/UDP/TCP connections. |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dscp</samp>](## "ip_access_lists.[].entries.[].dscp") | String |  |  |  | DSCP value or name. |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlan_number</samp>](## "ip_access_lists.[].entries.[].vlan_number") | Integer |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlan_inner</samp>](## "ip_access_lists.[].entries.[].vlan_inner") | Boolean |  | False |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlan_mask</samp>](## "ip_access_lists.[].entries.[].vlan_mask") | String |  |  |  | 0x000-0xFFF  Vlan mask |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlan_mask</samp>](## "ip_access_lists.[].entries.[].vlan_mask") | String |  |  |  | 0x000-0xFFF VLAN mask. |
 
 ### YAML
 
@@ -654,11 +666,11 @@ ip_access_lists:
         source: <str>
         source_ports_match: <str>
         source_ports:
-          - <int>
+          - <str>
         destination: <str>
         destination_ports_match: <str>
         destination_ports:
-          - <int>
+          - <str>
         tcp_flags:
           - <str>
         fragments: <bool>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -603,6 +603,78 @@ interface_profiles:
       - <str>
 ```
 
+## Ip Access Lists
+
+### Variables
+
+| Variable | Type | Required | Default | Value Restrictions | Description |
+| -------- | ---- | -------- | ------- | ------------------ | ----------- |
+| [<samp>ip_access_lists</samp>](## "ip_access_lists") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;- name</samp>](## "ip_access_lists.[].name") | String | Required, Unique |  |  | Access-list Name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;counters_per_entry</samp>](## "ip_access_lists.[].counters_per_entry") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;entries</samp>](## "ip_access_lists.[].entries") | List, items: Dictionary |  |  |  | Remark Entry |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- sequence</samp>](## "ip_access_lists.[].entries.[].sequence") | Integer |  |  |  | ACL entry sequence number<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;remark</samp>](## "ip_access_lists.[].entries.[].remark") | String |  |  |  | Comment up to 100 characters<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;action</samp>](## "ip_access_lists.[].entries.[].action") | String |  |  | Valid Values:<br>- permit<br>- deny |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;protocol</samp>](## "ip_access_lists.[].entries.[].protocol") | String |  |  |  | ip | tcp | udp | icmp | other protocol name or number.<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source</samp>](## "ip_access_lists.[].entries.[].source") | String |  |  |  | NOTE: A.B.C.D without a mask means host<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_ports_match</samp>](## "ip_access_lists.[].entries.[].source_ports_match") | String |  | eq | Valid Values:<br>- eq<br>- gt<br>- lt<br>- neq<br>- range |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_ports</samp>](## "ip_access_lists.[].entries.[].source_ports") | List, items: Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;int&gt;</samp>](## "ip_access_lists.[].entries.[].source_ports.[].&lt;int&gt;") | Integer |  |  |  | tcp/udp port name or number<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;destination</samp>](## "ip_access_lists.[].entries.[].destination") | String |  |  |  | NOTE: A.B.C.D without a mask means host<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;destination_ports_match</samp>](## "ip_access_lists.[].entries.[].destination_ports_match") | String |  | eq | Valid Values:<br>- eq<br>- gt<br>- lt<br>- neq<br>- range |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;destination_ports</samp>](## "ip_access_lists.[].entries.[].destination_ports") | List, items: Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;int&gt;</samp>](## "ip_access_lists.[].entries.[].destination_ports.[].&lt;int&gt;") | Integer |  |  |  | TCP/UDP port name or number<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tcp_flags</samp>](## "ip_access_lists.[].entries.[].tcp_flags") | List, items: String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "ip_access_lists.[].entries.[].tcp_flags.[].&lt;str&gt;") | String |  |  |  | TCP Flag Name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;fragments</samp>](## "ip_access_lists.[].entries.[].fragments") | Boolean |  |  |  | Match non-head fragment packets<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;log</samp>](## "ip_access_lists.[].entries.[].log") | Boolean |  |  |  | Log matches against this rule<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ttl</samp>](## "ip_access_lists.[].entries.[].ttl") | Integer |  |  |  | TTL value |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ttl_match</samp>](## "ip_access_lists.[].entries.[].ttl_match") | String |  | eq | Valid Values:<br>- eq<br>- gt<br>- lt<br>- neq |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;icmp_type</samp>](## "ip_access_lists.[].entries.[].icmp_type") | String |  |  |  | Message type name/number for ICMP packets.<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;icmp_code</samp>](## "ip_access_lists.[].entries.[].icmp_code") | String |  |  |  | Message code for ICMP packets<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;nexthop_group</samp>](## "ip_access_lists.[].entries.[].nexthop_group") | String |  |  |  | Nexthop-Group Name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tracked</samp>](## "ip_access_lists.[].entries.[].tracked") | Boolean |  |  |  | Match packets in existing ICMP/UDP/TCP connections.<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dscp</samp>](## "ip_access_lists.[].entries.[].dscp") | String |  |  |  | DSCP Name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlan_number</samp>](## "ip_access_lists.[].entries.[].vlan_number") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlan_inner</samp>](## "ip_access_lists.[].entries.[].vlan_inner") | Boolean |  | False |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlan_mask</samp>](## "ip_access_lists.[].entries.[].vlan_mask") | String |  |  |  | 0x000-0xFFF  Vlan mask |
+
+### YAML
+
+```yaml
+ip_access_lists:
+  - name: <str>
+    counters_per_entry: <bool>
+    entries:
+      - sequence: <int>
+        remark: <str>
+        action: <str>
+        protocol: <str>
+        source: <str>
+        source_ports_match: <str>
+        source_ports:
+          - <int>
+        destination: <str>
+        destination_ports_match: <str>
+        destination_ports:
+          - <int>
+        tcp_flags:
+          - <str>
+        fragments: <bool>
+        log: <bool>
+        ttl: <int>
+        ttl_match: <str>
+        icmp_type: <str>
+        icmp_code: <str>
+        nexthop_group: <str>
+        tracked: <bool>
+        dscp: <str>
+        vlan_number: <int>
+        vlan_inner: <bool>
+        vlan_mask: <str>
+```
+
 ## IP Community Lists
 
 ### Description

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -891,6 +891,180 @@
       },
       "title": "Interface Profiles"
     },
+    "ip_access_lists": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Access-list Name"
+          },
+          "counters_per_entry": {
+            "type": "boolean",
+            "title": "Counters Per Entry"
+          },
+          "entries": {
+            "type": "array",
+            "title": "Remark Entry",
+            "items": {
+              "type": "object",
+              "properties": {
+                "sequence": {
+                  "type": "integer",
+                  "description": "ACL entry sequence number\n",
+                  "title": "Sequence"
+                },
+                "remark": {
+                  "type": "string",
+                  "description": "Comment up to 100 characters\n",
+                  "title": "Remark"
+                },
+                "action": {
+                  "type": "string",
+                  "enum": [
+                    "permit",
+                    "deny"
+                  ],
+                  "title": "Action"
+                },
+                "protocol": {
+                  "type": "string",
+                  "description": "ip | tcp | udp | icmp | other protocol name or number.\n",
+                  "title": "Protocol"
+                },
+                "source": {
+                  "type": "string",
+                  "description": "NOTE: A.B.C.D without a mask means host\n",
+                  "title": "Source"
+                },
+                "source_ports_match": {
+                  "type": "string",
+                  "enum": [
+                    "eq",
+                    "gt",
+                    "lt",
+                    "neq",
+                    "range"
+                  ],
+                  "default": "eq",
+                  "title": "Source Ports Match"
+                },
+                "source_ports": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer",
+                    "description": "tcp/udp port name or number\n"
+                  },
+                  "title": "Source Ports"
+                },
+                "destination": {
+                  "type": "string",
+                  "description": "NOTE: A.B.C.D without a mask means host\n",
+                  "title": "Destination"
+                },
+                "destination_ports_match": {
+                  "type": "string",
+                  "enum": [
+                    "eq",
+                    "gt",
+                    "lt",
+                    "neq",
+                    "range"
+                  ],
+                  "default": "eq",
+                  "title": "Destination Ports Match"
+                },
+                "destination_ports": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer",
+                    "description": "TCP/UDP port name or number\n"
+                  },
+                  "title": "Destination Ports"
+                },
+                "tcp_flags": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "title": "TCP Flag Name"
+                  },
+                  "title": "Tcp Flags"
+                },
+                "fragments": {
+                  "type": "boolean",
+                  "description": "Match non-head fragment packets\n",
+                  "title": "Fragments"
+                },
+                "log": {
+                  "type": "boolean",
+                  "description": "Log matches against this rule\n",
+                  "title": "Log"
+                },
+                "ttl": {
+                  "type": "integer",
+                  "title": "TTL value"
+                },
+                "ttl_match": {
+                  "type": "string",
+                  "enum": [
+                    "eq",
+                    "gt",
+                    "lt",
+                    "neq"
+                  ],
+                  "default": "eq",
+                  "title": "Ttl Match"
+                },
+                "icmp_type": {
+                  "type": "string",
+                  "description": "Message type name/number for ICMP packets.\n",
+                  "title": "Icmp Type"
+                },
+                "icmp_code": {
+                  "type": "string",
+                  "description": "Message code for ICMP packets\n",
+                  "title": "Icmp Code"
+                },
+                "nexthop_group": {
+                  "type": "string",
+                  "title": "Nexthop-Group Name"
+                },
+                "tracked": {
+                  "type": "boolean",
+                  "description": "Match packets in existing ICMP/UDP/TCP connections.\n",
+                  "title": "Tracked"
+                },
+                "dscp": {
+                  "type": "string",
+                  "title": "DSCP Name"
+                },
+                "vlan_number": {
+                  "type": "integer",
+                  "title": "Vlan Number"
+                },
+                "vlan_inner": {
+                  "type": "boolean",
+                  "default": false,
+                  "title": "Vlan Inner"
+                },
+                "vlan_mask": {
+                  "type": "string",
+                  "description": "0x000-0xFFF  Vlan mask",
+                  "title": "Vlan Mask"
+                }
+              },
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false
+      },
+      "title": "Ip Access Lists"
+    },
     "ip_community_lists": {
       "type": "array",
       "title": "IP Community Lists",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -893,6 +893,8 @@
     },
     "ip_access_lists": {
       "type": "array",
+      "title": "IP Extended Access-Lists (improved model)",
+      "description": "AVD currently supports 2 different data models for extended ACLs:\n\n- The legacy `access_lists` data model, for compatibility with existing deployments\n- The improved `ip_access_lists` data model, for access to more EOS features\n\nBoth data models can coexists without conflicts, as different keys are used: `access_lists` vs `ip_access_lists`.\nAccess list names must be unique.\n\nThe improved data model has a more sophisticated design documented below:\n",
       "items": {
         "type": "object",
         "properties": {
@@ -906,18 +908,18 @@
           },
           "entries": {
             "type": "array",
-            "title": "Remark Entry",
+            "title": "ACL Entries",
             "items": {
               "type": "object",
               "properties": {
                 "sequence": {
                   "type": "integer",
-                  "description": "ACL entry sequence number\n",
+                  "description": "ACL entry sequence number.\n",
                   "title": "Sequence"
                 },
                 "remark": {
                   "type": "string",
-                  "description": "Comment up to 100 characters\n",
+                  "description": "Comment up to 100 characters.\nIf remark is defined, other keys in acl entry will be ignored.\n",
                   "title": "Remark"
                 },
                 "action": {
@@ -926,16 +928,17 @@
                     "permit",
                     "deny"
                   ],
+                  "description": "ACL action.\nRequired for standard entry.\n",
                   "title": "Action"
                 },
                 "protocol": {
                   "type": "string",
-                  "description": "ip | tcp | udp | icmp | other protocol name or number.\n",
+                  "description": "ip, tcp, udp, icmp or other protocol name or number.\nRequired for standard entry.\n",
                   "title": "Protocol"
                 },
                 "source": {
                   "type": "string",
-                  "description": "NOTE: A.B.C.D without a mask means host\n",
+                  "description": "any, A.B.C.D/E or A.B.C.D.\nA.B.C.D without a mask means host.\nRequired for standard entry.\n",
                   "title": "Source"
                 },
                 "source_ports_match": {
@@ -953,14 +956,14 @@
                 "source_ports": {
                   "type": "array",
                   "items": {
-                    "type": "integer",
-                    "description": "tcp/udp port name or number\n"
+                    "type": "string",
+                    "description": "TCP/UDP source port name or number."
                   },
                   "title": "Source Ports"
                 },
                 "destination": {
                   "type": "string",
-                  "description": "NOTE: A.B.C.D without a mask means host\n",
+                  "description": "any, A.B.C.D/E or A.B.C.D.\nA.B.C.D without a mask means host.\nRequired for standard entry.\n",
                   "title": "Destination"
                 },
                 "destination_ports_match": {
@@ -978,8 +981,8 @@
                 "destination_ports": {
                   "type": "array",
                   "items": {
-                    "type": "integer",
-                    "description": "TCP/UDP port name or number\n"
+                    "type": "string",
+                    "description": "TCP/UDP destination port name or number."
                   },
                   "title": "Destination Ports"
                 },
@@ -993,17 +996,19 @@
                 },
                 "fragments": {
                   "type": "boolean",
-                  "description": "Match non-head fragment packets\n",
+                  "description": "Match non-head fragment packets.",
                   "title": "Fragments"
                 },
                 "log": {
                   "type": "boolean",
-                  "description": "Log matches against this rule\n",
+                  "description": "Log matches against this rule.",
                   "title": "Log"
                 },
                 "ttl": {
                   "type": "integer",
-                  "title": "TTL value"
+                  "title": "TTL value",
+                  "minimum": 0,
+                  "maximum": 254
                 },
                 "ttl_match": {
                   "type": "string",
@@ -1018,26 +1023,28 @@
                 },
                 "icmp_type": {
                   "type": "string",
-                  "description": "Message type name/number for ICMP packets.\n",
+                  "description": "Message type name/number for ICMP packets.",
                   "title": "Icmp Type"
                 },
                 "icmp_code": {
                   "type": "string",
-                  "description": "Message code for ICMP packets\n",
+                  "description": "Message code for ICMP packets.",
                   "title": "Icmp Code"
                 },
                 "nexthop_group": {
                   "type": "string",
-                  "title": "Nexthop-Group Name"
+                  "description": "nexthop-group name.",
+                  "title": "Nexthop Group"
                 },
                 "tracked": {
                   "type": "boolean",
-                  "description": "Match packets in existing ICMP/UDP/TCP connections.\n",
+                  "description": "Match packets in existing ICMP/UDP/TCP connections.",
                   "title": "Tracked"
                 },
                 "dscp": {
                   "type": "string",
-                  "title": "DSCP Name"
+                  "description": "DSCP value or name.",
+                  "title": "Dscp"
                 },
                 "vlan_number": {
                   "type": "integer",
@@ -1050,7 +1057,7 @@
                 },
                 "vlan_mask": {
                   "type": "string",
-                  "description": "0x000-0xFFF  Vlan mask",
+                  "description": "0x000-0xFFF VLAN mask.",
                   "title": "Vlan Mask"
                 }
               },
@@ -1062,8 +1069,7 @@
           "name"
         ],
         "additionalProperties": false
-      },
-      "title": "Ip Access Lists"
+      }
     },
     "ip_community_lists": {
       "type": "array",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -829,6 +829,24 @@ keys:
     primary_key: name
     convert_types:
     - dict
+    display_name: IP Extended Access-Lists (improved model)
+    description: 'AVD currently supports 2 different data models for extended ACLs:
+
+
+      - The legacy `access_lists` data model, for compatibility with existing deployments
+
+      - The improved `ip_access_lists` data model, for access to more EOS features
+
+
+      Both data models can coexists without conflicts, as different keys are used:
+      `access_lists` vs `ip_access_lists`.
+
+      Access list names must be unique.
+
+
+      The improved data model has a more sophisticated design documented below:
+
+      '
     items:
       type: dict
       keys:
@@ -840,7 +858,7 @@ keys:
           type: bool
         entries:
           type: list
-          display_name: Remark Entry
+          display_name: ACL Entries
           items:
             type: dict
             keys:
@@ -848,12 +866,14 @@ keys:
                 type: int
                 convert_types:
                 - str
-                description: 'ACL entry sequence number
+                description: 'ACL entry sequence number.
 
                   '
               remark:
                 type: str
-                description: 'Comment up to 100 characters
+                description: 'Comment up to 100 characters.
+
+                  If remark is defined, other keys in acl entry will be ignored.
 
                   '
               action:
@@ -861,14 +881,25 @@ keys:
                 valid_values:
                 - permit
                 - deny
+                description: 'ACL action.
+
+                  Required for standard entry.
+
+                  '
               protocol:
                 type: str
-                description: 'ip | tcp | udp | icmp | other protocol name or number.
+                description: 'ip, tcp, udp, icmp or other protocol name or number.
+
+                  Required for standard entry.
 
                   '
               source:
                 type: str
-                description: 'NOTE: A.B.C.D without a mask means host
+                description: 'any, A.B.C.D/E or A.B.C.D.
+
+                  A.B.C.D without a mask means host.
+
+                  Required for standard entry.
 
                   '
               source_ports_match:
@@ -883,15 +914,17 @@ keys:
               source_ports:
                 type: list
                 items:
-                  type: int
+                  type: str
                   convert_types:
-                  - str
-                  description: 'tcp/udp port name or number
-
-                    '
+                  - int
+                  description: TCP/UDP source port name or number.
               destination:
                 type: str
-                description: 'NOTE: A.B.C.D without a mask means host
+                description: 'any, A.B.C.D/E or A.B.C.D.
+
+                  A.B.C.D without a mask means host.
+
+                  Required for standard entry.
 
                   '
               destination_ports_match:
@@ -906,12 +939,10 @@ keys:
               destination_ports:
                 type: list
                 items:
-                  type: int
+                  type: str
                   convert_types:
-                  - str
-                  description: 'TCP/UDP port name or number
-
-                    '
+                  - int
+                  description: TCP/UDP destination port name or number.
               tcp_flags:
                 type: list
                 items:
@@ -919,19 +950,17 @@ keys:
                   display_name: TCP Flag Name
               fragments:
                 type: bool
-                description: 'Match non-head fragment packets
-
-                  '
+                description: Match non-head fragment packets.
               log:
                 type: bool
-                description: 'Log matches against this rule
-
-                  '
+                description: Log matches against this rule.
               ttl:
                 type: int
                 display_name: TTL value
                 convert_types:
                 - str
+                min: 0
+                max: 254
               ttl_match:
                 type: str
                 valid_values:
@@ -944,29 +973,23 @@ keys:
                 type: str
                 convert_types:
                 - int
-                description: 'Message type name/number for ICMP packets.
-
-                  '
+                description: Message type name/number for ICMP packets.
               icmp_code:
                 type: str
                 convert_types:
                 - int
-                description: 'Message code for ICMP packets
-
-                  '
+                description: Message code for ICMP packets.
               nexthop_group:
                 type: str
-                display_name: Nexthop-Group Name
+                description: nexthop-group name.
               tracked:
                 type: bool
-                description: 'Match packets in existing ICMP/UDP/TCP connections.
-
-                  '
+                description: Match packets in existing ICMP/UDP/TCP connections.
               dscp:
                 type: str
                 convert_types:
                 - int
-                display_name: DSCP Name
+                description: DSCP value or name.
               vlan_number:
                 type: int
                 convert_types:
@@ -976,7 +999,7 @@ keys:
                 default: false
               vlan_mask:
                 type: str
-                description: 0x000-0xFFF  Vlan mask
+                description: 0x000-0xFFF VLAN mask.
   ip_community_lists:
     type: list
     secondary_key: entries

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -824,6 +824,159 @@ keys:
             description: 'EOS CLI interface command
 
               Example: "switchport mode access"'
+  ip_access_lists:
+    type: list
+    primary_key: name
+    convert_types:
+    - dict
+    items:
+      type: dict
+      keys:
+        name:
+          type: str
+          required: true
+          display_name: Access-list Name
+        counters_per_entry:
+          type: bool
+        entries:
+          type: list
+          display_name: Remark Entry
+          items:
+            type: dict
+            keys:
+              sequence:
+                type: int
+                convert_types:
+                - str
+                description: 'ACL entry sequence number
+
+                  '
+              remark:
+                type: str
+                description: 'Comment up to 100 characters
+
+                  '
+              action:
+                type: str
+                valid_values:
+                - permit
+                - deny
+              protocol:
+                type: str
+                description: 'ip | tcp | udp | icmp | other protocol name or number.
+
+                  '
+              source:
+                type: str
+                description: 'NOTE: A.B.C.D without a mask means host
+
+                  '
+              source_ports_match:
+                type: str
+                valid_values:
+                - eq
+                - gt
+                - lt
+                - neq
+                - range
+                default: eq
+              source_ports:
+                type: list
+                items:
+                  type: int
+                  convert_types:
+                  - str
+                  description: 'tcp/udp port name or number
+
+                    '
+              destination:
+                type: str
+                description: 'NOTE: A.B.C.D without a mask means host
+
+                  '
+              destination_ports_match:
+                type: str
+                valid_values:
+                - eq
+                - gt
+                - lt
+                - neq
+                - range
+                default: eq
+              destination_ports:
+                type: list
+                items:
+                  type: int
+                  convert_types:
+                  - str
+                  description: 'TCP/UDP port name or number
+
+                    '
+              tcp_flags:
+                type: list
+                items:
+                  type: str
+                  display_name: TCP Flag Name
+              fragments:
+                type: bool
+                description: 'Match non-head fragment packets
+
+                  '
+              log:
+                type: bool
+                description: 'Log matches against this rule
+
+                  '
+              ttl:
+                type: int
+                display_name: TTL value
+                convert_types:
+                - str
+              ttl_match:
+                type: str
+                valid_values:
+                - eq
+                - gt
+                - lt
+                - neq
+                default: eq
+              icmp_type:
+                type: str
+                convert_types:
+                - int
+                description: 'Message type name/number for ICMP packets.
+
+                  '
+              icmp_code:
+                type: str
+                convert_types:
+                - int
+                description: 'Message code for ICMP packets
+
+                  '
+              nexthop_group:
+                type: str
+                display_name: Nexthop-Group Name
+              tracked:
+                type: bool
+                description: 'Match packets in existing ICMP/UDP/TCP connections.
+
+                  '
+              dscp:
+                type: str
+                convert_types:
+                - int
+                display_name: DSCP Name
+              vlan_number:
+                type: int
+                convert_types:
+                - str
+              vlan_inner:
+                type: bool
+                default: false
+              vlan_mask:
+                type: str
+                description: 0x000-0xFFF  Vlan mask
   ip_community_lists:
     type: list
     secondary_key: entries

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ip_access_lists.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ip_access_lists.schema.yml
@@ -8,6 +8,17 @@ keys:
     primary_key: name
     convert_types:
     - dict
+    display_name: IP Extended Access-Lists (improved model)
+    description: |
+      AVD currently supports 2 different data models for extended ACLs:
+
+      - The legacy `access_lists` data model, for compatibility with existing deployments
+      - The improved `ip_access_lists` data model, for access to more EOS features
+
+      Both data models can coexists without conflicts, as different keys are used: `access_lists` vs `ip_access_lists`.
+      Access list names must be unique.
+
+      The improved data model has a more sophisticated design documented below:
     items:
       type: dict
       keys:
@@ -19,7 +30,7 @@ keys:
           type: bool
         entries:
           type: list
-          display_name: Remark Entry
+          display_name: ACL Entries
           items:
             type: dict
             keys:
@@ -28,22 +39,29 @@ keys:
                 convert_types:
                 - str
                 description: |
-                  ACL entry sequence number
+                  ACL entry sequence number.
               remark:
                 type: str
                 description: |
-                  Comment up to 100 characters
+                  Comment up to 100 characters.
+                  If remark is defined, other keys in acl entry will be ignored.
               action:
                 type: str
                 valid_values: ["permit", "deny"]
+                description: |
+                  ACL action.
+                  Required for standard entry.
               protocol:
                 type: str
                 description: |
-                  ip | tcp | udp | icmp | other protocol name or number.
+                  ip, tcp, udp, icmp or other protocol name or number.
+                  Required for standard entry.
               source:
                 type: str
                 description: |
-                  NOTE: A.B.C.D without a mask means host
+                  any, A.B.C.D/E or A.B.C.D.
+                  A.B.C.D without a mask means host.
+                  Required for standard entry.
               source_ports_match:
                 type: str
                 valid_values: ["eq", "gt", "lt", "neq", "range"]
@@ -51,15 +69,16 @@ keys:
               source_ports:
                 type: list
                 items:
-                  type: int
+                  type: str
                   convert_types:
-                  - str
-                  description: |
-                    tcp/udp port name or number
+                  - int
+                  description: TCP/UDP source port name or number.
               destination:
                 type: str
                 description: |
-                  NOTE: A.B.C.D without a mask means host
+                  any, A.B.C.D/E or A.B.C.D.
+                  A.B.C.D without a mask means host.
+                  Required for standard entry.
               destination_ports_match:
                 type: str
                 valid_values: ["eq", "gt", "lt", "neq", "range"]
@@ -67,11 +86,10 @@ keys:
               destination_ports:
                 type: list
                 items:
-                  type: int
+                  type: str
                   convert_types:
-                  - str
-                  description: |
-                    TCP/UDP port name or number
+                  - int
+                  description: TCP/UDP destination port name or number.
               tcp_flags:
                 type: list
                 items:
@@ -79,17 +97,17 @@ keys:
                   display_name: TCP Flag Name
               fragments:
                 type: bool
-                description: |
-                  Match non-head fragment packets
+                description: Match non-head fragment packets.
               log:
                 type: bool
-                description: |
-                  Log matches against this rule
+                description: Log matches against this rule.
               ttl:
                 type: int
                 display_name: TTL value
                 convert_types:
                 - str
+                min: 0
+                max: 254
               ttl_match:
                 type: str
                 valid_values: ["eq", "gt", "lt", "neq"]
@@ -98,26 +116,23 @@ keys:
                 type: str
                 convert_types:
                 - int
-                description: |
-                  Message type name/number for ICMP packets.
+                description: Message type name/number for ICMP packets.
               icmp_code:
                 type: str
                 convert_types:
                 - int
-                description: |
-                  Message code for ICMP packets
+                description: Message code for ICMP packets.
               nexthop_group:
                 type: str
-                display_name: Nexthop-Group Name
+                description: nexthop-group name.
               tracked:
                 type: bool
-                description: |
-                  Match packets in existing ICMP/UDP/TCP connections.
+                description: Match packets in existing ICMP/UDP/TCP connections.
               dscp:
                 type: str
                 convert_types:
                 - int
-                display_name: DSCP Name
+                description: DSCP value or name.
               vlan_number:
                 type: int
                 convert_types:
@@ -127,5 +142,4 @@ keys:
                 default: false
               vlan_mask:
                 type: str
-                description: |
-                  0x000-0xFFF  Vlan mask
+                description: 0x000-0xFFF VLAN mask.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ip_access_lists.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ip_access_lists.schema.yml
@@ -1,0 +1,131 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  ip_access_lists:
+    type: list
+    primary_key: name
+    convert_types:
+    - dict
+    items:
+      type: dict
+      keys:
+        name:
+          type: str
+          required: true
+          display_name: Access-list Name
+        counters_per_entry:
+          type: bool
+        entries:
+          type: list
+          display_name: Remark Entry
+          items:
+            type: dict
+            keys:
+              sequence:
+                type: int
+                convert_types:
+                - str
+                description: |
+                  ACL entry sequence number
+              remark:
+                type: str
+                description: |
+                  Comment up to 100 characters
+              action:
+                type: str
+                valid_values: ["permit", "deny"]
+              protocol:
+                type: str
+                description: |
+                  ip | tcp | udp | icmp | other protocol name or number.
+              source:
+                type: str
+                description: |
+                  NOTE: A.B.C.D without a mask means host
+              source_ports_match:
+                type: str
+                valid_values: ["eq", "gt", "lt", "neq", "range"]
+                default: "eq"
+              source_ports:
+                type: list
+                items:
+                  type: int
+                  convert_types:
+                  - str
+                  description: |
+                    tcp/udp port name or number
+              destination:
+                type: str
+                description: |
+                  NOTE: A.B.C.D without a mask means host
+              destination_ports_match:
+                type: str
+                valid_values: ["eq", "gt", "lt", "neq", "range"]
+                default: "eq"
+              destination_ports:
+                type: list
+                items:
+                  type: int
+                  convert_types:
+                  - str
+                  description: |
+                    TCP/UDP port name or number
+              tcp_flags:
+                type: list
+                items:
+                  type: str
+                  display_name: TCP Flag Name
+              fragments:
+                type: bool
+                description: |
+                  Match non-head fragment packets
+              log:
+                type: bool
+                description: |
+                  Log matches against this rule
+              ttl:
+                type: int
+                display_name: TTL value
+                convert_types:
+                - str
+              ttl_match:
+                type: str
+                valid_values: ["eq", "gt", "lt", "neq"]
+                default: "eq"
+              icmp_type:
+                type: str
+                convert_types:
+                - int
+                description: |
+                  Message type name/number for ICMP packets.
+              icmp_code:
+                type: str
+                convert_types:
+                - int
+                description: |
+                  Message code for ICMP packets
+              nexthop_group:
+                type: str
+                display_name: Nexthop-Group Name
+              tracked:
+                type: bool
+                description: |
+                  Match packets in existing ICMP/UDP/TCP connections.
+              dscp:
+                type: str
+                convert_types:
+                - int
+                display_name: DSCP Name
+              vlan_number:
+                type: int
+                convert_types:
+                - str
+              vlan_inner:
+                type: bool
+                default: false
+              vlan_mask:
+                type: str
+                description: |
+                  0x000-0xFFF  Vlan mask


### PR DESCRIPTION
## Add schema for data model

<!-- Use this PR Title: Feat(eos_cli_config_gen): Add schema for < data_model_key > -->

## Checklist

### Contributor Checklist

- [x] Create schema fragment matching data model described in README.md and README_v4.0.md
  - README.md is most complete with all keys. README_v4.0 includes partial data models after conversion to lists.
  - Schema fragment path is `roles/eos_cli_config_gen/schemas/schema_fragments/<data_model_key>.schema.yml`.
  - Copy line 1-5 from another schema (comments and outer type:dict).
  - Refer to [schema documentation](https://avd.sh/en/devel/docs/input-variable-validation-BETA.html) for syntax and/or use YAML Lint plugin from Redhat in VSCode.
  - Use `convert_types` on value that could be mixed type or misinterpreted like integers and numeric strings.
- [x] If the data model has been converted from wildcard dicts:
  - Add `convert_types: ['dict']` to the schema.
  - Remove `convert_dicts` from the `templates/eos/<>.j2` and `templates/documentation/<>.j2` templates.
- [x] Run `molecule converge -s build_schemas_and_docs` to update schema and documentation.
- [x] Test by running `molecule converge -s eos_cli_config_gen` and verify no errors or changes to generated configs/docs.

### Reviewer Checklist

- Reviewer 1: Carl
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2: Claus
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
