### PR TITLE
Feat(eos_cli_config_gen): Add schema for aaa accounting

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -1,6 +1,74 @@
 !!! warning
     This document describes the data model for AVD 4.x. It may or may not work in previous versions.
 
+## AAA Accounting
+
+### Variables
+
+| Variable | Type | Required | Default | Value Restrictions | Description |
+| -------- | ---- | -------- | ------- | ------------------ | ----------- |
+| [<samp>aaa_accounting</samp>](## "aaa_accounting") | Dictionary |  |  |  | AAA Accounting |
+| [<samp>&nbsp;&nbsp;exec</samp>](## "aaa_accounting.exec") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;console</samp>](## "aaa_accounting.exec.console") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;type</samp>](## "aaa_accounting.exec.console.type") | String |  |  | Valid Values:<br>- none<br>- start-stop<br>- stop-only |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;group</samp>](## "aaa_accounting.exec.console.group") | String |  |  |  | Group Name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;default</samp>](## "aaa_accounting.exec.default") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;type</samp>](## "aaa_accounting.exec.default.type") | String |  |  | Valid Values:<br>- none<br>- start-stop<br>- stop-only |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;group</samp>](## "aaa_accounting.exec.default.group") | String |  |  |  | Group Name |
+| [<samp>&nbsp;&nbsp;system</samp>](## "aaa_accounting.system") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;default</samp>](## "aaa_accounting.system.default") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;type</samp>](## "aaa_accounting.system.default.type") | String |  |  | Valid Values:<br>- none<br>- start-stop<br>- stop-only |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;group</samp>](## "aaa_accounting.system.default.group") | String |  |  |  | Group Name |
+| [<samp>&nbsp;&nbsp;commands</samp>](## "aaa_accounting.commands") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;console</samp>](## "aaa_accounting.commands.console") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- commands</samp>](## "aaa_accounting.commands.console.[].commands") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;type</samp>](## "aaa_accounting.commands.console.[].type") | String |  |  | Valid Values:<br>- none<br>- start-stop<br>- stop-only |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;group</samp>](## "aaa_accounting.commands.console.[].group") | String |  |  |  | Group Name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;logging</samp>](## "aaa_accounting.commands.console.[].logging") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;default</samp>](## "aaa_accounting.commands.default") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- commands</samp>](## "aaa_accounting.commands.default.[].commands") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;type</samp>](## "aaa_accounting.commands.default.[].type") | String |  |  | Valid Values:<br>- none<br>- start-stop<br>- stop-only |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;group</samp>](## "aaa_accounting.commands.default.[].group") | String |  |  |  | Group Name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;logging</samp>](## "aaa_accounting.commands.default.[].logging") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;commands_default</samp>](## "aaa_accounting.commands.commands_default") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- commands</samp>](## "aaa_accounting.commands.commands_default.[].commands") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;type</samp>](## "aaa_accounting.commands.commands_default.[].type") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;group</samp>](## "aaa_accounting.commands.commands_default.[].group") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;logging</samp>](## "aaa_accounting.commands.commands_default.[].logging") | Boolean |  |  |  |  |
+
+### YAML
+
+```yaml
+aaa_accounting:
+  exec:
+    console:
+      type: <str>
+      group: <str>
+    default:
+      type: <str>
+      group: <str>
+  system:
+    default:
+      type: <str>
+      group: <str>
+  commands:
+    console:
+      - commands: <str>
+        type: <str>
+        group: <str>
+        logging: <bool>
+    default:
+      - commands: <str>
+        type: <str>
+        group: <str>
+        logging: <bool>
+    commands_default:
+      - commands: <str>
+        type: <str>
+        group: <str>
+        logging: <bool>
+```
+
 ## AAA Authentication
 
 ### Variables

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -21,20 +21,16 @@
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;group</samp>](## "aaa_accounting.system.default.group") | String |  |  |  | Group Name |
 | [<samp>&nbsp;&nbsp;commands</samp>](## "aaa_accounting.commands") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;console</samp>](## "aaa_accounting.commands.console") | List, items: Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- commands</samp>](## "aaa_accounting.commands.console.[].commands") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- commands</samp>](## "aaa_accounting.commands.console.[].commands") | String |  |  |  | Privelege level 'all' or 0-15 |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;type</samp>](## "aaa_accounting.commands.console.[].type") | String |  |  | Valid Values:<br>- none<br>- start-stop<br>- stop-only |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;group</samp>](## "aaa_accounting.commands.console.[].group") | String |  |  |  | Group Name |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;logging</samp>](## "aaa_accounting.commands.console.[].logging") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;default</samp>](## "aaa_accounting.commands.default") | List, items: Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- commands</samp>](## "aaa_accounting.commands.default.[].commands") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- commands</samp>](## "aaa_accounting.commands.default.[].commands") | String |  |  |  | Privelege level 'all' or 0-15 |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;type</samp>](## "aaa_accounting.commands.default.[].type") | String |  |  | Valid Values:<br>- none<br>- start-stop<br>- stop-only |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;group</samp>](## "aaa_accounting.commands.default.[].group") | String |  |  |  | Group Name |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;logging</samp>](## "aaa_accounting.commands.default.[].logging") | Boolean |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;commands_default</samp>](## "aaa_accounting.commands.commands_default") | List, items: Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- commands</samp>](## "aaa_accounting.commands.commands_default.[].commands") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;type</samp>](## "aaa_accounting.commands.commands_default.[].type") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;group</samp>](## "aaa_accounting.commands.commands_default.[].group") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;logging</samp>](## "aaa_accounting.commands.commands_default.[].logging") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;commands_default</samp>](## "aaa_accounting.commands.commands_default") | List |  |  |  | Deprecated and removed key from AVD 2.x |
 
 ### YAML
 
@@ -63,10 +59,6 @@ aaa_accounting:
         group: <str>
         logging: <bool>
     commands_default:
-      - commands: <str>
-        type: <str>
-        group: <str>
-        logging: <bool>
 ```
 
 ## AAA Authentication

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -21,8 +21,9 @@
                   "title": "Type"
                 },
                 "group": {
-                  "title": "Group Name",
-                  "type": "string"
+                  "description": "Group Name",
+                  "type": "string",
+                  "title": "Group"
                 }
               },
               "additionalProperties": false,
@@ -41,8 +42,9 @@
                   "title": "Type"
                 },
                 "group": {
-                  "title": "Group Name",
-                  "type": "string"
+                  "description": "Group Name",
+                  "type": "string",
+                  "title": "Group"
                 }
               },
               "additionalProperties": false,
@@ -68,8 +70,9 @@
                   "title": "Type"
                 },
                 "group": {
-                  "title": "Group Name",
-                  "type": "string"
+                  "description": "Group Name",
+                  "type": "string",
+                  "title": "Group"
                 }
               },
               "additionalProperties": false,
@@ -89,6 +92,7 @@
                 "properties": {
                   "commands": {
                     "type": "string",
+                    "description": "Privelege level 'all' or 0-15",
                     "title": "Commands"
                   },
                   "type": {
@@ -101,8 +105,9 @@
                     "title": "Type"
                   },
                   "group": {
-                    "title": "Group Name",
-                    "type": "string"
+                    "description": "Group Name",
+                    "type": "string",
+                    "title": "Group"
                   },
                   "logging": {
                     "type": "boolean",
@@ -120,6 +125,7 @@
                 "properties": {
                   "commands": {
                     "type": "string",
+                    "description": "Privelege level 'all' or 0-15",
                     "title": "Commands"
                   },
                   "type": {
@@ -132,8 +138,9 @@
                     "title": "Type"
                   },
                   "group": {
-                    "title": "Group Name",
-                    "type": "string"
+                    "description": "Group Name",
+                    "type": "string",
+                    "title": "Group"
                   },
                   "logging": {
                     "type": "boolean",
@@ -146,28 +153,7 @@
             },
             "commands_default": {
               "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "commands": {
-                    "type": "string",
-                    "title": "Commands"
-                  },
-                  "type": {
-                    "type": "string",
-                    "title": "Type"
-                  },
-                  "group": {
-                    "type": "string",
-                    "title": "Group"
-                  },
-                  "logging": {
-                    "type": "boolean",
-                    "title": "Logging"
-                  }
-                },
-                "additionalProperties": false
-              },
+              "description": "Deprecated and removed key from AVD 2.x",
               "title": "Commands Default"
             }
           },

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -1,6 +1,182 @@
 {
   "type": "object",
   "properties": {
+    "aaa_accounting": {
+      "title": "AAA Accounting",
+      "type": "object",
+      "properties": {
+        "exec": {
+          "type": "object",
+          "properties": {
+            "console": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "none",
+                    "start-stop",
+                    "stop-only"
+                  ],
+                  "title": "Type"
+                },
+                "group": {
+                  "title": "Group Name",
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false,
+              "title": "Console"
+            },
+            "default": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "none",
+                    "start-stop",
+                    "stop-only"
+                  ],
+                  "title": "Type"
+                },
+                "group": {
+                  "title": "Group Name",
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false,
+              "title": "Default"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Exec"
+        },
+        "system": {
+          "type": "object",
+          "properties": {
+            "default": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "none",
+                    "start-stop",
+                    "stop-only"
+                  ],
+                  "title": "Type"
+                },
+                "group": {
+                  "title": "Group Name",
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false,
+              "title": "Default"
+            }
+          },
+          "additionalProperties": false,
+          "title": "System"
+        },
+        "commands": {
+          "type": "object",
+          "properties": {
+            "console": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "commands": {
+                    "type": "string",
+                    "title": "Commands"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "none",
+                      "start-stop",
+                      "stop-only"
+                    ],
+                    "title": "Type"
+                  },
+                  "group": {
+                    "title": "Group Name",
+                    "type": "string"
+                  },
+                  "logging": {
+                    "type": "boolean",
+                    "title": "Logging"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "title": "Console"
+            },
+            "default": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "commands": {
+                    "type": "string",
+                    "title": "Commands"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "none",
+                      "start-stop",
+                      "stop-only"
+                    ],
+                    "title": "Type"
+                  },
+                  "group": {
+                    "title": "Group Name",
+                    "type": "string"
+                  },
+                  "logging": {
+                    "type": "boolean",
+                    "title": "Logging"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "title": "Default"
+            },
+            "commands_default": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "commands": {
+                    "type": "string",
+                    "title": "Commands"
+                  },
+                  "type": {
+                    "type": "string",
+                    "title": "Type"
+                  },
+                  "group": {
+                    "type": "string",
+                    "title": "Group"
+                  },
+                  "logging": {
+                    "type": "boolean",
+                    "title": "Logging"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "title": "Commands Default"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Commands"
+        }
+      },
+      "additionalProperties": false
+    },
     "aaa_authentication": {
       "type": "object",
       "title": "AAA Authentication",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -1,6 +1,110 @@
 type: dict
 allow_other_keys: true
 keys:
+  aaa_accounting:
+    display_name: AAA Accounting
+    type: dict
+    keys:
+      exec:
+        type: dict
+        keys:
+          console:
+            type: dict
+            keys:
+              type:
+                type: str
+                valid_values:
+                - none
+                - start-stop
+                - stop-only
+              group:
+                display_name: Group Name
+                type: str
+          default:
+            type: dict
+            keys:
+              type:
+                type: str
+                valid_values:
+                - none
+                - start-stop
+                - stop-only
+              group:
+                display_name: Group Name
+                type: str
+      system:
+        type: dict
+        keys:
+          default:
+            type: dict
+            keys:
+              type:
+                type: str
+                valid_values:
+                - none
+                - start-stop
+                - stop-only
+              group:
+                display_name: Group Name
+                type: str
+      commands:
+        type: dict
+        keys:
+          console:
+            type: list
+            items:
+              type: dict
+              keys:
+                commands:
+                  type: str
+                  convert_types:
+                  - int
+                type:
+                  type: str
+                  valid_values:
+                  - none
+                  - start-stop
+                  - stop-only
+                group:
+                  display_name: Group Name
+                  type: str
+                logging:
+                  type: bool
+          default:
+            type: list
+            items:
+              type: dict
+              keys:
+                commands:
+                  type: str
+                  convert_types:
+                  - int
+                type:
+                  type: str
+                  valid_values:
+                  - none
+                  - start-stop
+                  - stop-only
+                group:
+                  display_name: Group Name
+                  type: str
+                logging:
+                  type: bool
+          commands_default:
+            type: list
+            items:
+              type: dict
+              keys:
+                commands:
+                  type: str
+                  convert_types:
+                  - int
+                type:
+                  type: str
+                group:
+                  type: str
+                logging:
+                  type: bool
   aaa_authentication:
     type: dict
     display_name: AAA Authentication

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -18,7 +18,7 @@ keys:
                 - start-stop
                 - stop-only
               group:
-                display_name: Group Name
+                description: Group Name
                 type: str
           default:
             type: dict
@@ -30,7 +30,7 @@ keys:
                 - start-stop
                 - stop-only
               group:
-                display_name: Group Name
+                description: Group Name
                 type: str
       system:
         type: dict
@@ -45,7 +45,7 @@ keys:
                 - start-stop
                 - stop-only
               group:
-                display_name: Group Name
+                description: Group Name
                 type: str
       commands:
         type: dict
@@ -59,6 +59,7 @@ keys:
                   type: str
                   convert_types:
                   - int
+                  description: Privelege level 'all' or 0-15
                 type:
                   type: str
                   valid_values:
@@ -66,7 +67,7 @@ keys:
                   - start-stop
                   - stop-only
                 group:
-                  display_name: Group Name
+                  description: Group Name
                   type: str
                 logging:
                   type: bool
@@ -79,6 +80,7 @@ keys:
                   type: str
                   convert_types:
                   - int
+                  description: Privelege level 'all' or 0-15
                 type:
                   type: str
                   valid_values:
@@ -86,25 +88,13 @@ keys:
                   - start-stop
                   - stop-only
                 group:
-                  display_name: Group Name
+                  description: Group Name
                   type: str
                 logging:
                   type: bool
           commands_default:
             type: list
-            items:
-              type: dict
-              keys:
-                commands:
-                  type: str
-                  convert_types:
-                  - int
-                type:
-                  type: str
-                group:
-                  type: str
-                logging:
-                  type: bool
+            description: Deprecated and removed key from AVD 2.x
   aaa_authentication:
     type: dict
     display_name: AAA Authentication

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/aaa_accounting.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/aaa_accounting.schema.yml
@@ -4,4 +4,91 @@
 type: dict
 keys:
   aaa_accounting:
-    type:
+    display_name: AAA Accounting
+    type: dict
+    keys:
+      exec:
+        type: dict
+        keys:
+          console:
+            type: dict
+            keys:
+              type:
+                type: str
+                valid_values: ["none", "start-stop", "stop-only"]
+              group:
+                display_name: Group Name
+                type: str
+          default:
+            type: dict
+            keys:
+              type:
+                type: str
+                valid_values: ["none", "start-stop", "stop-only"]
+              group:
+                display_name: Group Name
+                type: str
+      system:
+        type: dict
+        keys:
+          default:
+            type: dict
+            keys:
+              type:
+                type: str
+                valid_values: ["none", "start-stop", "stop-only"]
+              group:
+                display_name: Group Name
+                type: str
+      commands:
+        type: dict
+        keys:
+          console:
+            type: list
+            items:
+              type: dict
+              keys:
+                commands:
+                  type: str
+                  convert_types:
+                  - int
+                type:
+                  type: str
+                  valid_values: ["none", "start-stop", "stop-only"]
+                group:
+                  display_name: Group Name
+                  type: str
+                logging:
+                  type: bool
+          default:
+            type: list
+            items:
+              type: dict
+              keys:
+                commands:
+                  type: str
+                  convert_types:
+                  - int
+                type:
+                  type: str
+                  valid_values: ["none", "start-stop", "stop-only"]
+                group:
+                  display_name: Group Name
+                  type: str
+                logging:
+                  type: bool
+          commands_default:
+            type: list
+            items:
+              type: dict
+              keys:
+                commands:
+                  type: str
+                  convert_types:
+                  - int
+                type:
+                  type: str
+                group:
+                  type: str
+                logging:
+                  type: bool

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/aaa_accounting.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/aaa_accounting.schema.yml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  aaa_accounting:
+    type:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/aaa_accounting.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/aaa_accounting.schema.yml
@@ -17,7 +17,7 @@ keys:
                 type: str
                 valid_values: ["none", "start-stop", "stop-only"]
               group:
-                display_name: Group Name
+                description: Group Name
                 type: str
           default:
             type: dict
@@ -26,7 +26,7 @@ keys:
                 type: str
                 valid_values: ["none", "start-stop", "stop-only"]
               group:
-                display_name: Group Name
+                description: Group Name
                 type: str
       system:
         type: dict
@@ -38,7 +38,7 @@ keys:
                 type: str
                 valid_values: ["none", "start-stop", "stop-only"]
               group:
-                display_name: Group Name
+                description: Group Name
                 type: str
       commands:
         type: dict
@@ -52,11 +52,12 @@ keys:
                   type: str
                   convert_types:
                   - int
+                  description: "Privelege level 'all' or 0-15"
                 type:
                   type: str
                   valid_values: ["none", "start-stop", "stop-only"]
                 group:
-                  display_name: Group Name
+                  description: Group Name
                   type: str
                 logging:
                   type: bool
@@ -69,26 +70,15 @@ keys:
                   type: str
                   convert_types:
                   - int
+                  description: "Privelege level 'all' or 0-15"
                 type:
                   type: str
                   valid_values: ["none", "start-stop", "stop-only"]
                 group:
-                  display_name: Group Name
+                  description: Group Name
                   type: str
                 logging:
                   type: bool
           commands_default:
             type: list
-            items:
-              type: dict
-              keys:
-                commands:
-                  type: str
-                  convert_types:
-                  - int
-                type:
-                  type: str
-                group:
-                  type: str
-                logging:
-                  type: bool
+            description: "Deprecated and removed key from AVD 2.x"


### PR DESCRIPTION
## Add schema for data model

<!-- Use this PR Title: Feat(eos_cli_config_gen): Add schema for < data_model_key > -->

## Checklist

### Contributor Checklist

- [x] Create schema fragment matching data model described in README.md and README_v4.0.md
  - README.md is most complete with all keys. README_v4.0 includes partial data models after conversion to lists.
  - Schema fragment path is `roles/eos_cli_config_gen/schemas/schema_fragments/<data_model_key>.schema.yml`.
  - Copy line 1-5 from another schema (comments and outer type:dict).
  - Refer to [schema documentation](https://avd.sh/en/devel/docs/input-variable-validation-BETA.html) for syntax and/or use YAML Lint plugin from Redhat in VSCode.
  - Use `convert_types` on value that could be mixed type or misinterpreted like integers and numeric strings.
- [x] If the data model has been converted from wildcard dicts:
  - Add `convert_types: ['dict']` to the schema.
  - Remove `convert_dicts` from the `templates/eos/<>.j2` and `templates/documentation/<>.j2` templates.
- [x] Run `molecule converge -s build_schemas_and_docs` to update schema and documentation.
- [x] Test by running `molecule converge -s eos_cli_config_gen` and verify no errors or changes to generated configs/docs.

### Reviewer Checklist

- Reviewer 1: Claus
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2: Carl
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
