### PR TITLE
CI: Trim whitespace in PR labels

### DIFF
--- a/.github/actions/rn-pr-labeler-action/action.yml
+++ b/.github/actions/rn-pr-labeler-action/action.yml
@@ -18,7 +18,7 @@ runs:
       shell: bash
       if: ${{ env.OLD_LABEL }}
     - name: Set Label
-      run: echo "LABEL=$(echo '${{ github.event.pull_request.title }}' | cut -d ':' -f 1)" >> $GITHUB_ENV
+      run: echo "LABEL=$(echo '${{ github.event.pull_request.title }}' | cut -d ':' -f 1 | tr -d ' ')" >> $GITHUB_ENV
       shell: bash
       # an alternative to verifying if the target label already exist is to
       # create the label with --force in the next step, it will keep on changing


### PR DESCRIPTION
## Change Summary

trim whitespaces in PR names for the post merge PR labeler used for release notes

## Proposed changes

Use `tr -d ' '` when creating the label name

## How to test

Will need a PR with a space

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
