### PR TITLE
Feat(eos_cli_config_gen): Add schema for aaa_server_groups

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -97,18 +97,18 @@ aaa_root:
     sha512_password: <str>
 ```
 
-## Aaa Server Groups
+## AAA Server Groups
 
 ### Variables
 
 | Variable | Type | Required | Default | Value Restrictions | Description |
 | -------- | ---- | -------- | ------- | ------------------ | ----------- |
-| [<samp>aaa_server_groups</samp>](## "aaa_server_groups") | List, items: Dictionary |  |  |  |  |
+| [<samp>aaa_server_groups</samp>](## "aaa_server_groups") | List, items: Dictionary |  |  |  | AAA Server Groups |
 | [<samp>&nbsp;&nbsp;- name</samp>](## "aaa_server_groups.[].name") | String |  |  |  | Server Group Name |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;type</samp>](## "aaa_server_groups.[].type") | String |  |  | Valid Values:<br>- tacacs+<br>- radius<br>- ldap |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;servers</samp>](## "aaa_server_groups.[].servers") | List, items: Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- server</samp>](## "aaa_server_groups.[].servers.[].server") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "aaa_server_groups.[].servers.[].vrf") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- server</samp>](## "aaa_server_groups.[].servers.[].server") | String |  |  |  | Hostname or IP address |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "aaa_server_groups.[].servers.[].vrf") | String |  |  |  | VRF Name |
 
 ### YAML
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -104,11 +104,11 @@ aaa_root:
 | Variable | Type | Required | Default | Value Restrictions | Description |
 | -------- | ---- | -------- | ------- | ------------------ | ----------- |
 | [<samp>aaa_server_groups</samp>](## "aaa_server_groups") | List, items: Dictionary |  |  |  | AAA Server Groups |
-| [<samp>&nbsp;&nbsp;- name</samp>](## "aaa_server_groups.[].name") | String |  |  |  | Server Group Name |
+| [<samp>&nbsp;&nbsp;- name</samp>](## "aaa_server_groups.[].name") | String |  |  |  | Group name |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;type</samp>](## "aaa_server_groups.[].type") | String |  |  | Valid Values:<br>- tacacs+<br>- radius<br>- ldap |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;servers</samp>](## "aaa_server_groups.[].servers") | List, items: Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- server</samp>](## "aaa_server_groups.[].servers.[].server") | String |  |  |  | Hostname or IP address |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "aaa_server_groups.[].servers.[].vrf") | String |  |  |  | VRF Name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "aaa_server_groups.[].servers.[].vrf") | String |  |  |  | VRF name |
 
 ### YAML
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -97,6 +97,30 @@ aaa_root:
     sha512_password: <str>
 ```
 
+## Aaa Server Groups
+
+### Variables
+
+| Variable | Type | Required | Default | Value Restrictions | Description |
+| -------- | ---- | -------- | ------- | ------------------ | ----------- |
+| [<samp>aaa_server_groups</samp>](## "aaa_server_groups") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;- name</samp>](## "aaa_server_groups.[].name") | String |  |  |  | Server Group Name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;type</samp>](## "aaa_server_groups.[].type") | String |  |  | Valid Values:<br>- tacacs+<br>- radius<br>- ldap |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;servers</samp>](## "aaa_server_groups.[].servers") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- server</samp>](## "aaa_server_groups.[].servers.[].server") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "aaa_server_groups.[].servers.[].vrf") | String |  |  |  |  |
+
+### YAML
+
+```yaml
+aaa_server_groups:
+  - name: <str>
+    type: <str>
+    servers:
+      - server: <str>
+        vrf: <str>
+```
+
 ## IP Extended Access-Lists (legacy model)
 
 ### Description

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -177,6 +177,47 @@
       },
       "additionalProperties": false
     },
+    "aaa_server_groups": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "title": "Server Group Name",
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "tacacs+",
+              "radius",
+              "ldap"
+            ],
+            "title": "Type"
+          },
+          "servers": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "server": {
+                  "type": "string",
+                  "title": "Server"
+                },
+                "vrf": {
+                  "type": "string",
+                  "title": "Vrf"
+                }
+              },
+              "additionalProperties": false
+            },
+            "title": "Servers"
+          }
+        },
+        "additionalProperties": false
+      },
+      "title": "Aaa Server Groups"
+    },
     "access_lists": {
       "type": "array",
       "title": "IP Extended Access-Lists (legacy model)",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -178,6 +178,7 @@
       "additionalProperties": false
     },
     "aaa_server_groups": {
+      "title": "AAA Server Groups",
       "type": "array",
       "items": {
         "type": "object",
@@ -202,10 +203,12 @@
               "properties": {
                 "server": {
                   "type": "string",
+                  "description": "Hostname or IP address",
                   "title": "Server"
                 },
                 "vrf": {
                   "type": "string",
+                  "description": "VRF Name",
                   "title": "Vrf"
                 }
               },
@@ -215,8 +218,7 @@
           }
         },
         "additionalProperties": false
