### PR TITLE
Feat(eos_cli_config_gen): Add schema for qos

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -2405,6 +2405,36 @@ prefix_lists:
 prompt: <str>
 ```
 
+## Qos
+
+### Variables
+
+| Variable | Type | Required | Default | Value Restrictions | Description |
+| -------- | ---- | -------- | ------- | ------------------ | ----------- |
+| [<samp>qos</samp>](## "qos") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;map</samp>](## "qos.map") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;cos</samp>](## "qos.map.cos") | List, items: String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "qos.map.cos.[].&lt;str&gt;") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;dscp</samp>](## "qos.map.dscp") | List, items: String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "qos.map.dscp.[].&lt;str&gt;") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;traffic_class</samp>](## "qos.map.traffic_class") | List, items: String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "qos.map.traffic_class.[].&lt;str&gt;") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;rewrite_dscp</samp>](## "qos.rewrite_dscp") | Boolean |  |  |  |  |
+
+### YAML
+
+```yaml
+qos:
+  map:
+    cos:
+      - <str>
+    dscp:
+      - <str>
+    traffic_class:
+      - <str>
+  rewrite_dscp: <bool>
+```
+
 ## QOS Profiles
 
 ### Variables

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -2405,21 +2405,21 @@ prefix_lists:
 prompt: <str>
 ```
 
-## Qos
+## QOS
 
 ### Variables
 
 | Variable | Type | Required | Default | Value Restrictions | Description |
 | -------- | ---- | -------- | ------- | ------------------ | ----------- |
