### PR TITLE
Feat(eos_cli_config_gen): Add key_type for ntp.authentication_keys

### DIFF
--- a/ansible_collections/arista/avd/docs/release-notes/3.x.x.md
+++ b/ansible_collections/arista/avd/docs/release-notes/3.x.x.md
@@ -21,6 +21,12 @@ No changes are required for existing deployments.
   - `node_type_keys.<key>.custom_templates_extra_vars` introduced in 3.7.0 has been removed. This is non-breaking since the templating environment
   used for custom templates now supports all host and group vars by default.
 
+#### Changes to eos_cli_config_gen role
+
+- **NTP authentication keys variables:**
+
+  - `authentication_key.key_type` introduced in 3.8.0 allow you to define the authentication key type.  If the key type is not defined, the previous behavior will be preserved.  The key type will be set to 7 as default starting in 4.0.0.
+
 ### Changes to requirements
 
 - AVD now requires ansible-core from **2.11.3** to **2.12.x** excluding **2.12.0** to **2.12.5**<br>

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/dns-ntp.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/dns-ntp.md
@@ -116,7 +116,7 @@ ip domain lookup vrf mgt source-interface Management0
 
 #### NTP Authentication Keys
 
-| ID | Algoritm |
+| ID | Algorithm |
 | -- | -------- |
 | 1 | md5 |
 | 2 | sha1 |

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ntp.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ntp.md
@@ -70,22 +70,24 @@ interface Management1
 
 - Authentication enabled
 
-- Trusted Keys: 1-2
+- Trusted Keys: 1-3
 
 #### NTP Authentication Keys
 
 | ID | Algorithm |
 | -- | -------- |
 | 1 | md5 |
-| 2 | sha1 |
+| 2 | md5 |
+| 3 | sha1 |
 
 ### NTP Device Configuration
 
 ```eos
 !
 ntp authentication-key 1 md5 7 044F0E151B
-ntp authentication-key 2 sha1 8a $BYk2Sjahe+D9T7uDgIItSA==$JTw5JOAPcYEo0O2hsvsxFQ==$C7wmpXOo
-ntp trusted-key 1-2
+ntp authentication-key 2 md5 7 044F0E151B
+ntp authentication-key 3 sha1 8a $BYk2Sjahe+D9T7uDgIItSA==$JTw5JOAPcYEo0O2hsvsxFQ==$C7wmpXOo
+ntp trusted-key 1-3
 ntp authenticate
 ntp local-interface lo1
 ntp server 1.2.3.4 local-interface lo0

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ntp.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ntp.md
@@ -83,8 +83,8 @@ interface Management1
 
 ```eos
 !
-ntp authentication-key 1 md5 044F0E151B
-ntp authentication-key 2 sha1 15060E1F10
+ntp authentication-key 1 md5 7 044F0E151B
+ntp authentication-key 2 sha1 8a 15060E1F10
 ntp trusted-key 1-2
 ntp authenticate
 ntp local-interface lo1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ntp.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ntp.md
@@ -74,7 +74,7 @@ interface Management1
 
 #### NTP Authentication Keys
 
-| ID | Algoritm |
+| ID | Algorithm |
 | -- | -------- |
 | 1 | md5 |
 | 2 | sha1 |
