### PR TITLE
Test: Fix unknown_unicast in molecule

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3A.yml
@@ -793,7 +793,7 @@ port_channel_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     mlag: 14
@@ -816,7 +816,7 @@ port_channel_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     mlag: 15
@@ -839,7 +839,7 @@ port_channel_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     mlag: 17
@@ -865,7 +865,7 @@ port_channel_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     mlag: 18
@@ -891,7 +891,7 @@ port_channel_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     mlag: 19
@@ -1057,7 +1057,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
   Ethernet12:
@@ -1082,7 +1082,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
   Ethernet13:
@@ -1108,7 +1108,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
   Ethernet14:
@@ -1134,7 +1134,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     channel_group:
@@ -1162,7 +1162,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     channel_group:
@@ -1191,7 +1191,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
   Ethernet17:
@@ -1216,7 +1216,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     channel_group:
@@ -1246,7 +1246,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     channel_group:
@@ -1276,7 +1276,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     channel_group:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3B.yml
@@ -786,7 +786,7 @@ port_channel_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     mlag: 14
@@ -809,7 +809,7 @@ port_channel_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     mlag: 15
@@ -832,7 +832,7 @@ port_channel_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     mlag: 17
@@ -858,7 +858,7 @@ port_channel_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     mlag: 18
@@ -884,7 +884,7 @@ port_channel_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     mlag: 19
@@ -1038,7 +1038,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
   Ethernet12:
@@ -1063,7 +1063,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
   Ethernet13:
@@ -1089,7 +1089,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
   Ethernet14:
@@ -1115,7 +1115,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     channel_group:
@@ -1143,7 +1143,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     channel_group:
@@ -1172,7 +1172,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
   Ethernet17:
@@ -1197,7 +1197,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     channel_group:
@@ -1227,7 +1227,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     channel_group:
@@ -1257,7 +1257,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     channel_group:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_SERVERS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_SERVERS.yml
@@ -35,7 +35,7 @@ port_profiles:
       multicast:
         level: 1
         unit: percent
-      'unknown-unicast':
+      unknown_unicast:
         level: 2
         unit: percent
 
@@ -56,7 +56,7 @@ port_profiles:
       multicast:
         level: 1
         unit: percent
-      'unknown-unicast':
+      unknown_unicast:
         level: 2
         unit: percent
     port_channel:
@@ -80,7 +80,7 @@ port_profiles:
       multicast:
         level: 1
         unit: percent
-      'unknown-unicast':
+      unknown_unicast:
         level: 2
         unit: percent
     port_channel:
@@ -213,7 +213,7 @@ servers:
           multicast:
             level: 1
             unit: percent
-          'unknown-unicast':
+          unknown_unicast:
             level: 2
             unit: percent
 
@@ -239,7 +239,7 @@ servers:
           multicast:
             level: 1
             unit: percent
-          'unknown-unicast':
+          unknown_unicast:
             level: 2
             unit: percent
 
@@ -272,7 +272,7 @@ servers:
           multicast:
             level: 1
             unit: percent
-          'unknown-unicast':
+          unknown_unicast:
             level: 2
             unit: percent
         port_channel:
@@ -301,7 +301,7 @@ servers:
           multicast:
             level: 1
             unit: percent
-          'unknown-unicast':
+          unknown_unicast:
             level: 2
             unit: percent
         port_channel: null   #Setting to null, to override port-channel inherited from profile
@@ -327,7 +327,7 @@ servers:
           multicast:
             level: 1
             unit: percent
-          'unknown-unicast':
+          unknown_unicast:
             level: 2
             unit: percent
         port_channel:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-LEAF1A.yml
@@ -262,7 +262,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
 loopback_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SVC3A.yml
@@ -795,7 +795,7 @@ port_channel_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     mlag: 14
@@ -818,7 +818,7 @@ port_channel_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     mlag: 15
@@ -841,7 +841,7 @@ port_channel_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     mlag: 17
@@ -867,7 +867,7 @@ port_channel_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     mlag: 18
@@ -893,7 +893,7 @@ port_channel_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     mlag: 19
@@ -1059,7 +1059,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
   Ethernet12:
