### PR TITLE
Feat(eos_designs): Add support for Trident 2 devices (7050X2)

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_platform_7050X2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_platform_7050X2.cfg
@@ -1,0 +1,136 @@
+!RANCID-CONTENT-TYPE: arista
+!
+boot secret sha512 a153de6290ff1409257ade45f
+!
+daemon TerminAttr
+   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   no shutdown
+!
+vlan internal order ascending range 1006 1199
+!
+no ip igmp snooping vlan 120
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname mgmt_interface_platform_7050X2
+ip name-server vrf MGMT 8.8.8.8
+ip name-server vrf MGMT 192.168.200.5
+!
+ntp local-interface vrf MGMT Management1
+ntp server vrf MGMT 192.168.200.5 prefer
+!
+snmp-server contact example@example.com
+snmp-server location EOS_DESIGNS_UNIT_TESTS mgmt_interface_platform_7050X2
+!
+no enable password
+no aaa root
+!
+username admin privilege 15 role network-admin nopassword
+username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
+username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
+!
+vlan 110
+   name Tenant_A_OP_Zone_1
+!
+vlan 111
+   name Tenant_A_OP_Zone_2
+!
+vlan 112
+   name Tenant_A_OP_Zone_3
+!
+vlan 120
+   name Tenant_A_WEB_Zone_1
+!
+vlan 121
+   name Tenant_A_WEBZone_2
+!
+vlan 130
+   name Tenant_A_APP_Zone_1
+!
+vlan 131
+   name Tenant_A_APP_Zone_2
+!
+vlan 132
+   name Tenant_A_APP_Zone_3
+!
+vlan 140
+   name Tenant_A_DB_BZone_1
+!
+vlan 141
+   name Tenant_A_DB_Zone_2
+!
+vlan 150
+   name Tenant_A_WAN_Zone_1
+!
+vlan 151
+   name svi_with_no_tags
+!
+vlan 160
+   name Tenant_A_VMOTION
+!
+vlan 161
+   name Tenant_A_NFS
+!
+vlan 162
+   name l2vlan_with_no_tags
+!
+vlan 210
+   name Tenant_B_OP_Zone_1
+!
+vlan 211
+   name Tenant_B_OP_Zone_2
+!
+vlan 250
+   name Tenant_B_WAN_Zone_1
+!
+vlan 310
+   name Tenant_C_OP_Zone_1
+!
+vlan 311
+   name Tenant_C_OP_Zone_2
+!
+vlan 350
+   name Tenant_C_WAN_Zone_1
+!
+vlan 410
+   name Tenant_D_v6_OP_Zone_1
+!
+vlan 411
+   name Tenant_D_v6_OP_Zone_2
+!
+vlan 412
+   name Tenant_D_v6_OP_Zone_1
+!
+vlan 450
+   name Tenant_D_v6_WAN_Zone_1
+!
+vlan 451
+   name Tenant_D_v6_WAN_Zone_2
+!
+vlan 452
+   name Tenant_D_v6_WAN_Zone_3
+!
+vrf instance MGMT
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 1.1.1.3
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip route vrf MGMT 0.0.0.0/0 1.1.1.1
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_platform_7050X2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_platform_7050X2.yml
@@ -1,0 +1,144 @@
+static_routes:
+- vrf: MGMT
+  destination_address_prefix: 0.0.0.0/0
+  gateway: 1.1.1.1
+service_routing_protocols_model: multi-agent
+ip_routing: true
+daemon_terminattr:
+  cvaddrs:
+  - 192.168.200.11:9910
+  cvauth:
+    method: key
+    key: telarista
+  cvvrf: MGMT
+  smashexcludes: ale,flexCounter,hardware,kni,pulse,strata
+  ingestexclude: /Sysdb/cell/1/agent,/Sysdb/cell/2/agent
+  disable_aaa: false
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+name_server:
+  source:
+    vrf: MGMT
+  nodes:
+  - 192.168.200.5
+  - 8.8.8.8
+snmp_server:
+  contact: example@example.com
+  location: EOS_DESIGNS_UNIT_TESTS mgmt_interface_platform_7050X2
+local_users:
+  admin:
+    privilege: 15
+    role: network-admin
+    no_password: true
+  cvpadmin:
+    privilege: 15
+    role: network-admin
+    sha512_password: $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
+    ssh_key: ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU=
+      cvpadmin@hostmachine.local
+vrfs:
+  MGMT:
+    ip_routing: false
+management_interfaces:
+  Management1:
+    description: oob_management
+    shutdown: false
+    vrf: MGMT
+    ip_address: 1.1.1.3
+    gateway: 1.1.1.1
+    type: oob
+management_api_http:
+  enable_vrfs:
+    MGMT: {}
+  enable_https: true
+  default_services: false
+vlans:
+  130:
+    tenant: Tenant_A
+    name: Tenant_A_APP_Zone_1
+  131:
+    tenant: Tenant_A
+    name: Tenant_A_APP_Zone_2
+  132:
+    tenant: Tenant_A
+    name: Tenant_A_APP_Zone_3
+  140:
+    tenant: Tenant_A
+    name: Tenant_A_DB_BZone_1
+  141:
+    tenant: Tenant_A
+    name: Tenant_A_DB_Zone_2
+  110:
+    tenant: Tenant_A
+    name: Tenant_A_OP_Zone_1
+  111:
+    tenant: Tenant_A
+    name: Tenant_A_OP_Zone_2
+  112:
+    tenant: Tenant_A
+    name: Tenant_A_OP_Zone_3
+  150:
+    tenant: Tenant_A
+    name: Tenant_A_WAN_Zone_1
+  151:
+    tenant: Tenant_A
+    name: svi_with_no_tags
+  120:
+    tenant: Tenant_A
+    name: Tenant_A_WEB_Zone_1
+  121:
+    tenant: Tenant_A
+    name: Tenant_A_WEBZone_2
+  160:
+    tenant: Tenant_A
+    name: Tenant_A_VMOTION
+  161:
+    tenant: Tenant_A
+    name: Tenant_A_NFS
+  162:
+    tenant: Tenant_A
+    name: l2vlan_with_no_tags
+  210:
+    tenant: Tenant_B
+    name: Tenant_B_OP_Zone_1
+  211:
+    tenant: Tenant_B
+    name: Tenant_B_OP_Zone_2
+  250:
+    tenant: Tenant_B
+    name: Tenant_B_WAN_Zone_1
+  310:
+    tenant: Tenant_C
+    name: Tenant_C_OP_Zone_1
+  311:
+    tenant: Tenant_C
+    name: Tenant_C_OP_Zone_2
+  350:
+    tenant: Tenant_C
+    name: Tenant_C_WAN_Zone_1
+  410:
+    tenant: Tenant_D
+    name: Tenant_D_v6_OP_Zone_1
+  411:
+    tenant: Tenant_D
+    name: Tenant_D_v6_OP_Zone_2
+  412:
+    tenant: Tenant_D
+    name: Tenant_D_v6_OP_Zone_1
+  450:
+    tenant: Tenant_D
+    name: Tenant_D_v6_WAN_Zone_1
+  451:
+    tenant: Tenant_D
+    name: Tenant_D_v6_WAN_Zone_2
+  452:
+    tenant: Tenant_D
+    name: Tenant_D_v6_WAN_Zone_3
+ip_igmp_snooping:
+  globally_enabled: true
+  vlans:
+    120:
+      enabled: false

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/mgmt_interface_platform_7050X2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/mgmt_interface_platform_7050X2.yml
@@ -4,12 +4,8 @@ mgmt_gateway: 1.1.1.1
 l2leaf:
   defaults:
   nodes:
