### PR TITLE
Feat(eos_cli_config_gen): Add schema for hardware

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -697,18 +697,18 @@ generate_default_config: <bool>
 generate_device_documentation: <bool>
 ```
 
-## Speed-Group Settings
+## Hardware
 
 ### Variables
 
 | Variable | Type | Required | Default | Value Restrictions | Description |
 | -------- | ---- | -------- | ------- | ------------------ | ----------- |
-| [<samp>hardware</samp>](## "hardware") | Dictionary |  |  |  | Speed-Group Settings |
+| [<samp>hardware</samp>](## "hardware") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;access_list</samp>](## "hardware.access_list") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mechanism</samp>](## "hardware.access_list.mechanism") | String |  |  | Valid Values:<br>- algomatch<br>- none<br>- tcam |  |
 | [<samp>&nbsp;&nbsp;speed_groups</samp>](## "hardware.speed_groups") | List, items: Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- speed_group</samp>](## "hardware.speed_groups.[].speed_group") | Integer | Required, Unique |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;serdes</samp>](## "hardware.speed_groups.[].serdes") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;serdes</samp>](## "hardware.speed_groups.[].serdes") | String |  |  |  | Serdes speed like "10g" or "25g" |
 
 ### YAML
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -697,6 +697,30 @@ generate_default_config: <bool>
 generate_device_documentation: <bool>
 ```
 
