### PR TITLE
Refactor(eos_validate_state): Support for new data models

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/bgp_check.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/bgp_check.yml
@@ -36,14 +36,14 @@
 - name: Validate ip bgp neighbors peer state
   assert:
     that:
-      - bgp_summary.stdout[0].vrfs.default.peers[bgp_neighbor.key].peerState == 'Established'
-    fail_msg: "Session state {{ bgp_summary.stdout[0].vrfs.default.peers[bgp_neighbor.key].peerState | replace('\"','') }}"
+      - bgp_summary.stdout[0].vrfs.default.peers[bgp_neighbor.ip_address].peerState == 'Established'
+    fail_msg: "Session state {{ bgp_summary.stdout[0].vrfs.default.peers[bgp_neighbor.ip_address].peerState | replace('\"','') }}"
     quiet: yes
-  loop: "{{ router_bgp.neighbors | default({}, true) | dict2items }}"
+  loop: "{{ router_bgp.neighbors | arista.avd.default({}) | arista.avd.convert_dicts('ip_address') }}"
   loop_control:
     loop_var: bgp_neighbor
   when: |
-    (router_bgp.peer_groups[bgp_neighbor.value.peer_group].type == 'ipv4' and arbgp_state_results)
+    ((router_bgp.peer_groups | arista.avd.default({}) | arista.avd.convert_dicts('name') | selectattr('name', 'eq', bgp_neighbor.peer_group) | first).type == 'ipv4' and arbgp_state_results)
   ignore_errors: "{{ eos_validate_state_validation_mode_loose }}"
   register: ip_bgp_peer_state_results
   tags:
@@ -52,14 +52,14 @@
 - name: Validate bgp evpn neighbors peer state
   assert:
     that:
-      - bgp_summary.stdout[1].vrfs.default.peers[bgp_neighbor.key].peerState == 'Established'
-    fail_msg: "Session state {{ bgp_summary.stdout[1].vrfs.default.peers[bgp_neighbor.key].peerState | replace('\"','') }}"
+      - bgp_summary.stdout[1].vrfs.default.peers[bgp_neighbor.ip_address].peerState == 'Established'
+    fail_msg: "Session state {{ bgp_summary.stdout[1].vrfs.default.peers[bgp_neighbor.ip_address].peerState | replace('\"','') }}"
     quiet: yes
-  loop: "{{ router_bgp.neighbors | default({}, true) | dict2items }}"
+  loop: "{{ router_bgp.neighbors | arista.avd.default({}) | arista.avd.convert_dicts('ip_address') }}"
   loop_control:
     loop_var: bgp_neighbor
   when: |
-    (router_bgp.peer_groups[bgp_neighbor.value.peer_group].type == 'evpn'  and arbgp_state_results)
+    ((router_bgp.peer_groups | arista.avd.default({}) | arista.avd.convert_dicts('name') | selectattr('name', 'eq', bgp_neighbor.peer_group) | first).type == 'evpn'  and arbgp_state_results)
   ignore_errors: "{{ eos_validate_state_validation_mode_loose }}"
   register: bgp_evpn_peer_state_results
   tags:

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/interface_state.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/interface_state.yml
@@ -13,19 +13,19 @@
 - name: Validate Ethernet interfaces state
   assert:
     that:
