### PR TITLE
Feat(eos_designs): Support the ip_virtual_router_addresses and ip_address_virtual under the same svi

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2A.cfg
@@ -497,8 +497,10 @@ interface Vlan412
    no shutdown
    mtu 1560
    vrf Tenant_D_OP_Zone
-   ipv6 address virtual 2001:db8:412::1/64
-   ip address virtual 10.4.12.254/24
+   ip address 11.4.12.2/24
+   ipv6 address 2001:db9:412::2/64
+   ipv6 virtual-router address 2001:db9:412::1
+   ip virtual-router address 11.4.12.1
 !
 interface Vlan450
    description Tenant_D_v6_WAN_Zone_1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2A.cfg
@@ -96,6 +96,9 @@ vlan 411
 vlan 412
    name Tenant_D_v6_OP_Zone_1
 !
+vlan 413
+   name Tenant_D_v6_OP_Zone_3
+!
 vlan 450
    name Tenant_D_v6_WAN_Zone_1
 !
@@ -497,10 +500,19 @@ interface Vlan412
    no shutdown
    mtu 1560
    vrf Tenant_D_OP_Zone
-   ip address 11.4.12.2/24
-   ipv6 address 2001:db9:412::2/64
-   ipv6 virtual-router address 2001:db9:412::1
-   ip virtual-router address 11.4.12.1
+   ipv6 address virtual 2001:db8:412::1/64
+   ip address virtual 10.4.12.254/24
+!
+interface Vlan413
+   description Tenant_D_v6_OP_Zone_3
+   no shutdown
+   mtu 1560
+   vrf Tenant_D_OP_Zone
+   ip address 11.4.13.2/24
+   ip helper-address 1.1.1.1 vrf TEST source-interface lo101
+   ipv6 address 2001:db9:413::2/64
+   ipv6 virtual-router address 2001:db9:413::1
+   ip virtual-router address 11.4.13.1
 !
 interface Vlan450
    description Tenant_D_v6_WAN_Zone_1
@@ -545,6 +557,7 @@ interface Vxlan1
    vxlan vlan 410 vni 40410
    vxlan vlan 411 vni 40411
    vxlan vlan 412 vni 40412
+   vxlan vlan 413 vni 40413
    vxlan vlan 450 vni 40450
    vxlan vlan 451 vni 40451
    vxlan vlan 452 vni 40452
@@ -701,7 +714,7 @@ router bgp 65102
       rd 65001:40
       route-target both 100000:40
       redistribute learned
-      vlan 410-412
+      vlan 410-413
    !
    vlan-aware-bundle Tenant_D_WAN_Zone
       rd 65001:41

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2B.cfg
@@ -96,6 +96,9 @@ vlan 411
 vlan 412
    name Tenant_D_v6_OP_Zone_1
 !
+vlan 413
+   name Tenant_D_v6_OP_Zone_3
+!
 vlan 450
    name Tenant_D_v6_WAN_Zone_1
 !
@@ -464,6 +467,17 @@ interface Vlan412
    ipv6 address virtual 2001:db8:412::1/64
    ip address virtual 10.4.12.254/24
 !
+interface Vlan413
+   description Tenant_D_v6_OP_Zone_3
+   no shutdown
+   mtu 1560
+   vrf Tenant_D_OP_Zone
+   ip address 101.4.13.2/24
+   ip helper-address 1.1.1.1 vrf TEST source-interface lo101
+   ipv6 address 2002:db9:413::2/64
+   ipv6 virtual-router address 2002:db9:413::1
+   ip virtual-router address 101.4.13.1
+!
 interface Vlan450
    description Tenant_D_v6_WAN_Zone_1
    no shutdown
@@ -507,6 +521,7 @@ interface Vxlan1
    vxlan vlan 410 vni 40410
    vxlan vlan 411 vni 40411
    vxlan vlan 412 vni 40412
+   vxlan vlan 413 vni 40413
    vxlan vlan 450 vni 40450
    vxlan vlan 451 vni 40451
    vxlan vlan 452 vni 40452
@@ -663,7 +678,7 @@ router bgp 65102
       rd 65001:40
       route-target both 100000:40
       redistribute learned
-      vlan 410-412
+      vlan 410-413
    !
    vlan-aware-bundle Tenant_D_WAN_Zone
       rd 65001:41

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SVI_PROFILE_NODE_1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SVI_PROFILE_NODE_1.cfg
@@ -159,19 +159,16 @@ interface Vlan410
    description static_routes_410
    no shutdown
    vrf svi_profile_tests_vrf
-   ip virtual-router address 10.4.10.1/24
 !
 interface Vlan411
    description static_routes_411
    no shutdown
    vrf svi_profile_tests_vrf
-   ip virtual-router address 10.4.11.1/24
 !
 interface Vlan412
    description static_routes_412
    no shutdown
    vrf svi_profile_tests_vrf
-   ip virtual-router address 10.4.12.1/24
 !
 interface Vlan510
    description ospf_enabled_510
@@ -226,9 +223,6 @@ ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 20 permit 192.168.254.0/24 eq 32
 !
 ip route vrf MGMT 0.0.0.0/0 10.0.0.1
-ip route vrf svi_profile_tests_vrf 10.4.10.0/24 Vlan410 name VARP
-ip route vrf svi_profile_tests_vrf 10.4.11.0/24 Vlan411 name VARP
-ip route vrf svi_profile_tests_vrf 10.4.12.0/24 Vlan412 name VARP
 !
 route-map RM-CONN-2-BGP permit 10
    match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SVI_PROFILE_NODE_1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SVI_PROFILE_NODE_1.cfg
@@ -159,16 +159,22 @@ interface Vlan410
    description static_routes_410
    no shutdown
    vrf svi_profile_tests_vrf
+   ip address 11.4.10.1/24
+   ip virtual-router address 10.4.10.1/24
 !
 interface Vlan411
    description static_routes_411
    no shutdown
    vrf svi_profile_tests_vrf
+   ip address 11.4.11.1/24
+   ip virtual-router address 10.4.11.1/24
 !
 interface Vlan412
    description static_routes_412
    no shutdown
    vrf svi_profile_tests_vrf
+   ip address 11.4.12.1/24
+   ip virtual-router address 10.4.12.1/24
 !
 interface Vlan510
    description ospf_enabled_510
@@ -223,6 +229,9 @@ ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 20 permit 192.168.254.0/24 eq 32
 !
 ip route vrf MGMT 0.0.0.0/0 10.0.0.1
+ip route vrf svi_profile_tests_vrf 10.4.10.0/24 Vlan410 name VARP
+ip route vrf svi_profile_tests_vrf 10.4.11.0/24 Vlan411 name VARP
+ip route vrf svi_profile_tests_vrf 10.4.12.0/24 Vlan412 name VARP
 !
 route-map RM-CONN-2-BGP permit 10
    match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SVI_PROFILE_NODE_2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SVI_PROFILE_NODE_2.cfg
@@ -159,19 +159,16 @@ interface Vlan410
    description static_routes_410
    no shutdown
    vrf svi_profile_tests_vrf
-   ip virtual-router address 10.4.10.1/24
 !
 interface Vlan411
    description static_routes_411
    no shutdown
    vrf svi_profile_tests_vrf
-   ip virtual-router address 10.4.11.1/24
 !
 interface Vlan412
    description static_routes_412
    no shutdown
    vrf svi_profile_tests_vrf
-   ip virtual-router address 10.4.12.1/24
 !
 interface Vlan510
    description ospf_enabled_510
