### PR TITLE
Feat(eos_cli_config_gen): Add schema for aaa_authentication

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -1,6 +1,52 @@
 !!! warning
     This document describes the data model for AVD 4.x. It may or may not work in previous versions.
 
+## AAA Authentication
+
+### Variables
+
+| Variable | Type | Required | Default | Value Restrictions | Description |
+| -------- | ---- | -------- | ------- | ------------------ | ----------- |
+| [<samp>aaa_authentication</samp>](## "aaa_authentication") | Dictionary |  |  |  | AAA Authentication |
+| [<samp>&nbsp;&nbsp;login</samp>](## "aaa_authentication.login") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;default</samp>](## "aaa_authentication.login.default") | String |  |  |  | Login authentication method(s) as a string.<br>Examples:<br>- "group tacacs+ local"<br>- "group MYGROUP none"<br>- "group radius group MYGROUP local"<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;console</samp>](## "aaa_authentication.login.console") | String |  |  |  | Console authentication method(s) as a string.<br>Examples:<br>- "group tacacs+ local"<br>- "group MYGROUP none"<br>- "group radius group MYGROUP local"<br> |
+| [<samp>&nbsp;&nbsp;enable</samp>](## "aaa_authentication.enable") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;default</samp>](## "aaa_authentication.enable.default") | String |  |  |  | Enable authentication method(s) as a string.<br>Examples:<br>- "group tacacs+ local"<br>- "group MYGROUP none"<br>- "group radius group MYGROUP local"<br> |
+| [<samp>&nbsp;&nbsp;dot1x</samp>](## "aaa_authentication.dot1x") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;default</samp>](## "aaa_authentication.dot1x.default") | String |  |  |  | 802.1x authentication method(s) as a string.<br>Examples:<br>- "group radius"<br>- "group MYGROUP group radius"<br> |
+| [<samp>&nbsp;&nbsp;policies</samp>](## "aaa_authentication.policies") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;on_failure_log</samp>](## "aaa_authentication.policies.on_failure_log") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;on_success_log</samp>](## "aaa_authentication.policies.on_success_log") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;local</samp>](## "aaa_authentication.policies.local") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;allow_nopassword</samp>](## "aaa_authentication.policies.local.allow_nopassword") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;lockout</samp>](## "aaa_authentication.policies.lockout") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;failure</samp>](## "aaa_authentication.policies.lockout.failure") | Integer |  |  | Min: 1<br>Max: 255 |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;duration</samp>](## "aaa_authentication.policies.lockout.duration") | Integer |  |  | Min: 1<br>Max: 4294967295 |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;window</samp>](## "aaa_authentication.policies.lockout.window") | Integer |  |  | Min: 1<br>Max: 4294967295 |  |
+
+### YAML
+
+```yaml
+aaa_authentication:
+  login:
+    default: <str>
+    console: <str>
+  enable:
+    default: <str>
+  dot1x:
+    default: <str>
+  policies:
+    on_failure_log: <bool>
+    on_success_log: <bool>
+    local:
+      allow_nopassword: <bool>
+    lockout:
+      failure: <int>
+      duration: <int>
+      window: <int>
+```
+
 ## AAA Authorization
 
 ### Variables

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -1,6 +1,105 @@
 {
   "type": "object",
   "properties": {
+    "aaa_authentication": {
+      "type": "object",
+      "title": "AAA Authentication",
+      "properties": {
+        "login": {
+          "type": "object",
+          "properties": {
+            "default": {
+              "type": "string",
+              "description": "Login authentication method(s) as a string.\nExamples:\n- \"group tacacs+ local\"\n- \"group MYGROUP none\"\n- \"group radius group MYGROUP local\"\n",
+              "title": "Default"
+            },
+            "console": {
+              "type": "string",
+              "description": "Console authentication method(s) as a string.\nExamples:\n- \"group tacacs+ local\"\n- \"group MYGROUP none\"\n- \"group radius group MYGROUP local\"\n",
+              "title": "Console"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Login"
+        },
+        "enable": {
+          "type": "object",
+          "properties": {
+            "default": {
+              "type": "string",
+              "description": "Enable authentication method(s) as a string.\nExamples:\n- \"group tacacs+ local\"\n- \"group MYGROUP none\"\n- \"group radius group MYGROUP local\"\n",
+              "title": "Default"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Enable"
+        },
+        "dot1x": {
+          "type": "object",
+          "properties": {
+            "default": {
+              "type": "string",
+              "description": "802.1x authentication method(s) as a string.\nExamples:\n- \"group radius\"\n- \"group MYGROUP group radius\"\n",
+              "title": "Default"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Dot1X"
+        },
+        "policies": {
+          "type": "object",
+          "properties": {
+            "on_failure_log": {
+              "type": "boolean",
+              "title": "On Failure Log"
+            },
+            "on_success_log": {
+              "type": "boolean",
+              "title": "On Success Log"
+            },
+            "local": {
+              "type": "object",
+              "properties": {
+                "allow_nopassword": {
+                  "type": "boolean",
+                  "title": "Allow Nopassword"
+                }
+              },
+              "additionalProperties": false,
+              "title": "Local"
+            },
+            "lockout": {
+              "type": "object",
+              "properties": {
+                "failure": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "maximum": 255,
+                  "title": "Failure"
+                },
+                "duration": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "maximum": 4294967295,
+                  "title": "Duration"
+                },
+                "window": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "maximum": 4294967295,
+                  "title": "Window"
+                }
+              },
+              "additionalProperties": false,
+              "title": "Lockout"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Policies"
+        }
+      },
+      "additionalProperties": false
+    },
     "aaa_authorization": {
       "type": "object",
       "title": "AAA Authorization",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -1,6 +1,102 @@
 type: dict
 allow_other_keys: true
 keys:
+  aaa_authentication:
+    type: dict
+    display_name: AAA Authentication
+    keys:
+      login:
+        type: dict
+        keys:
+          default:
+            type: str
+            description: 'Login authentication method(s) as a string.
+
+              Examples:
+
+              - "group tacacs+ local"
+
+              - "group MYGROUP none"
+
+              - "group radius group MYGROUP local"
+
+              '
+          console:
+            type: str
+            description: 'Console authentication method(s) as a string.
+
+              Examples:
+
+              - "group tacacs+ local"
+
+              - "group MYGROUP none"
+
+              - "group radius group MYGROUP local"
+
+              '
+      enable:
+        type: dict
+        keys:
+          default:
+            type: str
+            description: 'Enable authentication method(s) as a string.
+
+              Examples:
+
+              - "group tacacs+ local"
+
+              - "group MYGROUP none"
+
+              - "group radius group MYGROUP local"
+
+              '
+      dot1x:
+        type: dict
+        keys:
+          default:
+            type: str
+            description: '802.1x authentication method(s) as a string.
+
+              Examples:
+
+              - "group radius"
+
+              - "group MYGROUP group radius"
+
+              '
+      policies:
+        type: dict
+        keys:
+          on_failure_log:
+            type: bool
+          on_success_log:
+            type: bool
+          local:
+            type: dict
+            keys:
+              allow_nopassword:
+                type: bool
+          lockout:
+            type: dict
+            keys:
+              failure:
+                type: int
+                min: 1
+                max: 255
+                convert_types:
+                - str
+              duration:
+                type: int
+                min: 1
+                max: 4294967295
+                convert_types:
+                - str
+              window:
+                type: int
+                min: 1
+                max: 4294967295
+                convert_types:
+                - str
   aaa_authorization:
     type: dict
     display_name: AAA Authorization

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/aaa_authentication.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/aaa_authentication.schema.yml
@@ -1,0 +1,82 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  aaa_authentication:
+    type: dict
+    display_name: AAA Authentication
+    keys:
+      login:
+        type: dict
+        keys:
+          default:
+            type: str
+            description: |
+              Login authentication method(s) as a string.
+              Examples:
+              - "group tacacs+ local"
+              - "group MYGROUP none"
+              - "group radius group MYGROUP local"
+          console:
+            type: str
+            description: |
+              Console authentication method(s) as a string.
+              Examples:
+              - "group tacacs+ local"
+              - "group MYGROUP none"
+              - "group radius group MYGROUP local"
+      enable:
+        type: dict
+        keys:
+          default:
+            type: str
+            description: |
+              Enable authentication method(s) as a string.
+              Examples:
+              - "group tacacs+ local"
+              - "group MYGROUP none"
+              - "group radius group MYGROUP local"
+      dot1x:
+        type: dict
+        keys:
+          default:
+            type: str
+            description: |
+              802.1x authentication method(s) as a string.
+              Examples:
+              - "group radius"
+              - "group MYGROUP group radius"
+      policies:
+        type: dict
+        keys:
+          on_failure_log:
+            type: bool
+          on_success_log:
+            type: bool
+          local:
+            type: dict
+            keys:
+              allow_nopassword:
+                type: bool
+          lockout:
+            type: dict
+            keys:
+              failure:
+                type: int
+                min: 1
+                max: 255
+                convert_types:
+                - str
+              duration:
+                type: int
+                min: 1
+                max: 4294967295
+                convert_types:
+                - str
+              window:
+                type: int
+                min: 1
+                max: 4294967295
+                convert_types:
+                - str


### PR DESCRIPTION
## Add schema for data model

<!-- Use this PR Title: Feat(eos_cli_config_gen): Add schema for < data_model_key > -->

## Checklist

### Contributor Checklist

- [x] Create schema fragment matching data model described in README.md and README_v4.0.md
  - README.md is most complete with all keys. README_v4.0 includes partial data models after conversion to lists.
  - Schema fragment path is `roles/eos_cli_config_gen/schemas/schema_fragments/<data_model_key>.schema.yml`.
  - Copy line 1-5 from another schema (comments and outer type:dict).
  - Refer to [schema documentation](https://avd.sh/en/devel/docs/input-variable-validation-BETA.html) for syntax and/or use YAML Lint plugin from Redhat in VSCode.
  - Use `convert_types` on value that could be mixed type or misinterpreted like integers and numeric strings.
- [x] If the data model has been converted from wildcard dicts:
  - Add `convert_types: ['dict']` to the schema.
  - Remove `convert_dicts` from the `templates/eos/<>.j2` and `templates/documentation/<>.j2` templates.
- [x] Run `molecule converge -s build_schemas_and_docs` to update schema and documentation.
- [x] Test by running `molecule converge -s eos_cli_config_gen` and verify no errors or changes to generated configs/docs.

### Reviewer Checklist

- Reviewer 1: Claus
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2: Carl
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
