### PR TITLE
Feat(eos_cli_config_gen): Add various config options for Sflow

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/sflow.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/sflow.md
@@ -53,11 +53,15 @@ interface Management1
 
 ### SFlow Summary
 
-| VRF | SFlow Source Interface | SFlow Destination | Port |
-| --- | ---------------------- | ----------------- | ---- |
+| VRF | SFlow Source | SFlow Destination | Port |
+| --- | ------------ | ----------------- | ---- |
 | AAA | - | 10.6.75.62 | 123 |
 | AAA | - | 10.6.75.63 | 333 |
 | AAA | Ethernet2 | - | - |
+| BBB | - | 10.6.75.62 | 6343 |
+| BBB | 1.1.1.1 | - | - |
+| CCC | - | 10.6.75.62 | 6343 |
+| CCC | Management1 | - | - |
 | MGMT | - | 10.6.75.59 | 6343 |
 | MGMT | - | 10.6.75.62 | 123 |
 | MGMT | - | 10.6.75.63 | 333 |
@@ -67,6 +71,8 @@ interface Management1
 | default | Management0 | - | - |
 
 sFlow Sample Rate: 1000
+
+sFlow Polling Interval: 10
 
 sFlow is enabled.
 
@@ -84,14 +90,28 @@ sFlow hardware accelerated Sample Rate: 1024
 | Linecard2 | True |
 | Linecard3 | False |
 