+## Speed-Group Settings
+
+### Variables
+
+| Variable | Type | Required | Default | Value Restrictions | Description |
+| -------- | ---- | -------- | ------- | ------------------ | ----------- |
+| [<samp>hardware</samp>](## "hardware") | Dictionary |  |  |  | Speed-Group Settings |
+| [<samp>&nbsp;&nbsp;access_list</samp>](## "hardware.access_list") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mechanism</samp>](## "hardware.access_list.mechanism") | String |  |  | Valid Values:<br>- algomatch<br>- none<br>- tcam |  |
+| [<samp>&nbsp;&nbsp;speed_groups</samp>](## "hardware.speed_groups") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- speed_group</samp>](## "hardware.speed_groups.[].speed_group") | Integer | Required, Unique |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;serdes</samp>](## "hardware.speed_groups.[].serdes") | String |  |  |  |  |
+
+### YAML
+
+```yaml
+hardware:
+  access_list:
+    mechanism: <str>
+  speed_groups:
+    - speed_group: <int>
+      serdes: <str>
+```
+
 ## Interface Defaults
 
 ### Variables

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -956,7 +956,6 @@
       "title": "Generate Device Documentation"
     },
     "hardware": {
-      "title": "Speed-Group Settings",
       "type": "object",
       "properties": {
         "access_list": {
@@ -986,6 +985,7 @@
               },
               "serdes": {
                 "type": "string",
+                "description": "Serdes speed like \"10g\" or \"25g\"",
                 "title": "Serdes"
               }
             },
@@ -997,7 +997,8 @@
           "title": "Speed Groups"
         }
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "title": "Hardware"
     },
     "interface_defaults": {
       "type": "object",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -955,6 +955,50 @@
       "default": true,
       "title": "Generate Device Documentation"
     },
+    "hardware": {
+      "title": "Speed-Group Settings",
+      "type": "object",
+      "properties": {
+        "access_list": {
+          "type": "object",
+          "properties": {
+            "mechanism": {
+              "type": "string",
+              "enum": [
+                "algomatch",
+                "none",
+                "tcam"
+              ],
+              "title": "Mechanism"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Access List"
+        },
+        "speed_groups": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "speed_group": {
+                "type": "integer",
+                "title": "Speed Group"
+              },
+              "serdes": {
+                "type": "string",
+                "title": "Serdes"
+              }
+            },
+            "required": [
+              "speed_group"
+            ],
+            "additionalProperties": false
+          },
+          "title": "Speed Groups"
+        }
+      },
+      "additionalProperties": false
+    },
     "interface_defaults": {
       "type": "object",
       "properties": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -871,6 +871,34 @@ keys:
   generate_device_documentation:
     type: bool
     default: true
+  hardware:
+    display_name: Speed-Group Settings
+    type: dict
+    keys:
+      access_list:
+        type: dict
+        keys:
+          mechanism:
+            type: str
+            valid_values:
+            - algomatch
+            - none
+            - tcam
+      speed_groups:
+        type: list
+        primary_key: speed_group
+        convert_types:
+        - dict
+        items:
+          type: dict
+          keys:
+            speed_group:
+              type: int
+              convert_types:
+              - str
+              required: true
+            serdes:
+              type: str
   interface_defaults:
     type: dict
     keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -872,7 +872,6 @@ keys:
     type: bool
     default: true
   hardware:
-    display_name: Speed-Group Settings
     type: dict
     keys:
       access_list:
@@ -899,6 +898,7 @@ keys:
               required: true
             serdes:
               type: str
+              description: Serdes speed like "10g" or "25g"
   interface_defaults:
     type: dict
     keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/hardware.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/hardware.schema.yml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  hardware:
+    display_name: Speed-Group Settings
+    type: dict
+    keys:
+      access_list:
+        type: dict
+        keys:
+          mechanism:
+            type: str
+            valid_values: ["algomatch", "none", "tcam"]
+      speed_groups:
+        type: list
+        primary_key: speed_group
+        convert_types:
+        - dict
+        items:
+          type: dict
+          keys:
+            speed_group:
+              type: int
+              convert_types:
+              - str
+              required: true
+            serdes:
+              type: str

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/hardware.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/hardware.schema.yml
@@ -4,7 +4,6 @@
 type: dict
 keys:
   hardware:
-    display_name: Speed-Group Settings
     type: dict
     keys:
       access_list:
@@ -28,3 +27,4 @@ keys:
               required: true
             serdes:
               type: str
+              description: Serdes speed like "10g" or "25g"

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/hardware.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/hardware.j2
@@ -5,7 +5,7 @@ hardware access-list mechanism {{ hardware.access_list.mechanism }}
 {% endif %}
 {% if hardware.speed_groups is arista.avd.defined %}
 !
-{%     for speed_group in hardware.speed_groups | arista.avd.convert_dicts('speed_group') %}
+{%     for speed_group in hardware.speed_groups %}
 {%         if speed_group.serdes is arista.avd.defined %}
 hardware speed-group {{ speed_group.speed_group }} serdes {{ speed_group.serdes }}
 {%         endif %}


### PR DESCRIPTION
## Add schema for data model

<!-- Use this PR Title: Feat(eos_cli_config_gen): Add schema for < data_model_key > -->

## Checklist

### Contributor Checklist

- [x] Create schema fragment matching data model described in README.md and README_v4.0.md
  - README.md is most complete with all keys. README_v4.0 includes partial data models after conversion to lists.
  - Schema fragment path is `roles/eos_cli_config_gen/schemas/schema_fragments/<data_model_key>.schema.yml`.
  - Copy line 1-5 from another schema (comments and outer type:dict).
  - Refer to [schema documentation](https://avd.sh/en/devel/docs/input-variable-validation-BETA.html) for syntax and/or use YAML Lint plugin from Redhat in VSCode.
  - Use `convert_types` on value that could be mixed type or misinterpreted like integers and numeric strings.
- [x] If the data model has been converted from wildcard dicts:
  - Add `convert_types: ['dict']` to the schema.
  - Remove `convert_dicts` from the `templates/eos/<>.j2` and `templates/documentation/<>.j2` templates.
- [x] Run `molecule converge -s build_schemas_and_docs` to update schema and documentation.
- [x] Test by running `molecule converge -s eos_cli_config_gen` and verify no errors or changes to generated configs/docs.

### Reviewer Checklist

- Reviewer 1: Claus
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2: Emil
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [ ] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [ ] Verify that CI pass
