### PR TITLE
Feat(eos_cli_config_gen): Support no queue-monitor length notifying

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/queue_monitor_length_notifying.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/queue_monitor_length_notifying.md
@@ -1,0 +1,91 @@
+# queue_monitor_length_notifying
+# Table of Contents
+
+- [Management](#management)
+  - [Management Interfaces](#management-interfaces)
+- [Authentication](#authentication)
+- [Monitoring](#monitoring)
+- [Internal VLAN Allocation Policy](#internal-vlan-allocation-policy)
+  - [Internal VLAN Allocation Policy Summary](#internal-vlan-allocation-policy-summary)
+- [Interfaces](#interfaces)
+- [Routing](#routing)
+  - [IP Routing](#ip-routing)
+  - [IPv6 Routing](#ipv6-routing)
+- [Multicast](#multicast)
+- [Filters](#filters)
+- [ACL](#acl)
+- [Quality Of Service](#quality-of-service)
+
+# Management
+
+## Management Interfaces
+
+### Management Interfaces Summary
+
+#### IPv4
+
+| Management Interface | description | Type | VRF | IP Address | Gateway |
+| -------------------- | ----------- | ---- | --- | ---------- | ------- |
+| Management1 | oob_management | oob | MGMT | 10.73.255.122/24 | 10.73.255.2 |
+
+#### IPv6
+
+| Management Interface | description | Type | VRF | IPv6 Address | IPv6 Gateway |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ |
+| Management1 | oob_management | oob | MGMT | - | - |
+
+### Management Interfaces Device Configuration
+
+```eos
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+```
+
+# Authentication
+
+# Monitoring
+
+# Internal VLAN Allocation Policy
+
+## Internal VLAN Allocation Policy Summary
+
+**Default Allocation Policy**
+
+| Policy Allocation | Range Beginning | Range Ending |
+| ------------------| --------------- | ------------ |
+| ascending | 1006 | 4094 |
+
+# Interfaces
+
+# Routing
+
+## IP Routing
+
+### IP Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | False |
+
+### IP Routing Device Configuration
+
+```eos
+```
+## IPv6 Routing
+
+### IPv6 Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | False |
+
+# Multicast
+
+# Filters
+
+# ACL
+
+# Quality Of Service

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/queue_monitor_length_notifying.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/queue_monitor_length_notifying.cfg
@@ -1,0 +1,18 @@
+!RANCID-CONTENT-TYPE: arista
+!
+transceiver qsfp default-mode 4x10G
+!
+queue-monitor length
+no queue-monitor length notifying
+!
+hostname queue_monitor_length_notifying
+!
+no enable password
+no aaa root
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/queue_monitor_length_notifying.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/queue_monitor_length_notifying.yml
@@ -1,0 +1,4 @@
+queue_monitor_length:
+  enabled: true
+  # test the negative case
+  notifying: false

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts.ini
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts.ini
@@ -87,6 +87,7 @@ prompt
 ptp
 qos
 queue_monitor_length
+queue_monitor_length_notifying
 queue_monitor_streaming
 redundancy
 roles

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/queue-monitor-length.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/queue-monitor-length.j2
@@ -6,6 +6,8 @@ queue-monitor length log {{ queue_monitor_length.log }}
 {%     endif %}
 {%     if queue_monitor_length.notifying is arista.avd.defined(true) %}
 queue-monitor length notifying
+{%     elif queue_monitor_length.notifying is arista.avd.defined(false) %}
+no queue-monitor length notifying
 {%     endif %}
 {%     if queue_monitor_length.cpu.thresholds.high is arista.avd.defined %}
 {%         if queue_monitor_length.cpu.thresholds.low is arista.avd.defined %}


### PR DESCRIPTION
## Change Summary

Support no queue-monitor length notifying

## Related Issue(s)

Fixes #2252 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

No changes. Added logic in jinja template to generate output for `false` condition
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

## How to test

`molecule converge -s eos_cli_config_gen -- --limit queue_monitor_length_notifying`

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
