### PR TITLE
CI: Bump github actions to avoid deprecation warnings

### DIFF
--- a/.github/workflows/devel-push.yml
+++ b/.github/workflows/devel-push.yml
@@ -22,7 +22,7 @@ jobs:
       requirements: ${{ steps.filter.outputs.requirements }}
       docs: ${{ steps.filter.outputs.docs }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dorny/paths-filter@v2
         id: filter
         with:
@@ -72,7 +72,7 @@ jobs:
     container: avdteam/base:3.8-v2.0
     if: needs.file-changes.outputs.requirements == 'true'
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
       - name: 'Send Webhook to docker hub'
         env:
           AUTH_TOKEN: ${{secrets.AVD_BUILDER_TOKEN}}

--- a/.github/workflows/installation-test.yml
+++ b/.github/workflows/installation-test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-20.04
     container: avdteam/base:3.8-v2.0
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
       - name: Execute one-liner installation
         run: |
           cd /tmp/

--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -23,7 +23,7 @@ jobs:
       requirements: ${{ steps.filter.outputs.requirements }}
       docs: ${{ steps.filter.outputs.docs }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dorny/paths-filter@v2
         id: filter
         with:
@@ -82,7 +82,7 @@ jobs:
     needs: file-changes
     if: needs.file-changes.outputs.eos_design == 'true' || needs.file-changes.outputs.config_gen == 'true' || needs.file-changes.outputs.requirements == 'true'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install requirements
         run: |
           pip install -r ansible_collections/arista/avd/requirements-dev.txt
@@ -100,7 +100,7 @@ jobs:
     needs: [ file-changes ]
     if: needs.file-changes.outputs.docs == 'true'
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
       - name: 'start docker-compose stack'
         run: |
           cp development/docker-compose.yml .
@@ -135,7 +135,7 @@ jobs:
         run: |
           echo "PY_COLORS=1" >> $GITHUB_ENV
           echo "ANSIBLE_FORCE_COLOR=1" >> $GITHUB_ENV
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Run molecule action
         uses: arista-netdevops-community/action-molecule-avd@v1.3
         with:
@@ -164,9 +164,9 @@ jobs:
         run: |
           echo "PY_COLORS=1" >> $GITHUB_ENV
           echo "ANSIBLE_FORCE_COLOR=1" >> $GITHUB_ENV
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python 3
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python_version }}
       - name: 'Install Python requirements'
@@ -200,7 +200,7 @@ jobs:
         run: |
           echo "PY_COLORS=1" >> $GITHUB_ENV
           echo "ANSIBLE_FORCE_COLOR=1" >> $GITHUB_ENV
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Run molecule action
         uses: arista-netdevops-community/action-molecule-avd@v1.3
         with:
@@ -212,7 +212,7 @@ jobs:
           ansible: ${{ matrix.ansible_version }}
           check_git: true
           check_git_enforced: true
-      # - uses: actions/upload-artifact@v2
+      # - uses: actions/upload-artifact@v3
       #   with:
       #     name: molecule-${{ matrix.avd_scenario }}-artifacts
       #     path: ${PWD}/ansible_collections/arista/avd/molecule/${{ matrix.avd_scenario }}
@@ -235,7 +235,7 @@ jobs:
         run: |
           echo "PY_COLORS=1" >> $GITHUB_ENV
           echo "ANSIBLE_FORCE_COLOR=1" >> $GITHUB_ENV
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Run molecule action
         uses: arista-netdevops-community/action-molecule-avd@v1.3
         with:
@@ -247,7 +247,7 @@ jobs:
           ansible: ${{ matrix.ansible_version }}
           check_git: true
           check_git_enforced: true
-      # - uses: actions/upload-artifact@v2
+      # - uses: actions/upload-artifact@v3
       #   with:
       #     name: molecule-${{ matrix.avd_scenario }}-artifacts
       #     path: ${PWD}/ansible_collections/arista/avd/molecule/${{ matrix.avd_scenario }}
@@ -289,7 +289,7 @@ jobs:
         run: |
           echo "PY_COLORS=1" >> $GITHUB_ENV
           echo "ANSIBLE_FORCE_COLOR=1" >> $GITHUB_ENV
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Run molecule action
         uses: arista-netdevops-community/action-molecule-avd@v1.3
         with:
@@ -301,7 +301,7 @@ jobs:
           ansible: ${{ matrix.ansible_version }}
           check_git: true
           check_git_enforced: true