@@ -1084,7 +1084,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
   Ethernet13:
@@ -1110,7 +1110,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
   Ethernet14:
@@ -1136,7 +1136,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     channel_group:
@@ -1164,7 +1164,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     channel_group:
@@ -1193,7 +1193,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
   Ethernet17:
@@ -1218,7 +1218,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     channel_group:
@@ -1248,7 +1248,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     channel_group:
@@ -1278,7 +1278,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     channel_group:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SVC3B.yml
@@ -788,7 +788,7 @@ port_channel_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     mlag: 14
@@ -811,7 +811,7 @@ port_channel_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     mlag: 15
@@ -834,7 +834,7 @@ port_channel_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     mlag: 17
@@ -860,7 +860,7 @@ port_channel_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     mlag: 18
@@ -886,7 +886,7 @@ port_channel_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     mlag: 19
@@ -1040,7 +1040,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
   Ethernet12:
@@ -1065,7 +1065,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
   Ethernet13:
@@ -1091,7 +1091,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
   Ethernet14:
@@ -1117,7 +1117,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     channel_group:
@@ -1145,7 +1145,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     channel_group:
@@ -1174,7 +1174,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
   Ethernet17:
@@ -1199,7 +1199,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     channel_group:
@@ -1229,7 +1229,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     channel_group:
@@ -1259,7 +1259,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     channel_group:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/inventory/group_vars/DC1_SERVERS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/inventory/group_vars/DC1_SERVERS.yml
@@ -35,7 +35,7 @@ port_profiles:
       multicast:
         level: 1
         unit: percent
-      'unknown-unicast':
+      unknown_unicast:
         level: 2
         unit: percent
 
@@ -56,7 +56,7 @@ port_profiles:
       multicast:
         level: 1
         unit: percent
-      'unknown-unicast':
+      unknown_unicast:
         level: 2
         unit: percent
     port_channel:
@@ -80,7 +80,7 @@ port_profiles:
       multicast:
         level: 1
         unit: percent
-      'unknown-unicast':
+      unknown_unicast:
         level: 2
         unit: percent
     port_channel:
@@ -194,7 +194,7 @@ servers:
           multicast:
             level: 1
             unit: percent
-          'unknown-unicast':
+          unknown_unicast:
             level: 2
             unit: percent
 
@@ -220,7 +220,7 @@ servers:
           multicast:
             level: 1
             unit: percent
-          'unknown-unicast':
+          unknown_unicast:
             level: 2
             unit: percent
 
@@ -253,7 +253,7 @@ servers:
           multicast:
             level: 1
             unit: percent
-          'unknown-unicast':
+          unknown_unicast:
             level: 2
             unit: percent
         port_channel:
@@ -282,7 +282,7 @@ servers:
           multicast:
             level: 1
             unit: percent
-          'unknown-unicast':
+          unknown_unicast:
             level: 2
             unit: percent
         port_channel: null   #Setting to null, to override port-channel inherited from profile
@@ -308,7 +308,7 @@ servers:
           multicast:
             level: 1
             unit: percent
-          'unknown-unicast':
+          unknown_unicast:
             level: 2
             unit: percent
         port_channel:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
@@ -255,7 +255,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
 loopback_interfaces:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -814,7 +814,7 @@ port_channel_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     mlag: 14
@@ -837,7 +837,7 @@ port_channel_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     mlag: 15
@@ -860,7 +860,7 @@ port_channel_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     mlag: 17
@@ -886,7 +886,7 @@ port_channel_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     mlag: 18
@@ -912,7 +912,7 @@ port_channel_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     mlag: 19
@@ -1041,7 +1041,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
   Ethernet12:
@@ -1066,7 +1066,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
   Ethernet13:
@@ -1092,7 +1092,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
   Ethernet14:
