### PR TITLE
Feat(eos_cli_config_gen): Add "bfd" key to router_pim_sparse_mode

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-pim-sparse-mode.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-pim-sparse-mode.md
@@ -91,7 +91,7 @@ interface Management1
 
 #### IP Sparse Mode Information
 
-BFD enabled: False
+BFD enabled: True
 
 ##### IP Rendezvous Information
 
@@ -107,7 +107,10 @@ BFD enabled: False
 
 ##### IP Sparse Mode VRFs
 
-BFD enabled: False
+| VRF Name | BFD Enabled | 
+| -------- | ----------- | 
+| MCAST_VRF1 | True |
+| MCAST_VRF2_ALL_GROUPS | False |
 
 | VRF Name | Rendezvous Point Address | Group Address |
 | -------- | ------------------------ | ------------- |

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-pim-sparse-mode.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-pim-sparse-mode.md
@@ -107,8 +107,8 @@ BFD enabled: True
 
 ##### IP Sparse Mode VRFs
 
-| VRF Name | BFD Enabled | 
-| -------- | ----------- | 
+| VRF Name | BFD Enabled |
+| -------- | ----------- |
 | MCAST_VRF1 | True |
 | MCAST_VRF2_ALL_GROUPS | False |
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-pim-sparse-mode.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-pim-sparse-mode.md
@@ -91,6 +91,8 @@ interface Management1
 
 #### IP Sparse Mode Information
 
+BFD enabled: False
+
 ##### IP Rendezvous Information
 
 | Rendezvous Point Address | Group Address |
@@ -105,6 +107,8 @@ interface Management1
 
 ##### IP Sparse Mode VRFs
 
+BFD enabled: False
+
 | VRF Name | Rendezvous Point Address | Group Address |
 | -------- | ------------------------ | ------------- |
 | MCAST_VRF1 | 10.238.2.161 | 239.12.22.12/32, 239.12.22.13/32, 239.12.22.14/32 |
@@ -116,6 +120,7 @@ interface Management1
 !
 router pim sparse-mode
    ipv4
+      bfd
       rp address 10.238.1.161 239.12.12.12/32
       rp address 10.238.1.161 239.12.12.13/32
       rp address 10.238.1.161 239.12.12.14/32
@@ -127,6 +132,7 @@ router pim sparse-mode
    !
    vrf MCAST_VRF1
       ipv4
+         bfd
          rp address 10.238.2.161 239.12.22.12/32
          rp address 10.238.2.161 239.12.22.13/32
          rp address 10.238.2.161 239.12.22.14/32

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-pim-sparse-mode.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-pim-sparse-mode.cfg
@@ -14,6 +14,7 @@ interface Management1
 !
 router pim sparse-mode
    ipv4
+      bfd
       rp address 10.238.1.161 239.12.12.12/32
       rp address 10.238.1.161 239.12.12.13/32
       rp address 10.238.1.161 239.12.12.14/32
@@ -25,6 +26,7 @@ router pim sparse-mode
    !
    vrf MCAST_VRF1
       ipv4
+         bfd
          rp address 10.238.2.161 239.12.22.12/32
          rp address 10.238.2.161 239.12.22.13/32
          rp address 10.238.2.161 239.12.22.14/32

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-pim-sparse-mode.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-pim-sparse-mode.yml
@@ -2,6 +2,7 @@
 
 router_pim_sparse_mode:
   ipv4:
+    bfd: true
     rp_addresses:
       10.238.1.161:
         groups:
@@ -20,6 +21,7 @@ router_pim_sparse_mode:
   vrfs:
     - name: MCAST_VRF1
       ipv4:
+        bfd: true
         rp_addresses:
           - address: 10.238.2.161
             groups:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/router-pim-sparse-mode.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/router-pim-sparse-mode.md
@@ -107,8 +107,8 @@ BFD enabled: False
 
 ##### IP Sparse Mode VRFs
 
-| VRF Name | BFD Enabled | 
-| -------- | ----------- | 
+| VRF Name | BFD Enabled |
+| -------- | ----------- |
 | MCAST_VRF1 | False |
 | MCAST_VRF2_ALL_GROUPS | False |
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/router-pim-sparse-mode.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/router-pim-sparse-mode.md
@@ -107,7 +107,10 @@ BFD enabled: False
 
 ##### IP Sparse Mode VRFs
 
-BFD enabled: False
+| VRF Name | BFD Enabled | 
+| -------- | ----------- | 
+| MCAST_VRF1 | False |
+| MCAST_VRF2_ALL_GROUPS | False |
 
 | VRF Name | Rendezvous Point Address | Group Address |
 | -------- | ------------------------ | ------------- |

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/router-pim-sparse-mode.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/router-pim-sparse-mode.md
@@ -91,6 +91,8 @@ interface Management1
 
 #### IP Sparse Mode Information
 
