### PR TITLE
Feat(eos_cli_config_gen): Add schema for domain_list

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -451,12 +451,15 @@ dns_domain: <str>
 
 ## Domain List
 
+### Description
+
+Search list of DNS domains
 ### Variables
 
 | Variable | Type | Required | Default | Value Restrictions | Description |
 | -------- | ---- | -------- | ------- | ------------------ | ----------- |
 | [<samp>domain_list</samp>](## "domain_list") | List, items: String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;- &lt;str&gt;</samp>](## "domain_list.[].&lt;str&gt;") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;- &lt;str&gt;</samp>](## "domain_list.[].&lt;str&gt;") | String |  |  |  | Domain name |
 
 ### YAML
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -449,6 +449,22 @@ Domain Name
 dns_domain: <str>
 ```
 
+## Domain List
+
+### Variables
+
+| Variable | Type | Required | Default | Value Restrictions | Description |
+| -------- | ---- | -------- | ------- | ------------------ | ----------- |
+| [<samp>domain_list</samp>](## "domain_list") | List, items: String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;- &lt;str&gt;</samp>](## "domain_list.[].&lt;str&gt;") | String |  |  |  |  |
+
+### YAML
+
+```yaml
+domain_list:
+  - <str>
+```
+
 ## EOS CLI
 
 ### Description

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -735,8 +735,10 @@
     },
     "domain_list": {
       "type": "array",
+      "description": "Search list of DNS domains",
       "items": {
-        "type": "string"
+        "type": "string",
+        "description": "Domain name"
       },
       "title": "Domain List"
     },

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -733,6 +733,13 @@
       "title": "DNS Domain",
       "description": "Domain Name"
     },
+    "domain_list": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "title": "Domain List"
+    },
     "eos_cli": {
       "type": "string",
       "title": "EOS CLI",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -685,8 +685,10 @@ keys:
     description: Domain Name
   domain_list:
     type: list
+    description: Search list of DNS domains
     items:
       type: str
+      description: Domain name
   eos_cli:
     type: str
     display_name: EOS CLI

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -683,6 +683,10 @@ keys:
     type: str
     display_name: DNS Domain
     description: Domain Name
+  domain_list:
+    type: list
+    items:
+      type: str
   eos_cli:
     type: str
     display_name: EOS CLI

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/domain_list.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/domain_list.schema.yml
@@ -5,5 +5,7 @@ type: dict
 keys:
   domain_list:
     type: list
+    description: Search list of DNS domains
     items:
       type: str
+      description: Domain name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/domain_list.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/domain_list.schema.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  domain_list:
+    type: list
+    items:
+      type: str


### PR DESCRIPTION
## Add schema for data model

<!-- Use this PR Title: Feat(eos_cli_config_gen): Add schema for < data_model_key > -->

## Checklist

### Contributor Checklist

- [x] Create schema fragment matching data model described in README.md and README_v4.0.md
  - README.md is most complete with all keys. README_v4.0 includes partial data models after conversion to lists.
  - Schema fragment path is `roles/eos_cli_config_gen/schemas/schema_fragments/<data_model_key>.schema.yml`.
  - Copy line 1-5 from another schema (comments and outer type:dict).
  - Refer to [schema documentation](https://avd.sh/en/devel/docs/input-variable-validation-BETA.html) for syntax and/or use YAML Lint plugin from Redhat in VSCode.
  - Use `convert_types` on value that could be mixed type or misinterpreted like integers and numeric strings.
- [x] If the data model has been converted from wildcard dicts:
  - Add `convert_types: ['dict']` to the schema.
  - Remove `convert_dicts` from the `templates/eos/<>.j2` and `templates/documentation/<>.j2` templates.
- [x] Run `molecule converge -s build_schemas_and_docs` to update schema and documentation.
- [x] Test by running `molecule converge -s eos_cli_config_gen` and verify no errors or changes to generated configs/docs.

### Reviewer Checklist

- Reviewer 1:
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2:
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