@@ -226,9 +223,6 @@ ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 20 permit 192.168.254.0/24 eq 32
 !
 ip route vrf MGMT 0.0.0.0/0 10.0.0.1
-ip route vrf svi_profile_tests_vrf 10.4.10.0/24 Vlan410 name VARP
-ip route vrf svi_profile_tests_vrf 10.4.11.0/24 Vlan411 name VARP
-ip route vrf svi_profile_tests_vrf 10.4.12.0/24 Vlan412 name VARP
 !
 route-map RM-CONN-2-BGP permit 10
    match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SVI_PROFILE_NODE_2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SVI_PROFILE_NODE_2.cfg
@@ -159,16 +159,22 @@ interface Vlan410
    description static_routes_410
    no shutdown
    vrf svi_profile_tests_vrf
+   ip address 11.4.10.2/24
+   ip virtual-router address 10.4.10.1/24
 !
 interface Vlan411
    description static_routes_411
    no shutdown
    vrf svi_profile_tests_vrf
+   ip address 11.4.11.2/24
+   ip virtual-router address 10.4.11.1/24
 !
 interface Vlan412
    description static_routes_412
    no shutdown
    vrf svi_profile_tests_vrf
+   ip address 11.4.12.2/24
+   ip virtual-router address 10.4.12.1/24
 !
 interface Vlan510
    description ospf_enabled_510
@@ -223,6 +229,9 @@ ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 20 permit 192.168.254.0/24 eq 32
 !
 ip route vrf MGMT 0.0.0.0/0 10.0.0.1
+ip route vrf svi_profile_tests_vrf 10.4.10.0/24 Vlan410 name VARP
+ip route vrf svi_profile_tests_vrf 10.4.11.0/24 Vlan411 name VARP
+ip route vrf svi_profile_tests_vrf 10.4.12.0/24 Vlan412 name VARP
 !
 route-map RM-CONN-2-BGP permit 10
    match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_false.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_false.cfg
@@ -103,6 +103,9 @@ vlan 411
 vlan 412
    name Tenant_D_v6_OP_Zone_1
 !
+vlan 413
+   name Tenant_D_v6_OP_Zone_3
+!
 vlan 450
    name Tenant_D_v6_WAN_Zone_1
 !
@@ -283,6 +286,10 @@ interface Vlan411
    description Tenant_D_v6_OP_Zone_2
    no shutdown
    vrf Tenant_D_OP_Zone
+   ip address 10.3.11.4/24
+   ipv6 address 2001:db8:311::4/64
+   ipv6 virtual-router address 2001:db8:311::1
+   ip virtual-router address 10.3.11.1/24
 !
 interface Vlan412
    description Tenant_D_v6_OP_Zone_1
@@ -291,6 +298,17 @@ interface Vlan412
    vrf Tenant_D_OP_Zone
    ipv6 address virtual 2001:db8:412::1/64
    ip address virtual 10.4.12.254/24
+!
+interface Vlan413
+   description Tenant_D_v6_OP_Zone_3
+   no shutdown
+   mtu 1560
+   vrf Tenant_D_OP_Zone
+   ip address 12.4.13.2/24
+   ip helper-address 1.1.1.2 vrf TEST source-interface lo102
+   ipv6 address 2012:db9:413::2/64
+   ipv6 virtual-router address 2012:db9:413::1
+   ip virtual-router address 12.4.13.1
 !
 interface Vlan450
    description Tenant_D_v6_WAN_Zone_1
@@ -341,6 +359,7 @@ interface Vxlan1
    vxlan vlan 410 vni 40410
    vxlan vlan 411 vni 40411
    vxlan vlan 412 vni 40412
+   vxlan vlan 413 vni 40413
    vxlan vlan 450 vni 40450
    vxlan vlan 451 vni 40451
    vxlan vlan 452 vni 40452
@@ -381,6 +400,7 @@ ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 20 permit 192.168.254.0/24 eq 32
 !
 ip route vrf MGMT 0.0.0.0/0 192.168.200.5
+ip route vrf Tenant_D_OP_Zone 10.3.11.0/24 Vlan411 name VARP
 !
 route-map RM-CONN-2-BGP permit 10
    match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
@@ -480,7 +500,7 @@ router bgp 101
       rd 192.168.255.109:40
       route-target both 40:40
       redistribute learned
-      vlan 410-412
+      vlan 410-413
    !
    vlan-aware-bundle Tenant_D_WAN_Zone
       rd 192.168.255.109:41

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_false.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_false.cfg
@@ -205,9 +205,6 @@ interface Vlan132
    description Tenant_A_APP_Zone_3
    no shutdown
    vrf Tenant_A_APP_Zone
-   ip virtual-router address 10.1.32.254
-   ip virtual-router address 10.2.32.254/24
-   ip virtual-router address 10.3.32.254/24
 !
 interface Vlan140
    description Tenant_A_DB_BZone_1
@@ -286,8 +283,6 @@ interface Vlan411
    description Tenant_D_v6_OP_Zone_2
    no shutdown
    vrf Tenant_D_OP_Zone
-   ipv6 virtual-router address 2001:db8:311::1
-   ip virtual-router address 10.3.11.1/24
 !
 interface Vlan412
    description Tenant_D_v6_OP_Zone_1
@@ -386,9 +381,6 @@ ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 20 permit 192.168.254.0/24 eq 32
 !
 ip route vrf MGMT 0.0.0.0/0 192.168.200.5
-ip route vrf Tenant_A_APP_Zone 10.2.32.0/24 Vlan132 name VARP
-ip route vrf Tenant_A_APP_Zone 10.3.32.0/24 Vlan132 name VARP
-ip route vrf Tenant_D_OP_Zone 10.3.11.0/24 Vlan411 name VARP
 !
 route-map RM-CONN-2-BGP permit 10
    match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_true.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_true.cfg
@@ -103,6 +103,9 @@ vlan 411
 vlan 412
    name Tenant_D_v6_OP_Zone_1
 !
+vlan 413
+   name Tenant_D_v6_OP_Zone_3
+!
 vlan 450
    name Tenant_D_v6_WAN_Zone_1
 !
@@ -152,6 +155,7 @@ interface Vxlan1
    vxlan vlan 410 vni 40410
    vxlan vlan 411 vni 40411
    vxlan vlan 412 vni 40412
+   vxlan vlan 413 vni 40413
    vxlan vlan 450 vni 40450
    vxlan vlan 451 vni 40451
    vxlan vlan 452 vni 40452
@@ -263,7 +267,7 @@ router bgp 101
       rd 192.168.255.109:40
       route-target both 40:40
       redistribute learned
-      vlan 410-412
+      vlan 410-413
    !
    vlan-aware-bundle Tenant_D_WAN_Zone
       rd 192.168.255.109:41

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_default.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_default.cfg
@@ -108,6 +108,9 @@ vlan 411
 vlan 412
    name Tenant_D_v6_OP_Zone_1
 !
+vlan 413
+   name Tenant_D_v6_OP_Zone_3
+!
 vlan 450
    name Tenant_D_v6_WAN_Zone_1
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_fabric.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_fabric.cfg
@@ -103,6 +103,9 @@ vlan 411
 vlan 412
    name Tenant_D_v6_OP_Zone_1
 !
+vlan 413
+   name Tenant_D_v6_OP_Zone_3
+!
 vlan 450
    name Tenant_D_v6_WAN_Zone_1
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_host.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_host.cfg
@@ -105,6 +105,9 @@ vlan 411
 vlan 412
    name Tenant_D_v6_OP_Zone_1
 !
