### PR TITLE
Fix(eos_designs, eos_cli_config_gen): Fix ipv6_address_virtual and ipv6_virtual_router

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
@@ -137,7 +137,7 @@ interface Management1
 | Interface | VRF | IPv6 Address | IPv6 Virtual Address | Virtual Router Address | VRRP | ND RA Disabled | Managed Config Flag | IPv6 ACL In | IPv6 ACL Out |
 | --------- | --- | ------------ | -------------------- | ---------------------- | ---- | -------------- | ------------------- | ----------- | ------------ |
 | Vlan24 | default | 1b11:3a00:22b0:6::15/64 | - | 1b11:3a00:22b0:6::1 | - | - | True | - | - |
-| Vlan25 | default | 1b11:3a00:22b0:16::16/64 | - | 1b11:3a00:22b0:16::15, 1b11:3a00:22b0:17::15/64 | - | - | - | - | - |
+| Vlan25 | default | 1b11:3a00:22b0:16::16/64 | - | 1b11:3a00:22b0:16::15, 1b11:3a00:22b0:16::14 | - | - | - | - | - |
 | Vlan75 | default | 1b11:3a00:22b0:1000::15/64 | - | 1b11:3a00:22b0:1000::1 | - | - | True | - | - |
 | Vlan81 | Tenant_C | - | fc00:10:10:81::1/64 | - | - | - | - | - | - |
 | Vlan89 | default | 1b11:3a00:22b0:5200::15/64 | - | 1b11:3a00:22b0:5200::3 | - | - | True | - | - |
@@ -192,7 +192,7 @@ interface Vlan25
    no shutdown
    ipv6 address 1b11:3a00:22b0:16::16/64
    ipv6 virtual-router address 1b11:3a00:22b0:16::15
-   ipv6 virtual-router address 1b11:3a00:22b0:17::15/64
+   ipv6 virtual-router address 1b11:3a00:22b0:16::14
 !
 interface Vlan41
    description SVI Description
@@ -229,6 +229,8 @@ interface Vlan81
    vrf Tenant_C
    ipv6 enable
    ipv6 address virtual fc00:10:10:81::1/64
+   ipv6 address virtual fc00:10:11:81::1/64
+   ipv6 address virtual fc00:10:12:81::1/64
    ip address virtual 10.10.81.1/24
 !
 interface Vlan83

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
@@ -26,7 +26,7 @@ interface Vlan25
    no shutdown
    ipv6 address 1b11:3a00:22b0:16::16/64
    ipv6 virtual-router address 1b11:3a00:22b0:16::15
-   ipv6 virtual-router address 1b11:3a00:22b0:17::15/64
+   ipv6 virtual-router address 1b11:3a00:22b0:16::14
 !
 interface Vlan41
    description SVI Description
@@ -63,6 +63,8 @@ interface Vlan81
    vrf Tenant_C
    ipv6 enable
    ipv6 address virtual fc00:10:10:81::1/64
+   ipv6 address virtual fc00:10:11:81::1/64
+   ipv6 address virtual fc00:10:12:81::1/64
    ip address virtual 10.10.81.1/24
 !
 interface Vlan83

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
@@ -23,6 +23,9 @@ vlan_interfaces:
     ip_address_virtual: 10.10.81.1/24
     ipv6_enable: true
     ipv6_address_virtual: fc00:10:10:81::1/64
+    ipv6_address_virtuals:
+      - fc00:10:11:81::1/64
+      - fc00:10:12:81::1/64
 
   Vlan83:
     description: SVI Description
@@ -168,8 +171,7 @@ vlan_interfaces:
     ipv6_address: 1b11:3a00:22b0:16::16/64
     ipv6_virtual_router_addresses:
       - 1b11:3a00:22b0:16::15
-      - 1b11:3a00:22b0:17::15/64
-
+      - 1b11:3a00:22b0:16::14
   Vlan1002:
     description: SVI Description
     shutdown: false

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2A.cfg
@@ -479,6 +479,8 @@ interface Vlan410
    no shutdown
    vrf Tenant_D_OP_Zone
    ipv6 address virtual 2001:db8:310::1/64
+   ipv6 address virtual 2001:db8:311::1/64
+   ipv6 address virtual 2001:db8:312::1/64
    ip address virtual 10.3.10.1/24
 !
 interface Vlan411
