### PR TITLE
Feat(eos_cli_config_gen): Add schema for aaa_authorization

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -1,21 +1,21 @@
 !!! warning
     This document describes the data model for AVD 4.x. It may or may not work in previous versions.
 
-## Aaa Authorization
+## AAA Authorization
 
 ### Variables
 
 | Variable | Type | Required | Default | Value Restrictions | Description |
 | -------- | ---- | -------- | ------- | ------------------ | ----------- |
-| [<samp>aaa_authorization</samp>](## "aaa_authorization") | Dictionary |  |  |  |  |
+| [<samp>aaa_authorization</samp>](## "aaa_authorization") | Dictionary |  |  |  | AAA Authorization |
 | [<samp>&nbsp;&nbsp;exec</samp>](## "aaa_authorization.exec") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;default</samp>](## "aaa_authorization.exec.default") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;default</samp>](## "aaa_authorization.exec.default") | String |  |  |  | Exec authorization method(s) as a string.<br>Examples:<br>- "group tacacs+ local"<br>- "group MYGROUP none"<br>- "group radius group MYGROUP local"<br> |
 | [<samp>&nbsp;&nbsp;config_commands</samp>](## "aaa_authorization.config_commands") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;serial_console</samp>](## "aaa_authorization.serial_console") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;commands</samp>](## "aaa_authorization.commands") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;all_default</samp>](## "aaa_authorization.commands.all_default") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;all_default</samp>](## "aaa_authorization.commands.all_default") | String |  |  |  | Command authorization method(s) as a string.<br>Examples:<br>- "group tacacs+ local"<br>- "group MYGROUP none"<br>- "group tacacs+ group MYGROUP local<br> |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;privilege</samp>](## "aaa_authorization.commands.privilege") | List, items: Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- level</samp>](## "aaa_authorization.commands.privilege.[].level") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- level</samp>](## "aaa_authorization.commands.privilege.[].level") | String |  |  |  | Privilege level(s) 0-15 |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;default</samp>](## "aaa_authorization.commands.privilege.[].default") | String |  |  |  |  |
 
 ### YAML

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -1,6 +1,38 @@
 !!! warning
     This document describes the data model for AVD 4.x. It may or may not work in previous versions.
 
+## Aaa Authorization
+
+### Variables
+
+| Variable | Type | Required | Default | Value Restrictions | Description |
+| -------- | ---- | -------- | ------- | ------------------ | ----------- |
+| [<samp>aaa_authorization</samp>](## "aaa_authorization") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;exec</samp>](## "aaa_authorization.exec") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;default</samp>](## "aaa_authorization.exec.default") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;config_commands</samp>](## "aaa_authorization.config_commands") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;serial_console</samp>](## "aaa_authorization.serial_console") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;commands</samp>](## "aaa_authorization.commands") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;all_default</samp>](## "aaa_authorization.commands.all_default") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;privilege</samp>](## "aaa_authorization.commands.privilege") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- level</samp>](## "aaa_authorization.commands.privilege.[].level") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;default</samp>](## "aaa_authorization.commands.privilege.[].default") | String |  |  |  |  |
+
+### YAML
+
+```yaml
+aaa_authorization:
+  exec:
+    default: <str>
+  config_commands: <bool>
+  serial_console: <bool>
+  commands:
+    all_default: <str>
+    privilege:
+      - level: <str>
+        default: <str>
+```
+
 ## AAA Root
 
 ### Variables

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -16,7 +16,7 @@
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;all_default</samp>](## "aaa_authorization.commands.all_default") | String |  |  |  | Command authorization method(s) as a string.<br>Examples:<br>- "group tacacs+ local"<br>- "group MYGROUP none"<br>- "group tacacs+ group MYGROUP local<br> |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;privilege</samp>](## "aaa_authorization.commands.privilege") | List, items: Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- level</samp>](## "aaa_authorization.commands.privilege.[].level") | String |  |  |  | Privilege level(s) 0-15 |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;default</samp>](## "aaa_authorization.commands.privilege.[].default") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;default</samp>](## "aaa_authorization.commands.privilege.[].default") | String |  |  |  | Command authorization method(s) as a string.<br>Examples:<br>- "group tacacs+ local"<br>- "group MYGROUP none"<br>- "group tacacs+ group MYGROUP local" |
 
 ### YAML
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -45,6 +45,7 @@
                   },
                   "default": {
                     "type": "string",
+                    "description": "Command authorization method(s) as a string.\nExamples:\n- \"group tacacs+ local\"\n- \"group MYGROUP none\"\n- \"group tacacs+ group MYGROUP local\"",
                     "title": "Default"
                   }
                 },

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -1,6 +1,61 @@
 {
   "type": "object",
   "properties": {
+    "aaa_authorization": {
+      "type": "object",
+      "properties": {
+        "exec": {
+          "type": "object",
+          "properties": {
+            "default": {
+              "type": "string",
+              "title": "Default"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Exec"
+        },
+        "config_commands": {
+          "type": "boolean",
+          "title": "Config Commands"
+        },
+        "serial_console": {
+          "type": "boolean",
+          "title": "Serial Console"
+        },
+        "commands": {
+          "type": "object",
+          "properties": {
+            "all_default": {
+              "type": "string",
+              "title": "All Default"
+            },
+            "privilege": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "level": {
+                    "type": "string",
+                    "title": "Level"
+                  },
+                  "default": {
+                    "type": "string",
+                    "title": "Default"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "title": "Privilege"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Commands"
+        }
+      },
+      "additionalProperties": false,
+      "title": "Aaa Authorization"
+    },
     "aaa_root": {
       "type": "object",
       "title": "AAA Root",
@@ -659,7 +714,7 @@
           "title": "Ethernet"
         },
         "mtu": {
-          "type": "string",
+          "type": "integer",
           "title": "Mtu"
         }
       },

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -3,12 +3,14 @@
   "properties": {
     "aaa_authorization": {
       "type": "object",
+      "title": "AAA Authorization",
       "properties": {
         "exec": {
           "type": "object",
           "properties": {
             "default": {
               "type": "string",
+              "description": "Exec authorization method(s) as a string.\nExamples:\n- \"group tacacs+ local\"\n- \"group MYGROUP none\"\n- \"group radius group MYGROUP local\"\n",
               "title": "Default"
             }
           },
@@ -28,6 +30,7 @@
           "properties": {
             "all_default": {
               "type": "string",
+              "description": "Command authorization method(s) as a string.\nExamples:\n- \"group tacacs+ local\"\n- \"group MYGROUP none\"\n- \"group tacacs+ group MYGROUP local\n",
               "title": "All Default"
             },
             "privilege": {
@@ -37,6 +40,7 @@
                 "properties": {
                   "level": {
                     "type": "string",
+                    "description": "Privilege level(s) 0-15",
                     "title": "Level"
                   },
                   "default": {
@@ -53,8 +57,7 @@
           "title": "Commands"
         }
       },
-      "additionalProperties": false,
-      "title": "Aaa Authorization"
+      "additionalProperties": false
     },
     "aaa_root": {
       "type": "object",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -3,12 +3,24 @@ allow_other_keys: true
 keys:
   aaa_authorization:
     type: dict
+    display_name: AAA Authorization
     keys:
       exec:
         type: dict
         keys:
           default:
             type: str
+            description: 'Exec authorization method(s) as a string.
+
+              Examples:
+
+              - "group tacacs+ local"
+
+              - "group MYGROUP none"
+
+              - "group radius group MYGROUP local"
+
+              '
       config_commands:
         type: bool
       serial_console:
@@ -18,6 +30,17 @@ keys:
         keys:
           all_default:
             type: str
+            description: 'Command authorization method(s) as a string.
+
+              Examples:
+
+              - "group tacacs+ local"
+
+              - "group MYGROUP none"
+
+              - "group tacacs+ group MYGROUP local
+
+              '
           privilege:
             type: list
             items:
@@ -25,6 +48,9 @@ keys:
               keys:
                 level:
                   type: str
+                  description: Privilege level(s) 0-15
+                  convert_types:
+                  - int
                 default:
                   type: str
   aaa_root:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -53,6 +53,15 @@ keys:
                   - int
                 default:
                   type: str
+                  description: 'Command authorization method(s) as a string.
+
+                    Examples:
+
+                    - "group tacacs+ local"
+
+                    - "group MYGROUP none"
+
+                    - "group tacacs+ group MYGROUP local"'
   aaa_root:
     type: dict
     display_name: AAA Root

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -1,6 +1,32 @@
 type: dict
 allow_other_keys: true
 keys:
+  aaa_authorization:
+    type: dict
+    keys:
+      exec:
+        type: dict
+        keys:
+          default:
+            type: str
+      config_commands:
+        type: bool
+      serial_console:
+        type: bool
+      commands:
+        type: dict
+        keys:
+          all_default:
+            type: str
+          privilege:
+            type: list
+            items:
+              type: dict
+              keys:
+                level:
+                  type: str
+                default:
+                  type: str
   aaa_root:
     type: dict
     display_name: AAA Root

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/aaa_authorization.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/aaa_authorization.schema.yml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  aaa_authorization:
+    type: dict
+    keys:
+      exec:
+        type: dict
+        keys:
+          default:
+            type: str
+      config_commands:
+        type: bool
+      serial_console:
+        type: bool
+      commands:
+        type: dict
+        keys:
+          all_default:
+            type: str
+          privilege:
+            type: list
+            items:
+              type: dict
+              keys:
+                level:
+                  type: str
+                default:
+                  type: str

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/aaa_authorization.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/aaa_authorization.schema.yml
@@ -45,3 +45,9 @@ keys:
                     - int
                 default:
                   type: str
+                  description: |
+                    Command authorization method(s) as a string.
+                    Examples:
+                    - "group tacacs+ local"
+                    - "group MYGROUP none"
+                    - "group tacacs+ group MYGROUP local"

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/aaa_authorization.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/aaa_authorization.schema.yml
@@ -5,12 +5,19 @@ type: dict
 keys:
   aaa_authorization:
     type: dict
+    display_name: AAA Authorization
     keys:
       exec:
         type: dict
         keys:
           default:
             type: str
+            description: |
+              Exec authorization method(s) as a string.
+              Examples:
+              - "group tacacs+ local"
+              - "group MYGROUP none"
+              - "group radius group MYGROUP local"
       config_commands:
         type: bool
       serial_console:
@@ -20,6 +27,12 @@ keys:
         keys:
           all_default:
             type: str
+            description: |
+              Command authorization method(s) as a string.
+              Examples:
+              - "group tacacs+ local"
+              - "group MYGROUP none"
+              - "group tacacs+ group MYGROUP local
           privilege:
             type: list
             items:
@@ -27,5 +40,8 @@ keys:
               keys:
                 level:
                   type: str
+                  description: Privilege level(s) 0-15
+                  convert_types:
+                    - int
                 default:
                   type: str


### PR DESCRIPTION
## Add schema for data model

<!-- Use this PR Title: Feat(eos_cli_config_gen): Add schema for < data_model_key > -->

## Checklist

### Contributor Checklist

- [x] Create schema fragment matching data model described in README.md and README_v4.0.md
  - README.md is most complete with all keys. README_v4.0 includes partial data models after conversion to lists.
  - Schema fragment path is `roles/eos_cli_config_gen/schemas/schema_fragments/<data_model_key>.schema.yml`.
  - Copy line 1-5 from another schema (comments and outer type:dict).
  - Refer to [schema documentation](https://avd.sh/en/devel/docs/input-variable-validation-BETA.html) for syntax and/or use YAML Lint plugin from Redhat in VSCode.
  - Use `convert_types` on value that could be mixed type or misinterpreted like integers and numeric strings.
- [x] If the data model has been converted from wildcard dicts:
  - Add `convert_types: ['dict']` to the schema.
  - Remove `convert_dicts` from the `templates/eos/<>.j2` and `templates/documentation/<>.j2` templates.
- [x] Run `molecule converge -s build_schemas_and_docs` to update schema and documentation.
- [x] Test by running `molecule converge -s eos_cli_config_gen` and verify no errors or changes to generated configs/docs.

### Reviewer Checklist

- Reviewer 1: Claus
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2: Carl
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