+vlan 413
+   name Tenant_D_v6_OP_Zone_3
+!
 vlan 450
    name Tenant_D_v6_WAN_Zone_1
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_platform.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_platform.cfg
@@ -105,6 +105,9 @@ vlan 411
 vlan 412
    name Tenant_D_v6_OP_Zone_1
 !
+vlan 413
+   name Tenant_D_v6_OP_Zone_3
+!
 vlan 450
    name Tenant_D_v6_WAN_Zone_1
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
@@ -271,7 +271,7 @@ router_bgp:
         - '100000:40'
       redistribute_routes:
       - learned
-      vlan: 410-412
+      vlan: 410-413
     Tenant_D_WAN_Zone:
       rd: '65001:41'
       route_targets:
@@ -821,6 +821,9 @@ vlans:
   412:
     tenant: Tenant_D
     name: Tenant_D_v6_OP_Zone_1
+  413:
+    tenant: Tenant_D
+    name: Tenant_D_v6_OP_Zone_3
   450:
     tenant: Tenant_D
     name: Tenant_D_v6_WAN_Zone_1
@@ -992,13 +995,27 @@ vlan_interfaces:
     description: Tenant_D_v6_OP_Zone_1
     shutdown: false
     vrf: Tenant_D_OP_Zone
-    ip_address: 11.4.12.2/24
-    ipv6_address: 2001:db9:412::2/64
-    ip_virtual_router_addresses:
-    - 11.4.12.1
-    ipv6_virtual_router_addresses:
-    - 2001:db9:412::1
+    ip_address_virtual: 10.4.12.254/24
+    ipv6_address_virtual: 2001:db8:412::1/64
     mtu: 1560
+  Vlan413:
+    tenant: Tenant_D
+    tags:
+    - v6opzone
+    description: Tenant_D_v6_OP_Zone_3
+    shutdown: false
+    vrf: Tenant_D_OP_Zone
+    ip_address: 11.4.13.2/24
+    ipv6_address: 2001:db9:413::2/64
+    ip_virtual_router_addresses:
+    - 11.4.13.1
+    ipv6_virtual_router_addresses:
+    - 2001:db9:413::1
+    mtu: 1560
+    ip_helpers:
+      1.1.1.1:
+        source_interface: lo101
+        vrf: TEST
   Vlan450:
     tenant: Tenant_D
     tags:
@@ -1085,6 +1102,8 @@ vxlan_interface:
           vni: 40411
         412:
           vni: 40412
+        413:
+          vni: 40413
         450:
           vni: 40450
         451:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
@@ -992,8 +992,12 @@ vlan_interfaces:
     description: Tenant_D_v6_OP_Zone_1
     shutdown: false
     vrf: Tenant_D_OP_Zone
-    ip_address_virtual: 10.4.12.254/24
-    ipv6_address_virtual: 2001:db8:412::1/64
+    ip_address: 11.4.12.2/24
+    ipv6_address: 2001:db9:412::2/64
+    ip_virtual_router_addresses:
+    - 11.4.12.1
+    ipv6_virtual_router_addresses:
+    - 2001:db9:412::1
     mtu: 1560
   Vlan450:
     tenant: Tenant_D

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
@@ -271,7 +271,7 @@ router_bgp:
         - '100000:40'
       redistribute_routes:
       - learned
-      vlan: 410-412
+      vlan: 410-413
     Tenant_D_WAN_Zone:
       rd: '65001:41'
       route_targets:
@@ -767,6 +767,9 @@ vlans:
   412:
     tenant: Tenant_D
     name: Tenant_D_v6_OP_Zone_1
+  413:
+    tenant: Tenant_D
+    name: Tenant_D_v6_OP_Zone_3
   450:
     tenant: Tenant_D
     name: Tenant_D_v6_WAN_Zone_1
@@ -941,6 +944,24 @@ vlan_interfaces:
     ip_address_virtual: 10.4.12.254/24
     ipv6_address_virtual: 2001:db8:412::1/64
     mtu: 1560
+  Vlan413:
+    tenant: Tenant_D
+    tags:
+    - v6opzone
+    description: Tenant_D_v6_OP_Zone_3
+    shutdown: false
+    vrf: Tenant_D_OP_Zone
+    ip_address: 101.4.13.2/24
+    ipv6_address: 2002:db9:413::2/64
+    ip_virtual_router_addresses:
+    - 101.4.13.1
+    ipv6_virtual_router_addresses:
+    - 2002:db9:413::1
+    mtu: 1560
+    ip_helpers:
+      1.1.1.1:
+        source_interface: lo101
+        vrf: TEST
   Vlan450:
     tenant: Tenant_D
     tags:
@@ -1026,6 +1047,8 @@ vxlan_interface:
           vni: 40411
         412:
           vni: 40412
+        413:
+          vni: 40413
         450:
           vni: 40450
         451:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/SVI_PROFILE_NODE_1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/SVI_PROFILE_NODE_1.yml
@@ -167,18 +167,6 @@ static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0
   gateway: 10.0.0.1
-- destination_address_prefix: 10.4.10.0/24
-  vrf: svi_profile_tests_vrf
-  name: VARP
-  interface: Vlan410
-- destination_address_prefix: 10.4.11.0/24
-  vrf: svi_profile_tests_vrf
-  name: VARP
-  interface: Vlan411
-- destination_address_prefix: 10.4.12.0/24
-  vrf: svi_profile_tests_vrf
-  name: VARP
-  interface: Vlan412
 service_routing_protocols_model: multi-agent
 ip_routing: true
 vlan_internal_order:
@@ -379,22 +367,16 @@ vlan_interfaces:
     description: static_routes_410
     shutdown: false
     vrf: svi_profile_tests_vrf
-    ip_virtual_router_addresses:
-    - 10.4.10.1/24
   Vlan411:
     tenant: svi_profile_tests
     description: static_routes_411
     shutdown: false
     vrf: svi_profile_tests_vrf
-    ip_virtual_router_addresses:
-    - 10.4.11.1/24
   Vlan412:
     tenant: svi_profile_tests
     description: static_routes_412
     shutdown: false
     vrf: svi_profile_tests_vrf
-    ip_virtual_router_addresses:
-    - 10.4.12.1/24
   Vlan510:
     tenant: svi_profile_tests
     description: ospf_enabled_510

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/SVI_PROFILE_NODE_1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/SVI_PROFILE_NODE_1.yml
@@ -167,6 +167,18 @@ static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0
   gateway: 10.0.0.1
+- destination_address_prefix: 10.4.10.0/24
+  vrf: svi_profile_tests_vrf
+  name: VARP
+  interface: Vlan410
+- destination_address_prefix: 10.4.11.0/24
+  vrf: svi_profile_tests_vrf
+  name: VARP
+  interface: Vlan411
+- destination_address_prefix: 10.4.12.0/24
+  vrf: svi_profile_tests_vrf
+  name: VARP
+  interface: Vlan412
 service_routing_protocols_model: multi-agent
 ip_routing: true
 vlan_internal_order:
@@ -367,16 +379,25 @@ vlan_interfaces:
     description: static_routes_410
     shutdown: false
     vrf: svi_profile_tests_vrf
+    ip_address: 11.4.10.1/24
+    ip_virtual_router_addresses:
+    - 10.4.10.1/24
   Vlan411:
     tenant: svi_profile_tests
     description: static_routes_411
     shutdown: false
     vrf: svi_profile_tests_vrf
+    ip_address: 11.4.11.1/24
+    ip_virtual_router_addresses:
+    - 10.4.11.1/24
   Vlan412:
     tenant: svi_profile_tests
     description: static_routes_412
     shutdown: false
     vrf: svi_profile_tests_vrf
