### PR TITLE
Feat(eos_designs): Add support for setting node_type by matching regexes against the hostname

### DIFF
--- a/.github/.markdownlintignore
+++ b/.github/.markdownlintignore
@@ -2,3 +2,4 @@ ansible_collections/arista/avd/molecule/
 ansible_collections/arista/avd/examples/*/documentation/
 ansible_collections/arista/avd/tests/unit/filters/toc_files/
 ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input\ Variables.md
+ansible_collections/arista/avd/roles/eos_designs/docs/Input\ Variables.md

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_NODE_TYPE_LEAF01.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_NODE_TYPE_LEAF01.cfg
@@ -1,0 +1,113 @@
+!RANCID-CONTENT-TYPE: arista
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname AUTO_NODE_TYPE_LEAF01
+!
+spanning-tree mode mstp
+spanning-tree mst 0 priority 4096
+!
+no enable password
+no aaa root
+!
+vrf instance MGMT
+!
+interface Ethernet1
+   description P2P_LINK_TO_AUTO_NODE_TYPE_SPINE01_Ethernet1
+   no shutdown
+   mtu 9000
+   no switchport
+   ip address 172.31.255.1/31
+!
+interface Ethernet2
+   description P2P_LINK_TO_AUTO_NODE_TYPE_SPINE02_Ethernet1
+   no shutdown
+   mtu 9000
+   no switchport
+   ip address 172.31.255.3/31
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 192.168.255.3/32
+!
+interface Loopback1
+   description VTEP_VXLAN_Tunnel_Source
+   no shutdown
+   ip address 192.168.254.3/32
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 192.168.203.12/24
+!
+interface Vxlan1
+   description AUTO_NODE_TYPE_LEAF01_VTEP
+   vxlan source-interface Loopback1
+   vxlan udp-port 4789
+!
+ip virtual-router mac-address 00:dc:00:00:00:0a
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+   seq 20 permit 192.168.254.0/24 eq 32
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.203.1
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+router bfd
+   multihop interval 300 min-rx 300 multiplier 3
+!
+router bgp 65101
+   router-id 192.168.255.3
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
+   maximum-paths 4 ecmp 4
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor IPv4-UNDERLAY-PEERS peer group
+   neighbor IPv4-UNDERLAY-PEERS send-community
+   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   neighbor 172.31.255.0 peer group IPv4-UNDERLAY-PEERS
+   neighbor 172.31.255.0 remote-as 65100
+   neighbor 172.31.255.0 description AUTO_NODE_TYPE_SPINE01_Ethernet1
+   neighbor 172.31.255.2 peer group IPv4-UNDERLAY-PEERS
+   neighbor 172.31.255.2 remote-as 65100
+   neighbor 172.31.255.2 description AUTO_NODE_TYPE_SPINE02_Ethernet1
+   neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.1 remote-as 65100
+   neighbor 192.168.255.1 description AUTO_NODE_TYPE_SPINE01
+   neighbor 192.168.255.2 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.2 remote-as 65100
+   neighbor 192.168.255.2 description AUTO_NODE_TYPE_SPINE02
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   address-family evpn
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor IPv4-UNDERLAY-PEERS activate
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_NODE_TYPE_SPINE01.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_NODE_TYPE_SPINE01.cfg
@@ -1,0 +1,100 @@
+!RANCID-CONTENT-TYPE: arista
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname AUTO_NODE_TYPE_SPINE01
+!
+spanning-tree mode none
+!
+no enable password
+no aaa root
+!
+vrf instance MGMT
+!
+interface Ethernet1
+   description P2P_LINK_TO_AUTO_NODE_TYPE_LEAF01_Ethernet1
+   no shutdown
+   mtu 9000
+   no switchport
+   ip address 172.31.255.0/31
+!
+interface Ethernet2
+   description P2P_LINK_TO_AUTO_NODE_TYPE_UNGROUPED_LEAF02_Ethernet1
+   no shutdown
+   mtu 9000
+   no switchport
+   ip address 172.31.255.4/31
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 192.168.255.1/32
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 192.168.203.10
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.203.1
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+router bfd
+   multihop interval 300 min-rx 300 multiplier 3
+!
+router bgp 65100
+   router-id 192.168.255.1
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
+   maximum-paths 4 ecmp 4
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor IPv4-UNDERLAY-PEERS peer group
+   neighbor IPv4-UNDERLAY-PEERS send-community
+   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   neighbor 172.31.255.1 peer group IPv4-UNDERLAY-PEERS
+   neighbor 172.31.255.1 remote-as 65101
+   neighbor 172.31.255.1 description AUTO_NODE_TYPE_LEAF01_Ethernet1
+   neighbor 172.31.255.5 peer group IPv4-UNDERLAY-PEERS
+   neighbor 172.31.255.5 remote-as 65102
+   neighbor 172.31.255.5 description AUTO_NODE_TYPE_UNGROUPED_LEAF02_Ethernet1
+   neighbor 192.168.255.3 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.3 remote-as 65101
+   neighbor 192.168.255.3 description AUTO_NODE_TYPE_LEAF01
+   neighbor 192.168.255.4 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.4 remote-as 65102
+   neighbor 192.168.255.4 description AUTO_NODE_TYPE_UNGROUPED_LEAF02
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   address-family evpn
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor IPv4-UNDERLAY-PEERS activate
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_NODE_TYPE_SPINE02.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_NODE_TYPE_SPINE02.cfg
@@ -1,0 +1,100 @@
+!RANCID-CONTENT-TYPE: arista
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname AUTO_NODE_TYPE_SPINE02
+!
+spanning-tree mode none
+!
+no enable password
+no aaa root
+!
+vrf instance MGMT
+!
+interface Ethernet1
+   description P2P_LINK_TO_AUTO_NODE_TYPE_LEAF01_Ethernet2
+   no shutdown
+   mtu 9000
+   no switchport
+   ip address 172.31.255.2/31
+!
+interface Ethernet2
+   description P2P_LINK_TO_AUTO_NODE_TYPE_UNGROUPED_LEAF02_Ethernet2
+   no shutdown
+   mtu 9000
+   no switchport
+   ip address 172.31.255.6/31
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 192.168.255.2/32
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 192.168.203.11
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.203.1
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+router bfd
+   multihop interval 300 min-rx 300 multiplier 3
+!
+router bgp 65100
+   router-id 192.168.255.2
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
+   maximum-paths 4 ecmp 4
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor IPv4-UNDERLAY-PEERS peer group
+   neighbor IPv4-UNDERLAY-PEERS send-community
+   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   neighbor 172.31.255.3 peer group IPv4-UNDERLAY-PEERS
+   neighbor 172.31.255.3 remote-as 65101
+   neighbor 172.31.255.3 description AUTO_NODE_TYPE_LEAF01_Ethernet2
+   neighbor 172.31.255.7 peer group IPv4-UNDERLAY-PEERS
+   neighbor 172.31.255.7 remote-as 65102
+   neighbor 172.31.255.7 description AUTO_NODE_TYPE_UNGROUPED_LEAF02_Ethernet2
+   neighbor 192.168.255.3 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.3 remote-as 65101
+   neighbor 192.168.255.3 description AUTO_NODE_TYPE_LEAF01
+   neighbor 192.168.255.4 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.4 remote-as 65102
+   neighbor 192.168.255.4 description AUTO_NODE_TYPE_UNGROUPED_LEAF02
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   address-family evpn
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor IPv4-UNDERLAY-PEERS activate
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_NODE_TYPE_UNGROUPED_LEAF02.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_NODE_TYPE_UNGROUPED_LEAF02.cfg
@@ -1,0 +1,113 @@
+!RANCID-CONTENT-TYPE: arista
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname AUTO_NODE_TYPE_UNGROUPED_LEAF02
+!
+spanning-tree mode mstp
+spanning-tree mst 0 priority 4096
+!
+no enable password
+no aaa root
+!
+vrf instance MGMT
+!
+interface Ethernet1
+   description P2P_LINK_TO_AUTO_NODE_TYPE_SPINE01_Ethernet2
+   no shutdown
+   mtu 9000
+   no switchport
+   ip address 172.31.255.5/31
+!
+interface Ethernet2
+   description P2P_LINK_TO_AUTO_NODE_TYPE_SPINE02_Ethernet2
+   no shutdown
+   mtu 9000
+   no switchport
+   ip address 172.31.255.7/31
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 192.168.255.4/32
+!
+interface Loopback1
+   description VTEP_VXLAN_Tunnel_Source
+   no shutdown
+   ip address 192.168.254.4/32
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 192.168.203.13/24
+!
+interface Vxlan1
+   description AUTO_NODE_TYPE_UNGROUPED_LEAF02_VTEP
+   vxlan source-interface Loopback1
+   vxlan udp-port 4789
+!
+ip virtual-router mac-address 00:dc:00:00:00:0a
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+   seq 20 permit 192.168.254.0/24 eq 32
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.203.1
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+router bfd
+   multihop interval 300 min-rx 300 multiplier 3
+!
+router bgp 65102
+   router-id 192.168.255.4
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
+   maximum-paths 4 ecmp 4
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor IPv4-UNDERLAY-PEERS peer group
+   neighbor IPv4-UNDERLAY-PEERS send-community
+   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   neighbor 172.31.255.4 peer group IPv4-UNDERLAY-PEERS
+   neighbor 172.31.255.4 remote-as 65100
+   neighbor 172.31.255.4 description AUTO_NODE_TYPE_SPINE01_Ethernet2
+   neighbor 172.31.255.6 peer group IPv4-UNDERLAY-PEERS
+   neighbor 172.31.255.6 remote-as 65100
+   neighbor 172.31.255.6 description AUTO_NODE_TYPE_SPINE02_Ethernet2
+   neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.1 remote-as 65100
+   neighbor 192.168.255.1 description AUTO_NODE_TYPE_SPINE01
+   neighbor 192.168.255.2 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.2 remote-as 65100
+   neighbor 192.168.255.2 description AUTO_NODE_TYPE_SPINE02
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   address-family evpn
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor IPv4-UNDERLAY-PEERS activate
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_NODE_TYPE_LEAF01.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_NODE_TYPE_LEAF01.yml
@@ -1,0 +1,136 @@
+router_bgp:
+  as: '65101'
+  router_id: 192.168.255.3
+  bgp_defaults:
+  - no bgp default ipv4-unicast
+  - distance bgp 20 200 200
+  - maximum-paths 4 ecmp 4
+  peer_groups:
+    IPv4-UNDERLAY-PEERS:
+      type: ipv4
+      maximum_routes: 12000
+      send_community: all
+    EVPN-OVERLAY-PEERS:
+      type: evpn
+      update_source: Loopback0
+      bfd: true
+      ebgp_multihop: '3'
+      send_community: all
+      maximum_routes: 0
+  address_family_ipv4:
+    peer_groups:
+      IPv4-UNDERLAY-PEERS:
+        activate: true
+      EVPN-OVERLAY-PEERS:
+        activate: false
+  redistribute_routes:
+    connected:
+      route_map: RM-CONN-2-BGP
+  neighbors:
+    172.31.255.0:
+      peer_group: IPv4-UNDERLAY-PEERS
+      remote_as: '65100'
+      description: AUTO_NODE_TYPE_SPINE01_Ethernet1
+    172.31.255.2:
+      peer_group: IPv4-UNDERLAY-PEERS
+      remote_as: '65100'
+      description: AUTO_NODE_TYPE_SPINE02_Ethernet1
+    192.168.255.1:
+      peer_group: EVPN-OVERLAY-PEERS
+      description: AUTO_NODE_TYPE_SPINE01
+      remote_as: '65100'
+    192.168.255.2:
+      peer_group: EVPN-OVERLAY-PEERS
+      description: AUTO_NODE_TYPE_SPINE02
+      remote_as: '65100'
+  address_family_evpn:
+    peer_groups:
+      EVPN-OVERLAY-PEERS:
+        activate: true
+static_routes:
+- vrf: MGMT
+  destination_address_prefix: 0.0.0.0/0
+  gateway: 192.168.203.1
+service_routing_protocols_model: multi-agent
+ip_routing: true
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+spanning_tree:
+  mode: mstp
+  mst_instances:
+    '0':
+      priority: 4096
+vrfs:
+  MGMT:
+    ip_routing: false
+management_interfaces:
+  Management1:
+    description: oob_management
+    shutdown: false
+    vrf: MGMT
+    ip_address: 192.168.203.12/24
+    gateway: 192.168.203.1
+    type: oob
+management_api_http:
+  enable_vrfs:
+    MGMT: {}
+  enable_https: true
+ethernet_interfaces:
+  Ethernet1:
+    peer: AUTO_NODE_TYPE_SPINE01
+    peer_interface: Ethernet1
+    peer_type: spine
+    description: P2P_LINK_TO_AUTO_NODE_TYPE_SPINE01_Ethernet1
+    mtu: 9000
+    type: routed
+    shutdown: false
+    ip_address: 172.31.255.1/31
+  Ethernet2:
+    peer: AUTO_NODE_TYPE_SPINE02
+    peer_interface: Ethernet1
+    peer_type: spine
+    description: P2P_LINK_TO_AUTO_NODE_TYPE_SPINE02_Ethernet1
+    mtu: 9000
+    type: routed
+    shutdown: false
+    ip_address: 172.31.255.3/31
+loopback_interfaces:
+  Loopback0:
+    description: EVPN_Overlay_Peering
+    shutdown: false
+    ip_address: 192.168.255.3/32
+  Loopback1:
+    description: VTEP_VXLAN_Tunnel_Source
+    shutdown: false
+    ip_address: 192.168.254.3/32
+prefix_lists:
+  PL-LOOPBACKS-EVPN-OVERLAY:
+    sequence_numbers:
+      10:
+        action: permit 192.168.255.0/24 eq 32
+      20:
+        action: permit 192.168.254.0/24 eq 32
+route_maps:
+  RM-CONN-2-BGP:
+    sequence_numbers:
+      10:
+        type: permit
+        match:
+        - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+router_bfd:
+  multihop:
+    interval: 300
+    min_rx: 300
+    multiplier: 3
+ip_igmp_snooping:
+  globally_enabled: true
+ip_virtual_router_mac_address: 00:dc:00:00:00:0a
+vxlan_interface:
+  Vxlan1:
+    description: AUTO_NODE_TYPE_LEAF01_VTEP
+    vxlan:
+      source_interface: Loopback1
+      udp_port: 4789

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_NODE_TYPE_LEAF01.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_NODE_TYPE_LEAF01.yml
@@ -132,5 +132,5 @@ vxlan_interface:
   Vxlan1:
     description: AUTO_NODE_TYPE_LEAF01_VTEP
     vxlan:
-      source_interface: Loopback1
       udp_port: 4789
+      source_interface: Loopback1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_NODE_TYPE_SPINE01.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_NODE_TYPE_SPINE01.yml
@@ -1,0 +1,119 @@
+router_bgp:
+  as: '65100'
+  router_id: 192.168.255.1
+  bgp_defaults:
+  - no bgp default ipv4-unicast
+  - distance bgp 20 200 200
+  - maximum-paths 4 ecmp 4
+  peer_groups:
+    IPv4-UNDERLAY-PEERS:
+      type: ipv4
+      maximum_routes: 12000
+      send_community: all
+    EVPN-OVERLAY-PEERS:
+      type: evpn
+      update_source: Loopback0
+      bfd: true
+      ebgp_multihop: '3'
+      send_community: all
+      maximum_routes: 0
+      next_hop_unchanged: true
+  address_family_ipv4:
+    peer_groups:
+      IPv4-UNDERLAY-PEERS:
+        activate: true
+      EVPN-OVERLAY-PEERS:
+        activate: false
+  redistribute_routes:
+    connected:
+      route_map: RM-CONN-2-BGP
+  neighbors:
+    172.31.255.1:
+      peer_group: IPv4-UNDERLAY-PEERS
+      remote_as: '65101'
+      description: AUTO_NODE_TYPE_LEAF01_Ethernet1
+    172.31.255.5:
+      peer_group: IPv4-UNDERLAY-PEERS
+      remote_as: '65102'
+      description: AUTO_NODE_TYPE_UNGROUPED_LEAF02_Ethernet1
+    192.168.255.3:
+      peer_group: EVPN-OVERLAY-PEERS
+      description: AUTO_NODE_TYPE_LEAF01
+      remote_as: '65101'
+    192.168.255.4:
+      peer_group: EVPN-OVERLAY-PEERS
+      description: AUTO_NODE_TYPE_UNGROUPED_LEAF02
+      remote_as: '65102'
+  address_family_evpn:
+    peer_groups:
+      EVPN-OVERLAY-PEERS:
+        activate: true
+static_routes:
+- vrf: MGMT
+  destination_address_prefix: 0.0.0.0/0
+  gateway: 192.168.203.1
+service_routing_protocols_model: multi-agent
+ip_routing: true
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+spanning_tree:
+  mode: none
+vrfs:
+  MGMT:
+    ip_routing: false
+management_interfaces:
+  Management1:
+    description: oob_management
+    shutdown: false
+    vrf: MGMT
+    ip_address: 192.168.203.10
+    gateway: 192.168.203.1
+    type: oob
+management_api_http:
+  enable_vrfs:
+    MGMT: {}
+  enable_https: true
+ethernet_interfaces:
+  Ethernet1:
+    peer: AUTO_NODE_TYPE_LEAF01
+    peer_interface: Ethernet1
+    peer_type: l3leaf
+    description: P2P_LINK_TO_AUTO_NODE_TYPE_LEAF01_Ethernet1
+    mtu: 9000
+    type: routed
+    shutdown: false
+    ip_address: 172.31.255.0/31
+  Ethernet2:
+    peer: AUTO_NODE_TYPE_UNGROUPED_LEAF02
+    peer_interface: Ethernet1
+    peer_type: l3leaf
+    description: P2P_LINK_TO_AUTO_NODE_TYPE_UNGROUPED_LEAF02_Ethernet1
+    mtu: 9000
+    type: routed
+    shutdown: false
+    ip_address: 172.31.255.4/31
+loopback_interfaces:
+  Loopback0:
+    description: EVPN_Overlay_Peering
+    shutdown: false
+    ip_address: 192.168.255.1/32
+prefix_lists:
+  PL-LOOPBACKS-EVPN-OVERLAY:
+    sequence_numbers:
+      10:
+        action: permit 192.168.255.0/24 eq 32
+route_maps:
+  RM-CONN-2-BGP:
+    sequence_numbers:
+      10:
+        type: permit
+        match:
+        - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+router_bfd:
+  multihop:
+    interval: 300
+    min_rx: 300
+    multiplier: 3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_NODE_TYPE_SPINE02.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_NODE_TYPE_SPINE02.yml
@@ -1,0 +1,119 @@
+router_bgp:
+  as: '65100'
+  router_id: 192.168.255.2
+  bgp_defaults:
+  - no bgp default ipv4-unicast
+  - distance bgp 20 200 200
+  - maximum-paths 4 ecmp 4
+  peer_groups:
+    IPv4-UNDERLAY-PEERS:
+      type: ipv4
+      maximum_routes: 12000
+      send_community: all
+    EVPN-OVERLAY-PEERS:
+      type: evpn
+      update_source: Loopback0
+      bfd: true
+      ebgp_multihop: '3'
+      send_community: all
+      maximum_routes: 0
+      next_hop_unchanged: true
+  address_family_ipv4:
+    peer_groups:
+      IPv4-UNDERLAY-PEERS:
+        activate: true
+      EVPN-OVERLAY-PEERS:
+        activate: false
+  redistribute_routes:
+    connected:
+      route_map: RM-CONN-2-BGP
+  neighbors:
+    172.31.255.3:
+      peer_group: IPv4-UNDERLAY-PEERS
+      remote_as: '65101'
+      description: AUTO_NODE_TYPE_LEAF01_Ethernet2
+    172.31.255.7:
+      peer_group: IPv4-UNDERLAY-PEERS
+      remote_as: '65102'
+      description: AUTO_NODE_TYPE_UNGROUPED_LEAF02_Ethernet2
+    192.168.255.3:
+      peer_group: EVPN-OVERLAY-PEERS
+      description: AUTO_NODE_TYPE_LEAF01
+      remote_as: '65101'
+    192.168.255.4:
+      peer_group: EVPN-OVERLAY-PEERS
+      description: AUTO_NODE_TYPE_UNGROUPED_LEAF02
+      remote_as: '65102'
+  address_family_evpn:
+    peer_groups:
+      EVPN-OVERLAY-PEERS:
+        activate: true
+static_routes:
+- vrf: MGMT
+  destination_address_prefix: 0.0.0.0/0
+  gateway: 192.168.203.1
+service_routing_protocols_model: multi-agent
+ip_routing: true
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+spanning_tree:
+  mode: none
+vrfs:
+  MGMT:
+    ip_routing: false
+management_interfaces:
+  Management1:
+    description: oob_management
+    shutdown: false
+    vrf: MGMT
+    ip_address: 192.168.203.11
+    gateway: 192.168.203.1
+    type: oob
+management_api_http:
+  enable_vrfs:
+    MGMT: {}
+  enable_https: true
+ethernet_interfaces:
+  Ethernet1:
+    peer: AUTO_NODE_TYPE_LEAF01
+    peer_interface: Ethernet2
+    peer_type: l3leaf
+    description: P2P_LINK_TO_AUTO_NODE_TYPE_LEAF01_Ethernet2
+    mtu: 9000
+    type: routed
+    shutdown: false
+    ip_address: 172.31.255.2/31
+  Ethernet2:
+    peer: AUTO_NODE_TYPE_UNGROUPED_LEAF02
+    peer_interface: Ethernet2
+    peer_type: l3leaf
+    description: P2P_LINK_TO_AUTO_NODE_TYPE_UNGROUPED_LEAF02_Ethernet2
+    mtu: 9000
+    type: routed
+    shutdown: false
+    ip_address: 172.31.255.6/31
+loopback_interfaces:
+  Loopback0:
+    description: EVPN_Overlay_Peering
+    shutdown: false
+    ip_address: 192.168.255.2/32
+prefix_lists:
+  PL-LOOPBACKS-EVPN-OVERLAY:
+    sequence_numbers:
+      10:
+        action: permit 192.168.255.0/24 eq 32
+route_maps:
+  RM-CONN-2-BGP:
+    sequence_numbers:
+      10:
+        type: permit
+        match:
+        - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+router_bfd:
+  multihop:
+    interval: 300
+    min_rx: 300
+    multiplier: 3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_NODE_TYPE_UNGROUPED_LEAF02.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_NODE_TYPE_UNGROUPED_LEAF02.yml
@@ -132,5 +132,5 @@ vxlan_interface:
   Vxlan1:
     description: AUTO_NODE_TYPE_UNGROUPED_LEAF02_VTEP
     vxlan:
-      source_interface: Loopback1
       udp_port: 4789
+      source_interface: Loopback1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_NODE_TYPE_UNGROUPED_LEAF02.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_NODE_TYPE_UNGROUPED_LEAF02.yml
@@ -1,0 +1,136 @@
+router_bgp:
+  as: '65102'
+  router_id: 192.168.255.4
+  bgp_defaults:
+  - no bgp default ipv4-unicast
+  - distance bgp 20 200 200
+  - maximum-paths 4 ecmp 4
+  peer_groups:
+    IPv4-UNDERLAY-PEERS:
+      type: ipv4
+      maximum_routes: 12000
+      send_community: all
+    EVPN-OVERLAY-PEERS:
+      type: evpn
+      update_source: Loopback0
+      bfd: true
+      ebgp_multihop: '3'
+      send_community: all
+      maximum_routes: 0
+  address_family_ipv4:
+    peer_groups:
+      IPv4-UNDERLAY-PEERS:
+        activate: true
+      EVPN-OVERLAY-PEERS:
+        activate: false
+  redistribute_routes:
+    connected:
+      route_map: RM-CONN-2-BGP
+  neighbors:
+    172.31.255.4:
+      peer_group: IPv4-UNDERLAY-PEERS
+      remote_as: '65100'
+      description: AUTO_NODE_TYPE_SPINE01_Ethernet2
+    172.31.255.6:
+      peer_group: IPv4-UNDERLAY-PEERS
+      remote_as: '65100'
+      description: AUTO_NODE_TYPE_SPINE02_Ethernet2
+    192.168.255.1:
+      peer_group: EVPN-OVERLAY-PEERS
+      description: AUTO_NODE_TYPE_SPINE01
+      remote_as: '65100'
+    192.168.255.2:
+      peer_group: EVPN-OVERLAY-PEERS
+      description: AUTO_NODE_TYPE_SPINE02
+      remote_as: '65100'
+  address_family_evpn:
+    peer_groups:
+      EVPN-OVERLAY-PEERS:
+        activate: true
+static_routes:
+- vrf: MGMT
+  destination_address_prefix: 0.0.0.0/0
+  gateway: 192.168.203.1
+service_routing_protocols_model: multi-agent
+ip_routing: true
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+spanning_tree:
+  mode: mstp
+  mst_instances:
+    '0':
+      priority: 4096
+vrfs:
+  MGMT:
+    ip_routing: false
+management_interfaces:
+  Management1:
+    description: oob_management
+    shutdown: false
+    vrf: MGMT
+    ip_address: 192.168.203.13/24
+    gateway: 192.168.203.1
+    type: oob
+management_api_http:
+  enable_vrfs:
+    MGMT: {}
+  enable_https: true
+ethernet_interfaces:
+  Ethernet1:
+    peer: AUTO_NODE_TYPE_SPINE01
+    peer_interface: Ethernet2
+    peer_type: spine
+    description: P2P_LINK_TO_AUTO_NODE_TYPE_SPINE01_Ethernet2
+    mtu: 9000
+    type: routed
+    shutdown: false
+    ip_address: 172.31.255.5/31
+  Ethernet2:
+    peer: AUTO_NODE_TYPE_SPINE02
+    peer_interface: Ethernet2
+    peer_type: spine
+    description: P2P_LINK_TO_AUTO_NODE_TYPE_SPINE02_Ethernet2
+    mtu: 9000
+    type: routed
+    shutdown: false
+    ip_address: 172.31.255.7/31
+loopback_interfaces:
+  Loopback0:
+    description: EVPN_Overlay_Peering
+    shutdown: false
+    ip_address: 192.168.255.4/32
+  Loopback1:
+    description: VTEP_VXLAN_Tunnel_Source
+    shutdown: false
+    ip_address: 192.168.254.4/32
+prefix_lists:
+  PL-LOOPBACKS-EVPN-OVERLAY:
+    sequence_numbers:
+      10:
+        action: permit 192.168.255.0/24 eq 32
+      20:
+        action: permit 192.168.254.0/24 eq 32
+route_maps:
+  RM-CONN-2-BGP:
+    sequence_numbers:
+      10:
+        type: permit
+        match:
+        - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+router_bfd:
+  multihop:
+    interval: 300
+    min_rx: 300
+    multiplier: 3
+ip_igmp_snooping:
+  globally_enabled: true
+ip_virtual_router_mac_address: 00:dc:00:00:00:0a
+vxlan_interface:
+  Vxlan1:
+    description: AUTO_NODE_TYPE_UNGROUPED_LEAF02_VTEP
+    vxlan:
+      source_interface: Loopback1
+      udp_port: 4789

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/AUTO_NODE_TYPE.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/AUTO_NODE_TYPE.yml
@@ -1,0 +1,55 @@
+mgmt_gateway: 192.168.203.1
+default_node_types:
+  - match_hostnames:
+      - AUTO_NODE_TYPE_LEAF.*
+      - AUTO_NODE_TYPE_UNGROUPED_.*
+    node_type: l3leaf
+  - match_hostnames:
+      - AUTO_NODE_TYPE_SPINE.*
+    node_type: spine
+
+spine:
+  defaults:
+    platform: vEOS-LAB
+    loopback_ipv4_pool: 192.168.255.0/24
+    bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']
+    bgp_as: 65100
+  node_groups:
+    AUTO_NODE_TYPE_SPINE:
+      nodes:
+        AUTO_NODE_TYPE_SPINE01:
+          id: 1
+          mgmt_ip: 192.168.203.10
+        AUTO_NODE_TYPE_SPINE02:
+          id: 2
+          mgmt_ip: 192.168.203.11
+l3leaf:
+  defaults:
+    platform: vEOS-LAB
+    loopback_ipv4_pool: 192.168.255.0/24
+    loopback_ipv4_offset: 2
+    vtep_loopback_ipv4_pool: 192.168.254.0/24
+    uplink_interfaces: [Ethernet1, Ethernet2]
+    uplink_switches: [AUTO_NODE_TYPE_SPINE01, AUTO_NODE_TYPE_SPINE02]
+    uplink_ipv4_pool: 172.31.255.0/24
+    bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']
+    mlag_interfaces: [ Ethernet3, Ethernet4 ]
+    virtual_router_mac_address: 00:dc:00:00:00:0a
+    mlag_peer_l3_ipv4_pool: 10.255.251.0/24
+    mlag_peer_ipv4_pool: 10.255.252.0/24
+    spanning_tree_mode: mstp
+    spanning_tree_priority: 4096
+    bgp_as: 65101-65110
+  node_groups:
+    AUTO_NODE_TYPE_LEAF1:
+      mlag: false
+      nodes:
+        AUTO_NODE_TYPE_LEAF01:
+          id: 1
+          mgmt_ip: 192.168.203.12/24
+          uplink_switch_interfaces: [Ethernet1, Ethernet1]
+  nodes:
+    AUTO_NODE_TYPE_UNGROUPED_LEAF02:
+      id: 2
+      mgmt_ip: 192.168.203.13/24
+      uplink_switch_interfaces: [Ethernet2, Ethernet2]

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
@@ -133,7 +133,12 @@ all:
                 AUTO_BGP_ASN_LEAF5A:
           hosts:
             AUTO_BGP_UNGROUPED_LEAF6:
-
+        AUTO_NODE_TYPE:
+          hosts:
+            AUTO_NODE_TYPE_SPINE01:
+            AUTO_NODE_TYPE_SPINE02:
+            AUTO_NODE_TYPE_LEAF01:
+            AUTO_NODE_TYPE_UNGROUPED_LEAF02:
         OVERLAY_ROUTING_PROTOCOL_HER_TESTS:
           hosts:
             OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF1:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/inventory/group_vars/DC1_FABRIC.yml
@@ -4,6 +4,20 @@
 
 fabric_name: DC1_FABRIC
 
+# This lab also used to test default_node_types
+default_node_types:
+  - match_hostnames:
+      - DC1-SPINE\d+
+    node_type: spine
+  - match_hostnames:
+      - DC1-LEAF\d+[AB]*
+      - DC1-SVC\d+[AB]*
+      - DC1-BL\d+[AB]*
+    node_type: l3leaf
+  - match_hostnames:
+      - DC1-L2LEAF\d+[AB]*
+    node_type: l2leaf
+
 # OSPF Parameters when underlay_routing_protocol=OSPF
 underlay_routing_protocol: OSPF
 underlay_ospf_process_id: 101

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/inventory/group_vars/DC1_L2LEAFS.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/inventory/group_vars/DC1_L2LEAFS.yml
@@ -1,1 +1,0 @@
-type: l2leaf

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/inventory/group_vars/DC1_LEAFS.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/inventory/group_vars/DC1_LEAFS.yml
@@ -1,1 +1,0 @@
-type: l3leaf

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/inventory/group_vars/DC1_SPINES.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/inventory/group_vars/DC1_SPINES.yml
@@ -1,1 +1,0 @@
-type: spine

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_facts.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_facts.py
@@ -53,14 +53,12 @@ class EosDesignsFacts(AvdFacts):
         """
         switch.type fact set based on type variable
         """
-        node_type = get(self._hostvars, "type", required=False)
-
-        if node_type:
+        if (node_type := get(self._hostvars, "type")) is not None:
             return node_type
         elif self._default_node_type:
             return self._default_node_type
 
-        raise AristaAvdMissingVariableError("type")
+        raise AristaAvdMissingVariableError(f"'type' for host {self.hostname}")
 
     @cached_property
     def hostname(self):

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_facts.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_facts.py
@@ -53,7 +53,14 @@ class EosDesignsFacts(AvdFacts):
         """
         switch.type fact set based on type variable
         """
-        return get(self._hostvars, "type", required=True)
+        node_type = get(self._hostvars, "type", required=False)
+
+        if node_type:
+            return node_type
+        elif self._default_node_type:
+            return self._default_node_type
+
+        raise AristaAvdMissingVariableError("type")
 
     @cached_property
     def hostname(self):
@@ -125,6 +132,21 @@ class EosDesignsFacts(AvdFacts):
                     return default_interface
 
         return {}
+
+    @cached_property
+    def _default_node_type(self):
+        """
+        switch._default_node_type set based on hostname, returning
+        first node type matching a regex in default_node_types
+        """
+        default_node_types = get(self._hostvars, "default_node_types", default=[])
+
+        for default_node_type in default_node_types:
+            for hostname_regex in default_node_type["match_hostnames"]:
+                if re.search(f"^{hostname_regex}$", self.hostname):
+                    return default_node_type["node_type"]
+
+        return None
 
     @cached_property
     def default_underlay_routing_protocol(self):

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/node-types.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/node-types.md
@@ -201,3 +201,21 @@ node_type_keys:
 
 !!! info
     The default node definition is available in the [default section](../defaults/main/main.yml) of the eos_designs role.
+
+## Default Node Types
+
+Node types can be defined statically on each node or in each group of nodes.  As an alternative to this, regular expressions can be used to determine the node type based
+on the hostname.
+
+Please note that using the `default_node_types` functionality will cause certain tests in the eos_validate_state role to not be executed.  This functionality will be restored as part of a later update to eos_validate_state and this note will then be removed.
+
+```yaml
+default_node_types:
+    # Required | A list of regular expressions that match complete hostnames
+    # i.e. the regex is automatically bounded by ^ and $ elements
+  - match_hostnames:
+      - < regular expression 1 >
+      - < regular expression 2 etc >
+
+    # Required | Resultant node_type to be used if any of the regexes above match
+    node_type: < node type, taken from node_type_keys above >

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/node-types.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/node-types.md
@@ -207,7 +207,9 @@ node_type_keys:
 Node types can be defined statically on each node or in each group of nodes.  As an alternative to this, regular expressions can be used to determine the node type based
 on the hostname.
 
-Please note that using the `default_node_types` functionality will cause certain tests in the eos_validate_state role to not be executed.  This functionality will be restored as part of a later update to eos_validate_state and this note will then be removed.
+!!! warning
+  Please note that using the `default_node_types` functionality will cause certain tests in the eos_validate_state role to not be executed.
+  This functionality will be restored as part of a later update to eos_validate_!!!state and this note will then be removed.
 
 ```yaml
 default_node_types:

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/Input Variables.md
@@ -1,2 +1,25 @@
 !!! warning
     This document describes the data model for AVD 4.x. It may or may not work in previous versions.
+
+## Default Node Types
+
+### Description
+
+Uses hostname matches against a regular expression to determine the node type.
+### Variables
+
+| Variable | Type | Required | Default | Value Restrictions | Description |
+| -------- | ---- | -------- | ------- | ------------------ | ----------- |
+| [<samp>default_node_types</samp>](## "default_node_types") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;- match_hostnames</samp>](## "default_node_types.[].match_hostnames") | List, items: String | Required |  |  | Regular expressions to match against hostnames |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "default_node_types.[].match_hostnames.[].&lt;str&gt;") | String | Required |  |  | Regex needs to match full hostname (i.e. is bounded by ^ and $ elements) |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;node_type</samp>](## "default_node_types.[].node_type") | String | Required, Unique |  |  | Resulting node type when regex matches |
+
+### YAML
+
+```yaml
+default_node_types:
+  - match_hostnames:
+      - <str>
+    node_type: <str>
+```

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -1,3 +1,35 @@
 {
+  "properties": {
+    "default_node_types": {
+      "description": "Uses hostname matches against a regular expression to determine the node type.",
+      "items": {
+        "properties": {
+          "match_hostnames": {
+            "description": "Regular expressions to match against hostnames",
+            "items": {
+              "description": "Regex needs to match full hostname (i.e. is bounded by ^ and $ elements)",
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Match Hostnames"
+          },
+          "node_type": {
+            "description": "Resulting node type when regex matches",
+            "type": "string",
+            "title": "Node Type"
+          }
+        },
+        "required": [
+          "match_hostnames",
+          "node_type"
+        ],
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "type": "array",
+      "title": "Default Node Types"
+    }
+  },
+  "additionalProperties": true,
   "type": "object"
 }

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
@@ -1,1 +1,24 @@
-{}
+allow_other_keys: true
+keys:
+  default_node_types:
+    description: Uses hostname matches against a regular expression to determine the
+      node type.
+    items:
+      keys:
+        match_hostnames:
+          description: Regular expressions to match against hostnames
+          items:
+            description: Regex needs to match full hostname (i.e. is bounded by ^
+              and $ elements)
+            required: true
+            type: str
+          required: true
+          type: list
+        node_type:
+          description: Resulting node type when regex matches
+          required: true
+          type: str
+      type: dict
+    primary_key: node_type
+    type: list
+type: dict

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/_defaults.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/_defaults.schema.yml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+allow_other_keys: true

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/default_node_types.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/default_node_types.schema.yml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  default_node_types:
+    type: list
+    primary_key: node_type
+    description: Uses hostname matches against a regular expression to determine the node type.
+    items:
+      type: dict
+      keys:
+        node_type:
+          type: str
+          required: true
+          description: Resulting node type when regex matches
+        match_hostnames:
+          type: list
+          required: true
+          description: Regular expressions to match against hostnames
+          items:
+            type: str
+            required: true
+            description: Regex needs to match full hostname (i.e. is bounded by ^ and $ elements)

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/documentation/fabric-documentation.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/documentation/fabric-documentation.j2
@@ -8,8 +8,8 @@
 {% set interfaces_done = [] %}
 {% for node in groups[fabric_name] | arista.avd.natural_sort %}
 {%     set node_hostvars = hostvars[node] %}
-{%     if node_hostvars.type | arista.avd.default('undefined') in node_types %}
-{%         set node_facts = avd_switch_facts[node] %}
+{%     set node_facts = avd_switch_facts[node] %}
+{%     if node_facts.switch.type | arista.avd.default('undefined') in node_types %}
 {# Populate network summaries #}
 {%         do uplink_ipv4_pools.append(node_facts.switch.uplink_ipv4_pool | arista.avd.default()) %}
 {%         do loopback_ipv4_pools.append(node_facts.switch.loopback_ipv4_pool | arista.avd.default()) %}
@@ -17,7 +17,7 @@
 {# Populate fabric_switch #}
 {%         set fabric_switch = namespace() %}
 {%         set fabric_switch.pod = node_hostvars.pod_name | arista.avd.default(node_hostvars.dc_name, fabric_name) %}
-{%         set fabric_switch.type = node_hostvars.type %}
+{%         set fabric_switch.type = node_facts.switch.type %}
 {%         set fabric_switch.node = node %}
 {%         set fabric_switch.mgmt_ip = node_facts.switch.mgmt_ip | arista.avd.default('-') %}
 {%         do assigned_ip_addresses.append(node_facts.switch.mgmt_ip) if node_facts.switch.mgmt_ip is arista.avd.defined %}
@@ -49,7 +49,7 @@
 {%                 set peer_interface = node_hostvars.ethernet_interfaces[ethernet_interface].peer_interface %}
 {%                 if peer is arista.avd.defined and peer_interface is arista.avd.defined and peer ~ "," ~ peer_interface not in interfaces_done %}
 {%                     set topology_link = namespace() %}
-{%                     set topology_link.type = node_hostvars.type %}
+{%                     set topology_link.type = node_facts.switch.type %}
 {%                     set topology_link.node = node %}
 {%                     set topology_link.node_interface = ethernet_interface %}
 {%                     set topology_link.node_ip_address = node_hostvars.ethernet_interfaces[ethernet_interface].ip_address %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/documentation/fabric-p2p-links.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/documentation/fabric-p2p-links.j2
@@ -3,7 +3,8 @@ Type,Node,Node Interface,Leaf IP Address,Peer Type,Peer Node,Peer Interface,Peer
 {% set node_types = node_type_keys | arista.avd.convert_dicts('key') | map(attribute="type") %}
 {% for node in groups[fabric_name] | arista.avd.natural_sort %}
 {%     set node_hostvars = hostvars[node] %}
-{%     if node_hostvars.type | arista.avd.default('undefined') in node_types %}
+{%     set node_facts = avd_switch_facts[node] %}
+{%     if node_facts.switch.type | arista.avd.default('undefined') in node_types %}
 {%         for ethernet_interface in node_hostvars.ethernet_interfaces | arista.avd.natural_sort %}
 {%             if node_hostvars.ethernet_interfaces[ethernet_interface].type is arista.avd.defined('routed') %}
 {%                 if node_hostvars.ethernet_interfaces[ethernet_interface].peer_type | arista.avd.default('undefined') in node_types %}
@@ -12,7 +13,7 @@ Type,Node,Node Interface,Leaf IP Address,Peer Type,Peer Node,Peer Interface,Peer
 {%                     set peer_interface = node_hostvars.ethernet_interfaces[ethernet_interface].peer_interface %}
 {%                     if peer is arista.avd.defined and peer_interface is arista.avd.defined and peer ~ "," ~ peer_interface not in interfaces_done %}
 {%                         set csv_line = [] %}
-{%                         do csv_line.append(node_hostvars.type) %}
+{%                         do csv_line.append(node_facts.switch.type) %}
 {%                         do csv_line.append(node) %}
 {%                         do csv_line.append(ethernet_interface) %}
 {%                         do csv_line.append(node_hostvars.ethernet_interfaces[ethernet_interface].ip_address | arista.avd.default("")) %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/documentation/fabric-topology.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/documentation/fabric-topology.j2
@@ -2,10 +2,11 @@ Node Type,Node,Node Interface,Peer Type,Peer Node,Peer Interface,Node Interface 
 {% set node_types = node_type_keys | arista.avd.convert_dicts('key') | map(attribute="type") %}
 {% for node in groups[fabric_name] | arista.avd.natural_sort %}
 {%     set node_hostvars = hostvars[node] %}
-{%     if node_hostvars.type | arista.avd.default('undefined') in node_types %}
+{%     set node_facts = avd_switch_facts[node] %}
+{%     if node_facts.switch.type | arista.avd.default('undefined') in node_types %}
 {%         for ethernet_interface in node_hostvars.ethernet_interfaces | arista.avd.natural_sort %}
 {%             set csv_line = [] %}
-{%             do csv_line.append(node_hostvars.type) %}
+{%             do csv_line.append(node_facts.switch.type) %}
 {%             do csv_line.append(node) %}
 {%             do csv_line.append(ethernet_interface) %}
 {%             do csv_line.append(node_hostvars.ethernet_interfaces[ethernet_interface].peer_type | arista.avd.default("")) %}


### PR DESCRIPTION
## Change Summary

Allows the node_type to be set without having to manually define it for each host.  Part of AVD inventory minimisation efforts.

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
New data model key default_node_types proposed:
```
default_node_types:
  - match_hostnames:
      - < regex match for hostname >
      - < regex match for hostname >
    node_type: < node_type to assign >
```

Instead of specifying a `type` for each node in the topology, this allows node types to be defined automatically by matching the node's hostname against multiple regular expressions until there is a match.  The matching regex determines the node type to be used for that host.

## How to test
 - Molecule tests added
 - Ran tests against demo repo

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been rebased from devel before I start
- [X] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [X] My change requires a change to the documentation and documentation have been updated accordingly.
- [X] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
