### PR TITLE
Feat(plugins): Add schema support for auto-conversion of floats

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-security.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-security.md
@@ -67,6 +67,8 @@ interface Management1
 | ---------------- | --------------------- | -------------------- | ------------ | ----------- |
 | certificate-profile | - | eAPI.crt | eAPI.key | - |
 | cipher-list-profile | - | - | - | ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384 |
+| tls-single-version-profile-as-float | 1.0 | - | - | - |
+| tls-single-version-profile-as-string | 1.1 | - | - | - |
 | tls-versions-profile | 1.0 1.1 | - | - | - |
 
 ## Management Security Configuration
@@ -82,6 +84,10 @@ management security
       certificate eAPI.crt key eAPI.key
    ssl profile cipher-list-profile
       cipher-list ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384
+   ssl profile tls-single-version-profile-as-float
+      tls versions 1.0
+   ssl profile tls-single-version-profile-as-string
+      tls versions 1.1
    ssl profile tls-versions-profile
       tls versions 1.0 1.1
 ```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/management-security.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/management-security.cfg
@@ -21,6 +21,10 @@ management security
       certificate eAPI.crt key eAPI.key
    ssl profile cipher-list-profile
       cipher-list ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384
+   ssl profile tls-single-version-profile-as-float
+      tls versions 1.0
+   ssl profile tls-single-version-profile-as-string
+      tls versions 1.1
    ssl profile tls-versions-profile
       tls versions 1.0 1.1
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/management-security.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/management-security.yml
@@ -14,3 +14,7 @@ management_security:
       certificate:
         file: eAPI.crt
         key: eAPI.key
+    - name: tls-single-version-profile-as-string
+      tls_versions: "1.1"
+    - name: tls-single-version-profile-as-float
+      tls_versions: 1.0

--- a/ansible_collections/arista/avd/plugins/plugin_utils/schema/avd_meta_schema.json
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/schema/avd_meta_schema.json
@@ -21,7 +21,8 @@
                                 "type": "string",
                                 "enum": [
                                     "bool",
-                                    "str"
+                                    "str",
+                                    "float"
                                 ]
                             }
                         },
@@ -111,7 +112,8 @@
                                 "type": "string",
                                 "enum": [
                                     "bool",
-                                    "int"
+                                    "int",
+                                    "float"
                                 ]
                             }
                         },

--- a/ansible_collections/arista/avd/plugins/plugin_utils/schema/avddataconverter.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/schema/avddataconverter.py
@@ -196,6 +196,10 @@ def _convert_types(validator, convert_types: list, instance, schema: dict):
     return instance
 
 
+def _is_float(validator, instance):
+    return isinstance(instance, float)
+
+
 """
 AvdDataConverter is used to convert AVD Data Types based on schema options.
 We have extra type checkers not covered by the AVD_META_SCHEMA (array, boolean etc)
@@ -223,6 +227,7 @@ else:
                 "bool": jsonschema._types.is_bool,
                 "list": jsonschema._types.is_array,
                 "int": jsonschema._types.is_integer,
+                "float": _is_float,
             }
         ),
     )

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -2014,7 +2014,7 @@ management_interfaces:
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;encryption_reversible</samp>](## "management_security.password.encryption_reversible") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;ssl_profiles</samp>](## "management_security.ssl_profiles") | List, items: Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "management_security.ssl_profiles.[].name") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tls_versions</samp>](## "management_security.ssl_profiles.[].tls_versions") | String |  |  |  | List of allowed TLS versions as string<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tls_versions</samp>](## "management_security.ssl_profiles.[].tls_versions") | String |  |  |  | List of allowed TLS versions as string<br>Examples:<br>  - "1.0"<br>  - "1.0 1.1"<br> |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;cipher_list</samp>](## "management_security.ssl_profiles.[].cipher_list") | String |  |  |  | cipher_list syntax follows the openssl cipher strings format.<br>Colon (:) separated list of allowed ciphers as a string<br> |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;certificate</samp>](## "management_security.ssl_profiles.[].certificate") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;file</samp>](## "management_security.ssl_profiles.[].certificate.file") | String |  |  |  |  |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -3349,7 +3349,7 @@
               },
               "tls_versions": {
                 "type": "string",
-                "description": "List of allowed TLS versions as string\n",
+                "description": "List of allowed TLS versions as string\nExamples:\n  - \"1.0\"\n  - \"1.0 1.1\"\n",
                 "title": "TLS Versions"
               },
               "cipher_list": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -2496,9 +2496,10 @@ keys:
               type: str
             tls_versions:
               type: str
-              description: 'List of allowed TLS versions as string
-
-                '
+              description: "List of allowed TLS versions as string\nExamples:\n  -
+                \"1.0\"\n  - \"1.0 1.1\"\n"
+              convert_types:
+              - float
             cipher_list:
               type: str
               description: 'cipher_list syntax follows the openssl cipher strings

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_security.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_security.schema.yml
@@ -32,6 +32,11 @@ keys:
               type: str
               description: |
                 List of allowed TLS versions as string
+                Examples:
+                  - "1.0"
+                  - "1.0 1.1"
+              convert_types:
+              - float
             cipher_list:
               type: str
               description: |


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Add schema support for auto-conversion of `float`

## Related Issue(s)

Fixes #2237

## Component(s) name

Schema auto conversion

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

- add ability to auto-convert from `float` to `str` and `float` to `int`

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Added schema conversion for `tls_versions` key and added molecule scenario to test.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