+    ip_address: 11.4.12.1/24
+    ip_virtual_router_addresses:
+    - 10.4.12.1/24
   Vlan510:
     tenant: svi_profile_tests
     description: ospf_enabled_510

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/SVI_PROFILE_NODE_2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/SVI_PROFILE_NODE_2.yml
@@ -55,18 +55,6 @@ static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0
   gateway: 10.0.0.1
-- destination_address_prefix: 10.4.10.0/24
-  vrf: svi_profile_tests_vrf
-  name: VARP
-  interface: Vlan410
-- destination_address_prefix: 10.4.11.0/24
-  vrf: svi_profile_tests_vrf
-  name: VARP
-  interface: Vlan411
-- destination_address_prefix: 10.4.12.0/24
-  vrf: svi_profile_tests_vrf
-  name: VARP
-  interface: Vlan412
 service_routing_protocols_model: multi-agent
 ip_routing: true
 vlan_internal_order:
@@ -267,22 +255,16 @@ vlan_interfaces:
     description: static_routes_410
     shutdown: false
     vrf: svi_profile_tests_vrf
-    ip_virtual_router_addresses:
-    - 10.4.10.1/24
   Vlan411:
     tenant: svi_profile_tests
     description: static_routes_411
     shutdown: false
     vrf: svi_profile_tests_vrf
-    ip_virtual_router_addresses:
-    - 10.4.11.1/24
   Vlan412:
     tenant: svi_profile_tests
     description: static_routes_412
     shutdown: false
     vrf: svi_profile_tests_vrf
-    ip_virtual_router_addresses:
-    - 10.4.12.1/24
   Vlan510:
     tenant: svi_profile_tests
     description: ospf_enabled_510

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/SVI_PROFILE_NODE_2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/SVI_PROFILE_NODE_2.yml
@@ -55,6 +55,18 @@ static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0
   gateway: 10.0.0.1
+- destination_address_prefix: 10.4.10.0/24
+  vrf: svi_profile_tests_vrf
+  name: VARP
+  interface: Vlan410
+- destination_address_prefix: 10.4.11.0/24
+  vrf: svi_profile_tests_vrf
+  name: VARP
+  interface: Vlan411
+- destination_address_prefix: 10.4.12.0/24
+  vrf: svi_profile_tests_vrf
+  name: VARP
+  interface: Vlan412
 service_routing_protocols_model: multi-agent
 ip_routing: true
 vlan_internal_order:
@@ -255,16 +267,25 @@ vlan_interfaces:
     description: static_routes_410
     shutdown: false
     vrf: svi_profile_tests_vrf
+    ip_address: 11.4.10.2/24
+    ip_virtual_router_addresses:
+    - 10.4.10.1/24
   Vlan411:
     tenant: svi_profile_tests
     description: static_routes_411
     shutdown: false
     vrf: svi_profile_tests_vrf
+    ip_address: 11.4.11.2/24
+    ip_virtual_router_addresses:
+    - 10.4.11.1/24
   Vlan412:
     tenant: svi_profile_tests
     description: static_routes_412
     shutdown: false
     vrf: svi_profile_tests_vrf
+    ip_address: 11.4.12.2/24
+    ip_virtual_router_addresses:
+    - 10.4.12.1/24
   Vlan510:
     tenant: svi_profile_tests
     description: ospf_enabled_510

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_false.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_false.yml
@@ -290,18 +290,6 @@ static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
-- destination_address_prefix: 10.2.32.0/24
-  vrf: Tenant_A_APP_Zone
-  name: VARP
-  interface: Vlan132
-- destination_address_prefix: 10.3.32.0/24
-  vrf: Tenant_A_APP_Zone
-  name: VARP
-  interface: Vlan132
-- destination_address_prefix: 10.3.11.0/24
-  vrf: Tenant_D_OP_Zone
-  name: VARP
-  interface: Vlan411
 service_routing_protocols_model: multi-agent
 ip_routing: true
 daemon_terminattr:
@@ -529,10 +517,6 @@ vlan_interfaces:
     description: Tenant_A_APP_Zone_3
     shutdown: false
     vrf: Tenant_A_APP_Zone
-    ip_virtual_router_addresses:
-    - 10.1.32.254
-    - 10.2.32.254/24
-    - 10.3.32.254/24
   Vlan140:
     tenant: Tenant_A
     tags:
@@ -693,10 +677,6 @@ vlan_interfaces:
     description: Tenant_D_v6_OP_Zone_2
     shutdown: false
     vrf: Tenant_D_OP_Zone
-    ip_virtual_router_addresses:
-    - 10.3.11.1/24
-    ipv6_virtual_router_addresses:
-    - 2001:db8:311::1
   Vlan412:
     tenant: Tenant_D
     tags:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_false.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_false.yml
@@ -277,7 +277,7 @@ router_bgp:
         - '40:40'
       redistribute_routes:
       - learned
-      vlan: 410-412
+      vlan: 410-413
     Tenant_D_WAN_Zone:
       rd: 192.168.255.109:41
       route_targets:
@@ -290,6 +290,10 @@ static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
+- destination_address_prefix: 10.3.11.0/24
+  vrf: Tenant_D_OP_Zone
+  name: VARP
+  interface: Vlan411
 service_routing_protocols_model: multi-agent
 ip_routing: true
 daemon_terminattr:
@@ -477,6 +481,9 @@ vlans:
   412:
     tenant: Tenant_D
     name: Tenant_D_v6_OP_Zone_1
+  413:
+    tenant: Tenant_D
+    name: Tenant_D_v6_OP_Zone_3
   450:
     tenant: Tenant_D
     name: Tenant_D_v6_WAN_Zone_1
@@ -677,6 +684,12 @@ vlan_interfaces:
     description: Tenant_D_v6_OP_Zone_2
     shutdown: false
     vrf: Tenant_D_OP_Zone
+    ip_address: 10.3.11.4/24
+    ipv6_address: 2001:db8:311::4/64
+    ip_virtual_router_addresses:
+    - 10.3.11.1/24
+    ipv6_virtual_router_addresses:
+    - 2001:db8:311::1
   Vlan412:
     tenant: Tenant_D
     tags:
@@ -687,6 +700,24 @@ vlan_interfaces:
     ip_address_virtual: 10.4.12.254/24
     ipv6_address_virtual: 2001:db8:412::1/64
     mtu: 1560
+  Vlan413:
+    tenant: Tenant_D
+    tags:
+    - v6opzone
+    description: Tenant_D_v6_OP_Zone_3
+    shutdown: false
+    vrf: Tenant_D_OP_Zone
+    ip_address: 12.4.13.2/24
+    ipv6_address: 2012:db9:413::2/64
+    ip_virtual_router_addresses:
+    - 12.4.13.1
+    ipv6_virtual_router_addresses:
+    - 2012:db9:413::1
+    mtu: 1560
+    ip_helpers:
+      1.1.1.2:
+        source_interface: lo102
+        vrf: TEST
   Vlan450:
     tenant: Tenant_D
     tags:
@@ -769,6 +800,8 @@ vxlan_interface:
           vni: 40411
         412:
           vni: 40412
+        413:
+          vni: 40413
         450:
           vni: 40450
         451:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_true.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_true.yml
@@ -142,7 +142,7 @@ router_bgp:
         - '40:40'
       redistribute_routes:
       - learned
-      vlan: 410-412
+      vlan: 410-413
     Tenant_D_WAN_Zone:
       rd: 192.168.255.109:41
       route_targets:
