### PR TITLE
Feat(eos_cli_config_gen): Add schema for ntp

### DIFF
--- a/ansible_collections/arista/avd/molecule/upgrade_eos_cli_config_gen/documentation/devices/ntp.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_eos_cli_config_gen/documentation/devices/ntp.md
@@ -72,11 +72,15 @@ interface Management1
 
 | ID | Algorithm |
 | -- | -------- |
+| 1 | md5 |
+| 2 | sha1 |
 
 ### NTP Device Configuration
 
 ```eos
 !
+ntp authentication-key 1 md5 044F0E151B
+ntp authentication-key 2 sha1 15060E1F10
 ntp trusted-key 1-2
 ntp authenticate
 ntp local-interface lo1

--- a/ansible_collections/arista/avd/molecule/upgrade_eos_cli_config_gen/eos_cli_config_gen_upgrade_2.x_to_3.0/ntp-upgrade-debug.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_eos_cli_config_gen/eos_cli_config_gen_upgrade_2.x_to_3.0/ntp-upgrade-debug.yml
@@ -1,8 +1,8 @@
 ntp:
   authenticate: true
   authentication_keys:
-    1: {hash_algorithm: md5, key: 044F0E151B}
-    2: {hash_algorithm: sha1, key: 15060E1F10}
+  - {hash_algorithm: md5, id: 1, key: 044F0E151B}
+  - {hash_algorithm: sha1, id: 2, key: 15060E1F10}
   local_interface: {name: lo1, vrf: default}
   servers:
   - {name: 10.1.1.1, preferred: true, vrf: default}

--- a/ansible_collections/arista/avd/molecule/upgrade_eos_cli_config_gen/intended/configs/ntp.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_eos_cli_config_gen/intended/configs/ntp.cfg
@@ -4,6 +4,8 @@ transceiver qsfp default-mode 4x10G
 !
 hostname ntp
 !
+ntp authentication-key 1 md5 044F0E151B
+ntp authentication-key 2 sha1 15060E1F10
 ntp trusted-key 1-2
 ntp authenticate
 ntp local-interface lo1

--- a/ansible_collections/arista/avd/molecule/upgrade_eos_cli_config_gen/inventory/host_vars/ntp.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_eos_cli_config_gen/inventory/host_vars/ntp.yml
@@ -10,10 +10,10 @@ ntp_server:
 ntp:
   authenticate: true
   authentication_keys:
-    1:
+    - id: 1
       hash_algorithm: "md5"
       key: "044F0E151B"
-    2:
+    - id: 2
       hash_algorithm: "sha1"
       key: "15060E1F10"
   trusted_keys: "1-2"

--- a/ansible_collections/arista/avd/plugins/plugin_utils/schema/key_to_display_name.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/schema/key_to_display_name.py
@@ -42,6 +42,7 @@ WORDLIST = {
     "mpls": "MPLS",
     "mtu": "MTU",
     "nd": "ND",
+    "ntp": "NTP",
     "ospf": "OSPF",
     "pbr": "PBR",
     "pim": "PIM",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -2582,7 +2582,7 @@ name_server:
     - <str>
 ```
 
