### PR TITLE
Feat(eos_cli_config_gen): Add schema for load_interval

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -1065,7 +1065,7 @@ lacp:
 | Variable | Type | Required | Default | Value Restrictions | Description |
 | -------- | ---- | -------- | ------- | ------------------ | ----------- |
 | [<samp>load_interval</samp>](## "load_interval") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;default</samp>](## "load_interval.default") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;default</samp>](## "load_interval.default") | Integer |  |  |  | Default load interval in seconds |
 
 ### YAML
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -1058,6 +1058,22 @@ lacp:
   system_priority: <int>
 ```
 
+## Load Interval
+
+### Variables
+
+| Variable | Type | Required | Default | Value Restrictions | Description |
+| -------- | ---- | -------- | ------- | ------------------ | ----------- |
+| [<samp>load_interval</samp>](## "load_interval") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;default</samp>](## "load_interval.default") | Integer |  |  |  |  |
+
+### YAML
+
+```yaml
+load_interval:
+  default: <int>
+```
+
 ## Local Users
 
 ### Variables

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -1636,6 +1636,17 @@
       },
       "additionalProperties": false
     },
+    "load_interval": {
+      "type": "object",
+      "properties": {
+        "default": {
+          "type": "integer",
+          "title": "Default"
+        }
+      },
+      "additionalProperties": false,
+      "title": "Load Interval"
+    },
     "local_users": {
       "type": "array",
       "items": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -1641,6 +1641,7 @@
       "properties": {
         "default": {
           "type": "integer",
+          "description": "Default load interval in seconds",
           "title": "Default"
         }
       },

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -1427,6 +1427,7 @@ keys:
     keys:
       default:
         type: int
+        description: Default load interval in seconds
         convert_types:
         - str
   local_users:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -1422,6 +1422,13 @@ keys:
         description: Set local system LACP priority.
         min: 0
         max: 65535
+  load_interval:
+    type: dict
+    keys:
+      default:
+        type: int
+        convert_types:
+        - str
   local_users:
     type: list
     primary_key: name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/load_interval.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/load_interval.schema.yml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  load_interval:
+    type: dict
+    keys:
+      default:
+        type: int
+        convert_types:
+        - str

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/load_interval.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/load_interval.schema.yml
@@ -8,5 +8,6 @@ keys:
     keys:
       default:
         type: int
+        description: Default load interval in seconds
         convert_types:
         - str


### PR DESCRIPTION
## Add schema for data model

<!-- Use this PR Title: Feat(eos_cli_config_gen): Add schema for < data_model_key > -->

## Checklist

### Contributor Checklist

- [x] Create schema fragment matching data model described in README.md and README_v4.0.md
  - README.md is most complete with all keys. README_v4.0 includes partial data models after conversion to lists.
  - Schema fragment path is `roles/eos_cli_config_gen/schemas/schema_fragments/<data_model_key>.schema.yml`.
  - Copy line 1-5 from another schema (comments and outer type:dict).
  - Refer to [schema documentation](https://avd.sh/en/devel/docs/input-variable-validation-BETA.html) for syntax and/or use YAML Lint plugin from Redhat in VSCode.
  - Use `convert_types` on value that could be mixed type or misinterpreted like integers and numeric strings.
- [x] If the data model has been converted from wildcard dicts:
  - Add `convert_types: ['dict']` to the schema.
  - Remove `convert_dicts` from the `templates/eos/<>.j2` and `templates/documentation/<>.j2` templates.
- [x] Run `molecule converge -s build_schemas_and_docs` to update schema and documentation.
- [x] Test by running `molecule converge -s eos_cli_config_gen` and verify no errors or changes to generated configs/docs.

### Reviewer Checklist

- Reviewer 1:
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2:
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