@@ -301,6 +301,9 @@ vlans:
   412:
     tenant: Tenant_D
     name: Tenant_D_v6_OP_Zone_1
+  413:
+    tenant: Tenant_D
+    name: Tenant_D_v6_OP_Zone_3
   450:
     tenant: Tenant_D
     name: Tenant_D_v6_WAN_Zone_1
@@ -370,6 +373,8 @@ vxlan_interface:
           vni: 40411
         412:
           vni: 40412
+        413:
+          vni: 40413
         450:
           vni: 40450
         451:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_default.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_default.yml
@@ -152,6 +152,9 @@ vlans:
   412:
     tenant: Tenant_D
     name: Tenant_D_v6_OP_Zone_1
+  413:
+    tenant: Tenant_D
+    name: Tenant_D_v6_OP_Zone_3
   450:
     tenant: Tenant_D
     name: Tenant_D_v6_WAN_Zone_1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_fabric.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_fabric.yml
@@ -128,6 +128,9 @@ vlans:
   412:
     tenant: Tenant_D
     name: Tenant_D_v6_OP_Zone_1
+  413:
+    tenant: Tenant_D
+    name: Tenant_D_v6_OP_Zone_3
   450:
     tenant: Tenant_D
     name: Tenant_D_v6_WAN_Zone_1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_host.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_host.yml
@@ -134,6 +134,9 @@ vlans:
   412:
     tenant: Tenant_D
     name: Tenant_D_v6_OP_Zone_1
+  413:
+    tenant: Tenant_D
+    name: Tenant_D_v6_OP_Zone_3
   450:
     tenant: Tenant_D
     name: Tenant_D_v6_WAN_Zone_1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_platform.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_platform.yml
@@ -134,6 +134,9 @@ vlans:
   412:
     tenant: Tenant_D
     name: Tenant_D_v6_OP_Zone_1
+  413:
+    tenant: Tenant_D
+    name: Tenant_D_v6_OP_Zone_3
   450:
     tenant: Tenant_D
     name: Tenant_D_v6_WAN_Zone_1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_D.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_D.yml
@@ -28,17 +28,41 @@ Tenant_D:
             DC1-LEAF2B:
               ip_address: 10.3.11.3/24
               ipv6_address: 2001:db8:311::3/64
+            evpn_services_l2_only_false:
+              ip_address: 10.3.11.4/24
+              ipv6_address: 2001:db8:311::4/64
         412:
           name: Tenant_D_v6_OP_Zone_1
           tags: ['v6opzone']
           enabled: True
           profile: GENERIC_DUAL_STACK
-          ip_virtual_router_addresses: [ "11.4.12.1" ]
-          ipv6_virtual_router_addresses: [ "2001:db9:412::1" ]
+        # Test case for SVI - Node config inheritance
+        413:
+          name: Tenant_D_v6_OP_Zone_3
+          tags: ['v6opzone']
+          enabled: True
+          profile: TEST_SVI_NODE_INHERIT
+          ip_virtual_router_addresses: [ "11.4.13.1" ]
+          ipv6_virtual_router_addresses: [ "2001:db9:413::1" ]
           nodes:
             DC1-LEAF2A:
-              ip_address: 11.4.12.2/24
-              ipv6_address: 2001:db9:412::2/64
+              # ip/ipv6 virtual_router_addresses will be configured
+              ip_address: 11.4.13.2/24
+              ipv6_address: 2001:db9:413::2/64
+            DC1-LEAF2B:
+              # Node specific config which has the highest precedence
+              ip_address: 101.4.13.2/24
+              ipv6_address: 2002:db9:413::2/64
+              ip_virtual_router_addresses: [ "101.4.13.1" ]
+              ipv6_virtual_router_addresses: [ "2002:db9:413::1" ]
+            evpn_services_l2_only_false:
+              # Inherit node specific config from the profile
+              # Configures the ip virtual router addresses picked from profile
+              # Configure the ip_helpers as mentioned below
+              ip_helpers:
+                - ip_helper: 1.1.1.2
+                  source_interface: lo102
+                  source_vrf: TEST
       static_routes:
         - destination_address_prefix: 0.0.0.0/0
           gateway: "10.3.11.4"

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_D.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_D.yml
@@ -33,6 +33,12 @@ Tenant_D:
           tags: ['v6opzone']
           enabled: True
           profile: GENERIC_DUAL_STACK
+          ip_virtual_router_addresses: [ "11.4.12.1" ]
+          ipv6_virtual_router_addresses: [ "2001:db9:412::1" ]
+          nodes:
+            DC1-LEAF2A:
+              ip_address: 11.4.12.2/24
+              ipv6_address: 2001:db9:412::2/64
       static_routes:
         - destination_address_prefix: 0.0.0.0/0
           gateway: "10.3.11.4"
@@ -58,7 +64,6 @@ Tenant_D:
           name: Tenant_D_v6_WAN_Zone_1
           tags: ['v6wan']
           enabled: True
-          ipv6_address: 2001:db8:350::1/64
           ipv6_address_virtual: 2001:db8:355::1/64
         451:
           name: Tenant_D_v6_WAN_Zone_2

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/main.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/main.yml
@@ -21,6 +21,22 @@ svi_profiles:
     enabled: false
     ip_address_virtual: 10.4.12.254/24
     ipv6_address_virtual: 2001:db8:412::1/64
+  TEST_SVI_NODE_INHERIT:
+    name: Test the SVI and node config inheritance
+    mtu: 1560
+    enabled: false
+    ip_address_virtual: 10.4.13.254/24
+    ipv6_address_virtual: 2001:db8:413::1/64
+    ip_helpers:
+      - ip_helper: 1.1.1.1
+        source_interface: lo101
+        source_vrf: TEST
+    nodes:
+      evpn_services_l2_only_false:
+        ip_address: 12.4.13.2/24
+        ipv6_address: 2012:db9:413::2/64
+        ip_virtual_router_addresses: [ "12.4.13.1" ]
+        ipv6_virtual_router_addresses: [ "2012:db9:413::1" ]
   GENERIC_DHCP:
     mtu: 1560
     enabled: false

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/SVI_PROFILE_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/SVI_PROFILE_TESTS.yml
@@ -315,6 +315,11 @@ tenants:
             enabled: true
             ip_virtual_router_addresses: [10.4.10.1/24]
             profile: static_routes_child_profile_1
+            nodes:
+              SVI_PROFILE_NODE_1:
+                ip_address: 11.4.10.1/24
+              SVI_PROFILE_NODE_2:
+                ip_address: 11.4.10.2/24
 
           # ip_virtual_router_addresses set on child_profile and parent_profile
           # expected result: child_profile.ip_virtual_router_addresses should win
@@ -322,6 +327,11 @@ tenants:
             name: static_routes_411
             enabled: true
             profile: static_routes_child_profile_2
+            nodes:
+              SVI_PROFILE_NODE_1:
+                ip_address: 11.4.11.1/24
+              SVI_PROFILE_NODE_2:
+                ip_address: 11.4.11.2/24
 
           # ip_virtual_router_addresses set on child_profile and parent_profile
           # expected result: parent_profile.ip_virtual_router_addresses should win
@@ -329,6 +339,11 @@ tenants:
             name: static_routes_412
             enabled: true
             profile: static_routes_child_profile_3
+            nodes:
+              SVI_PROFILE_NODE_1:
+                ip_address: 11.4.12.1/24
+              SVI_PROFILE_NODE_2:
+                ip_address: 11.4.12.2/24
 
 
 #### ---- Test inheritance of svi ospf.enabled ----- ###

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-LEAF1A.yml
@@ -356,10 +356,9 @@ vlan_interfaces:
     ip_address_virtual: 10.1.20.1/24
     ip_address_virtual_secondaries:
     - 10.2.20.1/24
