### PR TITLE
Feat(eos_cli_config_gen): Add schema for lldp

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -1503,6 +1503,40 @@ lacp:
   system_priority: <int>
 ```
 
+## Lldp
+
+### Variables
+
+| Variable | Type | Required | Default | Value Restrictions | Description |
+| -------- | ---- | -------- | ------- | ------------------ | ----------- |
+| [<samp>lldp</samp>](## "lldp") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;timer</samp>](## "lldp.timer") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;timer_reinitialization</samp>](## "lldp.timer_reinitialization") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;holdtime</samp>](## "lldp.holdtime") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;management_address</samp>](## "lldp.management_address") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;vrf</samp>](## "lldp.vrf") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;receive_packet_tagged_drop</samp>](## "lldp.receive_packet_tagged_drop") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;tlvs</samp>](## "lldp.tlvs") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "lldp.tlvs.[].name") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;transmit</samp>](## "lldp.tlvs.[].transmit") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;run</samp>](## "lldp.run") | Boolean |  |  |  |  |
+
+### YAML
+
+```yaml
+lldp:
+  timer: <int>
+  timer_reinitialization: <str>
+  holdtime: <int>
+  management_address: <str>
+  vrf: <str>
+  receive_packet_tagged_drop: <str>
+  tlvs:
+    - name: <str>
+      transmit: <bool>
+  run: <bool>
+```
+
 ## Load Interval
 
 ### Variables

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -1503,21 +1503,21 @@ lacp:
   system_priority: <int>
 ```
 
-## Lldp
+## LLDP
 
 ### Variables
 
 | Variable | Type | Required | Default | Value Restrictions | Description |
 | -------- | ---- | -------- | ------- | ------------------ | ----------- |
