### PR TITLE
Fix(eos_designs): Create mgmt interface even if no gateway is set

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/no_mgmt_gateway.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/no_mgmt_gateway.cfg
@@ -1,0 +1,32 @@
+!RANCID-CONTENT-TYPE: arista
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname no_mgmt_gateway
+!
+no enable password
+no aaa root
+!
+vrf instance MGMT
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 192.168.200.106
+!
+ip routing
+no ip routing vrf MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/no_mgmt_gateway.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/no_mgmt_gateway.yml
@@ -1,0 +1,24 @@
+service_routing_protocols_model: multi-agent
+ip_routing: true
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+vrfs:
+  MGMT:
+    ip_routing: false
+management_interfaces:
+  Management1:
+    description: oob_management
+    shutdown: false
+    vrf: MGMT
+    ip_address: 192.168.200.106
+    gateway: null
+    type: oob
+management_api_http:
+  enable_vrfs:
+    MGMT: {}
+  enable_https: true
+ip_igmp_snooping:
+  globally_enabled: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/no_mgmt_gateway.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/no_mgmt_gateway.yml
@@ -1,0 +1,10 @@
+# Minimum config to only test the specific feature.
+mgmt_gateway: null
+
+type: l2leaf
+l2leaf:
+  defaults:
+  nodes:
+    no_mgmt_gateway:
+      id: 106
+      mgmt_ip: 192.168.200.106

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
@@ -3,11 +3,13 @@ all:
   children:
     EOS_DESIGNS_UNIT_TESTS:
       children:
-        CLEAN_UNIT_TESTS:
+        CLEAN_UNIT_TESTS: # Single Devices testing one specific case and only using hostvars
           hosts:
             cvp-instance-ips-cvaas:
             device.with.dots.in.hostname:
             filter.only_vlans_in_use:
+            no_mgmt_interface:
+            no_mgmt_gateway:
         CORE_UNIT_TESTS:
           hosts:
             core-1-isis-sr-ldp:
@@ -275,7 +277,3 @@ all:
               children:
                 MH_LEAFS_TESTS:
                 MH_L2LEAFS_TESTS:
-
-        ISOLATED_HOSTS:
-          hosts:
-            no_mgmt_interface:

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/base/base.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/base/base.py
@@ -459,7 +459,7 @@ class AvdStructuredConfig(AvdFacts):
         mgmt_gateway and mgmt_interface_vrf variable
         """
         mgmt_interface = get(self._hostvars, "switch.mgmt_interface")
-        if mgmt_interface is not None and self._mgmt_ip is not None and self._mgmt_interface_vrf is not None and self._mgmt_gateway is not None:
+        if mgmt_interface is not None and self._mgmt_ip is not None and self._mgmt_interface_vrf is not None:
             return {
                 mgmt_interface: {
                     "description": "oob_management",


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Fix(eos_designs): Create mgmt interface even if no gateway is set

## Related Issue(s)

Management interface is not being created if gateway is not set. Documentation states that gateway is optional.

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

- Remove gateway from condition for configuration of management interface.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

- added molecule coverage for this scenario
- no other changes to molecule

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
