### PR TITLE
Fix(eos_cli_config_gen): Updates to schema for policy_maps

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -1953,6 +1953,8 @@ keys:
                         display_name: COS
                       dscp:
                         type: str
+                        convert_types:
+                        - int
                         display_name: DSCP
                       traffic_class:
                         type: int

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/policy_maps.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/policy_maps.schema.yml
@@ -84,6 +84,8 @@ keys:
                         display_name: COS
                       dscp:
                         type: str
+                        convert_types:
+                          - int
                         display_name: DSCP
                       traffic_class:
                         type: int


### PR DESCRIPTION
## Change Summary

`policy_maps.qos[].classes[].set.dscp` value can use a decimal value <0-63> or meaningful value i.e AF11, EF , therefore we should convert types int to string automatically.

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Add `change_types: [ "int" ]` to `policy_maps.qos[].classes[].set.dscp`

## How to test
N/A

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
