### PR TITLE
Fix(eos_designs): allow ':' in the description for network_ports

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/network-ports-tests.1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/network-ports-tests.1.cfg
@@ -501,6 +501,16 @@ interface Ethernet4
    spanning-tree portfast
    spanning-tree bpdufilter enable
 !
+interface Ethernet5
+   description N: blah
+   no shutdown
+   switchport
+!
+interface Ethernet6
+   description N: blah
+   no shutdown
+   switchport
+!
 interface Ethernet10/1
    description MLAG_PEER_network-ports-tests-2_Ethernet10/1
    no shutdown

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/network-ports-tests.1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/network-ports-tests.1.yml
@@ -57,6 +57,18 @@ ethernet_interfaces:
     channel_group:
       id: 101
       mode: active
+  Ethernet5:
+    peer: 'N: blah'
+    peer_type: network_port
+    description: 'N: blah'
+    type: switched
+    shutdown: false
+  Ethernet6:
+    peer: 'N: blah'
+    peer_type: network_port
+    description: 'N: blah'
+    type: switched
+    shutdown: false
   Ethernet1:
     peer: PCs
     peer_type: network_port

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/NETWORK_PORTS_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/NETWORK_PORTS_TESTS.yml
@@ -41,6 +41,13 @@ network_ports:
     profile: pc
     description: PCs
 
+  # Test for issue #2223 regarding colon in description
+  - switches:
+      - network-ports-tests.1
+    switch_ports:
+      - Ethernet5-6
+    description: "N: blah"
+
 # Only creating network services required to test the filter "only_vlans_in_use" combined with network ports
 tenants:
   TEST:

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/ethernet-interfaces.j2
@@ -32,7 +32,7 @@ ethernet_interfaces:
 {%                 set channel_group_id = (adapter_settings.port_channel.channel_id | arista.avd.default(adapter_settings.switch_ports[0] | regex_findall("\d") | join)) %}
 {%                 set peer_interface = endpoint_ports[loop.index0] | arista.avd.default %}
   {{ adapter_settings.switch_ports[loop.index0] }}:
-    peer: {{ peer }}
+    peer: "{{ peer }}"
     peer_interface: {{ peer_interface }}
     peer_type: {{ peer_type }}
     description: "{% include switch.interface_descriptions.connected_endpoints_ethernet_interfaces %}"


### PR DESCRIPTION
## Change Summary

* allow `:` character in the description for network_ports

## Related Issue(s)

Fixes #2223 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

* add quotes in `eos_designs/templates/connected_endpoints/ethernet-interfaces.j2` when defining `peer` to avoid yaml crashing when dumping the configuration
* add test in molecule for the scenario

## How to test

molecule scenario eos_designs_unit_tests

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
