### PR TITLE
Feat(eos_cli_config_gen): Add schema for boot

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -205,6 +205,30 @@ bgp_groups:
       - <str>
 ```
 
+## System Boot Settings
+
+### Description
+
+Set the Aboot password
+
+### Variables
+
+| Variable | Type | Required | Default | Value Restrictions | Description |
+| -------- | ---- | -------- | ------- | ------------------ | ----------- |
+| [<samp>boot</samp>](## "boot") | Dictionary |  |  |  | System Boot Settings |
+| [<samp>&nbsp;&nbsp;secret</samp>](## "boot.secret") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;hash_algorithm</samp>](## "boot.secret.hash_algorithm") | String |  | sha512 | Valid Values:<br>- md5<br>- sha512 |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "boot.secret.key") | String |  |  |  | Hashed Password |
+
+### YAML
+
+```yaml
+boot:
+  secret:
+    hash_algorithm: <str>
+    key: <str>
+```
+
 ## QOS Class-maps
 
 ### Variables

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -338,6 +338,34 @@
       },
       "title": "Bgp Groups"
     },
+    "boot": {
+      "title": "System Boot Settings",
+      "description": "Set the Aboot password\n",
+      "type": "object",
+      "properties": {
+        "secret": {
+          "type": "object",
+          "properties": {
+            "hash_algorithm": {
+              "type": "string",
+              "enum": [
+                "md5",
+                "sha512"
+              ],
+              "default": "sha512",
+              "title": "Hash Algorithm"
+            },
+            "key": {
+              "title": "Hashed Password",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Secret"
+        }
+      },
+      "additionalProperties": false
+    },
     "class_maps": {
       "type": "object",
       "title": "QOS Class-maps",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -291,6 +291,25 @@ keys:
           items:
             type: str
             display_name: Profile Name
+  boot:
+    display_name: System Boot Settings
+    description: 'Set the Aboot password
+
+      '
+    type: dict
+    keys:
+      secret:
+        type: dict
+        keys:
+          hash_algorithm:
+            type: str
+            valid_values:
+            - md5
+            - sha512
+            default: sha512
+          key:
+            display_name: Hashed Password
+            type: str
   class_maps:
     type: dict
     display_name: QOS Class-maps

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/boot.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/boot.schema.yml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  boot:
+    display_name: System Boot Settings
+    description: |
+      Set the Aboot password
+    type: dict
+    keys:
+      secret:
+        type: dict
+        keys:
+          hash_algorithm:
+            type: str
+            valid_values: ["md5", "sha512"]
+            default: "sha512"
+          key:
+            display_name: Hashed Password
+            type: str


### PR DESCRIPTION
## Add schema for data model

<!-- Use this PR Title: Feat(eos_cli_config_gen): Add schema for < data_model_key > -->

## Checklist

### Contributor Checklist

- [x] Create schema fragment matching data model described in README.md and README_v4.0.md
  - README.md is most complete with all keys. README_v4.0 includes partial data models after conversion to lists.
  - Schema fragment path is `roles/eos_cli_config_gen/schemas/schema_fragments/<data_model_key>.schema.yml`.
  - Copy line 1-5 from another schema (comments and outer type:dict).
  - Refer to [schema documentation](https://avd.sh/en/devel/docs/input-variable-validation-BETA.html) for syntax and/or use YAML Lint plugin from Redhat in VSCode.
  - Use `convert_types` on value that could be mixed type or misinterpreted like integers and numeric strings.
- [x] If the data model has been converted from wildcard dicts:
  - Add `convert_types: ['dict']` to the schema.
  - Remove `convert_dicts` from the `templates/eos/<>.j2` and `templates/documentation/<>.j2` templates.
- [x] Run `molecule converge -s build_schemas_and_docs` to update schema and documentation.
- [x] Test by running `molecule converge -s eos_cli_config_gen` and verify no errors or changes to generated configs/docs.

### Reviewer Checklist

- Reviewer 1:
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2:
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