@@ -84,7 +84,7 @@ interface Management1
 ```eos
 !
 ntp authentication-key 1 md5 7 044F0E151B
-ntp authentication-key 2 sha1 8a 15060E1F10
+ntp authentication-key 2 sha1 8a $BYk2Sjahe+D9T7uDgIItSA==$JTw5JOAPcYEo0O2hsvsxFQ==$C7wmpXOo
 ntp trusted-key 1-2
 ntp authenticate
 ntp local-interface lo1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ntp.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ntp.cfg
@@ -5,7 +5,7 @@ transceiver qsfp default-mode 4x10G
 hostname ntp
 !
 ntp authentication-key 1 md5 7 044F0E151B
-ntp authentication-key 2 sha1 8a 15060E1F10
+ntp authentication-key 2 sha1 8a $BYk2Sjahe+D9T7uDgIItSA==$JTw5JOAPcYEo0O2hsvsxFQ==$C7wmpXOo
 ntp trusted-key 1-2
 ntp authenticate
 ntp local-interface lo1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ntp.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ntp.cfg
@@ -5,8 +5,9 @@ transceiver qsfp default-mode 4x10G
 hostname ntp
 !
 ntp authentication-key 1 md5 7 044F0E151B
-ntp authentication-key 2 sha1 8a $BYk2Sjahe+D9T7uDgIItSA==$JTw5JOAPcYEo0O2hsvsxFQ==$C7wmpXOo
-ntp trusted-key 1-2
+ntp authentication-key 2 md5 7 044F0E151B
+ntp authentication-key 3 sha1 8a $BYk2Sjahe+D9T7uDgIItSA==$JTw5JOAPcYEo0O2hsvsxFQ==$C7wmpXOo
+ntp trusted-key 1-3
 ntp authenticate
 ntp local-interface lo1
 ntp server 1.2.3.4 local-interface lo0

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ntp.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ntp.cfg
@@ -4,8 +4,8 @@ transceiver qsfp default-mode 4x10G
 !
 hostname ntp
 !
-ntp authentication-key 1 md5 044F0E151B
-ntp authentication-key 2 sha1 15060E1F10
+ntp authentication-key 1 md5 7 044F0E151B
+ntp authentication-key 2 sha1 8a 15060E1F10
 ntp trusted-key 1-2
 ntp authenticate
 ntp local-interface lo1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ntp.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ntp.yml
@@ -23,6 +23,6 @@ ntp:
       key: "044F0E151B"
     - id: 2
       hash_algorithm: "sha1"
-      key: "15060E1F10"
+      key: "$BYk2Sjahe+D9T7uDgIItSA==$JTw5JOAPcYEo0O2hsvsxFQ==$C7wmpXOo"
       key_type: 8a
   trusted_keys: "1-2"

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ntp.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ntp.yml
@@ -20,9 +20,13 @@ ntp:
   authentication_keys:
     - id: 1
       hash_algorithm: "md5"
-      key: "044F0E151B"
+      key: "7 044F0E151B"
     - id: 2
+      hash_algorithm: "md5"
+      key: "044F0E151B"
+      key_type: 7
+    - id: 3
       hash_algorithm: "sha1"
       key: "$BYk2Sjahe+D9T7uDgIItSA==$JTw5JOAPcYEo0O2hsvsxFQ==$C7wmpXOo"
       key_type: 8a
-  trusted_keys: "1-2"
+  trusted_keys: "1-3"

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ntp.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ntp.yml
@@ -24,4 +24,5 @@ ntp:
     - id: 2
       hash_algorithm: "sha1"
       key: "15060E1F10"
+      key_type: 8a
   trusted_keys: "1-2"

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/ntp.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/ntp.md
@@ -74,7 +74,7 @@ interface Management1
 
 #### NTP Authentication Keys
 
-| ID | Algoritm |
+| ID | Algorithm |
 | -- | -------- |
 | 1 | md5 |
 | 2 | sha1 |

--- a/ansible_collections/arista/avd/molecule/upgrade_eos_cli_config_gen/documentation/devices/ntp.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_eos_cli_config_gen/documentation/devices/ntp.md
@@ -70,7 +70,7 @@ interface Management1
 
 #### NTP Authentication Keys
 
-| ID | Algoritm |
+| ID | Algorithm |
 | -- | -------- |
 
 ### NTP Device Configuration

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1994,7 +1994,7 @@ ntp:
     - id: < key_identifier | 1-65534 >
       hash_algorithm: < md5 | sha1 >
       key: "< obfuscated_key >"
-      key_type: < 0 | 7 | 8a | default -> 7 >
+      key_type: < 0 | 7 | 8a >
   trusted_keys: "< list of trusted-keys as string ex. 10-12,15 >"
 ```
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1993,7 +1993,8 @@ ntp:
   authentication_keys:
     - id: < key_identifier | 1-65534 >
       hash_algorithm: < md5 | sha1 >