-      ( interfaces_state.stdout[0].interfaceDescriptions[ethernet_interface.key].interfaceStatus == 'up' and
-      interfaces_state.stdout[0].interfaceDescriptions[ethernet_interface.key].lineProtocolStatus == 'up' and
-      not ethernet_interfaces[ethernet_interface.key].shutdown
+      ( interfaces_state.stdout[0].interfaceDescriptions[ethernet_interface.name].interfaceStatus == 'up' and
+      interfaces_state.stdout[0].interfaceDescriptions[ethernet_interface.name].lineProtocolStatus == 'up' and
+      not ethernet_interface.shutdown
       ) or
-      ( interfaces_state.stdout[0].interfaceDescriptions[ethernet_interface.key].interfaceStatus == 'adminDown' and
-      interfaces_state.stdout[0].interfaceDescriptions[ethernet_interface.key].lineProtocolStatus != 'up' and
-      ethernet_interfaces[ethernet_interface.key].shutdown
+      ( interfaces_state.stdout[0].interfaceDescriptions[ethernet_interface.name].interfaceStatus == 'adminDown' and
+      interfaces_state.stdout[0].interfaceDescriptions[ethernet_interface.name].lineProtocolStatus != 'up' and
+      ethernet_interface.shutdown
       )
-    fail_msg: "Interface shutdown: {{ ethernet_interfaces[ethernet_interface.key].shutdown | replace('\"','') }} -
-      interface status: {{ interfaces_state.stdout[0].interfaceDescriptions[ethernet_interface.key].interfaceStatus | replace('\"','') }} -
-      line protocol status: {{ interfaces_state.stdout[0].interfaceDescriptions[ethernet_interface.key].lineProtocolStatus | replace('\"','') }}"
+    fail_msg: "Interface shutdown: {{ ethernet_interface.shutdown | replace('\"','') }} -
+      interface status: {{ interfaces_state.stdout[0].interfaceDescriptions[ethernet_interface.name].interfaceStatus | replace('\"','') }} -
+      line protocol status: {{ interfaces_state.stdout[0].interfaceDescriptions[ethernet_interface.name].lineProtocolStatus | replace('\"','') }}"
     quiet: true
-  loop: "{{ ethernet_interfaces | default({}, true) | dict2items }}"
+  loop: "{{ ethernet_interfaces | arista.avd.default({}) | arista.avd.convert_dicts('name') }}"
   loop_control:
     loop_var: ethernet_interface
   ignore_errors: "{{ eos_validate_state_validation_mode_loose }}"
@@ -36,19 +36,19 @@
 - name: Validate Port-Channel interfaces state
   assert:
     that:
-      ( interfaces_state.stdout[0].interfaceDescriptions[port_channel_interface.key].interfaceStatus == 'up' and
-      interfaces_state.stdout[0].interfaceDescriptions[port_channel_interface.key].lineProtocolStatus == 'up' and
-      not port_channel_interfaces[port_channel_interface.key].shutdown
+      ( interfaces_state.stdout[0].interfaceDescriptions[port_channel_interface.name].interfaceStatus == 'up' and
+      interfaces_state.stdout[0].interfaceDescriptions[port_channel_interface.name].lineProtocolStatus == 'up' and
+      not port_channel_interface.shutdown
       ) or
-      ( interfaces_state.stdout[0].interfaceDescriptions[port_channel_interface.key].interfaceStatus == 'adminDown' and
-      interfaces_state.stdout[0].interfaceDescriptions[port_channel_interface.key].lineProtocolStatus != 'up' and
-      port_channel_interfaces[port_channel_interface.key].shutdown
+      ( interfaces_state.stdout[0].interfaceDescriptions[port_channel_interface.name].interfaceStatus == 'adminDown' and
+      interfaces_state.stdout[0].interfaceDescriptions[port_channel_interface.name].lineProtocolStatus != 'up' and
+      port_channel_interface.shutdown
       )
-    fail_msg: "Interface shutdown: {{ port_channel_interfaces[port_channel_interface.key].shutdown | replace('\"','') }} -
-      interface status: {{ interfaces_state.stdout[0].interfaceDescriptions[port_channel_interface.key].interfaceStatus | replace('\"','') }} -
-      line protocol status: {{ interfaces_state.stdout[0].interfaceDescriptions[port_channel_interface.key].lineProtocolStatus | replace('\"','') }}"
+    fail_msg: "Interface shutdown: {{ port_channel_interface.shutdown | replace('\"','') }} -
+      interface status: {{ interfaces_state.stdout[0].interfaceDescriptions[port_channel_interface.name].interfaceStatus | replace('\"','') }} -
+      line protocol status: {{ interfaces_state.stdout[0].interfaceDescriptions[port_channel_interface.name].lineProtocolStatus | replace('\"','') }}"
     quiet: true
-  loop: "{{ port_channel_interfaces | default({}, true) | dict2items }}"
+  loop: "{{ port_channel_interfaces | arista.avd.default({}) | arista.avd.convert_dicts('name') }}"
   loop_control:
     loop_var: port_channel_interface
   ignore_errors: "{{ eos_validate_state_validation_mode_loose }}"
@@ -59,19 +59,19 @@
 - name: Validate Vlan interfaces state
   assert:
     that:
-      ( interfaces_state.stdout[0].interfaceDescriptions[vlan_interface.key].interfaceStatus == 'up' and
-      interfaces_state.stdout[0].interfaceDescriptions[vlan_interface.key].lineProtocolStatus == 'up' and
-      not vlan_interfaces[vlan_interface.key].shutdown
+      ( interfaces_state.stdout[0].interfaceDescriptions[vlan_interface.name].interfaceStatus == 'up' and
+      interfaces_state.stdout[0].interfaceDescriptions[vlan_interface.name].lineProtocolStatus == 'up' and
+      not vlan_interface.shutdown
       ) or
-      ( interfaces_state.stdout[0].interfaceDescriptions[vlan_interface.key].interfaceStatus == 'adminDown' and
-      interfaces_state.stdout[0].interfaceDescriptions[vlan_interface.key].lineProtocolStatus != 'up' and
-      vlan_interfaces[vlan_interface.key].shutdown
+      ( interfaces_state.stdout[0].interfaceDescriptions[vlan_interface.name].interfaceStatus == 'adminDown' and
+      interfaces_state.stdout[0].interfaceDescriptions[vlan_interface.name].lineProtocolStatus != 'up' and
+      vlan_interface.shutdown
       )
-    fail_msg: "Interface shutdown: {{ vlan_interfaces[vlan_interface.key].shutdown | replace('\"','') }} -
-      interface status: {{ interfaces_state.stdout[0].interfaceDescriptions[vlan_interface.key].interfaceStatus | replace('\"','') }} -
-      line protocol status: {{ interfaces_state.stdout[0].interfaceDescriptions[vlan_interface.key].lineProtocolStatus | replace('\"','') }}"
+    fail_msg: "Interface shutdown: {{ vlan_interface.shutdown | replace('\"','') }} -
+      interface status: {{ interfaces_state.stdout[0].interfaceDescriptions[vlan_interface.name].interfaceStatus | replace('\"','') }} -
+      line protocol status: {{ interfaces_state.stdout[0].interfaceDescriptions[vlan_interface.name].lineProtocolStatus | replace('\"','') }}"
     quiet: true
-  loop: "{{ vlan_interfaces | default({}, true) | dict2items }}"
+  loop: "{{ vlan_interfaces| arista.avd.default({}) | arista.avd.convert_dicts('name') }}"
   loop_control:
     loop_var: vlan_interface
   ignore_errors: "{{ eos_validate_state_validation_mode_loose }}"
@@ -96,12 +96,12 @@
 - name: Validate Loopback interfaces state
   assert:
     that:
-      - interfaces_state.stdout[0].interfaceDescriptions[loopback_interface.key].interfaceStatus == 'up'
-      - interfaces_state.stdout[0].interfaceDescriptions[loopback_interface.key].lineProtocolStatus == 'up'
-    fail_msg: "Interface status: {{ interfaces_state.stdout[0].interfaceDescriptions[loopback_interface.key].interfaceStatus | replace('\"','') }} -
-      line protocol status: {{ interfaces_state.stdout[0].interfaceDescriptions[loopback_interface.key].lineProtocolStatus | replace('\"','') }}"
+      - interfaces_state.stdout[0].interfaceDescriptions[loopback_interface.name].interfaceStatus == 'up'
+      - interfaces_state.stdout[0].interfaceDescriptions[loopback_interface.name].lineProtocolStatus == 'up'
+    fail_msg: "Interface status: {{ interfaces_state.stdout[0].interfaceDescriptions[loopback_interface.name].interfaceStatus | replace('\"','') }} -
+      line protocol status: {{ interfaces_state.stdout[0].interfaceDescriptions[loopback_interface.name].lineProtocolStatus | replace('\"','') }}"
     quiet: true
-  loop: "{{ loopback_interfaces | default({}, true) | dict2items }}"
+  loop: "{{ loopback_interfaces | arista.avd.default({}) | arista.avd.convert_dicts('name') }}"
   loop_control:
     loop_var: loopback_interface
   ignore_errors: "{{ eos_validate_state_validation_mode_loose }}"

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/ip_reachability.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/ip_reachability.yml
@@ -17,7 +17,7 @@
     ethernet_interface.peer_interface is arista.avd.defined and
     peer_ip is arista.avd.defined
   vars:
-    peer_ip: "{{ (hostvars[ethernet_interface.peer].ethernet_interfaces | arista.avd.default({}) | arista.avd.convert_dicts('name') | selectattr('name', 'eq', ethernet_interface.peer_interface | arista.avd.default) | map(attribute='ip_address'))[0] | arista.avd.default }}"
+    peer_ip: "{{ (hostvars[ethernet_interface.peer | arista.avd.default('_')].ethernet_interfaces | arista.avd.default({}) | arista.avd.convert_dicts('name') | selectattr('name', 'eq', ethernet_interface.peer_interface | arista.avd.default) | map(attribute='ip_address'))[0] | arista.avd.default }}"
 
   register: ip_reachability_state
   tags:

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/ip_reachability.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/ip_reachability.yml
@@ -4,19 +4,21 @@
 
 - name: Gather ip reachability state (directly connected interfaces)
   eos_command:
-    commands: "ping {{ hostvars[ethernet_interface.value.peer]['ethernet_interfaces'][ethernet_interface.value.peer_interface]['ip_address'] | ansible.netcommon.ipaddr('address') }} source {{ ethernet_interface.value.ip_address  | ansible.netcommon.ipaddr('address') }} repeat 1"
-  loop: "{{ ethernet_interfaces | default({}, true) | dict2items }}"
+    commands: "ping {{ peer_ip | ansible.utils.ipaddr('address') }} source {{ ethernet_interface.ip_address | ansible.utils.ipaddr('address') }} repeat 1"
+  loop: "{{ ethernet_interfaces | arista.avd.default({}) | arista.avd.convert_dicts('name') }}"
   loop_control:
     loop_var: ethernet_interface
   ignore_errors: "{{ eos_validate_state_validation_mode_loose }}"
   when: |
-    (ethernet_interfaces is defined and ethernet_interfaces is not none) and
-    (ethernet_interface.value.type is defined and ethernet_interface.value.type is not none and ethernet_interface.value.type == 'routed') and
-    (ethernet_interface.value.ip_address is defined and ethernet_interface.value.ip_address is not none) and
-    (ethernet_interface.value.peer is defined and ethernet_interface.value.peer is not none) and
-    (ethernet_interface.value.peer_interface is defined and ethernet_interface.value.peer_interface is not none) and
-    (hostvars[ethernet_interface.value.peer]['ethernet_interfaces'][ethernet_interface.value.peer_interface]['ip_address'] is defined and
-    hostvars[ethernet_interface.value.peer]['ethernet_interfaces'][ethernet_interface.value.peer_interface]['ip_address'] is not none)
+    ethernet_interfaces is arista.avd.defined and
+    ethernet_interface.type is arista.avd.defined('routed') and
+    ethernet_interface.ip_address is arista.avd.defined and
+    ethernet_interface.peer is arista.avd.defined and
+    ethernet_interface.peer_interface is arista.avd.defined and
+    peer_ip is arista.avd.defined
+  vars:
+    peer_ip: "{{ (hostvars[ethernet_interface.peer].ethernet_interfaces | arista.avd.default({}) | arista.avd.convert_dicts('name') | selectattr('name', 'eq', ethernet_interface.peer_interface | arista.avd.default) | map(attribute='ip_address'))[0] | arista.avd.default }}"
+
   register: ip_reachability_state
   tags:
     - ip_reachability

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/lldp_topology_fqdn.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/lldp_topology_fqdn.yml
@@ -13,21 +13,21 @@
 - name: Validate lldp topology when there is a domain name
   assert:
     that:
-      - lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.key].lldpNeighborInfo[0] is defined
-      - lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.key].lldpNeighborInfo[0].systemName == ethernet_interface.value.peer + '.' + hostvars[ethernet_interface.value.peer]['dns_domain']
-      - lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.key].lldpNeighborInfo[0].neighborInterfaceInfo.interfaceId == "\"" + ethernet_interface.value.peer_interface + "\""
-    fail_msg: "{{ lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.key].lldpNeighborInfo[0].systemName | default('Interface Down') | replace('\"','') }} - {{ lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.key].lldpNeighborInfo[0].neighborInterfaceInfo.interfaceId | default('N/A') | replace('\"','') }}"
+      - lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.name].lldpNeighborInfo[0] is defined
+      - lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.name].lldpNeighborInfo[0].systemName == ethernet_interface.peer ~ '.' ~ hostvars[ethernet_interface.peer].dns_domain
+      - lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.name].lldpNeighborInfo[0].neighborInterfaceInfo.interfaceId == "\"" ~ ethernet_interface.peer_interface ~ "\""
+    fail_msg: "{{ lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.name].lldpNeighborInfo[0].systemName | default('Interface Down') | replace('\"','') }} - {{ lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.name].lldpNeighborInfo[0].neighborInterfaceInfo.interfaceId | default('N/A') | replace('\"','') }}"
     quiet: true
