### PR TITLE
Revert(eos_designs): Removing switch.x facts

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1A.cfg
@@ -211,6 +211,8 @@ ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.168.255.0/24 eq 32
    seq 20 permit 192.168.254.0/24 eq 32
 !
+mac address-table notification host-flap logging
+!
 ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 ip route vrf Tenant_A_WAN_Zone 10.3.4.0/24 1.2.3.4
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1A.yml
@@ -361,6 +361,8 @@ platform:
       hardware_only: true
 mac_address_table:
   aging_time: 42
+  notification_host_flap:
+    logging: true
 management_api_http:
   enable_vrfs:
     MGMT: {}
@@ -373,7 +375,7 @@ struct_cfg:
         destinations:
           192.168.200.10: null
           10.0.200.90: null
-        source_interface: Management1
+        source_interface: '{{ switch.mgmt_interface }}'
 ethernet_interfaces:
   Ethernet1:
     peer: DC1-SPINE1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1B.yml
@@ -360,7 +360,7 @@ struct_cfg:
         destinations:
           192.168.200.10: null
           10.0.200.90: null
-        source_interface: Management1
+        source_interface: '{{ switch.mgmt_interface }}'
 ethernet_interfaces:
   Ethernet1:
     peer: DC1-SPINE1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_FABRIC.yml
@@ -157,7 +157,9 @@ l3leaf:
               destinations:
                 192.168.200.10:
                 10.0.200.90:
-              source_interface: Management1
+              # Testing custom_structured_configuration using inline jinja with switch.x facts.
+              # Common customer use case, so we should make sure this does not break.
+              source_interface: "{{ switch.mgmt_interface }}"
       # NB - uplink_switch_interfaces Ethernet19-21 are used by MH_LEAF1A, 1B and 2A.
       nodes:
         DC1-BL1A:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/DC1-BL1A.yml
@@ -36,3 +36,18 @@ timezone: "{{ template_timezone }}"
 # Test Mac address table variables
 mac_address_table:
   aging_time: 42
+
+# Testing custom_structured_configuration setting a dict key from inline jinja with switch.x facts.
+# Rare customer use case, but known to be in the field, so we should make sure this does not break.
+#
+# Unless switch.x is available in hostvars when yaml_templates_to_facts run, this will _overwrite_ the
+# dict (aging_time: 42 will disappear), since the unresolved jinja will be seen as a string,
+# so combine is not possible.
+#
+# TODO: Refactor custom_structured_configuration_ to Python and load switch facts from avd_switch_facts
+# _before_ performing input data templating. Then we can remove switch facts from global vars
+my_mac_address_table:
+  notification_host_flap:
+    logging: "{{ switch.id == 6 }}"
+
+override_mac_address_table: "{{ my_mac_address_table }}"

--- a/ansible_collections/arista/avd/plugins/action/yaml_templates_to_facts.py
+++ b/ansible_collections/arista/avd/plugins/action/yaml_templates_to_facts.py
@@ -17,7 +17,7 @@ from ansible.utils.vars import isidentifier
 from ansible_collections.arista.avd.plugins.plugin_utils.avdfacts import AvdFacts
 from ansible_collections.arista.avd.plugins.plugin_utils.merge import merge
 from ansible_collections.arista.avd.plugins.plugin_utils.strip_empties import strip_null_from_data
-from ansible_collections.arista.avd.plugins.plugin_utils.utils import AristaAvdError, compile_searchpath, get
+from ansible_collections.arista.avd.plugins.plugin_utils.utils import AristaAvdError, compile_searchpath
 from ansible_collections.arista.avd.plugins.plugin_utils.utils import template as templater
 
 DEFAULT_PYTHON_CLASS_NAME = "AvdStructuredConfig"
@@ -79,20 +79,16 @@ class ActionModule(ActionBase):
         searchpath = compile_searchpath(task_vars.get("ansible_search_path"))
         templar = self._templar.copy_with_new_env(searchpath=searchpath, available_variables={})
 
-        hostname = task_vars["inventory_hostname"]
-        switch_facts = get(task_vars, f"avd_switch_facts..{hostname}", default={}, separator="..")
-
         # If the argument 'root_key' is set, output will be assigned to this variable. If not set, the output will be set at as "root" variables.
         # We use ChainMap to avoid copying large amounts of data around, mapping in
         #  - output or { root_key: output }
-        #  - eos_designs_facts for this switch
         #  - templated version of all other vars
         # Any var assignments will end up in output, so all other objects are protected.
         output = {}
         if root_key:
-            template_vars = ChainMap({root_key: output}, switch_facts, task_vars)
+            template_vars = ChainMap({root_key: output}, task_vars)
         else:
-            template_vars = ChainMap(output, switch_facts, task_vars)
+            template_vars = ChainMap(output, task_vars)
 
         # If the argument 'debug' is set, a 'avd_yaml_templates_to_facts_debug' list will be added to the output.
         # This list contains timestamps from every step for every template. This is useful for identifying slow templates.

--- a/ansible_collections/arista/avd/roles/eos_designs/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/tasks/main.yml
@@ -39,6 +39,13 @@
   check_mode: false
   run_once: true
 
+- name: Set eos_designs facts per device
+  tags: [build, provision, facts]
+  ansible.builtin.set_fact:
+    switch: "{{ avd_switch_facts[inventory_hostname].switch }}"
+  delegate_to: localhost
+  changed_when: false
+
 - name: Generate YAML file with hostvars (only for debugging)
   tags: [debug, never]
   ansible.builtin.template:


### PR DESCRIPTION
- Revert removing switch.x facts from the global variables
- Add test coverage for various corner cases where this removal caused issues.

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