@@ -487,7 +489,7 @@ interface Vlan411
    vrf Tenant_D_OP_Zone
    ip address 10.3.11.2/24
    ipv6 address 2001:db8:311::2/64
-   ipv6 virtual-router address 2001:db8:311::1/64
+   ipv6 virtual-router address 2001:db8:311::1
    ip virtual-router address 10.3.11.1/24
 !
 interface Vlan412
@@ -584,7 +586,6 @@ ip route vrf Tenant_D_OP_Zone 0.0.0.0/0 10.3.11.4
 ip route vrf Tenant_D_OP_Zone 10.3.11.0/24 Vlan411 name VARP
 !
 ipv6 route vrf Tenant_D_OP_Zone ::/0 2001:db8:311::4 name IPv6-test-2
-ipv6 route vrf Tenant_D_OP_Zone 2001:db8:311::/64 Vlan411 name VARPv6
 !
 route-map RM-CONN-2-BGP permit 10
    match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2B.cfg
@@ -443,6 +443,8 @@ interface Vlan410
    no shutdown
    vrf Tenant_D_OP_Zone
    ipv6 address virtual 2001:db8:310::1/64
+   ipv6 address virtual 2001:db8:311::1/64
+   ipv6 address virtual 2001:db8:312::1/64
    ip address virtual 10.3.10.1/24
 !
 interface Vlan411
@@ -451,7 +453,7 @@ interface Vlan411
    vrf Tenant_D_OP_Zone
    ip address 10.3.11.3/24
    ipv6 address 2001:db8:311::3/64
-   ipv6 virtual-router address 2001:db8:311::1/64
+   ipv6 virtual-router address 2001:db8:311::1
    ip virtual-router address 10.3.11.1/24
 !
 interface Vlan412
@@ -548,7 +550,6 @@ ip route vrf Tenant_D_OP_Zone 0.0.0.0/0 10.3.11.4
 ip route vrf Tenant_D_OP_Zone 10.3.11.0/24 Vlan411 name VARP
 !
 ipv6 route vrf Tenant_D_OP_Zone ::/0 2001:db8:311::4 name IPv6-test-2
-ipv6 route vrf Tenant_D_OP_Zone 2001:db8:311::/64 Vlan411 name VARPv6
 !
 route-map RM-CONN-2-BGP permit 10
    match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_false.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_false.cfg
@@ -278,13 +278,15 @@ interface Vlan410
    no shutdown
    vrf Tenant_D_OP_Zone
    ipv6 address virtual 2001:db8:310::1/64
+   ipv6 address virtual 2001:db8:311::1/64
+   ipv6 address virtual 2001:db8:312::1/64
    ip address virtual 10.3.10.1/24
 !
 interface Vlan411
    description Tenant_D_v6_OP_Zone_2
    no shutdown
    vrf Tenant_D_OP_Zone
-   ipv6 virtual-router address 2001:db8:311::1/64
+   ipv6 virtual-router address 2001:db8:311::1
    ip virtual-router address 10.3.11.1/24
 !
 interface Vlan412
@@ -387,8 +389,6 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 ip route vrf Tenant_A_APP_Zone 10.2.32.0/24 Vlan132 name VARP
 ip route vrf Tenant_A_APP_Zone 10.3.32.0/24 Vlan132 name VARP
 ip route vrf Tenant_D_OP_Zone 10.3.11.0/24 Vlan411 name VARP
-!
-ipv6 route vrf Tenant_D_OP_Zone 2001:db8:311::/64 Vlan411 name VARPv6
 !
 route-map RM-CONN-2-BGP permit 10
    match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
@@ -969,7 +969,7 @@ vlan_interfaces:
     vrf: Tenant_D_OP_Zone
     ip_address_virtual: 10.3.10.1/24
     ipv6_address_virtual: 2001:db8:310::1/64
-    ipv6_address_virtual_secondaries:
+    ipv6_address_virtuals:
     - 2001:db8:311::1/64
     - 2001:db8:312::1/64
   Vlan411:
@@ -984,7 +984,7 @@ vlan_interfaces:
     ip_virtual_router_addresses:
     - 10.3.11.1/24
     ipv6_virtual_router_addresses:
-    - 2001:db8:311::1/64
+    - 2001:db8:311::1
   Vlan412:
     tenant: Tenant_D
     tags:
