### PR TITLE
Feat(eos_cli_config_gen): Add schema for mpls

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -1491,6 +1491,32 @@ match_list_input:
           match_regex: <str>
 ```
 
+## Mpls
+
+### Variables
+
+| Variable | Type | Required | Default | Value Restrictions | Description |
+| -------- | ---- | -------- | ------- | ------------------ | ----------- |
+| [<samp>mpls</samp>](## "mpls") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;ip</samp>](## "mpls.ip") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;ldp</samp>](## "mpls.ldp") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;interface_disabled_default</samp>](## "mpls.ldp.interface_disabled_default") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;router_id</samp>](## "mpls.ldp.router_id") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;shutdown</samp>](## "mpls.ldp.shutdown") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;transport_address_interface</samp>](## "mpls.ldp.transport_address_interface") | String |  |  |  | Interface Name |
+
+### YAML
+
+```yaml
+mpls:
+  ip: <bool>
+  ldp:
+    interface_disabled_default: <bool>
+    router_id: <str>
+    shutdown: <bool>
+    transport_address_interface: <str>
+```
+
 ## Peer Filters
 
 ### Variables

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -1491,17 +1491,17 @@ match_list_input:
           match_regex: <str>
 ```
 
-## Mpls
+## MPLS
 
 ### Variables
 
 | Variable | Type | Required | Default | Value Restrictions | Description |
 | -------- | ---- | -------- | ------- | ------------------ | ----------- |
-| [<samp>mpls</samp>](## "mpls") | Dictionary |  |  |  |  |
+| [<samp>mpls</samp>](## "mpls") | Dictionary |  |  |  | MPLS |
 | [<samp>&nbsp;&nbsp;ip</samp>](## "mpls.ip") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;ldp</samp>](## "mpls.ldp") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;interface_disabled_default</samp>](## "mpls.ldp.interface_disabled_default") | Boolean |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;router_id</samp>](## "mpls.ldp.router_id") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;router_id</samp>](## "mpls.ldp.router_id") | String |  |  |  | Router ID |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;shutdown</samp>](## "mpls.ldp.shutdown") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;transport_address_interface</samp>](## "mpls.ldp.transport_address_interface") | String |  |  |  | Interface Name |
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -2459,6 +2459,40 @@
       },
       "additionalProperties": false
     },
+    "mpls": {
+      "type": "object",
+      "properties": {
+        "ip": {
+          "type": "boolean",
+          "title": "Ip"
+        },
+        "ldp": {
+          "type": "object",
+          "properties": {
+            "interface_disabled_default": {
+              "type": "boolean",
+              "title": "Interface Disabled Default"
+            },
+            "router_id": {
+              "type": "string",
+              "title": "Router Id"
+            },
+            "shutdown": {
+              "type": "boolean",
+              "title": "Shutdown"
+            },
+            "transport_address_interface": {
+              "title": "Interface Name",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Ldp"
+        }
+      },
+      "additionalProperties": false,
+      "title": "Mpls"
+    },
     "peer_filters": {
       "type": "array",
       "items": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -2461,6 +2461,7 @@
     },
     "mpls": {
       "type": "object",
+      "title": "MPLS",
       "properties": {
         "ip": {
           "type": "boolean",
@@ -2475,7 +2476,7 @@
             },
             "router_id": {
               "type": "string",
-              "title": "Router Id"
+              "title": "Router ID"
             },
             "shutdown": {
               "type": "boolean",
@@ -2490,8 +2491,7 @@
           "title": "Ldp"
         }
       },
-      "additionalProperties": false,
-      "title": "Mpls"
+      "additionalProperties": false
     },
     "peer_filters": {
       "type": "array",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -1996,6 +1996,23 @@ keys:
                     type: str
                     required: true
                     display_name: Regular Expression
+  mpls:
+    type: dict
+    keys:
+      ip:
+        type: bool
+      ldp:
+        type: dict
+        keys:
+          interface_disabled_default:
+            type: bool
+          router_id:
+            type: str
+          shutdown:
+            type: bool
+          transport_address_interface:
+            display_name: Interface Name
+            type: str
   peer_filters:
     type: list
     primary_key: name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -1998,6 +1998,7 @@ keys:
                     display_name: Regular Expression
   mpls:
     type: dict
+    display_name: MPLS
     keys:
       ip:
         type: bool
@@ -2008,6 +2009,7 @@ keys:
             type: bool
           router_id:
             type: str
+            display_name: Router ID
           shutdown:
             type: bool
           transport_address_interface:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/mpls.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/mpls.schema.yml
@@ -5,6 +5,7 @@ type: dict
 keys:
   mpls:
     type: dict
+    display_name: MPLS
     keys:
       ip:
         type: bool
@@ -15,6 +16,7 @@ keys:
             type: bool
           router_id:
             type: str
+            display_name: Router ID
           shutdown:
             type: bool
           transport_address_interface:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/mpls.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/mpls.schema.yml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  mpls:
+    type: dict
+    keys:
+      ip:
+        type: bool
+      ldp:
+        type: dict
+        keys:
+          interface_disabled_default:
+            type: bool
+          router_id:
+            type: str
+          shutdown:
+            type: bool
+          transport_address_interface:
+            display_name: Interface Name
+            type: str


### PR DESCRIPTION
## Add schema for data model

<!-- Use this PR Title: Feat(eos_cli_config_gen): Add schema for < data_model_key > -->

## Checklist

### Contributor Checklist

- [x] Create schema fragment matching data model described in README.md and README_v4.0.md
  - README.md is most complete with all keys. README_v4.0 includes partial data models after conversion to lists.
  - Schema fragment path is `roles/eos_cli_config_gen/schemas/schema_fragments/<data_model_key>.schema.yml`.
  - Copy line 1-5 from another schema (comments and outer type:dict).
  - Refer to [schema documentation](https://avd.sh/en/devel/docs/input-variable-validation-BETA.html) for syntax and/or use YAML Lint plugin from Redhat in VSCode.
  - Use `convert_types` on value that could be mixed type or misinterpreted like integers and numeric strings.
- [x] If the data model has been converted from wildcard dicts:
  - Add `convert_types: ['dict']` to the schema.
  - Remove `convert_dicts` from the `templates/eos/<>.j2` and `templates/documentation/<>.j2` templates.
- [x] Run `molecule converge -s build_schemas_and_docs` to update schema and documentation.
- [x] Test by running `molecule converge -s eos_cli_config_gen` and verify no errors or changes to generated configs/docs.

### Reviewer Checklist

- Reviewer 1:
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2:
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