-  loop: "{{ ethernet_interfaces | default({}, true) | dict2items }}"
+  loop: "{{ ethernet_interfaces | arista.avd.default({}) | arista.avd.convert_dicts('name') }}"
   loop_control:
     loop_var: ethernet_interface
   when: |
-    (ethernet_interfaces is defined and ethernet_interfaces is not none) and
-    (ethernet_interface.value.shutdown is not arista.avd.defined(true)) and
-    (ethernet_interface.value.peer is defined and ethernet_interface.value.peer is not none) and
-    (ethernet_interface.value.peer_interface is defined and ethernet_interface.value.peer_interface is not none) and
-    (hostvars[ethernet_interface.value.peer] is defined and hostvars[ethernet_interface.value.peer] is not none) and
-    (hostvars[ethernet_interface.value.peer]['dns_domain'] is defined and hostvars[ethernet_interface.value.peer]['dns_domain'] is not none)
+    ethernet_interfaces is arista.avd.defined and
+    ethernet_interface.shutdown is not arista.avd.defined(true) and
+    ethernet_interface.peer is arista.avd.defined and
+    ethernet_interface.peer_interface is arista.avd.defined and
+    hostvars[ethernet_interface.peer] is arista.avd.defined and
+    hostvars[ethernet_interface.peer].dns_domain is arista.avd.defined
   ignore_errors: "{{ eos_validate_state_validation_mode_loose }}"
   register: lldp_topology_results
   tags:

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/lldp_topology_no_fqdn.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/lldp_topology_no_fqdn.yml
@@ -13,20 +13,20 @@
 - name: Validate lldp topology when there is no domain name
   assert:
     that:
