### PR TITLE
CI: Update molecule dhcp_provisioning artifacts

### DIFF
--- a/ansible_collections/arista/avd/molecule/dhcp_provisionning/intended/configs/dhcpd.conf
+++ b/ansible_collections/arista/avd/molecule/dhcp_provisionning/intended/configs/dhcpd.conf
@@ -17,7 +17,6 @@ host DC1-L2LEAF1A {
     option routers 192.168.200.5;
     option domain-name-servers 8.8.8.8, 192.168.200.5;
 }
-
 host DC1-L2LEAF2B {
     option host-name "DC1-L2LEAF2B";
     option dhcp-client-identifier 0c:1d:c0:1d:62:22;
@@ -26,7 +25,6 @@ host DC1-L2LEAF2B {
     option routers 192.168.200.5;
     option domain-name-servers 8.8.8.8, 192.168.200.5;
 }
-
 host DC1-BL1A {
     option host-name "DC1-BL1A";
     option dhcp-client-identifier 0c:1d:c0:1d:62:16;
@@ -35,7 +33,6 @@ host DC1-BL1A {
     option routers 192.168.200.5;
     option domain-name-servers 8.8.8.8, 192.168.200.5;
 }
-
 host DC1-LEAF1A {
     option host-name "DC1-LEAF1A";
     option dhcp-client-identifier 0c:1d:c0:1d:62:11;
@@ -44,7 +41,6 @@ host DC1-LEAF1A {
     option routers 192.168.200.5;
     option domain-name-servers 8.8.8.8, 192.168.200.5;
 }
-
 host DC1-LEAF2A {
     option host-name "DC1-LEAF2A";
     option dhcp-client-identifier 0c:1d:c0:1d:62:12;
@@ -53,7 +49,6 @@ host DC1-LEAF2A {
     option routers 192.168.200.5;
     option domain-name-servers 8.8.8.8, 192.168.200.5;
 }
-
 host DC1-LEAF2B {
     option host-name "DC1-LEAF2B";
     option dhcp-client-identifier 0c:1d:c0:1d:62:13;
@@ -62,7 +57,6 @@ host DC1-LEAF2B {
     option routers 192.168.200.5;
     option domain-name-servers 8.8.8.8, 192.168.200.5;
 }
-
 host DC1-SVC3A {
     option host-name "DC1-SVC3A";
     option dhcp-client-identifier 0c:1d:c0:1d:62:14;
@@ -71,7 +65,6 @@ host DC1-SVC3A {
     option routers 192.168.200.5;
     option domain-name-servers 8.8.8.8, 192.168.200.5;
 }
-
 host DC1-SVC3B {
     option host-name "DC1-SVC3B";
     option dhcp-client-identifier 0c:1d:c0:1d:62:15;
@@ -80,7 +73,6 @@ host DC1-SVC3B {
     option routers 192.168.200.5;
     option domain-name-servers 8.8.8.8, 192.168.200.5;
 }
-
 host DC1-SPINE1 {
     option host-name "DC1-SPINE1";
     option dhcp-client-identifier 0c:1d:c0:1d:62:01;
@@ -89,7 +81,6 @@ host DC1-SPINE1 {
     option routers 192.168.200.5;
     option domain-name-servers 8.8.8.8, 192.168.200.5;
 }
-
 host DC1-SPINE2 {
     option host-name "DC1-SPINE2";
     option dhcp-client-identifier 50:08:00:06:00:00;
@@ -98,7 +89,6 @@ host DC1-SPINE2 {
     option routers 192.168.200.5;
     option domain-name-servers 8.8.8.8, 192.168.200.5;
 }
-
 host DC1-SPINE3 {
     option host-name "DC1-SPINE3";
     option dhcp-client-identifier 0c:1d:c0:1d:62:03;
@@ -107,7 +97,6 @@ host DC1-SPINE3 {
     option routers 192.168.200.5;
     option domain-name-servers 8.8.8.8, 192.168.200.5;
 }
-
 host DC1-SPINE4 {
     option host-name "DC1-SPINE4";
     option dhcp-client-identifier 0c:1d:c0:1d:62:04;
@@ -116,4 +105,3 @@ host DC1-SPINE4 {
     option routers 192.168.200.5;
     option domain-name-servers 8.8.8.8, 192.168.200.5;
 }
-


### PR DESCRIPTION
## Change Summary

Update dhcp_provisionning dhcp.conf artifact caused by an update of arista.cvp to version 3.5.0

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
