### PR TITLE
Feat(eos_cli_config_gen): Add schema for router multicast

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -2317,7 +2317,7 @@ router_l2_vpn:
 | Variable | Type | Required | Default | Value Restrictions | Description |
 | -------- | ---- | -------- | ------- | ------------------ | ----------- |
 | [<samp>router_multicast</samp>](## "router_multicast") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;ipv4</samp>](## "router_multicast.ipv4") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;ipv4</samp>](## "router_multicast.ipv4") | Dictionary |  |  |  | IPv4 |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;counters</samp>](## "router_multicast.ipv4.counters") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rate_period_decay</samp>](## "router_multicast.ipv4.counters.rate_period_decay") | Integer |  |  | Min: 0<br>Max: 600 | Rate in seconds |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;routing</samp>](## "router_multicast.ipv4.routing") | Boolean |  |  |  |  |
@@ -2325,13 +2325,13 @@ router_l2_vpn:
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;software_forwarding</samp>](## "router_multicast.ipv4.software_forwarding") | String |  |  | Valid Values:<br>- kernel<br>- sfe |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;rpf</samp>](## "router_multicast.ipv4.rpf") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;routes</samp>](## "router_multicast.ipv4.rpf.routes") | List, items: Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- source_prefix</samp>](## "router_multicast.ipv4.rpf.routes.[].source_prefix") | String |  |  |  | Source prefix A.B.C.D or Source address with prefix A.B.C.D/E |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;destinations</samp>](## "router_multicast.ipv4.rpf.routes.[].destinations") | List, items: Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- nexthop</samp>](## "router_multicast.ipv4.rpf.routes.[].destinations.[].nexthop") | String |  |  |  | Nenxthop ip address or Interface name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- source_prefix</samp>](## "router_multicast.ipv4.rpf.routes.[].source_prefix") | String | Required |  |  | Source address A.B.C.D or Source prefix A.B.C.D/E |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;destinations</samp>](## "router_multicast.ipv4.rpf.routes.[].destinations") | List, items: Dictionary | Required |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- nexthop</samp>](## "router_multicast.ipv4.rpf.routes.[].destinations.[].nexthop") | String | Required |  |  | Next-hop IP address or interface name |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;distance</samp>](## "router_multicast.ipv4.rpf.routes.[].destinations.[].distance") | Integer |  |  | Min: 1<br>Max: 255 | Administrative distance for this route |
-| [<samp>&nbsp;&nbsp;vrfs</samp>](## "router_multicast.vrfs") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;vrfs</samp>](## "router_multicast.vrfs") | List, items: Dictionary |  |  |  | VRFs |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "router_multicast.vrfs.[].name") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4</samp>](## "router_multicast.vrfs.[].ipv4") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4</samp>](## "router_multicast.vrfs.[].ipv4") | Dictionary |  |  |  | IPv4 |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;routing</samp>](## "router_multicast.vrfs.[].ipv4.routing") | Boolean |  |  |  |  |
 
 ### YAML

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -2310,6 +2310,52 @@ router_l2_vpn:
     prefix_list: <str>
 ```
 
+## Router Multicast
+
+### Variables
+
+| Variable | Type | Required | Default | Value Restrictions | Description |
+| -------- | ---- | -------- | ------- | ------------------ | ----------- |
+| [<samp>router_multicast</samp>](## "router_multicast") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;ipv4</samp>](## "router_multicast.ipv4") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;counters</samp>](## "router_multicast.ipv4.counters") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rate_period_decay</samp>](## "router_multicast.ipv4.counters.rate_period_decay") | Integer |  |  | Min: 0<br>Max: 600 |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;routing</samp>](## "router_multicast.ipv4.routing") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;multipath</samp>](## "router_multicast.ipv4.multipath") | String |  |  | Valid Values:<br>- none<br>- deterministic<br>- deterministic color<br>- deterministic router-id |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;software_forwarding</samp>](## "router_multicast.ipv4.software_forwarding") | String |  |  | Valid Values:<br>- kernel<br>- sfe |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;rpf</samp>](## "router_multicast.ipv4.rpf") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;routes</samp>](## "router_multicast.ipv4.rpf.routes") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- source_prefix</samp>](## "router_multicast.ipv4.rpf.routes.[].source_prefix") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;destinations</samp>](## "router_multicast.ipv4.rpf.routes.[].destinations") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- nexthop</samp>](## "router_multicast.ipv4.rpf.routes.[].destinations.[].nexthop") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;distance</samp>](## "router_multicast.ipv4.rpf.routes.[].destinations.[].distance") | Integer |  |  | Min: 1<br>Max: 255 |  |
+| [<samp>&nbsp;&nbsp;vrfs</samp>](## "router_multicast.vrfs") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "router_multicast.vrfs.[].name") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4</samp>](## "router_multicast.vrfs.[].ipv4") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;routing</samp>](## "router_multicast.vrfs.[].ipv4.routing") | Boolean |  |  |  |  |
+
+### YAML
+
+```yaml
+router_multicast:
+  ipv4:
+    counters:
+      rate_period_decay: <int>
+    routing: <bool>
+    multipath: <str>
+    software_forwarding: <str>
+    rpf:
+      routes:
+        - source_prefix: <str>
+          destinations:
+            - nexthop: <str>
+              distance: <int>
+  vrfs:
+    - name: <str>
+      ipv4:
+        routing: <bool>
+```
+
 ## Routing PIM Sparse Mode
 
 ### Variables

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -2319,16 +2319,16 @@ router_l2_vpn:
 | [<samp>router_multicast</samp>](## "router_multicast") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;ipv4</samp>](## "router_multicast.ipv4") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;counters</samp>](## "router_multicast.ipv4.counters") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rate_period_decay</samp>](## "router_multicast.ipv4.counters.rate_period_decay") | Integer |  |  | Min: 0<br>Max: 600 |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rate_period_decay</samp>](## "router_multicast.ipv4.counters.rate_period_decay") | Integer |  |  | Min: 0<br>Max: 600 | Rate in seconds |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;routing</samp>](## "router_multicast.ipv4.routing") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;multipath</samp>](## "router_multicast.ipv4.multipath") | String |  |  | Valid Values:<br>- none<br>- deterministic<br>- deterministic color<br>- deterministic router-id |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;software_forwarding</samp>](## "router_multicast.ipv4.software_forwarding") | String |  |  | Valid Values:<br>- kernel<br>- sfe |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;rpf</samp>](## "router_multicast.ipv4.rpf") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;routes</samp>](## "router_multicast.ipv4.rpf.routes") | List, items: Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- source_prefix</samp>](## "router_multicast.ipv4.rpf.routes.[].source_prefix") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- source_prefix</samp>](## "router_multicast.ipv4.rpf.routes.[].source_prefix") | String |  |  |  | Source prefix A.B.C.D or Source address with prefix A.B.C.D/E |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;destinations</samp>](## "router_multicast.ipv4.rpf.routes.[].destinations") | List, items: Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- nexthop</samp>](## "router_multicast.ipv4.rpf.routes.[].destinations.[].nexthop") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;distance</samp>](## "router_multicast.ipv4.rpf.routes.[].destinations.[].distance") | Integer |  |  | Min: 1<br>Max: 255 |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- nexthop</samp>](## "router_multicast.ipv4.rpf.routes.[].destinations.[].nexthop") | String |  |  |  | Nenxthop ip address or Interface name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;distance</samp>](## "router_multicast.ipv4.rpf.routes.[].destinations.[].distance") | Integer |  |  | Min: 1<br>Max: 255 | Administrative distance for this route |
 | [<samp>&nbsp;&nbsp;vrfs</samp>](## "router_multicast.vrfs") | List, items: Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "router_multicast.vrfs.[].name") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4</samp>](## "router_multicast.vrfs.[].ipv4") | Dictionary |  |  |  |  |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -3890,6 +3890,7 @@
       "properties": {
         "ipv4": {
           "type": "object",
+          "title": "IPv4",
           "properties": {
             "counters": {
               "type": "object",
@@ -3936,7 +3937,7 @@
                     "type": "object",
                     "properties": {
                       "source_prefix": {
-                        "description": "Source prefix A.B.C.D or Source address with prefix A.B.C.D/E",
+                        "description": "Source address A.B.C.D or Source prefix A.B.C.D/E",
                         "type": "string",
                         "title": "Source Prefix"
                       },
@@ -3946,7 +3947,7 @@
                           "type": "object",
                           "properties": {
                             "nexthop": {
-                              "description": "Nenxthop ip address or Interface name",
+                              "description": "Next-hop IP address or interface name",
                               "type": "string",
                               "title": "Nexthop"
                             },
@@ -3958,11 +3959,18 @@
                               "title": "Distance"
                             }
                           },
+                          "required": [
+                            "nexthop"
+                          ],
                           "additionalProperties": false
                         },
                         "title": "Destinations"
                       }
                     },
+                    "required": [
+                      "source_prefix",
+                      "destinations"
+                    ],
                     "additionalProperties": false
                   },
                   "title": "Routes"
@@ -3972,11 +3980,11 @@
               "title": "Rpf"
             }
           },
-          "additionalProperties": false,
-          "title": "Ipv4"
+          "additionalProperties": false
         },
         "vrfs": {
           "type": "array",
+          "title": "VRFs",
           "items": {
             "type": "object",
             "properties": {
@@ -3986,19 +3994,18 @@
               },
               "ipv4": {
                 "type": "object",
+                "title": "IPv4",
                 "properties": {
                   "routing": {
                     "type": "boolean",
                     "title": "Routing"
                   }
                 },
-                "additionalProperties": false,
-                "title": "Ipv4"
+                "additionalProperties": false
               }
             },
             "additionalProperties": false
-          },
-          "title": "Vrfs"
+          }
         }
       },
       "additionalProperties": false,

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -3895,6 +3895,7 @@
               "type": "object",
               "properties": {
                 "rate_period_decay": {
+                  "description": "Rate in seconds",
                   "type": "integer",
                   "minimum": 0,
                   "maximum": 600,
@@ -3935,6 +3936,7 @@
                     "type": "object",
                     "properties": {
                       "source_prefix": {
+                        "description": "Source prefix A.B.C.D or Source address with prefix A.B.C.D/E",
                         "type": "string",
                         "title": "Source Prefix"
                       },
@@ -3944,10 +3946,12 @@
                           "type": "object",
                           "properties": {
                             "nexthop": {
+                              "description": "Nenxthop ip address or Interface name",
                               "type": "string",
                               "title": "Nexthop"
                             },
                             "distance": {
+                              "description": "Administrative distance for this route",
                               "type": "integer",
                               "minimum": 1,
                               "maximum": 255,

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -3885,6 +3885,121 @@
       },
       "additionalProperties": false
     },
+    "router_multicast": {
+      "type": "object",
+      "properties": {
+        "ipv4": {
+          "type": "object",
+          "properties": {
+            "counters": {
+              "type": "object",
+              "properties": {
+                "rate_period_decay": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 600,
+                  "title": "Rate Period Decay"
+                }
+              },
+              "additionalProperties": false,
+              "title": "Counters"
+            },
+            "routing": {
+              "type": "boolean",
+              "title": "Routing"
+            },
+            "multipath": {
+              "type": "string",
+              "enum": [
+                "none",
+                "deterministic",
+                "deterministic color",
+                "deterministic router-id"
+              ],
+              "title": "Multipath"
+            },
+            "software_forwarding": {
+              "type": "string",
+              "enum": [
+                "kernel",
+                "sfe"
+              ],
+              "title": "Software Forwarding"
+            },
+            "rpf": {
+              "type": "object",
+              "properties": {
+                "routes": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "source_prefix": {
+                        "type": "string",
+                        "title": "Source Prefix"
+                      },
+                      "destinations": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "nexthop": {
+                              "type": "string",
+                              "title": "Nexthop"
+                            },
+                            "distance": {
+                              "type": "integer",
+                              "minimum": 1,
+                              "maximum": 255,
+                              "title": "Distance"
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "title": "Destinations"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "title": "Routes"
+                }
+              },
+              "additionalProperties": false,
+              "title": "Rpf"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Ipv4"
+        },
+        "vrfs": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "Name"
+              },
+              "ipv4": {
+                "type": "object",
+                "properties": {
+                  "routing": {
+                    "type": "boolean",
+                    "title": "Routing"
+                  }
+                },
+                "additionalProperties": false,
+                "title": "Ipv4"
+              }
+            },
+            "additionalProperties": false
+          },
+          "title": "Vrfs"
+        }
+      },
+      "additionalProperties": false,
+      "title": "Router Multicast"
+    },
     "router_pim_sparse_mode": {
       "type": "object",
       "title": "Routing PIM Sparse Mode",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -2940,6 +2940,7 @@ keys:
             type: dict
             keys:
               rate_period_decay:
+                description: Rate in seconds
                 type: int
                 min: 0
                 max: 600
@@ -2968,6 +2969,8 @@ keys:
                   type: dict
                   keys:
                     source_prefix:
+                      description: Source prefix A.B.C.D or Source address with prefix
+                        A.B.C.D/E
                       type: str
                     destinations:
                       type: list
@@ -2975,8 +2978,10 @@ keys:
                         type: dict
                         keys:
                           nexthop:
+                            description: Nenxthop ip address or Interface name
                             type: str
                           distance:
+                            description: Administrative distance for this route
                             type: int
                             min: 1
                             max: 255

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -2930,6 +2930,70 @@ keys:
           prefix_list:
             type: str
             description: Prefix-list Name
+  router_multicast:
+    type: dict
+    keys:
+      ipv4:
+        type: dict
+        keys:
+          counters:
+            type: dict
+            keys:
+              rate_period_decay:
+                type: int
+                min: 0
+                max: 600
+                convert_types:
+                - str
+          routing:
+            type: bool
+          multipath:
+            type: str
+            valid_values:
+            - none
+            - deterministic
+            - deterministic color
+            - deterministic router-id
+          software_forwarding:
+            type: str
+            valid_values:
+            - kernel
+            - sfe
+          rpf:
+            type: dict
+            keys:
+              routes:
+                type: list
+                items:
+                  type: dict
+                  keys:
+                    source_prefix:
+                      type: str
+                    destinations:
+                      type: list
+                      items:
+                        type: dict
+                        keys:
+                          nexthop:
+                            type: str
+                          distance:
+                            type: int
+                            min: 1
+                            max: 255
+                            convert_types:
+                            - str
+      vrfs:
+        type: list
+        items:
+          type: dict
+          keys:
+            name:
+              type: str
+            ipv4:
+              type: dict
+              keys:
+                routing:
+                  type: bool
   router_pim_sparse_mode:
     type: dict
     display_name: Routing PIM Sparse Mode

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -2935,6 +2935,7 @@ keys:
     keys:
       ipv4:
         type: dict
+        display_name: IPv4
         keys:
           counters:
             type: dict
@@ -2969,17 +2970,19 @@ keys:
                   type: dict
                   keys:
                     source_prefix:
-                      description: Source prefix A.B.C.D or Source address with prefix
-                        A.B.C.D/E
+                      description: Source address A.B.C.D or Source prefix A.B.C.D/E
                       type: str
+                      required: true
                     destinations:
                       type: list
+                      required: true
                       items:
                         type: dict
                         keys:
                           nexthop:
-                            description: Nenxthop ip address or Interface name
+                            description: Next-hop IP address or interface name
                             type: str
+                            required: true
                           distance:
                             description: Administrative distance for this route
                             type: int
@@ -2989,6 +2992,7 @@ keys:
                             - str
       vrfs:
         type: list
+        display_name: VRFs
         items:
           type: dict
           keys:
@@ -2996,6 +3000,7 @@ keys:
               type: str
             ipv4:
               type: dict
+              display_name: IPv4
               keys:
                 routing:
                   type: bool

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_multicast.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_multicast.schema.yml
@@ -8,6 +8,7 @@ keys:
     keys:
       ipv4:
         type: dict
+        display_name: IPv4
         keys:
           counters:
             type: dict
@@ -36,16 +37,19 @@ keys:
                   type: dict
                   keys:
                     source_prefix:
-                      description: Source prefix A.B.C.D or Source address with prefix A.B.C.D/E
+                      description: Source address A.B.C.D or Source prefix A.B.C.D/E
                       type: str
+                      required: true
                     destinations:
                       type: list
+                      required: true
                       items:
                         type: dict
                         keys:
                           nexthop:
-                            description: Nenxthop ip address or Interface name
+                            description: Next-hop IP address or interface name
                             type: str
+                            required: true
                           distance:
                             description: Administrative distance for this route
                             type: int
@@ -55,6 +59,7 @@ keys:
                             - str
       vrfs:
         type: list
+        display_name: VRFs
         items:
           type: dict
           keys:
@@ -62,6 +67,7 @@ keys:
               type: str
             ipv4:
               type: dict
+              display_name: IPv4
               keys:
                 routing:
                   type: bool

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_multicast.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_multicast.schema.yml
@@ -13,6 +13,7 @@ keys:
             type: dict
             keys:
               rate_period_decay:
+                description: Rate in seconds
                 type: int
                 min: 0
                 max: 600
@@ -35,6 +36,7 @@ keys:
                   type: dict
                   keys:
                     source_prefix:
+                      description: Source prefix A.B.C.D or Source address with prefix A.B.C.D/E
                       type: str
                     destinations:
                       type: list
@@ -42,8 +44,10 @@ keys:
                         type: dict
                         keys:
                           nexthop:
+                            description: Nenxthop ip address or Interface name
                             type: str
                           distance:
+                            description: Administrative distance for this route
                             type: int
                             min: 1
                             max: 255

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_multicast.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_multicast.schema.yml
@@ -1,0 +1,63 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  router_multicast:
+    type: dict
+    keys:
+      ipv4:
+        type: dict
+        keys:
+          counters:
+            type: dict
+            keys:
+              rate_period_decay:
+                type: int
+                min: 0
+                max: 600
+                convert_types:
+                - str
+          routing:
+            type: bool
+          multipath:
+            type: str
+            valid_values: ["none", "deterministic", "deterministic color", "deterministic router-id"]
+          software_forwarding:
+            type: str
+            valid_values: ["kernel", "sfe"]
+          rpf:
+            type: dict
+            keys:
+              routes:
+                type: list
+                items:
+                  type: dict
+                  keys:
+                    source_prefix:
+                      type: str
+                    destinations:
+                      type: list
+                      items:
+                        type: dict
+                        keys:
+                          nexthop:
+                            type: str
+                          distance:
+                            type: int
+                            min: 1
+                            max: 255
+                            convert_types:
+                            - str
+      vrfs:
+        type: list
+        items:
+          type: dict
+          keys:
+            name:
+              type: str
+            ipv4:
+              type: dict
+              keys:
+                routing:
+                  type: bool


### PR DESCRIPTION
## Add schema for data model

<!-- Use this PR Title: Feat(eos_cli_config_gen): Add schema for < data_model_key > -->

## Checklist

### Contributor Checklist

- [x] Create schema fragment matching data model described in README.md and README_v4.0.md
  - README.md is most complete with all keys. README_v4.0 includes partial data models after conversion to lists.
  - Schema fragment path is `roles/eos_cli_config_gen/schemas/schema_fragments/<data_model_key>.schema.yml`.
  - Copy line 1-5 from another schema (comments and outer type:dict).
  - Refer to [schema documentation](https://avd.sh/en/devel/docs/input-variable-validation-BETA.html) for syntax and/or use YAML Lint plugin from Redhat in VSCode.
  - Use `convert_types` on value that could be mixed type or misinterpreted like integers and numeric strings.
- [x] If the data model has been converted from wildcard dicts:
  - Add `convert_types: ['dict']` to the schema.
  - Remove `convert_dicts` from the `templates/eos/<>.j2` and `templates/documentation/<>.j2` templates.
- [x] Run `molecule converge -s build_schemas_and_docs` to update schema and documentation.
- [x] Test by running `molecule converge -s eos_cli_config_gen` and verify no errors or changes to generated configs/docs.

### Reviewer Checklist

- Reviewer 1: Carl
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2:
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
