### PR TITLE
Feat: Add peer hosts to CVX

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/cvx.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/cvx.md
@@ -48,6 +48,9 @@ interface Management1
 ```
 
 # CVX
+| Peer Hosts |
+| ---------- |
+| 1.1.1.1, 2.2.2.2 |
 
 CVX is enabled
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/cvx.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/cvx.md
@@ -48,6 +48,7 @@ interface Management1
 ```
 
 # CVX
+
 | Peer Hosts |
 | ---------- |
 | 1.1.1.1, 2.2.2.2 |

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/cvx.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/cvx.md
@@ -63,6 +63,8 @@ CVX is enabled
 !
 cvx
    no shutdown
+   peer host 1.1.1.1
+   peer host 2.2.2.2
    service mcs
       redis password 7 070E334ddD1D18
       no shutdown

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/cvx.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/cvx.cfg
@@ -9,6 +9,8 @@ no aaa root
 !
 cvx
    no shutdown
+   peer host 1.1.1.1
+   peer host 2.2.2.2
    service mcs
       redis password 7 070E334ddD1D18
       no shutdown

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/cvx.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/cvx.yml
@@ -1,6 +1,9 @@
 ### CVX ###
 cvx:
   shutdown: false
+  peer_hosts:
+  - 1.1.1.1
+  - 2.2.2.2
   services:
     mcs:
       redis:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -330,6 +330,7 @@ cvx:
         password: < password >
         password_type: < 0 | 7 | 8a | default -> 7 >
       shutdown: < true | false >
+      peer_hosts: < IP address or hostname >
 ```
 
 #### Enable Password

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -483,6 +483,8 @@ CVX server features are not supported on physical switches. See `management_cvx`
 | -------- | ---- | -------- | ------- | ------------------ | ----------- |
 | [<samp>cvx</samp>](## "cvx") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;shutdown</samp>](## "cvx.shutdown") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;peer_hosts</samp>](## "cvx.peer_hosts") | List, items: String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "cvx.peer_hosts.[].&lt;str&gt;") | String |  |  |  | IP address or hostname |
 | [<samp>&nbsp;&nbsp;services</samp>](## "cvx.services") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mcs</samp>](## "cvx.services.mcs") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;redis</samp>](## "cvx.services.mcs.redis") | Dictionary |  |  |  |  |
@@ -495,6 +497,8 @@ CVX server features are not supported on physical switches. See `management_cvx`
 ```yaml
 cvx:
   shutdown: <bool>
+  peer_hosts:
+    - <str>
   services:
     mcs:
       redis:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -746,6 +746,14 @@
           "type": "boolean",
           "title": "Shutdown"
         },