-      key: "< type7_obfuscated_key >"
+      key: "< obfuscated_key >"
+      key_type: < 0 | 7 | 8a | default -> 7 >
   trusted_keys: "< list of trusted-keys as string ex. 10-12,15 >"
 ```
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ntp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ntp.j2
@@ -56,7 +56,7 @@
 
 #### NTP Authentication Keys
 
-| ID | Algoritm |
+| ID | Algorithm |
 | -- | -------- |
 {%         for authentication_key in ntp.authentication_keys | arista.avd.natural_sort('id') %}
 {%             if authentication_key.id is arista.avd.defined and

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ntp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ntp.j2
@@ -5,7 +5,7 @@
 {%         if authentication_key.id is arista.avd.defined and
               authentication_key.key is arista.avd.defined and
               authentication_key.hash_algorithm is arista.avd.defined %}
-{%             set ntp_auth_key_cli = "ntp authentication-key "  ~ authentication_key.id ~ " " ~ authentication_key.hash_algorithm %}
+{%             set ntp_auth_key_cli = "ntp authentication-key " ~ authentication_key.id ~ " " ~ authentication_key.hash_algorithm %}
 {%             if authentication_key.key_type is arista.avd.defined %}
 {%                 set ntp_auth_key_cli = ntp_auth_key_cli ~ " " ~ authentication_key.key_type %}
 {%             endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ntp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ntp.j2
@@ -5,7 +5,7 @@
 {%         if authentication_key.id is arista.avd.defined and
               authentication_key.key is arista.avd.defined and
               authentication_key.hash_algorithm is arista.avd.defined %}
-ntp authentication-key {{ authentication_key.id }} {{ authentication_key.hash_algorithm }} {{ authentication_key.key }}
+ntp authentication-key {{ authentication_key.id }} {{ authentication_key.hash_algorithm }} {{ authentication_key.key_type | arista.avd.default("7") }} {{ authentication_key.key }}
 {%         endif %}
 {%     endfor %}
 {%     if ntp.trusted_keys is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ntp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ntp.j2
@@ -5,7 +5,12 @@
 {%         if authentication_key.id is arista.avd.defined and
               authentication_key.key is arista.avd.defined and
               authentication_key.hash_algorithm is arista.avd.defined %}
-ntp authentication-key {{ authentication_key.id }} {{ authentication_key.hash_algorithm }} {{ authentication_key.key_type | arista.avd.default("7") }} {{ authentication_key.key }}
+{%             set ntp_auth_key_cli = "ntp authentication-key "  ~ authentication_key.id ~ " " ~ authentication_key.hash_algorithm %}
+{%             if authentication_key.key_type is arista.avd.defined %}
+{%                 set ntp_auth_key_cli = ntp_auth_key_cli ~ " " ~ authentication_key.key_type %}
+{%             endif %}
+{%             set ntp_auth_key_cli = ntp_auth_key_cli ~ " " ~ authentication_key.key %}
+{{ ntp_auth_key_cli }}
 {%         endif %}
 {%     endfor %}
 {%     if ntp.trusted_keys is arista.avd.defined %}


### PR DESCRIPTION
## Change Summary

adding key_type under ntp in eos_cli_config_gen
To prevent impact on existing implementations, the current behaviour will be preserved until AVD 4.0.0 (see release notes)
Starting with AVD 4.0.0, if no key type is defined, type 7 will be default.

## Related Issue(s)

Fixes #2211 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Add a variable to define ntp encryption key type and define with type 7, 8a and no key for ntp authentication keys

example ( key 1 will use no key (old behaviour), key 2 type 7 and key 3 type 8a)
```yaml
  authentication_keys:
    - id: 1
      hash_algorithm: "md5"
      key: "7 044F0E151B"
    - id: 2
      hash_algorithm: "md5"
      key: "044F0E151B"
      key_type: 7
    - id: 3
      hash_algorithm: "sha1"
      key: "$BYk2Sjahe+D9T7uDgIItSA==$JTw5JOAPcYEo0O2hsvsxFQ==$C7wmpXOo"
      key_type: 8a
```

## How to test

tested without key_type set to confirm type 7 is used and test with other values

output in molecule:
```eos
ntp authentication-key 1 md5 7 044F0E151B
ntp authentication-key 2 md5 7 044F0E151B
ntp authentication-key 3 sha1 8a $BYk2Sjahe+D9T7uDgIItSA==$JTw5JOAPcYEo0O2hsvsxFQ==$C7wmpXOo

```

## Checklist

### User Checklist

- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