+BFD enabled: False
+
 ##### IP Rendezvous Information
 
 | Rendezvous Point Address | Group Address |
@@ -104,6 +106,8 @@ interface Management1
 | 10.38.1.161 | 10.50.64.16 | 15 |
 
 ##### IP Sparse Mode VRFs
+
+BFD enabled: False
 
 | VRF Name | Rendezvous Point Address | Group Address |
 | -------- | ------------------------ | ------------- |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -2098,6 +2098,7 @@ router_multicast:
 ```yaml
 router_pim_sparse_mode:
   ipv4:
+    bfd: < true | false >
     ssm_range: < range >
     rp_addresses:
       < rp_address_1 >:
@@ -2113,6 +2114,7 @@ router_pim_sparse_mode:
   vrfs:
     - name: < vrf_name >
       ipv4:
+        bfd: < true | false >
         rp_addresses:
           - address: < rp_address_1 >
             groups:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
@@ -1922,6 +1922,7 @@ router_multicast:
 ```yaml
 router_pim_sparse_mode:
   ipv4:
+    bfd: < true | false >
     ssm_range: < range >
     rp_addresses:
       - address: < rp_address_1 >
@@ -1937,6 +1938,7 @@ router_pim_sparse_mode:
   vrfs:
     - name: < vrf_name >
       ipv4:
