### PR TITLE
Feat(eos_cli_config_gen): Add schema for mcs_client

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -1625,19 +1625,19 @@ match_list_input:
           match_regex: <str>
 ```
 
-## Mcs Client
+## MCS Client
 
 ### Variables
 
 | Variable | Type | Required | Default | Value Restrictions | Description |
 | -------- | ---- | -------- | ------- | ------------------ | ----------- |
-| [<samp>mcs_client</samp>](## "mcs_client") | Dictionary |  |  |  |  |
+| [<samp>mcs_client</samp>](## "mcs_client") | Dictionary |  |  |  | MCS Client |
 | [<samp>&nbsp;&nbsp;shutdown</samp>](## "mcs_client.shutdown") | Boolean |  |  |  |  |
-| [<samp>&nbsp;&nbsp;cvx_secondary</samp>](## "mcs_client.cvx_secondary") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;cvx_secondary</samp>](## "mcs_client.cvx_secondary") | Dictionary |  |  |  | CVX Secondary |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "mcs_client.cvx_secondary.name") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;shutdown</samp>](## "mcs_client.cvx_secondary.shutdown") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;server_hosts</samp>](## "mcs_client.cvx_secondary.server_hosts") | List, items: String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "mcs_client.cvx_secondary.server_hosts.[].&lt;str&gt;") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "mcs_client.cvx_secondary.server_hosts.[].&lt;str&gt;") | String |  |  |  | IP or hostname |
 
 ### YAML
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -1625,6 +1625,32 @@ match_list_input:
           match_regex: <str>
 ```
 
+## Mcs Client
+
+### Variables
+
+| Variable | Type | Required | Default | Value Restrictions | Description |
+| -------- | ---- | -------- | ------- | ------------------ | ----------- |
+| [<samp>mcs_client</samp>](## "mcs_client") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;shutdown</samp>](## "mcs_client.shutdown") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;cvx_secondary</samp>](## "mcs_client.cvx_secondary") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "mcs_client.cvx_secondary.name") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;shutdown</samp>](## "mcs_client.cvx_secondary.shutdown") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;server_hosts</samp>](## "mcs_client.cvx_secondary.server_hosts") | List, items: String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "mcs_client.cvx_secondary.server_hosts.[].&lt;str&gt;") | String |  |  |  |  |
+
+### YAML
+
+```yaml
+mcs_client:
+  shutdown: <bool>
+  cvx_secondary:
+    name: <str>
+    shutdown: <bool>
+    server_hosts:
+      - <str>
+```
+
 ## Monitor Connectivity
 
 ### Variables

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -2558,6 +2558,39 @@
       },
       "additionalProperties": false
     },
+    "mcs_client": {
+      "type": "object",
+      "properties": {
+        "shutdown": {
+          "type": "boolean",
+          "title": "Shutdown"
+        },
+        "cvx_secondary": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "title": "Name"
+            },
+            "shutdown": {
+              "type": "boolean",
+              "title": "Shutdown"
+            },
+            "server_hosts": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "title": "Server Hosts"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Cvx Secondary"
+        }
+      },
+      "additionalProperties": false,
+      "title": "Mcs Client"
+    },
     "monitor_connectivity": {
       "type": "object",
       "properties": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -2560,6 +2560,7 @@
     },
     "mcs_client": {
       "type": "object",
+      "title": "MCS Client",
       "properties": {
         "shutdown": {
           "type": "boolean",
@@ -2567,6 +2568,7 @@
         },
         "cvx_secondary": {
           "type": "object",
+          "title": "CVX Secondary",
           "properties": {
             "name": {
               "type": "string",
@@ -2579,17 +2581,16 @@
             "server_hosts": {
               "type": "array",
               "items": {
-                "type": "string"
+                "type": "string",
+                "description": "IP or hostname"
               },
               "title": "Server Hosts"
             }
           },
-          "additionalProperties": false,
-          "title": "Cvx Secondary"
+          "additionalProperties": false
         }
       },
-      "additionalProperties": false,
-      "title": "Mcs Client"
+      "additionalProperties": false
     },
     "monitor_connectivity": {
       "type": "object",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -2064,6 +2064,22 @@ keys:
                     type: str
                     required: true
                     display_name: Regular Expression
+  mcs_client:
+    type: dict
+    keys:
+      shutdown:
+        type: bool
+      cvx_secondary:
+        type: dict
+        keys:
+          name:
+            type: str
+          shutdown:
+            type: bool
+          server_hosts:
+            type: list
+            items:
+              type: str
   monitor_connectivity:
     type: dict
     keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -2066,11 +2066,13 @@ keys:
                     display_name: Regular Expression
   mcs_client:
     type: dict
+    display_name: MCS Client
     keys:
       shutdown:
         type: bool
       cvx_secondary:
         type: dict
+        display_name: CVX Secondary
         keys:
           name:
             type: str
@@ -2080,6 +2082,7 @@ keys:
             type: list
             items:
               type: str
+              description: IP or hostname
   monitor_connectivity:
     type: dict
     keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/mcs_client.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/mcs_client.schema.yml
@@ -5,11 +5,13 @@ type: dict
 keys:
   mcs_client:
     type: dict
+    display_name: MCS Client
     keys:
       shutdown:
         type: bool
       cvx_secondary:
         type: dict
+        display_name: CVX Secondary
         keys:
           name:
             type: str
@@ -19,3 +21,4 @@ keys:
             type: list
             items:
               type: str
+              description: IP or hostname

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/mcs_client.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/mcs_client.schema.yml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  mcs_client:
+    type: dict
+    keys:
+      shutdown:
+        type: bool
+      cvx_secondary:
+        type: dict
+        keys:
+          name:
+            type: str
+          shutdown:
+            type: bool
+          server_hosts:
+            type: list
+            items:
+              type: str


### PR DESCRIPTION
## Add schema for data model

<!-- Use this PR Title: Feat(eos_cli_config_gen): Add schema for < data_model_key > -->

## Checklist

### Contributor Checklist

- [x] Create schema fragment matching data model described in README.md and README_v4.0.md
  - README.md is most complete with all keys. README_v4.0 includes partial data models after conversion to lists.
  - Schema fragment path is `roles/eos_cli_config_gen/schemas/schema_fragments/<data_model_key>.schema.yml`.
  - Copy line 1-5 from another schema (comments and outer type:dict).
  - Refer to [schema documentation](https://avd.sh/en/devel/docs/input-variable-validation-BETA.html) for syntax and/or use YAML Lint plugin from Redhat in VSCode.
  - Use `convert_types` on value that could be mixed type or misinterpreted like integers and numeric strings.
- [x] If the data model has been converted from wildcard dicts:
  - Add `convert_types: ['dict']` to the schema.
  - Remove `convert_dicts` from the `templates/eos/<>.j2` and `templates/documentation/<>.j2` templates.
- [x] Run `molecule converge -s build_schemas_and_docs` to update schema and documentation.
- [x] Test by running `molecule converge -s eos_cli_config_gen` and verify no errors or changes to generated configs/docs.

### Reviewer Checklist

- Reviewer 1:
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2:
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