-    - 10.2.21.1/24
     ip_helpers:
       1.1.1.1:
-        source_interface: lo100
+        source_interface: lo101
         vrf: TEST
   Vlan121:
     tenant: Tenant_A

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-LEAF2A.yml
@@ -705,11 +705,10 @@ vlan_interfaces:
     vrf: Tenant_A_WEB_Zone
     ip_address_virtual: 10.1.20.1/24
     ip_address_virtual_secondaries:
-    - 10.2.20.1/24
     - 10.2.21.1/24
     ip_helpers:
-      1.1.1.1:
-        source_interface: lo100
+      2.2.2.2:
+        source_interface: lo102
         vrf: TEST
   Vlan121:
     tenant: Tenant_A

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/evpn_services_l2_only_false.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/evpn_services_l2_only_false.yml
@@ -250,6 +250,10 @@ static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
+- destination_address_prefix: 10.2.32.0/24
+  vrf: Tenant_A_APP_Zone
+  name: VARP
+  interface: Vlan132
 service_routing_protocols_model: multi-agent
 ip_routing: true
 daemon_terminattr:
@@ -451,6 +455,9 @@ vlan_interfaces:
     description: Tenant_A_APP_Zone_3
     shutdown: false
     vrf: Tenant_A_APP_Zone
+    ip_address: 10.1.32.2/24
+    ip_virtual_router_addresses:
+    - 10.2.32.254/24
   Vlan140:
     tenant: Tenant_A
     tags:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/evpn_services_l2_only_false.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/evpn_services_l2_only_false.yml
@@ -250,14 +250,6 @@ static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
-- destination_address_prefix: 10.2.32.0/24
-  vrf: Tenant_A_APP_Zone
-  name: VARP
-  interface: Vlan132
-- destination_address_prefix: 10.3.32.0/24
-  vrf: Tenant_A_APP_Zone
-  name: VARP
-  interface: Vlan132
 service_routing_protocols_model: multi-agent
 ip_routing: true
 daemon_terminattr:
@@ -459,10 +451,6 @@ vlan_interfaces:
     description: Tenant_A_APP_Zone_3
     shutdown: false
     vrf: Tenant_A_APP_Zone
-    ip_virtual_router_addresses:
-    - 10.1.32.254
-    - 10.2.32.254/24
-    - 10.3.32.254/24
   Vlan140:
     tenant: Tenant_A
     tags:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/inventory/group_vars/DC1_TENANTS_NETWORKS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/inventory/group_vars/DC1_TENANTS_NETWORKS.yml
@@ -27,6 +27,20 @@ svi_profiles:
       - ip_helper: 1.1.1.1
         source_interface: lo100
         source_vrf: TEST
+    nodes:
+      - name: DC1-LEAF1A
+        # Should take config from svis[svi].nodes[node]
+        ip_address_virtual_secondaries:
+          - 10.2.21.1/24
+        # Over-writes the ip_helpers defined on svi settings profile
+        ip_helpers:
+          - ip_helper: 1.1.1.1
+            source_interface: lo101
+            source_vrf: TEST
+      - name: DC1-LEAF2A
+        # Should over-write the config from svi settings
+        ip_address_virtual_secondaries:
+          - 10.2.21.1/24
   - profile: WITH_DHCP
     enabled: true
     ip_helpers:
@@ -86,6 +100,17 @@ tenants:
             ip_address_virtual_secondaries:
               - 10.2.20.1/24
               - 10.2.21.1/24
+            nodes:
+              - name: DC1-LEAF1A
+                ip_address_virtual_secondaries:
+                  - 10.2.20.1/24
+              - name: DC1-LEAF2A
+                # Test the node priority on ip_helpers
+                # Merges the config from nodes
+                ip_helpers:
+                  - ip_helper: 2.2.2.2
+                    source_interface: lo102
+                    source_vrf: TEST
           - id: 121
             name: Tenant_A_WEBZone_2
             tags: ['web']
@@ -110,6 +135,11 @@ tenants:
             nodes:
               - name: DC1-LEAF1A
                 ip_address: 10.1.32.1/24
+              - name: evpn_services_l2_only_false
+                ip_address: 10.1.32.2/24
+                ip_virtual_router_addresses:
+                  # OverWrites the svi.ip_virtual_router_addresses
+                  - 10.2.32.254/24
             ip_virtual_router_addresses:
               - 10.1.32.254
               - 10.2.32.254/24

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
@@ -238,7 +238,6 @@ mac_address_table:
         # Dictionary of SVIs | Required.
         # This will create both the L3 SVI and L2 VLAN based on filters applied to l3leaf and l2leaf.
         # Any SVI setting, defined under svis[svi] can also be defined under the svis[svi].nodes[node]
-        # The node specific setting will over-write the svi settings on that given switch/node
         svis:
 
           # SVI interface id and VLAN id. | Required

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
@@ -318,7 +318,7 @@ mac_address_table:
             # note, also requires an IPv6 address to be configured on the SVI where it is applied.
             # Optional
             # When ipv6_address_virtual and ipv6_virtual_router_addresses are defined in an SVI the node that was defined with the ipv6_address
-            # will be configured with ipv6_virtual_router_addresses. For iv6p_virtual_router_addresses to be configured, ipv6_address must be defined
+            # will be configured with ipv6_virtual_router_addresses. For ipv6_virtual_router_addresses to be configured, ipv6_address must be defined
             ipv6_virtual_router_addresses:
               - < IPv6_address >
 

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
@@ -237,6 +237,8 @@ mac_address_table:
 
         # Dictionary of SVIs | Required.
         # This will create both the L3 SVI and L2 VLAN based on filters applied to l3leaf and l2leaf.
+        # Any SVI setting, defined under svis[svi] can also be defined under the svis[svi].nodes[node]
+        # The node specific setting will over-write the svi settings on that given switch/node
         svis:
 
           # SVI interface id and VLAN id. | Required
@@ -308,12 +310,16 @@ mac_address_table:
             # ip virtual-router address
             # note, also requires an IP address to be configured on the SVI where it is applied.
             # Optional
+            # When ip_address_virtual and ip_virtual_router_addresses are defined in an SVI the node that was defined with the ip_address
+            # will be configured with ip_virtual_router_addresses. For ip_virtual_router_addresses to be configured, ip_address must be defined
             ip_virtual_router_addresses:
               - < IPv4_address/Mask | IPv4_address >
 
             # ipv6 virtual-router address
             # note, also requires an IPv6 address to be configured on the SVI where it is applied.
             # Optional
+            # When ipv6_address_virtual and ipv6_virtual_router_addresses are defined in an SVI the node that was defined with the ipv6_address
+            # will be configured with ipv6_virtual_router_addresses. For iv6p_virtual_router_addresses to be configured, ipv6_address must be defined
             ipv6_virtual_router_addresses:
               - < IPv6_address >
 

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/logic.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/logic.j2
@@ -39,22 +39,24 @@
 {%                         if svi.id | int in whitelist.vlans %}
 {%                             if "all" in match_tags or svi.tags | arista.avd.default(['all']) is arista.avd.contains(match_tags) %}
 {%                                 set tmp_svi = {} %}
