### PR TITLE
Feat(eos_cli_config_gen): Add schema for router_isis

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -2176,6 +2176,108 @@ router_igmp:
   ssm_aware: <bool>
 ```
 
+## Router Isis
+
+### Variables
+
+| Variable | Type | Required | Default | Value Restrictions | Description |
+| -------- | ---- | -------- | ------- | ------------------ | ----------- |
+| [<samp>router_isis</samp>](## "router_isis") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;instance</samp>](## "router_isis.instance") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;net</samp>](## "router_isis.net") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;router_id</samp>](## "router_isis.router_id") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;is_type</samp>](## "router_isis.is_type") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;log_adjacency_changes</samp>](## "router_isis.log_adjacency_changes") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;mpls_ldp_sync_default</samp>](## "router_isis.mpls_ldp_sync_default") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;timers</samp>](## "router_isis.timers") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;local_convergence</samp>](## "router_isis.timers.local_convergence") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;protected_prefixes</samp>](## "router_isis.timers.local_convergence.protected_prefixes") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;delay</samp>](## "router_isis.timers.local_convergence.delay") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;advertise</samp>](## "router_isis.advertise") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;passive_only</samp>](## "router_isis.advertise.passive_only") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;address_family</samp>](## "router_isis.address_family") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;isis_af_defaults</samp>](## "router_isis.isis_af_defaults") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;redistribute_routes</samp>](## "router_isis.redistribute_routes") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- source_protocol</samp>](## "router_isis.redistribute_routes.[].source_protocol") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "router_isis.redistribute_routes.[].route_map") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;include_leaked</samp>](## "router_isis.redistribute_routes.[].include_leaked") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_route_type</samp>](## "router_isis.redistribute_routes.[].ospf_route_type") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;address_family_ipv4</samp>](## "router_isis.address_family_ipv4") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;maximum_paths</samp>](## "router_isis.address_family_ipv4.maximum_paths") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;fast_reroute_ti_lfa</samp>](## "router_isis.address_family_ipv4.fast_reroute_ti_lfa") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mode</samp>](## "router_isis.address_family_ipv4.fast_reroute_ti_lfa.mode") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level</samp>](## "router_isis.address_family_ipv4.fast_reroute_ti_lfa.level") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;srlg</samp>](## "router_isis.address_family_ipv4.fast_reroute_ti_lfa.srlg") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enable</samp>](## "router_isis.address_family_ipv4.fast_reroute_ti_lfa.srlg.enable") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;strict</samp>](## "router_isis.address_family_ipv4.fast_reroute_ti_lfa.srlg.strict") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;tunnel_source_labeled_unicast</samp>](## "router_isis.address_family_ipv4.tunnel_source_labeled_unicast") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "router_isis.address_family_ipv4.tunnel_source_labeled_unicast.enabled") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rcf</samp>](## "router_isis.address_family_ipv4.tunnel_source_labeled_unicast.rcf") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;address_family_ipv6</samp>](## "router_isis.address_family_ipv6") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;maximum_paths</samp>](## "router_isis.address_family_ipv6.maximum_paths") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;fast_reroute_ti_lfa</samp>](## "router_isis.address_family_ipv6.fast_reroute_ti_lfa") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mode</samp>](## "router_isis.address_family_ipv6.fast_reroute_ti_lfa.mode") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level</samp>](## "router_isis.address_family_ipv6.fast_reroute_ti_lfa.level") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;srlg</samp>](## "router_isis.address_family_ipv6.fast_reroute_ti_lfa.srlg") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enable</samp>](## "router_isis.address_family_ipv6.fast_reroute_ti_lfa.srlg.enable") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;strict</samp>](## "router_isis.address_family_ipv6.fast_reroute_ti_lfa.srlg.strict") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;segment_routing_mpls</samp>](## "router_isis.segment_routing_mpls") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "router_isis.segment_routing_mpls.enabled") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;router_id</samp>](## "router_isis.segment_routing_mpls.router_id") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;prefix_segments</samp>](## "router_isis.segment_routing_mpls.prefix_segments") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- prefix</samp>](## "router_isis.segment_routing_mpls.prefix_segments.[].prefix") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;index</samp>](## "router_isis.segment_routing_mpls.prefix_segments.[].index") | Integer |  |  |  |  |
+
+### YAML
+
+```yaml
+router_isis:
+  instance: <str>
+  net: <str>
+  router_id: <str>
+  is_type: <str>
+  log_adjacency_changes: <bool>
+  mpls_ldp_sync_default: <bool>
+  timers:
+    local_convergence:
+      protected_prefixes: <bool>
+      delay: <int>
+  advertise:
+    passive_only: <bool>
+  address_family: <str>
+  isis_af_defaults: <int>
+  redistribute_routes:
+    - source_protocol: <str>
+      route_map: <str>
+      include_leaked: <bool>
+      ospf_route_type: <str>
+  address_family_ipv4:
+    maximum_paths: <int>
+    fast_reroute_ti_lfa:
+      mode: <str>
+      level: <str>
+      srlg:
+        enable: <bool>
+        strict: <bool>
+    tunnel_source_labeled_unicast:
+      enabled: <bool>
+      rcf: <str>
+  address_family_ipv6:
+    maximum_paths: <int>
+    fast_reroute_ti_lfa:
+      mode: <str>
+      level: <str>
+      srlg:
+        enable: <bool>
+        strict: <bool>
+  segment_routing_mpls:
+    enabled: <bool>
+    router_id: <str>
+    prefix_segments:
+      - prefix: <str>
+        index: <int>
+```
+
 ## Router L2 VPN
 
 ### Variables

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -2207,7 +2207,7 @@ router_igmp:
 | [<samp>&nbsp;&nbsp;address_family_ipv4</samp>](## "router_isis.address_family_ipv4") | Dictionary |  |  |  | Address Family IPv4 |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;maximum_paths</samp>](## "router_isis.address_family_ipv4.maximum_paths") | Integer |  |  | Min: 1<br>Max: 128 |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;fast_reroute_ti_lfa</samp>](## "router_isis.address_family_ipv4.fast_reroute_ti_lfa") | Dictionary |  |  |  | Fast Reroute TI LFA |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mode</samp>](## "router_isis.address_family_ipv4.fast_reroute_ti_lfa.mode") | String |  |  | Valid Values:<br>- link-protection<br>- node_protection |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mode</samp>](## "router_isis.address_family_ipv4.fast_reroute_ti_lfa.mode") | String |  |  | Valid Values:<br>- link-protection<br>- node-protection |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level</samp>](## "router_isis.address_family_ipv4.fast_reroute_ti_lfa.level") | String |  |  | Valid Values:<br>- level-1<br>- level-2 |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;srlg</samp>](## "router_isis.address_family_ipv4.fast_reroute_ti_lfa.srlg") | Dictionary |  |  |  | SRLG<br>Shared Risk Link Group |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enable</samp>](## "router_isis.address_family_ipv4.fast_reroute_ti_lfa.srlg.enable") | Boolean |  |  |  |  |
@@ -2218,7 +2218,7 @@ router_igmp:
 | [<samp>&nbsp;&nbsp;address_family_ipv6</samp>](## "router_isis.address_family_ipv6") | Dictionary |  |  |  | Address Family IPv6 |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;maximum_paths</samp>](## "router_isis.address_family_ipv6.maximum_paths") | Integer |  |  | Min: 1<br>Max: 128 |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;fast_reroute_ti_lfa</samp>](## "router_isis.address_family_ipv6.fast_reroute_ti_lfa") | Dictionary |  |  |  | Fast Reroute TI LFA |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mode</samp>](## "router_isis.address_family_ipv6.fast_reroute_ti_lfa.mode") | String |  |  | Valid Values:<br>- link-protection<br>- node_protection |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mode</samp>](## "router_isis.address_family_ipv6.fast_reroute_ti_lfa.mode") | String |  |  | Valid Values:<br>- link-protection<br>- node-protection |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level</samp>](## "router_isis.address_family_ipv6.fast_reroute_ti_lfa.level") | String |  |  | Valid Values:<br>- level-1<br>- level-2 | Optional, default is to protect all levels |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;srlg</samp>](## "router_isis.address_family_ipv6.fast_reroute_ti_lfa.srlg") | Dictionary |  |  |  | SRLG<br>Shared Risk Link Group |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enable</samp>](## "router_isis.address_family_ipv6.fast_reroute_ti_lfa.srlg.enable") | Boolean |  |  |  |  |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -2219,7 +2219,7 @@ router_igmp:
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;maximum_paths</samp>](## "router_isis.address_family_ipv6.maximum_paths") | Integer |  |  | Min: 1<br>Max: 128 |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;fast_reroute_ti_lfa</samp>](## "router_isis.address_family_ipv6.fast_reroute_ti_lfa") | Dictionary |  |  |  | Fast Reroute TI LFA |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mode</samp>](## "router_isis.address_family_ipv6.fast_reroute_ti_lfa.mode") | String |  |  | Valid Values:<br>- link-protection<br>- node_protection |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level</samp>](## "router_isis.address_family_ipv6.fast_reroute_ti_lfa.level") | String |  |  | Valid Values:<br>- level-1<br>- level-2 |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level</samp>](## "router_isis.address_family_ipv6.fast_reroute_ti_lfa.level") | String |  |  | Valid Values:<br>- level-1<br>- level-2 | Optional, default is to protect all levels |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;srlg</samp>](## "router_isis.address_family_ipv6.fast_reroute_ti_lfa.srlg") | Dictionary |  |  |  | SRLG<br>Shared Risk Link Group |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enable</samp>](## "router_isis.address_family_ipv6.fast_reroute_ti_lfa.srlg.enable") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;strict</samp>](## "router_isis.address_family_ipv6.fast_reroute_ti_lfa.srlg.strict") | Boolean |  |  |  |  |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -2176,61 +2176,60 @@ router_igmp:
   ssm_aware: <bool>
 ```
 
