### PR TITLE
Feat(eos_cli_config_gen): Add schema for lacp

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -943,20 +943,23 @@ ipv6_standard_access_lists:
         action: <str>
 ```
 
-## Lacp
+## LACP
 
+### Description
+
+Set Link Aggregation Control Protocol (LACP) parameters.
 ### Variables
 
 | Variable | Type | Required | Default | Value Restrictions | Description |
 | -------- | ---- | -------- | ------- | ------------------ | ----------- |
-| [<samp>lacp</samp>](## "lacp") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;port_id</samp>](## "lacp.port_id") | Dictionary |  |  |  |  |
+| [<samp>lacp</samp>](## "lacp") | Dictionary |  |  |  | LACP |
+| [<samp>&nbsp;&nbsp;port_id</samp>](## "lacp.port_id") | Dictionary |  |  |  | LACP port-ID range configuration. |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;range</samp>](## "lacp.port_id.range") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;begin</samp>](## "lacp.port_id.range.begin") | Integer |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;end</samp>](## "lacp.port_id.range.end") | Integer |  |  |  |  |
-| [<samp>&nbsp;&nbsp;rate_limit</samp>](## "lacp.rate_limit") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;default</samp>](## "lacp.rate_limit.default") | Boolean |  |  |  |  |
-| [<samp>&nbsp;&nbsp;system_priority</samp>](## "lacp.system_priority") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;begin</samp>](## "lacp.port_id.range.begin") | Integer |  |  |  | Minimum LACP port-ID range. |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;end</samp>](## "lacp.port_id.range.end") | Integer |  |  |  | Maximum LACP port-ID range. |
+| [<samp>&nbsp;&nbsp;rate_limit</samp>](## "lacp.rate_limit") | Dictionary |  |  |  | Set LACPDU rate limit options. |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;default</samp>](## "lacp.rate_limit.default") | Boolean |  |  |  | Enable LACPDU rate limiting by default on all ports. |
+| [<samp>&nbsp;&nbsp;system_priority</samp>](## "lacp.system_priority") | Integer |  |  | Min: 0<br>Max: 65535 | Set local system LACP priority. |
 
 ### YAML
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -943,6 +943,34 @@ ipv6_standard_access_lists:
         action: <str>
 ```
 
