### PR TITLE
Feat(eos_cli_config_gen): Add schema for mlag_configuration

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -1764,26 +1764,26 @@ mcs_client:
       - <str>
 ```
 
-## Mlag Configuration
+## Multi-Chassis Link Aggregation (MLAG) Configuration
 
 ### Variables
 
 | Variable | Type | Required | Default | Value Restrictions | Description |
 | -------- | ---- | -------- | ------- | ------------------ | ----------- |
-| [<samp>mlag_configuration</samp>](## "mlag_configuration") | Dictionary |  |  |  |  |
+| [<samp>mlag_configuration</samp>](## "mlag_configuration") | Dictionary |  |  |  | Multi-Chassis Link Aggregation (MLAG) Configuration |
 | [<samp>&nbsp;&nbsp;domain_id</samp>](## "mlag_configuration.domain_id") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;heartbeat_interval</samp>](## "mlag_configuration.heartbeat_interval") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;heartbeat_interval</samp>](## "mlag_configuration.heartbeat_interval") | Integer |  |  |  | Heartbeat interval in milliseconds |
 | [<samp>&nbsp;&nbsp;local_interface</samp>](## "mlag_configuration.local_interface") | String |  |  |  | Interface Name |
-| [<samp>&nbsp;&nbsp;peer_address</samp>](## "mlag_configuration.peer_address") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;peer_address</samp>](## "mlag_configuration.peer_address") | String |  |  |  | IPv4 Address |
 | [<samp>&nbsp;&nbsp;peer_address_heartbeat</samp>](## "mlag_configuration.peer_address_heartbeat") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;peer_ip</samp>](## "mlag_configuration.peer_address_heartbeat.peer_ip") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;peer_ip</samp>](## "mlag_configuration.peer_address_heartbeat.peer_ip") | String |  |  |  | IPv4 Address |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "mlag_configuration.peer_address_heartbeat.vrf") | String |  |  |  | VRF Name |
-| [<samp>&nbsp;&nbsp;dual_primary_detection_delay</samp>](## "mlag_configuration.dual_primary_detection_delay") | Integer |  |  |  |  |
-| [<samp>&nbsp;&nbsp;dual_primary_recovery_delay_mlag</samp>](## "mlag_configuration.dual_primary_recovery_delay_mlag") | Integer |  |  | Min: 0<br>Max: 1000 |  |
-| [<samp>&nbsp;&nbsp;dual_primary_recovery_delay_non_mlag</samp>](## "mlag_configuration.dual_primary_recovery_delay_non_mlag") | Integer |  |  | Min: 0<br>Max: 1000 |  |
+| [<samp>&nbsp;&nbsp;dual_primary_detection_delay</samp>](## "mlag_configuration.dual_primary_detection_delay") | Integer |  |  | Min: 0<br>Max: 86400 | Delay in seconds |
+| [<samp>&nbsp;&nbsp;dual_primary_recovery_delay_mlag</samp>](## "mlag_configuration.dual_primary_recovery_delay_mlag") | Integer |  |  | Min: 0<br>Max: 86400 |  |
+| [<samp>&nbsp;&nbsp;dual_primary_recovery_delay_non_mlag</samp>](## "mlag_configuration.dual_primary_recovery_delay_non_mlag") | Integer |  |  | Min: 0<br>Max: 86400 |  |
 | [<samp>&nbsp;&nbsp;peer_link</samp>](## "mlag_configuration.peer_link") | String |  |  |  | Port-Channel ID |
-| [<samp>&nbsp;&nbsp;reload_delay_mlag</samp>](## "mlag_configuration.reload_delay_mlag") | Integer |  |  |  |  |
-| [<samp>&nbsp;&nbsp;reload_delay_non_mlag</samp>](## "mlag_configuration.reload_delay_non_mlag") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;reload_delay_mlag</samp>](## "mlag_configuration.reload_delay_mlag") | String |  |  |  | Delay in seconds <0-86400> or infinity |
+| [<samp>&nbsp;&nbsp;reload_delay_non_mlag</samp>](## "mlag_configuration.reload_delay_non_mlag") | String |  |  |  | Delay in seconds <0-86400> or infinity |
 
 ### YAML
 
@@ -1800,8 +1800,8 @@ mlag_configuration:
   dual_primary_recovery_delay_mlag: <int>
   dual_primary_recovery_delay_non_mlag: <int>
   peer_link: <str>
-  reload_delay_mlag: <int>
-  reload_delay_non_mlag: <int>
+  reload_delay_mlag: <str>
+  reload_delay_non_mlag: <str>
 ```
 
 ## Monitor Connectivity

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -1779,8 +1779,8 @@ mcs_client:
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;peer_ip</samp>](## "mlag_configuration.peer_address_heartbeat.peer_ip") | String |  |  |  | IPv4 Address |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "mlag_configuration.peer_address_heartbeat.vrf") | String |  |  |  | VRF Name |
 | [<samp>&nbsp;&nbsp;dual_primary_detection_delay</samp>](## "mlag_configuration.dual_primary_detection_delay") | Integer |  |  | Min: 0<br>Max: 86400 | Delay in seconds |
-| [<samp>&nbsp;&nbsp;dual_primary_recovery_delay_mlag</samp>](## "mlag_configuration.dual_primary_recovery_delay_mlag") | Integer |  |  | Min: 0<br>Max: 86400 |  |
-| [<samp>&nbsp;&nbsp;dual_primary_recovery_delay_non_mlag</samp>](## "mlag_configuration.dual_primary_recovery_delay_non_mlag") | Integer |  |  | Min: 0<br>Max: 86400 |  |
+| [<samp>&nbsp;&nbsp;dual_primary_recovery_delay_mlag</samp>](## "mlag_configuration.dual_primary_recovery_delay_mlag") | Integer |  |  | Min: 0<br>Max: 86400 | Delay in seconds |
+| [<samp>&nbsp;&nbsp;dual_primary_recovery_delay_non_mlag</samp>](## "mlag_configuration.dual_primary_recovery_delay_non_mlag") | Integer |  |  | Min: 0<br>Max: 86400 | Delay in seconds |
 | [<samp>&nbsp;&nbsp;peer_link</samp>](## "mlag_configuration.peer_link") | String |  |  |  | Port-Channel ID |
 | [<samp>&nbsp;&nbsp;reload_delay_mlag</samp>](## "mlag_configuration.reload_delay_mlag") | String |  |  |  | Delay in seconds <0-86400> or infinity |
 | [<samp>&nbsp;&nbsp;reload_delay_non_mlag</samp>](## "mlag_configuration.reload_delay_non_mlag") | String |  |  |  | Delay in seconds <0-86400> or infinity |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -1771,19 +1771,19 @@ mcs_client:
 | Variable | Type | Required | Default | Value Restrictions | Description |
 | -------- | ---- | -------- | ------- | ------------------ | ----------- |
 | [<samp>mlag_configuration</samp>](## "mlag_configuration") | Dictionary |  |  |  | Multi-Chassis Link Aggregation (MLAG) Configuration |
-| [<samp>&nbsp;&nbsp;domain_id</samp>](## "mlag_configuration.domain_id") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;domain_id</samp>](## "mlag_configuration.domain_id") | String |  |  |  | Domain ID |
 | [<samp>&nbsp;&nbsp;heartbeat_interval</samp>](## "mlag_configuration.heartbeat_interval") | Integer |  |  |  | Heartbeat interval in milliseconds |
-| [<samp>&nbsp;&nbsp;local_interface</samp>](## "mlag_configuration.local_interface") | String |  |  |  | Interface Name |
+| [<samp>&nbsp;&nbsp;local_interface</samp>](## "mlag_configuration.local_interface") | String |  |  |  | Local Interface Name |
 | [<samp>&nbsp;&nbsp;peer_address</samp>](## "mlag_configuration.peer_address") | String |  |  |  | IPv4 Address |
 | [<samp>&nbsp;&nbsp;peer_address_heartbeat</samp>](## "mlag_configuration.peer_address_heartbeat") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;peer_ip</samp>](## "mlag_configuration.peer_address_heartbeat.peer_ip") | String |  |  |  | IPv4 Address |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "mlag_configuration.peer_address_heartbeat.vrf") | String |  |  |  | VRF Name |
 | [<samp>&nbsp;&nbsp;dual_primary_detection_delay</samp>](## "mlag_configuration.dual_primary_detection_delay") | Integer |  |  | Min: 0<br>Max: 86400 | Delay in seconds |
-| [<samp>&nbsp;&nbsp;dual_primary_recovery_delay_mlag</samp>](## "mlag_configuration.dual_primary_recovery_delay_mlag") | Integer |  |  | Min: 0<br>Max: 86400 | Delay in seconds |
-| [<samp>&nbsp;&nbsp;dual_primary_recovery_delay_non_mlag</samp>](## "mlag_configuration.dual_primary_recovery_delay_non_mlag") | Integer |  |  | Min: 0<br>Max: 86400 | Delay in seconds |
-| [<samp>&nbsp;&nbsp;peer_link</samp>](## "mlag_configuration.peer_link") | String |  |  |  | Port-Channel ID |
-| [<samp>&nbsp;&nbsp;reload_delay_mlag</samp>](## "mlag_configuration.reload_delay_mlag") | String |  |  |  | Delay in seconds <0-86400> or infinity |
-| [<samp>&nbsp;&nbsp;reload_delay_non_mlag</samp>](## "mlag_configuration.reload_delay_non_mlag") | String |  |  |  | Delay in seconds <0-86400> or infinity |
+| [<samp>&nbsp;&nbsp;dual_primary_recovery_delay_mlag</samp>](## "mlag_configuration.dual_primary_recovery_delay_mlag") | Integer |  |  | Min: 0<br>Max: 86400 | Dual Primary Recovery Delay MLAG<br>Delay in seconds |
+| [<samp>&nbsp;&nbsp;dual_primary_recovery_delay_non_mlag</samp>](## "mlag_configuration.dual_primary_recovery_delay_non_mlag") | Integer |  |  | Min: 0<br>Max: 86400 | Dual Primary Recovery Delay Non MLAG<br>Delay in seconds |
+| [<samp>&nbsp;&nbsp;peer_link</samp>](## "mlag_configuration.peer_link") | String |  |  |  | Port-Channel interface name |
+| [<samp>&nbsp;&nbsp;reload_delay_mlag</samp>](## "mlag_configuration.reload_delay_mlag") | String |  |  |  | Reload Delay MLAG<br>Delay in seconds <0-86400> or 'infinity' |
+| [<samp>&nbsp;&nbsp;reload_delay_non_mlag</samp>](## "mlag_configuration.reload_delay_non_mlag") | String |  |  |  | Reload Delay Non MLAG<br>Delay in seconds <0-86400> or 'infinity' |
 
 ### YAML
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -1764,6 +1764,46 @@ mcs_client:
       - <str>
 ```
 
+## Mlag Configuration
+
+### Variables
+
+| Variable | Type | Required | Default | Value Restrictions | Description |
+| -------- | ---- | -------- | ------- | ------------------ | ----------- |
+| [<samp>mlag_configuration</samp>](## "mlag_configuration") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;domain_id</samp>](## "mlag_configuration.domain_id") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;heartbeat_interval</samp>](## "mlag_configuration.heartbeat_interval") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;local_interface</samp>](## "mlag_configuration.local_interface") | String |  |  |  | Interface Name |
+| [<samp>&nbsp;&nbsp;peer_address</samp>](## "mlag_configuration.peer_address") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;peer_address_heartbeat</samp>](## "mlag_configuration.peer_address_heartbeat") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;peer_ip</samp>](## "mlag_configuration.peer_address_heartbeat.peer_ip") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "mlag_configuration.peer_address_heartbeat.vrf") | String |  |  |  | VRF Name |
+| [<samp>&nbsp;&nbsp;dual_primary_detection_delay</samp>](## "mlag_configuration.dual_primary_detection_delay") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;dual_primary_recovery_delay_mlag</samp>](## "mlag_configuration.dual_primary_recovery_delay_mlag") | Integer |  |  | Min: 0<br>Max: 1000 |  |
+| [<samp>&nbsp;&nbsp;dual_primary_recovery_delay_non_mlag</samp>](## "mlag_configuration.dual_primary_recovery_delay_non_mlag") | Integer |  |  | Min: 0<br>Max: 1000 |  |
+| [<samp>&nbsp;&nbsp;peer_link</samp>](## "mlag_configuration.peer_link") | String |  |  |  | Port-Channel ID |
+| [<samp>&nbsp;&nbsp;reload_delay_mlag</samp>](## "mlag_configuration.reload_delay_mlag") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;reload_delay_non_mlag</samp>](## "mlag_configuration.reload_delay_non_mlag") | Integer |  |  |  |  |
+
+### YAML
+
+```yaml
+mlag_configuration:
+  domain_id: <str>
+  heartbeat_interval: <int>
+  local_interface: <str>
+  peer_address: <str>
+  peer_address_heartbeat:
+    peer_ip: <str>
+    vrf: <str>
+  dual_primary_detection_delay: <int>
+  dual_primary_recovery_delay_mlag: <int>
+  dual_primary_recovery_delay_non_mlag: <int>
+  peer_link: <str>
+  reload_delay_mlag: <int>
+  reload_delay_non_mlag: <int>
+```
+
 ## Monitor Connectivity
 
 ### Variables

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -2795,12 +2795,14 @@
         },
         "dual_primary_recovery_delay_mlag": {
           "type": "integer",
+          "description": "Delay in seconds",
           "minimum": 0,
           "maximum": 86400,
           "title": "Dual Primary Recovery Delay Mlag"
         },
         "dual_primary_recovery_delay_non_mlag": {
           "type": "integer",
+          "description": "Delay in seconds",
           "minimum": 0,
           "maximum": 86400,
           "title": "Dual Primary Recovery Delay Non Mlag"

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -2754,7 +2754,7 @@
       "properties": {
         "domain_id": {
           "type": "string",
-          "title": "Domain Id"
+          "title": "Domain ID"
         },
         "heartbeat_interval": {
           "type": "integer",
@@ -2762,7 +2762,7 @@
           "title": "Heartbeat Interval"
         },
         "local_interface": {
-          "title": "Interface Name",
+          "title": "Local Interface Name",
           "type": "string"
         },
         "peer_address": {
@@ -2795,31 +2795,32 @@
         },
         "dual_primary_recovery_delay_mlag": {
           "type": "integer",
+          "title": "Dual Primary Recovery Delay MLAG",
           "description": "Delay in seconds",
           "minimum": 0,
-          "maximum": 86400,
-          "title": "Dual Primary Recovery Delay Mlag"
+          "maximum": 86400
         },
         "dual_primary_recovery_delay_non_mlag": {
           "type": "integer",
+          "title": "Dual Primary Recovery Delay Non MLAG",
           "description": "Delay in seconds",
           "minimum": 0,
-          "maximum": 86400,
-          "title": "Dual Primary Recovery Delay Non Mlag"
+          "maximum": 86400
         },
         "peer_link": {
-          "title": "Port-Channel ID",
-          "type": "string"
+          "description": "Port-Channel interface name",
+          "type": "string",
+          "title": "Peer Link"
         },
         "reload_delay_mlag": {
           "type": "string",
-          "description": "Delay in seconds <0-86400> or infinity",
-          "title": "Reload Delay Mlag"
+          "title": "Reload Delay MLAG",
+          "description": "Delay in seconds <0-86400> or 'infinity'"
         },
         "reload_delay_non_mlag": {
           "type": "string",
-          "description": "Delay in seconds <0-86400> or infinity",
-          "title": "Reload Delay Non Mlag"
+          "title": "Reload Delay Non MLAG",
+          "description": "Delay in seconds <0-86400> or 'infinity'"
         }
       },
       "additionalProperties": false

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -2748,6 +2748,72 @@
       },
       "additionalProperties": false
     },
+    "mlag_configuration": {
+      "type": "object",
+      "properties": {
+        "domain_id": {
+          "type": "string",
+          "title": "Domain Id"
+        },
+        "heartbeat_interval": {
+          "type": "integer",
+          "title": "Heartbeat Interval"
+        },
+        "local_interface": {
+          "title": "Interface Name",
+          "type": "string"
+        },
+        "peer_address": {
+          "type": "string",
+          "title": "Peer Address"
+        },
+        "peer_address_heartbeat": {
+          "type": "object",
+          "properties": {
+            "peer_ip": {
+              "type": "string",
+              "title": "Peer Ip"
+            },
+            "vrf": {
+              "title": "VRF Name",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Peer Address Heartbeat"
+        },
+        "dual_primary_detection_delay": {
+          "type": "integer",
+          "title": "Dual Primary Detection Delay"
+        },
+        "dual_primary_recovery_delay_mlag": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 1000,
+          "title": "Dual Primary Recovery Delay Mlag"
+        },
+        "dual_primary_recovery_delay_non_mlag": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 1000,
+          "title": "Dual Primary Recovery Delay Non Mlag"
+        },
+        "peer_link": {
+          "title": "Port-Channel ID",
+          "type": "string"
+        },
+        "reload_delay_mlag": {
+          "type": "integer",
+          "title": "Reload Delay Mlag"
+        },
+        "reload_delay_non_mlag": {
+          "type": "integer",
+          "title": "Reload Delay Non Mlag"
+        }
+      },
+      "additionalProperties": false,
+      "title": "Mlag Configuration"
+    },
     "monitor_connectivity": {
       "type": "object",
       "properties": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -2750,6 +2750,7 @@
     },
     "mlag_configuration": {
       "type": "object",
+      "title": "Multi-Chassis Link Aggregation (MLAG) Configuration",
       "properties": {
         "domain_id": {
           "type": "string",
@@ -2757,6 +2758,7 @@
         },
         "heartbeat_interval": {
           "type": "integer",
+          "description": "Heartbeat interval in milliseconds",
           "title": "Heartbeat Interval"
         },
         "local_interface": {
@@ -2765,6 +2767,7 @@
         },
         "peer_address": {
           "type": "string",
+          "description": "IPv4 Address",
           "title": "Peer Address"
         },
         "peer_address_heartbeat": {
@@ -2772,6 +2775,7 @@
           "properties": {
             "peer_ip": {
               "type": "string",
+              "description": "IPv4 Address",
               "title": "Peer Ip"
             },
             "vrf": {
@@ -2784,18 +2788,21 @@
         },
         "dual_primary_detection_delay": {
           "type": "integer",
+          "description": "Delay in seconds",
+          "minimum": 0,
+          "maximum": 86400,
           "title": "Dual Primary Detection Delay"
         },
         "dual_primary_recovery_delay_mlag": {
           "type": "integer",
           "minimum": 0,
-          "maximum": 1000,
+          "maximum": 86400,
           "title": "Dual Primary Recovery Delay Mlag"
         },
         "dual_primary_recovery_delay_non_mlag": {
           "type": "integer",
           "minimum": 0,
-          "maximum": 1000,
+          "maximum": 86400,
           "title": "Dual Primary Recovery Delay Non Mlag"
         },
         "peer_link": {
@@ -2803,16 +2810,17 @@
           "type": "string"
         },
         "reload_delay_mlag": {
-          "type": "integer",
+          "type": "string",
+          "description": "Delay in seconds <0-86400> or infinity",
           "title": "Reload Delay Mlag"
         },
         "reload_delay_non_mlag": {
-          "type": "integer",
+          "type": "string",
+          "description": "Delay in seconds <0-86400> or infinity",
           "title": "Reload Delay Non Mlag"
         }
       },
-      "additionalProperties": false,
-      "title": "Mlag Configuration"
+      "additionalProperties": false
     },
     "monitor_connectivity": {
       "type": "object",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -2178,13 +2178,14 @@ keys:
     keys:
       domain_id:
         type: str
+        display_name: Domain ID
       heartbeat_interval:
         type: int
         description: Heartbeat interval in milliseconds
         convert_types:
         - str
       local_interface:
-        display_name: Interface Name
+        display_name: Local Interface Name
         type: str
       peer_address:
         type: str
@@ -2207,6 +2208,7 @@ keys:
         - str
       dual_primary_recovery_delay_mlag:
         type: int
+        display_name: Dual Primary Recovery Delay MLAG
         description: Delay in seconds
         min: 0
         max: 86400
@@ -2214,22 +2216,25 @@ keys:
         - str
       dual_primary_recovery_delay_non_mlag:
         type: int
+        display_name: Dual Primary Recovery Delay Non MLAG
         description: Delay in seconds
         min: 0
         max: 86400
         convert_types:
         - str
       peer_link:
-        display_name: Port-Channel ID
+        description: Port-Channel interface name
         type: str
       reload_delay_mlag:
         type: str
-        description: Delay in seconds <0-86400> or infinity
+        display_name: Reload Delay MLAG
+        description: Delay in seconds <0-86400> or 'infinity'
         convert_types:
         - int
       reload_delay_non_mlag:
         type: str
-        description: Delay in seconds <0-86400> or infinity
+        display_name: Reload Delay Non MLAG
+        description: Delay in seconds <0-86400> or 'infinity'
         convert_types:
         - int
   monitor_connectivity:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -2207,12 +2207,14 @@ keys:
         - str
       dual_primary_recovery_delay_mlag:
         type: int
+        description: Delay in seconds
         min: 0
         max: 86400
         convert_types:
         - str
       dual_primary_recovery_delay_non_mlag:
         type: int
+        description: Delay in seconds
         min: 0
         max: 86400
         convert_types:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -2172,6 +2172,55 @@ keys:
             items:
               type: str
               description: IP or hostname
+  mlag_configuration:
+    type: dict
+    keys:
+      domain_id:
+        type: str
+      heartbeat_interval:
+        type: int
+        convert_types:
+        - str
+      local_interface:
+        display_name: Interface Name
+        type: str
+      peer_address:
+        type: str
+      peer_address_heartbeat:
+        type: dict
+        keys:
+          peer_ip:
+            type: str
+          vrf:
+            display_name: VRF Name
+            type: str
+      dual_primary_detection_delay:
+        type: int
+        convert_types:
+        - str
+      dual_primary_recovery_delay_mlag:
+        type: int
+        min: 0
+        max: 1000
+        convert_types:
+        - str
+      dual_primary_recovery_delay_non_mlag:
+        type: int
+        min: 0
+        max: 1000
+        convert_types:
+        - str
+      peer_link:
+        display_name: Port-Channel ID
+        type: str
+      reload_delay_mlag:
+        type: int
+        convert_types:
+        - str
+      reload_delay_non_mlag:
+        type: int
+        convert_types:
+        - str
   monitor_connectivity:
     type: dict
     keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -2174,11 +2174,13 @@ keys:
               description: IP or hostname
   mlag_configuration:
     type: dict
+    display_name: Multi-Chassis Link Aggregation (MLAG) Configuration
     keys:
       domain_id:
         type: str
       heartbeat_interval:
         type: int
+        description: Heartbeat interval in milliseconds
         convert_types:
         - str
       local_interface:
@@ -2186,41 +2188,48 @@ keys:
         type: str
       peer_address:
         type: str
+        description: IPv4 Address
       peer_address_heartbeat:
         type: dict
         keys:
           peer_ip:
             type: str
+            description: IPv4 Address
           vrf:
             display_name: VRF Name
             type: str
       dual_primary_detection_delay:
         type: int
+        description: Delay in seconds
+        min: 0
+        max: 86400
         convert_types:
         - str
       dual_primary_recovery_delay_mlag:
         type: int
         min: 0
-        max: 1000
+        max: 86400
         convert_types:
         - str
       dual_primary_recovery_delay_non_mlag:
         type: int
         min: 0
-        max: 1000
+        max: 86400
         convert_types:
         - str
       peer_link:
         display_name: Port-Channel ID
         type: str
       reload_delay_mlag:
-        type: int
+        type: str
+        description: Delay in seconds <0-86400> or infinity
         convert_types:
-        - str
+        - int
       reload_delay_non_mlag:
-        type: int
+        type: str
+        description: Delay in seconds <0-86400> or infinity
         convert_types:
-        - str
+        - int
   monitor_connectivity:
     type: dict
     keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/mlag_configuration.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/mlag_configuration.schema.yml
@@ -1,0 +1,54 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  mlag_configuration:
+    type: dict
+    keys:
+      domain_id:
+        type: str
+      heartbeat_interval:
+        type: int
+        convert_types:
+        - str
+      local_interface:
+        display_name: Interface Name
+        type: str
+      peer_address:
+        type: str
+      peer_address_heartbeat:
+        type: dict
+        keys:
+          peer_ip:
+            type: str
+          vrf:
+            display_name: VRF Name
+            type: str
+      dual_primary_detection_delay:
+        type: int
+        convert_types:
+        - str
+      dual_primary_recovery_delay_mlag:
+        type: int
+        min: 0
+        max: 1000
+        convert_types:
+        - str
+      dual_primary_recovery_delay_non_mlag:
+        type: int
+        min: 0
+        max: 1000
+        convert_types:
+        - str
+      peer_link:
+        display_name: Port-Channel ID
+        type: str
+      reload_delay_mlag:
+        type: int
+        convert_types:
+        - str
+      reload_delay_non_mlag:
+        type: int
+        convert_types:
+        - str

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/mlag_configuration.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/mlag_configuration.schema.yml
@@ -5,11 +5,13 @@ type: dict
 keys:
   mlag_configuration:
     type: dict
+    display_name: Multi-Chassis Link Aggregation (MLAG) Configuration
     keys:
       domain_id:
         type: str
       heartbeat_interval:
         type: int
+        description: Heartbeat interval in milliseconds
         convert_types:
         - str
       local_interface:
@@ -17,38 +19,45 @@ keys:
         type: str
       peer_address:
         type: str
+        description: IPv4 Address
       peer_address_heartbeat:
         type: dict
         keys:
           peer_ip:
             type: str
+            description: IPv4 Address
           vrf:
             display_name: VRF Name
             type: str
       dual_primary_detection_delay:
         type: int
+        description: Delay in seconds
+        min: 0
+        max: 86400
         convert_types:
         - str
       dual_primary_recovery_delay_mlag:
         type: int
         min: 0
-        max: 1000
+        max: 86400
         convert_types:
         - str
       dual_primary_recovery_delay_non_mlag:
         type: int
         min: 0
-        max: 1000
+        max: 86400
         convert_types:
         - str
       peer_link:
         display_name: Port-Channel ID
         type: str
       reload_delay_mlag:
-        type: int
+        type: str
+        description: Delay in seconds <0-86400> or infinity
         convert_types:
-        - str
+        - int
       reload_delay_non_mlag:
-        type: int
+        type: str
+        description: Delay in seconds <0-86400> or infinity
         convert_types:
-        - str
+        - int

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/mlag_configuration.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/mlag_configuration.schema.yml
@@ -38,12 +38,14 @@ keys:
         - str
       dual_primary_recovery_delay_mlag:
         type: int
+        description: Delay in seconds
         min: 0
         max: 86400
         convert_types:
         - str
       dual_primary_recovery_delay_non_mlag:
         type: int
+        description: Delay in seconds
         min: 0
         max: 86400
         convert_types:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/mlag_configuration.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/mlag_configuration.schema.yml
@@ -9,13 +9,14 @@ keys:
     keys:
       domain_id:
         type: str
+        display_name: Domain ID
       heartbeat_interval:
         type: int
         description: Heartbeat interval in milliseconds
         convert_types:
         - str
       local_interface:
-        display_name: Interface Name
+        display_name: Local Interface Name
         type: str
       peer_address:
         type: str
@@ -38,6 +39,7 @@ keys:
         - str
       dual_primary_recovery_delay_mlag:
         type: int
+        display_name: Dual Primary Recovery Delay MLAG
         description: Delay in seconds
         min: 0
         max: 86400
@@ -45,21 +47,24 @@ keys:
         - str
       dual_primary_recovery_delay_non_mlag:
         type: int
+        display_name: Dual Primary Recovery Delay Non MLAG
         description: Delay in seconds
         min: 0
         max: 86400
         convert_types:
         - str
       peer_link:
-        display_name: Port-Channel ID
+        description: Port-Channel interface name
         type: str
       reload_delay_mlag:
         type: str
-        description: Delay in seconds <0-86400> or infinity
+        display_name: Reload Delay MLAG
+        description: Delay in seconds <0-86400> or 'infinity'
         convert_types:
         - int
       reload_delay_non_mlag:
         type: str
-        description: Delay in seconds <0-86400> or infinity
+        display_name: Reload Delay Non MLAG
+        description: Delay in seconds <0-86400> or 'infinity'
         convert_types:
         - int


### PR DESCRIPTION
## Add schema for data model

<!-- Use this PR Title: Feat(eos_cli_config_gen): Add schema for < data_model_key > -->

## Checklist

### Contributor Checklist

- [x] Create schema fragment matching data model described in README.md and README_v4.0.md
  - README.md is most complete with all keys. README_v4.0 includes partial data models after conversion to lists.
  - Schema fragment path is `roles/eos_cli_config_gen/schemas/schema_fragments/<data_model_key>.schema.yml`.
  - Copy line 1-5 from another schema (comments and outer type:dict).
  - Refer to [schema documentation](https://avd.sh/en/devel/docs/input-variable-validation-BETA.html) for syntax and/or use YAML Lint plugin from Redhat in VSCode.
  - Use `convert_types` on value that could be mixed type or misinterpreted like integers and numeric strings.
- [x] If the data model has been converted from wildcard dicts:
  - Add `convert_types: ['dict']` to the schema.
  - Remove `convert_dicts` from the `templates/eos/<>.j2` and `templates/documentation/<>.j2` templates.
- [x] Run `molecule converge -s build_schemas_and_docs` to update schema and documentation.
- [x] Test by running `molecule converge -s eos_cli_config_gen` and verify no errors or changes to generated configs/docs.

### Reviewer Checklist

- Reviewer 1: Claus
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2: Carl
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
