### PR TITLE
Feat(eos_cli_config_gen): Add schema for ip_virtual_router_mac_address

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -1151,13 +1151,13 @@ ip_ssh_client_source_interfaces:
     vrf: <str>
 ```
 
-## Ip Virtual Router Mac Address
+## IP Virtual Router MAC Address
 
 ### Variables
 
 | Variable | Type | Required | Default | Value Restrictions | Description |
 | -------- | ---- | -------- | ------- | ------------------ | ----------- |
-| [<samp>ip_virtual_router_mac_address</samp>](## "ip_virtual_router_mac_address") | String |  |  |  |  |
+| [<samp>ip_virtual_router_mac_address</samp>](## "ip_virtual_router_mac_address") | String |  |  |  | IP Virtual Router MAC Address |
 
 ### YAML
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -1153,6 +1153,9 @@ ip_ssh_client_source_interfaces:
 
 ## IP Virtual Router MAC Address
 
+### Description
+
+MAC address (hh:hh:hh:hh:hh:hh)
 ### Variables
 
 | Variable | Type | Required | Default | Value Restrictions | Description |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -1151,6 +1151,20 @@ ip_ssh_client_source_interfaces:
     vrf: <str>
 ```
 
+## Ip Virtual Router Mac Address
+
+### Variables
+
+| Variable | Type | Required | Default | Value Restrictions | Description |
+| -------- | ---- | -------- | ------- | ------------------ | ----------- |
+| [<samp>ip_virtual_router_mac_address</samp>](## "ip_virtual_router_mac_address") | String |  |  |  |  |
+
+### YAML
+
+```yaml
+ip_virtual_router_mac_address: <str>
+```
+
 ## IPv6 Extended Access-Lists
 
 ### Variables

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -1628,8 +1628,9 @@
       }
     },
     "ip_virtual_router_mac_address": {
+      "title": "IP Virtual Router MAC Address",
       "type": "string",
-      "title": "IP Virtual Router MAC Address"
+      "description": "MAC address (hh:hh:hh:hh:hh:hh)"
     },
     "ipv6_access_lists": {
       "type": "array",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -1627,6 +1627,10 @@
         "additionalProperties": false
       }
     },
+    "ip_virtual_router_mac_address": {
+      "type": "string",
+      "title": "Ip Virtual Router Mac Address"
+    },
     "ipv6_access_lists": {
       "type": "array",
       "title": "IPv6 Extended Access-Lists",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -1629,7 +1629,7 @@
     },
     "ip_virtual_router_mac_address": {
       "type": "string",
-      "title": "Ip Virtual Router Mac Address"
+      "title": "IP Virtual Router MAC Address"
     },
     "ipv6_access_lists": {
       "type": "array",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -1408,6 +1408,8 @@ keys:
           display_name: VRF
           type: str
           default: default
+  ip_virtual_router_mac_address:
+    type: str
   ipv6_access_lists:
     type: list
     primary_key: name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -1410,6 +1410,7 @@ keys:
           default: default
   ip_virtual_router_mac_address:
     type: str
+    display_name: IP Virtual Router MAC Address
   ipv6_access_lists:
     type: list
     primary_key: name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -1409,8 +1409,9 @@ keys:
           type: str
           default: default
   ip_virtual_router_mac_address:
-    type: str
     display_name: IP Virtual Router MAC Address
+    type: str
+    description: MAC address (hh:hh:hh:hh:hh:hh)
   ipv6_access_lists:
     type: list
     primary_key: name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ip_virtual_router_mac_address.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ip_virtual_router_mac_address.schema.yml
@@ -4,5 +4,6 @@
 type: dict
 keys:
   ip_virtual_router_mac_address:
-    type: str
     display_name: IP Virtual Router MAC Address
+    type: str
+    description: MAC address (hh:hh:hh:hh:hh:hh)

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ip_virtual_router_mac_address.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ip_virtual_router_mac_address.schema.yml
@@ -5,3 +5,4 @@ type: dict
 keys:
   ip_virtual_router_mac_address:
     type: str
+    display_name: IP Virtual Router MAC Address

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ip_virtual_router_mac_address.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ip_virtual_router_mac_address.schema.yml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  ip_virtual_router_mac_address:
+    type: str


### PR DESCRIPTION
## Add schema for data model

<!-- Use this PR Title: Feat(eos_cli_config_gen): Add schema for < data_model_key > -->

## Checklist

### Contributor Checklist

- [x] Create schema fragment matching data model described in README.md and README_v4.0.md
  - README.md is most complete with all keys. README_v4.0 includes partial data models after conversion to lists.
  - Schema fragment path is `roles/eos_cli_config_gen/schemas/schema_fragments/<data_model_key>.schema.yml`.
  - Copy line 1-5 from another schema (comments and outer type:dict).
  - Refer to [schema documentation](https://avd.sh/en/devel/docs/input-variable-validation-BETA.html) for syntax and/or use YAML Lint plugin from Redhat in VSCode.
  - Use `convert_types` on value that could be mixed type or misinterpreted like integers and numeric strings.
- [x] If the data model has been converted from wildcard dicts:
  - Add `convert_types: ['dict']` to the schema.
  - Remove `convert_dicts` from the `templates/eos/<>.j2` and `templates/documentation/<>.j2` templates.
- [x] Run `molecule converge -s build_schemas_and_docs` to update schema and documentation.
- [x] Test by running `molecule converge -s eos_cli_config_gen` and verify no errors or changes to generated configs/docs.

### Reviewer Checklist

- Reviewer 1: Carl
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2: 
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