-      - lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.key].lldpNeighborInfo[0] is defined
-      - lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.key].lldpNeighborInfo[0].systemName == ethernet_interface.value.peer
-      - lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.key].lldpNeighborInfo[0].neighborInterfaceInfo.interfaceId == "\"" + ethernet_interface.value.peer_interface + "\""
-    fail_msg: "{{ lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.key].lldpNeighborInfo[0].systemName | default('Interface Down') | replace('\"','') }} - {{ lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.key].lldpNeighborInfo[0].neighborInterfaceInfo.interfaceId | default('N/A') | replace('\"','') }}"
+      - lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.name].lldpNeighborInfo[0] is defined
+      - lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.name].lldpNeighborInfo[0].systemName == ethernet_interface.peer
+      - lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.name].lldpNeighborInfo[0].neighborInterfaceInfo.interfaceId == "\"" ~ ethernet_interface.peer_interface ~ "\""
+    fail_msg: "{{ lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.name].lldpNeighborInfo[0].systemName | default('Interface Down') | replace('\"','') }} - {{ lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.name].lldpNeighborInfo[0].neighborInterfaceInfo.interfaceId | default('N/A') | replace('\"','') }}"
     quiet: true
-  loop: "{{ ethernet_interfaces | default({}, true) | dict2items }}"
+  loop: "{{ ethernet_interfaces | arista.avd.default({}) | arista.avd.convert_dicts('name') }}"
   loop_control:
     loop_var: ethernet_interface
   when: |