@@ -1118,7 +1118,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     channel_group:
@@ -1146,7 +1146,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     channel_group:
@@ -1175,7 +1175,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
   Ethernet17:
@@ -1200,7 +1200,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     channel_group:
@@ -1230,7 +1230,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     channel_group:
@@ -1260,7 +1260,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     channel_group:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -814,7 +814,7 @@ port_channel_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     mlag: 14
@@ -837,7 +837,7 @@ port_channel_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     mlag: 15
@@ -860,7 +860,7 @@ port_channel_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     mlag: 17
@@ -886,7 +886,7 @@ port_channel_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     mlag: 18
@@ -912,7 +912,7 @@ port_channel_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     mlag: 19
@@ -1041,7 +1041,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
   Ethernet12:
@@ -1066,7 +1066,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
   Ethernet13:
@@ -1092,7 +1092,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
   Ethernet14:
@@ -1118,7 +1118,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     channel_group:
@@ -1146,7 +1146,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     channel_group:
@@ -1175,7 +1175,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
   Ethernet17:
@@ -1200,7 +1200,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     channel_group:
@@ -1230,7 +1230,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     channel_group:
@@ -1260,7 +1260,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     channel_group:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_SERVERS.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_SERVERS.yml
@@ -34,7 +34,7 @@ port_profiles:
       multicast:
         level: 1
         unit: percent
-      'unknown-unicast':
+      unknown_unicast:
         level: 2
         unit: percent
 
@@ -55,7 +55,7 @@ port_profiles:
       multicast:
         level: 1
         unit: percent
-      'unknown-unicast':
+      unknown_unicast:
         level: 2
         unit: percent
     port_channel:
@@ -79,7 +79,7 @@ port_profiles:
       multicast:
         level: 1
         unit: percent
-      'unknown-unicast':
+      unknown_unicast:
         level: 2
         unit: percent
     port_channel:
@@ -186,7 +186,7 @@ servers:
           multicast:
             level: 1
             unit: percent
-          'unknown-unicast':
+          unknown_unicast:
             level: 2
             unit: percent
 
@@ -212,7 +212,7 @@ servers:
           multicast:
             level: 1
             unit: percent
-          'unknown-unicast':
+          unknown_unicast:
             level: 2
             unit: percent
 
@@ -245,7 +245,7 @@ servers:
           multicast:
             level: 1
             unit: percent
-          'unknown-unicast':
+          unknown_unicast:
             level: 2
             unit: percent
         port_channel:
@@ -274,7 +274,7 @@ servers:
           multicast:
             level: 1
             unit: percent
-          'unknown-unicast':
+          unknown_unicast:
             level: 2
             unit: percent
         port_channel: null   #Setting to null, to override port-channel inherited from profile
@@ -300,7 +300,7 @@ servers:
           multicast:
             level: 1
             unit: percent
-          'unknown-unicast':
+          unknown_unicast:
             level: 2
             unit: percent
         port_channel:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
@@ -252,7 +252,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
 loopback_interfaces:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -792,7 +792,7 @@ port_channel_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     mlag: 14
@@ -815,7 +815,7 @@ port_channel_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     mlag: 15
@@ -930,7 +930,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
   Ethernet12:
@@ -955,7 +955,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
   Ethernet13:
@@ -980,7 +980,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
   Ethernet14:
@@ -1005,7 +1005,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     channel_group:
@@ -1033,7 +1033,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     channel_group:
@@ -1061,7 +1061,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
 mlag_configuration:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -785,7 +785,7 @@ port_channel_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     mlag: 14
@@ -808,7 +808,7 @@ port_channel_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     mlag: 15
@@ -911,7 +911,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
   Ethernet12:
@@ -936,7 +936,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
   Ethernet13:
@@ -961,7 +961,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
   Ethernet14:
@@ -986,7 +986,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     channel_group:
@@ -1014,7 +1014,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     channel_group:
@@ -1042,7 +1042,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
 mlag_configuration:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/inventory/group_vars/DC1_SERVERS.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/inventory/group_vars/DC1_SERVERS.yml
