### PR TITLE
Feat(eos_cli_config_gen): Add schema for router_l2_vpn

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -1959,6 +1959,30 @@ router_igmp:
   ssm_aware: <bool>
 ```
 
+## Router L2 Vpn
+
+### Variables
+
+| Variable | Type | Required | Default | Value Restrictions | Description |
+| -------- | ---- | -------- | ------- | ------------------ | ----------- |
+| [<samp>router_l2_vpn</samp>](## "router_l2_vpn") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;nd_rs_flooding_disabled</samp>](## "router_l2_vpn.nd_rs_flooding_disabled") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;virtual_router_nd_ra_flooding_disabled</samp>](## "router_l2_vpn.virtual_router_nd_ra_flooding_disabled") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;arp_selective_install</samp>](## "router_l2_vpn.arp_selective_install") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;arp_proxy</samp>](## "router_l2_vpn.arp_proxy") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;prefix_list</samp>](## "router_l2_vpn.arp_proxy.prefix_list") | String |  |  |  |  |
+
+### YAML
+
+```yaml
+router_l2_vpn:
+  nd_rs_flooding_disabled: <bool>
+  virtual_router_nd_ra_flooding_disabled: <bool>
+  arp_selective_install: <bool>
+  arp_proxy:
+    prefix_list: <str>
+```
+
 ## Routing PIM Sparse Mode
 
 ### Variables

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -1959,18 +1959,18 @@ router_igmp:
   ssm_aware: <bool>
 ```
 
-## Router L2 Vpn
+## Router L2 VPN
 
 ### Variables
 
 | Variable | Type | Required | Default | Value Restrictions | Description |
 | -------- | ---- | -------- | ------- | ------------------ | ----------- |