@@ -1027,10 +1027,6 @@ ipv6_static_routes:
   vrf: Tenant_D_OP_Zone
   gateway: 2001:db8:311::4
   name: IPv6-test-2
-- destination_address_prefix: 2001:db8:311::/64
-  vrf: Tenant_D_OP_Zone
-  name: VARPv6
-  interface: Vlan411
 router_ospf:
   process_ids:
     30:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
@@ -915,7 +915,7 @@ vlan_interfaces:
     vrf: Tenant_D_OP_Zone
     ip_address_virtual: 10.3.10.1/24
     ipv6_address_virtual: 2001:db8:310::1/64
-    ipv6_address_virtual_secondaries:
+    ipv6_address_virtuals:
     - 2001:db8:311::1/64
     - 2001:db8:312::1/64
   Vlan411:
@@ -930,7 +930,7 @@ vlan_interfaces:
     ip_virtual_router_addresses:
     - 10.3.11.1/24
     ipv6_virtual_router_addresses:
-    - 2001:db8:311::1/64
+    - 2001:db8:311::1
   Vlan412:
     tenant: Tenant_D
     tags:
@@ -973,10 +973,6 @@ ipv6_static_routes:
   vrf: Tenant_D_OP_Zone
   gateway: 2001:db8:311::4
   name: IPv6-test-2
-- destination_address_prefix: 2001:db8:311::/64
-  vrf: Tenant_D_OP_Zone
-  name: VARPv6
-  interface: Vlan411
 router_ospf:
   process_ids:
     30:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_false.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_false.yml
@@ -683,7 +683,7 @@ vlan_interfaces:
     vrf: Tenant_D_OP_Zone
     ip_address_virtual: 10.3.10.1/24
     ipv6_address_virtual: 2001:db8:310::1/64
-    ipv6_address_virtual_secondaries:
+    ipv6_address_virtuals:
     - 2001:db8:311::1/64
     - 2001:db8:312::1/64
   Vlan411:
@@ -696,7 +696,7 @@ vlan_interfaces:
     ip_virtual_router_addresses:
     - 10.3.11.1/24
     ipv6_virtual_router_addresses:
-    - 2001:db8:311::1/64
+    - 2001:db8:311::1
   Vlan412:
     tenant: Tenant_D
     tags:
@@ -734,11 +734,6 @@ vlan_interfaces:
     ip_address_virtual: 10.4.12.254/24
     ipv6_address_virtual: 2001:db8:412::1/64
     mtu: 1560
-ipv6_static_routes:
-- destination_address_prefix: 2001:db8:311::/64
-  vrf: Tenant_D_OP_Zone
-  name: VARPv6
-  interface: Vlan411
 vxlan_interface:
   Vxlan1:
     description: evpn_services_l2_only_false_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_D.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_D.yml
@@ -12,7 +12,7 @@ Tenant_D:
           enabled: True
           ip_address_virtual: 10.3.10.1/24
           ipv6_address_virtual: 2001:db8:310::1/64
-          ipv6_address_virtual_secondaries:
+          ipv6_address_virtuals:
             - 2001:db8:311::1/64
             - 2001:db8:312::1/64
         411:
@@ -20,7 +20,7 @@ Tenant_D:
           tags: ['v6opzone']
           enabled: True
           ip_virtual_router_addresses: [ 10.3.11.1/24 ]
-          ipv6_virtual_router_addresses: [ "2001:db8:311::1/64" ]
+          ipv6_virtual_router_addresses: [ "2001:db8:311::1" ]
           nodes:
             DC1-LEAF2A:
               ip_address: 10.3.11.2/24

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1378,8 +1378,10 @@ vlan_interfaces:
         source_interface: < source_interface_name >
     ipv6_enable: < true | false >
     ipv6_address: < IPv6_address/Mask >
+    # The below "ipv6_address_virtual" key will be deprecated in AVD v4.0 in favor of the new "ipv6_address_virtuals"
     # If both "ipv6_address_virtual" and "ipv6_address_virtuals" are set, all addresses will be configured
     ipv6_address_virtual: < IPv6_address/Mask >
