### PR TITLE
Feat(eos_validate_state): custom fan & pwr states

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_validate_state/README.md
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/README.md
@@ -84,6 +84,13 @@ fabric_name: "all"
 # Allow different manufacturers
 accepted_xcvr_manufacturers: "{{ validation_role.xcvr_own_manufacturers | arista.avd.default(['Arastra, Inc.', 'Arista Networks']) }}"
 
+# Allow different states for power supplies
+accepted_pwr_supply_states: "{{ validation_role.pwr_supply_states | arista.avd.default(['ok', 'Not Inserted']) }}"
+
+# Allow different states for fans
+accepted_fan_states: "{{ validation_role.fan_states | arista.avd.default(['ok', 'Not Inserted']) }}"
+
+
 # Generate CSV results file
 validation_report_csv: "{{ validation_role.validation_report_csv | arista.avd.default(true) }}"
 

--- a/ansible_collections/arista/avd/roles/eos_validate_state/README.md
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/README.md
@@ -85,10 +85,10 @@ fabric_name: "all"
 accepted_xcvr_manufacturers: "{{ validation_role.xcvr_own_manufacturers | arista.avd.default(['Arastra, Inc.', 'Arista Networks']) }}"
 
 # Allow different states for power supplies
-accepted_pwr_supply_states: "{{ validation_role.pwr_supply_states | arista.avd.default(['ok', 'Not Inserted']) }}"
+accepted_pwr_supply_states: "{{ validation_role.pwr_supply_states | arista.avd.default(['ok']) }}"
 
 # Allow different states for fans
-accepted_fan_states: "{{ validation_role.fan_states | arista.avd.default(['ok', 'Not Inserted']) }}"
+accepted_fan_states: "{{ validation_role.fan_states | arista.avd.default(['ok']) }}"
 
 
 # Generate CSV results file
@@ -176,6 +176,12 @@ validation_role:
   xcvr_own_manufacturers:
     - Manufacturer 1
     - Manufacturer 2
+  pwr_supply_states:
+    - ok
+    - notInserted
+  fan_states:
+    - ok
+    - notInserted
 ```
 
 ### inventory/intended/structured_configs/switch1.yml

--- a/ansible_collections/arista/avd/roles/eos_validate_state/README.md
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/README.md
@@ -105,6 +105,8 @@ The variable `fabric_name` is used to select the inventory group covering all de
 
 The default accepted manufacturers are "Arastra, Inc." and "Arista Networks." If `validation_role.xcvr_own_manufacturers` is set, it takes precedence and overrides the defined default variables.
 
+By default, all fans and power supplies are expected to be in the `ok` state. However chassis switches may intentionally be missing some fans or power supplies as they are not fully populated. In this case, `validation_role.fan_states` and `validation_role.pwr_supply_states` can be updated to include the `notInserted` state, as per the example below to avoid failures on missing fans/power supplies.
+
 Two user-defined variables control the generation of CSV and MD reports. These are `validation_role.validation_report_csv` and `validation_role.validation_report_md` respectively.
 
 The variable validation_role.only_failed_tests is used to limit the number of tests shown in the reports. When set, all reports will only show failed tests.

--- a/ansible_collections/arista/avd/roles/eos_validate_state/defaults/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/defaults/main.yml
@@ -19,6 +19,12 @@ fabric_name: "all"
 # Allow different manufacturers
 accepted_xcvr_manufacturers: "{{ validation_role.xcvr_own_manufacturers | arista.avd.default(['Arastra, Inc.', 'Arista Networks']) }}"
 
+# Allow different states for power supplies
+accepted_pwr_supply_states: "{{ validation_role.pwr_supply_states | arista.avd.default(['ok', 'Not Inserted']) }}"
+
+# Allow different states for fans
+accepted_fan_states: "{{ validation_role.fan_states | arista.avd.default(['ok', 'Not Inserted']) }}"
+
 # Print only FAILED tests
 only_failed_tests: "{{ validation_role.only_failed_tests | arista.avd.default(false) }}"
 

--- a/ansible_collections/arista/avd/roles/eos_validate_state/defaults/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/defaults/main.yml
@@ -20,10 +20,10 @@ fabric_name: "all"
 accepted_xcvr_manufacturers: "{{ validation_role.xcvr_own_manufacturers | arista.avd.default(['Arastra, Inc.', 'Arista Networks']) }}"
 
 # Allow different states for power supplies
-accepted_pwr_supply_states: "{{ validation_role.pwr_supply_states | arista.avd.default(['ok', 'Not Inserted']) }}"
+accepted_pwr_supply_states: "{{ validation_role.pwr_supply_states | arista.avd.default(['ok']) }}"
 
 # Allow different states for fans
-accepted_fan_states: "{{ validation_role.fan_states | arista.avd.default(['ok', 'Not Inserted']) }}"
+accepted_fan_states: "{{ validation_role.fan_states | arista.avd.default(['ok']) }}"
 
 # Print only FAILED tests
 only_failed_tests: "{{ validation_role.only_failed_tests | arista.avd.default(false) }}"

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/hardware.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/hardware.yml
@@ -12,7 +12,7 @@
 - name: Validate power supplies status
   assert:
     that:
-      - powerSupply.value.state == 'ok'
+      - "powerSupply.value.state in {{ accepted_pwr_supply_states }}"
     fail_msg: "Power supply state is {{ powerSupply.value.state | replace('\"','') }}"
     quiet: true
   loop: "{{ system_environment_power.stdout_lines.0.powerSupplies | dict2items }}"
@@ -33,7 +33,7 @@
 - name: Validate fan status (power supplies)
   assert:
     that:
-      - powerSupplySlot.status == 'ok'
+      - "powerSupplySlot.status in {{ accepted_fan_states }}"
     fail_msg: "Power supply fan status is {{ powerSupplySlot.status | replace('\"','') }}"
     quiet: true
   loop: "{{ system_environment_cooling.stdout_lines.0.powerSupplySlots }}"
@@ -47,7 +47,7 @@
 - name: Validate fan status (fan tray)
   assert:
     that:
-      - fanTraySlot.status == 'ok'
+      - "fanTraySlot.status in {{ accepted_fan_states }}"
     fail_msg: "Fan status is {{ fanTraySlot.status | replace('\"','') }}"
     quiet: true
   loop: "{{ system_environment_cooling.stdout_lines.0.fanTraySlots }}"


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->

Allow custom states, more than just 'ok' for the
fan and power supply states in the hardware
validation task.

## Related Issue(s)

_No Issue found in github for this. This was raised internally._

## Component(s) name

`arista.avd.eos_validate`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

_There is currently no Molecule tests for `eos_validate_state`._

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- [x] Tested on physical hardware. 
Models:
     - [x] 7808 with 1 power failure. The power failure was still reported when `notInserted` as was added to fan_states
     - [x] 7804 with some power fans missing. The failures were suppressed when `notInserted` was added to fan_states

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
