### PR TITLE
Feat(eos_cli_config_gen): Add schema for ip_ssh_client_source_interfaces

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -624,6 +624,24 @@ ip_igmp_snooping:
       proxy: <bool>
 ```
 
+## Ip Ssh Client Source Interfaces
+
+### Variables
+
+| Variable | Type | Required | Default | Value Restrictions | Description |
+| -------- | ---- | -------- | ------- | ------------------ | ----------- |
+| [<samp>ip_ssh_client_source_interfaces</samp>](## "ip_ssh_client_source_interfaces") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;- name</samp>](## "ip_ssh_client_source_interfaces.[].name") | String |  |  |  | Interface Name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "ip_ssh_client_source_interfaces.[].vrf") | String |  | default |  | VRF Name |
+
+### YAML
+
+```yaml
+ip_ssh_client_source_interfaces:
+  - name: <str>
+    vrf: <str>
+```
+
 ## IPv6 Extended Access-Lists
 
 ### Variables

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -624,15 +624,15 @@ ip_igmp_snooping:
       proxy: <bool>
 ```
 
-## Ip Ssh Client Source Interfaces
+## IP SSH Client Source Interfaces
 
 ### Variables
 
 | Variable | Type | Required | Default | Value Restrictions | Description |
 | -------- | ---- | -------- | ------- | ------------------ | ----------- |
-| [<samp>ip_ssh_client_source_interfaces</samp>](## "ip_ssh_client_source_interfaces") | List, items: Dictionary |  |  |  |  |
+| [<samp>ip_ssh_client_source_interfaces</samp>](## "ip_ssh_client_source_interfaces") | List, items: Dictionary |  |  |  | IP SSH Client Source Interfaces |
 | [<samp>&nbsp;&nbsp;- name</samp>](## "ip_ssh_client_source_interfaces.[].name") | String |  |  |  | Interface Name |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "ip_ssh_client_source_interfaces.[].vrf") | String |  | default |  | VRF Name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "ip_ssh_client_source_interfaces.[].vrf") | String |  | default |  | VRF |
 
 ### YAML
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -985,6 +985,7 @@
     },
     "ip_ssh_client_source_interfaces": {
       "type": "array",
+      "title": "IP SSH Client Source Interfaces",
       "items": {
         "type": "object",
         "properties": {
@@ -993,14 +994,13 @@
             "type": "string"
           },
           "vrf": {
-            "title": "VRF Name",
+            "title": "VRF",
             "type": "string",
             "default": "default"
           }
         },
         "additionalProperties": false
-      },
-      "title": "Ip Ssh Client Source Interfaces"
+      }
     },
     "ipv6_access_lists": {
       "type": "array",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -983,6 +983,25 @@
       },
       "additionalProperties": false
     },
+    "ip_ssh_client_source_interfaces": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "title": "Interface Name",
+            "type": "string"
+          },
+          "vrf": {
+            "title": "VRF Name",
+            "type": "string",
+            "default": "default"
+          }
+        },
+        "additionalProperties": false
+      },
+      "title": "Ip Ssh Client Source Interfaces"
+    },
     "ipv6_access_lists": {
       "type": "array",
       "title": "IPv6 Extended Access-Lists",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -874,6 +874,18 @@ keys:
               type: bool
               description: Global proxy settings should be enabled before enabling
                 per-vlan
+  ip_ssh_client_source_interfaces:
+    type: list
+    items:
+      type: dict
+      keys:
+        name:
+          display_name: Interface Name
+          type: str
+        vrf:
+          display_name: VRF Name
+          type: str
+          default: default
   ipv6_access_lists:
     type: list
     primary_key: name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -876,6 +876,7 @@ keys:
                 per-vlan
   ip_ssh_client_source_interfaces:
     type: list
+    display_name: IP SSH Client Source Interfaces
     items:
       type: dict
       keys:
@@ -883,7 +884,7 @@ keys:
           display_name: Interface Name
           type: str
         vrf:
-          display_name: VRF Name
+          display_name: VRF
           type: str
           default: default
   ipv6_access_lists:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ip_ssh_client_source_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ip_ssh_client_source_interfaces.schema.yml
@@ -5,6 +5,7 @@ type: dict
 keys:
   ip_ssh_client_source_interfaces:
     type: list
+    display_name: IP SSH Client Source Interfaces
     items:
       type: dict
       keys:
@@ -12,6 +13,6 @@ keys:
           display_name: Interface Name
           type: str
         vrf:
-          display_name: VRF Name
+          display_name: VRF
           type: str
           default: "default"

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ip_ssh_client_source_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ip_ssh_client_source_interfaces.schema.yml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  ip_ssh_client_source_interfaces:
+    type: list
+    items:
+      type: dict
+      keys:
+        name:
+          display_name: Interface Name
+          type: str
+        vrf:
+          display_name: VRF Name
+          type: str
+          default: "default"


### PR DESCRIPTION
## Add schema for data model

<!-- Use this PR Title: Feat(eos_cli_config_gen): Add schema for < data_model_key > -->

## Checklist

### Contributor Checklist

- [x] Create schema fragment matching data model described in README.md and README_v4.0.md
  - README.md is most complete with all keys. README_v4.0 includes partial data models after conversion to lists.
  - Schema fragment path is `roles/eos_cli_config_gen/schemas/schema_fragments/<data_model_key>.schema.yml`.
  - Copy line 1-5 from another schema (comments and outer type:dict).
  - Refer to [schema documentation](https://avd.sh/en/devel/docs/input-variable-validation-BETA.html) for syntax and/or use YAML Lint plugin from Redhat in VSCode.
  - Use `convert_types` on value that could be mixed type or misinterpreted like integers and numeric strings.
- [x] If the data model has been converted from wildcard dicts:
  - Add `convert_types: ['dict']` to the schema.
  - Remove `convert_dicts` from the `templates/eos/<>.j2` and `templates/documentation/<>.j2` templates.
- [x] Run `molecule converge -s build_schemas_and_docs` to update schema and documentation.
- [x] Test by running `molecule converge -s eos_cli_config_gen` and verify no errors or changes to generated configs/docs.

### Reviewer Checklist

- Reviewer 1: Claus
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2: Carl
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