-## Ntp
+## NTP
 
 ### Variables
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -2593,13 +2593,13 @@ name_server:
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "ntp.local_interface.name") | String |  |  |  | Source interface |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "ntp.local_interface.vrf") | String |  |  |  | VRF name |
 | [<samp>&nbsp;&nbsp;servers</samp>](## "ntp.servers") | List, items: Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "ntp.servers.[].name") | String |  |  |  | IP or hostname ex-2.2.2.55, ie.pool.ntp.org |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "ntp.servers.[].name") | String |  |  |  | IP or hostname e.g., 2.2.2.55, ie.pool.ntp.org |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;burst</samp>](## "ntp.servers.[].burst") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;iburst</samp>](## "ntp.servers.[].iburst") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "ntp.servers.[].key") | Integer |  |  | Min: 1<br>Max: 65535 |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;local_interface</samp>](## "ntp.servers.[].local_interface") | String |  |  |  | Source interface |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;maxpoll</samp>](## "ntp.servers.[].maxpoll") | Integer |  |  | Min: 3<br>Max: 17 | Value of maxpoll betweeen 3 - 17 (Logarithmic) |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;minpoll</samp>](## "ntp.servers.[].minpoll") | Integer |  |  | Min: 3<br>Max: 17 | Value of minpoll betweeen 3 - 17 (Logarithmic) |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;maxpoll</samp>](## "ntp.servers.[].maxpoll") | Integer |  |  | Min: 3<br>Max: 17 | Value of maxpoll between 3 - 17 (Logarithmic) |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;minpoll</samp>](## "ntp.servers.[].minpoll") | Integer |  |  | Min: 3<br>Max: 17 | Value of minpoll between 3 - 17 (Logarithmic) |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;preferred</samp>](## "ntp.servers.[].preferred") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;version</samp>](## "ntp.servers.[].version") | Integer |  |  | Min: 1<br>Max: 4 |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "ntp.servers.[].vrf") | String |  |  |  | VRF name |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -2582,63 +2582,39 @@ name_server:
     - <str>
 ```
 
-<<<<<<< HEAD
-## Patch Panel
-=======
 ## Ntp
->>>>>>> 354fbf33 (Feat(eos_cli_config_gen): Add schema for ntp)
 
 ### Variables
 
 | Variable | Type | Required | Default | Value Restrictions | Description |
 | -------- | ---- | -------- | ------- | ------------------ | ----------- |
-<<<<<<< HEAD
-| [<samp>patch_panel</samp>](## "patch_panel") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;patches</samp>](## "patch_panel.patches") | List, items: Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "patch_panel.patches.[].name") | String | Required, Unique |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "patch_panel.patches.[].enabled") | Boolean |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;connectors</samp>](## "patch_panel.patches.[].connectors") | List, items: Dictionary |  |  | Min Length: 2<br>Max Length: 2 | Must have exactly two connectors to a patch of which at least one must be of type "interface" |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- id</samp>](## "patch_panel.patches.[].connectors.[].id") | String | Required, Unique |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;type</samp>](## "patch_panel.patches.[].connectors.[].type") | String | Required |  | Valid Values:<br>- interface<br>- pseudowire |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;endpoint</samp>](## "patch_panel.patches.[].connectors.[].endpoint") | String | Required |  |  | String with relevant endpoint depending on type.<br>Examples:<br>- "Ethernet1"<br>- "Ethernet1 dot1q vlan 123"<br>- "bgp vpws TENANT_A pseudowire VPWS_PW_1"<br>- "ldp LDP_PW_1"<br> |
-=======
 | [<samp>ntp</samp>](## "ntp") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;local_interface</samp>](## "ntp.local_interface") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "ntp.local_interface.name") | String |  |  |  | Source Interface |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "ntp.local_interface.vrf") | String |  |  |  | VRF Name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "ntp.local_interface.name") | String |  |  |  | Source interface |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "ntp.local_interface.vrf") | String |  |  |  | VRF name |
 | [<samp>&nbsp;&nbsp;servers</samp>](## "ntp.servers") | List, items: Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "ntp.servers.[].name") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "ntp.servers.[].name") | String |  |  |  | IP or hostname ex-2.2.2.55, ie.pool.ntp.org |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;burst</samp>](## "ntp.servers.[].burst") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;iburst</samp>](## "ntp.servers.[].iburst") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "ntp.servers.[].key") | Integer |  |  | Min: 1<br>Max: 65535 |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;local_interface</samp>](## "ntp.servers.[].local_interface") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;maxpoll</samp>](## "ntp.servers.[].maxpoll") | Integer |  |  | Min: 3<br>Max: 17 |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;minpoll</samp>](## "ntp.servers.[].minpoll") | Integer |  |  | Min: 3<br>Max: 17 |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;local_interface</samp>](## "ntp.servers.[].local_interface") | String |  |  |  | Source interface |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;maxpoll</samp>](## "ntp.servers.[].maxpoll") | Integer |  |  | Min: 3<br>Max: 17 | Value of maxpoll betweeen 3 - 17 (Logarithmic) |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;minpoll</samp>](## "ntp.servers.[].minpoll") | Integer |  |  | Min: 3<br>Max: 17 | Value of minpoll betweeen 3 - 17 (Logarithmic) |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;preferred</samp>](## "ntp.servers.[].preferred") | Boolean |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;version</samp>](## "ntp.servers.[].version") | Integer |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "ntp.servers.[].vrf") | String |  |  |  | VRF Name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;version</samp>](## "ntp.servers.[].version") | Integer |  |  | Min: 1<br>Max: 4 |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "ntp.servers.[].vrf") | String |  |  |  | VRF name |
 | [<samp>&nbsp;&nbsp;authenticate</samp>](## "ntp.authenticate") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;authenticate_servers_only</samp>](## "ntp.authenticate_servers_only") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;authentication_keys</samp>](## "ntp.authentication_keys") | List, items: Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- id</samp>](## "ntp.authentication_keys.[].id") | Integer |  |  | Min: 1<br>Max: 65534 | Key Identifier |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- id</samp>](## "ntp.authentication_keys.[].id") | Integer | Required, Unique |  | Min: 1<br>Max: 65534 | Key identifier |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hash_algorithm</samp>](## "ntp.authentication_keys.[].hash_algorithm") | String |  |  | Valid Values:<br>- md5<br>- sha1 |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "ntp.authentication_keys.[].key") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;trusted_keys</samp>](## "ntp.trusted_keys") | String |  |  |  |  |
->>>>>>> 354fbf33 (Feat(eos_cli_config_gen): Add schema for ntp)
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "ntp.authentication_keys.[].key") | String |  |  |  | Obfuscated key |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_type</samp>](## "ntp.authentication_keys.[].key_type") | String |  |  | Valid Values:<br>- 0<br>- 7<br>- 8a |  |
+| [<samp>&nbsp;&nbsp;trusted_keys</samp>](## "ntp.trusted_keys") | String |  |  |  | List of trusted-keys as string ex. 10-12,15 |
 
 ### YAML
 
 ```yaml
-<<<<<<< HEAD
-patch_panel:
-  patches:
-    - name: <str>
-      enabled: <bool>
-      connectors:
-        - id: <str>
-          type: <str>
-          endpoint: <str>
-=======
 ntp:
   local_interface:
     name: <str>
@@ -2660,8 +2636,36 @@ ntp:
     - id: <int>
       hash_algorithm: <str>
       key: <str>
+      key_type: <str>
   trusted_keys: <str>
->>>>>>> 354fbf33 (Feat(eos_cli_config_gen): Add schema for ntp)
+```
+
+## Patch Panel
+
+### Variables
+
+| Variable | Type | Required | Default | Value Restrictions | Description |
+| -------- | ---- | -------- | ------- | ------------------ | ----------- |
+| [<samp>patch_panel</samp>](## "patch_panel") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;patches</samp>](## "patch_panel.patches") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "patch_panel.patches.[].name") | String | Required, Unique |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "patch_panel.patches.[].enabled") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;connectors</samp>](## "patch_panel.patches.[].connectors") | List, items: Dictionary |  |  | Min Length: 2<br>Max Length: 2 | Must have exactly two connectors to a patch of which at least one must be of type "interface" |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- id</samp>](## "patch_panel.patches.[].connectors.[].id") | String | Required, Unique |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;type</samp>](## "patch_panel.patches.[].connectors.[].type") | String | Required |  | Valid Values:<br>- interface<br>- pseudowire |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;endpoint</samp>](## "patch_panel.patches.[].connectors.[].endpoint") | String | Required |  |  | String with relevant endpoint depending on type.<br>Examples:<br>- "Ethernet1"<br>- "Ethernet1 dot1q vlan 123"<br>- "bgp vpws TENANT_A pseudowire VPWS_PW_1"<br>- "ldp LDP_PW_1"<br> |
+
+### YAML
+
+```yaml
+patch_panel:
+  patches:
+    - name: <str>
+      enabled: <bool>
+      connectors:
+        - id: <str>
+          type: <str>
+          endpoint: <str>
 ```
 
 ## Peer Filters

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -2582,12 +2582,17 @@ name_server:
     - <str>
 ```
 
+<<<<<<< HEAD
 ## Patch Panel
+=======
+## Ntp
+>>>>>>> 354fbf33 (Feat(eos_cli_config_gen): Add schema for ntp)
 
 ### Variables
 
 | Variable | Type | Required | Default | Value Restrictions | Description |
 | -------- | ---- | -------- | ------- | ------------------ | ----------- |
+<<<<<<< HEAD
 | [<samp>patch_panel</samp>](## "patch_panel") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;patches</samp>](## "patch_panel.patches") | List, items: Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "patch_panel.patches.[].name") | String | Required, Unique |  |  |  |
@@ -2596,10 +2601,35 @@ name_server:
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- id</samp>](## "patch_panel.patches.[].connectors.[].id") | String | Required, Unique |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;type</samp>](## "patch_panel.patches.[].connectors.[].type") | String | Required |  | Valid Values:<br>- interface<br>- pseudowire |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;endpoint</samp>](## "patch_panel.patches.[].connectors.[].endpoint") | String | Required |  |  | String with relevant endpoint depending on type.<br>Examples:<br>- "Ethernet1"<br>- "Ethernet1 dot1q vlan 123"<br>- "bgp vpws TENANT_A pseudowire VPWS_PW_1"<br>- "ldp LDP_PW_1"<br> |
+=======
+| [<samp>ntp</samp>](## "ntp") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;local_interface</samp>](## "ntp.local_interface") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "ntp.local_interface.name") | String |  |  |  | Source Interface |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "ntp.local_interface.vrf") | String |  |  |  | VRF Name |
+| [<samp>&nbsp;&nbsp;servers</samp>](## "ntp.servers") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "ntp.servers.[].name") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;burst</samp>](## "ntp.servers.[].burst") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;iburst</samp>](## "ntp.servers.[].iburst") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "ntp.servers.[].key") | Integer |  |  | Min: 1<br>Max: 65535 |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;local_interface</samp>](## "ntp.servers.[].local_interface") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;maxpoll</samp>](## "ntp.servers.[].maxpoll") | Integer |  |  | Min: 3<br>Max: 17 |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;minpoll</samp>](## "ntp.servers.[].minpoll") | Integer |  |  | Min: 3<br>Max: 17 |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;preferred</samp>](## "ntp.servers.[].preferred") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;version</samp>](## "ntp.servers.[].version") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "ntp.servers.[].vrf") | String |  |  |  | VRF Name |
+| [<samp>&nbsp;&nbsp;authenticate</samp>](## "ntp.authenticate") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;authenticate_servers_only</samp>](## "ntp.authenticate_servers_only") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;authentication_keys</samp>](## "ntp.authentication_keys") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- id</samp>](## "ntp.authentication_keys.[].id") | Integer |  |  | Min: 1<br>Max: 65534 | Key Identifier |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hash_algorithm</samp>](## "ntp.authentication_keys.[].hash_algorithm") | String |  |  | Valid Values:<br>- md5<br>- sha1 |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "ntp.authentication_keys.[].key") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;trusted_keys</samp>](## "ntp.trusted_keys") | String |  |  |  |  |
+>>>>>>> 354fbf33 (Feat(eos_cli_config_gen): Add schema for ntp)
 
 ### YAML
 
 ```yaml
+<<<<<<< HEAD
 patch_panel:
   patches:
     - name: <str>
@@ -2608,6 +2638,30 @@ patch_panel:
         - id: <str>
           type: <str>
           endpoint: <str>
+=======
+ntp:
+  local_interface:
+    name: <str>
+    vrf: <str>
+  servers:
+    - name: <str>
+      burst: <bool>
+      iburst: <bool>
+      key: <int>
+      local_interface: <str>
+      maxpoll: <int>
+      minpoll: <int>
+      preferred: <bool>
+      version: <int>
+      vrf: <str>
+  authenticate: <bool>
+  authenticate_servers_only: <bool>
+  authentication_keys:
+    - id: <int>
+      hash_algorithm: <str>
+      key: <str>
+  trusted_keys: <str>
+>>>>>>> 354fbf33 (Feat(eos_cli_config_gen): Add schema for ntp)
 ```
 
 ## Peer Filters

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -4494,12 +4494,6 @@
       "additionalProperties": false,
       "title": "Name Server"
     },
-<<<<<<< HEAD
-    "patch_panel": {
-      "type": "object",
-      "properties": {
-        "patches": {
-=======
     "ntp": {
       "type": "object",
       "properties": {
@@ -4507,19 +4501,145 @@
           "type": "object",
           "properties": {
             "name": {
-              "title": "Source Interface",
-              "type": "string"
+              "type": "string",
+              "description": "Source interface",
+              "title": "Name"
             },
             "vrf": {
               "type": "string",
-              "title": "VRF Name"
+              "description": "VRF name",
+              "title": "VRF"
             }
           },
           "additionalProperties": false,
           "title": "Local Interface"
         },
         "servers": {
->>>>>>> 354fbf33 (Feat(eos_cli_config_gen): Add schema for ntp)
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "IP or hostname ex-2.2.2.55, ie.pool.ntp.org",
+                "title": "Name"
+              },
+              "burst": {
+                "type": "boolean",
+                "title": "Burst"
+              },
+              "iburst": {
+                "type": "boolean",
+                "title": "Iburst"
+              },
+              "key": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 65535,
+                "title": "Key"
+              },
+              "local_interface": {
+                "type": "string",
+                "description": "Source interface",
+                "title": "Local Interface"
+              },
+              "maxpoll": {
+                "type": "integer",
+                "minimum": 3,
+                "maximum": 17,
+                "description": "Value of maxpoll betweeen 3 - 17 (Logarithmic)",
+                "title": "Maxpoll"
+              },
+              "minpoll": {
+                "type": "integer",
+                "minimum": 3,
+                "maximum": 17,
+                "description": "Value of minpoll betweeen 3 - 17 (Logarithmic)",
+                "title": "Minpoll"
+              },
+              "preferred": {
+                "type": "boolean",
+                "title": "Preferred"
+              },
+              "version": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 4,
+                "title": "Version"
+              },
+              "vrf": {
+                "type": "string",
+                "description": "VRF name",
+                "title": "VRF"
+              }
+            },
+            "additionalProperties": false
+          },
+          "title": "Servers"
+        },
+        "authenticate": {
+          "type": "boolean",
+          "title": "Authenticate"
+        },
+        "authenticate_servers_only": {
+          "type": "boolean",
+          "title": "Authenticate Servers Only"
+        },
+        "authentication_keys": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 65534,
+                "description": "Key identifier",
+                "title": "ID"
+              },
+              "hash_algorithm": {
+                "type": "string",
+                "enum": [
+                  "md5",
+                  "sha1"
+                ],
+                "title": "Hash Algorithm"
+              },
+              "key": {
+                "type": "string",
+                "description": "Obfuscated key",
+                "title": "Key"
+              },
+              "key_type": {
+                "type": "string",
+                "enum": [
+                  "0",
+                  "7",
+                  "8a"
+                ],
+                "title": "Key Type"
+              }
+            },
+            "additionalProperties": false,
+            "required": [
+              "id"
+            ]
+          },
+          "title": "Authentication Keys"
+        },
+        "trusted_keys": {
+          "type": "string",
+          "description": "List of trusted-keys as string ex. 10-12,15",
+          "title": "Trusted Keys"
+        }
+      },
+      "additionalProperties": false,
+      "title": "Ntp"
+    },
+    "patch_panel": {
+      "type": "object",
+      "properties": {
+        "patches": {
           "type": "array",
           "items": {
             "type": "object",
@@ -4528,7 +4648,6 @@
                 "type": "string",
                 "title": "Name"
               },
-<<<<<<< HEAD
               "enabled": {
                 "type": "boolean",
                 "title": "Enabled"
@@ -4579,98 +4698,6 @@
       },
       "additionalProperties": false,
       "title": "Patch Panel"
-=======
-              "burst": {
-                "type": "boolean",
-                "title": "Burst"
-              },
-              "iburst": {
-                "type": "boolean",
-                "title": "Iburst"
-              },
-              "key": {
-                "type": "integer",
-                "minimum": 1,
-                "maximum": 65535,
-                "title": "Key"
-              },
-              "local_interface": {
-                "type": "string",
-                "title": "Local Interface"
-              },
-              "maxpoll": {
-                "type": "integer",
-                "minimum": 3,
-                "maximum": 17,
-                "title": "Maxpoll"
-              },
-              "minpoll": {
-                "type": "integer",
-                "minimum": 3,
-                "maximum": 17,
-                "title": "Minpoll"
-              },
-              "preferred": {
-                "type": "boolean",
-                "title": "Preferred"
-              },
-              "version": {
-                "type": "integer",
-                "title": "Version"
-              },
-              "vrf": {
-                "type": "string",
-                "title": "VRF Name"
-              }
-            },
-            "additionalProperties": false
-          },
-          "title": "Servers"
-        },
-        "authenticate": {
-          "type": "boolean",
-          "title": "Authenticate"
-        },
-        "authenticate_servers_only": {
-          "type": "boolean",
-          "title": "Authenticate Servers Only"
-        },
-        "authentication_keys": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "id": {
-                "title": "Key Identifier",
-                "type": "integer",
-                "minimum": 1,
-                "maximum": 65534
-              },
-              "hash_algorithm": {
-                "type": "string",
-                "enum": [
-                  "md5",
-                  "sha1"
-                ],
-                "title": "Hash Algorithm"
-              },
-              "key": {
-                "type": "string",
-                "title": "Key"
-              }
-            },
-            "additionalProperties": false
-          },
-          "title": "Authentication Keys"
-        },
-        "trusted_keys": {
-          "type": "string",
-          "title": "Trusted Keys"
-        }
-      },
-      "additionalProperties": false,
-      "title": "Ntp"
->>>>>>> 354fbf33 (Feat(eos_cli_config_gen): Add schema for ntp)
     },
     "peer_filters": {
       "type": "array",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -4521,7 +4521,7 @@
             "properties": {
               "name": {
                 "type": "string",
-                "description": "IP or hostname ex-2.2.2.55, ie.pool.ntp.org",
+                "description": "IP or hostname e.g., 2.2.2.55, ie.pool.ntp.org",
                 "title": "Name"
               },
               "burst": {
@@ -4547,14 +4547,14 @@
                 "type": "integer",
                 "minimum": 3,
                 "maximum": 17,
-                "description": "Value of maxpoll betweeen 3 - 17 (Logarithmic)",
+                "description": "Value of maxpoll between 3 - 17 (Logarithmic)",
                 "title": "Maxpoll"
               },
               "minpoll": {
                 "type": "integer",
                 "minimum": 3,
                 "maximum": 17,
-                "description": "Value of minpoll betweeen 3 - 17 (Logarithmic)",
+                "description": "Value of minpoll between 3 - 17 (Logarithmic)",
                 "title": "Minpoll"
               },
               "preferred": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -4494,10 +4494,32 @@
       "additionalProperties": false,
       "title": "Name Server"
     },
+<<<<<<< HEAD
     "patch_panel": {
       "type": "object",
       "properties": {
         "patches": {
+=======
+    "ntp": {
+      "type": "object",
+      "properties": {
+        "local_interface": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "title": "Source Interface",
+              "type": "string"
+            },
+            "vrf": {
+              "type": "string",
+              "title": "VRF Name"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Local Interface"
+        },
+        "servers": {
+>>>>>>> 354fbf33 (Feat(eos_cli_config_gen): Add schema for ntp)
           "type": "array",
           "items": {
             "type": "object",
@@ -4506,6 +4528,7 @@
                 "type": "string",
                 "title": "Name"
               },
+<<<<<<< HEAD
               "enabled": {
                 "type": "boolean",
                 "title": "Enabled"
@@ -4556,6 +4579,98 @@
       },
       "additionalProperties": false,
       "title": "Patch Panel"
+=======
+              "burst": {
+                "type": "boolean",
+                "title": "Burst"
+              },
+              "iburst": {
+                "type": "boolean",
+                "title": "Iburst"
+              },
+              "key": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 65535,
+                "title": "Key"
+              },
+              "local_interface": {
+                "type": "string",
+                "title": "Local Interface"
+              },
+              "maxpoll": {
+                "type": "integer",
+                "minimum": 3,
+                "maximum": 17,
+                "title": "Maxpoll"
+              },
+              "minpoll": {
+                "type": "integer",
+                "minimum": 3,
+                "maximum": 17,
+                "title": "Minpoll"
+              },
+              "preferred": {
+                "type": "boolean",
+                "title": "Preferred"
+              },
+              "version": {
+                "type": "integer",
+                "title": "Version"
+              },
+              "vrf": {
+                "type": "string",
+                "title": "VRF Name"
+              }
+            },
+            "additionalProperties": false
+          },
+          "title": "Servers"
+        },
+        "authenticate": {
+          "type": "boolean",
+          "title": "Authenticate"
+        },
+        "authenticate_servers_only": {
+          "type": "boolean",
+          "title": "Authenticate Servers Only"
+        },
+        "authentication_keys": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "title": "Key Identifier",
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 65534
+              },
+              "hash_algorithm": {
+                "type": "string",
+                "enum": [
+                  "md5",
+                  "sha1"
+                ],
+                "title": "Hash Algorithm"
+              },
+              "key": {
+                "type": "string",
+                "title": "Key"
+              }
+            },
+            "additionalProperties": false
+          },
+          "title": "Authentication Keys"
+        },
+        "trusted_keys": {
+          "type": "string",
+          "title": "Trusted Keys"
+        }
+      },
+      "additionalProperties": false,
+      "title": "Ntp"
+>>>>>>> 354fbf33 (Feat(eos_cli_config_gen): Add schema for ntp)
     },
     "peer_filters": {
       "type": "array",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -4634,7 +4634,7 @@
         }
       },
       "additionalProperties": false,