+        "peer_hosts": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "description": "IP address or hostname"
+          },
+          "title": "Peer Hosts"
+        },
         "services": {
           "type": "object",
           "properties": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -338,9 +338,9 @@ keys:
                   Example: "deny ip any any"'
   aliases:
     type: str
-    description: "Multi-line string with one or more alias commands.\n\nExample:\n\n```yaml\naliases:
-      |\n  alias wr copy running-config startup-config\n  alias siib show ip interface
-      brief\n```"
+    description: "Multi-line string with one or more alias commands.\n\nExample:\n\
+      \n```yaml\naliases: |\n  alias wr copy running-config startup-config\n  alias\
+      \ siib show ip interface brief\n```"
   arp:
     type: dict
     keys:
@@ -540,14 +540,14 @@ keys:
   custom_templates:
     type: list
     display_name: Extensibility with Custom Templates
-    description: "- Custom templates can be added below the playbook directory.\n-
-      If a location above the directory is desired, a symbolic link can be used.\n-
-      Example under the `playbooks` directory create symbolic link with the following
-      command:\n\n  ```bash\n  ln -s ../../shared_repo/custom_avd_templates/ ./custom_avd_templates\n
-      \ ```\n\n- The output will be rendered at the end of the configuration.\n- The
-      order of custom templates in the list can be important if they overlap.\n- It
-      is recommenended to use a `!` delimiter at the top of each custom template.\n\nAdd
-      `custom_templates` to group/host variables:\n"
+    description: "- Custom templates can be added below the playbook directory.\n\
+      - If a location above the directory is desired, a symbolic link can be used.\n\
+      - Example under the `playbooks` directory create symbolic link with the following\
+      \ command:\n\n  ```bash\n  ln -s ../../shared_repo/custom_avd_templates/ ./custom_avd_templates\n\
+      \  ```\n\n- The output will be rendered at the end of the configuration.\n-\
+      \ The order of custom templates in the list can be important if they overlap.\n\
+      - It is recommenended to use a `!` delimiter at the top of each custom template.\n\
+      \nAdd `custom_templates` to group/host variables:\n"
     items:
       type: str
       description: Template relative path below playbook directory
@@ -558,6 +558,11 @@ keys:
     keys:
       shutdown:
         type: bool
+      peer_hosts:
+        type: list
+        items:
+          type: str
+          description: IP address or hostname
       services:
         type: dict
         keys:
@@ -583,12 +588,12 @@ keys:
                 type: bool
   daemon_terminattr:
     type: dict
-    description: "You can either provide a list of IPs/FQDNs to target on-premise
-      Cloudvision cluster or use DNS name for your Cloudvision as a Service instance.\nStreaming
-      to multiple clusters both on-prem and cloud service is supported.\n> Note For
-      TerminAttr version recommendation and EOS compatibility matrix, please refer
-      to the latest TerminAttr Release Notes\n  which always contain the latest recommended
-      versions and minimum required versions per EOS release.\n"
+    description: "You can either provide a list of IPs/FQDNs to target on-premise\
+      \ Cloudvision cluster or use DNS name for your Cloudvision as a Service instance.\n\
+      Streaming to multiple clusters both on-prem and cloud service is supported.\n\
+      > Note For TerminAttr version recommendation and EOS compatibility matrix, please\
+      \ refer to the latest TerminAttr Release Notes\n  which always contain the latest\
+      \ recommended versions and minimum required versions per EOS release.\n"
     keys:
       cvaddrs:
         type: list
@@ -1450,15 +1455,15 @@ keys:
     convert_types:
     - dict
     display_name: IP Community Lists
-    description: "AVD supports 2 different data models for community lists:\n\n- The
-      legacy `community_lists` data model that can be used for compatibility with
-      the existing deployments.\n- The improved `ip_community_lists` data model.\n\nBoth
-      data models can coexist without conflicts, as different keys are used: `community_lists`
-      vs `ip_community_lists`.\nCommunity list names must be unique.\n\nThe improved
-      data model has a better design documented below:\n\ncommunities and regexp MUST
-      not be configured together in the same entry\npossible community strings are
-      (case insensitive):\n - GSHUT\n - internet\n - local-as\n - no-advertise\n -
-      no-export\n - <1-4294967040>\n - aa:nn\n"
+    description: "AVD supports 2 different data models for community lists:\n\n- The\
+      \ legacy `community_lists` data model that can be used for compatibility with\
+      \ the existing deployments.\n- The improved `ip_community_lists` data model.\n\
+      \nBoth data models can coexist without conflicts, as different keys are used:\
+      \ `community_lists` vs `ip_community_lists`.\nCommunity list names must be unique.\n\
+      \nThe improved data model has a better design documented below:\n\ncommunities\
+      \ and regexp MUST not be configured together in the same entry\npossible community\
+      \ strings are (case insensitive):\n - GSHUT\n - internet\n - local-as\n - no-advertise\n\
+      \ - no-export\n - <1-4294967040>\n - aa:nn\n"
     items:
       type: dict
       keys:
@@ -2799,8 +2804,8 @@ keys:
               type: str
             tls_versions:
               type: str
-              description: "List of allowed TLS versions as string\nExamples:\n  -
-                \"1.0\"\n  - \"1.0 1.1\"\n"
+              description: "List of allowed TLS versions as string\nExamples:\n  -\
+                \ \"1.0\"\n  - \"1.0 1.1\"\n"
               convert_types:
               - float
             cipher_list:
@@ -3198,12 +3203,12 @@ keys:
               type: str
         rate_limit_per_ingress_chip:
           type: str
-          description: "Ratelimit and unit as string.\nExamples:\n  \"100000 bps\"\n
-            \ \"100 kbps\"\n  \"10 mbps\"\n"
+          description: "Ratelimit and unit as string.\nExamples:\n  \"100000 bps\"\
+            \n  \"100 kbps\"\n  \"10 mbps\"\n"
         rate_limit_per_egress_chip:
           type: str
-          description: "Ratelimit and unit as string.\nExamples:\n  \"100000 bps\"\n
-            \ \"100 kbps\"\n  \"10 mbps\"\n"
+          description: "Ratelimit and unit as string.\nExamples:\n  \"100000 bps\"\
+            \n  \"100 kbps\"\n  \"10 mbps\"\n"
         sample:
           type: int
           convert_types:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -338,9 +338,9 @@ keys:
                   Example: "deny ip any any"'
   aliases:
     type: str
-    description: "Multi-line string with one or more alias commands.\n\nExample:\n\
-      \n```yaml\naliases: |\n  alias wr copy running-config startup-config\n  alias\
-      \ siib show ip interface brief\n```"
+    description: "Multi-line string with one or more alias commands.\n\nExample:\n\n```yaml\naliases:
+      |\n  alias wr copy running-config startup-config\n  alias siib show ip interface
+      brief\n```"
   arp:
     type: dict
     keys:
@@ -540,14 +540,14 @@ keys:
   custom_templates:
     type: list
     display_name: Extensibility with Custom Templates
-    description: "- Custom templates can be added below the playbook directory.\n\
-      - If a location above the directory is desired, a symbolic link can be used.\n\
-      - Example under the `playbooks` directory create symbolic link with the following\
-      \ command:\n\n  ```bash\n  ln -s ../../shared_repo/custom_avd_templates/ ./custom_avd_templates\n\
-      \  ```\n\n- The output will be rendered at the end of the configuration.\n-\
-      \ The order of custom templates in the list can be important if they overlap.\n\
-      - It is recommenended to use a `!` delimiter at the top of each custom template.\n\
-      \nAdd `custom_templates` to group/host variables:\n"
+    description: "- Custom templates can be added below the playbook directory.\n-
+      If a location above the directory is desired, a symbolic link can be used.\n-
+      Example under the `playbooks` directory create symbolic link with the following
+      command:\n\n  ```bash\n  ln -s ../../shared_repo/custom_avd_templates/ ./custom_avd_templates\n
+      \ ```\n\n- The output will be rendered at the end of the configuration.\n- The
+      order of custom templates in the list can be important if they overlap.\n- It
+      is recommenended to use a `!` delimiter at the top of each custom template.\n\nAdd
+      `custom_templates` to group/host variables:\n"
     items:
       type: str
       description: Template relative path below playbook directory
@@ -588,12 +588,12 @@ keys:
                 type: bool
   daemon_terminattr:
     type: dict
-    description: "You can either provide a list of IPs/FQDNs to target on-premise\
-      \ Cloudvision cluster or use DNS name for your Cloudvision as a Service instance.\n\
-      Streaming to multiple clusters both on-prem and cloud service is supported.\n\
-      > Note For TerminAttr version recommendation and EOS compatibility matrix, please\
-      \ refer to the latest TerminAttr Release Notes\n  which always contain the latest\
-      \ recommended versions and minimum required versions per EOS release.\n"
+    description: "You can either provide a list of IPs/FQDNs to target on-premise
+      Cloudvision cluster or use DNS name for your Cloudvision as a Service instance.\nStreaming
+      to multiple clusters both on-prem and cloud service is supported.\n> Note For
+      TerminAttr version recommendation and EOS compatibility matrix, please refer
+      to the latest TerminAttr Release Notes\n  which always contain the latest recommended
+      versions and minimum required versions per EOS release.\n"
     keys:
       cvaddrs:
         type: list
@@ -1455,15 +1455,15 @@ keys:
     convert_types:
     - dict
     display_name: IP Community Lists
-    description: "AVD supports 2 different data models for community lists:\n\n- The\
-      \ legacy `community_lists` data model that can be used for compatibility with\
-      \ the existing deployments.\n- The improved `ip_community_lists` data model.\n\
-      \nBoth data models can coexist without conflicts, as different keys are used:\
-      \ `community_lists` vs `ip_community_lists`.\nCommunity list names must be unique.\n\
-      \nThe improved data model has a better design documented below:\n\ncommunities\
-      \ and regexp MUST not be configured together in the same entry\npossible community\
-      \ strings are (case insensitive):\n - GSHUT\n - internet\n - local-as\n - no-advertise\n\
-      \ - no-export\n - <1-4294967040>\n - aa:nn\n"
+    description: "AVD supports 2 different data models for community lists:\n\n- The
+      legacy `community_lists` data model that can be used for compatibility with
+      the existing deployments.\n- The improved `ip_community_lists` data model.\n\nBoth
+      data models can coexist without conflicts, as different keys are used: `community_lists`
+      vs `ip_community_lists`.\nCommunity list names must be unique.\n\nThe improved
+      data model has a better design documented below:\n\ncommunities and regexp MUST
+      not be configured together in the same entry\npossible community strings are
+      (case insensitive):\n - GSHUT\n - internet\n - local-as\n - no-advertise\n -
+      no-export\n - <1-4294967040>\n - aa:nn\n"
     items:
       type: dict
       keys:
@@ -2804,8 +2804,8 @@ keys:
               type: str
             tls_versions:
               type: str
-              description: "List of allowed TLS versions as string\nExamples:\n  -\
-                \ \"1.0\"\n  - \"1.0 1.1\"\n"
+              description: "List of allowed TLS versions as string\nExamples:\n  -
+                \"1.0\"\n  - \"1.0 1.1\"\n"
               convert_types:
               - float
             cipher_list:
@@ -3203,12 +3203,12 @@ keys:
               type: str
         rate_limit_per_ingress_chip:
           type: str
-          description: "Ratelimit and unit as string.\nExamples:\n  \"100000 bps\"\
-            \n  \"100 kbps\"\n  \"10 mbps\"\n"
+          description: "Ratelimit and unit as string.\nExamples:\n  \"100000 bps\"\n
+            \ \"100 kbps\"\n  \"10 mbps\"\n"
         rate_limit_per_egress_chip:
           type: str
-          description: "Ratelimit and unit as string.\nExamples:\n  \"100000 bps\"\
-            \n  \"100 kbps\"\n  \"10 mbps\"\n"
+          description: "Ratelimit and unit as string.\nExamples:\n  \"100000 bps\"\n
+            \ \"100 kbps\"\n  \"10 mbps\"\n"
         sample:
           type: int
           convert_types:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/cvx.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/cvx.schema.yml
@@ -9,6 +9,11 @@ keys:
     keys:
       shutdown:
         type: bool
+      peer_hosts:
+        type: list
+        items:
+          type: str
+          description: IP address or hostname
       services:
         type: dict
         keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/cvx.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/cvx.j2
@@ -3,6 +3,7 @@
 
 # CVX
 {%     if cvx.peer_hosts is arista.avd.defined %}
+
 | Peer Hosts |
 | ---------- |
 {%         set peer_hosts = cvx.peer_hosts | arista.avd.natural_sort | join(', ') %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/cvx.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/cvx.j2
@@ -2,6 +2,12 @@
 {% if cvx is arista.avd.defined %}
 
 # CVX
+{%     if cvx.peer_hosts is arista.avd.defined %}
+| Peer Hosts |
+| ---------- |
+{%         set peer_hosts = cvx.peer_hosts | arista.avd.natural_sort | join(', ') %}
+{%     endif %}
+| {{ peer_hosts }} |
 {%     if cvx.shutdown is arista.avd.defined(true) %}
 
 CVX is disabled

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/cvx.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/cvx.j2
@@ -7,6 +7,9 @@ cvx
 {%     elif cvx.shutdown is arista.avd.defined(false) %}
    no shutdown
 {%     endif %}
+{%     for peer_hosts in cvx.peer_hosts | arista.avd.natural_sort %}
+   peer host {{ peer_hosts }}
+{%     endfor %}
 {%     if cvx.services is arista.avd.defined %}
 {%         if cvx.services.mcs is arista.avd.defined %}
    service mcs

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/cvx.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/cvx.j2
@@ -7,8 +7,8 @@ cvx
 {%     elif cvx.shutdown is arista.avd.defined(false) %}
    no shutdown
 {%     endif %}
-{%     for peer_hosts in cvx.peer_hosts | arista.avd.natural_sort %}
-   peer host {{ peer_hosts }}
+{%     for peer_host in cvx.peer_hosts | arista.avd.natural_sort %}
+   peer host {{ peer_host }}
 {%     endfor %}
 {%     if cvx.services is arista.avd.defined %}
 {%         if cvx.services.mcs is arista.avd.defined %}


### PR DESCRIPTION
## Change Summary

Added `peer host` knob to CVX

## Related Issue(s)

Fixes #2074 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Data Model
```
cvx:
  shutdown: false
  peer_hosts:
  - 1.1.1.1
  - 2.2.2.2
  services:
    mcs:
      redis:
        password: 070E334ddD1D18
        password_type: 7
      shutdown: false
```

Config:
```
cvx
   no shutdown
   peer host 1.1.1.1
   peer host 2.2.2.2
   service mcs
      redis password 7 070E334ddD1D18
      no shutdown
```


## How to test
`molecule converge --scenario-name eos_cli_config_gen -- --limit cvx`

## Checklist


### Repository Checklist

- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
