### PR TITLE
Feat(eos_cli_config_gen): Add schema for dns_domain

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -300,6 +300,20 @@ daemons:
     enabled: <bool>
 ```
 
+## Domain Name
+
+### Variables
+
+| Variable | Type | Required | Default | Value Restrictions | Description |
+| -------- | ---- | -------- | ------- | ------------------ | ----------- |
+| [<samp>dns_domain</samp>](## "dns_domain") | String |  |  |  | Domain Name |
+
+### YAML
+
+```yaml
+dns_domain: <str>
+```
+
 ## EOS CLI
 
 ### Description

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -300,13 +300,16 @@ daemons:
     enabled: <bool>
 ```
 
-## Domain Name
+## DNS Domain
 
+### Description
+
+Domain Name
 ### Variables
 
 | Variable | Type | Required | Default | Value Restrictions | Description |
 | -------- | ---- | -------- | ------- | ------------------ | ----------- |
-| [<samp>dns_domain</samp>](## "dns_domain") | String |  |  |  | Domain Name |
+| [<samp>dns_domain</samp>](## "dns_domain") | String |  |  |  | DNS Domain |
 
 ### YAML
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -525,7 +525,8 @@
     },
     "dns_domain": {
       "type": "string",
-      "title": "Domain Name"
+      "title": "DNS Domain",
+      "description": "Domain Name"
     },
     "eos_cli": {
       "type": "string",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -523,6 +523,10 @@
         "additionalProperties": false
       }
     },
+    "dns_domain": {
+      "type": "string",
+      "title": "Domain Name"
+    },
     "eos_cli": {
       "type": "string",
       "title": "EOS CLI",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -497,6 +497,9 @@ keys:
         enabled:
           type: bool
           default: true
+  dns_domain:
+    type: str
+    display_name: Domain Name
   eos_cli:
     type: str
     display_name: EOS CLI

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -499,7 +499,8 @@ keys:
           default: true
   dns_domain:
     type: str
-    display_name: Domain Name
+    display_name: DNS Domain
+    description: Domain Name
   eos_cli:
     type: str
     display_name: EOS CLI

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/dns_domain.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/dns_domain.schema.yml
@@ -5,5 +5,5 @@ type: dict
 keys:
   dns_domain:
     type: str
-    display_name: Domain Name
- 
+    display_name: DNS Domain
+    description: Domain Name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/dns_domain.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/dns_domain.schema.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  dns_domain:
+    type: str
+    display_name: Domain Name
+ 


### PR DESCRIPTION
## Add schema for data model

<!-- Use this PR Title: Feat(eos_cli_config_gen): Add schema for < data_model_key > -->

## Checklist

### Contributor Checklist

- [x] Create schema fragment matching data model described in README.md and README_v4.0.md
  - README.md is most complete with all keys. README_v4.0 includes partial data models after conversion to lists.
  - Schema fragment path is `roles/eos_cli_config_gen/schemas/schema_fragments/<data_model_key>.schema.yml`.
  - Copy line 1-5 from another schema (comments and outer type:dict).
  - Refer to [schema documentation](https://avd.sh/en/devel/docs/input-variable-validation-BETA.html) for syntax and/or use YAML Lint plugin from Redhat in VSCode.
  - Use `convert_types` on value that could be mixed type or misinterpreted like integers and numeric strings.
- [x] If the data model has been converted from wildcard dicts:
  - Add `convert_types: ['dict']` to the schema.
  - Remove `convert_dicts` from the `templates/eos/<>.j2` and `templates/documentation/<>.j2` templates.
- [x] Run `molecule converge -s build_schemas_and_docs` to update schema and documentation.
- [x] Test by running `molecule converge -s eos_cli_config_gen` and verify no errors or changes to generated configs/docs.

### Reviewer Checklist

- Reviewer 1: Carl
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2: Claus
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
