### PR TITLE
Feat(eos_cli_config_gen): Add schema for management_cvx

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -1509,16 +1509,16 @@ management_console:
   idle_timeout: <int>
 ```
 
-## Management Cvx
+## Management CVX
 
 ### Variables
 
 | Variable | Type | Required | Default | Value Restrictions | Description |
 | -------- | ---- | -------- | ------- | ------------------ | ----------- |
-| [<samp>management_cvx</samp>](## "management_cvx") | Dictionary |  |  |  |  |
+| [<samp>management_cvx</samp>](## "management_cvx") | Dictionary |  |  |  | Management CVX |
 | [<samp>&nbsp;&nbsp;shutdown</samp>](## "management_cvx.shutdown") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;server_hosts</samp>](## "management_cvx.server_hosts") | List, items: String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "management_cvx.server_hosts.[].&lt;str&gt;") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "management_cvx.server_hosts.[].&lt;str&gt;") | String |  |  |  | IP or hostname |
 
 ### YAML
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -1509,6 +1509,26 @@ management_console:
   idle_timeout: <int>
 ```
 
+## Management Cvx
+
+### Variables
+
+| Variable | Type | Required | Default | Value Restrictions | Description |
+| -------- | ---- | -------- | ------- | ------------------ | ----------- |
+| [<samp>management_cvx</samp>](## "management_cvx") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;shutdown</samp>](## "management_cvx.shutdown") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;server_hosts</samp>](## "management_cvx.server_hosts") | List, items: String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "management_cvx.server_hosts.[].&lt;str&gt;") | String |  |  |  |  |
+
+### YAML
+
+```yaml
+management_cvx:
+  shutdown: <bool>
+  server_hosts:
+    - <str>
+```
+
 ## Management Defaults
 
 ### Variables

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -2295,6 +2295,7 @@
     },
     "management_cvx": {
       "type": "object",
+      "title": "Management CVX",
       "properties": {
         "shutdown": {
           "type": "boolean",
@@ -2303,13 +2304,13 @@
         "server_hosts": {
           "type": "array",
           "items": {
-            "type": "string"
+            "type": "string",
+            "description": "IP or hostname"
           },
           "title": "Server Hosts"
         }
       },
-      "additionalProperties": false,
-      "title": "Management Cvx"
+      "additionalProperties": false
     },
     "management_defaults": {
       "type": "object",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -2293,6 +2293,24 @@
       "additionalProperties": false,
       "title": "Management Console"
     },
+    "management_cvx": {
+      "type": "object",
+      "properties": {
+        "shutdown": {
+          "type": "boolean",
+          "title": "Shutdown"
+        },
+        "server_hosts": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "title": "Server Hosts"
+        }
+      },
+      "additionalProperties": false,
+      "title": "Management Cvx"
+    },
     "management_defaults": {
       "type": "object",
       "properties": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -1880,6 +1880,7 @@ keys:
         - str
   management_cvx:
     type: dict
+    display_name: Management CVX
     keys:
       shutdown:
         type: bool
@@ -1887,6 +1888,7 @@ keys:
         type: list
         items:
           type: str
+          description: IP or hostname
   management_defaults:
     type: dict
     keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -1878,6 +1878,15 @@ keys:
         max: 86400
         convert_types:
         - str
+  management_cvx:
+    type: dict
+    keys:
+      shutdown:
+        type: bool
+      server_hosts:
+        type: list
+        items:
+          type: str
   management_defaults:
     type: dict
     keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_cvx.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_cvx.schema.yml
@@ -5,6 +5,7 @@ type: dict
 keys:
   management_cvx:
     type: dict
+    display_name: Management CVX
     keys:
       shutdown:
         type: bool
@@ -12,3 +13,4 @@ keys:
         type: list
         items:
           type: str
+          description: IP or hostname

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_cvx.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_cvx.schema.yml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  management_cvx:
+    type: dict
+    keys:
+      shutdown:
+        type: bool
+      server_hosts:
+        type: list
+        items:
+          type: str


### PR DESCRIPTION
## Add schema for data model

<!-- Use this PR Title: Feat(eos_cli_config_gen): Add schema for < data_model_key > -->

## Checklist

### Contributor Checklist

- [x] Create schema fragment matching data model described in README.md and README_v4.0.md
  - README.md is most complete with all keys. README_v4.0 includes partial data models after conversion to lists.
  - Schema fragment path is `roles/eos_cli_config_gen/schemas/schema_fragments/<data_model_key>.schema.yml`.
  - Copy line 1-5 from another schema (comments and outer type:dict).
  - Refer to [schema documentation](https://avd.sh/en/devel/docs/input-variable-validation-BETA.html) for syntax and/or use YAML Lint plugin from Redhat in VSCode.
  - Use `convert_types` on value that could be mixed type or misinterpreted like integers and numeric strings.
- [x] If the data model has been converted from wildcard dicts:
  - Add `convert_types: ['dict']` to the schema.
  - Remove `convert_dicts` from the `templates/eos/<>.j2` and `templates/documentation/<>.j2` templates.
- [x] Run `molecule converge -s build_schemas_and_docs` to update schema and documentation.
- [x] Test by running `molecule converge -s eos_cli_config_gen` and verify no errors or changes to generated configs/docs.

### Reviewer Checklist

- Reviewer 1:
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2:
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