-| [<samp>lldp</samp>](## "lldp") | Dictionary |  |  |  |  |
+| [<samp>lldp</samp>](## "lldp") | Dictionary |  |  |  | LLDP |
 | [<samp>&nbsp;&nbsp;timer</samp>](## "lldp.timer") | Integer |  |  |  |  |
 | [<samp>&nbsp;&nbsp;timer_reinitialization</samp>](## "lldp.timer_reinitialization") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;holdtime</samp>](## "lldp.holdtime") | Integer |  |  |  |  |
 | [<samp>&nbsp;&nbsp;management_address</samp>](## "lldp.management_address") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;vrf</samp>](## "lldp.vrf") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;vrf</samp>](## "lldp.vrf") | String |  |  |  | VRF |
 | [<samp>&nbsp;&nbsp;receive_packet_tagged_drop</samp>](## "lldp.receive_packet_tagged_drop") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;tlvs</samp>](## "lldp.tlvs") | List, items: Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "lldp.tlvs.[].name") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;tlvs</samp>](## "lldp.tlvs") | List, items: Dictionary |  |  |  | TLVs |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "lldp.tlvs.[].name") | String |  |  | Valid Values:<br>- link-aggregation<br>- management-address<br>- max-frame-size<br>- med<br>- port-description<br>- port-vlan<br>- power-via-mdi<br>- system-capabilities<br>- system-description<br>- system-name<br>- vlan-name |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;transmit</samp>](## "lldp.tlvs.[].transmit") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;run</samp>](## "lldp.run") | Boolean |  |  |  |  |
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -2232,6 +2232,7 @@
     },
     "lldp": {
       "type": "object",
+      "title": "LLDP",
       "properties": {
         "timer": {
           "type": "integer",
@@ -2251,7 +2252,7 @@
         },
         "vrf": {
           "type": "string",
-          "title": "Vrf"
+          "title": "VRF"
         },
         "receive_packet_tagged_drop": {
           "type": "string",
@@ -2259,11 +2260,25 @@
         },
         "tlvs": {
           "type": "array",
+          "title": "TLVs",
           "items": {
             "type": "object",
             "properties": {
               "name": {
                 "type": "string",
+                "enum": [
+                  "link-aggregation",
+                  "management-address",
+                  "max-frame-size",
+                  "med",
+                  "port-description",
+                  "port-vlan",
+                  "power-via-mdi",
+                  "system-capabilities",
+                  "system-description",
+                  "system-name",
+                  "vlan-name"
+                ],
                 "title": "Name"
               },
               "transmit": {
@@ -2272,16 +2287,14 @@
               }
             },
             "additionalProperties": false
-          },
-          "title": "Tlvs"
+          }
         },
         "run": {
           "type": "boolean",
           "title": "Run"
         }
       },
-      "additionalProperties": false,
-      "title": "Lldp"
+      "additionalProperties": false
     },
     "load_interval": {
       "type": "object",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -2230,6 +2230,59 @@
       },
       "additionalProperties": false
     },
+    "lldp": {
+      "type": "object",
+      "properties": {
+        "timer": {
+          "type": "integer",
+          "title": "Timer"
+        },
+        "timer_reinitialization": {
+          "type": "string",
+          "title": "Timer Reinitialization"
+        },
+        "holdtime": {
+          "type": "integer",
+          "title": "Holdtime"
+        },
+        "management_address": {
+          "type": "string",
+          "title": "Management Address"
+        },
+        "vrf": {
+          "type": "string",
+          "title": "Vrf"
+        },
+        "receive_packet_tagged_drop": {
+          "type": "string",
+          "title": "Receive Packet Tagged Drop"
+        },
+        "tlvs": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "Name"
+              },
+              "transmit": {
+                "type": "boolean",
+                "title": "Transmit"
+              }
+            },
+            "additionalProperties": false
+          },
+          "title": "Tlvs"
+        },
+        "run": {
+          "type": "boolean",
+          "title": "Run"
+        }
+      },
+      "additionalProperties": false,
+      "title": "Lldp"
+    },
     "load_interval": {
       "type": "object",
       "properties": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -1800,6 +1800,35 @@ keys:
         description: Set local system LACP priority.
         min: 0
         max: 65535
+  lldp:
+    type: dict
+    keys:
+      timer:
+        type: int
+      timer_reinitialization:
+        type: str
+      holdtime:
+        type: int
+      management_address:
+        type: str
+      vrf:
+        type: str
+      receive_packet_tagged_drop:
+        type: str
+      tlvs:
+        type: list
+        primary_key: name
+        convert_types:
+        - dict
+        items:
+          type: dict
+          keys:
+            name:
+              type: str
+            transmit:
+              type: bool
+      run:
+        type: bool
   load_interval:
     type: dict
     keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -1802,6 +1802,7 @@ keys:
         max: 65535
   lldp:
     type: dict
+    display_name: LLDP
     keys:
       timer:
         type: int
@@ -1813,10 +1814,12 @@ keys:
         type: str
       vrf:
         type: str
+        display_name: VRF
       receive_packet_tagged_drop:
         type: str
       tlvs:
         type: list
+        display_name: TLVs
         primary_key: name
         convert_types:
         - dict
@@ -1825,6 +1828,18 @@ keys:
           keys:
             name:
               type: str
+              valid_values:
+              - link-aggregation
+              - management-address
+              - max-frame-size
+              - med
+              - port-description
+              - port-vlan
+              - power-via-mdi
+              - system-capabilities
+              - system-description
+              - system-name
+              - vlan-name
             transmit:
               type: bool
       run:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/lldp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/lldp.schema.yml
@@ -5,6 +5,7 @@ type: dict
 keys:
   lldp:
     type: dict
+    display_name: LLDP
     keys:
       timer:
         type: int
@@ -16,10 +17,12 @@ keys:
         type: str
       vrf:
         type: str
+        display_name: VRF
       receive_packet_tagged_drop:
         type: str
       tlvs:
         type: list
+        display_name: TLVs
         primary_key: name
         convert_types:
         - dict
@@ -28,6 +31,18 @@ keys:
           keys:
             name:
               type: str
+              valid_values:
+              - "link-aggregation"
+              - "management-address"
+              - "max-frame-size"
+              - "med"
+              - "port-description"
+              - "port-vlan"
+              - "power-via-mdi"
+              - "system-capabilities"
+              - "system-description"
+              - "system-name"
+              - "vlan-name"
             transmit:
               type: bool
       run:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/lldp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/lldp.schema.yml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  lldp:
+    type: dict
+    keys:
+      timer:
+        type: int
+      timer_reinitialization:
+        type: str
+      holdtime:
+        type: int
+      management_address:
+        type: str
+      vrf:
+        type: str
+      receive_packet_tagged_drop:
+        type: str
+      tlvs:
+        type: list
+        primary_key: name
+        convert_types:
+        - dict
+        items:
+          type: dict
+          keys:
+            name:
+              type: str
+            transmit:
+              type: bool 
+      run:
+        type: bool                       

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/lldp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/lldp.schema.yml
@@ -29,6 +29,6 @@ keys:
             name:
               type: str
             transmit:
-              type: bool 
+              type: bool
       run:
-        type: bool                       
+        type: bool


### PR DESCRIPTION
## Add schema for data model

<!-- Use this PR Title: Feat(eos_cli_config_gen): Add schema for < data_model_key > -->

## Checklist

### Contributor Checklist

- [x] Create schema fragment matching data model described in README.md and README_v4.0.md
  - README.md is most complete with all keys. README_v4.0 includes partial data models after conversion to lists.
  - Schema fragment path is `roles/eos_cli_config_gen/schemas/schema_fragments/<data_model_key>.schema.yml`.
  - Copy line 1-5 from another schema (comments and outer type:dict).
  - Refer to [schema documentation](https://avd.sh/en/devel/docs/input-variable-validation-BETA.html) for syntax and/or use YAML Lint plugin from Redhat in VSCode.
  - Use `convert_types` on value that could be mixed type or misinterpreted like integers and numeric strings.
- [x] If the data model has been converted from wildcard dicts:
  - Add `convert_types: ['dict']` to the schema.
  - Remove `convert_dicts` from the `templates/eos/<>.j2` and `templates/documentation/<>.j2` templates.
- [x] Run `molecule converge -s build_schemas_and_docs` to update schema and documentation.
- [x] Test by running `molecule converge -s eos_cli_config_gen` and verify no errors or changes to generated configs/docs.

### Reviewer Checklist

- Reviewer 1:
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2:
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
