### PR TITLE
Feat(eos_cli_config_gen): Add schema for queue_monitor_streaming

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -2203,9 +2203,9 @@ queue_monitor_length:
 | -------- | ---- | -------- | ------- | ------------------ | ----------- |
 | [<samp>queue_monitor_streaming</samp>](## "queue_monitor_streaming") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;enable</samp>](## "queue_monitor_streaming.enable") | Boolean |  |  |  |  |
-| [<samp>&nbsp;&nbsp;ip_access_group</samp>](## "queue_monitor_streaming.ip_access_group") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;ipv6_access_group</samp>](## "queue_monitor_streaming.ipv6_access_group") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;max_connections</samp>](## "queue_monitor_streaming.max_connections") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;ip_access_group</samp>](## "queue_monitor_streaming.ip_access_group") | String |  |  |  | IP Access Group<br>Name of IP ACL |
+| [<samp>&nbsp;&nbsp;ipv6_access_group</samp>](## "queue_monitor_streaming.ipv6_access_group") | String |  |  |  | IPv6 Access Group<br>Name of IPv6 ACL |
+| [<samp>&nbsp;&nbsp;max_connections</samp>](## "queue_monitor_streaming.max_connections") | Integer |  |  | Min: 1<br>Max: 100 |  |
 | [<samp>&nbsp;&nbsp;vrf</samp>](## "queue_monitor_streaming.vrf") | String |  |  |  | VRF |
 
 ### YAML

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -2195,6 +2195,30 @@ queue_monitor_length:
       low: <int>
 ```
 
+## Queue Monitor Streaming
+
+### Variables
+
+| Variable | Type | Required | Default | Value Restrictions | Description |
+| -------- | ---- | -------- | ------- | ------------------ | ----------- |
+| [<samp>queue_monitor_streaming</samp>](## "queue_monitor_streaming") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;enable</samp>](## "queue_monitor_streaming.enable") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;ip_access_group</samp>](## "queue_monitor_streaming.ip_access_group") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;ipv6_access_group</samp>](## "queue_monitor_streaming.ipv6_access_group") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;max_connections</samp>](## "queue_monitor_streaming.max_connections") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;vrf</samp>](## "queue_monitor_streaming.vrf") | String |  |  |  | VRF |
+
+### YAML
+
+```yaml
+queue_monitor_streaming:
+  enable: <bool>
+  ip_access_group: <str>
+  ipv6_access_group: <str>
+  max_connections: <int>
+  vrf: <str>
+```
+
 ## Redundancy
 
 ### Variables

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -3560,14 +3560,18 @@
         },
         "ip_access_group": {
           "type": "string",
-          "title": "Ip Access Group"
+          "title": "IP Access Group",
+          "description": "Name of IP ACL"
         },
         "ipv6_access_group": {
           "type": "string",
-          "title": "Ipv6 Access Group"
+          "title": "IPv6 Access Group",
+          "description": "Name of IPv6 ACL"
         },
         "max_connections": {
           "type": "integer",
+          "minimum": 1,
+          "maximum": 100,
           "title": "Max Connections"
         },
         "vrf": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -3551,6 +3551,33 @@
       "additionalProperties": false,
       "title": "Queue Monitor Length"
     },
+    "queue_monitor_streaming": {
+      "type": "object",
+      "properties": {
+        "enable": {
+          "type": "boolean",
+          "title": "Enable"
+        },
+        "ip_access_group": {
+          "type": "string",
+          "title": "Ip Access Group"
+        },
+        "ipv6_access_group": {
+          "type": "string",
+          "title": "Ipv6 Access Group"
+        },
+        "max_connections": {
+          "type": "integer",
+          "title": "Max Connections"
+        },
+        "vrf": {
+          "type": "string",
+          "title": "VRF"
+        }
+      },
+      "additionalProperties": false,
+      "title": "Queue Monitor Streaming"
+    },
     "redundancy": {
       "type": "object",
       "properties": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -2725,6 +2725,20 @@ keys:
                 type: int
                 convert_types:
                 - str
+  queue_monitor_streaming:
+    type: dict
+    keys:
+      enable:
+        type: bool
+      ip_access_group:
+        type: str
+      ipv6_access_group:
+        type: str
+      max_connections:
+        type: int
+      vrf:
+        type: str
+        display_name: VRF
   redundancy:
     type: dict
     keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -2732,10 +2732,18 @@ keys:
         type: bool
       ip_access_group:
         type: str
+        display_name: IP Access Group
+        description: Name of IP ACL
       ipv6_access_group:
         type: str
+        display_name: IPv6 Access Group
+        description: Name of IPv6 ACL
       max_connections:
         type: int
+        convert_types:
+        - str
+        min: 1
+        max: 100
       vrf:
         type: str
         display_name: VRF

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/queue_monitor_streaming.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/queue_monitor_streaming.schema.yml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  queue_monitor_streaming:
+    type: dict
+    keys:
+      enable:
+        type: bool
+      ip_access_group:
+        type: str
+      ipv6_access_group:
+        type: str
+      max_connections:
+        type: int
+      vrf:
+        type: str
+        display_name: VRF          

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/queue_monitor_streaming.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/queue_monitor_streaming.schema.yml
@@ -10,10 +10,18 @@ keys:
         type: bool
       ip_access_group:
         type: str
+        display_name: IP Access Group
+        description: Name of IP ACL
       ipv6_access_group:
         type: str
+        display_name: IPv6 Access Group
+        description: Name of IPv6 ACL
       max_connections:
         type: int
+        convert_types:
+          - str
+        min: 1
+        max: 100
       vrf:
         type: str
         display_name: VRF

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/queue_monitor_streaming.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/queue_monitor_streaming.schema.yml
@@ -16,4 +16,4 @@ keys:
         type: int
       vrf:
         type: str
-        display_name: VRF          
+        display_name: VRF


### PR DESCRIPTION
## Add schema for data model

<!-- Use this PR Title: Feat(eos_cli_config_gen): Add schema for < data_model_key > -->

## Checklist

### Contributor Checklist

- [x] Create schema fragment matching data model described in README.md and README_v4.0.md
  - README.md is most complete with all keys. README_v4.0 includes partial data models after conversion to lists.
  - Schema fragment path is `roles/eos_cli_config_gen/schemas/schema_fragments/<data_model_key>.schema.yml`.
  - Copy line 1-5 from another schema (comments and outer type:dict).
  - Refer to [schema documentation](https://avd.sh/en/devel/docs/input-variable-validation-BETA.html) for syntax and/or use YAML Lint plugin from Redhat in VSCode.
  - Use `convert_types` on value that could be mixed type or misinterpreted like integers and numeric strings.
- [x] If the data model has been converted from wildcard dicts:
  - Add `convert_types: ['dict']` to the schema.
  - Remove `convert_dicts` from the `templates/eos/<>.j2` and `templates/documentation/<>.j2` templates.
- [x] Run `molecule converge -s build_schemas_and_docs` to update schema and documentation.
- [x] Test by running `molecule converge -s eos_cli_config_gen` and verify no errors or changes to generated configs/docs.

### Reviewer Checklist

- Reviewer 1:
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2: Carl
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
