### PR TITLE
Feat(eos_cli_config_gen): Add schema for system

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -2595,8 +2595,8 @@ switchport_default:
 | [<samp>system</samp>](## "system") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;control_plane</samp>](## "system.control_plane") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;tcp_mss</samp>](## "system.control_plane.tcp_mss") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4</samp>](## "system.control_plane.tcp_mss.ipv4") | Integer |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6</samp>](## "system.control_plane.tcp_mss.ipv6") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4</samp>](## "system.control_plane.tcp_mss.ipv4") | Integer |  |  |  | Segment size |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6</samp>](## "system.control_plane.tcp_mss.ipv6") | Integer |  |  |  | Segment size |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv4_access_groups</samp>](## "system.control_plane.ipv4_access_groups") | List, items: Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- acl_name</samp>](## "system.control_plane.ipv4_access_groups.[].acl_name") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "system.control_plane.ipv4_access_groups.[].vrf") | String |  |  |  |  |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -2586,6 +2586,40 @@ switchport_default:
     vlan: <int>
 ```
 
+## System
+
+### Variables
+
+| Variable | Type | Required | Default | Value Restrictions | Description |
+| -------- | ---- | -------- | ------- | ------------------ | ----------- |
+| [<samp>system</samp>](## "system") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;control_plane</samp>](## "system.control_plane") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;tcp_mss</samp>](## "system.control_plane.tcp_mss") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4</samp>](## "system.control_plane.tcp_mss.ipv4") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6</samp>](## "system.control_plane.tcp_mss.ipv6") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv4_access_groups</samp>](## "system.control_plane.ipv4_access_groups") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- acl_name</samp>](## "system.control_plane.ipv4_access_groups.[].acl_name") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "system.control_plane.ipv4_access_groups.[].vrf") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_access_groups</samp>](## "system.control_plane.ipv6_access_groups") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- acl_name</samp>](## "system.control_plane.ipv6_access_groups.[].acl_name") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "system.control_plane.ipv6_access_groups.[].vrf") | String |  |  |  |  |
+
+### YAML
+
+```yaml
+system:
+  control_plane:
+    tcp_mss:
+      ipv4: <int>
+      ipv6: <int>
+    ipv4_access_groups:
+      - acl_name: <str>
+        vrf: <str>
+    ipv6_access_groups:
+      - acl_name: <str>
+        vrf: <str>
+```
+
 ## Hardware TCAM Profiles
 
 ### Variables

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -4445,10 +4445,12 @@
               "properties": {
                 "ipv4": {
                   "type": "integer",
+                  "description": "Segment size",
                   "title": "Ipv4"
                 },
                 "ipv6": {
                   "type": "integer",
+                  "description": "Segment size",
                   "title": "Ipv6"
                 }
               },

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -4434,6 +4434,71 @@
       "additionalProperties": false,
       "title": "Switchport Default"
     },
+    "system": {
+      "type": "object",
+      "properties": {
+        "control_plane": {
+          "type": "object",
+          "properties": {
+            "tcp_mss": {
+              "type": "object",
+              "properties": {
+                "ipv4": {
+                  "type": "integer",
+                  "title": "Ipv4"
+                },
+                "ipv6": {
+                  "type": "integer",
+                  "title": "Ipv6"
+                }
+              },
+              "additionalProperties": false,
+              "title": "Tcp Mss"
+            },
+            "ipv4_access_groups": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "acl_name": {
+                    "type": "string",
+                    "title": "Acl Name"
+                  },
+                  "vrf": {
+                    "type": "string",
+                    "title": "Vrf"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "title": "Ipv4 Access Groups"
+            },
+            "ipv6_access_groups": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "acl_name": {
+                    "type": "string",
+                    "title": "Acl Name"
+                  },
+                  "vrf": {
+                    "type": "string",
+                    "title": "Vrf"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "title": "Ipv6 Access Groups"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Control Plane"
+        }
+      },
+      "additionalProperties": false,
+      "title": "System"
+    },
     "tcam_profile": {
       "type": "object",
       "title": "Hardware TCAM Profiles",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -3345,8 +3345,10 @@ keys:
             keys:
               ipv4:
                 type: int
+                description: Segment size
               ipv6:
                 type: int
+                description: Segment size
           ipv4_access_groups:
             type: list
             primary_key: acl_name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -3334,6 +3334,43 @@ keys:
             - str
             min: 1
             max: 4094
+  system:
+    type: dict
+    keys:
+      control_plane:
+        type: dict
+        keys:
+          tcp_mss:
+            type: dict
+            keys:
+              ipv4:
+                type: int
+              ipv6:
+                type: int
+          ipv4_access_groups:
+            type: list
+            primary_key: acl_name
+            convert_types:
+            - dict
+            items:
+              type: dict
+              keys:
+                acl_name:
+                  type: str
+                vrf:
+                  type: str
+          ipv6_access_groups:
+            type: list
+            primary_key: acl_name
+            convert_types:
+            - dict
+            items:
+              type: dict
+              keys:
+                acl_name:
+                  type: str
+                vrf:
+                  type: str
   tcam_profile:
     type: dict
     display_name: Hardware TCAM Profiles

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/system.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/system.schema.yml
@@ -1,0 +1,43 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+allow_other_keys: true
+keys:
+  system:
+    type: dict
+    keys:
+      control_plane:
+        type: dict
+        keys:
+          tcp_mss:
+            type: dict
+            keys:
+              ipv4:
+                type: int
+              ipv6:
+                type: int
+          ipv4_access_groups:
+            type: list
+            primary_key: acl_name 
+            convert_types:
+            - dict
+            items:
+              type: dict
+              keys:
+                acl_name:
+                  type: str
+                vrf:
+                  type: str
+          ipv6_access_groups:
+            type: list
+            primary_key: acl_name 
+            convert_types:
+            - dict
+            items:
+              type: dict
+              keys:
+                acl_name:
+                  type: str
+                vrf:
+                  type: str                                    

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/system.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/system.schema.yml
@@ -19,7 +19,7 @@ keys:
                 type: int
           ipv4_access_groups:
             type: list
-            primary_key: acl_name 
+            primary_key: acl_name
             convert_types:
             - dict
             items:
@@ -31,7 +31,7 @@ keys:
                   type: str
           ipv6_access_groups:
             type: list
-            primary_key: acl_name 
+            primary_key: acl_name
             convert_types:
             - dict
             items:
@@ -40,4 +40,4 @@ keys:
                 acl_name:
                   type: str
                 vrf:
-                  type: str                                    
+                  type: str

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/system.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/system.schema.yml
@@ -15,8 +15,10 @@ keys:
             keys:
               ipv4:
                 type: int
+                description: Segment size
               ipv6:
                 type: int
+                description: Segment size
           ipv4_access_groups:
             type: list
             primary_key: acl_name


### PR DESCRIPTION
## Add schema for data model

<!-- Use this PR Title: Feat(eos_cli_config_gen): Add schema for < data_model_key > -->

## Checklist

### Contributor Checklist

- [x] Create schema fragment matching data model described in README.md and README_v4.0.md
  - README.md is most complete with all keys. README_v4.0 includes partial data models after conversion to lists.
  - Schema fragment path is `roles/eos_cli_config_gen/schemas/schema_fragments/<data_model_key>.schema.yml`.
  - Copy line 1-5 from another schema (comments and outer type:dict).
  - Refer to [schema documentation](https://avd.sh/en/devel/docs/input-variable-validation-BETA.html) for syntax and/or use YAML Lint plugin from Redhat in VSCode.
  - Use `convert_types` on value that could be mixed type or misinterpreted like integers and numeric strings.
- [x] If the data model has been converted from wildcard dicts:
  - Add `convert_types: ['dict']` to the schema.
  - Remove `convert_dicts` from the `templates/eos/<>.j2` and `templates/documentation/<>.j2` templates.
- [x] Run `molecule converge -s build_schemas_and_docs` to update schema and documentation.
- [x] Test by running `molecule converge -s eos_cli_config_gen` and verify no errors or changes to generated configs/docs.

### Reviewer Checklist

- Reviewer 1: Carl
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2: Julio
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