-{%                                 set tmp_svi_struct_cfg = svi.nodes | arista.avd.default({}) |
-                                                                        arista.avd.convert_dicts('name') |
-                                                                        selectattr('name', 'arista.avd.defined', inventory_hostname) |
-                                                                        map(attribute='structured_config') |
-                                                                        first %}
+{%                                 set tmp_svi_node_cfg = {} %}
+{%                                 set tmp_node_cfg = (svi.nodes | arista.avd.default({}) |
+                                                                   arista.avd.convert_dicts('name') |
+                                                                   selectattr('name', 'arista.avd.defined', inventory_hostname)
+                                                       )[0] | arista.avd.default({}) %}
+{%                                 set tmp_svi_struct_cfg = tmp_node_cfg.pop('structured_config', none) %}
 {%                                 set bgp_svi_struct_cfg = svi.bgp.structured_config | arista.avd.default %}
 {%                                 if svi.profile is arista.avd.defined %}
 {%                                     set svi_profile = svi_profiles | arista.avd.default({}) |
                                                                         arista.avd.convert_dicts('profile') |
                                                                         selectattr('profile', 'arista.avd.defined', svi.profile) |
                                                                         first %}
-{%                                     if tmp_svi_struct_cfg is not arista.avd.defined and svi_profile.nodes is arista.avd.defined %}
-{%                                         set tmp_svi_struct_cfg = svi_profile.nodes | arista.avd.convert_dicts('name') |
-                                                                                        selectattr('name', 'arista.avd.defined', inventory_hostname) |
-                                                                                        map(attribute='structured_config') |
-                                                                                        first %}
+{%                                     set tmp_node_profile_cfg = (svi_profile.nodes | arista.avd.default({}) |
+                                                                                       arista.avd.convert_dicts('name') |
+                                                                                       selectattr('name', 'arista.avd.defined', inventory_hostname)
+                                                                   )[0] | arista.avd.default({}) %}
+{%                                     if tmp_svi_struct_cfg is not arista.avd.defined %}
+{%                                         set tmp_svi_struct_cfg = tmp_node_profile_cfg.pop('structured_config', none) %}
 {%                                     endif %}
 {%                                     if bgp_svi_struct_cfg is not arista.avd.defined and svi_profile.bgp.structured_config is arista.avd.defined %}
 {%                                         set bgp_svi_struct_cfg = svi_profile.bgp.structured_config %}
@@ -64,37 +66,35 @@
                                                                                    arista.avd.convert_dicts('profile') |
                                                                                    selectattr('profile', 'arista.avd.defined', svi_profile.parent_profile) |
                                                                                    first %}
-{%                                         if tmp_svi_struct_cfg is not arista.avd.defined and svi_parent_profile.nodes is arista.avd.defined %}
-{%                                             set tmp_svi_struct_cfg = svi_parent_profile.nodes | arista.avd.convert_dicts('name') |
-                                                                                                   selectattr('name', 'arista.avd.defined', inventory_hostname) |
-                                                                                                   map(attribute='structured_config') |
-                                                                                                   first %}
+{%                                         set tmp_node_parent_profile_cfg = (svi_parent_profile.nodes | arista.avd.default({}) |
+                                                                                                         arista.avd.convert_dicts('name') |
+                                                                                                         selectattr('name', 'arista.avd.defined', inventory_hostname)
+                                                                              )[0] | arista.avd.default({}) %}
+{%                                         if tmp_svi_struct_cfg is not arista.avd.defined %}
+{%                                             set tmp_svi_struct_cfg = tmp_node_parent_profile_cfg.pop('structured_config', none) %}
 {%                                         endif %}
 {%                                         if bgp_svi_struct_cfg is not arista.avd.defined and svi_parent_profile.bgp.structured_config is arista.avd.defined %}
 {%                                             set bgp_svi_struct_cfg = svi_parent_profile.bgp.structured_config %}
 {%                                         endif %}
 {%                                         set tmp_svi = svi_parent_profile %}
+{%                                         set tmp_svi_node_cfg = tmp_node_parent_profile_cfg %}
 {%                                     endif %}
 {%                                     set tmp_svi = tmp_svi | ansible.builtin.combine(svi_profile, recursive=true, list_merge='replace') %}
+{%                                     set tmp_svi_node_cfg = tmp_svi_node_cfg | ansible.builtin.combine(tmp_node_profile_cfg, recursive=true, list_merge='replace') %}
 {%                                 endif %}
 {%                                 set tmp_svi = tmp_svi | ansible.builtin.combine(svi, recursive=true, list_merge='replace') %}
