### PR TITLE
Feat(eos_cli_config_gen): Add schema for enable_password

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -492,6 +492,24 @@ domain_list:
   - <str>
 ```
 
+## Enable Password
+
+### Variables
+
+| Variable | Type | Required | Default | Value Restrictions | Description |
+| -------- | ---- | -------- | ------- | ------------------ | ----------- |
+| [<samp>enable_password</samp>](## "enable_password") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;hash_algorithm</samp>](## "enable_password.hash_algorithm") | String |  |  | Valid Values:<br>- md5<br>- sha512 |  |
+| [<samp>&nbsp;&nbsp;key</samp>](## "enable_password.key") | String |  |  |  |  |
+
+### YAML
+
+```yaml
+enable_password:
+  hash_algorithm: <str>
+  key: <str>
+```
+
 ## EOS CLI
 
 ### Description

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -500,7 +500,7 @@ domain_list:
 | -------- | ---- | -------- | ------- | ------------------ | ----------- |
 | [<samp>enable_password</samp>](## "enable_password") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;hash_algorithm</samp>](## "enable_password.hash_algorithm") | String |  |  | Valid Values:<br>- md5<br>- sha512 |  |
-| [<samp>&nbsp;&nbsp;key</samp>](## "enable_password.key") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;key</samp>](## "enable_password.key") | String |  |  |  | Must be the hash of the password using the specified algorithm.<br>By default EOS salts the password, so the simplest is to generate the hash on an EOS device. |
 
 ### YAML
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -783,6 +783,7 @@
         },
         "key": {
           "type": "string",
+          "description": "Must be the hash of the password using the specified algorithm.\nBy default EOS salts the password, so the simplest is to generate the hash on an EOS device.",
           "title": "Key"
         }
       },

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -770,6 +770,25 @@
       },
       "title": "Domain List"
     },
+    "enable_password": {
+      "type": "object",
+      "properties": {
+        "hash_algorithm": {
+          "type": "string",
+          "enum": [
+            "md5",
+            "sha512"
+          ],
+          "title": "Hash Algorithm"
+        },
+        "key": {
+          "type": "string",
+          "title": "Key"
+        }
+      },
+      "additionalProperties": false,
+      "title": "Enable Password"
+    },
     "eos_cli": {
       "type": "string",
       "title": "EOS CLI",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -718,6 +718,10 @@ keys:
         - sha512
       key:
         type: str
+        description: 'Must be the hash of the password using the specified algorithm.
+
+          By default EOS salts the password, so the simplest is to generate the hash
+          on an EOS device.'
   eos_cli:
     type: str
     display_name: EOS CLI

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -708,6 +708,16 @@ keys:
     items:
       type: str
       description: Domain name
+  enable_password:
+    type: dict
+    keys:
+      hash_algorithm:
+        type: str
+        valid_values:
+        - md5
+        - sha512
+      key:
+        type: str
   eos_cli:
     type: str
     display_name: EOS CLI

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/enable_password.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/enable_password.schema.yml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  enable_password:
+    type: dict
+    keys:
+      hash_algorithm:
+        type: str
+        valid_values: ["md5", "sha512"]
+      key:
+        type: str

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/enable_password.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/enable_password.schema.yml
@@ -11,3 +11,6 @@ keys:
         valid_values: ["md5", "sha512"]
       key:
         type: str
+        description: |
+          Must be the hash of the password using the specified algorithm.
+          By default EOS salts the password, so the simplest is to generate the hash on an EOS device.


### PR DESCRIPTION
## Add schema for data model

<!-- Use this PR Title: Feat(eos_cli_config_gen): Add schema for < data_model_key > -->

## Checklist

### Contributor Checklist

- [x] Create schema fragment matching data model described in README.md and README_v4.0.md
  - README.md is most complete with all keys. README_v4.0 includes partial data models after conversion to lists.
  - Schema fragment path is `roles/eos_cli_config_gen/schemas/schema_fragments/<data_model_key>.schema.yml`.
  - Copy line 1-5 from another schema (comments and outer type:dict).
  - Refer to [schema documentation](https://avd.sh/en/devel/docs/input-variable-validation-BETA.html) for syntax and/or use YAML Lint plugin from Redhat in VSCode.
  - Use `convert_types` on value that could be mixed type or misinterpreted like integers and numeric strings.
- [x] If the data model has been converted from wildcard dicts:
  - Add `convert_types: ['dict']` to the schema.
  - Remove `convert_dicts` from the `templates/eos/<>.j2` and `templates/documentation/<>.j2` templates.
- [x] Run `molecule converge -s build_schemas_and_docs` to update schema and documentation.
- [x] Test by running `molecule converge -s eos_cli_config_gen` and verify no errors or changes to generated configs/docs.

### Reviewer Checklist

- Reviewer 1: Claus
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2: Carl
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
