### PR TITLE
Fix(eos_validate_state): Always create directory for reports

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/main.yml
@@ -20,6 +20,8 @@
     - "{{ eos_validate_state_dir }}"
   delegate_to: localhost
   run_once: true
+  tags:
+    - always
 
 - name: Include device intended structure configuration variables
   include_vars: "{{ filename }}"


### PR DESCRIPTION
## Change Summary

Currently there is a bug in `eos_validate_state` where if the task is called with any of the tags *and* the directory for the reports does not yet exists, it is not created. This results in the play failing when the vars need to be created in that directory. 

This Pul Requests adds the following line to always run the task to create the directory, irrelevant what tags are supplied at runtime. 
```yaml
tags:
  - always
```

## Related Issue(s)

No issues had been raised about this. 

## Component(s) name

`arista.avd.eos_validate_state`

## Proposed changes

This change will make sure the task `Create required output directories if not present` is always run, even when tags are used to just run subsets of tests. 

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

1. Delete any directory previously used for reports (example: `inventory/reports`)
2. Run the playbook that uses `eos_validate_state` with some tags. Example:

```shell
ansible-playbook <playbook_name>.yml --tags interfaces_state -i <inventory>.yml
```

3. The directory where reports are save should be created.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
