### PR TITLE
Doc: Fix incorrect key names for custom mlag interface descriptions

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_designs/doc/node-types-v4.0.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/node-types-v4.0.md
@@ -63,8 +63,8 @@ node_type_keys:
     interface_descriptions:
       underlay_ethernet_interfaces: <path to J2 template - default inherited from templates.interface_descriptions.underlay_ethernet_interfaces >
       underlay_port_channel_interfaces: <path to J2 template - default inherited from templates.interface_descriptions.underlay_port_channel_interfaces >
-      underlay_ethernet_mlag_interfaces: <path to J2 template - default inherited from templates.interface_descriptions.underlay_ethernet_mlag_interfaces >
-      underlay_port_channel_mlag_interfaces: <path to J2 template - default inherited from templates.interface_descriptions.underlay_port_channel_mlag_interfaces >
+      mlag_ethernet_interfaces: <path to J2 template - default inherited from templates.interface_descriptions.underlay_ethernet_mlag_interfaces >
+      mlag_port_channel_interfaces: <path to J2 template - default inherited from templates.interface_descriptions.underlay_port_channel_mlag_interfaces >
       connected_endpoints_ethernet_interfaces: <path to J2 template - default inherited from templates.interface_descriptions.connected_endpoints_ethernet_interfaces >
       connected_endpoints_port_channel_interfaces: <path to J2 template - default inherited from templates.interface_descriptions.connected_endpoints_port_channel_interfaces >
       overlay_loopback_interface: <path to J2 template - default inherited from templates.interface_descriptions.overlay_loopback_interface >

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/node-types.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/node-types.md
@@ -63,8 +63,8 @@ node_type_keys:
     interface_descriptions:
       underlay_ethernet_interfaces: <path to J2 template - default inherited from templates.interface_descriptions.underlay_ethernet_interfaces >
       underlay_port_channel_interfaces: <path to J2 template - default inherited from templates.interface_descriptions.underlay_port_channel_interfaces >
-      underlay_ethernet_mlag_interfaces: <path to J2 template - default inherited from templates.interface_descriptions.underlay_ethernet_mlag_interfaces >
-      underlay_port_channel_mlag_interfaces: <path to J2 template - default inherited from templates.interface_descriptions.underlay_port_channel_mlag_interfaces >
+      mlag_ethernet_interfaces: <path to J2 template - default inherited from templates.interface_descriptions.underlay_ethernet_mlag_interfaces >
+      mlag_port_channel_interfaces: <path to J2 template - default inherited from templates.interface_descriptions.underlay_port_channel_mlag_interfaces >
       connected_endpoints_ethernet_interfaces: <path to J2 template - default inherited from templates.interface_descriptions.connected_endpoints_ethernet_interfaces >
       connected_endpoints_port_channel_interfaces: <path to J2 template - default inherited from templates.interface_descriptions.connected_endpoints_port_channel_interfaces >
       overlay_loopback_interface: <path to J2 template - default inherited from templates.interface_descriptions.overlay_loopback_interface >


### PR DESCRIPTION
## Change Summary

Fix incorrect key names for custom MLAG interface descriptions.

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

Correct documentation.

Molecule tests has correct key name:
`molecule/eos_designs_unit_tests/inventory/group_vars/CUSTOM_TEMPLATES_TESTS.yml`

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
