### PR TITLE
Feat(eos_cli_config_gen): Add schema for queue_monitor_length

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -2078,7 +2078,7 @@ prefix_lists:
 | [<samp>&nbsp;&nbsp;notifying</samp>](## "queue_monitor_length.notifying") | Boolean |  |  |  | should only be used for platforms supporting the "queue-monitor length notifying" CLI |
 | [<samp>&nbsp;&nbsp;cpu</samp>](## "queue_monitor_length.cpu") | Dictionary |  |  |  | CPU |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;thresholds</samp>](## "queue_monitor_length.cpu.thresholds") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;high</samp>](## "queue_monitor_length.cpu.thresholds.high") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;high</samp>](## "queue_monitor_length.cpu.thresholds.high") | Integer | Required |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;low</samp>](## "queue_monitor_length.cpu.thresholds.low") | Integer |  |  |  |  |
 
 ### YAML

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -2073,10 +2073,10 @@ prefix_lists:
 | Variable | Type | Required | Default | Value Restrictions | Description |
 | -------- | ---- | -------- | ------- | ------------------ | ----------- |
 | [<samp>queue_monitor_length</samp>](## "queue_monitor_length") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;enabled</samp>](## "queue_monitor_length.enabled") | Boolean |  |  |  |  |
-| [<samp>&nbsp;&nbsp;log</samp>](## "queue_monitor_length.log") | Integer |  |  |  |  |
-| [<samp>&nbsp;&nbsp;notifying</samp>](## "queue_monitor_length.notifying") | Boolean |  |  |  |  |
-| [<samp>&nbsp;&nbsp;cpu</samp>](## "queue_monitor_length.cpu") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;enabled</samp>](## "queue_monitor_length.enabled") | Boolean |  |  |  | "enabled: true" will be required in AVD4.0.<br>In AVD3.x default is true as long as queue_monitor_length is defined and not None<br> |
+| [<samp>&nbsp;&nbsp;log</samp>](## "queue_monitor_length.log") | Integer |  |  |  | Logging interval in seconds |
+| [<samp>&nbsp;&nbsp;notifying</samp>](## "queue_monitor_length.notifying") | Boolean |  |  |  | should only be used for platforms supporting the "queue-monitor length notifying" CLI |
+| [<samp>&nbsp;&nbsp;cpu</samp>](## "queue_monitor_length.cpu") | Dictionary |  |  |  | CPU |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;thresholds</samp>](## "queue_monitor_length.cpu.thresholds") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;high</samp>](## "queue_monitor_length.cpu.thresholds.high") | Integer |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;low</samp>](## "queue_monitor_length.cpu.thresholds.low") | Integer |  |  |  |  |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -2066,6 +2066,34 @@ prefix_lists:
         action: <str>
 ```
 
+## Queue Monitor Length
+
+### Variables
+
+| Variable | Type | Required | Default | Value Restrictions | Description |
+| -------- | ---- | -------- | ------- | ------------------ | ----------- |
+| [<samp>queue_monitor_length</samp>](## "queue_monitor_length") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;enabled</samp>](## "queue_monitor_length.enabled") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;log</samp>](## "queue_monitor_length.log") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;notifying</samp>](## "queue_monitor_length.notifying") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;cpu</samp>](## "queue_monitor_length.cpu") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;thresholds</samp>](## "queue_monitor_length.cpu.thresholds") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;high</samp>](## "queue_monitor_length.cpu.thresholds.high") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;low</samp>](## "queue_monitor_length.cpu.thresholds.low") | Integer |  |  |  |  |
+
+### YAML
+
+```yaml
+queue_monitor_length:
+  enabled: <bool>
+  log: <int>
+  notifying: <bool>
+  cpu:
+    thresholds:
+      high: <int>
+      low: <int>
+```
+
 ## Redundancy
 
 ### Variables

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -3362,6 +3362,47 @@
       },
       "title": "Prefix Lists"
     },
+    "queue_monitor_length": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "title": "Enabled"
+        },
+        "log": {
+          "type": "integer",
+          "title": "Log"
+        },
+        "notifying": {
+          "type": "boolean",
+          "title": "Notifying"
+        },
+        "cpu": {
+          "type": "object",
+          "properties": {
+            "thresholds": {
+              "type": "object",
+              "properties": {
+                "high": {
+                  "type": "integer",
+                  "title": "High"
+                },
+                "low": {
+                  "type": "integer",
+                  "title": "Low"
+                }
+              },
+              "additionalProperties": false,
+              "title": "Thresholds"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Cpu"
+        }
+      },
+      "additionalProperties": false,
+      "title": "Queue Monitor Length"
+    },
     "redundancy": {
       "type": "object",
       "properties": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -3367,18 +3367,22 @@
       "properties": {
         "enabled": {
           "type": "boolean",
+          "description": "\"enabled: true\" will be required in AVD4.0.\nIn AVD3.x default is true as long as queue_monitor_length is defined and not None\n",
           "title": "Enabled"
         },
         "log": {
           "type": "integer",
+          "description": "Logging interval in seconds",
           "title": "Log"
         },
         "notifying": {
           "type": "boolean",
+          "description": "should only be used for platforms supporting the \"queue-monitor length notifying\" CLI",
           "title": "Notifying"
         },
         "cpu": {
           "type": "object",
+          "title": "CPU",
           "properties": {
             "thresholds": {
               "type": "object",
@@ -3396,8 +3400,7 @@
               "title": "Thresholds"
             }
           },
-          "additionalProperties": false,
-          "title": "Cpu"
+          "additionalProperties": false
         }
       },
       "additionalProperties": false,

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -3396,6 +3396,9 @@
                   "title": "Low"
                 }
               },
+              "required": [
+                "high"
+              ],
               "additionalProperties": false,
               "title": "Thresholds"
             }

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -2588,20 +2588,36 @@ keys:
     keys:
       enabled:
         type: bool
+        description: '"enabled: true" will be required in AVD4.0.
+
+          In AVD3.x default is true as long as queue_monitor_length is defined and
+          not None
+
+          '
       log:
         type: int
+        convert_types:
+        - str
+        description: Logging interval in seconds
       notifying:
         type: bool
+        description: should only be used for platforms supporting the "queue-monitor
+          length notifying" CLI
       cpu:
         type: dict
+        display_name: CPU
         keys:
           thresholds:
             type: dict
             keys:
               high:
                 type: int
+                convert_types:
+                - str
               low:
                 type: int
+                convert_types:
+                - str
   redundancy:
     type: dict
     keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -2583,6 +2583,25 @@ keys:
                 description: 'Action as string
 
                   Example: "permit 10.255.0.0/27 eq 32"'
+  queue_monitor_length:
+    type: dict
+    keys:
+      enabled:
+        type: bool
+      log:
+        type: int
+      notifying:
+        type: bool
+      cpu:
+        type: dict
+        keys:
+          thresholds:
+            type: dict
+            keys:
+              high:
+                type: int
+              low:
+                type: int
   redundancy:
     type: dict
     keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -410,14 +410,14 @@ keys:
   custom_templates:
     type: list
     display_name: Extensibility with Custom Templates
-    description: "- Custom templates can be added below the playbook directory.\n\
-      - If a location above the directory is desired, a symbolic link can be used.\n\
-      - Example under the `playbooks` directory create symbolic link with the following\
-      \ command:\n\n  ```bash\n  ln -s ../../shared_repo/custom_avd_templates/ ./custom_avd_templates\n\
-      \  ```\n\n- The output will be rendered at the end of the configuration.\n-\
-      \ The order of custom templates in the list can be important if they overlap.\n\
-      - It is recommenended to use a `!` delimiter at the top of each custom template.\n\
-      \nAdd `custom_templates` to group/host variables:\n"
+    description: "- Custom templates can be added below the playbook directory.\n-
+      If a location above the directory is desired, a symbolic link can be used.\n-
+      Example under the `playbooks` directory create symbolic link with the following
+      command:\n\n  ```bash\n  ln -s ../../shared_repo/custom_avd_templates/ ./custom_avd_templates\n
+      \ ```\n\n- The output will be rendered at the end of the configuration.\n- The
+      order of custom templates in the list can be important if they overlap.\n- It
+      is recommenended to use a `!` delimiter at the top of each custom template.\n\nAdd
+      `custom_templates` to group/host variables:\n"
     items:
       type: str
       description: Template relative path below playbook directory
@@ -456,12 +456,12 @@ keys:
   daemon_terminattr:
     type: dict
     display_name: Daemon TerminAttr
-    description: "You can either provide a list of IPs/FQDNs to target on-premise\
-      \ Cloudvision cluster or use DNS name for your Cloudvision as a Service instance.\n\
-      Streaming to multiple clusters both on-prem and cloud service is supported.\n\
-      > Note For TerminAttr version recommendation and EOS compatibility matrix, please\
-      \ refer to the latest TerminAttr Release Notes\n  which always contain the latest\
-      \ recommended versions and minimum required versions per EOS release.\n"
+    description: "You can either provide a list of IPs/FQDNs to target on-premise
+      Cloudvision cluster or use DNS name for your Cloudvision as a Service instance.\nStreaming
+      to multiple clusters both on-prem and cloud service is supported.\n> Note For
+      TerminAttr version recommendation and EOS compatibility matrix, please refer
+      to the latest TerminAttr Release Notes\n  which always contain the latest recommended
+      versions and minimum required versions per EOS release.\n"
     keys:
       cvaddrs:
         type: list
@@ -1108,15 +1108,15 @@ keys:
     convert_types:
     - dict
     display_name: IP Community Lists
-    description: "AVD supports 2 different data models for community lists:\n\n- The\
-      \ legacy `community_lists` data model that can be used for compatibility with\
-      \ the existing deployments.\n- The improved `ip_community_lists` data model.\n\
-      \nBoth data models can coexist without conflicts, as different keys are used:\
-      \ `community_lists` vs `ip_community_lists`.\nCommunity list names must be unique.\n\
-      \nThe improved data model has a better design documented below:\n\ncommunities\
-      \ and regexp MUST not be configured together in the same entry\npossible community\
-      \ strings are (case insensitive):\n - GSHUT\n - internet\n - local-as\n - no-advertise\n\
-      \ - no-export\n - <1-4294967040>\n - aa:nn\n"
+    description: "AVD supports 2 different data models for community lists:\n\n- The
+      legacy `community_lists` data model that can be used for compatibility with
+      the existing deployments.\n- The improved `ip_community_lists` data model.\n\nBoth
+      data models can coexist without conflicts, as different keys are used: `community_lists`
+      vs `ip_community_lists`.\nCommunity list names must be unique.\n\nThe improved
+      data model has a better design documented below:\n\ncommunities and regexp MUST
+      not be configured together in the same entry\npossible community strings are
+      (case insensitive):\n - GSHUT\n - internet\n - local-as\n - no-advertise\n -
+      no-export\n - <1-4294967040>\n - aa:nn\n"
     items:
       type: dict
       keys:
@@ -2319,12 +2319,12 @@ keys:
               type: str
         rate_limit_per_ingress_chip:
           type: str
-          description: "Ratelimit and unit as string.\nExamples:\n  \"100000 bps\"\
-            \n  \"100 kbps\"\n  \"10 mbps\"\n"
+          description: "Ratelimit and unit as string.\nExamples:\n  \"100000 bps\"\n
+            \ \"100 kbps\"\n  \"10 mbps\"\n"
         rate_limit_per_egress_chip:
           type: str
-          description: "Ratelimit and unit as string.\nExamples:\n  \"100000 bps\"\
-            \n  \"100 kbps\"\n  \"10 mbps\"\n"
+          description: "Ratelimit and unit as string.\nExamples:\n  \"100000 bps\"\n
+            \ \"100 kbps\"\n  \"10 mbps\"\n"
         sample:
           type: int
           convert_types:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -410,14 +410,14 @@ keys:
   custom_templates:
     type: list
     display_name: Extensibility with Custom Templates
-    description: "- Custom templates can be added below the playbook directory.\n-
-      If a location above the directory is desired, a symbolic link can be used.\n-
-      Example under the `playbooks` directory create symbolic link with the following
-      command:\n\n  ```bash\n  ln -s ../../shared_repo/custom_avd_templates/ ./custom_avd_templates\n
-      \ ```\n\n- The output will be rendered at the end of the configuration.\n- The
-      order of custom templates in the list can be important if they overlap.\n- It
-      is recommenended to use a `!` delimiter at the top of each custom template.\n\nAdd
-      `custom_templates` to group/host variables:\n"
+    description: "- Custom templates can be added below the playbook directory.\n\
+      - If a location above the directory is desired, a symbolic link can be used.\n\
+      - Example under the `playbooks` directory create symbolic link with the following\
+      \ command:\n\n  ```bash\n  ln -s ../../shared_repo/custom_avd_templates/ ./custom_avd_templates\n\
+      \  ```\n\n- The output will be rendered at the end of the configuration.\n-\
+      \ The order of custom templates in the list can be important if they overlap.\n\
+      - It is recommenended to use a `!` delimiter at the top of each custom template.\n\
+      \nAdd `custom_templates` to group/host variables:\n"
     items:
       type: str
       description: Template relative path below playbook directory
@@ -456,12 +456,12 @@ keys:
   daemon_terminattr:
     type: dict
     display_name: Daemon TerminAttr
-    description: "You can either provide a list of IPs/FQDNs to target on-premise
-      Cloudvision cluster or use DNS name for your Cloudvision as a Service instance.\nStreaming
-      to multiple clusters both on-prem and cloud service is supported.\n> Note For
-      TerminAttr version recommendation and EOS compatibility matrix, please refer
-      to the latest TerminAttr Release Notes\n  which always contain the latest recommended
-      versions and minimum required versions per EOS release.\n"
+    description: "You can either provide a list of IPs/FQDNs to target on-premise\
+      \ Cloudvision cluster or use DNS name for your Cloudvision as a Service instance.\n\
+      Streaming to multiple clusters both on-prem and cloud service is supported.\n\
+      > Note For TerminAttr version recommendation and EOS compatibility matrix, please\
+      \ refer to the latest TerminAttr Release Notes\n  which always contain the latest\
+      \ recommended versions and minimum required versions per EOS release.\n"
     keys:
       cvaddrs:
         type: list
@@ -1108,15 +1108,15 @@ keys:
     convert_types:
     - dict
     display_name: IP Community Lists
-    description: "AVD supports 2 different data models for community lists:\n\n- The
-      legacy `community_lists` data model that can be used for compatibility with
-      the existing deployments.\n- The improved `ip_community_lists` data model.\n\nBoth
-      data models can coexist without conflicts, as different keys are used: `community_lists`
-      vs `ip_community_lists`.\nCommunity list names must be unique.\n\nThe improved
-      data model has a better design documented below:\n\ncommunities and regexp MUST
-      not be configured together in the same entry\npossible community strings are
-      (case insensitive):\n - GSHUT\n - internet\n - local-as\n - no-advertise\n -
-      no-export\n - <1-4294967040>\n - aa:nn\n"
+    description: "AVD supports 2 different data models for community lists:\n\n- The\
+      \ legacy `community_lists` data model that can be used for compatibility with\
+      \ the existing deployments.\n- The improved `ip_community_lists` data model.\n\
+      \nBoth data models can coexist without conflicts, as different keys are used:\
+      \ `community_lists` vs `ip_community_lists`.\nCommunity list names must be unique.\n\
+      \nThe improved data model has a better design documented below:\n\ncommunities\
+      \ and regexp MUST not be configured together in the same entry\npossible community\
+      \ strings are (case insensitive):\n - GSHUT\n - internet\n - local-as\n - no-advertise\n\
+      \ - no-export\n - <1-4294967040>\n - aa:nn\n"
     items:
       type: dict
       keys:
@@ -2319,12 +2319,12 @@ keys:
               type: str
         rate_limit_per_ingress_chip:
           type: str
-          description: "Ratelimit and unit as string.\nExamples:\n  \"100000 bps\"\n
-            \ \"100 kbps\"\n  \"10 mbps\"\n"
+          description: "Ratelimit and unit as string.\nExamples:\n  \"100000 bps\"\
+            \n  \"100 kbps\"\n  \"10 mbps\"\n"
         rate_limit_per_egress_chip:
           type: str
-          description: "Ratelimit and unit as string.\nExamples:\n  \"100000 bps\"\n
-            \ \"100 kbps\"\n  \"10 mbps\"\n"
+          description: "Ratelimit and unit as string.\nExamples:\n  \"100000 bps\"\
+            \n  \"100 kbps\"\n  \"10 mbps\"\n"
         sample:
           type: int
           convert_types:
@@ -2612,6 +2612,7 @@ keys:
             keys:
               high:
                 type: int
+                required: true
                 convert_types:
                 - str
               low:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/queue_monitor_length.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/queue_monitor_length.schema.yml
@@ -8,17 +8,29 @@ keys:
     keys:
       enabled:
         type: bool
+        description: |
+          "enabled: true" will be required in AVD4.0.
+          In AVD3.x default is true as long as queue_monitor_length is defined and not None
       log:
         type: int
+        convert_types:
+          - str
+        description: "Logging interval in seconds"
       notifying:
         type: bool
+        description: should only be used for platforms supporting the "queue-monitor length notifying" CLI
       cpu:
         type: dict
+        display_name: CPU
         keys:
           thresholds:
             type: dict
             keys:
               high:
                 type: int
+                convert_types:
+                  - str
               low:
                 type: int
+                convert_types:
+                  - str

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/queue_monitor_length.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/queue_monitor_length.schema.yml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  queue_monitor_length:
+    type: dict
+    keys:
+      enabled:
+        type: bool
+      log:
+        type: int
+      notifying:
+        type: bool
+      cpu:
+        type: dict
+        keys:
+          thresholds:
+            type: dict
+            keys:
+              high:
+                type: int
+              low:
+                type: int

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/queue_monitor_length.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/queue_monitor_length.schema.yml
@@ -28,6 +28,7 @@ keys:
             keys:
               high:
                 type: int
+                required: true
                 convert_types:
                   - str
               low:


### PR DESCRIPTION
## Add schema for data model

<!-- Use this PR Title: Feat(eos_cli_config_gen): Add schema for < data_model_key > -->

## Checklist

### Contributor Checklist

- [x] Create schema fragment matching data model described in README.md and README_v4.0.md
  - README.md is most complete with all keys. README_v4.0 includes partial data models after conversion to lists.
  - Schema fragment path is `roles/eos_cli_config_gen/schemas/schema_fragments/<data_model_key>.schema.yml`.
  - Copy line 1-5 from another schema (comments and outer type:dict).
  - Refer to [schema documentation](https://avd.sh/en/devel/docs/input-variable-validation-BETA.html) for syntax and/or use YAML Lint plugin from Redhat in VSCode.
  - Use `convert_types` on value that could be mixed type or misinterpreted like integers and numeric strings.
- [x] If the data model has been converted from wildcard dicts:
  - Add `convert_types: ['dict']` to the schema.
  - Remove `convert_dicts` from the `templates/eos/<>.j2` and `templates/documentation/<>.j2` templates.
- [x] Run `molecule converge -s build_schemas_and_docs` to update schema and documentation.
- [x] Test by running `molecule converge -s eos_cli_config_gen` and verify no errors or changes to generated configs/docs.

### Reviewer Checklist

- Reviewer 1:
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2:
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