-      "title": "Ntp"
+      "title": "NTP"
     },
     "patch_panel": {
       "type": "object",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -3199,6 +3199,7 @@ keys:
         type: list
         items:
           type: str
+<<<<<<< HEAD
   patch_panel:
     type: dict
     keys:
@@ -3207,11 +3208,28 @@ keys:
         primary_key: name
         convert_types:
         - dict
+=======
+  ntp:
+    type: dict
+    keys:
+      local_interface:
+        type: dict
+        keys:
+          name:
+            display_name: Source Interface
+            type: str
+          vrf:
+            type: str
+            display_name: VRF Name
+      servers:
+        type: list
+>>>>>>> 354fbf33 (Feat(eos_cli_config_gen): Add schema for ntp)
         items:
           type: dict
           keys:
             name:
               type: str
+<<<<<<< HEAD
               required: true
             enabled:
               type: bool
@@ -3254,6 +3272,68 @@ keys:
 
                       '
                     required: true
+=======
+            burst:
+              type: bool
+            iburst:
+              type: bool
+            key:
+              type: int
+              min: 1
+              max: 65535
+              convert_types:
+              - str
+            local_interface:
+              type: str
+            maxpoll:
+              type: int
+              min: 3
+              max: 17
+              convert_types:
+              - str
+            minpoll:
+              type: int
+              min: 3
+              max: 17
+              convert_types:
+              - str
+            preferred:
+              type: bool
+            version:
+              type: int
+              convert_types:
+              - str
+            vrf:
+              type: str
+              display_name: VRF Name
+      authenticate:
+        type: bool
+      authenticate_servers_only:
+        type: bool
+      authentication_keys:
+        type: list
+        convert_types:
+        - dict
+        items:
+          type: dict
+          keys:
+            id:
+              display_name: Key Identifier
+              type: int
+              min: 1
+              max: 65534
+              convert_types:
+              - str
+            hash_algorithm:
+              type: str
+              valid_values:
+              - md5
+              - sha1
+            key:
+              type: str
+      trusted_keys:
+        type: str
+>>>>>>> 354fbf33 (Feat(eos_cli_config_gen): Add schema for ntp)
   peer_filters:
     type: list
     primary_key: name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -3218,7 +3218,7 @@ keys:
           keys:
             name:
               type: str
-              description: IP or hostname ex-2.2.2.55, ie.pool.ntp.org
+              description: IP or hostname e.g., 2.2.2.55, ie.pool.ntp.org
             burst:
               type: bool
             iburst:
@@ -3238,14 +3238,14 @@ keys:
               max: 17
               convert_types:
               - str
-              description: Value of maxpoll betweeen 3 - 17 (Logarithmic)
+              description: Value of maxpoll between 3 - 17 (Logarithmic)
             minpoll:
               type: int
               min: 3
               max: 17
               convert_types:
               - str
-              description: Value of minpoll betweeen 3 - 17 (Logarithmic)
+              description: Value of minpoll between 3 - 17 (Logarithmic)
             preferred:
               type: bool
             version:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -3199,7 +3199,102 @@ keys:
         type: list
         items:
           type: str
-<<<<<<< HEAD
+  ntp:
+    type: dict
+    keys:
+      local_interface:
+        type: dict
+        keys:
+          name:
+            type: str
+            description: Source interface
+          vrf:
+            type: str
+            description: VRF name
+      servers:
+        type: list
+        items:
+          type: dict
+          keys:
+            name:
+              type: str
+              description: IP or hostname ex-2.2.2.55, ie.pool.ntp.org
+            burst:
+              type: bool
+            iburst:
+              type: bool
+            key:
+              type: int
+              min: 1
+              max: 65535
+              convert_types:
+              - str
+            local_interface:
+              type: str
+              description: Source interface
+            maxpoll:
+              type: int
+              min: 3
+              max: 17
+              convert_types:
+              - str
+              description: Value of maxpoll betweeen 3 - 17 (Logarithmic)
+            minpoll:
+              type: int
+              min: 3
+              max: 17
+              convert_types:
+              - str
+              description: Value of minpoll betweeen 3 - 17 (Logarithmic)
+            preferred:
+              type: bool
+            version:
+              type: int
+              min: 1
+              max: 4
+              convert_types:
+              - str
+            vrf:
+              type: str
+              description: VRF name
+      authenticate:
+        type: bool
+      authenticate_servers_only:
+        type: bool
+      authentication_keys:
+        type: list
+        primary_key: id
+        convert_types:
+        - dict
+        items:
+          type: dict
+          keys:
+            id:
+              type: int
+              min: 1
+              max: 65534
+              convert_types:
+              - str
+              description: Key identifier
+            hash_algorithm:
+              type: str
+              valid_values:
+              - md5
+              - sha1
+            key:
+              type: str
+              description: Obfuscated key
+            key_type:
+              type: str
+              convert_types:
+              - int
+              valid_values:
+              - '0'
+              - '7'
+              - 8a
+      trusted_keys:
+        type: str
+        description: List of trusted-keys as string ex. 10-12,15
   patch_panel:
     type: dict
     keys:
@@ -3208,28 +3303,11 @@ keys:
         primary_key: name
         convert_types:
         - dict
-=======
-  ntp:
-    type: dict
-    keys:
-      local_interface:
-        type: dict
-        keys:
-          name:
-            display_name: Source Interface
-            type: str
-          vrf:
-            type: str
-            display_name: VRF Name
-      servers:
-        type: list
->>>>>>> 354fbf33 (Feat(eos_cli_config_gen): Add schema for ntp)
         items:
           type: dict
           keys:
             name:
               type: str
-<<<<<<< HEAD
               required: true
             enabled:
               type: bool
@@ -3272,68 +3350,6 @@ keys:
 
                       '
                     required: true
-=======
-            burst:
-              type: bool
-            iburst:
-              type: bool
-            key:
-              type: int
-              min: 1
-              max: 65535
-              convert_types:
-              - str
-            local_interface:
-              type: str
-            maxpoll:
-              type: int
-              min: 3
-              max: 17
-              convert_types:
-              - str
-            minpoll:
-              type: int
-              min: 3
-              max: 17
-              convert_types:
-              - str
-            preferred:
-              type: bool
-            version:
-              type: int
-              convert_types:
-              - str
-            vrf:
-              type: str
-              display_name: VRF Name
-      authenticate:
-        type: bool
-      authenticate_servers_only:
-        type: bool
-      authentication_keys:
-        type: list
-        convert_types:
-        - dict
-        items:
-          type: dict
-          keys:
-            id:
-              display_name: Key Identifier
-              type: int
-              min: 1
-              max: 65534
-              convert_types:
-              - str
-            hash_algorithm:
-              type: str
-              valid_values:
-              - md5
-              - sha1
-            key:
-              type: str
-      trusted_keys:
-        type: str
->>>>>>> 354fbf33 (Feat(eos_cli_config_gen): Add schema for ntp)
   peer_filters:
     type: list
     primary_key: name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ntp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ntp.schema.yml
@@ -1,0 +1,82 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  ntp:
+    type: dict
+    keys:
+      local_interface:
+        type: dict
+        keys:
+          name:
+            display_name: Source Interface
+            type: str
+          vrf:
+            type: str
+            display_name: VRF Name
+      servers:
+        type: list
+        items:
+          type: dict
+          keys:
+            name:
+              type: str
+            burst:
+              type: bool
+            iburst:
+              type: bool
+            key:
+              type: int
+              min: 1
+              max: 65535
+              convert_types:
+              - str
+            local_interface:
+              type: str
+            maxpoll:
+              type: int
+              min: 3
+              max: 17
+              convert_types:
+              - str
+            minpoll:
+              type: int
+              min: 3
+              max: 17
+              convert_types:
+              - str
+            preferred:
+              type: bool
+            version:
+              type: int
+              convert_types:
+              - str
+            vrf:
+              type: str
+              display_name: VRF Name
+      authenticate:
+        type: bool
+      authenticate_servers_only:
+        type: bool
+      authentication_keys:
+        type: list
+        convert_types:
+        - dict
+        items:
+          type: dict
+          keys:
+            id:
+              display_name: Key Identifier
+              type: int
+              min: 1
+              max: 65534
+              convert_types:
+              - str
+            hash_algorithm:
+              type: str
+              valid_values: ["md5", "sha1"]
+            key:
+              type: str
+      trusted_keys:
+        type: str

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ntp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ntp.schema.yml
@@ -22,7 +22,7 @@ keys:
           keys:
             name:
               type: str
-              description: IP or hostname ex-2.2.2.55, ie.pool.ntp.org
+              description: IP or hostname e.g., 2.2.2.55, ie.pool.ntp.org
             burst:
               type: bool
             iburst:
@@ -42,14 +42,14 @@ keys:
               max: 17
               convert_types:
               - str
-              description: Value of maxpoll betweeen 3 - 17 (Logarithmic)
+              description: Value of maxpoll between 3 - 17 (Logarithmic)
             minpoll:
               type: int
               min: 3
               max: 17
               convert_types:
               - str
-              description: Value of minpoll betweeen 3 - 17 (Logarithmic)
+              description: Value of minpoll between 3 - 17 (Logarithmic)
             preferred:
               type: bool
             version:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ntp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ntp.schema.yml
@@ -10,11 +10,11 @@ keys:
         type: dict
         keys:
           name:
-            display_name: Source Interface
             type: str
+            description: Source interface
           vrf:
             type: str
-            display_name: VRF Name
+            description: VRF name
       servers:
         type: list
         items:
@@ -22,6 +22,7 @@ keys:
           keys:
             name:
               type: str
+              description: IP or hostname ex-2.2.2.55, ie.pool.ntp.org
             burst:
               type: bool
             iburst:
@@ -34,49 +35,62 @@ keys:
               - str
             local_interface:
               type: str
+              description: Source interface
             maxpoll:
               type: int
               min: 3
               max: 17
               convert_types:
               - str
+              description: Value of maxpoll betweeen 3 - 17 (Logarithmic)
             minpoll:
               type: int
               min: 3
               max: 17
               convert_types:
               - str
+              description: Value of minpoll betweeen 3 - 17 (Logarithmic)
             preferred:
               type: bool
             version:
               type: int
+              min: 1
+              max: 4
               convert_types:
               - str
             vrf:
               type: str
-              display_name: VRF Name
+              description: VRF name
       authenticate:
         type: bool
       authenticate_servers_only:
         type: bool
       authentication_keys:
         type: list
+        primary_key: id
         convert_types:
         - dict
         items:
           type: dict
           keys:
             id:
-              display_name: Key Identifier
               type: int
               min: 1
               max: 65534
               convert_types:
               - str
+              description: Key identifier
             hash_algorithm:
               type: str
               valid_values: ["md5", "sha1"]
             key:
               type: str
+              description: Obfuscated key
+            key_type:
+              type: str
+              convert_types:
+              - int
+              valid_values: ["0", "7", "8a"]
       trusted_keys:
         type: str
+        description: List of trusted-keys as string ex. 10-12,15


### PR DESCRIPTION
## Add schema for data model

<!-- Use this PR Title: Feat(eos_cli_config_gen): Add schema for < data_model_key > -->

## Checklist

### Contributor Checklist

- [x] Create schema fragment matching data model described in README.md and README_v4.0.md
  - README.md is most complete with all keys. README_v4.0 includes partial data models after conversion to lists.
  - Schema fragment path is `roles/eos_cli_config_gen/schemas/schema_fragments/<data_model_key>.schema.yml`.
  - Copy line 1-5 from another schema (comments and outer type:dict).
  - Refer to [schema documentation](https://avd.sh/en/devel/docs/input-variable-validation-BETA.html) for syntax and/or use YAML Lint plugin from Redhat in VSCode.
  - Use `convert_types` on value that could be mixed type or misinterpreted like integers and numeric strings.
- [x] If the data model has been converted from wildcard dicts:
  - Add `convert_types: ['dict']` to the schema.
  - Remove `convert_dicts` from the `templates/eos/<>.j2` and `templates/documentation/<>.j2` templates.
- [x] Run `molecule converge -s build_schemas_and_docs` to update schema and documentation.
- [x] Test by running `molecule converge -s eos_cli_config_gen` and verify no errors or changes to generated configs/docs.

### Reviewer Checklist

- Reviewer 1: Carl
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2: Claus
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