-| [<samp>qos</samp>](## "qos") | Dictionary |  |  |  |  |
+| [<samp>qos</samp>](## "qos") | Dictionary |  |  |  | QOS |
 | [<samp>&nbsp;&nbsp;map</samp>](## "qos.map") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;cos</samp>](## "qos.map.cos") | List, items: String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "qos.map.cos.[].&lt;str&gt;") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;dscp</samp>](## "qos.map.dscp") | List, items: String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "qos.map.dscp.[].&lt;str&gt;") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;cos</samp>](## "qos.map.cos") | List, items: String |  |  |  | COS |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "qos.map.cos.[].&lt;str&gt;") | String |  |  |  | Example: "0 1 to traffic-class 1"<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;dscp</samp>](## "qos.map.dscp") | List, items: String |  |  |  | DSCP |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "qos.map.dscp.[].&lt;str&gt;") | String |  |  |  | Example: "8 9 10 to traffic-class 1"<br> |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;traffic_class</samp>](## "qos.map.traffic_class") | List, items: String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "qos.map.traffic_class.[].&lt;str&gt;") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;rewrite_dscp</samp>](## "qos.rewrite_dscp") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "qos.map.traffic_class.[].&lt;str&gt;") | String |  |  |  | Example: "1 to dscp 32"<br> |
+| [<samp>&nbsp;&nbsp;rewrite_dscp</samp>](## "qos.rewrite_dscp") | Boolean |  |  |  | Rewrite DSCP |
 
 ### YAML
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -4100,6 +4100,45 @@
       "type": "string",
       "title": "Prompt"
     },
+    "qos": {
+      "type": "object",
+      "properties": {
+        "map": {
+          "type": "object",
+          "properties": {
+            "cos": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "title": "Cos"
+            },
+            "dscp": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "title": "Dscp"
+            },
+            "traffic_class": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "title": "Traffic Class"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Map"
+        },
+        "rewrite_dscp": {
+          "type": "boolean",
+          "title": "Rewrite Dscp"
+        }
+      },
+      "additionalProperties": false,
+      "title": "Qos"
+    },
     "qos_profiles": {
       "type": "array",
       "title": "QOS Profiles",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -4102,28 +4102,32 @@
     },
     "qos": {
       "type": "object",
+      "title": "QOS",
       "properties": {
         "map": {
           "type": "object",
           "properties": {
             "cos": {
               "type": "array",
+              "title": "COS",
               "items": {
-                "type": "string"
-              },
-              "title": "Cos"
+                "type": "string",
+                "description": "Example: \"0 1 to traffic-class 1\"\n"
+              }
             },
             "dscp": {
               "type": "array",
+              "title": "DSCP",
               "items": {
-                "type": "string"
-              },
-              "title": "Dscp"
+                "type": "string",
+                "description": "Example: \"8 9 10 to traffic-class 1\"\n"
+              }
             },
             "traffic_class": {
               "type": "array",
               "items": {
-                "type": "string"
+                "type": "string",
+                "description": "Example: \"1 to dscp 32\"\n"
               },
               "title": "Traffic Class"
             }
@@ -4132,12 +4136,11 @@
           "title": "Map"
         },
         "rewrite_dscp": {
-          "type": "boolean",
-          "title": "Rewrite Dscp"
+          "title": "Rewrite DSCP",
+          "type": "boolean"
         }
       },
-      "additionalProperties": false,
-      "title": "Qos"
+      "additionalProperties": false
     },
     "qos_profiles": {
       "type": "array",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -3096,6 +3096,26 @@ keys:
                   Example: "permit 10.255.0.0/27 eq 32"'
   prompt:
     type: str
+  qos:
+    type: dict
+    keys:
+      map:
+        type: dict
+        keys:
+          cos:
+            type: list
+            items:
+              type: str
+          dscp:
+            type: list
+            items:
+              type: str
+          traffic_class:
+            type: list
+            items:
+              type: str
+      rewrite_dscp:
+        type: bool
   qos_profiles:
     type: list
     display_name: QOS Profiles

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -3098,23 +3098,36 @@ keys:
     type: str
   qos:
     type: dict
+    display_name: QOS
     keys:
       map:
         type: dict
         keys:
           cos:
             type: list
+            display_name: COS
             items:
               type: str
+              description: 'Example: "0 1 to traffic-class 1"
+
+                '
           dscp:
             type: list
+            display_name: DSCP
             items:
               type: str
+              description: 'Example: "8 9 10 to traffic-class 1"
+
+                '
           traffic_class:
             type: list
             items:
               type: str
+              description: 'Example: "1 to dscp 32"
+
+                '
       rewrite_dscp:
+        display_name: Rewrite DSCP
         type: bool
   qos_profiles:
     type: list

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/qos.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/qos.schema.yml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  qos:
+    type: dict
+    keys:
+      map:
+        type: dict
+        keys:
+          cos:
+            type: list
+            items:
+              type: str
+          dscp:
+            type: list
+            items:
+              type: str
+          traffic_class:
+            type: list
+            items:
+              type: str
+      rewrite_dscp:
+        type: bool

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/qos.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/qos.schema.yml
@@ -5,21 +5,31 @@ type: dict
 keys:
   qos:
     type: dict
+    display_name: QOS
     keys:
       map:
         type: dict
         keys:
           cos:
             type: list
+            display_name: COS
             items:
               type: str
+              description: |
+                Example: "0 1 to traffic-class 1"
           dscp:
             type: list
+            display_name: DSCP
             items:
               type: str
+              description: |
+                Example: "8 9 10 to traffic-class 1"
           traffic_class:
             type: list
             items:
               type: str
+              description: |
+                Example: "1 to dscp 32"
       rewrite_dscp:
+        display_name: Rewrite DSCP
         type: bool


### PR DESCRIPTION
## Add schema for data model

<!-- Use this PR Title: Feat(eos_cli_config_gen): Add schema for < data_model_key > -->

## Checklist

### Contributor Checklist

- [x] Create schema fragment matching data model described in README.md and README_v4.0.md
  - README.md is most complete with all keys. README_v4.0 includes partial data models after conversion to lists.
  - Schema fragment path is `roles/eos_cli_config_gen/schemas/schema_fragments/<data_model_key>.schema.yml`.
  - Copy line 1-5 from another schema (comments and outer type:dict).
  - Refer to [schema documentation](https://avd.sh/en/devel/docs/input-variable-validation-BETA.html) for syntax and/or use YAML Lint plugin from Redhat in VSCode.
  - Use `convert_types` on value that could be mixed type or misinterpreted like integers and numeric strings.
- [x] If the data model has been converted from wildcard dicts:
  - Add `convert_types: ['dict']` to the schema.
  - Remove `convert_dicts` from the `templates/eos/<>.j2` and `templates/documentation/<>.j2` templates.
- [x] Run `molecule converge -s build_schemas_and_docs` to update schema and documentation.
- [x] Test by running `molecule converge -s eos_cli_config_gen` and verify no errors or changes to generated configs/docs.

### Reviewer Checklist

- Reviewer 1: Carl
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2: Claus
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
