### PR TITLE
Fix: Ensure get.avd.sh make script sets the correct UID

### DIFF
--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     image: avdteam/base:3.8-v2.0
     container_name: ansible_avd
     environment:
+      - AVD_UID=${AVD_UID}
       - AVD_GIT_USER=${GIT_USER}
       - AVD_GIT_EMAIL=${GIT_EMAIL}
     volumes:

--- a/development/docker-stack.env
+++ b/development/docker-stack.env
@@ -1,4 +1,4 @@
 #!/bin/bash
-
+export AVD_UID=$(id -u)
 export GIT_USER=$(git config --get user.name)
 export GIT_EMAIL=$(git config --get user.email)


### PR DESCRIPTION
## Change Summary

When using the get.avd.sh script (https://github.com/arista-netdevops-community/avd-install) the default docker-compose file starts with the default UID. This tends to mismatch the UID that is being used for the original git pull, hence causing permission issues when working in the container

## Related Issue(s)

Permission issues in docker container after running make start in the https://github.com/arista-netdevops-community/avd-install script

## Component(s) name

docker-compose file

## Proposed changes

Add the AVD_UID variable to the docker-stack.env and pass it onto the container using the docker-compose.yml file

## How to test

Start the container using the get.avd.sh quickstart script by executing make start

## Checklist


### User Checklist

- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [X] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [X] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)

### Notes

oh-my-zsh will give the following notification on initial container launch. When exiting out of the container and re-entering it, the message will no longer be shown. 

[oh-my-zsh] For safety, we will not load completions from these directories until
[oh-my-zsh] you fix their permissions and ownership and restart zsh.
[oh-my-zsh] See the above list for directories with group or other writability.

[oh-my-zsh] To fix your permissions you can do so by disabling
[oh-my-zsh] the write permission of "group" and "others" and making sure that the
[oh-my-zsh] owner of these directories is either root or your current user.
[oh-my-zsh] The following command may help:
[oh-my-zsh]     compaudit | xargs chmod g-w,o-w

[oh-my-zsh] If the above didn't help or you want to skip the verification of
[oh-my-zsh] insecure directories you can set the variable ZSH_DISABLE_COMPFIX to
[oh-my-zsh] "true" before oh-my-zsh is sourced in your zshrc file.