-      # - uses: actions/upload-artifact@v2
+      # - uses: actions/upload-artifact@v3
       #   with:
       #     name: molecule-${{ matrix.avd_scenario }}-artifacts
       #     path: ${PWD}/ansible_collections/arista/avd/molecule/${{ matrix.avd_scenario }}
@@ -323,7 +323,7 @@ jobs:
         run: |
           echo "PY_COLORS=1" >> $GITHUB_ENV
           echo "ANSIBLE_FORCE_COLOR=1" >> $GITHUB_ENV
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Run molecule action
         uses: arista-netdevops-community/action-molecule-avd@v1.3
         with:
@@ -335,7 +335,7 @@ jobs:
           ansible: ${{ matrix.ansible_version }}
           check_git: true
           check_git_enforced: true
-      # - uses: actions/upload-artifact@v2
+      # - uses: actions/upload-artifact@v3
       #   with:
       #     name: molecule-${{ matrix.avd_scenario }}-artifacts
       #     path: ${PWD}/ansible_collections/arista/avd/molecule/${{ matrix.avd_scenario }}
@@ -352,9 +352,9 @@ jobs:
       - name: 'set environment variables'
         run: |
           echo "PY_COLORS=1" >> $GITHUB_ENV
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python 3
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.8"
       - name: 'Install Python requirements'
@@ -374,9 +374,9 @@ jobs:
       - name: 'set environment variables'
         run: |
           echo "PY_COLORS=1" >> $GITHUB_ENV
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python 3
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.8"
       - name: 'Install Python requirements'
@@ -396,9 +396,9 @@ jobs:
       - name: 'set environment variables'
         run: |
           echo "PY_COLORS=1" >> $GITHUB_ENV
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python 3
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.8"
       - name: 'Install Python requirements'
@@ -424,7 +424,7 @@ jobs:
         run: |
           echo "PY_COLORS=1" >> $GITHUB_ENV
           echo "ANSIBLE_FORCE_COLOR=1" >> $GITHUB_ENV
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: install requirements
         run: |
           pip install -r ansible_collections/arista/avd/requirements.txt
@@ -433,7 +433,7 @@ jobs:
         run: make collection-build
       - name: 'run galaxy-importer checks'
         run: python -m galaxy_importer.main *.tar.gz
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: importer-logs
           path: ./importer_result.json

--- a/.github/workflows/pull-request-triage.yml
+++ b/.github/workflows/pull-request-triage.yml
@@ -17,7 +17,6 @@ jobs:
     # https://github.com/actions/labeler
     runs-on: ubuntu-latest
     steps:
-      # V3 is not used as we hit following issue: https://github.com/actions/labeler/issues/107
       - uses: actions/labeler@v4
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
@@ -28,7 +27,7 @@ jobs:
     # https://github.com/marketplace/actions/auto-author-assign
     runs-on: ubuntu-latest
     steps:
-      - uses: toshimaru/auto-author-assign@v1.2.0
+      - uses: toshimaru/auto-author-assign@v1.6.1
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/pull-request-triage.yml
+++ b/.github/workflows/pull-request-triage.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # V3 is not used as we hit following issue: https://github.com/actions/labeler/issues/107
-      - uses: actions/labeler@v2
+      - uses: actions/labeler@v4
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           configuration-path: '.github/labeler.yml'
@@ -40,7 +40,7 @@ jobs:
     steps:
       # Please look up the latest version from
       # https://github.com/amannn/action-semantic-pull-request/releases
-      - uses: amannn/action-semantic-pull-request@v3.4.1
+      - uses: amannn/action-semantic-pull-request@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Issue stale management
-    - uses: actions/stale@v4
+    - uses: actions/stale@v6
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         days-before-stale: 90
@@ -21,7 +21,7 @@ jobs:
         exempt-pr-labels: 'state: accepted, state: in-progress'
 
     #   # PR Stale Management
-    # - uses: actions/stale@v4
+    # - uses: actions/stale@v6
     #   with:
     #     repo-token: ${{ secrets.GITHUB_TOKEN }}
     #     days-before-stale: 30


### PR DESCRIPTION
Bump GitHub Actions to address deprecation warnings:

- actions/checkout@v2 -> actions/checkout@v3
- actions/setup-python@v2 -> actions/setup-python@v4
- actions/labeler@v2 -> actions/labeler@v4
- toshimaru/auto-author-assign@v1.2.0 -> toshimaru/auto-author-assign@v1.6.1
- amannn/action-semantic-pull-request@v3.4.1 -> amannn/action-semantic-pull-request@v5
- actions/stale@v4 -> actions/stale@v6
- actions/upload-artifact@v2 -> actions/upload-artifact@v3