### PR TITLE
Feat(eos_cli_config_gen): Add schema for patch_panel

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -2384,6 +2384,34 @@ name_server:
     - <str>
 ```
 
+## Patch Panel
+
+### Variables
+
+| Variable | Type | Required | Default | Value Restrictions | Description |
+| -------- | ---- | -------- | ------- | ------------------ | ----------- |
+| [<samp>patch_panel</samp>](## "patch_panel") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;patches</samp>](## "patch_panel.patches") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "patch_panel.patches.[].name") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "patch_panel.patches.[].enabled") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;connectors</samp>](## "patch_panel.patches.[].connectors") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- id</samp>](## "patch_panel.patches.[].connectors.[].id") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;type</samp>](## "patch_panel.patches.[].connectors.[].type") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;endpoint</samp>](## "patch_panel.patches.[].connectors.[].endpoint") | String |  |  |  |  |
+
+### YAML
+
+```yaml
+patch_panel:
+  patches:
+    - name: <str>
+      enabled: <bool>
+      connectors:
+        - id: <int>
+          type: <str>
+          endpoint: <str>
+```
+
 ## Peer Filters
 
 ### Variables

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -2392,12 +2392,12 @@ name_server:
 | -------- | ---- | -------- | ------- | ------------------ | ----------- |
 | [<samp>patch_panel</samp>](## "patch_panel") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;patches</samp>](## "patch_panel.patches") | List, items: Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "patch_panel.patches.[].name") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "patch_panel.patches.[].name") | String | Required, Unique |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "patch_panel.patches.[].enabled") | Boolean |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;connectors</samp>](## "patch_panel.patches.[].connectors") | List, items: Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- id</samp>](## "patch_panel.patches.[].connectors.[].id") | Integer |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;type</samp>](## "patch_panel.patches.[].connectors.[].type") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;endpoint</samp>](## "patch_panel.patches.[].connectors.[].endpoint") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;connectors</samp>](## "patch_panel.patches.[].connectors") | List, items: Dictionary |  |  | Min Length: 2<br>Max Length: 2 | Must have exactly two connectors to a patch of which at least one must be of type "interface" |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- id</samp>](## "patch_panel.patches.[].connectors.[].id") | String | Required, Unique |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;type</samp>](## "patch_panel.patches.[].connectors.[].type") | String | Required |  | Valid Values:<br>- interface<br>- pseudowire |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;endpoint</samp>](## "patch_panel.patches.[].connectors.[].endpoint") | String | Required |  |  | String with relevant endpoint depending on type.<br>Examples:<br>- "Ethernet1"<br>- "Ethernet1 dot1q vlan 123"<br>- "bgp vpws TENANT_A pseudowire VPWS_PW_1"<br>- "ldp LDP_PW_1"<br> |
 
 ### YAML
 
@@ -2407,7 +2407,7 @@ patch_panel:
     - name: <str>
       enabled: <bool>
       connectors:
-        - id: <int>
+        - id: <str>
           type: <str>
           endpoint: <str>
 ```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -4108,7 +4108,7 @@
                   "properties": {
                     "id": {
                       "type": "string",
-                      "title": "Id"
+                      "title": "ID"
                     },
                     "type": {
                       "type": "string",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -4100,27 +4100,43 @@
               },
               "connectors": {
                 "type": "array",
+                "minItems": 2,
+                "maxItems": 2,
+                "description": "Must have exactly two connectors to a patch of which at least one must be of type \"interface\"",
                 "items": {
                   "type": "object",
                   "properties": {
                     "id": {
-                      "type": "integer",
+                      "type": "string",
                       "title": "Id"
                     },
                     "type": {
                       "type": "string",
+                      "enum": [
+                        "interface",
+                        "pseudowire"
+                      ],
                       "title": "Type"
                     },
                     "endpoint": {
                       "type": "string",
+                      "description": "String with relevant endpoint depending on type.\nExamples:\n- \"Ethernet1\"\n- \"Ethernet1 dot1q vlan 123\"\n- \"bgp vpws TENANT_A pseudowire VPWS_PW_1\"\n- \"ldp LDP_PW_1\"\n",
                       "title": "Endpoint"
                     }
                   },
+                  "required": [
+                    "id",
+                    "type",
+                    "endpoint"
+                  ],
                   "additionalProperties": false
                 },
                 "title": "Connectors"
               }
             },
+            "required": [
+              "name"
+            ],
             "additionalProperties": false
           },
           "title": "Patches"

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -4082,6 +4082,53 @@
       "additionalProperties": false,
       "title": "Name Server"
     },
