### PR TITLE
Feat(eos_cli_config_gen): Add schema for router_traffic_engineering

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -3361,7 +3361,7 @@ router_pim_sparse_mode:
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;policy_endpoints</samp>](## "router_traffic_engineering.segment_routing.policy_endpoints") | List, items: Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- address</samp>](## "router_traffic_engineering.segment_routing.policy_endpoints.[].address") | String |  |  |  | IPv4 or IPv6 address |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;colors</samp>](## "router_traffic_engineering.segment_routing.policy_endpoints.[].colors") | List, items: Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- value</samp>](## "router_traffic_engineering.segment_routing.policy_endpoints.[].colors.[].value") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- value</samp>](## "router_traffic_engineering.segment_routing.policy_endpoints.[].colors.[].value") | Integer | Required, Unique |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;binding_sid</samp>](## "router_traffic_engineering.segment_routing.policy_endpoints.[].colors.[].binding_sid") | Integer |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;description</samp>](## "router_traffic_engineering.segment_routing.policy_endpoints.[].colors.[].description") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "router_traffic_engineering.segment_routing.policy_endpoints.[].colors.[].name") | String |  |  |  |  |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -3353,11 +3353,11 @@ router_pim_sparse_mode:
 | Variable | Type | Required | Default | Value Restrictions | Description |
 | -------- | ---- | -------- | ------- | ------------------ | ----------- |
 | [<samp>router_traffic_engineering</samp>](## "router_traffic_engineering") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;router_id</samp>](## "router_traffic_engineering.router_id") | Dictionary |  |  |  | Router ID |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv4</samp>](## "router_traffic_engineering.router_id.ipv4") | String |  |  |  | IPv4 |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6</samp>](## "router_traffic_engineering.router_id.ipv6") | String |  |  |  | IPv6 |
+| [<samp>&nbsp;&nbsp;router_id</samp>](## "router_traffic_engineering.router_id") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv4</samp>](## "router_traffic_engineering.router_id.ipv4") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6</samp>](## "router_traffic_engineering.router_id.ipv6") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;segment_routing</samp>](## "router_traffic_engineering.segment_routing") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;colored_tunnel_rib</samp>](## "router_traffic_engineering.segment_routing.colored_tunnel_rib") | Boolean |  |  |  | Colored Tunnel RIB |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;colored_tunnel_rib</samp>](## "router_traffic_engineering.segment_routing.colored_tunnel_rib") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;policy_endpoints</samp>](## "router_traffic_engineering.segment_routing.policy_endpoints") | List, items: Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- address</samp>](## "router_traffic_engineering.segment_routing.policy_endpoints.[].address") | String |  |  |  | IPv4 or IPv6 address |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;colors</samp>](## "router_traffic_engineering.segment_routing.policy_endpoints.[].colors") | List, items: Dictionary |  |  |  |  |
@@ -3365,7 +3365,7 @@ router_pim_sparse_mode:
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;binding_sid</samp>](## "router_traffic_engineering.segment_routing.policy_endpoints.[].colors.[].binding_sid") | Integer |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;description</samp>](## "router_traffic_engineering.segment_routing.policy_endpoints.[].colors.[].description") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "router_traffic_engineering.segment_routing.policy_endpoints.[].colors.[].name") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;sbfd_remote_discriminator</samp>](## "router_traffic_engineering.segment_routing.policy_endpoints.[].colors.[].sbfd_remote_discriminator") | String |  |  |  | SBFD Remote Discriminator<br>IPv4 address or 32 bit integer |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;sbfd_remote_discriminator</samp>](## "router_traffic_engineering.segment_routing.policy_endpoints.[].colors.[].sbfd_remote_discriminator") | String |  |  |  | IPv4 address or 32 bit integer |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;path_group</samp>](## "router_traffic_engineering.segment_routing.policy_endpoints.[].colors.[].path_group") | List, items: Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- preference</samp>](## "router_traffic_engineering.segment_routing.policy_endpoints.[].colors.[].path_group.[].preference") | Integer |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;explicit_null</samp>](## "router_traffic_engineering.segment_routing.policy_endpoints.[].colors.[].path_group.[].explicit_null") | String |  |  | Valid Values:<br>- ipv4<br>- ipv6<br>- ipv4 ipv6<br>- none |  |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -3365,11 +3365,12 @@ router_pim_sparse_mode:
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;binding_sid</samp>](## "router_traffic_engineering.segment_routing.policy_endpoints.[].colors.[].binding_sid") | Integer |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;description</samp>](## "router_traffic_engineering.segment_routing.policy_endpoints.[].colors.[].description") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "router_traffic_engineering.segment_routing.policy_endpoints.[].colors.[].name") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;sbfd_remote_discriminator</samp>](## "router_traffic_engineering.segment_routing.policy_endpoints.[].colors.[].sbfd_remote_discriminator") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;path_group</samp>](## "router_traffic_engineering.segment_routing.policy_endpoints.[].colors.[].path_group") | List, items: Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- preference</samp>](## "router_traffic_engineering.segment_routing.policy_endpoints.[].colors.[].path_group.[].preference") | Integer |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;explicit_null</samp>](## "router_traffic_engineering.segment_routing.policy_endpoints.[].colors.[].path_group.[].explicit_null") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;segment_list</samp>](## "router_traffic_engineering.segment_routing.policy_endpoints.[].colors.[].path_group.[].segment_list") | List, items: Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- label_stack</samp>](## "router_traffic_engineering.segment_routing.policy_endpoints.[].colors.[].path_group.[].segment_list.[].label_stack") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- label_stack</samp>](## "router_traffic_engineering.segment_routing.policy_endpoints.[].colors.[].path_group.[].segment_list.[].label_stack") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;weight</samp>](## "router_traffic_engineering.segment_routing.policy_endpoints.[].colors.[].path_group.[].segment_list.[].weight") | Integer |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;index</samp>](## "router_traffic_engineering.segment_routing.policy_endpoints.[].colors.[].path_group.[].segment_list.[].index") | Integer |  |  |  |  |
 
@@ -3389,11 +3390,12 @@ router_traffic_engineering:
             binding_sid: <int>
             description: <str>
             name: <str>
+            sbfd_remote_discriminator: <str>
             path_group:
               - preference: <int>
                 explicit_null: <str>
                 segment_list:
-                  - label_stack: <int>
+                  - label_stack: <str>
                     weight: <int>
                     index: <int>
 ```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -3346,6 +3346,58 @@ router_pim_sparse_mode:
               - <str>
 ```
 
+## Router Traffic Engineering
+
+### Variables
+
+| Variable | Type | Required | Default | Value Restrictions | Description |
+| -------- | ---- | -------- | ------- | ------------------ | ----------- |
+| [<samp>router_traffic_engineering</samp>](## "router_traffic_engineering") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;router_id</samp>](## "router_traffic_engineering.router_id") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv4</samp>](## "router_traffic_engineering.router_id.ipv4") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6</samp>](## "router_traffic_engineering.router_id.ipv6") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;segment_routing</samp>](## "router_traffic_engineering.segment_routing") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;colored_tunnel_rib</samp>](## "router_traffic_engineering.segment_routing.colored_tunnel_rib") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;policy_endpoints</samp>](## "router_traffic_engineering.segment_routing.policy_endpoints") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- address</samp>](## "router_traffic_engineering.segment_routing.policy_endpoints.[].address") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;colors</samp>](## "router_traffic_engineering.segment_routing.policy_endpoints.[].colors") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- value</samp>](## "router_traffic_engineering.segment_routing.policy_endpoints.[].colors.[].value") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;binding_sid</samp>](## "router_traffic_engineering.segment_routing.policy_endpoints.[].colors.[].binding_sid") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;description</samp>](## "router_traffic_engineering.segment_routing.policy_endpoints.[].colors.[].description") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "router_traffic_engineering.segment_routing.policy_endpoints.[].colors.[].name") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;path_group</samp>](## "router_traffic_engineering.segment_routing.policy_endpoints.[].colors.[].path_group") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- preference</samp>](## "router_traffic_engineering.segment_routing.policy_endpoints.[].colors.[].path_group.[].preference") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;explicit_null</samp>](## "router_traffic_engineering.segment_routing.policy_endpoints.[].colors.[].path_group.[].explicit_null") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;segment_list</samp>](## "router_traffic_engineering.segment_routing.policy_endpoints.[].colors.[].path_group.[].segment_list") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- label_stack</samp>](## "router_traffic_engineering.segment_routing.policy_endpoints.[].colors.[].path_group.[].segment_list.[].label_stack") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;weight</samp>](## "router_traffic_engineering.segment_routing.policy_endpoints.[].colors.[].path_group.[].segment_list.[].weight") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;index</samp>](## "router_traffic_engineering.segment_routing.policy_endpoints.[].colors.[].path_group.[].segment_list.[].index") | Integer |  |  |  |  |
+
+### YAML
+
+```yaml
+router_traffic_engineering:
+  router_id:
+    ipv4: <str>
+    ipv6: <str>
+  segment_routing:
+    colored_tunnel_rib: <bool>
+    policy_endpoints:
+      - address: <str>
+        colors:
+          - value: <int>
+            binding_sid: <int>
+            description: <str>
+            name: <str>
+            path_group:
+              - preference: <int>
+                explicit_null: <str>
+                segment_list:
+                  - label_stack: <int>
+                    weight: <int>
+                    index: <int>
+```
+
 ## Service Routing Configuration BGP
 
 ### Variables

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -3353,24 +3353,24 @@ router_pim_sparse_mode:
 | Variable | Type | Required | Default | Value Restrictions | Description |
 | -------- | ---- | -------- | ------- | ------------------ | ----------- |
 | [<samp>router_traffic_engineering</samp>](## "router_traffic_engineering") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;router_id</samp>](## "router_traffic_engineering.router_id") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv4</samp>](## "router_traffic_engineering.router_id.ipv4") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6</samp>](## "router_traffic_engineering.router_id.ipv6") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;router_id</samp>](## "router_traffic_engineering.router_id") | Dictionary |  |  |  | Router ID |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv4</samp>](## "router_traffic_engineering.router_id.ipv4") | String |  |  |  | IPv4 |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6</samp>](## "router_traffic_engineering.router_id.ipv6") | String |  |  |  | IPv6 |
 | [<samp>&nbsp;&nbsp;segment_routing</samp>](## "router_traffic_engineering.segment_routing") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;colored_tunnel_rib</samp>](## "router_traffic_engineering.segment_routing.colored_tunnel_rib") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;colored_tunnel_rib</samp>](## "router_traffic_engineering.segment_routing.colored_tunnel_rib") | Boolean |  |  |  | Colored Tunnel RIB |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;policy_endpoints</samp>](## "router_traffic_engineering.segment_routing.policy_endpoints") | List, items: Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- address</samp>](## "router_traffic_engineering.segment_routing.policy_endpoints.[].address") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- address</samp>](## "router_traffic_engineering.segment_routing.policy_endpoints.[].address") | String |  |  |  | IPv4 or IPv6 address |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;colors</samp>](## "router_traffic_engineering.segment_routing.policy_endpoints.[].colors") | List, items: Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- value</samp>](## "router_traffic_engineering.segment_routing.policy_endpoints.[].colors.[].value") | Integer |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;binding_sid</samp>](## "router_traffic_engineering.segment_routing.policy_endpoints.[].colors.[].binding_sid") | Integer |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;description</samp>](## "router_traffic_engineering.segment_routing.policy_endpoints.[].colors.[].description") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "router_traffic_engineering.segment_routing.policy_endpoints.[].colors.[].name") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;sbfd_remote_discriminator</samp>](## "router_traffic_engineering.segment_routing.policy_endpoints.[].colors.[].sbfd_remote_discriminator") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;sbfd_remote_discriminator</samp>](## "router_traffic_engineering.segment_routing.policy_endpoints.[].colors.[].sbfd_remote_discriminator") | String |  |  |  | SBFD Remote Discriminator<br>IPv4 address or 32 bit integer |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;path_group</samp>](## "router_traffic_engineering.segment_routing.policy_endpoints.[].colors.[].path_group") | List, items: Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- preference</samp>](## "router_traffic_engineering.segment_routing.policy_endpoints.[].colors.[].path_group.[].preference") | Integer |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;explicit_null</samp>](## "router_traffic_engineering.segment_routing.policy_endpoints.[].colors.[].path_group.[].explicit_null") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;explicit_null</samp>](## "router_traffic_engineering.segment_routing.policy_endpoints.[].colors.[].path_group.[].explicit_null") | String |  |  | Valid Values:<br>- ipv4<br>- ipv6<br>- ipv4 ipv6<br>- none |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;segment_list</samp>](## "router_traffic_engineering.segment_routing.policy_endpoints.[].colors.[].path_group.[].segment_list") | List, items: Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- label_stack</samp>](## "router_traffic_engineering.segment_routing.policy_endpoints.[].colors.[].path_group.[].segment_list.[].label_stack") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- label_stack</samp>](## "router_traffic_engineering.segment_routing.policy_endpoints.[].colors.[].path_group.[].segment_list.[].label_stack") | String |  |  |  | Label Stack as string.<br>Example: "100 2000 30"<br> |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;weight</samp>](## "router_traffic_engineering.segment_routing.policy_endpoints.[].colors.[].path_group.[].segment_list.[].weight") | Integer |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;index</samp>](## "router_traffic_engineering.segment_routing.policy_endpoints.[].colors.[].path_group.[].segment_list.[].index") | Integer |  |  |  |  |
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -6259,7 +6259,6 @@
       "properties": {
         "router_id": {
           "type": "object",
-          "title": "Router ID",
           "properties": {
             "ipv4": {
               "type": "string",
@@ -6270,14 +6269,15 @@
               "title": "IPv6"
             }
           },
-          "additionalProperties": false
+          "additionalProperties": false,
+          "title": "Router ID"
         },
         "segment_routing": {
           "type": "object",
           "properties": {
             "colored_tunnel_rib": {
               "type": "boolean",
-              "title": "Colored Tunnel RIB"
+              "title": "Colored Tunnel Rib"
             },
             "policy_endpoints": {
               "type": "array",
@@ -6312,8 +6312,8 @@
                         },
                         "sbfd_remote_discriminator": {
                           "type": "string",
-                          "title": "SBFD Remote Discriminator",
-                          "description": "IPv4 address or 32 bit integer"
+                          "description": "IPv4 address or 32 bit integer",
+                          "title": "SBFD Remote Discriminator"
                         },
                         "path_group": {
                           "type": "array",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -6363,7 +6363,10 @@
                           "title": "Path Group"
                         }
                       },
-                      "additionalProperties": false
+                      "additionalProperties": false,
+                      "required": [
+                        "value"
+                      ]
                     },
                     "title": "Colors"
                   }

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -6309,6 +6309,10 @@
                           "type": "string",
                           "title": "Name"
                         },
+                        "sbfd_remote_discriminator": {
+                          "type": "string",
+                          "title": "Sbfd Remote Discriminator"
+                        },
                         "path_group": {
                           "type": "array",
                           "items": {
@@ -6328,7 +6332,7 @@
                                   "type": "object",
                                   "properties": {
                                     "label_stack": {
-                                      "type": "integer",
+                                      "type": "string",
                                       "title": "Label Stack"
                                     },
                                     "weight": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -6259,25 +6259,25 @@
       "properties": {
         "router_id": {
           "type": "object",
+          "title": "Router ID",
           "properties": {
             "ipv4": {
               "type": "string",
-              "title": "Ipv4"
+              "title": "IPv4"
             },
             "ipv6": {
               "type": "string",
-              "title": "Ipv6"
+              "title": "IPv6"
             }
           },
-          "additionalProperties": false,
-          "title": "Router Id"
+          "additionalProperties": false
         },
         "segment_routing": {
           "type": "object",
           "properties": {
             "colored_tunnel_rib": {
               "type": "boolean",
-              "title": "Colored Tunnel Rib"
+              "title": "Colored Tunnel RIB"
             },
             "policy_endpoints": {
               "type": "array",
@@ -6286,6 +6286,7 @@
                 "properties": {
                   "address": {
                     "type": "string",
+                    "description": "IPv4 or IPv6 address",
                     "title": "Address"
                   },
                   "colors": {
@@ -6311,7 +6312,8 @@
                         },
                         "sbfd_remote_discriminator": {
                           "type": "string",
-                          "title": "Sbfd Remote Discriminator"
+                          "title": "SBFD Remote Discriminator",
+                          "description": "IPv4 address or 32 bit integer"
                         },
                         "path_group": {
                           "type": "array",
@@ -6324,6 +6326,12 @@
                               },
                               "explicit_null": {
                                 "type": "string",
+                                "enum": [
+                                  "ipv4",
+                                  "ipv6",
+                                  "ipv4 ipv6",
+                                  "none"
+                                ],
                                 "title": "Explicit Null"
                               },
                               "segment_list": {
@@ -6333,6 +6341,7 @@
                                   "properties": {
                                     "label_stack": {
                                       "type": "string",
+                                      "description": "Label Stack as string.\nExample: \"100 2000 30\"\n",
                                       "title": "Label Stack"
                                     },
                                     "weight": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -6254,6 +6254,119 @@
       "additionalProperties": false,
       "title": "Router PIM Sparse Mode"
     },
+    "router_traffic_engineering": {
+      "type": "object",
+      "properties": {
+        "router_id": {
+          "type": "object",
+          "properties": {
+            "ipv4": {
+              "type": "string",
+              "title": "Ipv4"
+            },
+            "ipv6": {
+              "type": "string",
+              "title": "Ipv6"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Router Id"
+        },
+        "segment_routing": {
+          "type": "object",
+          "properties": {
+            "colored_tunnel_rib": {
+              "type": "boolean",
+              "title": "Colored Tunnel Rib"
+            },
+            "policy_endpoints": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "address": {
+                    "type": "string",
+                    "title": "Address"
+                  },
+                  "colors": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "value": {
+                          "type": "integer",
+                          "title": "Value"
+                        },
+                        "binding_sid": {
+                          "type": "integer",
+                          "title": "Binding Sid"
+                        },
+                        "description": {
+                          "type": "string",
+                          "title": "Description"
+                        },
+                        "name": {
+                          "type": "string",
+                          "title": "Name"
+                        },
+                        "path_group": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "preference": {
+                                "type": "integer",
+                                "title": "Preference"
+                              },
+                              "explicit_null": {
+                                "type": "string",
+                                "title": "Explicit Null"
+                              },
+                              "segment_list": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "label_stack": {
+                                      "type": "integer",
+                                      "title": "Label Stack"
+                                    },
+                                    "weight": {
+                                      "type": "integer",
+                                      "title": "Weight"
+                                    },
+                                    "index": {
+                                      "type": "integer",
+                                      "title": "Index"
+                                    }
+                                  },
+                                  "additionalProperties": false
+                                },
+                                "title": "Segment List"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "title": "Path Group"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "title": "Colors"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "title": "Policy Endpoints"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Segment Routing"
+        }
+      },
+      "additionalProperties": false,
+      "title": "Router Traffic Engineering"
+    },
     "service_routing_configuration_bgp": {
       "type": "object",
       "properties": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -4354,20 +4354,16 @@ keys:
     keys:
       router_id:
         type: dict
-        display_name: Router ID
         keys:
           ipv4:
             type: str
-            display_name: IPv4
           ipv6:
             type: str
-            display_name: IPv6
       segment_routing:
         type: dict
         keys:
           colored_tunnel_rib:
             type: bool
-            display_name: Colored Tunnel RIB
           policy_endpoints:
             type: list
             items:
@@ -4398,7 +4394,6 @@ keys:
                         type: str
                       sbfd_remote_discriminator:
                         type: str
-                        display_name: SBFD Remote Discriminator
                         description: IPv4 address or 32 bit integer
                         convert_types:
                         - int

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -4387,6 +4387,10 @@ keys:
                         type: str
                       name:
                         type: str
+                      sbfd_remote_discriminator:
+                        type: str
+                        convert_types:
+                        - int
                       path_group:
                         type: list
                         items:
@@ -4402,7 +4406,7 @@ keys:
                                 type: dict
                                 keys:
                                   label_stack:
-                                    type: int
+                                    type: str
                                   weight:
                                     type: int
                                   index:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -4354,16 +4354,20 @@ keys:
     keys:
       router_id:
         type: dict
+        display_name: Router ID
         keys:
           ipv4:
             type: str
+            display_name: IPv4
           ipv6:
             type: str
+            display_name: IPv6
       segment_routing:
         type: dict
         keys:
           colored_tunnel_rib:
             type: bool
+            display_name: Colored Tunnel RIB
           policy_endpoints:
             type: list
             items:
@@ -4371,6 +4375,7 @@ keys:
               keys:
                 address:
                   type: str
+                  description: IPv4 or IPv6 address
                 colors:
                   type: list
                   primary_key: value
@@ -4381,14 +4386,20 @@ keys:
                     keys:
                       value:
                         type: int
+                        convert_types:
+                        - str
                       binding_sid:
                         type: int
+                        convert_types:
+                        - str
                       description:
                         type: str
                       name:
                         type: str
                       sbfd_remote_discriminator:
                         type: str
+                        display_name: SBFD Remote Discriminator
+                        description: IPv4 address or 32 bit integer
                         convert_types:
                         - int
                       path_group:
@@ -4398,8 +4409,15 @@ keys:
                           keys:
                             preference:
                               type: int
+                              convert_types:
+                              - str
                             explicit_null:
                               type: str
+                              valid_values:
+                              - ipv4
+                              - ipv6
+                              - ipv4 ipv6
+                              - none
                             segment_list:
                               type: list
                               items:
@@ -4407,10 +4425,21 @@ keys:
                                 keys:
                                   label_stack:
                                     type: str
+                                    convert_types:
+                                    - int
+                                    description: 'Label Stack as string.
+
+                                      Example: "100 2000 30"
+
+                                      '
                                   weight:
                                     type: int
+                                    convert_types:
+                                    - str
                                   index:
                                     type: int
+                                    convert_types:
+                                    - str
   service_routing_configuration_bgp:
     type: dict
     keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -4349,6 +4349,64 @@ keys:
                         type: list
                         items:
                           type: str
+  router_traffic_engineering:
+    type: dict
+    keys:
+      router_id:
+        type: dict
+        keys:
+          ipv4:
+            type: str
+          ipv6:
+            type: str
+      segment_routing:
+        type: dict
+        keys:
+          colored_tunnel_rib:
+            type: bool
+          policy_endpoints:
+            type: list
+            items:
+              type: dict
+              keys:
+                address:
+                  type: str
+                colors:
+                  type: list
+                  primary_key: value
+                  convert_types:
+                  - dict
+                  items:
+                    type: dict
+                    keys:
+                      value:
+                        type: int
+                      binding_sid:
+                        type: int
+                      description:
+                        type: str
+                      name:
+                        type: str
+                      path_group:
+                        type: list
+                        items:
+                          type: dict
+                          keys:
+                            preference:
+                              type: int
+                            explicit_null:
+                              type: str
+                            segment_list:
+                              type: list
+                              items:
+                                type: dict
+                                keys:
+                                  label_stack:
+                                    type: int
+                                  weight:
+                                    type: int
+                                  index:
+                                    type: int
   service_routing_configuration_bgp:
     type: dict
     keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_traffic_engineering.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_traffic_engineering.schema.yml
@@ -1,0 +1,63 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  router_traffic_engineering:
+    type: dict
+    keys:
+      router_id:
+        type: dict
+        keys:
+          ipv4:
+            type: str
+          ipv6:
+            type: str
+      segment_routing:
+        type: dict
+        keys:
+          colored_tunnel_rib:
+            type: bool
+          policy_endpoints:
+            type: list
+            items:
+              type: dict
+              keys:
+                address:
+                  type: str
+                colors:
+                  type: list
+                  primary_key: value
+                  convert_types:
+                  - dict
+                  items:
+                    type: dict
+                    keys:
+                      value:
+                        type: int
+                      binding_sid:
+                        type: int
+                      description:
+                        type: str
+                      name:
+                        type: str
+                      path_group:
+                        type: list
+                        items:
+                          type: dict
+                          keys:
+                            preference:
+                              type: int
+                            explicit_null:
+                              type: str
+                            segment_list:
+                              type: list
+                              items:
+                                type: dict
+                                keys:
+                                  label_stack:
+                                    type: int
+                                  weight:
+                                    type: int
+                                  index:
+                                    type: int

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_traffic_engineering.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_traffic_engineering.schema.yml
@@ -8,20 +8,16 @@ keys:
     keys:
       router_id:
         type: dict
-        display_name: Router ID
         keys:
           ipv4:
             type: str
-            display_name: IPv4
           ipv6:
             type: str
-            display_name: IPv6
       segment_routing:
         type: dict
         keys:
           colored_tunnel_rib:
             type: bool
-            display_name: Colored Tunnel RIB
           policy_endpoints:
             type: list
             items:
@@ -52,7 +48,6 @@ keys:
                         type: str
                       sbfd_remote_discriminator:
                         type: str
-                        display_name: SBFD Remote Discriminator
                         description: IPv4 address or 32 bit integer
                         convert_types:
                         - int

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_traffic_engineering.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_traffic_engineering.schema.yml
@@ -8,16 +8,20 @@ keys:
     keys:
       router_id:
         type: dict
+        display_name: Router ID
         keys:
           ipv4:
             type: str
+            display_name: IPv4
           ipv6:
             type: str
+            display_name: IPv6
       segment_routing:
         type: dict
         keys:
           colored_tunnel_rib:
             type: bool
+            display_name: Colored Tunnel RIB
           policy_endpoints:
             type: list
             items:
@@ -25,6 +29,7 @@ keys:
               keys:
                 address:
                   type: str
+                  description: IPv4 or IPv6 address
                 colors:
                   type: list
                   primary_key: value
@@ -35,14 +40,20 @@ keys:
                     keys:
                       value:
                         type: int
+                        convert_types:
+                        - "str"
                       binding_sid:
                         type: int
+                        convert_types:
+                        - "str"
                       description:
                         type: str
                       name:
                         type: str
                       sbfd_remote_discriminator:
                         type: str
+                        display_name: SBFD Remote Discriminator
+                        description: IPv4 address or 32 bit integer
                         convert_types:
                         - int
                       path_group:
@@ -52,8 +63,15 @@ keys:
                           keys:
                             preference:
                               type: int
+                              convert_types:
+                              - "str"
                             explicit_null:
                               type: str
+                              valid_values:
+                              - "ipv4"
+                              - "ipv6"
+                              - "ipv4 ipv6"
+                              - "none"
                             segment_list:
                               type: list
                               items:
@@ -61,7 +79,16 @@ keys:
                                 keys:
                                   label_stack:
                                     type: str
+                                    convert_types:
+                                    - "int"
+                                    description: |
+                                      Label Stack as string.
+                                      Example: "100 2000 30"
                                   weight:
                                     type: int
+                                    convert_types:
+                                    - "str"
                                   index:
                                     type: int
+                                    convert_types:
+                                    - "str"

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_traffic_engineering.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_traffic_engineering.schema.yml
@@ -44,7 +44,7 @@ keys:
                       sbfd_remote_discriminator:
                         type: str
                         convert_types:
-                        - int  
+                        - int
                       path_group:
                         type: list
                         items:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_traffic_engineering.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_traffic_engineering.schema.yml
@@ -41,6 +41,10 @@ keys:
                         type: str
                       name:
                         type: str
+                      sbfd_remote_discriminator:
+                        type: str
+                        convert_types:
+                        - int  
                       path_group:
                         type: list
                         items:
@@ -56,7 +60,7 @@ keys:
                                 type: dict
                                 keys:
                                   label_stack:
-                                    type: int
+                                    type: str
                                   weight:
                                     type: int
                                   index:


### PR DESCRIPTION
## Add schema for data model

<!-- Use this PR Title: Feat(eos_cli_config_gen): Add schema for < data_model_key > -->

## Checklist

### Contributor Checklist

- [x] Create schema fragment matching data model described in README.md and README_v4.0.md
  - README.md is most complete with all keys. README_v4.0 includes partial data models after conversion to lists.
  - Schema fragment path is `roles/eos_cli_config_gen/schemas/schema_fragments/<data_model_key>.schema.yml`.
  - Copy line 1-5 from another schema (comments and outer type:dict).
  - Refer to [schema documentation](https://avd.sh/en/devel/docs/input-variable-validation-BETA.html) for syntax and/or use YAML Lint plugin from Redhat in VSCode.
  - Use `convert_types` on value that could be mixed type or misinterpreted like integers and numeric strings.
- [x] If the data model has been converted from wildcard dicts:
  - Add `convert_types: ['dict']` to the schema.
  - Remove `convert_dicts` from the `templates/eos/<>.j2` and `templates/documentation/<>.j2` templates.
- [x] Run `molecule converge -s build_schemas_and_docs` to update schema and documentation.
- [x] Test by running `molecule converge -s eos_cli_config_gen` and verify no errors or changes to generated configs/docs.

### Reviewer Checklist

- Reviewer 1:
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2: Julio
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
