### PR TITLE
Feat(eos_cli_config_gen): Add schema for arp

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -133,6 +133,24 @@ access_lists:
         action: <str>
 ```
 
+## Arp
+
+### Variables
+
+| Variable | Type | Required | Default | Value Restrictions | Description |
+| -------- | ---- | -------- | ------- | ------------------ | ----------- |
+| [<samp>arp</samp>](## "arp") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;aging</samp>](## "arp.aging") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;timeout_default</samp>](## "arp.aging.timeout_default") | Integer |  |  |  |  |
+
+### YAML
+
+```yaml
+arp:
+  aging:
+    timeout_default: <int>
+```
+
 ## As Path
 
 ### Variables

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -133,15 +133,15 @@ access_lists:
         action: <str>
 ```
 
-## Arp
+## ARP
 
 ### Variables
 
 | Variable | Type | Required | Default | Value Restrictions | Description |
 | -------- | ---- | -------- | ------- | ------------------ | ----------- |
-| [<samp>arp</samp>](## "arp") | Dictionary |  |  |  |  |
+| [<samp>arp</samp>](## "arp") | Dictionary |  |  |  | ARP |
 | [<samp>&nbsp;&nbsp;aging</samp>](## "arp.aging") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;timeout_default</samp>](## "arp.aging.timeout_default") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;timeout_default</samp>](## "arp.aging.timeout_default") | Integer |  |  | Min: 60<br>Max: 65535 | Timeout in seconds |
 
 ### YAML
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -224,13 +224,17 @@
       }
     },
     "arp": {
+      "title": "ARP",
       "type": "object",
       "properties": {
         "aging": {
           "type": "object",
           "properties": {
             "timeout_default": {
+              "description": "Timeout in seconds",
               "type": "integer",
+              "minimum": 60,
+              "maximum": 65535,
               "title": "Timeout Default"
             }
           },
@@ -238,8 +242,7 @@
           "title": "Aging"
         }
       },
-      "additionalProperties": false,
-      "title": "Arp"
+      "additionalProperties": false
     },
     "as_path": {
       "type": "object",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -223,6 +223,24 @@
         "additionalProperties": false
       }
     },
+    "arp": {
+      "type": "object",
+      "properties": {
+        "aging": {
+          "type": "object",
+          "properties": {
+            "timeout_default": {
+              "type": "integer",
+              "title": "Timeout Default"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Aging"
+        }
+      },
+      "additionalProperties": false,
+      "title": "Arp"
+    },
     "as_path": {
       "type": "object",
       "properties": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -221,6 +221,14 @@ keys:
                 description: 'Action as string
 
                   Example: "deny ip any any"'
+  arp:
+    type: dict
+    keys:
+      aging:
+        type: dict
+        keys:
+          timeout_default:
+            type: int
   as_path:
     type: dict
     keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -222,13 +222,17 @@ keys:
 
                   Example: "deny ip any any"'
   arp:
+    display_name: ARP
     type: dict
     keys:
       aging:
         type: dict
         keys:
           timeout_default:
+            description: Timeout in seconds
             type: int
+            min: 60
+            max: 65535
   as_path:
     type: dict
     keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/arp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/arp.schema.yml
@@ -4,10 +4,14 @@
 type: dict
 keys:
   arp:
+    display_name: ARP
     type: dict
     keys:
       aging:
         type: dict
         keys:
           timeout_default:
+            description: Timeout in seconds
             type: int
+            min: 60
+            max: 65535

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/arp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/arp.schema.yml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  arp:
+    type: dict
+    keys:
+      aging:
+        type: dict
+        keys:
+          timeout_default:
+            type: int


### PR DESCRIPTION
## Add schema for data model

<!-- Use this PR Title: Feat(eos_cli_config_gen): Add schema for < data_model_key > -->

## Checklist

### Contributor Checklist

- [x] Create schema fragment matching data model described in README.md and README_v4.0.md
  - README.md is most complete with all keys. README_v4.0 includes partial data models after conversion to lists.
  - Schema fragment path is `roles/eos_cli_config_gen/schemas/schema_fragments/<data_model_key>.schema.yml`.
  - Copy line 1-5 from another schema (comments and outer type:dict).
  - Refer to [schema documentation](https://avd.sh/en/devel/docs/input-variable-validation-BETA.html) for syntax and/or use YAML Lint plugin from Redhat in VSCode.
  - Use `convert_types` on value that could be mixed type or misinterpreted like integers and numeric strings.
- [x] If the data model has been converted from wildcard dicts:
  - Add `convert_types: ['dict']` to the schema.
  - Remove `convert_dicts` from the `templates/eos/<>.j2` and `templates/documentation/<>.j2` templates.
- [x] Run `molecule converge -s build_schemas_and_docs` to update schema and documentation.
- [x] Test by running `molecule converge -s eos_cli_config_gen` and verify no errors or changes to generated configs/docs.

### Reviewer Checklist

- Reviewer 1: Carl
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2:
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