+    "patch_panel": {
+      "type": "object",
+      "properties": {
+        "patches": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "Name"
+              },
+              "enabled": {
+                "type": "boolean",
+                "title": "Enabled"
+              },
+              "connectors": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "integer",
+                      "title": "Id"
+                    },
+                    "type": {
+                      "type": "string",
+                      "title": "Type"
+                    },
+                    "endpoint": {
+                      "type": "string",
+                      "title": "Endpoint"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "title": "Connectors"
+              }
+            },
+            "additionalProperties": false
+          },
+          "title": "Patches"
+        }
+      },
+      "additionalProperties": false,
+      "title": "Patch Panel"
+    },
     "peer_filters": {
       "type": "array",
       "items": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -2957,6 +2957,7 @@ keys:
           keys:
             name:
               type: str
+              required: true
             enabled:
               type: bool
             connectors:
@@ -2964,17 +2965,40 @@ keys:
               primary_key: id
               convert_types:
               - dict
+              min_length: 2
+              max_length: 2
+              description: Must have exactly two connectors to a patch of which at
+                least one must be of type "interface"
               items:
                 type: dict
                 keys:
                   id:
-                    type: int
+                    type: str
                     convert_types:
-                    - str
+                    - int
+                    required: true
                   type:
                     type: str
+                    valid_values:
+                    - interface
+                    - pseudowire
+                    required: true
                   endpoint:
                     type: str
+                    description: 'String with relevant endpoint depending on type.
+
+                      Examples:
+
+                      - "Ethernet1"
+
+                      - "Ethernet1 dot1q vlan 123"
+
+                      - "bgp vpws TENANT_A pseudowire VPWS_PW_1"
+
+                      - "ldp LDP_PW_1"
+
+                      '
+                    required: true
   peer_filters:
     type: list
     primary_key: name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -2944,6 +2944,37 @@ keys:
         type: list
         items:
           type: str
+  patch_panel:
+    type: dict
+    keys:
+      patches:
+        type: list
+        primary_key: name
+        convert_types:
+        - dict
+        items:
+          type: dict
+          keys:
+            name:
+              type: str
+            enabled:
+              type: bool
+            connectors:
+              type: list
+              primary_key: id
+              convert_types:
+              - dict
+              items:
+                type: dict
+                keys:
+                  id:
+                    type: int
+                    convert_types:
+                    - str
+                  type:
+                    type: str
+                  endpoint:
+                    type: str
   peer_filters:
     type: list
     primary_key: name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/patch_panel.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/patch_panel.schema.yml
@@ -16,6 +16,7 @@ keys:
           keys:
             name:
               type: str
+              required: true
             enabled:
               type: bool
             connectors:
@@ -23,14 +24,30 @@ keys:
               primary_key: id
               convert_types:
               - dict
+              min_length: 2
+              max_length: 2
+              description: Must have exactly two connectors to a patch of which at least one must be of type "interface"
               items:
                 type: dict
                 keys:
                   id:
-                    type: int
+                    type: str
                     convert_types:
-                    - str
+                    - int
+                    required: true
                   type:
                     type: str
+                    valid_values:
+                    - interface
+                    - pseudowire
+                    required: true
                   endpoint:
                     type: str
+                    description: |
+                      String with relevant endpoint depending on type.
+                      Examples:
+                      - "Ethernet1"
+                      - "Ethernet1 dot1q vlan 123"
+                      - "bgp vpws TENANT_A pseudowire VPWS_PW_1"
+                      - "ldp LDP_PW_1"
+                    required: true

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/patch_panel.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/patch_panel.schema.yml
@@ -4,33 +4,33 @@
 type: dict
 keys:
   patch_panel:
-   type: dict
-   keys:
-    patches:
-      type: list
-      primary_key: name
-      convert_types:
-      - dict
-      items:
-        type: dict
-        keys:
-          name:
-            type: str
-          enabled:
-            type: bool
-          connectors:
-            type: list
-            primary_key: id
-            convert_types:
-            - dict
-            items:
-              type: dict
-              keys:
-                id:
-                  type: int
-                  convert_types:
-                  - str
-                type:
-                  type: str
-                endpoint:
-                  type: str
+    type: dict
+    keys:
+      patches:
+        type: list
+        primary_key: name
+        convert_types:
+        - dict
+        items:
+          type: dict
+          keys:
+            name:
+              type: str
+            enabled:
+              type: bool
+            connectors:
+              type: list
+              primary_key: id
+              convert_types:
+              - dict
+              items:
+                type: dict
+                keys:
+                  id:
+                    type: int
+                    convert_types:
+                    - str
+                  type:
+                    type: str
+                  endpoint:
+                    type: str

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/patch_panel.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/patch_panel.schema.yml
@@ -33,4 +33,4 @@ keys:
                 type:
                   type: str
                 endpoint:
-                  type: str       
+                  type: str

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/patch_panel.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/patch_panel.schema.yml
@@ -1,0 +1,36 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  patch_panel:
+   type: dict
+   keys:
+    patches:
+      type: list
+      primary_key: name
+      convert_types:
+      - dict
+      items:
+        type: dict
+        keys:
+          name:
+            type: str
+          enabled:
+            type: bool
+          connectors:
+            type: list
+            primary_key: id
+            convert_types:
+            - dict
+            items:
+              type: dict
+              keys:
+                id:
+                  type: int
+                  convert_types:
+                  - str
+                type:
+                  type: str
+                endpoint:
+                  type: str       


### PR DESCRIPTION
## Add schema for data model

<!-- Use this PR Title: Feat(eos_cli_config_gen): Add schema for < data_model_key > -->

## Checklist

### Contributor Checklist

- [x] Create schema fragment matching data model described in README.md and README_v4.0.md
  - README.md is most complete with all keys. README_v4.0 includes partial data models after conversion to lists.
  - Schema fragment path is `roles/eos_cli_config_gen/schemas/schema_fragments/<data_model_key>.schema.yml`.
  - Copy line 1-5 from another schema (comments and outer type:dict).
  - Refer to [schema documentation](https://avd.sh/en/devel/docs/input-variable-validation-BETA.html) for syntax and/or use YAML Lint plugin from Redhat in VSCode.
  - Use `convert_types` on value that could be mixed type or misinterpreted like integers and numeric strings.
- [x] If the data model has been converted from wildcard dicts:
  - Add `convert_types: ['dict']` to the schema.
  - Remove `convert_dicts` from the `templates/eos/<>.j2` and `templates/documentation/<>.j2` templates.
- [x] Run `molecule converge -s build_schemas_and_docs` to update schema and documentation.
- [x] Test by running `molecule converge -s eos_cli_config_gen` and verify no errors or changes to generated configs/docs.

### Reviewer Checklist

- Reviewer 1:
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2:
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