+    # The new "ipv6_address_virtuals" key support multiple virtual ip addresses.
     ipv6_address_virtuals:
       - < IPv6_address/Mask >
       - < IPv6_address/Mask >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1378,8 +1378,18 @@ vlan_interfaces:
         source_interface: < source_interface_name >
     ipv6_enable: < true | false >
     ipv6_address: < IPv6_address/Mask >
+    # If both "ipv6_address_virtual" and "ipv6_address_virtuals" are set, all addresses will be configured
     ipv6_address_virtual: < IPv6_address/Mask >
+    ipv6_address_virtuals:
+      - < IPv6_address/Mask >
+      - < IPv6_address/Mask >
     ipv6_address_link_local: < link_local_IPv6_address/Mask >
+    # The below "ipv6_virtual_router_address" key will be deprecated in AVD v4.0 - These should not be mixed with the new "ipv6_virtual_router_addresses" key below to avoid conflicts.
+    ipv6_virtual_router_address: < IPv6_address >
+    # New improved "VARPv6" data model to support multiple VARPv6 addresses.
+    ipv6_virtual_router_addresses:
+      - < IPv6_address >
+      - < IPv6_address >
     ipv6_nd_ra_disabled: < true | false >
     ipv6_nd_managed_config_flag: < true | false >
     ipv6_nd_prefixes:
@@ -1423,12 +1433,6 @@ vlan_interfaces:
         dr_priority: < 0-429467295 >
         sparse_mode: < true | false >
         local_interface: < local_interface_name >
-    # The below "ipv6_virtual_router_address" key will be deprecated in AVD v4.0 - These should not be mixed with the new "ipv6_virtual_router_addresses" key below to avoid conflicts.
-    ipv6_virtual_router_address: < IPv6_address >
-    # New improved "VARPv6" data model to support multiple VARPv6 addresses.
-    ipv6_virtual_router_addresses:
-      - < IPv6_address >
-      - < IPv6_address >
     isis_enable: < ISIS Instance >
     isis_passive: < boolean >
     isis_metric: < integer >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1427,8 +1427,8 @@ vlan_interfaces:
     ipv6_virtual_router_address: < IPv6_address >
     # New improved "VARPv6" data model to support multiple VARPv6 addresses.
     ipv6_virtual_router_addresses:
-      - < IPv6_address/Mask | IPv6_address >
-      - < IPv6_address/Mask | IPv6_address >
+      - < IPv6_address >
+      - < IPv6_address >
     isis_enable: < ISIS Instance >
     isis_passive: < boolean >
     isis_metric: < integer >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
@@ -70,6 +70,9 @@ interface {{ vlan_interface.name }}
 {%     if vlan_interface.ipv6_address_virtual is arista.avd.defined %}
    ipv6 address virtual {{ vlan_interface.ipv6_address_virtual }}
 {%     endif %}
+{%     for ipv6_address_virtual in vlan_interface.ipv6_address_virtuals | arista.avd.natural_sort %}
+   ipv6 address virtual {{ ipv6_address_virtual }}
+{%     endfor %}
 {%     if vlan_interface.ipv6_nd_ra_disabled is arista.avd.defined(true) %}
    ipv6 nd ra disabled
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
@@ -296,11 +296,13 @@ mac_address_table:
             ip_address_virtual_secondaries:
               - < IPv4_address/Mask >
 
-            # ipv6 address virtual(s) to configure VXLAN Anycast IP address
+            # ipv6 address virtuals to configure VXLAN Anycast IP address | Optional
+            # The below "ipv6_address_virtual" key will be deprecated in AVD v4.0 in favor of the new "ipv6_address_virtuals"
             # If both "ipv6_address_virtual" and "ipv6_address_virtuals" are set, all addresses will be configured
-            # Optional
             ipv6_address_virtual: < IPv6_address/Mask >
+            # The new "ipv6_address_virtuals" key support multiple virtual ip addresses.
             ipv6_address_virtuals:
+              - < IPv6_address/Mask >
               - < IPv6_address/Mask >
 
             # ip virtual-router address

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
@@ -297,6 +297,7 @@ mac_address_table:
               - < IPv4_address/Mask >
 
             # ipv6 address virtual(s) to configure VXLAN Anycast IP address
+            # If both "ipv6_address_virtual" and "ipv6_address_virtuals" are set, all addresses will be configured
             # Optional
             ipv6_address_virtual: < IPv6_address/Mask >
             ipv6_address_virtuals:

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
@@ -296,10 +296,10 @@ mac_address_table:
             ip_address_virtual_secondaries:
               - < IPv4_address/Mask >
 
