### PR TITLE
Feat(eos_cli_config_gen): Add schema for ipv6_unicast_routing

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -1472,6 +1472,20 @@ ipv6_static_routes:
     metric: <int>
 ```
 
+## Ipv6 Unicast Routing
+
+### Variables
+
+| Variable | Type | Required | Default | Value Restrictions | Description |
+| -------- | ---- | -------- | ------- | ------------------ | ----------- |
+| [<samp>ipv6_unicast_routing</samp>](## "ipv6_unicast_routing") | Boolean |  |  |  |  |
+
+### YAML
+
+```yaml
+ipv6_unicast_routing: <bool>
+```
+
 ## LACP
 
 ### Description

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -1472,13 +1472,13 @@ ipv6_static_routes:
     metric: <int>
 ```
 
-## Ipv6 Unicast Routing
+## IPv6 Unicast Routing
 
 ### Variables
 
 | Variable | Type | Required | Default | Value Restrictions | Description |
 | -------- | ---- | -------- | ------- | ------------------ | ----------- |
-| [<samp>ipv6_unicast_routing</samp>](## "ipv6_unicast_routing") | Boolean |  |  |  |  |
+| [<samp>ipv6_unicast_routing</samp>](## "ipv6_unicast_routing") | Boolean |  |  |  | IPv6 Unicast Routing |
 
 ### YAML
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -2177,6 +2177,10 @@
         "additionalProperties": false
       }
     },
+    "ipv6_unicast_routing": {
+      "type": "boolean",
+      "title": "Ipv6 Unicast Routing"
+    },
     "lacp": {
       "type": "object",
       "title": "LACP",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -2179,7 +2179,7 @@
     },
     "ipv6_unicast_routing": {
       "type": "boolean",
-      "title": "Ipv6 Unicast Routing"
+      "title": "IPv6 Unicast Routing"
     },
     "lacp": {
       "type": "object",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -1772,6 +1772,7 @@ keys:
           max: 4294967295
   ipv6_unicast_routing:
     type: bool
+    display_name: IPv6 Unicast Routing
   lacp:
     type: dict
     display_name: LACP

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -1770,6 +1770,8 @@ keys:
           - str
           min: 0
           max: 4294967295
+  ipv6_unicast_routing:
+    type: bool
   lacp:
     type: dict
     display_name: LACP

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ipv6_unicast_routing.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ipv6_unicast_routing.schema.yml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  ipv6_unicast_routing:
+    type: bool

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ipv6_unicast_routing.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ipv6_unicast_routing.schema.yml
@@ -5,3 +5,4 @@ type: dict
 keys:
   ipv6_unicast_routing:
     type: bool
+    display_name: IPv6 Unicast Routing


### PR DESCRIPTION
## Add schema for data model

<!-- Use this PR Title: Feat(eos_cli_config_gen): Add schema for < data_model_key > -->

## Checklist

### Contributor Checklist

- [x] Create schema fragment matching data model described in README.md and README_v4.0.md
  - README.md is most complete with all keys. README_v4.0 includes partial data models after conversion to lists.
  - Schema fragment path is `roles/eos_cli_config_gen/schemas/schema_fragments/<data_model_key>.schema.yml`.
  - Copy line 1-5 from another schema (comments and outer type:dict).
  - Refer to [schema documentation](https://avd.sh/en/devel/docs/input-variable-validation-BETA.html) for syntax and/or use YAML Lint plugin from Redhat in VSCode.
  - Use `convert_types` on value that could be mixed type or misinterpreted like integers and numeric strings.
- [x] If the data model has been converted from wildcard dicts:
  - Add `convert_types: ['dict']` to the schema.
  - Remove `convert_dicts` from the `templates/eos/<>.j2` and `templates/documentation/<>.j2` templates.
- [x] Run `molecule converge -s build_schemas_and_docs` to update schema and documentation.
- [x] Test by running `molecule converge -s eos_cli_config_gen` and verify no errors or changes to generated configs/docs.

### Reviewer Checklist

- Reviewer 1: Carl
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2: Claus
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
