### PR TITLE
Feat(eos_cli_config_gen): Add schema for management_security

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -1127,10 +1127,10 @@ management_interfaces:
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;minimum_length</samp>](## "management_security.password.minimum_length") | Integer |  |  | Min: 1<br>Max: 32 |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;encryption_key_common</samp>](## "management_security.password.encryption_key_common") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;encryption_reversible</samp>](## "management_security.password.encryption_reversible") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;ssl_profiles</samp>](## "management_security.ssl_profiles") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;ssl_profiles</samp>](## "management_security.ssl_profiles") | List, items: Dictionary |  |  |  | SSL Profiles |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "management_security.ssl_profiles.[].name") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tls_versions</samp>](## "management_security.ssl_profiles.[].tls_versions") | String |  |  |  | List of allowed tls versions as string<br> |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;cipher_list</samp>](## "management_security.ssl_profiles.[].cipher_list") | String |  |  |  | cipher_list syntax follows the openssl cipher strings format.<br>Column separated list of allowed ciphers as a string<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tls_versions</samp>](## "management_security.ssl_profiles.[].tls_versions") | String |  |  |  | TLS Versions<br>List of allowed TLS versions as string<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;cipher_list</samp>](## "management_security.ssl_profiles.[].cipher_list") | String |  |  |  | cipher_list syntax follows the openssl cipher strings format.<br>Colon (:) separated list of allowed ciphers as a string<br> |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;certificate</samp>](## "management_security.ssl_profiles.[].certificate") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;file</samp>](## "management_security.ssl_profiles.[].certificate.file") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "management_security.ssl_profiles.[].certificate.key") | String |  |  |  |  |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -1115,6 +1115,44 @@ management_interfaces:
     ipv6_gateway: <str>
 ```
 
+## Management Security
+
+### Variables
+
+| Variable | Type | Required | Default | Value Restrictions | Description |
+| -------- | ---- | -------- | ------- | ------------------ | ----------- |
+| [<samp>management_security</samp>](## "management_security") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;entropy_source</samp>](## "management_security.entropy_source") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;password</samp>](## "management_security.password") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;minimum_length</samp>](## "management_security.password.minimum_length") | Integer |  |  | Min: 1<br>Max: 32 |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;encryption_key_common</samp>](## "management_security.password.encryption_key_common") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;encryption_reversible</samp>](## "management_security.password.encryption_reversible") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;ssl_profiles</samp>](## "management_security.ssl_profiles") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "management_security.ssl_profiles.[].name") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tls_versions</samp>](## "management_security.ssl_profiles.[].tls_versions") | String |  |  |  | List of allowed tls versions as string<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;cipher_list</samp>](## "management_security.ssl_profiles.[].cipher_list") | String |  |  |  | cipher_list syntax follows the openssl cipher strings format.<br>Column separated list of allowed ciphers as a string<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;certificate</samp>](## "management_security.ssl_profiles.[].certificate") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;file</samp>](## "management_security.ssl_profiles.[].certificate.file") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "management_security.ssl_profiles.[].certificate.key") | String |  |  |  |  |
+
+### YAML
+
+```yaml
+management_security:
+  entropy_source: <str>
+  password:
+    minimum_length: <int>
+    encryption_key_common: <bool>
+    encryption_reversible: <str>
+  ssl_profiles:
+    - name: <str>
+      tls_versions: <str>
+      cipher_list: <str>
+      certificate:
+        file: <str>
+        key: <str>
+```
+
 ## Management SSH
 
 ### Variables

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -1759,6 +1759,77 @@
       },
       "title": "Management Interfaces"
     },
+    "management_security": {
+      "type": "object",
+      "properties": {
+        "entropy_source": {
+          "type": "string",
+          "title": "Entropy Source"
+        },
+        "password": {
+          "type": "object",
+          "properties": {
+            "minimum_length": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 32,
+              "title": "Minimum Length"
+            },
+            "encryption_key_common": {
+              "type": "boolean",
+              "title": "Encryption Key Common"
+            },
+            "encryption_reversible": {
+              "type": "string",
+              "title": "Encryption Reversible"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Password"
+        },
+        "ssl_profiles": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "Name"
+              },
+              "tls_versions": {
+                "type": "string",
+                "description": "List of allowed tls versions as string\n",
+                "title": "Tls Versions"
+              },
+              "cipher_list": {
+                "type": "string",
+                "description": "cipher_list syntax follows the openssl cipher strings format.\nColumn separated list of allowed ciphers as a string\n",
+                "title": "Cipher List"
+              },
+              "certificate": {
+                "type": "object",
+                "properties": {
+                  "file": {
+                    "type": "string",
+                    "title": "File"
+                  },
+                  "key": {
+                    "type": "string",
+                    "title": "Key"
+                  }
+                },
+                "additionalProperties": false,
+                "title": "Certificate"
+              }
+            },
+            "additionalProperties": false
+          },
+          "title": "Ssl Profiles"
+        }
+      },
+      "additionalProperties": false,
+      "title": "Management Security"
+    },
     "management_ssh": {
       "type": "object",
       "title": "Management SSH",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -659,7 +659,7 @@
           "title": "Ethernet"
         },
         "mtu": {
-          "type": "string",
+          "type": "integer",
           "title": "Mtu"
         }
       },
@@ -1789,6 +1789,7 @@
         },
         "ssl_profiles": {
           "type": "array",
+          "title": "SSL Profiles",
           "items": {
             "type": "object",
             "properties": {
@@ -1798,12 +1799,12 @@
               },
               "tls_versions": {
                 "type": "string",
-                "description": "List of allowed tls versions as string\n",
-                "title": "Tls Versions"
+                "title": "TLS Versions",
+                "description": "List of allowed TLS versions as string\n"
               },
               "cipher_list": {
                 "type": "string",
-                "description": "cipher_list syntax follows the openssl cipher strings format.\nColumn separated list of allowed ciphers as a string\n",
+                "description": "cipher_list syntax follows the openssl cipher strings format.\nColon (:) separated list of allowed ciphers as a string\n",
                 "title": "Cipher List"
               },
               "certificate": {
@@ -1823,8 +1824,7 @@
               }
             },
             "additionalProperties": false
-          },
-          "title": "Ssl Profiles"
+          }
         }
       },
       "additionalProperties": false,

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -1444,6 +1444,7 @@ keys:
             type: str
       ssl_profiles:
         type: list
+        display_name: SSL Profiles
         items:
           type: dict
           keys:
@@ -1451,7 +1452,8 @@ keys:
               type: str
             tls_versions:
               type: str
-              description: 'List of allowed tls versions as string
+              display_name: TLS Versions
+              description: 'List of allowed TLS versions as string
 
                 '
             cipher_list:
@@ -1459,7 +1461,7 @@ keys:
               description: 'cipher_list syntax follows the openssl cipher strings
                 format.
 
-                Column separated list of allowed ciphers as a string
+                Colon (:) separated list of allowed ciphers as a string
 
                 '
             certificate:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -1424,6 +1424,51 @@ keys:
         ipv6_gateway:
           type: str
           description: IPv6 address of default gateway in management VRF
+  management_security:
+    type: dict
+    keys:
+      entropy_source:
+        type: str
+      password:
+        type: dict
+        keys:
+          minimum_length:
+            type: int
+            min: 1
+            max: 32
+            convert_types:
+            - str
+          encryption_key_common:
+            type: bool
+          encryption_reversible:
+            type: str
+      ssl_profiles:
+        type: list
+        items:
+          type: dict
+          keys:
+            name:
+              type: str
+            tls_versions:
+              type: str
+              description: 'List of allowed tls versions as string
+
+                '
+            cipher_list:
+              type: str
+              description: 'cipher_list syntax follows the openssl cipher strings
+                format.
+
+                Column separated list of allowed ciphers as a string
+
+                '
+            certificate:
+              type: dict
+              keys:
+                file:
+                  type: str
+                key:
+                  type: str
   management_ssh:
     type: dict
     display_name: Management SSH

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_security.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_security.schema.yml
@@ -1,0 +1,46 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  management_security:
+    type: dict
+    keys:
+      entropy_source:
+        type: str
+      password:
+        type: dict
+        keys:
+          minimum_length:
+            type: int
+            min: 1
+            max: 32
+            convert_types:
+            - str
+          encryption_key_common:
+            type: bool
+          encryption_reversible:
+            type: str
+      ssl_profiles:
+        type: list
+        items:
+          type: dict
+          keys:
+            name:
+              type: str
+            tls_versions:
+              type: str
+              description: |
+                List of allowed tls versions as string
+            cipher_list:
+              type: str
+              description: |
+                cipher_list syntax follows the openssl cipher strings format.
+                Column separated list of allowed ciphers as a string
+            certificate:
+              type: dict
+              keys:
+                file:
+                  type: str
+                key:
+                  type: str

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_security.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_security.schema.yml
@@ -23,6 +23,7 @@ keys:
             type: str
       ssl_profiles:
         type: list
+        display_name: SSL Profiles
         items:
           type: dict
           keys:
@@ -30,13 +31,14 @@ keys:
               type: str
             tls_versions:
               type: str
+              display_name: TLS Versions
               description: |
-                List of allowed tls versions as string
+                List of allowed TLS versions as string
             cipher_list:
               type: str
               description: |
                 cipher_list syntax follows the openssl cipher strings format.
-                Column separated list of allowed ciphers as a string
+                Colon (:) separated list of allowed ciphers as a string
             certificate:
               type: dict
               keys:


### PR DESCRIPTION
## Add schema for data model

<!-- Use this PR Title: Feat(eos_cli_config_gen): Add schema for < data_model_key > -->

## Checklist

### Contributor Checklist

- [x] Create schema fragment matching data model described in README.md and README_v4.0.md
  - README.md is most complete with all keys. README_v4.0 includes partial data models after conversion to lists.
  - Schema fragment path is `roles/eos_cli_config_gen/schemas/schema_fragments/<data_model_key>.schema.yml`.
  - Copy line 1-5 from another schema (comments and outer type:dict).
  - Refer to [schema documentation](https://avd.sh/en/devel/docs/input-variable-validation-BETA.html) for syntax and/or use YAML Lint plugin from Redhat in VSCode.
  - Use `convert_types` on value that could be mixed type or misinterpreted like integers and numeric strings.
- [x] If the data model has been converted from wildcard dicts:
  - Add `convert_types: ['dict']` to the schema.
  - Remove `convert_dicts` from the `templates/eos/<>.j2` and `templates/documentation/<>.j2` templates.
- [x] Run `molecule converge -s build_schemas_and_docs` to update schema and documentation.
- [x] Test by running `molecule converge -s eos_cli_config_gen` and verify no errors or changes to generated configs/docs.

### Reviewer Checklist

- Reviewer 1: Claus
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2: Carl
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