-      },
-      "title": "Aaa Server Groups"
+      }
     },
     "access_lists": {
       "type": "array",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -184,8 +184,9 @@
         "type": "object",
         "properties": {
           "name": {
-            "title": "Server Group Name",
-            "type": "string"
+            "description": "Group name",
+            "type": "string",
+            "title": "Name"
           },
           "type": {
             "type": "string",
@@ -208,7 +209,7 @@
                 },
                 "vrf": {
                   "type": "string",
-                  "description": "VRF Name",
+                  "description": "VRF name",
                   "title": "Vrf"
                 }
               },

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -168,6 +168,7 @@ keys:
           sha512_password:
             type: str
   aaa_server_groups:
+    display_name: AAA Server Groups
     type: list
     items:
       type: dict
@@ -188,8 +189,10 @@ keys:
             keys:
               server:
                 type: str
+                description: Hostname or IP address
               vrf:
                 type: str
+                description: VRF Name
   access_lists:
     type: list
     primary_key: name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -167,6 +167,29 @@ keys:
         keys:
           sha512_password:
             type: str
+  aaa_server_groups:
+    type: list
+    items:
+      type: dict
+      keys:
+        name:
+          display_name: Server Group Name
+          type: str
+        type:
+          type: str
+          valid_values:
+          - tacacs+
+          - radius
+          - ldap
+        servers:
+          type: list
+          items:
+            type: dict
+            keys:
+              server:
+                type: str
+              vrf:
+                type: str
   access_lists:
     type: list
     primary_key: name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -174,7 +174,7 @@ keys:
       type: dict
       keys:
         name:
-          display_name: Server Group Name
+          description: Group name
           type: str
         type:
           type: str
@@ -192,7 +192,7 @@ keys:
                 description: Hostname or IP address
               vrf:
                 type: str
-                description: VRF Name
+                description: VRF name
   access_lists:
     type: list
     primary_key: name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/aaa_server_groups.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/aaa_server_groups.schema.yml
@@ -10,7 +10,7 @@ keys:
       type: dict
       keys:
         name:
-          display_name: Server Group Name
+          description: Group name
           type: str
         type:
           type: str
@@ -25,4 +25,4 @@ keys:
                 description: Hostname or IP address
               vrf:
                 type: str
-                description: VRF Name
+                description: VRF name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/aaa_server_groups.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/aaa_server_groups.schema.yml
@@ -4,6 +4,7 @@
 type: dict
 keys:
   aaa_server_groups:
+    display_name: AAA Server Groups
     type: list
     items:
       type: dict
@@ -21,5 +22,7 @@ keys:
             keys:
               server:
                 type: str
+                description: Hostname or IP address
               vrf:
                 type: str
+                description: VRF Name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/aaa_server_groups.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/aaa_server_groups.schema.yml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  aaa_server_groups:
+    type: list
+    items:
+      type: dict
+      keys:
+        name:
+          display_name: Server Group Name
+          type: str
+        type:
+          type: str
+          valid_values: ["tacacs+", "radius", "ldap"]
+        servers:
+          type: list
+          items:
+            type: dict
+            keys:
+              server:
+                type: str
+              vrf:
+                type: str


### PR DESCRIPTION
## Add schema for data model

<!-- Use this PR Title: Feat(eos_cli_config_gen): Add schema for < data_model_key > -->

## Checklist

### Contributor Checklist

- [x] Create schema fragment matching data model described in README.md and README_v4.0.md
  - README.md is most complete with all keys. README_v4.0 includes partial data models after conversion to lists.
  - Schema fragment path is `roles/eos_cli_config_gen/schemas/schema_fragments/<data_model_key>.schema.yml`.
  - Copy line 1-5 from another schema (comments and outer type:dict).
  - Refer to [schema documentation](https://avd.sh/en/devel/docs/input-variable-validation-BETA.html) for syntax and/or use YAML Lint plugin from Redhat in VSCode.
  - Use `convert_types` on value that could be mixed type or misinterpreted like integers and numeric strings.
- [x] If the data model has been converted from wildcard dicts:
  - Add `convert_types: ['dict']` to the schema.
  - Remove `convert_dicts` from the `templates/eos/<>.j2` and `templates/documentation/<>.j2` templates.
- [x] Run `molecule converge -s build_schemas_and_docs` to update schema and documentation.
- [x] Test by running `molecule converge -s eos_cli_config_gen` and verify no errors or changes to generated configs/docs.

### Reviewer Checklist

- Reviewer 1: Carl
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2:
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
