### PR TITLE
Feat(eos_cli_config_gen): Add schema for management_tech_support

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -2100,6 +2100,32 @@ management_ssh:
   log_level: <str>
 ```
 
+## Management Tech Support
+
+### Variables
+
+| Variable | Type | Required | Default | Value Restrictions | Description |
+| -------- | ---- | -------- | ------- | ------------------ | ----------- |
+| [<samp>management_tech_support</samp>](## "management_tech_support") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;policy_show_tech_support</samp>](## "management_tech_support.policy_show_tech_support") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;exclude_commands</samp>](## "management_tech_support.policy_show_tech_support.exclude_commands") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- command</samp>](## "management_tech_support.policy_show_tech_support.exclude_commands.[].command") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;type</samp>](## "management_tech_support.policy_show_tech_support.exclude_commands.[].type") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;include_commands</samp>](## "management_tech_support.policy_show_tech_support.include_commands") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- command</samp>](## "management_tech_support.policy_show_tech_support.include_commands.[].command") | String |  |  |  |  |
+
+### YAML
+
+```yaml
+management_tech_support:
+  policy_show_tech_support:
+    exclude_commands:
+      - command: <str>
+        type: <str>
+    include_commands:
+      - command: <str>
+```
+
 ## Match Lists
 
 ### Variables

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -2109,10 +2109,10 @@ management_ssh:
 | [<samp>management_tech_support</samp>](## "management_tech_support") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;policy_show_tech_support</samp>](## "management_tech_support.policy_show_tech_support") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;exclude_commands</samp>](## "management_tech_support.policy_show_tech_support.exclude_commands") | List, items: Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- command</samp>](## "management_tech_support.policy_show_tech_support.exclude_commands.[].command") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;type</samp>](## "management_tech_support.policy_show_tech_support.exclude_commands.[].type") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- command</samp>](## "management_tech_support.policy_show_tech_support.exclude_commands.[].command") | String |  |  |  | Command to exclude from tech-support |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;type</samp>](## "management_tech_support.policy_show_tech_support.exclude_commands.[].type") | String |  | text | Valid Values:<br>- text<br>- json | The supported values for type are platform dependent. |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;include_commands</samp>](## "management_tech_support.policy_show_tech_support.include_commands") | List, items: Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- command</samp>](## "management_tech_support.policy_show_tech_support.include_commands.[].command") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- command</samp>](## "management_tech_support.policy_show_tech_support.include_commands.[].command") | String |  |  |  | Command to include in tech-support |
 
 ### YAML
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -3528,6 +3528,52 @@
       "additionalProperties": false,
       "title": "Management SSH"
     },
+    "management_tech_support": {
+      "type": "object",
+      "properties": {
+        "policy_show_tech_support": {
+          "type": "object",
+          "properties": {
+            "exclude_commands": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "command": {
+                    "type": "string",
+                    "title": "Command"
+                  },
+                  "type": {
+                    "type": "string",
+                    "title": "Type"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "title": "Exclude Commands"
+            },
+            "include_commands": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "command": {
+                    "type": "string",
+                    "title": "Command"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "title": "Include Commands"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Policy Show Tech Support"
+        }
+      },
+      "additionalProperties": false,
+      "title": "Management Tech Support"
+    },
     "match_list_input": {
       "type": "object",
       "title": "Match Lists",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -3541,10 +3541,17 @@
                 "properties": {
                   "command": {
                     "type": "string",
+                    "description": "Command to exclude from tech-support",
                     "title": "Command"
                   },
                   "type": {
                     "type": "string",
+                    "enum": [
+                      "text",
+                      "json"
+                    ],
+                    "default": "text",
+                    "description": "The supported values for type are platform dependent.",
                     "title": "Type"
                   }
                 },
@@ -3559,6 +3566,7 @@
                 "properties": {
                   "command": {
                     "type": "string",
+                    "description": "Command to include in tech-support",
                     "title": "Command"
                   }
                 },

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -2607,6 +2607,28 @@ keys:
       log_level:
         type: str
         description: SSH daemon log level
+  management_tech_support:
+    type: dict
+    keys:
+      policy_show_tech_support:
+        type: dict
+        keys:
+          exclude_commands:
+            type: list
+            items:
+              type: dict
+              keys:
+                command:
+                  type: str
+                type:
+                  type: str
+          include_commands:
+            type: list
+            items:
+              type: dict
+              keys:
+                command:
+                  type: str
   match_list_input:
     type: dict
     display_name: Match Lists

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -2620,8 +2620,14 @@ keys:
               keys:
                 command:
                   type: str
+                  description: Command to exclude from tech-support
                 type:
                   type: str
+                  valid_values:
+                  - text
+                  - json
+                  default: text
+                  description: The supported values for type are platform dependent.
           include_commands:
             type: list
             items:
@@ -2629,6 +2635,7 @@ keys:
               keys:
                 command:
                   type: str
+                  description: Command to include in tech-support
   match_list_input:
     type: dict
     display_name: Match Lists

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_tech_support.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_tech_support.schema.yml
@@ -16,8 +16,14 @@ keys:
               keys:
                 command:
                   type: str
+                  description: Command to exclude from tech-support
                 type:
                   type: str
+                  valid_values:
+                  - text
+                  - json
+                  default: text
+                  description: The supported values for type are platform dependent.
           include_commands:
             type: list
             items:
@@ -25,3 +31,4 @@ keys:
               keys:
                 command:
                   type: str
+                  description: Command to include in tech-support

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_tech_support.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_tech_support.schema.yml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  management_tech_support:
+    type: dict
+    keys:
+      policy_show_tech_support:
+        type: dict
+        keys:
+          exclude_commands:
+            type: list
+            items:
+              type: dict
+              keys:
+                command:
+                  type: str
+                type:
+                  type: str
+          include_commands:
+            type: list
+            items:
+              type: dict
+              keys:
+                command:
+                  type: str


### PR DESCRIPTION
## Add schema for data model

<!-- Use this PR Title: Feat(eos_cli_config_gen): Add schema for < data_model_key > -->

## Checklist

### Contributor Checklist

- [x] Create schema fragment matching data model described in README.md and README_v4.0.md
  - README.md is most complete with all keys. README_v4.0 includes partial data models after conversion to lists.
  - Schema fragment path is `roles/eos_cli_config_gen/schemas/schema_fragments/<data_model_key>.schema.yml`.
  - Copy line 1-5 from another schema (comments and outer type:dict).
  - Refer to [schema documentation](https://avd.sh/en/devel/docs/input-variable-validation-BETA.html) for syntax and/or use YAML Lint plugin from Redhat in VSCode.
  - Use `convert_types` on value that could be mixed type or misinterpreted like integers and numeric strings.
- [x] If the data model has been converted from wildcard dicts:
  - Add `convert_types: ['dict']` to the schema.
  - Remove `convert_dicts` from the `templates/eos/<>.j2` and `templates/documentation/<>.j2` templates.
- [x] Run `molecule converge -s build_schemas_and_docs` to update schema and documentation.
- [x] Test by running `molecule converge -s eos_cli_config_gen` and verify no errors or changes to generated configs/docs.

### Reviewer Checklist

- Reviewer 1:
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2:
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