+## Lacp
+
+### Variables
+
+| Variable | Type | Required | Default | Value Restrictions | Description |
+| -------- | ---- | -------- | ------- | ------------------ | ----------- |
+| [<samp>lacp</samp>](## "lacp") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;port_id</samp>](## "lacp.port_id") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;range</samp>](## "lacp.port_id.range") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;begin</samp>](## "lacp.port_id.range.begin") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;end</samp>](## "lacp.port_id.range.end") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;rate_limit</samp>](## "lacp.rate_limit") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;default</samp>](## "lacp.rate_limit.default") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;system_priority</samp>](## "lacp.system_priority") | Integer |  |  |  |  |
+
+### YAML
+
+```yaml
+lacp:
+  port_id:
+    range:
+      begin: <int>
+      end: <int>
+  rate_limit:
+    default: <bool>
+  system_priority: <int>
+```
+
 ## Local Users
 
 ### Variables

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -1405,19 +1405,24 @@
     },
     "lacp": {
       "type": "object",
+      "title": "LACP",
+      "description": "Set Link Aggregation Control Protocol (LACP) parameters.",
       "properties": {
         "port_id": {
           "type": "object",
+          "description": "LACP port-ID range configuration.",
           "properties": {
             "range": {
               "type": "object",
               "properties": {
                 "begin": {
                   "type": "integer",
+                  "description": "Minimum LACP port-ID range.",
                   "title": "Begin"
                 },
                 "end": {
                   "type": "integer",
+                  "description": "Maximum LACP port-ID range.",
                   "title": "End"
                 }
               },
@@ -1430,9 +1435,11 @@
         },
         "rate_limit": {
           "type": "object",
+          "description": "Set LACPDU rate limit options.",
           "properties": {
             "default": {
               "type": "boolean",
+              "description": "Enable LACPDU rate limiting by default on all ports.",
               "title": "Default"
             }
           },
@@ -1441,11 +1448,13 @@
         },
         "system_priority": {
           "type": "integer",
+          "description": "Set local system LACP priority.",
+          "minimum": 0,
+          "maximum": 65535,
           "title": "System Priority"
         }
       },
-      "additionalProperties": false,
-      "title": "Lacp"
+      "additionalProperties": false
     },
     "local_users": {
       "type": "array",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -1403,6 +1403,50 @@
         "additionalProperties": false
       }
     },
+    "lacp": {
+      "type": "object",
+      "properties": {
+        "port_id": {
+          "type": "object",
+          "properties": {
+            "range": {
+              "type": "object",
+              "properties": {
+                "begin": {
+                  "type": "integer",
+                  "title": "Begin"
+                },
+                "end": {
+                  "type": "integer",
+                  "title": "End"
+                }
+              },
+              "additionalProperties": false,
+              "title": "Range"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Port Id"
+        },
+        "rate_limit": {
+          "type": "object",
+          "properties": {
+            "default": {
+              "type": "boolean",
+              "title": "Default"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Rate Limit"
+        },
+        "system_priority": {
+          "type": "integer",
+          "title": "System Priority"
+        }
+      },
+      "additionalProperties": false,
+      "title": "Lacp"
+    },
     "local_users": {
       "type": "array",
       "items": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -1216,6 +1216,26 @@ keys:
                 description: 'Action as string
 
                   Example: "deny ipv6 any any"'
+  lacp:
+    type: dict
+    keys:
+      port_id:
+        type: dict
+        keys:
+          range:
+            type: dict
+            keys:
+              begin:
+                type: int
+              end:
+                type: int
+      rate_limit:
+        type: dict
+        keys:
+          default:
+            type: bool
+      system_priority:
+        type: int
   local_users:
     type: list
     primary_key: name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -1218,24 +1218,34 @@ keys:
                   Example: "deny ipv6 any any"'
   lacp:
     type: dict
+    display_name: LACP
+    description: Set Link Aggregation Control Protocol (LACP) parameters.
     keys:
       port_id:
         type: dict
+        description: LACP port-ID range configuration.
         keys:
           range:
             type: dict
             keys:
               begin:
                 type: int
+                description: Minimum LACP port-ID range.
               end:
                 type: int
+                description: Maximum LACP port-ID range.
       rate_limit:
         type: dict
+        description: Set LACPDU rate limit options.
         keys:
           default:
             type: bool
+            description: Enable LACPDU rate limiting by default on all ports.
       system_priority:
         type: int
+        description: Set local system LACP priority.
+        min: 0
+        max: 65535
   local_users:
     type: list
     primary_key: name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/lacp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/lacp.schema.yml
@@ -5,23 +5,31 @@ type: dict
 keys:
   lacp:
     type: dict
+    display_name: LACP
+    description: Set Link Aggregation Control Protocol (LACP) parameters.
     keys:
       port_id:
         type: dict
+        description: LACP port-ID range configuration.
         keys:
           range:
             type: dict
             keys:
               begin:
                 type: int
+                description: Minimum LACP port-ID range.
               end:
                 type: int
+                description: Maximum LACP port-ID range.
       rate_limit:
         type: dict
+        description: Set LACPDU rate limit options.
         keys:
           default:
-            type: bool  
+            type: bool
+            description: Enable LACPDU rate limiting by default on all ports.
       system_priority:
         type: int
-
-
+        description: Set local system LACP priority.
+        min: 0
+        max: 65535

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/lacp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/lacp.schema.yml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  lacp:
+    type: dict
+    keys:
+      port_id:
+        type: dict
+        keys:
+          range:
+            type: dict
+            keys:
+              begin:
+                type: int
+              end:
+                type: int
+      rate_limit:
+        type: dict
+        keys:
+          default:
+            type: bool  
+      system_priority:
+        type: int
+
+


### PR DESCRIPTION
## Add schema for data model

<!-- Use this PR Title: Feat(eos_cli_config_gen): Add schema for < data_model_key > -->

## Checklist

### Contributor Checklist

- [x] Create schema fragment matching data model described in README.md and README_v4.0.md
  - README.md is most complete with all keys. README_v4.0 includes partial data models after conversion to lists.
  - Schema fragment path is `roles/eos_cli_config_gen/schemas/schema_fragments/<data_model_key>.schema.yml`.
  - Copy line 1-5 from another schema (comments and outer type:dict).
  - Refer to [schema documentation](https://avd.sh/en/devel/docs/input-variable-validation-BETA.html) for syntax and/or use YAML Lint plugin from Redhat in VSCode.
  - Use `convert_types` on value that could be mixed type or misinterpreted like integers and numeric strings.
- [x] If the data model has been converted from wildcard dicts:
  - Add `convert_types: ['dict']` to the schema.
  - Remove `convert_dicts` from the `templates/eos/<>.j2` and `templates/documentation/<>.j2` templates.
- [x] Run `molecule converge -s build_schemas_and_docs` to update schema and documentation.
- [x] Test by running `molecule converge -s eos_cli_config_gen` and verify no errors or changes to generated configs/docs.

### Reviewer Checklist

- Reviewer 1: Carl
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2: Tony
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