-    (ethernet_interfaces is defined and ethernet_interfaces is not none) and
-    (ethernet_interface.value.shutdown is not arista.avd.defined(true)) and
-    (ethernet_interface.value.peer is defined and ethernet_interface.value.peer is not none) and
-    (ethernet_interface.value.peer_interface is defined and ethernet_interface.value.peer_interface is not none) and
-    (hostvars[ethernet_interface.value.peer] is defined and hostvars[ethernet_interface.value.peer] is not none)
+    ethernet_interfaces is arista.avd.defined and
+    ethernet_interface.shutdown is not arista.avd.defined(true) and
+    ethernet_interface.peer is arista.avd.defined and
+    ethernet_interface.peer_interface is arista.avd.defined and
+    hostvars[ethernet_interface.peer] is arista.avd.defined
   ignore_errors: "{{ eos_validate_state_validation_mode_loose }}"
   register: lldp_topology_results
   tags:

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/loopback_reachability.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/loopback_reachability.yml
@@ -2,15 +2,18 @@
 
 - name: Gather ip reachability state between devices (loopback0 <-> loopback0)
   eos_command:
-    commands: "ping {{ loopback0_address | ansible.netcommon.ipaddr('address') }} source {{ loopback_interfaces.Loopback0.ip_address | ansible.netcommon.ipaddr('address') }} repeat 1"
+    commands: "ping {{ loopback0_address | ansible.utils.ipaddr('address') }} source {{ source_ip_address | ansible.utils.ipaddr('address') }} repeat 1"
   loop: "{{ loopback0_reachability.loopback0_range }}"
   loop_control:
     loop_var: loopback0_address
   ignore_errors: "{{ eos_validate_state_validation_mode_loose }}"
