### PR TITLE
Feat(eos_cli_config_gen): Add schema for link_tracking_groups

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -1620,8 +1620,8 @@ lacp:
 | -------- | ---- | -------- | ------- | ------------------ | ----------- |
 | [<samp>link_tracking_groups</samp>](## "link_tracking_groups") | List, items: Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;- name</samp>](## "link_tracking_groups.[].name") | String | Required, Unique |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;links_minimum</samp>](## "link_tracking_groups.[].links_minimum") | Integer |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;recovery_delay</samp>](## "link_tracking_groups.[].recovery_delay") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;links_minimum</samp>](## "link_tracking_groups.[].links_minimum") | Integer |  |  | Min: 1<br>Max: 100000 |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;recovery_delay</samp>](## "link_tracking_groups.[].recovery_delay") | Integer |  |  | Min: 0<br>Max: 3600 |  |
 
 ### YAML
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -1612,6 +1612,26 @@ lacp:
   system_priority: <int>
 ```
 
+## Link Tracking Groups
+
+### Variables
+
+| Variable | Type | Required | Default | Value Restrictions | Description |
+| -------- | ---- | -------- | ------- | ------------------ | ----------- |
+| [<samp>link_tracking_groups</samp>](## "link_tracking_groups") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;- name</samp>](## "link_tracking_groups.[].name") | String | Required, Unique |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;links_minimum</samp>](## "link_tracking_groups.[].links_minimum") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;recovery_delay</samp>](## "link_tracking_groups.[].recovery_delay") | Integer |  |  |  |  |
+
+### YAML
+
+```yaml
+link_tracking_groups:
+  - name: <str>
+    links_minimum: <int>
+    recovery_delay: <int>
+```
+
 ## LLDP
 
 ### Variables

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -2437,17 +2437,21 @@
           },
           "links_minimum": {
             "type": "integer",
+            "minimum": 1,
+            "maximum": 100000,
             "title": "Links Minimum"
           },
           "recovery_delay": {
             "type": "integer",
+            "minimum": 0,
+            "maximum": 3600,
             "title": "Recovery Delay"
           }
         },
-        "additionalProperties": false,
         "required": [
           "name"
-        ]
+        ],
+        "additionalProperties": false
       },
       "title": "Link Tracking Groups"
     },

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -2426,6 +2426,31 @@
       "additionalProperties": false,
       "title": "Lacp"
     },
+    "link_tracking_groups": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "links_minimum": {
+            "type": "integer",
+            "title": "Links Minimum"
+          },
+          "recovery_delay": {
+            "type": "integer",
+            "title": "Recovery Delay"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "name"
+        ]
+      },
+      "title": "Link Tracking Groups"
+    },
     "lldp": {
       "type": "object",
       "properties": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -1859,10 +1859,15 @@ keys:
       keys:
         name:
           type: str
+          required: true
         links_minimum:
           type: int
+          min: 1
+          max: 100000
         recovery_delay:
           type: int
+          min: 0
+          max: 3600
   lldp:
     type: dict
     keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -1849,6 +1849,20 @@ keys:
         description: Set local system LACP priority.
         min: 0
         max: 65535
+  link_tracking_groups:
+    type: list
+    primary_key: name
+    convert_types:
+    - dict
+    items:
+      type: dict
+      keys:
+        name:
+          type: str
+        links_minimum:
+          type: int
+        recovery_delay:
+          type: int
   lldp:
     type: dict
     keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/link_tracking_groups.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/link_tracking_groups.schema.yml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  link_tracking_groups:
+    type: list
+    primary_key: name
+    convert_types:
+    - dict
+    items:
+      type: dict
+      keys:
+        name:
+          type: str
+        links_minimum:
+          type: int
+        recovery_delay:
+          type: int    

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/link_tracking_groups.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/link_tracking_groups.schema.yml
@@ -13,7 +13,12 @@ keys:
       keys:
         name:
           type: str
+          required: true
         links_minimum:
           type: int
+          min: 1
+          max: 100000
         recovery_delay:
           type: int
+          min: 0
+          max: 3600

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/link_tracking_groups.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/link_tracking_groups.schema.yml
@@ -16,4 +16,4 @@ keys:
         links_minimum:
           type: int
         recovery_delay:
-          type: int    
+          type: int


### PR DESCRIPTION
## Add schema for data model

<!-- Use this PR Title: Feat(eos_cli_config_gen): Add schema for < data_model_key > -->

## Checklist

### Contributor Checklist

- [x] Create schema fragment matching data model described in README.md and README_v4.0.md
  - README.md is most complete with all keys. README_v4.0 includes partial data models after conversion to lists.
  - Schema fragment path is `roles/eos_cli_config_gen/schemas/schema_fragments/<data_model_key>.schema.yml`.
  - Copy line 1-5 from another schema (comments and outer type:dict).
  - Refer to [schema documentation](https://avd.sh/en/devel/docs/input-variable-validation-BETA.html) for syntax and/or use YAML Lint plugin from Redhat in VSCode.
  - Use `convert_types` on value that could be mixed type or misinterpreted like integers and numeric strings.
- [x] If the data model has been converted from wildcard dicts:
  - Add `convert_types: ['dict']` to the schema.
  - Remove `convert_dicts` from the `templates/eos/<>.j2` and `templates/documentation/<>.j2` templates.
- [x] Run `molecule converge -s build_schemas_and_docs` to update schema and documentation.
- [x] Test by running `molecule converge -s eos_cli_config_gen` and verify no errors or changes to generated configs/docs.

### Reviewer Checklist

- Reviewer 1: Claus
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2: Julio
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
