### PR TITLE
Feat(eos_cli_config_gen): Add schema for monitor_connectivity

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -1491,6 +1491,70 @@ match_list_input:
           match_regex: <str>
 ```
 
+## Monitor Connectivity
+
+### Variables
+
+| Variable | Type | Required | Default | Value Restrictions | Description |
+| -------- | ---- | -------- | ------- | ------------------ | ----------- |
+| [<samp>monitor_connectivity</samp>](## "monitor_connectivity") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;shutdown</samp>](## "monitor_connectivity.shutdown") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;interval</samp>](## "monitor_connectivity.interval") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;interface_sets</samp>](## "monitor_connectivity.interface_sets") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "monitor_connectivity.interface_sets.[].name") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interfaces</samp>](## "monitor_connectivity.interface_sets.[].interfaces") | String |  |  |  | Interface range(s) should be of same type, Ethernet, Loopback, Management etc.<br>Multiple interface ranges can be specified separated by ","<br> |
+| [<samp>&nbsp;&nbsp;local_interfaces</samp>](## "monitor_connectivity.local_interfaces") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;hosts</samp>](## "monitor_connectivity.hosts") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "monitor_connectivity.hosts.[].name") | String |  |  |  | Host Name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;description</samp>](## "monitor_connectivity.hosts.[].description") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ip</samp>](## "monitor_connectivity.hosts.[].ip") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;local_interfaces</samp>](## "monitor_connectivity.hosts.[].local_interfaces") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;url</samp>](## "monitor_connectivity.hosts.[].url") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;vrfs</samp>](## "monitor_connectivity.vrfs") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "monitor_connectivity.vrfs.[].name") | String |  |  |  | VRF Name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;description</samp>](## "monitor_connectivity.vrfs.[].description") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interface_sets</samp>](## "monitor_connectivity.vrfs.[].interface_sets") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "monitor_connectivity.vrfs.[].interface_sets.[].name") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interfaces</samp>](## "monitor_connectivity.vrfs.[].interface_sets.[].interfaces") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;local_interfaces</samp>](## "monitor_connectivity.vrfs.[].local_interfaces") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hosts</samp>](## "monitor_connectivity.vrfs.[].hosts") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "monitor_connectivity.vrfs.[].hosts.[].name") | String |  |  |  | Host name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;description</samp>](## "monitor_connectivity.vrfs.[].hosts.[].description") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ip</samp>](## "monitor_connectivity.vrfs.[].hosts.[].ip") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;local_interfaces</samp>](## "monitor_connectivity.vrfs.[].hosts.[].local_interfaces") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;url</samp>](## "monitor_connectivity.vrfs.[].hosts.[].url") | String |  |  |  |  |
+
+### YAML
+
+```yaml
+monitor_connectivity:
+  shutdown: <bool>
+  interval: <int>
+  interface_sets:
+    - name: <str>
+      interfaces: <str>
+  local_interfaces: <str>
+  hosts:
+    - name: <str>
+      description: <str>
+      ip: <str>
+      local_interfaces: <str>
+      url: <str>
+  vrfs:
+    - name: <str>
+      description: <str>
+      interface_sets:
+        - name: <str>
+          interfaces: <str>
+      local_interfaces: <str>
+      hosts:
+        - name: <str>
+          description: <str>
+          ip: <str>
+          local_interfaces: <str>
+          url: <str>
+```
+
 ## MPLS
 
 ### Variables

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -2459,6 +2459,144 @@
       },
       "additionalProperties": false
     },
+    "monitor_connectivity": {
+      "type": "object",
+      "properties": {
+        "shutdown": {
+          "type": "boolean",
+          "title": "Shutdown"
+        },
+        "interval": {
+          "type": "integer",
+          "title": "Interval"
+        },
+        "interface_sets": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "Name"
+              },
+              "interfaces": {
+                "type": "string",
+                "description": "Interface range(s) should be of same type, Ethernet, Loopback, Management etc.\nMultiple interface ranges can be specified separated by \",\"\n",
+                "title": "Interfaces"
+              }
+            },
+            "additionalProperties": false
+          },
+          "title": "Interface Sets"
+        },
+        "local_interfaces": {
+          "type": "string",
+          "title": "Local Interfaces"
+        },
+        "hosts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "title": "Host Name",
+                "type": "string"
+              },
+              "description": {
+                "type": "string",
+                "title": "Description"
+              },
+              "ip": {
+                "type": "string",
+                "title": "Ip"
+              },
+              "local_interfaces": {
+                "type": "string",
+                "title": "Local Interfaces"
+              },
+              "url": {
+                "type": "string",
+                "title": "Url"
+              }
+            },
+            "additionalProperties": false
+          },
+          "title": "Hosts"
+        },
+        "vrfs": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "title": "VRF Name",
+                "type": "string"
+              },
+              "description": {
+                "type": "string",
+                "title": "Description"
+              },
+              "interface_sets": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "title": "Name"
+                    },
+                    "interfaces": {
+                      "type": "string",
+                      "title": "Interfaces"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "title": "Interface Sets"
+              },
+              "local_interfaces": {
+                "type": "string",
+                "title": "Local Interfaces"
+              },
+              "hosts": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "title": "Host name",
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string",
+                      "title": "Description"
+                    },
+                    "ip": {
+                      "type": "string",
+                      "title": "Ip"
+                    },
+                    "local_interfaces": {
+                      "type": "string",
+                      "title": "Local Interfaces"
+                    },
+                    "url": {
+                      "type": "string",
+                      "title": "Url"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "title": "Hosts"
+              }
+            },
+            "additionalProperties": false
+          },
+          "title": "Vrfs"
+        }
+      },
+      "additionalProperties": false,
+      "title": "Monitor Connectivity"
+    },
     "mpls": {
       "type": "object",
       "title": "MPLS",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -1996,6 +1996,85 @@ keys:
                     type: str
                     required: true
                     display_name: Regular Expression
+  monitor_connectivity:
+    type: dict
+    keys:
+      shutdown:
+        type: bool
+      interval:
+        type: int
+        convert_types:
+        - str
+      interface_sets:
+        type: list
+        items:
+          type: dict
+          keys:
+            name:
+              type: str
+            interfaces:
+              type: str
+              description: 'Interface range(s) should be of same type, Ethernet, Loopback,
+                Management etc.
+
+                Multiple interface ranges can be specified separated by ","
+
+                '
+      local_interfaces:
+        type: str
+      hosts:
+        type: list
+        items:
+          type: dict
+          keys:
+            name:
+              display_name: Host Name
+              type: str
+            description:
+              type: str
+            ip:
+              type: str
+            local_interfaces:
+              type: str
+            url:
+              type: str
+      vrfs:
+        type: list
+        items:
+          type: dict
+          keys:
+            name:
+              display_name: VRF Name
+              type: str
+            description:
+              type: str
+            interface_sets:
+              type: list
+              items:
+                type: dict
+                keys:
+                  name:
+                    type: str
+                  interfaces:
+                    type: str
+            local_interfaces:
+              type: str
+            hosts:
+              type: list
+              items:
+                type: dict
+                keys:
+                  name:
+                    display_name: Host name
+                    type: str
+                  description:
+                    type: str
+                  ip:
+                    type: str
+                  local_interfaces:
+                    type: str
+                  url:
+                    type: str
   mpls:
     type: dict
     display_name: MPLS

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/monitor_connectivity.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/monitor_connectivity.schema.yml
@@ -1,0 +1,81 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  monitor_connectivity:
+    type: dict
+    keys:
+      shutdown:
+        type: bool
+      interval:
+        type: int
+        convert_types:
+        - str
+      interface_sets:
+        type: list
+        items:
+          type: dict
+          keys:
+            name:
+              type: str
+            interfaces:
+              type: str
+              description: |
+                Interface range(s) should be of same type, Ethernet, Loopback, Management etc.
+                Multiple interface ranges can be specified separated by ","
+      local_interfaces:
+        type: str
+      hosts:
+        type: list
+        items:
+          type: dict
+          keys:
+            name:
+              display_name: Host Name
+              type: str
+            description:
+              type: str
+            ip:
+              type: str
+            local_interfaces:
+              type: str
+            url:
+              type: str
+      vrfs:
+        type: list
+        items:
+          type: dict
+          keys:
+            name:
+              display_name: VRF Name
+              type: str
+            description:
+              type: str
+            interface_sets:
+              type: list
+              items:
+                type: dict
+                keys:
+                  name:
+                    type: str
+                  interfaces:
+                    type: str
+            local_interfaces:
+              type: str
+            hosts:
+              type: list
+              items:
+                type: dict
+                keys:
+                  name:
+                    display_name: Host name
+                    type: str
+                  description:
+                    type: str
+                  ip:
+                    type: str
+                  local_interfaces:
+                    type: str
+                  url:
+                    type: str


### PR DESCRIPTION
## Add schema for data model

<!-- Use this PR Title: Feat(eos_cli_config_gen): Add schema for < data_model_key > -->

## Checklist

### Contributor Checklist

- [x] Create schema fragment matching data model described in README.md and README_v4.0.md
  - README.md is most complete with all keys. README_v4.0 includes partial data models after conversion to lists.
  - Schema fragment path is `roles/eos_cli_config_gen/schemas/schema_fragments/<data_model_key>.schema.yml`.
  - Copy line 1-5 from another schema (comments and outer type:dict).
  - Refer to [schema documentation](https://avd.sh/en/devel/docs/input-variable-validation-BETA.html) for syntax and/or use YAML Lint plugin from Redhat in VSCode.
  - Use `convert_types` on value that could be mixed type or misinterpreted like integers and numeric strings.
- [x] If the data model has been converted from wildcard dicts:
  - Add `convert_types: ['dict']` to the schema.
  - Remove `convert_dicts` from the `templates/eos/<>.j2` and `templates/documentation/<>.j2` templates.
- [x] Run `molecule converge -s build_schemas_and_docs` to update schema and documentation.
- [x] Test by running `molecule converge -s eos_cli_config_gen` and verify no errors or changes to generated configs/docs.

### Reviewer Checklist

- Reviewer 1:
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2:
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