-| [<samp>router_l2_vpn</samp>](## "router_l2_vpn") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;nd_rs_flooding_disabled</samp>](## "router_l2_vpn.nd_rs_flooding_disabled") | Boolean |  |  |  |  |
-| [<samp>&nbsp;&nbsp;virtual_router_nd_ra_flooding_disabled</samp>](## "router_l2_vpn.virtual_router_nd_ra_flooding_disabled") | Boolean |  |  |  |  |
-| [<samp>&nbsp;&nbsp;arp_selective_install</samp>](## "router_l2_vpn.arp_selective_install") | Boolean |  |  |  |  |
-| [<samp>&nbsp;&nbsp;arp_proxy</samp>](## "router_l2_vpn.arp_proxy") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;prefix_list</samp>](## "router_l2_vpn.arp_proxy.prefix_list") | String |  |  |  |  |
+| [<samp>router_l2_vpn</samp>](## "router_l2_vpn") | Dictionary |  |  |  | Router L2 VPN |
+| [<samp>&nbsp;&nbsp;nd_rs_flooding_disabled</samp>](## "router_l2_vpn.nd_rs_flooding_disabled") | Boolean |  |  |  | ND RS Flooding Disabled |
+| [<samp>&nbsp;&nbsp;virtual_router_nd_ra_flooding_disabled</samp>](## "router_l2_vpn.virtual_router_nd_ra_flooding_disabled") | Boolean |  |  |  | Virtual Router ND RA Flooding Disabled |
+| [<samp>&nbsp;&nbsp;arp_selective_install</samp>](## "router_l2_vpn.arp_selective_install") | Boolean |  |  |  | ARP Selective Install |
+| [<samp>&nbsp;&nbsp;arp_proxy</samp>](## "router_l2_vpn.arp_proxy") | Dictionary |  |  |  | ARP Proxy |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;prefix_list</samp>](## "router_l2_vpn.arp_proxy.prefix_list") | String |  |  |  | Prefix-list Name |
 
 ### YAML
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -3198,33 +3198,34 @@
     },
     "router_l2_vpn": {
       "type": "object",
+      "title": "Router L2 VPN",
       "properties": {
         "nd_rs_flooding_disabled": {
           "type": "boolean",
-          "title": "Nd Rs Flooding Disabled"
+          "title": "ND RS Flooding Disabled"
         },
         "virtual_router_nd_ra_flooding_disabled": {
           "type": "boolean",
-          "title": "Virtual Router Nd Ra Flooding Disabled"
+          "title": "Virtual Router ND RA Flooding Disabled"
         },
         "arp_selective_install": {
           "type": "boolean",
-          "title": "Arp Selective Install"
+          "title": "ARP Selective Install"
         },
         "arp_proxy": {
           "type": "object",
+          "title": "ARP Proxy",
           "properties": {
             "prefix_list": {
               "type": "string",
+              "description": "Prefix-list Name",
               "title": "Prefix List"
             }
           },
-          "additionalProperties": false,
-          "title": "Arp Proxy"
+          "additionalProperties": false
         }
       },
-      "additionalProperties": false,
-      "title": "Router L2 Vpn"
+      "additionalProperties": false
     },
     "router_pim_sparse_mode": {
       "type": "object",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -3196,6 +3196,36 @@
       },
       "additionalProperties": false
     },
+    "router_l2_vpn": {
+      "type": "object",
+      "properties": {
+        "nd_rs_flooding_disabled": {
+          "type": "boolean",
+          "title": "Nd Rs Flooding Disabled"
+        },
+        "virtual_router_nd_ra_flooding_disabled": {
+          "type": "boolean",
+          "title": "Virtual Router Nd Ra Flooding Disabled"
+        },
+        "arp_selective_install": {
+          "type": "boolean",
+          "title": "Arp Selective Install"
+        },
+        "arp_proxy": {
+          "type": "object",
+          "properties": {
+            "prefix_list": {
+              "type": "string",
+              "title": "Prefix List"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Arp Proxy"
+        }
+      },
+      "additionalProperties": false,
+      "title": "Router L2 Vpn"
+    },
     "router_pim_sparse_mode": {
       "type": "object",
       "title": "Routing PIM Sparse Mode",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -2499,6 +2499,20 @@ keys:
     keys:
       ssm_aware:
         type: bool
+  router_l2_vpn:
+    type: dict
+    keys:
+      nd_rs_flooding_disabled:
+        type: bool
+      virtual_router_nd_ra_flooding_disabled:
+        type: bool
+      arp_selective_install:
+        type: bool
+      arp_proxy:
+        type: dict
+        keys:
+          prefix_list:
+            type: str
   router_pim_sparse_mode:
     type: dict
     display_name: Routing PIM Sparse Mode

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -2501,18 +2501,24 @@ keys:
         type: bool
   router_l2_vpn:
     type: dict
+    display_name: Router L2 VPN
     keys:
       nd_rs_flooding_disabled:
         type: bool
+        display_name: ND RS Flooding Disabled
       virtual_router_nd_ra_flooding_disabled:
         type: bool
+        display_name: Virtual Router ND RA Flooding Disabled
       arp_selective_install:
         type: bool
+        display_name: ARP Selective Install
       arp_proxy:
         type: dict
+        display_name: ARP Proxy
         keys:
           prefix_list:
             type: str
+            description: Prefix-list Name
   router_pim_sparse_mode:
     type: dict
     display_name: Routing PIM Sparse Mode

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_l2_vpn.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_l2_vpn.schema.yml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  router_l2_vpn:
+    type: dict
+    keys:
+      nd_rs_flooding_disabled:
+        type: bool
+      virtual_router_nd_ra_flooding_disabled:
+        type: bool
+      arp_selective_install:
+        type: bool
+      arp_proxy:
+        type: dict
+        keys:
+          prefix_list:
+            type: str

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_l2_vpn.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_l2_vpn.schema.yml
@@ -5,15 +5,21 @@ type: dict
 keys:
   router_l2_vpn:
     type: dict
+    display_name: Router L2 VPN
     keys:
       nd_rs_flooding_disabled:
         type: bool
+        display_name: ND RS Flooding Disabled
       virtual_router_nd_ra_flooding_disabled:
         type: bool
+        display_name: Virtual Router ND RA Flooding Disabled
       arp_selective_install:
         type: bool
+        display_name: ARP Selective Install
       arp_proxy:
         type: dict
+        display_name: ARP Proxy
         keys:
           prefix_list:
             type: str
+            description: Prefix-list Name


### PR DESCRIPTION
## Add schema for data model

<!-- Use this PR Title: Feat(eos_cli_config_gen): Add schema for < data_model_key > -->

## Checklist

### Contributor Checklist

- [x] Create schema fragment matching data model described in README.md and README_v4.0.md
  - README.md is most complete with all keys. README_v4.0 includes partial data models after conversion to lists.
  - Schema fragment path is `roles/eos_cli_config_gen/schemas/schema_fragments/<data_model_key>.schema.yml`.
  - Copy line 1-5 from another schema (comments and outer type:dict).
  - Refer to [schema documentation](https://avd.sh/en/devel/docs/input-variable-validation-BETA.html) for syntax and/or use YAML Lint plugin from Redhat in VSCode.
  - Use `convert_types` on value that could be mixed type or misinterpreted like integers and numeric strings.
- [x] If the data model has been converted from wildcard dicts:
  - Add `convert_types: ['dict']` to the schema.
  - Remove `convert_dicts` from the `templates/eos/<>.j2` and `templates/documentation/<>.j2` templates.
- [x] Run `molecule converge -s build_schemas_and_docs` to update schema and documentation.
- [x] Test by running `molecule converge -s eos_cli_config_gen` and verify no errors or changes to generated configs/docs.

### Reviewer Checklist

- Reviewer 1:
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2:
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