+  vars:
+    # Vars are not rendered when being evaluated by "when" condition so we cannot use this var for that.
+    source_ip_address: "{{ (loopback_interfaces | arista.avd.default({}) | arista.avd.convert_dicts('name') | selectattr('name', 'eq', 'Loopback0') | map(attribute='ip_address'))[0] | arista.avd.default }}"
   when: |
-    (loopback0_reachability.loopback0_range is arista.avd.defined) and
-    (loopback_interfaces.Loopback0.ip_address is arista.avd.defined) and
-    (type is arista.avd.defined('l3leaf'))
+    loopback0_reachability.loopback0_range is arista.avd.defined and
+    (loopback_interfaces | arista.avd.default({}) | arista.avd.convert_dicts('name') | selectattr('name', 'eq', 'Loopback0') | map(attribute='ip_address'))[0] is arista.avd.defined and
+    type is arista.avd.defined('l3leaf')
   register: loopback0_reachability_state
   tags:
     - loopback0_reachability
@@ -31,7 +34,7 @@
     - loopback0_reachability
 
 - include_tasks: ping_inband.yml
-  loop: "{{ management_interfaces | default({}, true) | dict2items }}"
+  loop: "{{ management_interfaces | arista.avd.default({}) | arista.avd.convert_dicts('name') }}"
   loop_control:
     loop_var: management_interface
   when: |

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/ping_inband.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/ping_inband.yml
@@ -1,15 +1,15 @@
 ---
 
-- name: Gather fabric reachability from Management Interface {{ management_interface.key }}
+- name: Gather fabric reachability from Management Interface {{ management_interface.name }}
   eos_command:
-    commands: "ping {{ loopback0_address | ansible.netcommon.ipaddr('address') }} repeat 1 interface {{ management_interface.key }}"
+    commands: "ping {{ loopback0_address | ansible.utils.ipaddr('address') }} repeat 1 interface {{ management_interface.name }}"
   loop: "{{ loopback0_reachability.loopback0_range }}"
   loop_control:
     loop_var: loopback0_address
   ignore_errors: "{{ eos_validate_state_validation_mode_loose }}"
   when: |
     (loopback0_reachability.loopback0_range is arista.avd.defined) and
-    (management_interface.value.type is arista.avd.defined('inband'))
+    (management_interface.type is arista.avd.defined('inband'))
   register: inb_mgmt_loopback0_reachability_state
   tags:
     - loopback0_reachability

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/routing_table.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/routing_table.yml
@@ -37,9 +37,9 @@
     loop_var: loopback0_address
   ignore_errors: "{{ eos_validate_state_validation_mode_loose }}"
   when: |
-    (loopback0_reachability.loopback0_range is arista.avd.defined) and
-    (loopback_interfaces.Loopback0.ip_address is arista.avd.defined) and
-    (type is arista.avd.defined('l3leaf'))
+    loopback0_reachability.loopback0_range is arista.avd.defined and
+    (loopback_interfaces | arista.avd.default({}) | arista.avd.convert_dicts('name') | selectattr('name', 'eq', 'Loopback0'))[0].ip_address is arista.avd.defined and
+    type is arista.avd.defined('l3leaf')
   register: routing_table_loopback0_state
   tags:
     - routing_table

--- a/ansible_collections/arista/avd/roles/eos_validate_state/templates/generate_state_report_results.j2
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/templates/generate_state_report_results.j2
@@ -121,12 +121,12 @@ eos_validate_state_report:
 - id: {{ test_id.value }}
   device: "{{ node }}"
   test_category: "Interface State"
-{%             if not result.ethernet_interface.value.shutdown %}
+{%             if not result.ethernet_interface.shutdown %}
   test_description: "Ethernet Interface & Line Protocol == \"up\""
 {%             else %}
   test_description: "Ethernet Interface & Line Protocol == \"adminDown\""
 {%             endif %}