-## Router Isis
+## Router ISIS
 
 ### Variables
 
 | Variable | Type | Required | Default | Value Restrictions | Description |
 | -------- | ---- | -------- | ------- | ------------------ | ----------- |
-| [<samp>router_isis</samp>](## "router_isis") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;instance</samp>](## "router_isis.instance") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;net</samp>](## "router_isis.net") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;router_id</samp>](## "router_isis.router_id") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;is_type</samp>](## "router_isis.is_type") | String |  |  |  |  |
+| [<samp>router_isis</samp>](## "router_isis") | Dictionary |  |  |  | Router ISIS |
+| [<samp>&nbsp;&nbsp;instance</samp>](## "router_isis.instance") | String |  |  |  | ISIS Instance Name |
+| [<samp>&nbsp;&nbsp;net</samp>](## "router_isis.net") | String |  |  |  | CLNS Address like "49.0001.0001.0000.0001.00" |
+| [<samp>&nbsp;&nbsp;router_id</samp>](## "router_isis.router_id") | String |  |  |  | Router ID<br>IPv4 Address |
+| [<samp>&nbsp;&nbsp;is_type</samp>](## "router_isis.is_type") | String |  |  | Valid Values:<br>- level-1<br>- level-1-2<br>- level-2 | IS Type |
 | [<samp>&nbsp;&nbsp;log_adjacency_changes</samp>](## "router_isis.log_adjacency_changes") | Boolean |  |  |  |  |
-| [<samp>&nbsp;&nbsp;mpls_ldp_sync_default</samp>](## "router_isis.mpls_ldp_sync_default") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;mpls_ldp_sync_default</samp>](## "router_isis.mpls_ldp_sync_default") | Boolean |  |  |  | MPLS LDP Sync Default |
 | [<samp>&nbsp;&nbsp;timers</samp>](## "router_isis.timers") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;local_convergence</samp>](## "router_isis.timers.local_convergence") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;protected_prefixes</samp>](## "router_isis.timers.local_convergence.protected_prefixes") | Boolean |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;delay</samp>](## "router_isis.timers.local_convergence.delay") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;delay</samp>](## "router_isis.timers.local_convergence.delay") | Integer |  | 10000 |  | Delay in milliseconds. |
 | [<samp>&nbsp;&nbsp;advertise</samp>](## "router_isis.advertise") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;passive_only</samp>](## "router_isis.advertise.passive_only") | Boolean |  |  |  |  |
-| [<samp>&nbsp;&nbsp;no_passive_interfaces</samp>](## "router_isis.no_passive_interfaces") | List, items: String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "router_isis.no_passive_interfaces.[].&lt;str&gt;") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;address_family</samp>](## "router_isis.address_family") | List, items: String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "router_isis.address_family.[].&lt;str&gt;") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;isis_af_defaults</samp>](## "router_isis.isis_af_defaults") | List, items: String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "router_isis.isis_af_defaults.[].&lt;str&gt;") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "router_isis.address_family.[].&lt;str&gt;") | String |  |  | Valid Values:<br>- ipv4<br>- ipv6<br>- ipv4 unicast<br>- ipv6 unicast | Address Family |
+| [<samp>&nbsp;&nbsp;isis_af_defaults</samp>](## "router_isis.isis_af_defaults") | List, items: String |  |  |  | ISIS AF Defaults |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "router_isis.isis_af_defaults.[].&lt;str&gt;") | String |  |  |  | EOS CLI rendered under the address families<br>Example "maximum-paths 64"<br> |
 | [<samp>&nbsp;&nbsp;redistribute_routes</samp>](## "router_isis.redistribute_routes") | List, items: Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- source_protocol</samp>](## "router_isis.redistribute_routes.[].source_protocol") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "router_isis.redistribute_routes.[].route_map") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- source_protocol</samp>](## "router_isis.redistribute_routes.[].source_protocol") | String | Required |  | Valid Values:<br>- bgp<br>- connected<br>- isis<br>- ospf<br>- ospfv3<br>- static |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "router_isis.redistribute_routes.[].route_map") | String |  |  |  | Route-map name |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;include_leaked</samp>](## "router_isis.redistribute_routes.[].include_leaked") | Boolean |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_route_type</samp>](## "router_isis.redistribute_routes.[].ospf_route_type") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;address_family_ipv4</samp>](## "router_isis.address_family_ipv4") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;maximum_paths</samp>](## "router_isis.address_family_ipv4.maximum_paths") | Integer |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;fast_reroute_ti_lfa</samp>](## "router_isis.address_family_ipv4.fast_reroute_ti_lfa") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mode</samp>](## "router_isis.address_family_ipv4.fast_reroute_ti_lfa.mode") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level</samp>](## "router_isis.address_family_ipv4.fast_reroute_ti_lfa.level") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;srlg</samp>](## "router_isis.address_family_ipv4.fast_reroute_ti_lfa.srlg") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_route_type</samp>](## "router_isis.redistribute_routes.[].ospf_route_type") | String |  |  | Valid Values:<br>- external<br>- internal<br>- nssa-external | OSPF Route Type<br>ospf_route_type is required with source_protocols 'ospf' and 'ospfv3' |
+| [<samp>&nbsp;&nbsp;address_family_ipv4</samp>](## "router_isis.address_family_ipv4") | Dictionary |  |  |  | Address Family IPv4 |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;maximum_paths</samp>](## "router_isis.address_family_ipv4.maximum_paths") | Integer |  |  | Min: 1<br>Max: 128 |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;fast_reroute_ti_lfa</samp>](## "router_isis.address_family_ipv4.fast_reroute_ti_lfa") | Dictionary |  |  |  | Fast Reroute TI LFA |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mode</samp>](## "router_isis.address_family_ipv4.fast_reroute_ti_lfa.mode") | String |  |  | Valid Values:<br>- link-protection<br>- node_protection |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level</samp>](## "router_isis.address_family_ipv4.fast_reroute_ti_lfa.level") | String |  |  | Valid Values:<br>- level-1<br>- level-2 |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;srlg</samp>](## "router_isis.address_family_ipv4.fast_reroute_ti_lfa.srlg") | Dictionary |  |  |  | SRLG<br>Shared Risk Link Group |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enable</samp>](## "router_isis.address_family_ipv4.fast_reroute_ti_lfa.srlg.enable") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;strict</samp>](## "router_isis.address_family_ipv4.fast_reroute_ti_lfa.srlg.strict") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;tunnel_source_labeled_unicast</samp>](## "router_isis.address_family_ipv4.tunnel_source_labeled_unicast") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "router_isis.address_family_ipv4.tunnel_source_labeled_unicast.enabled") | Boolean |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rcf</samp>](## "router_isis.address_family_ipv4.tunnel_source_labeled_unicast.rcf") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;address_family_ipv6</samp>](## "router_isis.address_family_ipv6") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;maximum_paths</samp>](## "router_isis.address_family_ipv6.maximum_paths") | Integer |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;fast_reroute_ti_lfa</samp>](## "router_isis.address_family_ipv6.fast_reroute_ti_lfa") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mode</samp>](## "router_isis.address_family_ipv6.fast_reroute_ti_lfa.mode") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level</samp>](## "router_isis.address_family_ipv6.fast_reroute_ti_lfa.level") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;srlg</samp>](## "router_isis.address_family_ipv6.fast_reroute_ti_lfa.srlg") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rcf</samp>](## "router_isis.address_family_ipv4.tunnel_source_labeled_unicast.rcf") | String |  |  |  | RCF<br>Route Control Function |
+| [<samp>&nbsp;&nbsp;address_family_ipv6</samp>](## "router_isis.address_family_ipv6") | Dictionary |  |  |  | Address Family IPv6 |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;maximum_paths</samp>](## "router_isis.address_family_ipv6.maximum_paths") | Integer |  |  | Min: 1<br>Max: 128 |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;fast_reroute_ti_lfa</samp>](## "router_isis.address_family_ipv6.fast_reroute_ti_lfa") | Dictionary |  |  |  | Fast Reroute TI LFA |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mode</samp>](## "router_isis.address_family_ipv6.fast_reroute_ti_lfa.mode") | String |  |  | Valid Values:<br>- link-protection<br>- node_protection |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level</samp>](## "router_isis.address_family_ipv6.fast_reroute_ti_lfa.level") | String |  |  | Valid Values:<br>- level-1<br>- level-2 |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;srlg</samp>](## "router_isis.address_family_ipv6.fast_reroute_ti_lfa.srlg") | Dictionary |  |  |  | SRLG<br>Shared Risk Link Group |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enable</samp>](## "router_isis.address_family_ipv6.fast_reroute_ti_lfa.srlg.enable") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;strict</samp>](## "router_isis.address_family_ipv6.fast_reroute_ti_lfa.srlg.strict") | Boolean |  |  |  |  |
-| [<samp>&nbsp;&nbsp;segment_routing_mpls</samp>](## "router_isis.segment_routing_mpls") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;segment_routing_mpls</samp>](## "router_isis.segment_routing_mpls") | Dictionary |  |  |  | Segment Routing MPLS |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "router_isis.segment_routing_mpls.enabled") | Boolean |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;router_id</samp>](## "router_isis.segment_routing_mpls.router_id") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;router_id</samp>](## "router_isis.segment_routing_mpls.router_id") | String |  |  |  | Router ID |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;prefix_segments</samp>](## "router_isis.segment_routing_mpls.prefix_segments") | List, items: Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- prefix</samp>](## "router_isis.segment_routing_mpls.prefix_segments.[].prefix") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;index</samp>](## "router_isis.segment_routing_mpls.prefix_segments.[].index") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;no_passive_interfaces</samp>](## "router_isis.no_passive_interfaces") | List |  |  |  | Unused key - to be removed from eos_designs. |
 
 ### YAML
 
@@ -2248,8 +2247,6 @@ router_isis:
       delay: <int>
   advertise:
     passive_only: <bool>
-  no_passive_interfaces:
-    - <str>
   address_family:
     - <str>
   isis_af_defaults:
@@ -2284,6 +2281,7 @@ router_isis:
     prefix_segments:
       - prefix: <str>
         index: <int>
+  no_passive_interfaces:
 ```
 
 ## Router L2 VPN

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -2195,8 +2195,12 @@ router_igmp:
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;delay</samp>](## "router_isis.timers.local_convergence.delay") | Integer |  |  |  |  |
 | [<samp>&nbsp;&nbsp;advertise</samp>](## "router_isis.advertise") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;passive_only</samp>](## "router_isis.advertise.passive_only") | Boolean |  |  |  |  |
-| [<samp>&nbsp;&nbsp;address_family</samp>](## "router_isis.address_family") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;isis_af_defaults</samp>](## "router_isis.isis_af_defaults") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;no_passive_interfaces</samp>](## "router_isis.no_passive_interfaces") | List, items: String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "router_isis.no_passive_interfaces.[].&lt;str&gt;") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;address_family</samp>](## "router_isis.address_family") | List, items: String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "router_isis.address_family.[].&lt;str&gt;") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;isis_af_defaults</samp>](## "router_isis.isis_af_defaults") | List, items: String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "router_isis.isis_af_defaults.[].&lt;str&gt;") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;redistribute_routes</samp>](## "router_isis.redistribute_routes") | List, items: Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- source_protocol</samp>](## "router_isis.redistribute_routes.[].source_protocol") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "router_isis.redistribute_routes.[].route_map") | String |  |  |  |  |
@@ -2244,8 +2248,12 @@ router_isis:
       delay: <int>
   advertise:
     passive_only: <bool>
-  address_family: <str>
-  isis_af_defaults: <int>
+  no_passive_interfaces:
+    - <str>
+  address_family:
+    - <str>
+  isis_af_defaults:
+    - <str>
   redistribute_routes:
     - source_protocol: <str>
       route_map: <str>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -3613,12 +3613,25 @@
           "additionalProperties": false,
           "title": "Advertise"
         },
+        "no_passive_interfaces": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "title": "No Passive Interfaces"
+        },
         "address_family": {
-          "type": "string",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
           "title": "Address Family"
         },
         "isis_af_defaults": {
-          "type": "integer",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
           "title": "Isis Af Defaults"
         },
         "redistribute_routes": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -3553,6 +3553,234 @@
       },
       "additionalProperties": false
     },
+    "router_isis": {
+      "type": "object",
+      "properties": {
+        "instance": {
+          "type": "string",
+          "title": "Instance"
+        },
+        "net": {
+          "type": "string",
+          "title": "Net"
+        },
+        "router_id": {
+          "type": "string",
+          "title": "Router Id"
+        },
+        "is_type": {
+          "type": "string",
+          "title": "Is Type"
+        },
+        "log_adjacency_changes": {
+          "type": "boolean",
+          "title": "Log Adjacency Changes"
+        },
+        "mpls_ldp_sync_default": {
+          "type": "boolean",
+          "title": "Mpls Ldp Sync Default"
+        },
+        "timers": {
+          "type": "object",
+          "properties": {
+            "local_convergence": {
+              "type": "object",
+              "properties": {
+                "protected_prefixes": {
+                  "type": "boolean",
+                  "title": "Protected Prefixes"
+                },
+                "delay": {
+                  "type": "integer",
+                  "title": "Delay"
+                }
+              },
+              "additionalProperties": false,
+              "title": "Local Convergence"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Timers"
+        },
+        "advertise": {
+          "type": "object",
+          "properties": {
+            "passive_only": {
+              "type": "boolean",
+              "title": "Passive Only"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Advertise"
+        },
+        "address_family": {
+          "type": "string",
+          "title": "Address Family"
+        },
+        "isis_af_defaults": {
+          "type": "integer",
+          "title": "Isis Af Defaults"
+        },
+        "redistribute_routes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "source_protocol": {
+                "type": "string",
+                "title": "Source Protocol"
+              },
+              "route_map": {
+                "type": "string",
+                "title": "Route Map"
+              },
+              "include_leaked": {
+                "type": "boolean",
+                "title": "Include Leaked"
+              },
+              "ospf_route_type": {
+                "type": "string",
+                "title": "Ospf Route Type"
+              }
+            },
+            "additionalProperties": false
+          },
+          "title": "Redistribute Routes"
+        },
+        "address_family_ipv4": {
+          "type": "object",
+          "properties": {
+            "maximum_paths": {
+              "type": "integer",
+              "title": "Maximum Paths"
+            },
+            "fast_reroute_ti_lfa": {
+              "type": "object",
+              "properties": {
+                "mode": {
+                  "type": "string",
+                  "title": "Mode"
+                },
+                "level": {
+                  "type": "string",
+                  "title": "Level"
+                },
+                "srlg": {
+                  "type": "object",
+                  "properties": {
+                    "enable": {
+                      "type": "boolean",
+                      "title": "Enable"
+                    },
+                    "strict": {
+                      "type": "boolean",
+                      "title": "Strict"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "title": "Srlg"
+                }
+              },
+              "additionalProperties": false,
+              "title": "Fast Reroute Ti Lfa"
+            },
+            "tunnel_source_labeled_unicast": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "title": "Enabled"
+                },
+                "rcf": {
+                  "type": "string",
+                  "title": "Rcf"
+                }
+              },
+              "additionalProperties": false,
+              "title": "Tunnel Source Labeled Unicast"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Address Family Ipv4"
+        },
+        "address_family_ipv6": {
+          "type": "object",
+          "properties": {
+            "maximum_paths": {
+              "type": "integer",
+              "title": "Maximum Paths"
+            },
+            "fast_reroute_ti_lfa": {
+              "type": "object",
+              "properties": {
+                "mode": {
+                  "type": "string",
+                  "title": "Mode"
+                },
+                "level": {
+                  "type": "string",
+                  "title": "Level"
+                },
+                "srlg": {
+                  "type": "object",
+                  "properties": {
+                    "enable": {
+                      "type": "boolean",
+                      "title": "Enable"
+                    },
+                    "strict": {
+                      "type": "boolean",
+                      "title": "Strict"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "title": "Srlg"
+                }
+              },
+              "additionalProperties": false,
+              "title": "Fast Reroute Ti Lfa"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Address Family Ipv6"
+        },
+        "segment_routing_mpls": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "title": "Enabled"
+            },
+            "router_id": {
+              "type": "string",
+              "title": "Router Id"
+            },
+            "prefix_segments": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "prefix": {
+                    "type": "string",
+                    "title": "Prefix"
+                  },
+                  "index": {
+                    "type": "integer",
+                    "title": "Index"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "title": "Prefix Segments"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Segment Routing Mpls"
+        }
+      },
+      "additionalProperties": false,
+      "title": "Router Isis"
+    },
     "router_l2_vpn": {
       "type": "object",
       "title": "Router L2 VPN",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -3708,7 +3708,7 @@
                   "type": "string",
                   "enum": [
                     "link-protection",
-                    "node_protection"
+                    "node-protection"
                   ],
                   "title": "Mode"
                 },
@@ -3718,7 +3718,6 @@
                     "level-1",
                     "level-2"
                   ],
-                  "description": "Optional, default is to protect all levels",
                   "title": "Level"
                 },
                 "srlg": {
@@ -3777,7 +3776,7 @@
                   "type": "string",
                   "enum": [
                     "link-protection",
-                    "node_protection"
+                    "node-protection"
                   ],
                   "title": "Mode"
                 },
@@ -3787,6 +3786,7 @@
                     "level-1",
                     "level-2"
                   ],
+                  "description": "Optional, default is to protect all levels",
                   "title": "Level"
                 },
                 "srlg": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -3555,22 +3555,31 @@
     },
     "router_isis": {
       "type": "object",
+      "title": "Router ISIS",
       "properties": {
         "instance": {
           "type": "string",
+          "description": "ISIS Instance Name",
           "title": "Instance"
         },
         "net": {
           "type": "string",
+          "description": "CLNS Address like \"49.0001.0001.0000.0001.00\"",
           "title": "Net"
         },
         "router_id": {
           "type": "string",
-          "title": "Router Id"
+          "title": "Router ID",
+          "description": "IPv4 Address"
         },
         "is_type": {
           "type": "string",
-          "title": "Is Type"
+          "title": "IS Type",
+          "enum": [
+            "level-1",
+            "level-1-2",
+            "level-2"
+          ]
         },
         "log_adjacency_changes": {
           "type": "boolean",
@@ -3578,7 +3587,7 @@
         },
         "mpls_ldp_sync_default": {
           "type": "boolean",
-          "title": "Mpls Ldp Sync Default"
+          "title": "MPLS LDP Sync Default"
         },
         "timers": {
           "type": "object",
@@ -3592,6 +3601,8 @@
                 },
                 "delay": {
                   "type": "integer",
+                  "default": 10000,
+                  "description": "Delay in milliseconds.",
                   "title": "Delay"
                 }
               },
@@ -3613,26 +3624,27 @@
           "additionalProperties": false,
           "title": "Advertise"
         },
-        "no_passive_interfaces": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "title": "No Passive Interfaces"
-        },
         "address_family": {
           "type": "array",
           "items": {
-            "type": "string"
+            "type": "string",
+            "enum": [
+              "ipv4",
+              "ipv6",
+              "ipv4 unicast",
+              "ipv6 unicast"
+            ],
+            "description": "Address Family"
           },
           "title": "Address Family"
         },
         "isis_af_defaults": {
           "type": "array",
+          "title": "ISIS AF Defaults",
           "items": {
-            "type": "string"
-          },
-          "title": "Isis Af Defaults"
+            "type": "string",
+            "description": "EOS CLI rendered under the address families\nExample \"maximum-paths 64\"\n"
+          }
         },
         "redistribute_routes": {
           "type": "array",
@@ -3641,10 +3653,19 @@
             "properties": {
               "source_protocol": {
                 "type": "string",
+                "enum": [
+                  "bgp",
+                  "connected",
+                  "isis",
+                  "ospf",
+                  "ospfv3",
+                  "static"
+                ],
                 "title": "Source Protocol"
               },
               "route_map": {
                 "type": "string",
+                "description": "Route-map name",
                 "title": "Route Map"
               },
               "include_leaked": {
@@ -3653,33 +3674,56 @@
               },
               "ospf_route_type": {
                 "type": "string",
-                "title": "Ospf Route Type"
+                "title": "OSPF Route Type",
+                "enum": [
+                  "external",
+                  "internal",
+                  "nssa-external"
+                ],
+                "description": "ospf_route_type is required with source_protocols 'ospf' and 'ospfv3'"
               }
             },
+            "required": [
+              "source_protocol"
+            ],
             "additionalProperties": false
           },
           "title": "Redistribute Routes"
         },
         "address_family_ipv4": {
           "type": "object",
+          "title": "Address Family IPv4",
           "properties": {
             "maximum_paths": {
               "type": "integer",
+              "minimum": 1,
+              "maximum": 128,
               "title": "Maximum Paths"
             },
             "fast_reroute_ti_lfa": {
               "type": "object",
+              "title": "Fast Reroute TI LFA",
               "properties": {
                 "mode": {
                   "type": "string",
+                  "enum": [
+                    "link-protection",
+                    "node_protection"
+                  ],
                   "title": "Mode"
                 },
                 "level": {
                   "type": "string",
+                  "enum": [
+                    "level-1",
+                    "level-2"
+                  ],
                   "title": "Level"
                 },
                 "srlg": {
                   "type": "object",
+                  "title": "SRLG",
+                  "description": "Shared Risk Link Group",
                   "properties": {
                     "enable": {
                       "type": "boolean",
@@ -3690,12 +3734,10 @@
                       "title": "Strict"
                     }
                   },
-                  "additionalProperties": false,
-                  "title": "Srlg"
+                  "additionalProperties": false
                 }
               },
-              "additionalProperties": false,
-              "title": "Fast Reroute Ti Lfa"
+              "additionalProperties": false
             },
             "tunnel_source_labeled_unicast": {
               "type": "object",
@@ -3706,36 +3748,50 @@
                 },
                 "rcf": {
                   "type": "string",
-                  "title": "Rcf"
+                  "title": "RCF",
+                  "description": "Route Control Function"
                 }
               },
               "additionalProperties": false,
               "title": "Tunnel Source Labeled Unicast"
             }
           },
-          "additionalProperties": false,
-          "title": "Address Family Ipv4"
+          "additionalProperties": false
         },
         "address_family_ipv6": {
           "type": "object",
+          "title": "Address Family IPv6",
           "properties": {
             "maximum_paths": {
               "type": "integer",
+              "minimum": 1,
+              "maximum": 128,
               "title": "Maximum Paths"
             },
             "fast_reroute_ti_lfa": {
               "type": "object",
+              "title": "Fast Reroute TI LFA",
               "properties": {
                 "mode": {
                   "type": "string",
+                  "enum": [
+                    "link-protection",
+                    "node_protection"
+                  ],
                   "title": "Mode"
                 },
                 "level": {
                   "type": "string",
+                  "enum": [
+                    "level-1",
+                    "level-2"
+                  ],
                   "title": "Level"
                 },
                 "srlg": {
                   "type": "object",
+                  "title": "SRLG",
+                  "description": "Shared Risk Link Group",
                   "properties": {
                     "enable": {
                       "type": "boolean",
@@ -3746,19 +3802,17 @@
                       "title": "Strict"
                     }
                   },
-                  "additionalProperties": false,
-                  "title": "Srlg"
+                  "additionalProperties": false
                 }
               },
-              "additionalProperties": false,
-              "title": "Fast Reroute Ti Lfa"
+              "additionalProperties": false
             }
           },
-          "additionalProperties": false,
-          "title": "Address Family Ipv6"
+          "additionalProperties": false
         },
         "segment_routing_mpls": {
           "type": "object",
+          "title": "Segment Routing MPLS",
           "properties": {
             "enabled": {
               "type": "boolean",
@@ -3766,7 +3820,7 @@
             },
             "router_id": {
               "type": "string",
-              "title": "Router Id"
+              "title": "Router ID"
             },
             "prefix_segments": {
               "type": "array",
@@ -3787,12 +3841,15 @@
               "title": "Prefix Segments"
             }
           },
-          "additionalProperties": false,
-          "title": "Segment Routing Mpls"
+          "additionalProperties": false
+        },
+        "no_passive_interfaces": {
+          "type": "array",
+          "description": "Unused key - to be removed from eos_designs.",
+          "title": "No Passive Interfaces"
         }
       },
-      "additionalProperties": false,
-      "title": "Router Isis"
+      "additionalProperties": false
     },
     "router_l2_vpn": {
       "type": "object",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -3718,6 +3718,7 @@
                     "level-1",
                     "level-2"
                   ],
+                  "description": "Optional, default is to protect all levels",
                   "title": "Level"
                 },
                 "srlg": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -2824,13 +2824,12 @@ keys:
                 type: str
                 valid_values:
                 - link-protection
-                - node_protection
+                - node-protection
               level:
                 type: str
                 valid_values:
                 - level-1
                 - level-2
-                description: Optional, default is to protect all levels
               srlg:
                 type: dict
                 display_name: SRLG
@@ -2867,12 +2866,13 @@ keys:
                 type: str
                 valid_values:
                 - link-protection
-                - node_protection
+                - node-protection
               level:
                 type: str
                 valid_values:
                 - level-1
                 - level-2
+                description: Optional, default is to protect all levels
               srlg:
                 type: dict
                 display_name: SRLG

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -2714,19 +2714,30 @@ keys:
         type: bool
   router_isis:
     type: dict
+    display_name: Router ISIS
     keys:
       instance:
         type: str
+        description: ISIS Instance Name
       net:
         type: str
+        description: CLNS Address like "49.0001.0001.0000.0001.00"
       router_id:
         type: str
+        display_name: Router ID
+        description: IPv4 Address
       is_type:
         type: str
+        display_name: IS Type
+        valid_values:
+        - level-1
+        - level-1-2
+        - level-2
       log_adjacency_changes:
         type: bool
       mpls_ldp_sync_default:
         type: bool
+        display_name: MPLS LDP Sync Default
       timers:
         type: dict
         keys:
@@ -2737,23 +2748,35 @@ keys:
                 type: bool
               delay:
                 type: int
+                convert_types:
+                - str
+                default: 10000
+                description: Delay in milliseconds.
       advertise:
         type: dict
         keys:
           passive_only:
             type: bool
-      no_passive_interfaces:
-        type: list
-        items:
-          type: str
       address_family:
         type: list
         items:
           type: str
+          valid_values:
+          - ipv4
+          - ipv6
+          - ipv4 unicast
+          - ipv6 unicast
+          description: Address Family
       isis_af_defaults:
         type: list
+        display_name: ISIS AF Defaults
         items:
           type: str
+          description: 'EOS CLI rendered under the address families
+
+            Example "maximum-paths 64"
+
+            '
       redistribute_routes:
         type: list
         items:
@@ -2761,26 +2784,56 @@ keys:
           keys:
             source_protocol:
               type: str
+              required: true
+              valid_values:
+              - bgp
+              - connected
+              - isis
+              - ospf
+              - ospfv3
+              - static
             route_map:
               type: str
+              description: Route-map name
             include_leaked:
               type: bool
             ospf_route_type:
               type: str
+              display_name: OSPF Route Type
+              valid_values:
+              - external
+              - internal
+              - nssa-external
+              description: ospf_route_type is required with source_protocols 'ospf'
+                and 'ospfv3'
       address_family_ipv4:
         type: dict
+        display_name: Address Family IPv4
         keys:
           maximum_paths:
             type: int
+            convert_types:
+            - str
+            min: 1
+            max: 128
           fast_reroute_ti_lfa:
             type: dict
+            display_name: Fast Reroute TI LFA
             keys:
               mode:
                 type: str
+                valid_values:
+                - link-protection
+                - node_protection
               level:
                 type: str
+                valid_values:
+                - level-1
+                - level-2
               srlg:
                 type: dict
+                display_name: SRLG
+                description: Shared Risk Link Group
                 keys:
                   enable:
                     type: bool
@@ -2793,20 +2846,36 @@ keys:
                 type: bool
               rcf:
                 type: str
+                display_name: RCF
+                description: Route Control Function
       address_family_ipv6:
         type: dict
+        display_name: Address Family IPv6
         keys:
           maximum_paths:
             type: int
+            convert_types:
+            - str
+            min: 1
+            max: 128
           fast_reroute_ti_lfa:
             type: dict
+            display_name: Fast Reroute TI LFA
             keys:
               mode:
                 type: str
+                valid_values:
+                - link-protection
+                - node_protection
               level:
                 type: str
+                valid_values:
+                - level-1
+                - level-2
               srlg:
                 type: dict
+                display_name: SRLG
+                description: Shared Risk Link Group
                 keys:
                   enable:
                     type: bool
@@ -2814,11 +2883,13 @@ keys:
                     type: bool
       segment_routing_mpls:
         type: dict
+        display_name: Segment Routing MPLS
         keys:
           enabled:
             type: bool
           router_id:
             type: str
+            display_name: Router ID
           prefix_segments:
             type: list
             convert_types:
@@ -2830,6 +2901,11 @@ keys:
                   type: str
                 index:
                   type: int
+                  convert_types:
+                  - str
+      no_passive_interfaces:
+        type: list
+        description: Unused key - to be removed from eos_designs.
   router_l2_vpn:
     type: dict
     display_name: Router L2 VPN

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -2742,10 +2742,18 @@ keys:
         keys:
           passive_only:
             type: bool
+      no_passive_interfaces:
+        type: list
+        items:
+          type: str
       address_family:
-        type: str
+        type: list
+        items:
+          type: str
       isis_af_defaults:
-        type: int
+        type: list
+        items:
+          type: str
       redistribute_routes:
         type: list
         items:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -2830,6 +2830,7 @@ keys:
                 valid_values:
                 - level-1
                 - level-2
+                description: Optional, default is to protect all levels
               srlg:
                 type: dict
                 display_name: SRLG

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -2712,6 +2712,116 @@ keys:
     keys:
       ssm_aware:
         type: bool
+  router_isis:
+    type: dict
+    keys:
+      instance:
+        type: str
+      net:
+        type: str
+      router_id:
+        type: str
+      is_type:
+        type: str
+      log_adjacency_changes:
+        type: bool
+      mpls_ldp_sync_default:
+        type: bool
+      timers:
+        type: dict
+        keys:
+          local_convergence:
+            type: dict
+            keys:
+              protected_prefixes:
+                type: bool
+              delay:
+                type: int
+      advertise:
+        type: dict
+        keys:
+          passive_only:
+            type: bool
+      address_family:
+        type: str
+      isis_af_defaults:
+        type: int
+      redistribute_routes:
+        type: list
+        items:
+          type: dict
+          keys:
+            source_protocol:
+              type: str
+            route_map:
+              type: str
+            include_leaked:
+              type: bool
+            ospf_route_type:
+              type: str
+      address_family_ipv4:
+        type: dict
+        keys:
+          maximum_paths:
+            type: int
+          fast_reroute_ti_lfa:
+            type: dict
+            keys:
+              mode:
+                type: str
+              level:
+                type: str
+              srlg:
+                type: dict
+                keys:
+                  enable:
+                    type: bool
+                  strict:
+                    type: bool
+          tunnel_source_labeled_unicast:
+            type: dict
+            keys:
+              enabled:
+                type: bool
+              rcf:
+                type: str
+      address_family_ipv6:
+        type: dict
+        keys:
+          maximum_paths:
+            type: int
+          fast_reroute_ti_lfa:
+            type: dict
+            keys:
+              mode:
+                type: str
+              level:
+                type: str
+              srlg:
+                type: dict
+                keys:
+                  enable:
+                    type: bool
+                  strict:
+                    type: bool
+      segment_routing_mpls:
+        type: dict
+        keys:
+          enabled:
+            type: bool
+          router_id:
+            type: str
+          prefix_segments:
+            type: list
+            convert_types:
+            - dict
+            items:
+              type: dict
+              keys:
+                prefix:
+                  type: str
+                index:
+                  type: int
   router_l2_vpn:
     type: dict
     display_name: Router L2 VPN

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_isis.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_isis.schema.yml
@@ -160,6 +160,7 @@ keys:
                 valid_values:
                   - "level-1"
                   - "level-2"
+                description: Optional, default is to protect all levels
               srlg:
                 type: dict
                 display_name: SRLG

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_isis.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_isis.schema.yml
@@ -33,10 +33,18 @@ keys:
         keys:
           passive_only:
             type: bool
+      no_passive_interfaces:
+        type: list
+        items:
+          type: str
       address_family:
-        type: str
+        type: list
+        items:
+          type: str
       isis_af_defaults:
-        type: int
+        type: list
+        items:
+          type: str
       redistribute_routes:
         type: list
         items:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_isis.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_isis.schema.yml
@@ -112,7 +112,7 @@ keys:
                 type: str
                 valid_values:
                   - "link-protection"
-                  - "node_protection"
+                  - "node-protection"
               level:
                 type: str
                 valid_values:
@@ -154,7 +154,7 @@ keys:
                 type: str
                 valid_values:
                   - "link-protection"
-                  - "node_protection"
+                  - "node-protection"
               level:
                 type: str
                 valid_values:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_isis.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_isis.schema.yml
@@ -5,19 +5,30 @@ type: dict
 keys:
   router_isis:
     type: dict
+    display_name: Router ISIS
     keys:
       instance:
         type: str
+        description: ISIS Instance Name
       net:
         type: str
+        description: CLNS Address like "49.0001.0001.0000.0001.00"
       router_id:
         type: str
+        display_name: Router ID
+        description: IPv4 Address
       is_type:
         type: str
+        display_name: IS Type
+        valid_values:
+          - "level-1"
+          - "level-1-2"
+          - "level-2"
       log_adjacency_changes:
         type: bool
       mpls_ldp_sync_default:
         type: bool
+        display_name: MPLS LDP Sync Default
       timers:
         type: dict
         keys:
@@ -28,23 +39,33 @@ keys:
                 type: bool
               delay:
                 type: int
+                convert_types:
+                  - str
+                default: 10000
+                description: Delay in milliseconds.
       advertise:
         type: dict
         keys:
           passive_only:
             type: bool
-      no_passive_interfaces:
-        type: list
-        items:
-          type: str
       address_family:
         type: list
         items:
           type: str
+          valid_values:
+            - "ipv4"
+            - "ipv6"
+            - "ipv4 unicast"
+            - "ipv6 unicast"
+          description: Address Family
       isis_af_defaults:
         type: list
+        display_name: ISIS AF Defaults
         items:
           type: str
+          description: |
+            EOS CLI rendered under the address families
+            Example "maximum-paths 64"
       redistribute_routes:
         type: list
         items:
@@ -52,26 +73,55 @@ keys:
           keys:
             source_protocol:
               type: str
+              required: true
+              valid_values:
+                - "bgp"
+                - "connected"
+                - "isis"
+                - "ospf"
+                - "ospfv3"
+                - "static"
             route_map:
               type: str
+              description: Route-map name
             include_leaked:
               type: bool
             ospf_route_type:
               type: str
+              display_name: OSPF Route Type
+              valid_values:
+                - "external"
+                - "internal"
+                - "nssa-external"
+              description: ospf_route_type is required with source_protocols 'ospf' and 'ospfv3'
       address_family_ipv4:
         type: dict
+        display_name: Address Family IPv4
         keys:
           maximum_paths:
             type: int
+            convert_types:
+              - "str"
+            min: 1
+            max: 128
           fast_reroute_ti_lfa:
             type: dict
+            display_name: Fast Reroute TI LFA
             keys:
               mode:
                 type: str
+                valid_values:
+                  - "link-protection"
+                  - "node_protection"
               level:
                 type: str
+                valid_values:
+                  - "level-1"
+                  - "level-2"
               srlg:
                 type: dict
+                display_name: SRLG
+                description: Shared Risk Link Group
                 keys:
                   enable:
                     type: bool
@@ -84,20 +134,36 @@ keys:
                 type: bool
               rcf:
                 type: str
+                display_name: RCF
+                description: Route Control Function
       address_family_ipv6:
         type: dict
+        display_name: Address Family IPv6
         keys:
           maximum_paths:
             type: int
+            convert_types:
+              - "str"
+            min: 1
+            max: 128
           fast_reroute_ti_lfa:
             type: dict
+            display_name: Fast Reroute TI LFA
             keys:
               mode:
                 type: str
+                valid_values:
+                  - "link-protection"
+                  - "node_protection"
               level:
                 type: str
+                valid_values:
+                  - "level-1"
+                  - "level-2"
               srlg:
                 type: dict
+                display_name: SRLG
+                description: Shared Risk Link Group
                 keys:
                   enable:
                     type: bool
@@ -105,15 +171,17 @@ keys:
                     type: bool
       segment_routing_mpls:
         type: dict
+        display_name: Segment Routing MPLS
         keys:
           enabled:
             type: bool
           router_id:
             type: str
+            display_name: Router ID
           prefix_segments:
             type: list
             convert_types:
-            - dict
+              - dict
             items:
               type: dict
               keys:
@@ -121,3 +189,8 @@ keys:
                   type: str
                 index:
                   type: int
+                  convert_types:
+                    - str
+      no_passive_interfaces:
+        type: list
+        description: Unused key - to be removed from eos_designs.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_isis.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_isis.schema.yml
@@ -1,0 +1,115 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  router_isis:
+    type: dict
+    keys:
+      instance:
+        type: str
+      net:
+        type: str
+      router_id:
+        type: str
+      is_type:
+        type: str
+      log_adjacency_changes:
+        type: bool
+      mpls_ldp_sync_default:
+        type: bool
+      timers:
+        type: dict
+        keys:
+          local_convergence:
+            type: dict
+            keys:
+              protected_prefixes:
+                type: bool
+              delay:
+                type: int
+      advertise:
+        type: dict
+        keys:
+          passive_only:
+            type: bool
+      address_family:
+        type: str
+      isis_af_defaults:
+        type: int
+      redistribute_routes:
+        type: list
+        items:
+          type: dict
+          keys:
+            source_protocol:
+              type: str
+            route_map:
+              type: str
+            include_leaked:
+              type: bool
+            ospf_route_type:
+              type: str
+      address_family_ipv4:
+        type: dict
+        keys:
+          maximum_paths:
+            type: int
+          fast_reroute_ti_lfa:
+            type: dict
+            keys:
+              mode:
+                type: str
+              level:
+                type: str
+              srlg:
+                type: dict
+                keys:
+                  enable:
+                    type: bool
+                  strict:
+                    type: bool
+          tunnel_source_labeled_unicast:
+            type: dict
+            keys:
+              enabled:
+                type: bool
+              rcf:
+                type: str
+      address_family_ipv6:
+        type: dict
+        keys:
+          maximum_paths:
+            type: int
+          fast_reroute_ti_lfa:
+            type: dict
+            keys:
+              mode:
+                type: str
+              level:
+                type: str
+              srlg:
+                type: dict
+                keys:
+                  enable:
+                    type: bool
+                  strict:
+                    type: bool
+      segment_routing_mpls:
+        type: dict
+        keys:
+          enabled:
+            type: bool
+          router_id:
+            type: str
+          prefix_segments:
+            type: list
+            convert_types:
+            - dict
+            items:
+              type: dict
+              keys:
+                prefix:
+                  type: str
+                index:
+                  type: int


### PR DESCRIPTION
## Add schema for data model

<!-- Use this PR Title: Feat(eos_cli_config_gen): Add schema for < data_model_key > -->

## Checklist

### Contributor Checklist

- [x] Create schema fragment matching data model described in README.md and README_v4.0.md
  - README.md is most complete with all keys. README_v4.0 includes partial data models after conversion to lists.
  - Schema fragment path is `roles/eos_cli_config_gen/schemas/schema_fragments/<data_model_key>.schema.yml`.
  - Copy line 1-5 from another schema (comments and outer type:dict).
  - Refer to [schema documentation](https://avd.sh/en/devel/docs/input-variable-validation-BETA.html) for syntax and/or use YAML Lint plugin from Redhat in VSCode.
  - Use `convert_types` on value that could be mixed type or misinterpreted like integers and numeric strings.
- [x] If the data model has been converted from wildcard dicts:
  - Add `convert_types: ['dict']` to the schema.
  - Remove `convert_dicts` from the `templates/eos/<>.j2` and `templates/documentation/<>.j2` templates.
- [x] Run `molecule converge -s build_schemas_and_docs` to update schema and documentation.
- [x] Test by running `molecule converge -s eos_cli_config_gen` and verify no errors or changes to generated configs/docs.

### Reviewer Checklist

- Reviewer 1: Claus
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2: Carl
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
