### PR TITLE
Feat(eos_cli_config_gen): Add schema for monitor_sessions

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -1676,25 +1676,25 @@ monitor_connectivity:
 | [<samp>monitor_sessions</samp>](## "monitor_sessions") | List, items: Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;- name</samp>](## "monitor_sessions.[].name") | String | Required |  |  | Session Name |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;sources</samp>](## "monitor_sessions.[].sources") | List, items: Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "monitor_sessions.[].sources.[].name") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "monitor_sessions.[].sources.[].name") | String |  |  |  | Interface name, range or comma separated list |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;direction</samp>](## "monitor_sessions.[].sources.[].direction") | String |  |  | Valid Values:<br>- rx<br>- tx<br>- both |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;access_group</samp>](## "monitor_sessions.[].sources.[].access_group") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;type</samp>](## "monitor_sessions.[].sources.[].access_group.type") | String |  |  | Valid Values:<br>- ip<br>- ipv6<br>- mac |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "monitor_sessions.[].sources.[].access_group.name") | String |  |  |  | ACL Name |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;priority</samp>](## "monitor_sessions.[].sources.[].access_group.priority") | Integer |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;destinations</samp>](## "monitor_sessions.[].destinations") | List, items: String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "monitor_sessions.[].destinations.[].&lt;str&gt;") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;encapsulation_gre_metadata_tx</samp>](## "monitor_sessions.[].encapsulation_gre_metadata_tx") | Boolean |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;header_remove_size</samp>](## "monitor_sessions.[].header_remove_size") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "monitor_sessions.[].destinations.[].&lt;str&gt;") | String |  |  |  | 'cpu' or interface name, range or comma separated list |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;encapsulation_gre_metadata_tx</samp>](## "monitor_sessions.[].encapsulation_gre_metadata_tx") | Boolean |  |  |  | Encapsulation GRE metadata TX |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;header_remove_size</samp>](## "monitor_sessions.[].header_remove_size") | Integer |  |  |  | Number of bytes to remove from header |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;access_group</samp>](## "monitor_sessions.[].access_group") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;type</samp>](## "monitor_sessions.[].access_group.type") | String |  |  | Valid Values:<br>- ip<br>- ipv6<br>- mac |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "monitor_sessions.[].access_group.name") | String |  |  |  | ACL Name |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;rate_limit_per_ingress_chip</samp>](## "monitor_sessions.[].rate_limit_per_ingress_chip") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;rate_limit_per_egress_chip</samp>](## "monitor_sessions.[].rate_limit_per_egress_chip") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;rate_limit_per_ingress_chip</samp>](## "monitor_sessions.[].rate_limit_per_ingress_chip") | String |  |  |  | Ratelimit and unit as string.<br>Examples:<br>  "100000 bps"<br>  "100 kbps"<br>  "10 mbps"<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;rate_limit_per_egress_chip</samp>](## "monitor_sessions.[].rate_limit_per_egress_chip") | String |  |  |  | Ratelimit and unit as string.<br>Examples:<br>  "100000 bps"<br>  "100 kbps"<br>  "10 mbps"<br> |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;sample</samp>](## "monitor_sessions.[].sample") | Integer |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;truncate</samp>](## "monitor_sessions.[].truncate") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "monitor_sessions.[].truncate.enabled") | Boolean |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;size</samp>](## "monitor_sessions.[].truncate.size") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;size</samp>](## "monitor_sessions.[].truncate.size") | Integer |  |  |  | Size in bytes |
 
 ### YAML
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -1667,6 +1667,62 @@ monitor_connectivity:
           url: <str>
 ```
 
+## Monitor Sessions
+
+### Variables
+
+| Variable | Type | Required | Default | Value Restrictions | Description |
+| -------- | ---- | -------- | ------- | ------------------ | ----------- |
+| [<samp>monitor_sessions</samp>](## "monitor_sessions") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;- name</samp>](## "monitor_sessions.[].name") | String | Required |  |  | Session Name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;sources</samp>](## "monitor_sessions.[].sources") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "monitor_sessions.[].sources.[].name") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;direction</samp>](## "monitor_sessions.[].sources.[].direction") | String |  |  | Valid Values:<br>- rx<br>- tx<br>- both |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;access_group</samp>](## "monitor_sessions.[].sources.[].access_group") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;type</samp>](## "monitor_sessions.[].sources.[].access_group.type") | String |  |  | Valid Values:<br>- ip<br>- ipv6<br>- mac |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "monitor_sessions.[].sources.[].access_group.name") | String |  |  |  | ACL Name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;priority</samp>](## "monitor_sessions.[].sources.[].access_group.priority") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;destinations</samp>](## "monitor_sessions.[].destinations") | List, items: String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "monitor_sessions.[].destinations.[].&lt;str&gt;") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;encapsulation_gre_metadata_tx</samp>](## "monitor_sessions.[].encapsulation_gre_metadata_tx") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;header_remove_size</samp>](## "monitor_sessions.[].header_remove_size") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;access_group</samp>](## "monitor_sessions.[].access_group") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;type</samp>](## "monitor_sessions.[].access_group.type") | String |  |  | Valid Values:<br>- ip<br>- ipv6<br>- mac |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "monitor_sessions.[].access_group.name") | String |  |  |  | ACL Name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;rate_limit_per_ingress_chip</samp>](## "monitor_sessions.[].rate_limit_per_ingress_chip") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;rate_limit_per_egress_chip</samp>](## "monitor_sessions.[].rate_limit_per_egress_chip") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;sample</samp>](## "monitor_sessions.[].sample") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;truncate</samp>](## "monitor_sessions.[].truncate") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "monitor_sessions.[].truncate.enabled") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;size</samp>](## "monitor_sessions.[].truncate.size") | Integer |  |  |  |  |
+
+### YAML
+
+```yaml
+monitor_sessions:
+  - name: <str>
+    sources:
+      - name: <str>
+        direction: <str>
+        access_group:
+          type: <str>
+          name: <str>
+          priority: <int>
+    destinations:
+      - <str>
+    encapsulation_gre_metadata_tx: <bool>
+    header_remove_size: <int>
+    access_group:
+      type: <str>
+      name: <str>
+    rate_limit_per_ingress_chip: <str>
+    rate_limit_per_egress_chip: <str>
+    sample: <int>
+    truncate:
+      enabled: <bool>
+      size: <int>
+```
+
 ## MPLS
 
 ### Variables

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -2663,6 +2663,132 @@
       "additionalProperties": false,
       "title": "Monitor Connectivity"
     },
+    "monitor_sessions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Session Name"
+          },
+          "sources": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "title": "Name"
+                },
+                "direction": {
+                  "type": "string",
+                  "enum": [
+                    "rx",
+                    "tx",
+                    "both"
+                  ],
+                  "title": "Direction"
+                },
+                "access_group": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "ip",
+                        "ipv6",
+                        "mac"
+                      ],
+                      "title": "Type"
+                    },
+                    "name": {
+                      "title": "ACL Name",
+                      "type": "string"
+                    },
+                    "priority": {
+                      "type": "integer",
+                      "title": "Priority"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "title": "Access Group"
+                }
+              },
+              "additionalProperties": false
+            },
+            "title": "Sources"
+          },
+          "destinations": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "title": "Destinations"
+          },
+          "encapsulation_gre_metadata_tx": {
+            "type": "boolean",
+            "title": "Encapsulation Gre Metadata Tx"
+          },
+          "header_remove_size": {
+            "type": "integer",
+            "title": "Header Remove Size"
+          },
+          "access_group": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "ip",
+                  "ipv6",
+                  "mac"
+                ],
+                "title": "Type"
+              },
+              "name": {
+                "title": "ACL Name",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false,
+            "title": "Access Group"
+          },
+          "rate_limit_per_ingress_chip": {
+            "type": "string",
+            "title": "Rate Limit Per Ingress Chip"
+          },
+          "rate_limit_per_egress_chip": {
+            "type": "string",
+            "title": "Rate Limit Per Egress Chip"
+          },
+          "sample": {
+            "type": "integer",
+            "title": "Sample"
+          },
+          "truncate": {
+            "type": "object",
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "title": "Enabled"
+              },
+              "size": {
+                "type": "integer",
+                "title": "Size"
+              }
+            },
+            "additionalProperties": false,
+            "title": "Truncate"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false
+      },
+      "title": "Monitor Sessions"
+    },
     "mpls": {
       "type": "object",
       "title": "MPLS",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -2670,7 +2670,8 @@
         "properties": {
           "name": {
             "type": "string",
-            "title": "Session Name"
+            "description": "Session Name",
+            "title": "Name"
           },
           "sources": {
             "type": "array",
@@ -2679,6 +2680,7 @@
               "properties": {
                 "name": {
                   "type": "string",
+                  "description": "Interface name, range or comma separated list",
                   "title": "Name"
                 },
                 "direction": {
@@ -2703,8 +2705,9 @@
                       "title": "Type"
                     },
                     "name": {
-                      "title": "ACL Name",
-                      "type": "string"
+                      "description": "ACL Name",
+                      "type": "string",
+                      "title": "Name"
                     },
                     "priority": {
                       "type": "integer",
@@ -2722,16 +2725,18 @@
           "destinations": {
             "type": "array",
             "items": {
-              "type": "string"
+              "type": "string",
+              "description": "'cpu' or interface name, range or comma separated list"
             },
             "title": "Destinations"
           },
           "encapsulation_gre_metadata_tx": {
             "type": "boolean",
-            "title": "Encapsulation Gre Metadata Tx"
+            "title": "Encapsulation GRE metadata TX"
           },
           "header_remove_size": {
             "type": "integer",
+            "description": "Number of bytes to remove from header",
             "title": "Header Remove Size"
           },
           "access_group": {
@@ -2756,10 +2761,12 @@
           },
           "rate_limit_per_ingress_chip": {
             "type": "string",
+            "description": "Ratelimit and unit as string.\nExamples:\n  \"100000 bps\"\n  \"100 kbps\"\n  \"10 mbps\"\n",
             "title": "Rate Limit Per Ingress Chip"
           },
           "rate_limit_per_egress_chip": {
             "type": "string",
+            "description": "Ratelimit and unit as string.\nExamples:\n  \"100000 bps\"\n  \"100 kbps\"\n  \"10 mbps\"\n",
             "title": "Rate Limit Per Egress Chip"
           },
           "sample": {
@@ -2775,6 +2782,7 @@
               },
               "size": {
                 "type": "integer",
+                "description": "Size in bytes",
                 "title": "Size"
               }
             },

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -2126,6 +2126,85 @@ keys:
                     type: str
                   url:
                     type: str
+  monitor_sessions:
+    type: list
+    convert_types:
+    - dict
+    items:
+      type: dict
+      keys:
+        name:
+          type: str
+          required: true
+          display_name: Session Name
+        sources:
+          type: list
+          items:
+            type: dict
+            keys:
+              name:
+                type: str
+              direction:
+                type: str
+                valid_values:
+                - rx
+                - tx
+                - both
+              access_group:
+                type: dict
+                keys:
+                  type:
+                    type: str
+                    valid_values:
+                    - ip
+                    - ipv6
+                    - mac
+                  name:
+                    display_name: ACL Name
+                    type: str
+                  priority:
+                    type: int
+                    convert_types:
+                    - str
+        destinations:
+          type: list
+          items:
+            type: str
+        encapsulation_gre_metadata_tx:
+          type: bool
+        header_remove_size:
+          type: int
+          convert_types:
+          - str
+        access_group:
+          type: dict
+          keys:
+            type:
+              type: str
+              valid_values:
+              - ip
+              - ipv6
+              - mac
+            name:
+              display_name: ACL Name
+              type: str
+        rate_limit_per_ingress_chip:
+          type: str
+        rate_limit_per_egress_chip:
+          type: str
+        sample:
+          type: int
+          convert_types:
+          - str
+        truncate:
+          type: dict
+          keys:
+            enabled:
+              type: bool
+            size:
+              type: int
+              convert_types:
+              - str
   mpls:
     type: dict
     display_name: MPLS

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -2136,7 +2136,7 @@ keys:
         name:
           type: str
           required: true
-          display_name: Session Name
+          description: Session Name
         sources:
           type: list
           items:
@@ -2144,6 +2144,7 @@ keys:
             keys:
               name:
                 type: str
+                description: Interface name, range or comma separated list
               direction:
                 type: str
                 valid_values:
@@ -2160,7 +2161,7 @@ keys:
                     - ipv6
                     - mac
                   name:
-                    display_name: ACL Name
+                    description: ACL Name
                     type: str
                   priority:
                     type: int
@@ -2170,10 +2171,13 @@ keys:
           type: list
           items:
             type: str
+            description: '''cpu'' or interface name, range or comma separated list'
         encapsulation_gre_metadata_tx:
           type: bool
+          display_name: Encapsulation GRE metadata TX
         header_remove_size:
           type: int
+          description: Number of bytes to remove from header
           convert_types:
           - str
         access_group:
@@ -2190,8 +2194,12 @@ keys:
               type: str
         rate_limit_per_ingress_chip:
           type: str
+          description: "Ratelimit and unit as string.\nExamples:\n  \"100000 bps\"\n
+            \ \"100 kbps\"\n  \"10 mbps\"\n"
         rate_limit_per_egress_chip:
           type: str
+          description: "Ratelimit and unit as string.\nExamples:\n  \"100000 bps\"\n
+            \ \"100 kbps\"\n  \"10 mbps\"\n"
         sample:
           type: int
           convert_types:
@@ -2203,6 +2211,7 @@ keys:
               type: bool
             size:
               type: int
+              description: Size in bytes
               convert_types:
               - str
   mpls:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/monitor_sessions.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/monitor_sessions.schema.yml
@@ -13,7 +13,7 @@ keys:
         name:
           type: str
           required: true
-          display_name: Session Name
+          description: Session Name
         sources:
           type: list
           items:
@@ -21,6 +21,7 @@ keys:
             keys:
               name:
                 type: str
+                description: Interface name, range or comma separated list
               direction:
                 type: str
                 valid_values: ["rx", "tx", "both"]
@@ -31,7 +32,7 @@ keys:
                     type: str
                     valid_values: ["ip", "ipv6", "mac"]
                   name:
-                    display_name: ACL Name
+                    description: ACL Name
                     type: str
                   priority:
                     type: int
@@ -41,10 +42,13 @@ keys:
           type: list
           items:
             type: str
+            description: "'cpu' or interface name, range or comma separated list"
         encapsulation_gre_metadata_tx:
           type: bool
+          display_name: Encapsulation GRE metadata TX
         header_remove_size:
           type: int
+          description: Number of bytes to remove from header
           convert_types:
           - str
         access_group:
@@ -58,8 +62,20 @@ keys:
               type: str
         rate_limit_per_ingress_chip:
           type: str
+          description: |
+            Ratelimit and unit as string.
+            Examples:
+              "100000 bps"
+              "100 kbps"
+              "10 mbps"
         rate_limit_per_egress_chip:
           type: str
+          description: |
+            Ratelimit and unit as string.
+            Examples:
+              "100000 bps"
+              "100 kbps"
+              "10 mbps"
         sample:
           type: int
           convert_types:
@@ -71,5 +87,6 @@ keys:
               type: bool
             size:
               type: int
+              description: Size in bytes
               convert_types:
               - str

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/monitor_sessions.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/monitor_sessions.schema.yml
@@ -1,0 +1,75 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  monitor_sessions:
+    type: list
+    convert_types:
+    - dict
+    items:
+      type: dict
+      keys:
+        name:
+          type: str
+          required: true
+          display_name: Session Name
+        sources:
+          type: list
+          items:
+            type: dict
+            keys:
+              name:
+                type: str
+              direction:
+                type: str
+                valid_values: ["rx", "tx", "both"]
+              access_group:
+                type: dict
+                keys:
+                  type:
+                    type: str
+                    valid_values: ["ip", "ipv6", "mac"]
+                  name:
+                    display_name: ACL Name
+                    type: str
+                  priority:
+                    type: int
+                    convert_types:
+                    - str
+        destinations:
+          type: list
+          items:
+            type: str
+        encapsulation_gre_metadata_tx:
+          type: bool
+        header_remove_size:
+          type: int
+          convert_types:
+          - str
+        access_group:
+          type: dict
+          keys:
+            type:
+              type: str
+              valid_values: ["ip", "ipv6", "mac"]
+            name:
+              display_name: ACL Name
+              type: str
+        rate_limit_per_ingress_chip:
+          type: str
+        rate_limit_per_egress_chip:
+          type: str
+        sample:
+          type: int
+          convert_types:
+          - str
+        truncate:
+          type: dict
+          keys:
+            enabled:
+              type: bool
+            size:
+              type: int
+              convert_types:
+              - str


### PR DESCRIPTION
## Add schema for data model

<!-- Use this PR Title: Feat(eos_cli_config_gen): Add schema for < data_model_key > -->

## Checklist

### Contributor Checklist

- [x] Create schema fragment matching data model described in README.md and README_v4.0.md
  - README.md is most complete with all keys. README_v4.0 includes partial data models after conversion to lists.
  - Schema fragment path is `roles/eos_cli_config_gen/schemas/schema_fragments/<data_model_key>.schema.yml`.
  - Copy line 1-5 from another schema (comments and outer type:dict).
  - Refer to [schema documentation](https://avd.sh/en/devel/docs/input-variable-validation-BETA.html) for syntax and/or use YAML Lint plugin from Redhat in VSCode.
  - Use `convert_types` on value that could be mixed type or misinterpreted like integers and numeric strings.
- [x] If the data model has been converted from wildcard dicts:
  - Add `convert_types: ['dict']` to the schema.
  - Remove `convert_dicts` from the `templates/eos/<>.j2` and `templates/documentation/<>.j2` templates.
- [x] Run `molecule converge -s build_schemas_and_docs` to update schema and documentation.
- [x] Test by running `molecule converge -s eos_cli_config_gen` and verify no errors or changes to generated configs/docs.

### Reviewer Checklist

- Reviewer 1:
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2:
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