-{%                                 set tmp_svi_node = tmp_svi.pop("nodes", {}) | arista.avd.convert_dicts('name') |
-                                                                                 selectattr('name', 'arista.avd.defined', inventory_hostname) |
-                                                                                 first %}
-{%                                 if tmp_svi_node is arista.avd.defined %}
-{%                                     if tmp_svi.ip_address_virtual is arista.avd.defined and
-                                          tmp_svi_node.ip_address is arista.avd.defined and tmp_svi.ip_virtual_router_addresses is arista.avd.defined %}
-{%                                         do tmp_svi.update({"ip_address_virtual": none, "ip_address_virtual_secondaries": none}) %}
-{%                                     endif %}
-{%                                     if tmp_svi.ipv6_address_virtual is arista.avd.defined and
-                                          tmp_svi_node.ipv6_address is arista.avd.defined and tmp_svi.ipv6_virtual_router_addresses is arista.avd.defined %}
-{%                                         do tmp_svi.update({"ipv6_address_virtual": none, "ipv6_address_virtuals": none}) %}
-{%                                     endif %}
-{%                                     do tmp_svi_node.pop("structured_config", none) %}
-{%                                     do tmp_svi_node.pop("name") %}
-{%                                     do tmp_svi.update(tmp_svi_node) %}
-{%                                 else %}
-{%                                     do tmp_svi.update({"ip_virtual_router_addresses": none, "ipv6_virtual_router_addresses": none}) %}
+{%                                 set tmp_svi_node_cfg = tmp_svi_node_cfg | ansible.builtin.combine(tmp_node_cfg, recursive=true, list_merge='replace') %}
+{%                                 do tmp_svi_node_cfg.pop("name", none) %}
+{%                                 do tmp_svi.update(tmp_svi_node_cfg) %}
+{%                                 if tmp_svi.ip_address_virtual is arista.avd.defined and tmp_svi.ip_address is arista.avd.defined and tmp_svi.ip_virtual_router_addresses is arista.avd.defined %}
+{%                                     do tmp_svi.update({"ip_address_virtual": none, "ip_address_virtual_secondaries": none}) %}
+{%                                 elif tmp_svi.ip_virtual_router_addresses is arista.avd.defined and tmp_svi.ip_address is not arista.avd.defined %}
+{%                                     do tmp_svi.update({"ip_virtual_router_addresses": none}) %}
+{%                                 endif %}
+{%                                 if tmp_svi.ipv6_address_virtual is arista.avd.defined and tmp_svi.ipv6_address is arista.avd.defined and tmp_svi.ipv6_virtual_router_addresses is arista.avd.defined %}
+{%                                     do tmp_svi.update({"ipv6_address_virtual": none, "ip_address_virtual_secondaries": none}) %}
+{%                                 elif tmp_svi.ipv6_virtual_router_addresses is arista.avd.defined and tmp_svi.ipv6_address is not arista.avd.defined %}
+{%                                     do tmp_svi.update({"ipv6_virtual_router_addresses": none}) %}
 {%                                 endif %}
 {#                                 Structured config should not be merged recursively, but will be taken directly from the most specific level #}
 

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/logic.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/logic.j2
@@ -78,6 +78,24 @@
 {%                                     set tmp_svi = tmp_svi | ansible.builtin.combine(svi_profile, recursive=true, list_merge='replace') %}
 {%                                 endif %}
 {%                                 set tmp_svi = tmp_svi | ansible.builtin.combine(svi, recursive=true, list_merge='replace') %}
+{%                                 set tmp_svi_node = tmp_svi.pop("nodes", {}) | arista.avd.convert_dicts('name') |
+                                                                                 selectattr('name', 'arista.avd.defined', inventory_hostname) |
+                                                                                 first %}
+{%                                 if tmp_svi_node is arista.avd.defined %}
+{%                                     if tmp_svi.ip_address_virtual is arista.avd.defined and
+                                          tmp_svi_node.ip_address is arista.avd.defined and tmp_svi.ip_virtual_router_addresses is arista.avd.defined %}
+{%                                         do tmp_svi.update({"ip_address_virtual": none, "ip_address_virtual_secondaries": none}) %}
+{%                                     endif %}
+{%                                     if tmp_svi.ipv6_address_virtual is arista.avd.defined and
+                                          tmp_svi_node.ipv6_address is arista.avd.defined and tmp_svi.ipv6_virtual_router_addresses is arista.avd.defined %}
+{%                                         do tmp_svi.update({"ipv6_address_virtual": none, "ipv6_address_virtuals": none}) %}
+{%                                     endif %}
+{%                                     do tmp_svi_node.pop("structured_config", none) %}
+{%                                     do tmp_svi_node.pop("name") %}
+{%                                     do tmp_svi.update(tmp_svi_node) %}
+{%                                 else %}
+{%                                     do tmp_svi.update({"ip_virtual_router_addresses": none, "ipv6_virtual_router_addresses": none}) %}
+{%                                 endif %}
 {#                                 Structured config should not be merged recursively, but will be taken directly from the most specific level #}
 
 {%                                 do tmp_svi.update({"structured_config": tmp_svi_struct_cfg | arista.avd.default(

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/logic.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/logic.j2
@@ -85,7 +85,7 @@
 {%                                 set tmp_svi = tmp_svi | ansible.builtin.combine(svi, recursive=true, list_merge='replace') %}
 {%                                 set tmp_svi_node_cfg = tmp_svi_node_cfg | ansible.builtin.combine(tmp_node_cfg, recursive=true, list_merge='replace') %}
 {%                                 do tmp_svi_node_cfg.pop("name", none) %}
-{%                                 do tmp_svi.update(tmp_svi_node_cfg) %}
+{%                                 set tmp_svi = tmp_svi | ansible.builtin.combine(tmp_svi_node_cfg, recursive=true, list_merge='replace') %}
 {%                                 if tmp_svi.ip_address_virtual is arista.avd.defined and tmp_svi.ip_address is arista.avd.defined and tmp_svi.ip_virtual_router_addresses is arista.avd.defined %}
 {%                                     do tmp_svi.update({"ip_address_virtual": none, "ip_address_virtual_secondaries": none}) %}
 {%                                 elif tmp_svi.ip_virtual_router_addresses is arista.avd.defined and tmp_svi.ip_address is not arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/logic.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/logic.j2
@@ -91,8 +91,8 @@
 {%                                 elif tmp_svi.ip_virtual_router_addresses is arista.avd.defined and tmp_svi.ip_address is not arista.avd.defined %}
 {%                                     do tmp_svi.update({"ip_virtual_router_addresses": none}) %}
 {%                                 endif %}
-{%                                 if tmp_svi.ipv6_address_virtual is arista.avd.defined and tmp_svi.ipv6_address is arista.avd.defined and tmp_svi.ipv6_virtual_router_addresses is arista.avd.defined %}
-{%                                     do tmp_svi.update({"ipv6_address_virtual": none, "ip_address_virtual_secondaries": none}) %}
+{%                                 if (tmp_svi.ipv6_address_virtual is arista.avd.defined or tmp_svi.ipv6_address_virtuals is arista.avd.defined) and tmp_svi.ipv6_address is arista.avd.defined and tmp_svi.ipv6_virtual_router_addresses is arista.avd.defined %}
+{%                                     do tmp_svi.update({"ipv6_address_virtual": none, "ipv6_address_virtuals": none}) %}
 {%                                 elif tmp_svi.ipv6_virtual_router_addresses is arista.avd.defined and tmp_svi.ipv6_address is not arista.avd.defined %}
 {%                                     do tmp_svi.update({"ipv6_virtual_router_addresses": none}) %}
 {%                                 endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/vlan-interfaces.j2
@@ -3,12 +3,6 @@ vlan_interfaces:
 {% for tenant in network_services_data.tenants %}
 {%     for vrf in tenant.vrfs %}
 {%         for svi in vrf.svis %}
-{%             set svi_node = svi.nodes | arista.avd.default({}) |
-                                          arista.avd.convert_dicts('name') |
-                                          selectattr('name', 'arista.avd.defined', inventory_hostname) |
-                                          first %}
-{%             set svi_raw_eos_cli = svi_node.raw_eos_cli | arista.avd.default(
-                                     svi.raw_eos_cli) %}
 {%             set svi_ip_helpers = svi.ip_helpers | arista.avd.default(vrf.ip_helpers) %}
   Vlan{{ svi.id | int }}:
     tenant: {{ tenant.name }}
@@ -22,19 +16,19 @@ vlan_interfaces:
 {%             if vrf.name != 'default' %}
     vrf: {{ vrf.name }}
 {%             else %}
-{%                 set svi_subnet = svi_node.ip_address | arista.avd.default(svi.ip_address_virtual) | ansible.netcommon.ipaddr('subnet') %}
+{%                 set svi_subnet = svi.ip_address | arista.avd.default(svi.ip_address_virtual) | ansible.netcommon.ipaddr('subnet') %}
 {%                 if svi_subnet is arista.avd.defined and svi_subnet %}
 {%                     do default_vrf.svi_subnets.append(svi_subnet) %}
 {%                 endif %}
 {%             endif %}
 {# IP address configuration #}
-{%             if svi_node.ip_address is arista.avd.defined %}
-    ip_address: {{ svi_node.ip_address }}
+{%             if svi.ip_address is arista.avd.defined %}
+    ip_address: {{ svi.ip_address }}
 {%             endif %}
 {# IPv6 address configuration #}
-{%             if svi_node.ipv6_address is arista.avd.defined %}
+{%             if svi.ipv6_address is arista.avd.defined %}
 {%                 do network_services_data.ipv6vrfs.update({vrf.name: True}) %}
-    ipv6_address: {{ svi_node.ipv6_address }}
+    ipv6_address: {{ svi.ipv6_address }}
 {%             endif %}
 {# Virtual Router IP Address #}
 {%             if svi.ip_virtual_router_addresses is arista.avd.defined %}
@@ -95,9 +89,9 @@ vlan_interfaces:
 {%                     endfor %}
 {%                 endif %}
 {%             endif %}
-{%             if svi_raw_eos_cli is arista.avd.defined %}
+{%             if svi.raw_eos_cli is arista.avd.defined %}
     eos_cli: |
-      {{ svi_raw_eos_cli | indent(6,false) }}
+      {{ svi.raw_eos_cli | indent(6,false) }}
 {%             endif %}
 {%             if svi.structured_config is arista.avd.defined %}
     struct_cfg: {{ svi.structured_config }}


### PR DESCRIPTION
## Change Summary

Configure `ip virtual-router address` only when the node is defined with `ip address`. This will allow other nodes defined with in the SVI can still use the `ip virtual address`.

## Related Issue(s)

Fixes #2228 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

No changes, just the logic is changed
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

## How to test

`molecule converge -s eos_designs_unit_tests`
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
