### PR TITLE
Feat(eos_cli_config_gen): Add schema for event_monitor

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -494,6 +494,22 @@ event_handlers:
     asynchronous: <bool>
 ```
 
+## Event Monitor
+
+### Variables
+
+| Variable | Type | Required | Default | Value Restrictions | Description |
+| -------- | ---- | -------- | ------- | ------------------ | ----------- |
+| [<samp>event_monitor</samp>](## "event_monitor") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;enabled</samp>](## "event_monitor.enabled") | Boolean |  |  |  |  |
+
+### YAML
+
+```yaml
+event_monitor:
+  enabled: <bool>
+```
+
 ## Generate Default Config
 
 ### Description

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -791,6 +791,17 @@
         "additionalProperties": false
       }
     },
+    "event_monitor": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "title": "Enabled"
+        }
+      },
+      "additionalProperties": false,
+      "title": "Event Monitor"
+    },
     "generate_default_config": {
       "type": "boolean",
       "default": true,

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -737,6 +737,11 @@ keys:
           type: bool
           default: false
           description: Set the action to be non-blocking.
+  event_monitor:
+    type: dict
+    keys:
+      enabled:
+        type: bool
   generate_default_config:
     type: bool
     default: true

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/event_monitor.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/event_monitor.schema.yml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  event_monitor:
+    type: dict
+    keys:
+      enabled:
+        type: bool


### PR DESCRIPTION
## Add schema for data model

<!-- Use this PR Title: Feat(eos_cli_config_gen): Add schema for < data_model_key > -->

## Checklist

### Contributor Checklist

- [x] Create schema fragment matching data model described in README.md and README_v4.0.md
  - README.md is most complete with all keys. README_v4.0 includes partial data models after conversion to lists.
  - Schema fragment path is `roles/eos_cli_config_gen/schemas/schema_fragments/<data_model_key>.schema.yml`.
  - Copy line 1-5 from another schema (comments and outer type:dict).
  - Refer to [schema documentation](https://avd.sh/en/devel/docs/input-variable-validation-BETA.html) for syntax and/or use YAML Lint plugin from Redhat in VSCode.
  - Use `convert_types` on value that could be mixed type or misinterpreted like integers and numeric strings.
- [x] If the data model has been converted from wildcard dicts:
  - Add `convert_types: ['dict']` to the schema.
  - Remove `convert_dicts` from the `templates/eos/<>.j2` and `templates/documentation/<>.j2` templates.
- [x] Run `molecule converge -s build_schemas_and_docs` to update schema and documentation.
- [x] Test by running `molecule converge -s eos_cli_config_gen` and verify no errors or changes to generated configs/docs.

### Reviewer Checklist

- Reviewer 1: Tony
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2: Carl
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