@@ -32,7 +32,7 @@ port_profiles:
       multicast:
         level: 1
         unit: percent
-      'unknown-unicast':
+      unknown_unicast:
         level: 2
         unit: percent
 
@@ -52,7 +52,7 @@ port_profiles:
       multicast:
         level: 1
         unit: percent
-      'unknown-unicast':
+      unknown_unicast:
         level: 2
         unit: percent
     port_channel:
@@ -150,7 +150,7 @@ servers:
           multicast:
             level: 1
             unit: percent
-          'unknown-unicast':
+          unknown_unicast:
             level: 2
             unit: percent
 
@@ -176,7 +176,7 @@ servers:
           multicast:
             level: 1
             unit: percent
-          'unknown-unicast':
+          unknown_unicast:
             level: 2
             unit: percent
 
@@ -209,7 +209,7 @@ servers:
           multicast:
             level: 1
             unit: percent
-          'unknown-unicast':
+          unknown_unicast:
             level: 2
             unit: percent
         port_channel:
@@ -238,7 +238,7 @@ servers:
           multicast:
             level: 1
             unit: percent
-          'unknown-unicast':
+          unknown_unicast:
             level: 2
             unit: percent
         port_channel: null   #Setting to null, to override port-channel inherited from profile

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
@@ -259,7 +259,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
 loopback_interfaces:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -779,7 +779,7 @@ port_channel_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     mlag: 14
@@ -802,7 +802,7 @@ port_channel_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     mlag: 15
@@ -825,7 +825,7 @@ port_channel_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     mlag: 17
@@ -851,7 +851,7 @@ port_channel_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     mlag: 18
@@ -877,7 +877,7 @@ port_channel_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     mlag: 19
@@ -999,7 +999,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
   Ethernet12:
@@ -1024,7 +1024,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
   Ethernet13:
@@ -1050,7 +1050,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
   Ethernet14:
@@ -1076,7 +1076,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     channel_group:
@@ -1104,7 +1104,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     channel_group:
@@ -1133,7 +1133,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
   Ethernet17:
@@ -1158,7 +1158,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     channel_group:
@@ -1188,7 +1188,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     channel_group:
@@ -1218,7 +1218,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     channel_group:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -779,7 +779,7 @@ port_channel_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     mlag: 14
@@ -802,7 +802,7 @@ port_channel_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     mlag: 15
@@ -825,7 +825,7 @@ port_channel_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     mlag: 17
@@ -851,7 +851,7 @@ port_channel_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     mlag: 18
@@ -877,7 +877,7 @@ port_channel_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     mlag: 19
@@ -999,7 +999,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
   Ethernet12:
@@ -1024,7 +1024,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
   Ethernet13:
@@ -1050,7 +1050,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
   Ethernet14:
@@ -1076,7 +1076,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     channel_group:
@@ -1104,7 +1104,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     channel_group:
@@ -1133,7 +1133,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
   Ethernet17:
@@ -1158,7 +1158,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     channel_group:
@@ -1188,7 +1188,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     channel_group:
@@ -1218,7 +1218,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     channel_group:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_SERVERS.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_SERVERS.yml
@@ -34,7 +34,7 @@ port_profiles:
       multicast:
         level: 1
         unit: percent
-      'unknown-unicast':
+      unknown_unicast:
         level: 2
         unit: percent
 
@@ -55,7 +55,7 @@ port_profiles:
       multicast:
         level: 1
         unit: percent
-      'unknown-unicast':
+      unknown_unicast:
         level: 2
         unit: percent
     port_channel:
@@ -79,7 +79,7 @@ port_profiles:
       multicast:
         level: 1
         unit: percent
-      'unknown-unicast':
+      unknown_unicast:
         level: 2
         unit: percent
     port_channel:
@@ -186,7 +186,7 @@ servers:
           multicast:
             level: 1
             unit: percent