-  test: "{{ result.ethernet_interface.key }} - {{ result.ethernet_interface.value.description | arista.avd.default('') }}"
+  test: "{{ result.ethernet_interface.name }} - {{ result.ethernet_interface.description | arista.avd.default('') }}"
 {%             if result.failed is arista.avd.defined(false) %}
   result: "PASS"
 {%             else %}
@@ -144,12 +144,12 @@ eos_validate_state_report:
 - id: {{ test_id.value }}
   device: "{{ node }}"
   test_category: "Interface State"
-{%             if not result.port_channel_interface.value.shutdown %}
+{%             if not result.port_channel_interface.shutdown %}
   test_description: "Port-Channel Interface & Line Protocol == \"up\""
 {%             else %}
   test_description: "Port-Channel Interface & Line Protocol == \"adminDown\""
 {%             endif %}
-  test: "{{ result.port_channel_interface.key }} - {{ result.port_channel_interface.value.description | arista.avd.default('') }}"
+  test: "{{ result.port_channel_interface.name }} - {{ result.port_channel_interface.description | arista.avd.default('') }}"
 {%             if result.failed is arista.avd.defined(false) %}
   result: "PASS"
 {%             else %}
@@ -167,12 +167,12 @@ eos_validate_state_report:
 - id: {{ test_id.value }}
   device: "{{ node }}"
   test_category: "Interface State"
-{%             if not result.vlan_interface.value.shutdown %}
+{%             if not result.vlan_interface.shutdown %}
   test_description: "Vlan Interface & Line Protocol == \"up\""
 {%             else %}
   test_description: "Vlan Interface & Line Protocol == \"adminDown\""
 {%             endif %}
-  test: "{{ result.vlan_interface.key }} - {{ result.vlan_interface.value.description | arista.avd.default('') }}"
+  test: "{{ result.vlan_interface.name }} - {{ result.vlan_interface.description | arista.avd.default('') }}"
 {%             if result.failed is arista.avd.defined(false) %}
   result: "PASS"
 {%             else %}
@@ -208,7 +208,7 @@ eos_validate_state_report:
   device: "{{ node }}"
   test_category: "Interface State"
   test_description: "Loopback Interface Status & Line Protocol == \"up\""
-  test: "{{ result.loopback_interface.key }} - {{ result.loopback_interface.value.description | arista.avd.default('') }}"
+  test: "{{ result.loopback_interface.name }} - {{ result.loopback_interface.description | arista.avd.default('') }}"
 {%             if result.failed is arista.avd.defined(false) %}
   result: "PASS"
 {%             else %}
@@ -228,7 +228,7 @@ eos_validate_state_report:
   device: "{{ node }}"
   test_category: "LLDP Topology"
   test_description: "LLDP topology - validate peer and interface"
-  test: "local: {{ result.ethernet_interface.key }} - remote: {{ copy_hostvars[node].ethernet_interfaces[result.ethernet_interface.key].peer }}_{{ copy_hostvars[node].ethernet_interfaces[result.ethernet_interface.key].peer_interface }}"
+  test: "local: {{ result.ethernet_interface.name }} - remote: {{ result.ethernet_interface.peer }}_{{ result.ethernet_interface.peer_interface }}"
 {%                 if result.failed is arista.avd.defined(false) %}
   result: "PASS"
 {%                 else %}
@@ -266,7 +266,7 @@ eos_validate_state_report:
   device: "{{ node }}"
   test_category: "IP Reachability"
   test_description: "ip reachability test p2p links"
-  test: "Source: {{ node }}_{{ result.ip_reachability_test.ethernet_interface.key }} - Destination: {{ result.ip_reachability_test.ethernet_interface.value.peer }}_{{ result.ip_reachability_test.ethernet_interface.value.peer_interface }}"
+  test: "Source: {{ node }}_{{ result.ip_reachability_test.ethernet_interface.name }} - Destination: {{ result.ip_reachability_test.ethernet_interface.peer }}_{{ result.ip_reachability_test.ethernet_interface.peer_interface }}"
 {%                 if result.failed is arista.avd.defined(false) %}
   result: "PASS"
 {%                 else %}
@@ -405,7 +405,7 @@ eos_validate_state_report:
   device: "{{ node }}"
   test_category: "Loopback0 Reachability"
   test_description: "Loopback0 Reachability"