+        bfd: < true | false >
         rp_addresses:
           - address: < rp_address_1 >
             groups:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -3326,6 +3326,7 @@ router_ospf:
 | -------- | ---- | -------- | ------- | ------------------ | ----------- |
 | [<samp>router_pim_sparse_mode</samp>](## "router_pim_sparse_mode") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;ipv4</samp>](## "router_pim_sparse_mode.ipv4") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;bfd</samp>](## "router_pim_sparse_mode.ipv4.bfd") | Boolean |  |  |  | Enable/Disable BFD |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ssm_range</samp>](## "router_pim_sparse_mode.ipv4.ssm_range") | String |  |  |  | IPv4 Prefix associated with SSM |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;rp_addresses</samp>](## "router_pim_sparse_mode.ipv4.rp_addresses") | List, items: Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- address</samp>](## "router_pim_sparse_mode.ipv4.rp_addresses.[].address") | String | Required, Unique |  |  | RP Address |
@@ -3339,6 +3340,7 @@ router_ospf:
 | [<samp>&nbsp;&nbsp;vrfs</samp>](## "router_pim_sparse_mode.vrfs") | List, items: Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "router_pim_sparse_mode.vrfs.[].name") | String |  |  |  | VRF Name |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4</samp>](## "router_pim_sparse_mode.vrfs.[].ipv4") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bfd</samp>](## "router_pim_sparse_mode.vrfs.[].ipv4.bfd") | Boolean |  |  |  | Enable/Disable BFD |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rp_addresses</samp>](## "router_pim_sparse_mode.vrfs.[].ipv4.rp_addresses") | List, items: Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- address</samp>](## "router_pim_sparse_mode.vrfs.[].ipv4.rp_addresses.[].address") | String |  |  |  | RP Address |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;groups</samp>](## "router_pim_sparse_mode.vrfs.[].ipv4.rp_addresses.[].groups") | List, items: String |  |  |  |  |
@@ -3349,6 +3351,7 @@ router_ospf:
 ```yaml
 router_pim_sparse_mode:
   ipv4:
+    bfd: <bool>
     ssm_range: <str>
     rp_addresses:
       - address: <str>
@@ -3362,6 +3365,7 @@ router_pim_sparse_mode:
   vrfs:
     - name: <str>
       ipv4:
+        bfd: <bool>
         rp_addresses:
           - address: <str>
             groups:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -6168,6 +6168,11 @@
         "ipv4": {
           "type": "object",
           "properties": {
+            "bfd": {
+              "type": "boolean",
+              "description": "Enable/Disable BFD",
+              "title": "BFD"
+            },
             "ssm_range": {
               "type": "string",
               "description": "IPv4 Prefix associated with SSM",
@@ -6255,6 +6260,11 @@
               "ipv4": {
                 "type": "object",
                 "properties": {
+                  "bfd": {
+                    "type": "boolean",
+                    "description": "Enable/Disable BFD",
+                    "title": "BFD"
+                  },
                   "rp_addresses": {
                     "type": "array",
                     "items": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -4294,6 +4294,9 @@ keys:
       ipv4:
         type: dict
         keys:
+          bfd:
+            type: bool
+            description: Enable/Disable BFD
           ssm_range:
             type: str
             description: IPv4 Prefix associated with SSM
@@ -4354,6 +4357,9 @@ keys:
             ipv4:
               type: dict
               keys:
+                bfd:
+                  type: bool
+                  description: Enable/Disable BFD
                 rp_addresses:
                   type: list
                   items:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_pim_sparse_mode.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_pim_sparse_mode.schema.yml
@@ -9,6 +9,9 @@ keys:
       ipv4:
         type: dict
         keys:
+          bfd:
+            type: bool
+            description: Enable/Disable BFD
           ssm_range:
             type: str
             description: IPv4 Prefix associated with SSM
@@ -69,6 +72,9 @@ keys:
             ipv4:
               type: dict
               keys:
+                bfd:
+                  type: bool
+                  description: Enable/Disable BFD
                 rp_addresses:
                   type: list
                   items:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-pim-sparse-mode.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-pim-sparse-mode.j2
@@ -36,8 +36,8 @@ BFD enabled: {{ router_pim_sparse_mode.ipv4.bfd | arista.avd.default(false) }}
 
 ##### IP Sparse Mode VRFs
 
-| VRF Name | BFD Enabled | 
-| -------- | ----------- | 
+| VRF Name | BFD Enabled |
+| -------- | ----------- |
 {%         for vrf in router_pim_sparse_mode.vrfs | arista.avd.natural_sort('name') %}
 | {{ vrf.name }} | {{ vrf.ipv4.bfd | arista.avd.default(false) }} |
 {%         endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-pim-sparse-mode.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-pim-sparse-mode.j2
@@ -7,6 +7,8 @@
 {%     if router_pim_sparse_mode.ipv4 is arista.avd.defined %}
 {%         if router_pim_sparse_mode.ipv4.rp_addresses is arista.avd.defined %}
 
+BFD enabled: {{ router_pim_sparse_mode.bfd | arista.avd.default(false) }}
+
 ##### IP Rendezvous Information
 
 | Rendezvous Point Address | Group Address |
@@ -33,6 +35,8 @@
 {%     if router_pim_sparse_mode.vrfs is arista.avd.defined %}
 
 ##### IP Sparse Mode VRFs
+
+BFD enabled: {{ router_pim_sparse_mode.bfd | arista.avd.default(false) }}
 
 | VRF Name | Rendezvous Point Address | Group Address |
 | -------- | ------------------------ | ------------- |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-pim-sparse-mode.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-pim-sparse-mode.j2
@@ -5,9 +5,9 @@
 
 #### IP Sparse Mode Information
 {%     if router_pim_sparse_mode.ipv4 is arista.avd.defined %}
-{%         if router_pim_sparse_mode.ipv4.rp_addresses is arista.avd.defined %}
 
-BFD enabled: {{ router_pim_sparse_mode.bfd | arista.avd.default(false) }}
+BFD enabled: {{ router_pim_sparse_mode.ipv4.bfd | arista.avd.default(false) }}
+{%         if router_pim_sparse_mode.ipv4.rp_addresses is arista.avd.defined %}
 
 ##### IP Rendezvous Information
 
@@ -36,7 +36,11 @@ BFD enabled: {{ router_pim_sparse_mode.bfd | arista.avd.default(false) }}
 
 ##### IP Sparse Mode VRFs
 
-BFD enabled: {{ router_pim_sparse_mode.bfd | arista.avd.default(false) }}
+| VRF Name | BFD Enabled | 
+| -------- | ----------- | 
+{%         for vrf in router_pim_sparse_mode.vrfs | arista.avd.natural_sort('name') %}
+| {{ vrf.name }} | {{ vrf.ipv4.bfd | arista.avd.default(false) }} |
+{%         endfor %}
 
 | VRF Name | Rendezvous Point Address | Group Address |
 | -------- | ------------------------ | ------------- |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-pim-sparse-mode.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-pim-sparse-mode.j2
@@ -4,6 +4,9 @@
 router pim sparse-mode
 {%     if router_pim_sparse_mode.ipv4 is arista.avd.defined %}
    ipv4
+{%         if router_pim_sparse_mode.ipv4.bfd is arista.avd.defined(true) %}
+      bfd
+{%         endif %}
 {%         for rp_address in router_pim_sparse_mode.ipv4.rp_addresses | arista.avd.natural_sort('address') %}
 {%             if rp_address.groups is arista.avd.defined %}
 {%                 for group in rp_address.groups | arista.avd.natural_sort %}
@@ -31,6 +34,9 @@ router pim sparse-mode
    vrf {{ vrf.name }}
 {%         if vrf.ipv4 is arista.avd.defined %}
       ipv4
+{%             if vrf.ipv4.bfd is arista.avd.defined(true) %}
+         bfd
+{%             endif %}
 {%             for rp_address in vrf.ipv4.rp_addresses | arista.avd.natural_sort('address') %}
 {%                 if rp_address.groups is arista.avd.defined %}
 {%                     for group in rp_address.groups | arista.avd.natural_sort %}


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Enable support for enabling / disabling bfd under the `router_pim_sparse_mode` datamodel (globally or inside VRF)

## Related Issue(s)

Fixes #2255 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->
Added simple `bfd` boolean key to the data structure

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
See molecule test results

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
