### PR TITLE
Feat(eos_cli_config_gen): Add schema for aliases

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -221,9 +221,11 @@ access_lists:
 
 ### Description
 
-Multiline string with one or more multiple alias commands.
+Multi-line string with one or more alias commands.
+
 Example:
-```
+
+```yaml
 aliases: |
   alias wr copy running-config startup-config
   alias siib show ip interface brief

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -217,6 +217,29 @@ access_lists:
         action: <str>
 ```
 
+## Aliases
+
+### Description
+
+Multiline string with one or more multiple alias commands.
+Example:
+```
+aliases: |
+  alias wr copy running-config startup-config
+  alias siib show ip interface brief
+```
+### Variables
+
+| Variable | Type | Required | Default | Value Restrictions | Description |
+| -------- | ---- | -------- | ------- | ------------------ | ----------- |
+| [<samp>aliases</samp>](## "aliases") | String |  |  |  |  |
+
+### YAML
+
+```yaml
+aliases: <str>
+```
+
 ## ARP
 
 ### Variables

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -429,6 +429,11 @@
         "additionalProperties": false
       }
     },
+    "aliases": {
+      "type": "string",
+      "description": "Multiline string with one or more multiple alias commands.\nExample:\n```\naliases: |\n  alias wr copy running-config startup-config\n  alias siib show ip interface brief\n```",
+      "title": "Aliases"
+    },
     "arp": {
       "title": "ARP",
       "type": "object",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -431,7 +431,7 @@
     },
     "aliases": {
       "type": "string",
-      "description": "Multiline string with one or more multiple alias commands.\nExample:\n```\naliases: |\n  alias wr copy running-config startup-config\n  alias siib show ip interface brief\n```",
+      "description": "Multi-line string with one or more alias commands.\n\nExample:\n\n```yaml\naliases: |\n  alias wr copy running-config startup-config\n  alias siib show ip interface brief\n```",
       "title": "Aliases"
     },
     "arp": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -341,6 +341,11 @@ keys:
                 description: 'Action as string
 
                   Example: "deny ip any any"'
+  aliases:
+    type: str
+    description: "Multiline string with one or more multiple alias commands.\nExample:\n```\naliases:
+      |\n  alias wr copy running-config startup-config\n  alias siib show ip interface
+      brief\n```"
   arp:
     display_name: ARP
     type: dict

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -343,7 +343,7 @@ keys:
                   Example: "deny ip any any"'
   aliases:
     type: str
-    description: "Multiline string with one or more multiple alias commands.\nExample:\n```\naliases:
+    description: "Multi-line string with one or more alias commands.\n\nExample:\n\n```yaml\naliases:
       |\n  alias wr copy running-config startup-config\n  alias siib show ip interface
       brief\n```"
   arp:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/aliases.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/aliases.schema.yml
@@ -6,9 +6,11 @@ keys:
   aliases:
     type: str
     description: |
-      Multiline string with one or more multiple alias commands.
+      Multi-line string with one or more alias commands.
+
       Example:
-      ```
+
+      ```yaml
       aliases: |
         alias wr copy running-config startup-config
         alias siib show ip interface brief

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/aliases.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/aliases.schema.yml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  aliases:
+    type: str
+    description: |
+      Multiline string with one or more multiple alias commands.
+      Example:
+      ```
+      aliases: |
+        alias wr copy running-config startup-config
+        alias siib show ip interface brief
+      ```


### PR DESCRIPTION
## Add schema for data model

<!-- Use this PR Title: Feat(eos_cli_config_gen): Add schema for < data_model_key > -->

## Checklist

### Contributor Checklist

- [x] Create schema fragment matching data model described in README.md and README_v4.0.md
  - README.md is most complete with all keys. README_v4.0 includes partial data models after conversion to lists.
  - Schema fragment path is `roles/eos_cli_config_gen/schemas/schema_fragments/<data_model_key>.schema.yml`.
  - Copy line 1-5 from another schema (comments and outer type:dict).
  - Refer to [schema documentation](https://avd.sh/en/devel/docs/input-variable-validation-BETA.html) for syntax and/or use YAML Lint plugin from Redhat in VSCode.
  - Use `convert_types` on value that could be mixed type or misinterpreted like integers and numeric strings.
- [x] If the data model has been converted from wildcard dicts:
  - Add `convert_types: ['dict']` to the schema.
  - Remove `convert_dicts` from the `templates/eos/<>.j2` and `templates/documentation/<>.j2` templates.
- [x] Run `molecule converge -s build_schemas_and_docs` to update schema and documentation.
- [x] Test by running `molecule converge -s eos_cli_config_gen` and verify no errors or changes to generated configs/docs.

### Reviewer Checklist

- Reviewer 1: Claus
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2: Carl
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