-          'unknown-unicast':
+          unknown_unicast:
             level: 2
             unit: percent
 
@@ -212,7 +212,7 @@ servers:
           multicast:
             level: 1
             unit: percent
-          'unknown-unicast':
+          unknown_unicast:
             level: 2
             unit: percent
 
@@ -245,7 +245,7 @@ servers:
           multicast:
             level: 1
             unit: percent
-          'unknown-unicast':
+          unknown_unicast:
             level: 2
             unit: percent
         port_channel:
@@ -274,7 +274,7 @@ servers:
           multicast:
             level: 1
             unit: percent
-          'unknown-unicast':
+          unknown_unicast:
             level: 2
             unit: percent
         port_channel: null   #Setting to null, to override port-channel inherited from profile
@@ -300,7 +300,7 @@ servers:
           multicast:
             level: 1
             unit: percent
-          'unknown-unicast':
+          unknown_unicast:
             level: 2
             unit: percent
         port_channel:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
@@ -261,7 +261,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
 loopback_interfaces:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -783,7 +783,7 @@ port_channel_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     mlag: 14
@@ -806,7 +806,7 @@ port_channel_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     mlag: 15
@@ -921,7 +921,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
   Ethernet12:
@@ -946,7 +946,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
   Ethernet13:
@@ -971,7 +971,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
   Ethernet14:
@@ -996,7 +996,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     channel_group:
@@ -1024,7 +1024,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     channel_group:
@@ -1052,7 +1052,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
 mlag_configuration:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -776,7 +776,7 @@ port_channel_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     mlag: 14
@@ -799,7 +799,7 @@ port_channel_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     mlag: 15
@@ -902,7 +902,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
   Ethernet12:
@@ -927,7 +927,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
   Ethernet13:
@@ -952,7 +952,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
   Ethernet14:
@@ -977,7 +977,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     channel_group:
@@ -1005,7 +1005,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
     channel_group:
@@ -1033,7 +1033,7 @@ ethernet_interfaces:
       multicast:
         level: 1
         unit: percent
-      unknown-unicast:
+      unknown_unicast:
         level: 2
         unit: percent
 mlag_configuration:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/inventory/group_vars/DC1_SERVERS.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/inventory/group_vars/DC1_SERVERS.yml
@@ -32,7 +32,7 @@ port_profiles:
       multicast:
         level: 1
         unit: percent
-      'unknown-unicast':
+      unknown_unicast:
         level: 2
         unit: percent
 
@@ -52,7 +52,7 @@ port_profiles:
       multicast:
         level: 1
         unit: percent
-      'unknown-unicast':
+      unknown_unicast:
         level: 2
         unit: percent
     port_channel:
@@ -150,7 +150,7 @@ servers:
           multicast:
             level: 1
             unit: percent
-          'unknown-unicast':
+          unknown_unicast:
             level: 2
             unit: percent
 
@@ -176,7 +176,7 @@ servers:
           multicast:
             level: 1
             unit: percent
-          'unknown-unicast':
+          unknown_unicast:
             level: 2
             unit: percent
 
@@ -209,7 +209,7 @@ servers:
           multicast:
             level: 1
             unit: percent
-          'unknown-unicast':
+          unknown_unicast:
             level: 2
             unit: percent
         port_channel:
@@ -238,7 +238,7 @@ servers:
           multicast:
             level: 1
             unit: percent
-          'unknown-unicast':
+          unknown_unicast:
             level: 2
             unit: percent
         port_channel: null   #Setting to null, to override port-channel inherited from profile


### PR DESCRIPTION
## Change Summary

The molecule scenarios were using `unknown-unicast` in some places which is not what is documented in `eos_cli_config_gen` but was working because of the leniency of the template. This PR is made to prepare the repo for schema.

## Component(s) name

`molecule`

## Proposed changes

replace all occurences of `unknown-unicast` with `unknown_unicast` in molecule scenarios

## How to test

Expect no changes in the configs but only in the structured_configs.

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
