### PR TITLE
Feat(eos_cli_config_gen): MAC address on management interfaces

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-interfaces.md
@@ -45,8 +45,8 @@
 ```eos
 !
 interface Management0
-   ip address 10.0.0.0
    mac-address 00:1c:73:00:00:aa
+   ip address 10.0.0.0
 !
 interface Management1
    description oob_management

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-interfaces.md
@@ -26,6 +26,7 @@
 
 | Management Interface | description | Type | VRF | IP Address | Gateway |
 | -------------------- | ----------- | ---- | --- | ---------- | ------- |
+| Management0 | - | oob | default | 10.0.0.0 | - |
 | Management1 | oob_management | oob | MGMT | 10.73.255.122/24 | 10.73.255.2 |
 | Management42 | - | oob | default | - | - |
 | Vlan123 | inband_management | inband | default | 10.73.0.123/24 | 10.73.0.1 |
@@ -34,6 +35,7 @@
 
 | Management Interface | description | Type | VRF | IPv6 Address | IPv6 Gateway |
 | -------------------- | ----------- | ---- | --- | ------------ | ------------ |
+| Management0 | - | oob | default | - | - |
 | Management1 | oob_management | oob | MGMT | - | - |
 | Management42 | - | oob | default | - | - |
 | Vlan123 | inband_management | inband | default | - | - |
@@ -41,6 +43,10 @@
 ### Management Interfaces Device Configuration
 
 ```eos
+!
+interface Management0
+   ip address 10.0.0.0
+   mac-address 00:1c:73:00:00:aa
 !
 interface Management1
    description oob_management

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/management-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/management-interfaces.cfg
@@ -8,8 +8,8 @@ no enable password
 no aaa root
 !
 interface Management0
-   ip address 10.0.0.0
    mac-address 00:1c:73:00:00:aa
+   ip address 10.0.0.0
 !
 interface Management1
    description oob_management

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/management-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/management-interfaces.cfg
@@ -7,6 +7,10 @@ hostname management-interfaces
 no enable password
 no aaa root
 !
+interface Management0
+   ip address 10.0.0.0
+   mac-address 00:1c:73:00:00:aa
+!
 interface Management1
    description oob_management
    vrf MGMT

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/management-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/management-interfaces.yml
@@ -6,6 +6,9 @@ management_interfaces:
     ip_address: 10.73.255.122/24
     gateway: 10.73.255.2
     type: oob
+  Management0:
+    ip_address: 10.0.0.0
+    mac_address: 00:1c:73:00:00:aa
   Vlan123:
     description: inband_management
     vrf: default

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1855,7 +1855,7 @@ management_interfaces:
     # For documentation purpose only
     gateway: < IPv4 address of default gateway in management VRF >
     ipv6_gateway: < IPv6 address of default gateway in management VRF >