-            # ipv6 address virtual to configure VXLAN Anycast IP address
+            # ipv6 address virtual(s) to configure VXLAN Anycast IP address
             # Optional
             ipv6_address_virtual: < IPv6_address/Mask >
-            ipv6_address_virtual_secondaries:
+            ipv6_address_virtuals:
               - < IPv6_address/Mask >
 
             # ip virtual-router address
@@ -312,7 +312,7 @@ mac_address_table:
             # note, also requires an IPv6 address to be configured on the SVI where it is applied.
             # Optional
             ipv6_virtual_router_addresses:
-              - < IPv6_address/Mask | IPv6_address >
+              - < IPv6_address >
 
             # IP Helper for DHCP relay
             ip_helpers:
@@ -829,7 +829,7 @@ dc1_tenants:
             tags: [ DC1_BL1, DC1_BL2 ]
             enabled: true
             ipv6_virtual_router_addresses:
-              - 2001:db8:253::/64
+              - 2001:db8:253::1
             nodes:
               DC1-BL1A:
                 ip_address: 2001:db8:253::2/64

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/static-routes.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/static-routes.j2
@@ -27,18 +27,6 @@ ipv6_static_routes:
 {%                 endif %}
 {%             endfor %}
 {%         endif %}
-{%         for svi in vrf.svis %}
-{%             if svi.ipv6_virtual_router_addresses is arista.avd.defined %}
-{# Detect if VARP addresses with prefixes exist and loop through the ip_address/prefix #}
-{# If the VARP address with prefix doesn't exist then it will loop through empty_list [], so config is not generated in this scenario #}
-{%                 for dest_addr_prefix in svi.ipv6_virtual_router_addresses | ansible.netcommon.ipaddr(0) | ansible.netcommon.ipaddr('net') %}
-  - destination_address_prefix: {{ dest_addr_prefix }}
-    vrf: {{ vrf.name }}
-    name: "VARPv6"
-    interface: Vlan{{ svi.id | int }}
-{%                 endfor %}
-{%             endif %}
-{%         endfor %}
 {%     endfor %}
 {% endfor %}
 static_routes:

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/vlan-interfaces.j2
@@ -58,8 +58,8 @@ vlan_interfaces:
     ip_address_virtual_secondaries: {{ svi.ip_address_virtual_secondaries }}
 {%             endif %}
 {# Virtual Secondary IPv6 address #}
-{%             if svi.ipv6_address_virtual_secondaries is arista.avd.defined %}
-    ipv6_address_virtual_secondaries: {{ svi.ipv6_address_virtual_secondaries }}
+{%             if svi.ipv6_address_virtuals is arista.avd.defined %}
+    ipv6_address_virtuals: {{ svi.ipv6_address_virtuals }}
 {%             endif %}
 {# MTU definition #}
 {%             if svi.mtu is arista.avd.defined %}


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Several fixes in SVI `ipv6_address_virtual_secondaries` and `ipv6_virtual_router_addresses`.

## Related Issue(s)

- Fixes #2087 - eos_cli_config_gen did not implement support for `ipv6_address_virtual_secondaries`
- EOS CLI should be multiple `ipv6 address virtual <ipv6cidr>` instead of `ipv6 address virtual <ipv6cidr> secondary` CLI
- Documentation on `ipv6_virtual_router_addresses` suggests support for IPv6 CIDR, but the EOS command only supports an IPv6 address.
- eos_designs inserted ipv6 static routes for VARPv6 addresses if mask was set. But since mask support should not be there, this feature should also be removed.

## Component(s) name

`arista.avd.eos_designs`
`arista.avd.eos_cli_config_gen`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

- rename the key `ipv6_address_virtual_secondaries` to `ipv6_address_virtuals` since the secondary keyword has no meaning for IPv6. This is not breaking, since it never worked.
- Fix documentation to make it clear that only IPv6 addresses are supported for ´ipv6_virtual_router_addresses`
- Remove unneeded VARPv6 static route injection from `eos_designs`
- Update related molecule scenarios to only generate supported configurations

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Various updates and fixes will produce a few changes. The old artifacts where not valid on EOS, so these are fixes.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