+### SFlow Extensions
+
+| Extension | Enabled |
+| --------- | ------- |
+| bgp | True |
+| router | True |
+| switch | False |
+| tunnel | False |
+
 ### SFlow Device Configuration
 
 ```eos
 !
 sflow sample dangerous 1000
+sflow polling-interval 10
 sflow vrf AAA destination 10.6.75.62 123
 sflow vrf AAA destination 10.6.75.63 333
 sflow vrf AAA source-interface Ethernet2
+sflow vrf BBB destination 10.6.75.62
+sflow vrf BBB source 1.1.1.1
+sflow vrf CCC destination 10.6.75.62
+sflow vrf CCC source-interface Management1
 sflow vrf MGMT destination 10.6.75.59
 sflow vrf MGMT destination 10.6.75.62 123
 sflow vrf MGMT destination 10.6.75.63 333
@@ -99,8 +119,12 @@ sflow vrf MGMT source-interface Ethernet3
 sflow destination 10.6.75.61
 sflow destination 10.6.75.62 123
 sflow source-interface Management0
-sflow run
+sflow extension bgp
+sflow extension router
+no sflow extension switch
+no sflow extension tunnel
 sflow interface disable default
+sflow run
 sflow hardware acceleration
 sflow hardware acceleration sample 1024
 sflow hardware acceleration module Linecard1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/sflow.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/sflow.cfg
@@ -5,9 +5,14 @@ transceiver qsfp default-mode 4x10G
 hostname sflow
 !
 sflow sample dangerous 1000
+sflow polling-interval 10
 sflow vrf AAA destination 10.6.75.62 123
 sflow vrf AAA destination 10.6.75.63 333
 sflow vrf AAA source-interface Ethernet2
+sflow vrf BBB destination 10.6.75.62
+sflow vrf BBB source 1.1.1.1
+sflow vrf CCC destination 10.6.75.62
+sflow vrf CCC source-interface Management1
 sflow vrf MGMT destination 10.6.75.59
 sflow vrf MGMT destination 10.6.75.62 123
 sflow vrf MGMT destination 10.6.75.63 333
@@ -15,8 +20,12 @@ sflow vrf MGMT source-interface Ethernet3
 sflow destination 10.6.75.61
 sflow destination 10.6.75.62 123
 sflow source-interface Management0
-sflow run
+sflow extension bgp
+sflow extension router
+no sflow extension switch
+no sflow extension tunnel
 sflow interface disable default
+sflow run
 sflow hardware acceleration
 sflow hardware acceleration sample 1024
 sflow hardware acceleration module Linecard1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/sflow.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/sflow.yml
@@ -16,6 +16,15 @@ sflow:
         10.6.75.63:
           port: 333
       source_interface: Ethernet2
+    BBB:
+      destinations:
+        10.6.75.62:
+      source: 1.1.1.1
+    CCC:
+      destinations:
+        10.6.75.62:
+      source_interface: Management1
+      source: 1.1.1.1
   destinations:
     10.6.75.62:
       port: 123
@@ -23,6 +32,16 @@ sflow:
   source_interface: Management0
   sample: 1000
   dangerous: true
+  polling_interval: 10
+  extensions:
+    - name: bgp
+      enabled: true
+    - name: router
+      enabled: true
+    - name: switch
+      enabled: false
+    - name: tunnel
+      enabled: false
   run: true
   interface:
     disable:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/sflow.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/sflow.md
@@ -53,8 +53,8 @@ interface Management1
 
 ### SFlow Summary
 
-| VRF | SFlow Source Interface | SFlow Destination | Port |
-| --- | ---------------------- | ----------------- | ---- |
+| VRF | SFlow Source | SFlow Destination | Port |
+| --- | ------------ | ----------------- | ---- |
 | AAA | - | 10.6.75.62 | 123 |
 | AAA | - | 10.6.75.63 | 333 |
 | AAA | Ethernet2 | - | - |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -2325,12 +2325,15 @@ trackers:
 sflow:
   sample: < sample_rate >
   dangerous: < true | false >
+  polling_interval: < polling_interval_seconds >
   vrfs:
     <vrf_name_1>:
       destinations:
         < sflow_destination_ip_1>:
         < sflow_destination_ip_2>:
           port: < port_number >
+      # source and source_interface are mutually exclusive. If both are defined, source_interface takes precedence
+      source: < source_ip_address >
       source_interface: < source_interface >
     <vrf_name_2>:
       destinations:
@@ -2340,7 +2343,12 @@ sflow:
     < sflow_destination_ip_1 >:
       port: < port_number >
     < sflow_destination_ip_2 >:
+  # source and source_interface are mutually exclusive. If both are defined, source_interface takes precedence
+  source: < source_ip_address >
   source_interface: < source_interface >
+  extensions:
+    - name: <bgp | router | switch | tunnel >
+      enabled: < true | false >
   interface:
     disable:
       default: < true | false >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -3445,12 +3445,12 @@ service_routing_protocols_model: <str>
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;destinations</samp>](## "sflow.vrfs.[].destinations") | List, items: Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- destination</samp>](## "sflow.vrfs.[].destinations.[].destination") | String | Required, Unique |  |  | Sflow Destination IP |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;port</samp>](## "sflow.vrfs.[].destinations.[].port") | Integer |  |  |  | Port Number |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source</samp>](## "sflow.vrfs.[].source") | String |  |  |  | "Source IP Address<br>source and source_interface are mutually exclusive. If both are defined, source_interface takes precedence"<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source</samp>](## "sflow.vrfs.[].source") | String |  |  |  | Source IP Address.<br>"source" and "source_interface" are mutually exclusive. If both are defined, "source_interface" takes precedence.<br> |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_interface</samp>](## "sflow.vrfs.[].source_interface") | String |  |  |  | Source Interface |
 | [<samp>&nbsp;&nbsp;destinations</samp>](## "sflow.destinations") | List, items: Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- destination</samp>](## "sflow.destinations.[].destination") | String | Required, Unique |  |  | Sflow Destination IP |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;port</samp>](## "sflow.destinations.[].port") | Integer |  |  |  | Port Number |
-| [<samp>&nbsp;&nbsp;source</samp>](## "sflow.source") | String |  |  |  | "Source IP Address<br>source and source_interface are mutually exclusive. If both are defined, source_interface takes precedence"<br> |
+| [<samp>&nbsp;&nbsp;source</samp>](## "sflow.source") | String |  |  |  | Source IP Address.<br>"source" and "source_interface" are mutually exclusive. If both are defined, "source_interface" takes precedence.<br> |
 | [<samp>&nbsp;&nbsp;source_interface</samp>](## "sflow.source_interface") | String |  |  |  | Source Interface |
 | [<samp>&nbsp;&nbsp;extensions</samp>](## "sflow.extensions") | List, items: Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "sflow.extensions.[].name") | String |  |  |  | Extension Name |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -3443,17 +3443,17 @@ service_routing_protocols_model: <str>
 | [<samp>&nbsp;&nbsp;vrfs</samp>](## "sflow.vrfs") | List, items: Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "sflow.vrfs.[].name") | String | Required, Unique |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;destinations</samp>](## "sflow.vrfs.[].destinations") | List, items: Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- destination</samp>](## "sflow.vrfs.[].destinations.[].destination") | String | Required, Unique |  |  | Sflow Destination IP |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- destination</samp>](## "sflow.vrfs.[].destinations.[].destination") | String | Required, Unique |  |  | Sflow Destination IP Address |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;port</samp>](## "sflow.vrfs.[].destinations.[].port") | Integer |  |  |  | Port Number |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source</samp>](## "sflow.vrfs.[].source") | String |  |  |  | Source IP Address.<br>"source" and "source_interface" are mutually exclusive. If both are defined, "source_interface" takes precedence.<br> |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_interface</samp>](## "sflow.vrfs.[].source_interface") | String |  |  |  | Source Interface |
 | [<samp>&nbsp;&nbsp;destinations</samp>](## "sflow.destinations") | List, items: Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- destination</samp>](## "sflow.destinations.[].destination") | String | Required, Unique |  |  | Sflow Destination IP |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- destination</samp>](## "sflow.destinations.[].destination") | String | Required, Unique |  |  | Sflow Destination IP Address |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;port</samp>](## "sflow.destinations.[].port") | Integer |  |  |  | Port Number |
 | [<samp>&nbsp;&nbsp;source</samp>](## "sflow.source") | String |  |  |  | Source IP Address.<br>"source" and "source_interface" are mutually exclusive. If both are defined, "source_interface" takes precedence.<br> |
 | [<samp>&nbsp;&nbsp;source_interface</samp>](## "sflow.source_interface") | String |  |  |  | Source Interface |
 | [<samp>&nbsp;&nbsp;extensions</samp>](## "sflow.extensions") | List, items: Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "sflow.extensions.[].name") | String |  |  |  | Extension Name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "sflow.extensions.[].name") | String | Required, Unique |  |  | Extension Name |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "sflow.extensions.[].enabled") | Boolean | Required |  |  | Enable or Disable Extension |
 | [<samp>&nbsp;&nbsp;interface</samp>](## "sflow.interface") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;disable</samp>](## "sflow.interface.disable") | Dictionary |  |  |  |  |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -3439,7 +3439,7 @@ service_routing_protocols_model: <str>
 | [<samp>sflow</samp>](## "sflow") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;sample</samp>](## "sflow.sample") | Integer |  |  |  |  |
 | [<samp>&nbsp;&nbsp;dangerous</samp>](## "sflow.dangerous") | Boolean |  |  |  |  |
-| [<samp>&nbsp;&nbsp;polling_interval</samp>](## "sflow.polling_interval") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;polling_interval</samp>](## "sflow.polling_interval") | Integer |  |  |  | Polling interval in seconds |
 | [<samp>&nbsp;&nbsp;vrfs</samp>](## "sflow.vrfs") | List, items: Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "sflow.vrfs.[].name") | String | Required, Unique |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;destinations</samp>](## "sflow.vrfs.[].destinations") | List, items: Dictionary |  |  |  |  |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -3445,12 +3445,12 @@ service_routing_protocols_model: <str>
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;destinations</samp>](## "sflow.vrfs.[].destinations") | List, items: Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- destination</samp>](## "sflow.vrfs.[].destinations.[].destination") | String | Required, Unique |  |  | Sflow Destination IP |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;port</samp>](## "sflow.vrfs.[].destinations.[].port") | Integer |  |  |  | Port Number |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source</samp>](## "sflow.vrfs.[].source") | String |  |  |  | Source IP Address |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source</samp>](## "sflow.vrfs.[].source") | String |  |  |  | "Source IP Address<br>source and source_interface are mutually exclusive. If both are defined, source_interface takes precedence"<br> |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_interface</samp>](## "sflow.vrfs.[].source_interface") | String |  |  |  | Source Interface |
 | [<samp>&nbsp;&nbsp;destinations</samp>](## "sflow.destinations") | List, items: Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- destination</samp>](## "sflow.destinations.[].destination") | String | Required, Unique |  |  | Sflow Destination IP |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;port</samp>](## "sflow.destinations.[].port") | Integer |  |  |  | Port Number |
-| [<samp>&nbsp;&nbsp;source</samp>](## "sflow.source") | String |  |  |  | Source IP Address |
+| [<samp>&nbsp;&nbsp;source</samp>](## "sflow.source") | String |  |  |  | "Source IP Address<br>source and source_interface are mutually exclusive. If both are defined, source_interface takes precedence"<br> |
 | [<samp>&nbsp;&nbsp;source_interface</samp>](## "sflow.source_interface") | String |  |  |  | Source Interface |
 | [<samp>&nbsp;&nbsp;extensions</samp>](## "sflow.extensions") | List, items: Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "sflow.extensions.[].name") | String |  |  |  | Extension Name |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -3439,16 +3439,22 @@ service_routing_protocols_model: <str>
 | [<samp>sflow</samp>](## "sflow") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;sample</samp>](## "sflow.sample") | Integer |  |  |  |  |
 | [<samp>&nbsp;&nbsp;dangerous</samp>](## "sflow.dangerous") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;polling_interval</samp>](## "sflow.polling_interval") | Integer |  |  |  |  |
 | [<samp>&nbsp;&nbsp;vrfs</samp>](## "sflow.vrfs") | List, items: Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "sflow.vrfs.[].name") | String | Required, Unique |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;destinations</samp>](## "sflow.vrfs.[].destinations") | List, items: Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- destination</samp>](## "sflow.vrfs.[].destinations.[].destination") | String | Required, Unique |  |  | Sflow Destination IP |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;port</samp>](## "sflow.vrfs.[].destinations.[].port") | Integer |  |  |  | Port Number |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_interface</samp>](## "sflow.vrfs.[].source_interface") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source</samp>](## "sflow.vrfs.[].source") | String |  |  |  | Source IP Address |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_interface</samp>](## "sflow.vrfs.[].source_interface") | String |  |  |  | Source Interface |
 | [<samp>&nbsp;&nbsp;destinations</samp>](## "sflow.destinations") | List, items: Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- destination</samp>](## "sflow.destinations.[].destination") | String | Required, Unique |  |  | Sflow Destination IP |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;port</samp>](## "sflow.destinations.[].port") | Integer |  |  |  | Port Number |
-| [<samp>&nbsp;&nbsp;source_interface</samp>](## "sflow.source_interface") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;source</samp>](## "sflow.source") | String |  |  |  | Source IP Address |
+| [<samp>&nbsp;&nbsp;source_interface</samp>](## "sflow.source_interface") | String |  |  |  | Source Interface |
+| [<samp>&nbsp;&nbsp;extensions</samp>](## "sflow.extensions") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "sflow.extensions.[].name") | String |  |  |  | Extension Name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "sflow.extensions.[].enabled") | Boolean | Required |  |  | Enable or Disable Extension |
 | [<samp>&nbsp;&nbsp;interface</samp>](## "sflow.interface") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;disable</samp>](## "sflow.interface.disable") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;default</samp>](## "sflow.interface.disable.default") | Boolean |  |  |  |  |
@@ -3466,16 +3472,22 @@ service_routing_protocols_model: <str>
 sflow:
   sample: <int>
   dangerous: <bool>
+  polling_interval: <int>
   vrfs:
     - name: <str>
       destinations:
         - destination: <str>
           port: <int>
+      source: <str>
       source_interface: <str>
   destinations:
     - destination: <str>
       port: <int>
+  source: <str>
   source_interface: <str>
+  extensions:
+    - name: <str>
+      enabled: <bool>
   interface:
     disable:
       default: <bool>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -6451,7 +6451,7 @@
               },
               "source": {
                 "type": "string",
-                "description": "\"Source IP Address\nsource and source_interface are mutually exclusive. If both are defined, source_interface takes precedence\"\n",
+                "description": "Source IP Address.\n\"source\" and \"source_interface\" are mutually exclusive. If both are defined, \"source_interface\" takes precedence.\n",
                 "title": "Source"
               },
               "source_interface": {
@@ -6492,7 +6492,7 @@
         },
         "source": {
           "type": "string",
-          "description": "\"Source IP Address\nsource and source_interface are mutually exclusive. If both are defined, source_interface takes precedence\"\n",
+          "description": "Source IP Address.\n\"source\" and \"source_interface\" are mutually exclusive. If both are defined, \"source_interface\" takes precedence.\n",
           "title": "Source"
         },
         "source_interface": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -6451,7 +6451,7 @@
               },
               "source": {
                 "type": "string",
-                "description": "Source IP Address",
+                "description": "\"Source IP Address\nsource and source_interface are mutually exclusive. If both are defined, source_interface takes precedence\"\n",
                 "title": "Source"
               },
               "source_interface": {
@@ -6492,7 +6492,7 @@
         },
         "source": {
           "type": "string",
-          "description": "Source IP Address",
+          "description": "\"Source IP Address\nsource and source_interface are mutually exclusive. If both are defined, source_interface takes precedence\"\n",
           "title": "Source"
         },
         "source_interface": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -6413,6 +6413,10 @@
           "type": "boolean",
           "title": "Dangerous"
         },
+        "polling_interval": {
+          "type": "integer",
+          "title": "Polling Interval"
+        },
         "vrfs": {
           "type": "array",
           "items": {
@@ -6429,7 +6433,7 @@
                   "properties": {
                     "destination": {
                       "type": "string",
-                      "description": "Sflow Destination IP",
+                      "description": "Sflow Destination IP Address",
                       "title": "Destination"
                     },
                     "port": {
@@ -6445,8 +6449,14 @@
                 },
                 "title": "Destinations"
               },
+              "source": {
+                "type": "string",
+                "description": "Source IP Address",
+                "title": "Source"
+              },
               "source_interface": {
                 "type": "string",
+                "description": "Source Interface",
                 "title": "Source Interface"
               }
             },
@@ -6464,7 +6474,7 @@
             "properties": {
               "destination": {
                 "type": "string",
-                "description": "Sflow Destination IP",
+                "description": "Sflow Destination IP Address",
                 "title": "Destination"
               },
               "port": {
@@ -6480,9 +6490,38 @@
           },
           "title": "Destinations"
         },
+        "source": {
+          "type": "string",
+          "description": "Source IP Address",
+          "title": "Source"
+        },
         "source_interface": {
           "type": "string",
+          "description": "Source Interface",
           "title": "Source Interface"
+        },
+        "extensions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Extension Name",
+                "title": "Name"
+              },
+              "enabled": {
+                "type": "boolean",
+                "description": "Enable or Disable Extension",
+                "title": "Enabled"
+              }
+            },
+            "required": [
+              "enabled"
+            ],
+            "additionalProperties": false
+          },
+          "title": "Extensions"
         },
         "interface": {
           "type": "object",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -6415,6 +6415,7 @@
         },
         "polling_interval": {
           "type": "integer",
+          "description": "Polling interval in seconds",
           "title": "Polling Interval"
         },
         "vrfs": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -6517,7 +6517,8 @@
               }
             },
             "required": [
-              "enabled"
+              "enabled",
+              "name"
             ],
             "additionalProperties": false
           },

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -4484,10 +4484,10 @@ keys:
                     - str
             source:
               type: str
-              description: '"Source IP Address
+              description: 'Source IP Address.
 
-                source and source_interface are mutually exclusive. If both are defined,
-                source_interface takes precedence"
+                "source" and "source_interface" are mutually exclusive. If both are
+                defined, "source_interface" takes precedence.
 
                 '
             source_interface:
@@ -4511,10 +4511,10 @@ keys:
               - str
       source:
         type: str
-        description: '"Source IP Address
+        description: 'Source IP Address.
 
-          source and source_interface are mutually exclusive. If both are defined,
-          source_interface takes precedence"
+          "source" and "source_interface" are mutually exclusive. If both are defined,
+          "source_interface" takes precedence.
 
           '
       source_interface:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -4456,6 +4456,9 @@ keys:
         type: bool
       polling_interval:
         type: int
+        convert_types:
+        - str
+        description: Polling interval in seconds
       vrfs:
         type: list
         primary_key: name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -4484,7 +4484,12 @@ keys:
                     - str
             source:
               type: str
-              description: Source IP Address
+              description: '"Source IP Address
+
+                source and source_interface are mutually exclusive. If both are defined,
+                source_interface takes precedence"
+
+                '
             source_interface:
               type: str
               description: Source Interface
@@ -4506,7 +4511,12 @@ keys:
               - str
       source:
         type: str
-        description: Source IP Address
+        description: '"Source IP Address
+
+          source and source_interface are mutually exclusive. If both are defined,
+          source_interface takes precedence"
+
+          '
       source_interface:
         type: str
         description: Source Interface

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -4454,6 +4454,8 @@ keys:
         - str
       dangerous:
         type: bool
+      polling_interval:
+        type: int
       vrfs:
         type: list
         primary_key: name
@@ -4474,14 +4476,18 @@ keys:
                 keys:
                   destination:
                     type: str
-                    description: Sflow Destination IP
+                    description: Sflow Destination IP Address
                   port:
                     type: int
                     description: Port Number
                     convert_types:
                     - str
+            source:
+              type: str
+              description: Source IP Address
             source_interface:
               type: str
+              description: Source Interface
       destinations:
         type: list
         primary_key: destination
@@ -4492,14 +4498,31 @@ keys:
           keys:
             destination:
               type: str
-              description: Sflow Destination IP
+              description: Sflow Destination IP Address
             port:
               type: int
               description: Port Number
               convert_types:
               - str
+      source:
+        type: str
+        description: Source IP Address
       source_interface:
         type: str
+        description: Source Interface
+      extensions:
+        type: list
+        primary_key: name
+        items:
+          type: dict
+          keys:
+            name:
+              type: str
+              description: Extension Name
+            enabled:
+              type: bool
+              description: Enable or Disable Extension
+              required: true
       interface:
         type: dict
         keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/sflow.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/sflow.schema.yml
@@ -15,6 +15,9 @@ keys:
         type: bool
       polling_interval:
         type: int
+        convert_types:
+        - str
+        description: Polling interval in seconds
       vrfs:
         type: list
         primary_key: name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/sflow.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/sflow.schema.yml
@@ -43,7 +43,9 @@ keys:
                     - str
             source:
               type: str
-              description: Source IP Address
+              description: |
+                "Source IP Address
+                source and source_interface are mutually exclusive. If both are defined, source_interface takes precedence"
             source_interface:
               type: str
               description: Source Interface
@@ -65,7 +67,9 @@ keys:
               - str
       source:
         type: str
-        description: Source IP Address
+        description: |
+          "Source IP Address
+          source and source_interface are mutually exclusive. If both are defined, source_interface takes precedence"
       source_interface:
         type: str
         description: Source Interface

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/sflow.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/sflow.schema.yml
@@ -13,6 +13,8 @@ keys:
         - str
       dangerous:
         type: bool
+      polling_interval:
+        type: int
       vrfs:
         type: list
         primary_key: name
@@ -33,14 +35,18 @@ keys:
                 keys:
                   destination:
                     type: str
-                    description: Sflow Destination IP
+                    description: Sflow Destination IP Address
                   port:
                     type: int
                     description: Port Number
                     convert_types:
                     - str
+            source:
+              type: str
+              description: Source IP Address
             source_interface:
               type: str
+              description: Source Interface
       destinations:
         type: list
         primary_key: destination
@@ -51,14 +57,31 @@ keys:
           keys:
             destination:
               type: str
-              description: Sflow Destination IP
+              description: Sflow Destination IP Address
             port:
               type: int
               description: Port Number
               convert_types:
               - str
+      source:
+        type: str
+        description: Source IP Address
       source_interface:
         type: str
+        description: Source Interface
+      extensions:
+        type: list
+        primary_key: name
+        items:
+          type: dict
+          keys:
+            name:
+              type: str
+              description: Extension Name
+            enabled:
+              type: bool
+              description: Enable or Disable Extension
+              required: true
       interface:
         type: dict
         keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/sflow.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/sflow.schema.yml
@@ -44,8 +44,8 @@ keys:
             source:
               type: str
               description: |
-                "Source IP Address
-                source and source_interface are mutually exclusive. If both are defined, source_interface takes precedence"
+                Source IP Address.
+                "source" and "source_interface" are mutually exclusive. If both are defined, "source_interface" takes precedence.
             source_interface:
               type: str
               description: Source Interface
@@ -68,8 +68,8 @@ keys:
       source:
         type: str
         description: |
-          "Source IP Address
-          source and source_interface are mutually exclusive. If both are defined, source_interface takes precedence"
+          Source IP Address.
+          "source" and "source_interface" are mutually exclusive. If both are defined, "source_interface" takes precedence.
       source_interface:
         type: str
         description: Source Interface

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/sflow.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/sflow.j2
@@ -5,8 +5,8 @@
 ### SFlow Summary
 {%     if ((sflow.vrfs is arista.avd.defined) or (sflow.destinations is arista.avd.defined) or (sflow.source_interface is arista.avd.defined)) %}
 
-| VRF | SFlow Source Interface | SFlow Destination | Port |
-| --- | ---------------------- | ----------------- | ---- |
+| VRF | SFlow Source | SFlow Destination | Port |
+| --- | ------------ | ----------------- | ---- |
 {%         if sflow.vrfs is arista.avd.defined %}
 {%             for vrf in sflow.vrfs | arista.avd.natural_sort('name') %}
 {%                 if vrf.destinations is arista.avd.defined %}
@@ -17,6 +17,8 @@
 {%                 endif %}
 {%                 if vrf.source_interface is arista.avd.defined %}
 | {{ vrf.name }} | {{ vrf.source_interface }} | - | - |
+{%                 elif vrf.source is arista.avd.defined %}
+| {{ vrf.name }} | {{ vrf.source }} | - | - |
 {%                 endif %}
 {%             endfor %}
 {%         endif %}
@@ -28,11 +30,17 @@
 {%         endif %}
 {%         if sflow.source_interface is arista.avd.defined %}
 | default | {{ sflow.source_interface }} | - | - |
+{%         elif sflow.source is arista.avd.defined %}
+| default | {{ sflow.source }} | - | - |
 {%         endif %}
 {%     endif %}
 {%     if sflow.sample is arista.avd.defined %}
 
 sFlow Sample Rate: {{ sflow.sample }}
+{%     endif %}
+{%     if sflow.polling_interval is arista.avd.defined %}
+
+sFlow Polling Interval: {{ sflow.polling_interval }}
 {%     endif %}
 {%     if sflow.run is defined and sflow.run == true %}
 
@@ -63,6 +71,16 @@ sFlow hardware accelerated Sample Rate: {{ sflow.hardware_acceleration.sample }}
 {%             if module.name is arista.avd.defined %}
 | {{ module.name }} | {{ module.enabled | arista.avd.default(true) }} |
 {%             endif %}
+{%         endfor %}
+{%     endif %}
+{%     if sflow.extensions is arista.avd.defined %}
+
+### SFlow Extensions
+
+| Extension | Enabled |
+| --------- | ------- |
+{%         for extension in sflow.extensions | arista.avd.natural_sort('name') if extension.name is arista.avd.defined and extension.enabled is arista.avd.defined %}
+| {{ extension.name }} | {{ extension.enabled }} |
 {%         endfor %}
 {%     endif %}
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/sflow.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/sflow.j2
@@ -9,6 +9,9 @@
 {%         set sample_cli = sample_cli ~ sflow.sample %}
 {{ sample_cli }}
 {%     endif %}
+{%     if sflow.polling_interval is arista.avd.defined %}
+sflow polling-interval {{ sflow.polling_interval }}
+{%     endif %}
 {%     for vrf in sflow.vrfs | arista.avd.natural_sort('name') %}
 {%         for destination in vrf.destinations | arista.avd.natural_sort('destination') %}
 {%             set vrf_cli = "sflow vrf " ~ vrf.name ~ " destination " ~ destination.destination %}
@@ -19,6 +22,8 @@
 {%         endfor %}
 {%         if vrf.source_interface is arista.avd.defined %}
 sflow vrf {{ vrf.name }} source-interface {{ vrf.source_interface }}
+{%         elif vrf.source is arista.avd.defined %}
+sflow vrf {{ vrf.name }} source {{ vrf.source }}
 {%         endif %}
 {%     endfor %}
 {%     for destination in sflow.destinations | arista.avd.natural_sort('destination') %}
@@ -30,12 +35,23 @@ sflow vrf {{ vrf.name }} source-interface {{ vrf.source_interface }}
 {%     endfor %}
 {%     if sflow.source_interface is arista.avd.defined %}
 sflow source-interface {{ sflow.source_interface }}
+{%     elif sflow.source is arista.avd.defined %}
+sflow source {{ sflow.source }}
 {%     endif %}
-{%     if sflow.run is arista.avd.defined(true) %}
-sflow run
+{%     if sflow.extensions is arista.avd.defined %}
+{%         for extension in sflow.extensions | arista.avd.natural_sort('name') if extension.name is arista.avd.defined and extension.enabled is arista.avd.defined %}
+{%             if extension.enabled is arista.avd.defined(true) %}
+sflow extension {{ extension.name }}
+{%             else %}
+no sflow extension {{ extension.name }}
+{%             endif %}
+{%         endfor %}
 {%     endif %}
 {%     if sflow.interface.disable.default is arista.avd.defined(true) %}
 sflow interface disable default
+{%     endif %}
+{%     if sflow.run is arista.avd.defined(true) %}
+sflow run
 {%     endif %}
 {%     if sflow.hardware_acceleration.enabled is arista.avd.defined(true) %}
 sflow hardware acceleration


### PR DESCRIPTION
## Change Summary

Adding the following options for Sflow configuration:

a) SFlow source as IP under vrf and global
b) SFlow custom polling interval
c) SFlow BGP Extensions

Also reordered "sflow run" according to output in EOS cli

## Related Issue(s)

Fixes #<N/A>

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
a) and b) are self explanatory, just key: value
c)

```
sflow:
  extensions:
    - name: < ext_name >
       enabled: < true | false >
```

## How to test
Added testcases to molecule

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