-    mac_address: <MAC address>
+    mac_address: < MAC address >
 ```
 
 #### Management HTTP

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1855,6 +1855,7 @@ management_interfaces:
     # For documentation purpose only
     gateway: < IPv4 address of default gateway in management VRF >
     ipv6_gateway: < IPv6 address of default gateway in management VRF >
+    mac_address: <MAC address>
 ```
 
 #### Management HTTP

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -2194,6 +2194,7 @@ management_defaults:
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;type</samp>](## "management_interfaces.[].type") | String |  | oob | Valid Values:<br>- oob<br>- inband | For documentation purposes only |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;gateway</samp>](## "management_interfaces.[].gateway") | String |  |  |  | IPv4 address of default gateway in management VRF |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_gateway</samp>](## "management_interfaces.[].ipv6_gateway") | String |  |  |  | IPv6 address of default gateway in management VRF |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mac_address</samp>](## "management_interfaces.[].mac_address") | String |  |  |  | MAC_address |
 
 ### YAML
 
@@ -2210,6 +2211,7 @@ management_interfaces:
     type: <str>
     gateway: <str>
     ipv6_gateway: <str>
+    mac_address: <str>
 ```
 
 ## Management Security

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -2194,7 +2194,7 @@ management_defaults:
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;type</samp>](## "management_interfaces.[].type") | String |  | oob | Valid Values:<br>- oob<br>- inband | For documentation purposes only |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;gateway</samp>](## "management_interfaces.[].gateway") | String |  |  |  | IPv4 address of default gateway in management VRF |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_gateway</samp>](## "management_interfaces.[].ipv6_gateway") | String |  |  |  | IPv6 address of default gateway in management VRF |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mac_address</samp>](## "management_interfaces.[].mac_address") | String |  |  |  | MAC_address |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mac_address</samp>](## "management_interfaces.[].mac_address") | String |  |  |  | MAC address |
 
 ### YAML
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -3767,6 +3767,11 @@
             "type": "string",
             "description": "IPv6 address of default gateway in management VRF",
             "title": "IPv6 Gateway"
+          },
+          "mac_address": {
+            "type": "string",
+            "description": "MAC_address",
+            "title": "MAC Address"
           }
         },
         "required": [

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -3770,7 +3770,7 @@
           },
           "mac_address": {
             "type": "string",
-            "description": "MAC_address",
+            "description": "MAC address",
             "title": "MAC Address"
           }
         },

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -338,9 +338,9 @@ keys:
                   Example: "deny ip any any"'
   aliases:
     type: str
-    description: "Multi-line string with one or more alias commands.\n\nExample:\n\n```yaml\naliases:
-      |\n  alias wr copy running-config startup-config\n  alias siib show ip interface
-      brief\n```"
+    description: "Multi-line string with one or more alias commands.\n\nExample:\n\
+      \n```yaml\naliases: |\n  alias wr copy running-config startup-config\n  alias\
+      \ siib show ip interface brief\n```"
   arp:
     type: dict
     keys:
@@ -540,14 +540,14 @@ keys:
   custom_templates:
     type: list
     display_name: Extensibility with Custom Templates
-    description: "- Custom templates can be added below the playbook directory.\n-
-      If a location above the directory is desired, a symbolic link can be used.\n-
-      Example under the `playbooks` directory create symbolic link with the following
-      command:\n\n  ```bash\n  ln -s ../../shared_repo/custom_avd_templates/ ./custom_avd_templates\n
-      \ ```\n\n- The output will be rendered at the end of the configuration.\n- The
-      order of custom templates in the list can be important if they overlap.\n- It
-      is recommenended to use a `!` delimiter at the top of each custom template.\n\nAdd
-      `custom_templates` to group/host variables:\n"
+    description: "- Custom templates can be added below the playbook directory.\n\
+      - If a location above the directory is desired, a symbolic link can be used.\n\
+      - Example under the `playbooks` directory create symbolic link with the following\
+      \ command:\n\n  ```bash\n  ln -s ../../shared_repo/custom_avd_templates/ ./custom_avd_templates\n\
+      \  ```\n\n- The output will be rendered at the end of the configuration.\n-\
+      \ The order of custom templates in the list can be important if they overlap.\n\
+      - It is recommenended to use a `!` delimiter at the top of each custom template.\n\
+      \nAdd `custom_templates` to group/host variables:\n"
     items:
       type: str
       description: Template relative path below playbook directory
@@ -583,12 +583,12 @@ keys:
                 type: bool
   daemon_terminattr:
     type: dict
-    description: "You can either provide a list of IPs/FQDNs to target on-premise
-      Cloudvision cluster or use DNS name for your Cloudvision as a Service instance.\nStreaming
-      to multiple clusters both on-prem and cloud service is supported.\n> Note For
-      TerminAttr version recommendation and EOS compatibility matrix, please refer
-      to the latest TerminAttr Release Notes\n  which always contain the latest recommended
-      versions and minimum required versions per EOS release.\n"
+    description: "You can either provide a list of IPs/FQDNs to target on-premise\
+      \ Cloudvision cluster or use DNS name for your Cloudvision as a Service instance.\n\
+      Streaming to multiple clusters both on-prem and cloud service is supported.\n\
+      > Note For TerminAttr version recommendation and EOS compatibility matrix, please\
+      \ refer to the latest TerminAttr Release Notes\n  which always contain the latest\
+      \ recommended versions and minimum required versions per EOS release.\n"
     keys:
       cvaddrs:
         type: list
@@ -1434,15 +1434,15 @@ keys:
     convert_types:
     - dict
     display_name: IP Community Lists
-    description: "AVD supports 2 different data models for community lists:\n\n- The
-      legacy `community_lists` data model that can be used for compatibility with
-      the existing deployments.\n- The improved `ip_community_lists` data model.\n\nBoth
-      data models can coexist without conflicts, as different keys are used: `community_lists`
-      vs `ip_community_lists`.\nCommunity list names must be unique.\n\nThe improved
-      data model has a better design documented below:\n\ncommunities and regexp MUST
-      not be configured together in the same entry\npossible community strings are
-      (case insensitive):\n - GSHUT\n - internet\n - local-as\n - no-advertise\n -
-      no-export\n - <1-4294967040>\n - aa:nn\n"
+    description: "AVD supports 2 different data models for community lists:\n\n- The\
+      \ legacy `community_lists` data model that can be used for compatibility with\
+      \ the existing deployments.\n- The improved `ip_community_lists` data model.\n\
+      \nBoth data models can coexist without conflicts, as different keys are used:\
+      \ `community_lists` vs `ip_community_lists`.\nCommunity list names must be unique.\n\
+      \nThe improved data model has a better design documented below:\n\ncommunities\
+      \ and regexp MUST not be configured together in the same entry\npossible community\
+      \ strings are (case insensitive):\n - GSHUT\n - internet\n - local-as\n - no-advertise\n\
+      \ - no-export\n - <1-4294967040>\n - aa:nn\n"
     items:
       type: dict
       keys:
@@ -2753,6 +2753,9 @@ keys:
         ipv6_gateway:
           type: str
           description: IPv6 address of default gateway in management VRF
+        mac_address:
+          type: str
+          description: MAC_address
   management_security:
     type: dict
     keys:
@@ -2780,8 +2783,8 @@ keys:
               type: str
             tls_versions:
               type: str
-              description: "List of allowed TLS versions as string\nExamples:\n  -
-                \"1.0\"\n  - \"1.0 1.1\"\n"
+              description: "List of allowed TLS versions as string\nExamples:\n  -\
+                \ \"1.0\"\n  - \"1.0 1.1\"\n"
               convert_types:
               - float
             cipher_list:
@@ -3179,12 +3182,12 @@ keys:
               type: str
         rate_limit_per_ingress_chip:
           type: str
-          description: "Ratelimit and unit as string.\nExamples:\n  \"100000 bps\"\n
-            \ \"100 kbps\"\n  \"10 mbps\"\n"
+          description: "Ratelimit and unit as string.\nExamples:\n  \"100000 bps\"\
+            \n  \"100 kbps\"\n  \"10 mbps\"\n"
         rate_limit_per_egress_chip:
           type: str
-          description: "Ratelimit and unit as string.\nExamples:\n  \"100000 bps\"\n
-            \ \"100 kbps\"\n  \"10 mbps\"\n"
+          description: "Ratelimit and unit as string.\nExamples:\n  \"100000 bps\"\
+            \n  \"100 kbps\"\n  \"10 mbps\"\n"
         sample:
           type: int
           convert_types:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -338,9 +338,9 @@ keys:
                   Example: "deny ip any any"'
   aliases:
     type: str
-    description: "Multi-line string with one or more alias commands.\n\nExample:\n\n```yaml\naliases:
-      |\n  alias wr copy running-config startup-config\n  alias siib show ip interface
-      brief\n```"
+    description: "Multi-line string with one or more alias commands.\n\nExample:\n\
+      \n```yaml\naliases: |\n  alias wr copy running-config startup-config\n  alias\
+      \ siib show ip interface brief\n```"
   arp:
     type: dict
     keys:
@@ -540,14 +540,14 @@ keys:
   custom_templates:
     type: list
     display_name: Extensibility with Custom Templates
-    description: "- Custom templates can be added below the playbook directory.\n-
-      If a location above the directory is desired, a symbolic link can be used.\n-
-      Example under the `playbooks` directory create symbolic link with the following
-      command:\n\n  ```bash\n  ln -s ../../shared_repo/custom_avd_templates/ ./custom_avd_templates\n
-      \ ```\n\n- The output will be rendered at the end of the configuration.\n- The
-      order of custom templates in the list can be important if they overlap.\n- It
-      is recommenended to use a `!` delimiter at the top of each custom template.\n\nAdd
-      `custom_templates` to group/host variables:\n"
+    description: "- Custom templates can be added below the playbook directory.\n\
+      - If a location above the directory is desired, a symbolic link can be used.\n\
+      - Example under the `playbooks` directory create symbolic link with the following\
+      \ command:\n\n  ```bash\n  ln -s ../../shared_repo/custom_avd_templates/ ./custom_avd_templates\n\
+      \  ```\n\n- The output will be rendered at the end of the configuration.\n-\
+      \ The order of custom templates in the list can be important if they overlap.\n\
+      - It is recommenended to use a `!` delimiter at the top of each custom template.\n\
+      \nAdd `custom_templates` to group/host variables:\n"
     items:
       type: str
       description: Template relative path below playbook directory
@@ -583,12 +583,12 @@ keys:
                 type: bool
   daemon_terminattr:
     type: dict
-    description: "You can either provide a list of IPs/FQDNs to target on-premise
-      Cloudvision cluster or use DNS name for your Cloudvision as a Service instance.\nStreaming
-      to multiple clusters both on-prem and cloud service is supported.\n> Note For
-      TerminAttr version recommendation and EOS compatibility matrix, please refer
-      to the latest TerminAttr Release Notes\n  which always contain the latest recommended
-      versions and minimum required versions per EOS release.\n"
+    description: "You can either provide a list of IPs/FQDNs to target on-premise\
+      \ Cloudvision cluster or use DNS name for your Cloudvision as a Service instance.\n\
+      Streaming to multiple clusters both on-prem and cloud service is supported.\n\
+      > Note For TerminAttr version recommendation and EOS compatibility matrix, please\
+      \ refer to the latest TerminAttr Release Notes\n  which always contain the latest\
+      \ recommended versions and minimum required versions per EOS release.\n"
     keys:
       cvaddrs:
         type: list
@@ -1434,15 +1434,15 @@ keys:
     convert_types:
     - dict
     display_name: IP Community Lists
-    description: "AVD supports 2 different data models for community lists:\n\n- The
-      legacy `community_lists` data model that can be used for compatibility with
-      the existing deployments.\n- The improved `ip_community_lists` data model.\n\nBoth
-      data models can coexist without conflicts, as different keys are used: `community_lists`
-      vs `ip_community_lists`.\nCommunity list names must be unique.\n\nThe improved
-      data model has a better design documented below:\n\ncommunities and regexp MUST
-      not be configured together in the same entry\npossible community strings are
-      (case insensitive):\n - GSHUT\n - internet\n - local-as\n - no-advertise\n -
-      no-export\n - <1-4294967040>\n - aa:nn\n"
+    description: "AVD supports 2 different data models for community lists:\n\n- The\
+      \ legacy `community_lists` data model that can be used for compatibility with\
+      \ the existing deployments.\n- The improved `ip_community_lists` data model.\n\
+      \nBoth data models can coexist without conflicts, as different keys are used:\
+      \ `community_lists` vs `ip_community_lists`.\nCommunity list names must be unique.\n\
+      \nThe improved data model has a better design documented below:\n\ncommunities\
+      \ and regexp MUST not be configured together in the same entry\npossible community\
+      \ strings are (case insensitive):\n - GSHUT\n - internet\n - local-as\n - no-advertise\n\
+      \ - no-export\n - <1-4294967040>\n - aa:nn\n"
     items:
       type: dict
       keys:
@@ -2755,7 +2755,7 @@ keys:
           description: IPv6 address of default gateway in management VRF
         mac_address:
           type: str
-          description: MAC_address
+          description: MAC address
   management_security:
     type: dict
     keys:
@@ -2783,8 +2783,8 @@ keys:
               type: str
             tls_versions:
               type: str
-              description: "List of allowed TLS versions as string\nExamples:\n  -
-                \"1.0\"\n  - \"1.0 1.1\"\n"
+              description: "List of allowed TLS versions as string\nExamples:\n  -\
+                \ \"1.0\"\n  - \"1.0 1.1\"\n"
               convert_types:
               - float
             cipher_list:
@@ -3182,12 +3182,12 @@ keys:
               type: str
         rate_limit_per_ingress_chip:
           type: str
-          description: "Ratelimit and unit as string.\nExamples:\n  \"100000 bps\"\n
-            \ \"100 kbps\"\n  \"10 mbps\"\n"
+          description: "Ratelimit and unit as string.\nExamples:\n  \"100000 bps\"\
+            \n  \"100 kbps\"\n  \"10 mbps\"\n"
         rate_limit_per_egress_chip:
           type: str
-          description: "Ratelimit and unit as string.\nExamples:\n  \"100000 bps\"\n
-            \ \"100 kbps\"\n  \"10 mbps\"\n"
+          description: "Ratelimit and unit as string.\nExamples:\n  \"100000 bps\"\
+            \n  \"100 kbps\"\n  \"10 mbps\"\n"
         sample:
           type: int
           convert_types:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -338,9 +338,9 @@ keys:
                   Example: "deny ip any any"'
   aliases:
     type: str
-    description: "Multi-line string with one or more alias commands.\n\nExample:\n\
-      \n```yaml\naliases: |\n  alias wr copy running-config startup-config\n  alias\
-      \ siib show ip interface brief\n```"
+    description: "Multi-line string with one or more alias commands.\n\nExample:\n\n```yaml\naliases:
+      |\n  alias wr copy running-config startup-config\n  alias siib show ip interface
+      brief\n```"
   arp:
     type: dict
     keys:
@@ -540,14 +540,14 @@ keys:
   custom_templates:
     type: list
     display_name: Extensibility with Custom Templates
-    description: "- Custom templates can be added below the playbook directory.\n\
-      - If a location above the directory is desired, a symbolic link can be used.\n\
-      - Example under the `playbooks` directory create symbolic link with the following\
-      \ command:\n\n  ```bash\n  ln -s ../../shared_repo/custom_avd_templates/ ./custom_avd_templates\n\
-      \  ```\n\n- The output will be rendered at the end of the configuration.\n-\
-      \ The order of custom templates in the list can be important if they overlap.\n\
-      - It is recommenended to use a `!` delimiter at the top of each custom template.\n\
-      \nAdd `custom_templates` to group/host variables:\n"
+    description: "- Custom templates can be added below the playbook directory.\n-
+      If a location above the directory is desired, a symbolic link can be used.\n-
+      Example under the `playbooks` directory create symbolic link with the following
+      command:\n\n  ```bash\n  ln -s ../../shared_repo/custom_avd_templates/ ./custom_avd_templates\n
+      \ ```\n\n- The output will be rendered at the end of the configuration.\n- The
+      order of custom templates in the list can be important if they overlap.\n- It
+      is recommenended to use a `!` delimiter at the top of each custom template.\n\nAdd
+      `custom_templates` to group/host variables:\n"
     items:
       type: str
       description: Template relative path below playbook directory
@@ -583,12 +583,12 @@ keys:
                 type: bool
   daemon_terminattr:
     type: dict
-    description: "You can either provide a list of IPs/FQDNs to target on-premise\
-      \ Cloudvision cluster or use DNS name for your Cloudvision as a Service instance.\n\
-      Streaming to multiple clusters both on-prem and cloud service is supported.\n\
-      > Note For TerminAttr version recommendation and EOS compatibility matrix, please\
-      \ refer to the latest TerminAttr Release Notes\n  which always contain the latest\
-      \ recommended versions and minimum required versions per EOS release.\n"
+    description: "You can either provide a list of IPs/FQDNs to target on-premise
+      Cloudvision cluster or use DNS name for your Cloudvision as a Service instance.\nStreaming
+      to multiple clusters both on-prem and cloud service is supported.\n> Note For
+      TerminAttr version recommendation and EOS compatibility matrix, please refer
+      to the latest TerminAttr Release Notes\n  which always contain the latest recommended
+      versions and minimum required versions per EOS release.\n"
     keys:
       cvaddrs:
         type: list
@@ -1434,15 +1434,15 @@ keys:
     convert_types:
     - dict
     display_name: IP Community Lists
-    description: "AVD supports 2 different data models for community lists:\n\n- The\
-      \ legacy `community_lists` data model that can be used for compatibility with\
-      \ the existing deployments.\n- The improved `ip_community_lists` data model.\n\
-      \nBoth data models can coexist without conflicts, as different keys are used:\
-      \ `community_lists` vs `ip_community_lists`.\nCommunity list names must be unique.\n\
-      \nThe improved data model has a better design documented below:\n\ncommunities\
-      \ and regexp MUST not be configured together in the same entry\npossible community\
-      \ strings are (case insensitive):\n - GSHUT\n - internet\n - local-as\n - no-advertise\n\
-      \ - no-export\n - <1-4294967040>\n - aa:nn\n"
+    description: "AVD supports 2 different data models for community lists:\n\n- The
+      legacy `community_lists` data model that can be used for compatibility with
+      the existing deployments.\n- The improved `ip_community_lists` data model.\n\nBoth
+      data models can coexist without conflicts, as different keys are used: `community_lists`
+      vs `ip_community_lists`.\nCommunity list names must be unique.\n\nThe improved
+      data model has a better design documented below:\n\ncommunities and regexp MUST
+      not be configured together in the same entry\npossible community strings are
+      (case insensitive):\n - GSHUT\n - internet\n - local-as\n - no-advertise\n -
+      no-export\n - <1-4294967040>\n - aa:nn\n"
     items:
       type: dict
       keys:
@@ -2783,8 +2783,8 @@ keys:
               type: str
             tls_versions:
               type: str
-              description: "List of allowed TLS versions as string\nExamples:\n  -\
-                \ \"1.0\"\n  - \"1.0 1.1\"\n"
+              description: "List of allowed TLS versions as string\nExamples:\n  -
+                \"1.0\"\n  - \"1.0 1.1\"\n"
               convert_types:
               - float
             cipher_list:
@@ -3182,12 +3182,12 @@ keys:
               type: str
         rate_limit_per_ingress_chip:
           type: str
-          description: "Ratelimit and unit as string.\nExamples:\n  \"100000 bps\"\
-            \n  \"100 kbps\"\n  \"10 mbps\"\n"
+          description: "Ratelimit and unit as string.\nExamples:\n  \"100000 bps\"\n
+            \ \"100 kbps\"\n  \"10 mbps\"\n"
         rate_limit_per_egress_chip:
           type: str
-          description: "Ratelimit and unit as string.\nExamples:\n  \"100000 bps\"\
-            \n  \"100 kbps\"\n  \"10 mbps\"\n"
+          description: "Ratelimit and unit as string.\nExamples:\n  \"100000 bps\"\n
+            \ \"100 kbps\"\n  \"10 mbps\"\n"
         sample:
           type: int
           convert_types:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_interfaces.schema.yml
@@ -43,3 +43,6 @@ keys:
         ipv6_gateway:
           type: str
           description: IPv6 address of default gateway in management VRF
+        mac_address:
+          type: str
+          description: MAC_address

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_interfaces.schema.yml
@@ -45,4 +45,4 @@ keys:
           description: IPv6 address of default gateway in management VRF
         mac_address:
           type: str
-          description: MAC_address
+          description: MAC address

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-interfaces.j2
@@ -13,6 +13,9 @@ interface {{ management_interface.name }}
 {%     if management_interface.mtu is arista.avd.defined %}
    mtu {{ management_interface.mtu }}
 {%     endif %}
+{%     if management_interface.mac_address is arista.avd.defined %}
+   mac-address {{ management_interface.mac_address }}
+{%     endif %}
 {%     if management_interface.vrf is arista.avd.defined and management_interface.vrf != 'default' %}
    vrf {{ management_interface.vrf }}
 {%     endif %}
@@ -24,8 +27,5 @@ interface {{ management_interface.name }}
 {%     endif %}
 {%     if management_interface.ipv6_address is arista.avd.defined %}
    ipv6 address {{ management_interface.ipv6_address }}
-{%     endif %}
-{%     if management_interface.mac_address is arista.avd.defined %}
-   mac-address {{ management_interface.mac_address }}
 {%     endif %}
 {% endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-interfaces.j2
@@ -25,4 +25,7 @@ interface {{ management_interface.name }}
 {%     if management_interface.ipv6_address is arista.avd.defined %}
    ipv6 address {{ management_interface.ipv6_address }}
 {%     endif %}
+{%     if management_interface.mac_address is arista.avd.defined %}
+   mac-address {{ management_interface.mac_address }}
+{%     endif %}
 {% endfor %}


### PR DESCRIPTION
## Change Summary

Adding support for Ma0 VIP for High Availability

## Related Issue(s)

Fixes #2073 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Data Model:
```
  Management0:
    ip_address: 10.0.0.0
    mac_address: 00:1c:73:00:00:aa
```
intended config:
```
interface Management0
   ip address 10.0.0.0
   mac-address 00:1c:73:00:00:aa
```


## How to test
`molecule converge --scenario-name eos_cli_config_gen -- --limit management-interfaces`

## Checklist

### User Checklist
- N/A

### Repository Checklist

- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