-    mgmt_interface_platform:
-      platform: 7500R2
-      mgmt_ip: 1.1.1.2
-      id: 105
     mgmt_interface_platform_7050X2:
       platform: 7050X2
       mgmt_ip: 1.1.1.3
-      id: 100
+      id: 106
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
@@ -237,6 +237,7 @@ all:
                         mgmt_interface_fabric:
                         mgmt_interface_host:
                         mgmt_interface_platform:
+                        mgmt_interface_platform_7050X2:
                 MH_LEAFS_TESTS:
                   # Connected to Spine1 Eth10-12
                   children:

--- a/ansible_collections/arista/avd/roles/eos_designs/defaults/main/default-platform-settings.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/defaults/main/default-platform-settings.yml
@@ -18,6 +18,13 @@ default_platform_settings:
     feature_support:
       # "queue-monitor length notify" is only valid for R-Series so should be disabled on default platform.
       queue_monitor_length_notify: false
+  - platforms: ['7050X2']
+    reload_delay:
+      mlag: 300
+      non_mlag: 330
+    feature_support:
+      # "queue-monitor length notify" is only valid for R-Series. Not supported on this platform.
+      queue_monitor_length_notify: false
   - platforms: ['7280R', '7280R2']
     tcam_profile: vxlan-routing
     lag_hardware_only: true

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/platform-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/platform-settings.md
@@ -62,6 +62,12 @@ default_platform_settings:
       non_mlag: 330
     feature_support:
       queue_monitor_length_notify: false
+  - platforms: ['7050X2']
+    reload_delay:
+      mlag: 300
+      non_mlag: 330
+    feature_support:
+      queue_monitor_length_notify: false
   - platforms: ['7280R', '7280R2']
     tcam_profile: vxlan-routing
     lag_hardware_only: true


### PR DESCRIPTION
## Change Summary

Add new platform under default_platform_settings and set the right variables to support 7050X2 devices.

## Related Issue(s)

Fixes #2216 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
Add new platform:


## How to test
Molecule test included

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
