### PR TITLE
Feat(eos_cli_config_gen): Add schema for ip_http_client_source_interfaces

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -528,15 +528,15 @@ ip_extcommunity_lists_regexp:
         regexp: <str>
 ```
 
-## Ip Http Client Source Interfaces
+## IP HTTP Client Source Interfaces
 
 ### Variables
 
 | Variable | Type | Required | Default | Value Restrictions | Description |
 | -------- | ---- | -------- | ------- | ------------------ | ----------- |
-| [<samp>ip_http_client_source_interfaces</samp>](## "ip_http_client_source_interfaces") | List, items: Dictionary |  |  |  |  |
+| [<samp>ip_http_client_source_interfaces</samp>](## "ip_http_client_source_interfaces") | List, items: Dictionary |  |  |  | IP HTTP Client Source Interfaces |
 | [<samp>&nbsp;&nbsp;- name</samp>](## "ip_http_client_source_interfaces.[].name") | String |  |  |  | Interface Name |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "ip_http_client_source_interfaces.[].vrf") | String |  |  |  | VRF Name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "ip_http_client_source_interfaces.[].vrf") | String |  |  |  | VRF |
 
 ### YAML
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -528,6 +528,24 @@ ip_extcommunity_lists_regexp:
         regexp: <str>
 ```
 
+## Ip Http Client Source Interfaces
+
+### Variables
+
+| Variable | Type | Required | Default | Value Restrictions | Description |
+| -------- | ---- | -------- | ------- | ------------------ | ----------- |
+| [<samp>ip_http_client_source_interfaces</samp>](## "ip_http_client_source_interfaces") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;- name</samp>](## "ip_http_client_source_interfaces.[].name") | String |  |  |  | Interface Name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "ip_http_client_source_interfaces.[].vrf") | String |  |  |  | VRF Name |
+
+### YAML
+
+```yaml
+ip_http_client_source_interfaces:
+  - name: <str>
+    vrf: <str>
+```
+
 ## IP IGMP Snooping
 
 ### Variables

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -813,6 +813,24 @@
         "additionalProperties": false
       }
     },
+    "ip_http_client_source_interfaces": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "title": "Interface Name",
+            "type": "string"
+          },
+          "vrf": {
+            "title": "VRF Name",
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "title": "Ip Http Client Source Interfaces"
+    },
     "ip_igmp_snooping": {
       "type": "object",
       "title": "IP IGMP Snooping",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -815,6 +815,7 @@
     },
     "ip_http_client_source_interfaces": {
       "type": "array",
+      "title": "IP HTTP Client Source Interfaces",
       "items": {
         "type": "object",
         "properties": {
@@ -823,13 +824,12 @@
             "type": "string"
           },
           "vrf": {
-            "title": "VRF Name",
+            "title": "VRF",
             "type": "string"
           }
         },
         "additionalProperties": false
-      },
-      "title": "Ip Http Client Source Interfaces"
+      }
     },
     "ip_igmp_snooping": {
       "type": "object",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -744,6 +744,17 @@ keys:
                 type: str
                 required: true
                 description: Regular Expression
+  ip_http_client_source_interfaces:
+    type: list
+    items:
+      type: dict
+      keys:
+        name:
+          display_name: Interface Name
+          type: str
+        vrf:
+          display_name: VRF Name
+          type: str
   ip_igmp_snooping:
     type: dict
     display_name: IP IGMP Snooping

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -746,6 +746,7 @@ keys:
                 description: Regular Expression
   ip_http_client_source_interfaces:
     type: list
+    display_name: IP HTTP Client Source Interfaces
     items:
       type: dict
       keys:
@@ -753,7 +754,7 @@ keys:
           display_name: Interface Name
           type: str
         vrf:
-          display_name: VRF Name
+          display_name: VRF
           type: str
   ip_igmp_snooping:
     type: dict

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ip_http_client_source_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ip_http_client_source_interfaces.schema.yml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  ip_http_client_source_interfaces:
+    type: list
+    items:
+      type: dict
+      keys:
+        name:
+          display_name: Interface Name
+          type: str
+        vrf:
+          display_name: VRF Name
+          type: str

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ip_http_client_source_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ip_http_client_source_interfaces.schema.yml
@@ -5,6 +5,7 @@ type: dict
 keys:
   ip_http_client_source_interfaces:
     type: list
+    display_name: IP HTTP Client Source Interfaces
     items:
       type: dict
       keys:
@@ -12,5 +13,5 @@ keys:
           display_name: Interface Name
           type: str
         vrf:
-          display_name: VRF Name
+          display_name: VRF
           type: str


### PR DESCRIPTION
…aces

## Add schema for data model

<!-- Use this PR Title: Feat(eos_cli_config_gen): Add schema for < data_model_key > -->

## Checklist

### Contributor Checklist

- [x] Create schema fragment matching data model described in README.md and README_v4.0.md
  - README.md is most complete with all keys. README_v4.0 includes partial data models after conversion to lists.
  - Schema fragment path is `roles/eos_cli_config_gen/schemas/schema_fragments/<data_model_key>.schema.yml`.
  - Copy line 1-5 from another schema (comments and outer type:dict).
  - Refer to [schema documentation](https://avd.sh/en/devel/docs/input-variable-validation-BETA.html) for syntax and/or use YAML Lint plugin from Redhat in VSCode.
  - Use `convert_types` on value that could be mixed type or misinterpreted like integers and numeric strings.
- [x] If the data model has been converted from wildcard dicts:
  - Add `convert_types: ['dict']` to the schema.
  - Remove `convert_dicts` from the `templates/eos/<>.j2` and `templates/documentation/<>.j2` templates.
- [x] Run `molecule converge -s build_schemas_and_docs` to update schema and documentation.
- [x] Test by running `molecule converge -s eos_cli_config_gen` and verify no errors or changes to generated configs/docs.

### Reviewer Checklist

- Reviewer 1: Claus
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2: Carl
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
