### PR TITLE
Feat(eos_cli_config_gen): Add schema for tap_aggregation

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -2645,7 +2645,7 @@ system:
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;header</samp>](## "tap_aggregation.mac.timestamp.header") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;format</samp>](## "tap_aggregation.mac.timestamp.header.format") | String |  |  | Valid Values:<br>- 48-bit<br>- 64-bit |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;eth_type</samp>](## "tap_aggregation.mac.timestamp.header.eth_type") | Integer |  |  |  | EtherType |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;fcs_append</samp>](## "tap_aggregation.mac.fcs_append") | Boolean |  |  |  | FCS Append<br>mac_fcs_append and mac_fcs_error are mutually exclusive. If both are defined, mac_fcs_append takes precedence<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;fcs_append</samp>](## "tap_aggregation.mac.fcs_append") | Boolean |  |  |  | FCS Append<br>mac.fcs_append and mac.fcs_error are mutually exclusive. If both are defined, mac.fcs_append takes precedence<br> |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;fcs_error</samp>](## "tap_aggregation.mac.fcs_error") | String |  |  | Valid Values:<br>- correct<br>- discard<br>- pass-through | FCS Error |
 
 ### YAML

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -2634,7 +2634,7 @@ system:
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "tap_aggregation.mode.exclusive.enabled") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;profile</samp>](## "tap_aggregation.mode.exclusive.profile") | String |  |  |  | Profile Name |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;no_errdisable</samp>](## "tap_aggregation.mode.exclusive.no_errdisable") | List, items: String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "tap_aggregation.mode.exclusive.no_errdisable.[].&lt;str&gt;") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "tap_aggregation.mode.exclusive.no_errdisable.[].&lt;str&gt;") | String |  |  |  | Interface name e.g Ethernet1, Port-Channel1 |
 | [<samp>&nbsp;&nbsp;encapsulation_dot1br_strip</samp>](## "tap_aggregation.encapsulation_dot1br_strip") | Boolean |  |  |  | Encapsulation dot1br Strip |
 | [<samp>&nbsp;&nbsp;encapsulation_vn_tag_strip</samp>](## "tap_aggregation.encapsulation_vn_tag_strip") | Boolean |  |  |  | Encapsulation VN Tag Strip |
 | [<samp>&nbsp;&nbsp;protocol_lldp_trap</samp>](## "tap_aggregation.protocol_lldp_trap") | Boolean |  |  |  | Protocol LLDP Trap |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -2622,6 +2622,56 @@ system:
         vrf: <str>
 ```
 
+## Tap Aggregation
+
+### Variables
+
+| Variable | Type | Required | Default | Value Restrictions | Description |
+| -------- | ---- | -------- | ------- | ------------------ | ----------- |
+| [<samp>tap_aggregation</samp>](## "tap_aggregation") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;mode</samp>](## "tap_aggregation.mode") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;exclusive</samp>](## "tap_aggregation.mode.exclusive") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "tap_aggregation.mode.exclusive.enabled") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;profile</samp>](## "tap_aggregation.mode.exclusive.profile") | String |  |  |  | Profile Name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;no_errdisable</samp>](## "tap_aggregation.mode.exclusive.no_errdisable") | List, items: String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "tap_aggregation.mode.exclusive.no_errdisable.[].&lt;str&gt;") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;encapsulation_dot1br_strip</samp>](## "tap_aggregation.encapsulation_dot1br_strip") | Boolean |  |  |  | Encapsulation dot1br Strip |
+| [<samp>&nbsp;&nbsp;encapsulation_vn_tag_strip</samp>](## "tap_aggregation.encapsulation_vn_tag_strip") | Boolean |  |  |  | Encapsulation VN Tag Strip |
+| [<samp>&nbsp;&nbsp;protocol_lldp_trap</samp>](## "tap_aggregation.protocol_lldp_trap") | Boolean |  |  |  | Protocol LLDP Trap |
+| [<samp>&nbsp;&nbsp;truncation_size</samp>](## "tap_aggregation.truncation_size") | Integer |  |  |  | Allowed truncation_size values vary depending on the platform<br> |
+| [<samp>&nbsp;&nbsp;mac</samp>](## "tap_aggregation.mac") | Dictionary |  |  |  | MAC |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;timestamp</samp>](## "tap_aggregation.mac.timestamp") | Dictionary |  |  |  | mac.timestamp.replace_source_mac and mac.timestamp.header.format are mutually exclsuive. If both are defined, replace_source_mac takes precedence<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;replace_source_mac</samp>](## "tap_aggregation.mac.timestamp.replace_source_mac") | Boolean |  |  |  | Replace Source MAC |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;header</samp>](## "tap_aggregation.mac.timestamp.header") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;format</samp>](## "tap_aggregation.mac.timestamp.header.format") | String |  |  | Valid Values:<br>- 48-bit<br>- 64-bit |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;eth_type</samp>](## "tap_aggregation.mac.timestamp.header.eth_type") | Integer |  |  |  | EtherType |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;fcs_append</samp>](## "tap_aggregation.mac.fcs_append") | Boolean |  |  |  | FCS Append<br>mac_fcs_append and mac_fcs_error are mutually exclusive. If both are defined, mac_fcs_append takes precedence<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;fcs_error</samp>](## "tap_aggregation.mac.fcs_error") | String |  |  | Valid Values:<br>- correct<br>- discard<br>- pass-through | FCS Error |
+
+### YAML
+
+```yaml
+tap_aggregation:
+  mode:
+    exclusive:
+      enabled: <bool>
+      profile: <str>
+      no_errdisable:
+        - <str>
+  encapsulation_dot1br_strip: <bool>
+  encapsulation_vn_tag_strip: <bool>
+  protocol_lldp_trap: <bool>
+  truncation_size: <int>
+  mac:
+    timestamp:
+      replace_source_mac: <bool>
+      header:
+        format: <str>
+        eth_type: <int>
+    fcs_append: <bool>
+    fcs_error: <str>
+```
+
 ## Hardware TCAM Profiles
 
 ### Variables

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -4517,8 +4517,9 @@
                   "title": "Enabled"
                 },
                 "profile": {
-                  "title": "Profile Name",
-                  "type": "string"
+                  "description": "Profile Name",
+                  "type": "string",
+                  "title": "Profile"
                 },
                 "no_errdisable": {
                   "type": "array",
@@ -4591,7 +4592,7 @@
             "fcs_append": {
               "title": "FCS Append",
               "type": "boolean",
-              "description": "mac_fcs_append and mac_fcs_error are mutually exclusive. If both are defined, mac_fcs_append takes precedence\n"
+              "description": "mac.fcs_append and mac.fcs_error are mutually exclusive. If both are defined, mac.fcs_append takes precedence\n"
             },
             "fcs_error": {
               "title": "FCS Error",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -4523,7 +4523,8 @@
                 "no_errdisable": {
                   "type": "array",
                   "items": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Interface name e.g Ethernet1, Port-Channel1"
                   },
                   "title": "No Errdisable"
                 }

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -4503,6 +4503,111 @@
       "additionalProperties": false,
       "title": "System"
     },
+    "tap_aggregation": {
+      "type": "object",
+      "properties": {
+        "mode": {
+          "type": "object",
+          "properties": {
+            "exclusive": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "title": "Enabled"
+                },
+                "profile": {
+                  "title": "Profile Name",
+                  "type": "string"
+                },
+                "no_errdisable": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "title": "No Errdisable"
+                }
+              },
+              "additionalProperties": false,
+              "title": "Exclusive"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Mode"
+        },
+        "encapsulation_dot1br_strip": {
+          "title": "Encapsulation dot1br Strip",
+          "type": "boolean"
+        },
+        "encapsulation_vn_tag_strip": {
+          "title": "Encapsulation VN Tag Strip",
+          "type": "boolean"
+        },
+        "protocol_lldp_trap": {
+          "title": "Protocol LLDP Trap",
+          "type": "boolean"
+        },
+        "truncation_size": {
+          "type": "integer",
+          "description": "Allowed truncation_size values vary depending on the platform\n",
+          "title": "Truncation Size"
+        },
+        "mac": {
+          "title": "MAC",
+          "type": "object",
+          "properties": {
+            "timestamp": {
+              "type": "object",
+              "description": "mac.timestamp.replace_source_mac and mac.timestamp.header.format are mutually exclsuive. If both are defined, replace_source_mac takes precedence\n",
+              "properties": {
+                "replace_source_mac": {
+                  "title": "Replace Source MAC",
+                  "type": "boolean"
+                },
+                "header": {
+                  "type": "object",
+                  "properties": {
+                    "format": {
+                      "type": "string",
+                      "enum": [
+                        "48-bit",
+                        "64-bit"
+                      ],
+                      "title": "Format"
+                    },
+                    "eth_type": {
+                      "title": "EtherType",
+                      "type": "integer"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "title": "Header"
+                }
+              },
+              "additionalProperties": false,
+              "title": "Timestamp"
+            },
+            "fcs_append": {
+              "title": "FCS Append",
+              "type": "boolean",
+              "description": "mac_fcs_append and mac_fcs_error are mutually exclusive. If both are defined, mac_fcs_append takes precedence\n"
+            },
+            "fcs_error": {
+              "title": "FCS Error",
+              "type": "string",
+              "enum": [
+                "correct",
+                "discard",
+                "pass-through"
+              ]
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false,
+      "title": "Tap Aggregation"
+    },
     "tcam_profile": {
       "type": "object",
       "title": "Hardware TCAM Profiles",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -3394,6 +3394,7 @@ keys:
                 type: list
                 items:
                   type: str
+                  description: Interface name e.g Ethernet1, Port-Channel1
       encapsulation_dot1br_strip:
         display_name: Encapsulation dot1br Strip
         type: bool

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -3376,6 +3376,80 @@ keys:
                   type: str
                 vrf:
                   type: str
+  tap_aggregation:
+    type: dict
+    keys:
+      mode:
+        type: dict
+        keys:
+          exclusive:
+            type: dict
+            keys:
+              enabled:
+                type: bool
+              profile:
+                display_name: Profile Name
+                type: str
+              no_errdisable:
+                type: list
+                items:
+                  type: str
+      encapsulation_dot1br_strip:
+        display_name: Encapsulation dot1br Strip
+        type: bool
+      encapsulation_vn_tag_strip:
+        display_name: Encapsulation VN Tag Strip
+        type: bool
+      protocol_lldp_trap:
+        display_name: Protocol LLDP Trap
+        type: bool
+      truncation_size:
+        type: int
+        description: 'Allowed truncation_size values vary depending on the platform
+
+          '
+      mac:
+        display_name: MAC
+        type: dict
+        keys:
+          timestamp:
+            type: dict
+            description: 'mac.timestamp.replace_source_mac and mac.timestamp.header.format
+              are mutually exclsuive. If both are defined, replace_source_mac takes
+              precedence
+
+              '
+            keys:
+              replace_source_mac:
+                display_name: Replace Source MAC
+                type: bool
+              header:
+                type: dict
+                keys:
+                  format:
+                    type: str
+                    valid_values:
+                    - 48-bit
+                    - 64-bit
+                  eth_type:
+                    display_name: EtherType
+                    type: int
+                    convert_types:
+                    - str
+          fcs_append:
+            display_name: FCS Append
+            type: bool
+            description: 'mac_fcs_append and mac_fcs_error are mutually exclusive.
+              If both are defined, mac_fcs_append takes precedence
+
+              '
+          fcs_error:
+            display_name: FCS Error
+            type: str
+            valid_values:
+            - correct
+            - discard
+            - pass-through
   tcam_profile:
     type: dict
     display_name: Hardware TCAM Profiles

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -3388,7 +3388,7 @@ keys:
               enabled:
                 type: bool
               profile:
-                display_name: Profile Name
+                description: Profile Name
                 type: str
               no_errdisable:
                 type: list
@@ -3440,8 +3440,8 @@ keys:
           fcs_append:
             display_name: FCS Append
             type: bool
-            description: 'mac_fcs_append and mac_fcs_error are mutually exclusive.
-              If both are defined, mac_fcs_append takes precedence
+            description: 'mac.fcs_append and mac.fcs_error are mutually exclusive.
+              If both are defined, mac.fcs_append takes precedence
 
               '
           fcs_error:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/tap_aggregation.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/tap_aggregation.schema.yml
@@ -15,7 +15,7 @@ keys:
               enabled:
                 type: bool
               profile:
-                display_name: Profile Name
+                description: Profile Name
                 type: str
               no_errdisable:
                 type: list
@@ -62,7 +62,7 @@ keys:
             display_name: FCS Append
             type: bool
             description: |
-              mac_fcs_append and mac_fcs_error are mutually exclusive. If both are defined, mac_fcs_append takes precedence
+              mac.fcs_append and mac.fcs_error are mutually exclusive. If both are defined, mac.fcs_append takes precedence
           fcs_error:
             display_name: FCS Error
             type: str

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/tap_aggregation.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/tap_aggregation.schema.yml
@@ -21,6 +21,7 @@ keys:
                 type: list
                 items:
                   type: str
+                  description: Interface name e.g Ethernet1, Port-Channel1
       encapsulation_dot1br_strip:
         display_name: Encapsulation dot1br Strip
         type: bool

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/tap_aggregation.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/tap_aggregation.schema.yml
@@ -1,0 +1,68 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  tap_aggregation:
+    type: dict
+    keys:
+      mode:
+        type: dict
+        keys:
+          exclusive:
+            type: dict
+            keys:
+              enabled:
+                type: bool
+              profile:
+                display_name: Profile Name
+                type: str
+              no_errdisable:
+                type: list
+                items:
+                  type: str
+      encapsulation_dot1br_strip:
+        display_name: Encapsulation dot1br Strip
+        type: bool
+      encapsulation_vn_tag_strip:
+        display_name: Encapsulation VN Tag Strip
+        type: bool
+      protocol_lldp_trap:
+        display_name: Protocol LLDP Trap
+        type: bool
+      truncation_size:
+        type: int
+        description: |
+          Allowed truncation_size values vary depending on the platform
+      mac:
+        display_name: MAC
+        type: dict
+        keys:
+          timestamp:
+            type: dict
+            description: |
+              mac.timestamp.replace_source_mac and mac.timestamp.header.format are mutually exclsuive. If both are defined, replace_source_mac takes precedence
+            keys:
+              replace_source_mac:
+                display_name: Replace Source MAC
+                type: bool
+              header:
+                type: dict
+                keys:
+                  format:
+                    type: str
+                    valid_values: ["48-bit", "64-bit"]
+                  eth_type:
+                    display_name: EtherType
+                    type: int
+                    convert_types:
+                    - str
+          fcs_append:
+            display_name: FCS Append
+            type: bool
+            description: |
+              mac_fcs_append and mac_fcs_error are mutually exclusive. If both are defined, mac_fcs_append takes precedence
+          fcs_error:
+            display_name: FCS Error
+            type: str
+            valid_values: ["correct", "discard", "pass-through"]


### PR DESCRIPTION
## Add schema for data model

<!-- Use this PR Title: Feat(eos_cli_config_gen): Add schema for < data_model_key > -->

## Checklist

### Contributor Checklist

- [x] Create schema fragment matching data model described in README.md and README_v4.0.md
  - README.md is most complete with all keys. README_v4.0 includes partial data models after conversion to lists.
  - Schema fragment path is `roles/eos_cli_config_gen/schemas/schema_fragments/<data_model_key>.schema.yml`.
  - Copy line 1-5 from another schema (comments and outer type:dict).
  - Refer to [schema documentation](https://avd.sh/en/devel/docs/input-variable-validation-BETA.html) for syntax and/or use YAML Lint plugin from Redhat in VSCode.
  - Use `convert_types` on value that could be mixed type or misinterpreted like integers and numeric strings.
- [x] If the data model has been converted from wildcard dicts:
  - Add `convert_types: ['dict']` to the schema.
  - Remove `convert_dicts` from the `templates/eos/<>.j2` and `templates/documentation/<>.j2` templates.
- [x] Run `molecule converge -s build_schemas_and_docs` to update schema and documentation.
- [x] Test by running `molecule converge -s eos_cli_config_gen` and verify no errors or changes to generated configs/docs.

### Reviewer Checklist

- Reviewer 1: Carl
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2:
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