-  test: "Source: {{ node }} - {{ copy_hostvars[node].loopback_interfaces.Loopback0.ip_address | ansible.netcommon.ipaddr('address') }} Destination: {{ result.loopback0_reachability_test.loopback0_address }}"
+  test: "Source: {{ node }} - {{ (copy_hostvars[node].loopback_interfaces | arista.avd.default({}) | arista.avd.convert_dicts('name') | selectattr('name', 'eq', 'Loopback0'))[0].ip_address | ansible.utils.ipaddr('address') }} Destination: {{ result.loopback0_reachability_test.loopback0_address }}"
 {%                 if result.failed is arista.avd.defined(false) %}
   result: "PASS"
 {%                 else %}

--- a/ansible_collections/arista/avd/roles/eos_validate_state/templates/generate_state_report_results.j2
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/templates/generate_state_report_results.j2
@@ -304,7 +304,7 @@ eos_validate_state_report:
   device: "{{ node }}"
   test_category: "BGP"
   test_description: "ip bgp peer state established (ipv4)"
-  test: "bgp_neighbor: {{ result.bgp_neighbor.key }}"
+  test: "bgp_neighbor: {{ result.bgp_neighbor.ip_address }}"
 {%                 if result.failed is arista.avd.defined(false) %}
   result: "PASS"
 {%                 else %}
@@ -325,7 +325,7 @@ eos_validate_state_report:
   device: "{{ node }}"
   test_category: "BGP"
   test_description: "bgp evpn peer state established (evpn)"
-  test: "bgp_neighbor: {{ result.bgp_neighbor.key }}"
+  test: "bgp_neighbor: {{ result.bgp_neighbor.ip_address }}"
 {%                 if result.failed is arista.avd.defined(false) %}
   result: "PASS"
 {%                 else %}

--- a/ansible_collections/arista/avd/roles/eos_validate_state/templates/generate_vars_for_testing.j2
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/templates/generate_vars_for_testing.j2
@@ -1,8 +1,9 @@
 {# loopback0 reachability test #}
 {% set address = [] %}
 {% for node in groups[fabric_name] | arista.avd.natural_sort %}
-{%     if hostvars[node].loopback_interfaces.Loopback0.ip_address is arista.avd.defined %}
-{%         do address.append(hostvars[node].loopback_interfaces.Loopback0.ip_address | ansible.netcommon.ipaddr('address')) %}
+{%     set loopback0_ip_address = (hostvars[node].loopback_interfaces | arista.avd.default({}) | arista.avd.convert_dicts('name') | selectattr('name', 'eq', 'Loopback0') | map(attribute='ip_address'))[0] | arista.avd.default %}
+{%     if loopback0_ip_address is arista.avd.defined %}
+{%         do address.append(loopback0_ip_address | ansible.utils.ipaddr('address')) %}
 {%     endif %}
 {% endfor %}
 loopback0_reachability:
@@ -13,8 +14,9 @@ loopback0_reachability:
 {% for node in groups[fabric_name] | arista.avd.natural_sort %}
 {%     if hostvars[node].vxlan_interface.Vxlan1.vxlan.source_interface is arista.avd.defined %}
 {%         set vtep_reachability_int = hostvars[node].vxlan_interface.Vxlan1.vxlan.source_interface %}
-{%         if hostvars[node].loopback_interfaces[vtep_reachability_int].ip_address is arista.avd.defined %}
-{%             do address.append(hostvars[node].loopback_interfaces[vtep_reachability_int].ip_address | ansible.netcommon.ipaddr('address')) %}
+{%         set vtep_loopback_ip_address = (hostvars[node].loopback_interfaces | arista.avd.default({}) | arista.avd.convert_dicts('name') | selectattr('name', 'eq', vtep_reachability_int) | map(attribute='ip_address'))[0] | arista.avd.default %}
+{%         if vtep_loopback_ip_address is arista.avd.defined %}
+{%             do address.append(vtep_loopback_ip_address | ansible.utils.ipaddr('address')) %}
 {%         endif %}
 {%     endif %}
 {% endfor %}


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Update eos_validate_state to support new list-of-dicts data models.

## Component(s) name

`arista.avd.eos_validate_state`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

Update all accesses to to-be-changed data models like `ethernet_interfaces` to use `convert_dicts` and hence be compatible with both new and old.
Update use of related vars accordingly. 

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- Tested locally with running validate state using 3.7 and then rerunning with this code. No changes to report.
- Converted one structured config file to new data model and reran the tests. No changes to report.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
