### PR TITLE
Feat(eos_cli_config_gen): Add schema for ptp

### DIFF
--- a/ansible_collections/arista/avd/plugins/plugin_utils/schema/key_to_display_name.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/schema/key_to_display_name.py
@@ -47,6 +47,7 @@ WORDLIST = {
     "ospf": "OSPF",
     "pbr": "PBR",
     "pim": "PIM",
+    "ptp": "PTP",
     "pvlan": "PVLAN",
     "qos": "QOS",
     "ra": "RA",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -2837,28 +2837,28 @@ prompt: <str>
 | Variable | Type | Required | Default | Value Restrictions | Description |
 | -------- | ---- | -------- | ------- | ------------------ | ----------- |
 | [<samp>ptp</samp>](## "ptp") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;mode</samp>](## "ptp.mode") | String |  |  | Valid Values:<br>- boundary<br>- transparent | Mode value |
+| [<samp>&nbsp;&nbsp;mode</samp>](## "ptp.mode") | String |  |  | Valid Values:<br>- boundary<br>- transparent |  |
 | [<samp>&nbsp;&nbsp;forward_unicast</samp>](## "ptp.forward_unicast") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;clock_identity</samp>](## "ptp.clock_identity") | String |  |  |  | The clock-id in xx:xx:xx:xx:xx:xx format |
 | [<samp>&nbsp;&nbsp;source</samp>](## "ptp.source") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip</samp>](## "ptp.source.ip") | String |  |  |  | Source IP |
 | [<samp>&nbsp;&nbsp;priority1</samp>](## "ptp.priority1") | Integer |  |  | Min: 0<br>Max: 255 |  |
 | [<samp>&nbsp;&nbsp;priority2</samp>](## "ptp.priority2") | Integer |  |  | Min: 0<br>Max: 255 |  |
-| [<samp>&nbsp;&nbsp;ttl</samp>](## "ptp.ttl") | Integer |  |  | Min: 1<br>Max: 254 | TTL value |
+| [<samp>&nbsp;&nbsp;ttl</samp>](## "ptp.ttl") | Integer |  |  | Min: 1<br>Max: 254 |  |
 | [<samp>&nbsp;&nbsp;domain</samp>](## "ptp.domain") | Integer |  |  | Min: 0<br>Max: 255 |  |
 | [<samp>&nbsp;&nbsp;message_type</samp>](## "ptp.message_type") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;general</samp>](## "ptp.message_type.general") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dscp</samp>](## "ptp.message_type.general.dscp") | Integer |  |  |  | DSCP value |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dscp</samp>](## "ptp.message_type.general.dscp") | Integer |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;event</samp>](## "ptp.message_type.event") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dscp</samp>](## "ptp.message_type.event.dscp") | Integer |  |  |  | DSCP value |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dscp</samp>](## "ptp.message_type.event.dscp") | Integer |  |  |  |  |
 | [<samp>&nbsp;&nbsp;monitor</samp>](## "ptp.monitor") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "ptp.monitor.enabled") | Boolean |  | True |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;threshold</samp>](## "ptp.monitor.threshold") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;offset_from_master</samp>](## "ptp.monitor.threshold.offset_from_master") | Integer |  |  | Min: 0<br>Max: 1000000000 | Offset value |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mean_path_delay</samp>](## "ptp.monitor.threshold.mean_path_delay") | Integer |  |  | Min: 0<br>Max: 1000000000 | Delay value |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;offset_from_master</samp>](## "ptp.monitor.threshold.offset_from_master") | Integer |  |  | Min: 0<br>Max: 1000000000 |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mean_path_delay</samp>](## "ptp.monitor.threshold.mean_path_delay") | Integer |  |  | Min: 0<br>Max: 1000000000 |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;drop</samp>](## "ptp.monitor.threshold.drop") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;offset_from_master</samp>](## "ptp.monitor.threshold.drop.offset_from_master") | Integer |  |  | Min: 0<br>Max: 1000000000 | Offset value |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mean_path_delay</samp>](## "ptp.monitor.threshold.drop.mean_path_delay") | Integer |  |  | Min: 0<br>Max: 1000000000 | Delay value |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;offset_from_master</samp>](## "ptp.monitor.threshold.drop.offset_from_master") | Integer |  |  | Min: 0<br>Max: 1000000000 |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mean_path_delay</samp>](## "ptp.monitor.threshold.drop.mean_path_delay") | Integer |  |  | Min: 0<br>Max: 1000000000 |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;missing_message</samp>](## "ptp.monitor.missing_message") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;intervals</samp>](## "ptp.monitor.missing_message.intervals") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;announce</samp>](## "ptp.monitor.missing_message.intervals.announce") | Integer |  |  | Min: 2<br>Max: 255 |  |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -2865,7 +2865,7 @@ prompt: <str>
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;follow_up</samp>](## "ptp.monitor.missing_message.intervals.follow_up") | Integer |  |  | Min: 2<br>Max: 255 |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;sync</samp>](## "ptp.monitor.missing_message.intervals.sync") | Integer |  |  | Min: 2<br>Max: 255 |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;sequence_ids</samp>](## "ptp.monitor.missing_message.sequence_ids") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "ptp.monitor.missing_message.sequence_ids.enabled") | Boolean |  | False |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "ptp.monitor.missing_message.sequence_ids.enabled") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;announce</samp>](## "ptp.monitor.missing_message.sequence_ids.announce") | Integer |  |  | Min: 2<br>Max: 255 |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;delay_resp</samp>](## "ptp.monitor.missing_message.sequence_ids.delay_resp") | Integer |  |  | Min: 2<br>Max: 255 |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;follow_up</samp>](## "ptp.monitor.missing_message.sequence_ids.follow_up") | Integer |  |  | Min: 2<br>Max: 255 |  |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -2830,6 +2830,86 @@ prefix_lists:
 prompt: <str>
 ```
 
+## Ptp
+
+### Variables
+
+| Variable | Type | Required | Default | Value Restrictions | Description |
+| -------- | ---- | -------- | ------- | ------------------ | ----------- |
+| [<samp>ptp</samp>](## "ptp") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;mode</samp>](## "ptp.mode") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;forward_unicast</samp>](## "ptp.forward_unicast") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;clock_identity</samp>](## "ptp.clock_identity") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;source</samp>](## "ptp.source") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip</samp>](## "ptp.source.ip") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;priority1</samp>](## "ptp.priority1") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;priority2</samp>](## "ptp.priority2") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;ttl</samp>](## "ptp.ttl") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;domain</samp>](## "ptp.domain") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;message_type</samp>](## "ptp.message_type") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;general</samp>](## "ptp.message_type.general") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dscp</samp>](## "ptp.message_type.general.dscp") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;event</samp>](## "ptp.message_type.event") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dscp</samp>](## "ptp.message_type.event.dscp") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;monitor</samp>](## "ptp.monitor") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "ptp.monitor.enabled") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;threshold</samp>](## "ptp.monitor.threshold") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;offset_from_master</samp>](## "ptp.monitor.threshold.offset_from_master") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mean_path_delay</samp>](## "ptp.monitor.threshold.mean_path_delay") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;drop</samp>](## "ptp.monitor.threshold.drop") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;offset_from_master</samp>](## "ptp.monitor.threshold.drop.offset_from_master") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mean_path_delay</samp>](## "ptp.monitor.threshold.drop.mean_path_delay") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;missing_message</samp>](## "ptp.monitor.missing_message") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;intervals</samp>](## "ptp.monitor.missing_message.intervals") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;announce</samp>](## "ptp.monitor.missing_message.intervals.announce") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;follow_up</samp>](## "ptp.monitor.missing_message.intervals.follow_up") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;sync</samp>](## "ptp.monitor.missing_message.intervals.sync") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;sequence_ids</samp>](## "ptp.monitor.missing_message.sequence_ids") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "ptp.monitor.missing_message.sequence_ids.enabled") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;announce</samp>](## "ptp.monitor.missing_message.sequence_ids.announce") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;delay_resp</samp>](## "ptp.monitor.missing_message.sequence_ids.delay_resp") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;follow_up</samp>](## "ptp.monitor.missing_message.sequence_ids.follow_up") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;sync</samp>](## "ptp.monitor.missing_message.sequence_ids.sync") | Integer |  |  |  |  |
+
+### YAML
+
+```yaml
+ptp:
+  mode: <str>
+  forward_unicast: <bool>
+  clock_identity: <str>
+  source:
+    ip: <str>
+  priority1: <int>
+  priority2: <int>
+  ttl: <int>
+  domain: <int>
+  message_type:
+    general:
+      dscp: <int>
+    event:
+      dscp: <int>
+  monitor:
+    enabled: <bool>
+    threshold:
+      offset_from_master: <int>
+      mean_path_delay: <int>
+      drop:
+        offset_from_master: <int>
+        mean_path_delay: <int>
+    missing_message:
+      intervals:
+        announce: <int>
+        follow_up: <int>
+        sync: <int>
+      sequence_ids:
+        enabled: <bool>
+        announce: <int>
+        delay_resp: <int>
+        follow_up: <int>
+        sync: <int>
+```
+
 ## QOS
 
 ### Variables

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -2837,39 +2837,39 @@ prompt: <str>
 | Variable | Type | Required | Default | Value Restrictions | Description |
 | -------- | ---- | -------- | ------- | ------------------ | ----------- |
 | [<samp>ptp</samp>](## "ptp") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;mode</samp>](## "ptp.mode") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;mode</samp>](## "ptp.mode") | String |  |  | Valid Values:<br>- boundary<br>- transparent | Mode value |
 | [<samp>&nbsp;&nbsp;forward_unicast</samp>](## "ptp.forward_unicast") | Boolean |  |  |  |  |
-| [<samp>&nbsp;&nbsp;clock_identity</samp>](## "ptp.clock_identity") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;clock_identity</samp>](## "ptp.clock_identity") | String |  |  |  | The clock-id in xx:xx:xx:xx:xx:xx format |
 | [<samp>&nbsp;&nbsp;source</samp>](## "ptp.source") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip</samp>](## "ptp.source.ip") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;priority1</samp>](## "ptp.priority1") | Integer |  |  |  |  |
-| [<samp>&nbsp;&nbsp;priority2</samp>](## "ptp.priority2") | Integer |  |  |  |  |
-| [<samp>&nbsp;&nbsp;ttl</samp>](## "ptp.ttl") | Integer |  |  |  |  |
-| [<samp>&nbsp;&nbsp;domain</samp>](## "ptp.domain") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip</samp>](## "ptp.source.ip") | String |  |  |  | Source IP |
+| [<samp>&nbsp;&nbsp;priority1</samp>](## "ptp.priority1") | Integer |  |  | Min: 0<br>Max: 255 |  |
+| [<samp>&nbsp;&nbsp;priority2</samp>](## "ptp.priority2") | Integer |  |  | Min: 0<br>Max: 255 |  |
+| [<samp>&nbsp;&nbsp;ttl</samp>](## "ptp.ttl") | Integer |  |  | Min: 1<br>Max: 254 | TTL value |
+| [<samp>&nbsp;&nbsp;domain</samp>](## "ptp.domain") | Integer |  |  | Min: 0<br>Max: 255 |  |
 | [<samp>&nbsp;&nbsp;message_type</samp>](## "ptp.message_type") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;general</samp>](## "ptp.message_type.general") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dscp</samp>](## "ptp.message_type.general.dscp") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dscp</samp>](## "ptp.message_type.general.dscp") | Integer |  |  |  | DSCP value |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;event</samp>](## "ptp.message_type.event") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dscp</samp>](## "ptp.message_type.event.dscp") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dscp</samp>](## "ptp.message_type.event.dscp") | Integer |  |  |  | DSCP value |
 | [<samp>&nbsp;&nbsp;monitor</samp>](## "ptp.monitor") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "ptp.monitor.enabled") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "ptp.monitor.enabled") | Boolean |  | True |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;threshold</samp>](## "ptp.monitor.threshold") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;offset_from_master</samp>](## "ptp.monitor.threshold.offset_from_master") | Integer |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mean_path_delay</samp>](## "ptp.monitor.threshold.mean_path_delay") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;offset_from_master</samp>](## "ptp.monitor.threshold.offset_from_master") | Integer |  |  | Min: 0<br>Max: 1000000000 | Offset value |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mean_path_delay</samp>](## "ptp.monitor.threshold.mean_path_delay") | Integer |  |  | Min: 0<br>Max: 1000000000 | Delay value |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;drop</samp>](## "ptp.monitor.threshold.drop") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;offset_from_master</samp>](## "ptp.monitor.threshold.drop.offset_from_master") | Integer |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mean_path_delay</samp>](## "ptp.monitor.threshold.drop.mean_path_delay") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;offset_from_master</samp>](## "ptp.monitor.threshold.drop.offset_from_master") | Integer |  |  | Min: 0<br>Max: 1000000000 | Offset value |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mean_path_delay</samp>](## "ptp.monitor.threshold.drop.mean_path_delay") | Integer |  |  | Min: 0<br>Max: 1000000000 | Delay value |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;missing_message</samp>](## "ptp.monitor.missing_message") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;intervals</samp>](## "ptp.monitor.missing_message.intervals") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;announce</samp>](## "ptp.monitor.missing_message.intervals.announce") | Integer |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;follow_up</samp>](## "ptp.monitor.missing_message.intervals.follow_up") | Integer |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;sync</samp>](## "ptp.monitor.missing_message.intervals.sync") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;announce</samp>](## "ptp.monitor.missing_message.intervals.announce") | Integer |  |  | Min: 2<br>Max: 255 |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;follow_up</samp>](## "ptp.monitor.missing_message.intervals.follow_up") | Integer |  |  | Min: 2<br>Max: 255 |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;sync</samp>](## "ptp.monitor.missing_message.intervals.sync") | Integer |  |  | Min: 2<br>Max: 255 |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;sequence_ids</samp>](## "ptp.monitor.missing_message.sequence_ids") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "ptp.monitor.missing_message.sequence_ids.enabled") | Boolean |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;announce</samp>](## "ptp.monitor.missing_message.sequence_ids.announce") | Integer |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;delay_resp</samp>](## "ptp.monitor.missing_message.sequence_ids.delay_resp") | Integer |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;follow_up</samp>](## "ptp.monitor.missing_message.sequence_ids.follow_up") | Integer |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;sync</samp>](## "ptp.monitor.missing_message.sequence_ids.sync") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "ptp.monitor.missing_message.sequence_ids.enabled") | Boolean |  | False |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;announce</samp>](## "ptp.monitor.missing_message.sequence_ids.announce") | Integer |  |  | Min: 2<br>Max: 255 |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;delay_resp</samp>](## "ptp.monitor.missing_message.sequence_ids.delay_resp") | Integer |  |  | Min: 2<br>Max: 255 |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;follow_up</samp>](## "ptp.monitor.missing_message.sequence_ids.follow_up") | Integer |  |  | Min: 2<br>Max: 255 |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;sync</samp>](## "ptp.monitor.missing_message.sequence_ids.sync") | Integer |  |  | Min: 2<br>Max: 255 |  |
 
 ### YAML
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -2830,7 +2830,7 @@ prefix_lists:
 prompt: <str>
 ```
 
-## Ptp
+## PTP
 
 ### Variables
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -5062,6 +5062,175 @@
       "type": "string",
       "title": "Prompt"
     },
+    "ptp": {
+      "type": "object",
+      "properties": {
+        "mode": {
+          "type": "string",
+          "title": "Mode"
+        },
+        "forward_unicast": {
+          "type": "boolean",
+          "title": "Forward Unicast"
+        },
+        "clock_identity": {
+          "type": "string",
+          "title": "Clock Identity"
+        },
+        "source": {
+          "type": "object",
+          "properties": {
+            "ip": {
+              "type": "string",
+              "title": "IP"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Source"
+        },
+        "priority1": {
+          "type": "integer",
+          "title": "Priority1"
+        },
+        "priority2": {
+          "type": "integer",
+          "title": "Priority2"
+        },
+        "ttl": {
+          "type": "integer",
+          "title": "TTL"
+        },
+        "domain": {
+          "type": "integer",
+          "title": "Domain"
+        },
+        "message_type": {
+          "type": "object",
+          "properties": {
+            "general": {
+              "type": "object",
+              "properties": {
+                "dscp": {
+                  "type": "integer",
+                  "title": "DSCP"
+                }
+              },
+              "additionalProperties": false,
+              "title": "General"
+            },
+            "event": {
+              "type": "object",
+              "properties": {
+                "dscp": {
+                  "type": "integer",
+                  "title": "DSCP"
+                }
+              },
+              "additionalProperties": false,
+              "title": "Event"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Message Type"
+        },
+        "monitor": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "title": "Enabled"
+            },
+            "threshold": {
+              "type": "object",
+              "properties": {
+                "offset_from_master": {
+                  "type": "integer",
+                  "title": "Offset From Master"
+                },
+                "mean_path_delay": {
+                  "type": "integer",
+                  "title": "Mean Path Delay"
+                },
+                "drop": {
+                  "type": "object",
+                  "properties": {
+                    "offset_from_master": {
+                      "type": "integer",
+                      "title": "Offset From Master"
+                    },
+                    "mean_path_delay": {
+                      "type": "integer",
+                      "title": "Mean Path Delay"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "title": "Drop"
+                }
+              },
+              "additionalProperties": false,
+              "title": "Threshold"
+            },
+            "missing_message": {
+              "type": "object",
+              "properties": {
+                "intervals": {
+                  "type": "object",
+                  "properties": {
+                    "announce": {
+                      "type": "integer",
+                      "title": "Announce"
+                    },
+                    "follow_up": {
+                      "type": "integer",
+                      "title": "Follow Up"
+                    },
+                    "sync": {
+                      "type": "integer",
+                      "title": "Sync"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "title": "Intervals"
+                },
+                "sequence_ids": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean",
+                      "title": "Enabled"
+                    },
+                    "announce": {
+                      "type": "integer",
+                      "title": "Announce"
+                    },
+                    "delay_resp": {
+                      "type": "integer",
+                      "title": "Delay Resp"
+                    },
+                    "follow_up": {
+                      "type": "integer",
+                      "title": "Follow Up"
+                    },
+                    "sync": {
+                      "type": "integer",
+                      "title": "Sync"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "title": "Sequence IDs"
+                }
+              },
+              "additionalProperties": false,
+              "title": "Missing Message"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Monitor"
+        }
+      },
+      "additionalProperties": false,
+      "title": "Ptp"
+    },
     "qos": {
       "type": "object",
       "properties": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -5067,6 +5067,11 @@
       "properties": {
         "mode": {
           "type": "string",
+          "description": "Mode value",
+          "enum": [
+            "boundary",
+            "transparent"
+          ],
           "title": "Mode"
         },
         "forward_unicast": {
@@ -5075,12 +5080,14 @@
         },
         "clock_identity": {
           "type": "string",
+          "description": "The clock-id in xx:xx:xx:xx:xx:xx format",
           "title": "Clock Identity"
         },
         "source": {
           "type": "object",
           "properties": {
             "ip": {
+              "description": "Source IP",
               "type": "string",
               "title": "IP"
             }
@@ -5090,18 +5097,27 @@
         },
         "priority1": {
           "type": "integer",
+          "minimum": 0,
+          "maximum": 255,
           "title": "Priority1"
         },
         "priority2": {
           "type": "integer",
+          "minimum": 0,
+          "maximum": 255,
           "title": "Priority2"
         },
         "ttl": {
           "type": "integer",
+          "minimum": 1,
+          "maximum": 254,
+          "description": "TTL value",
           "title": "TTL"
         },
         "domain": {
           "type": "integer",
+          "minimum": 0,
+          "maximum": 255,
           "title": "Domain"
         },
         "message_type": {
@@ -5112,6 +5128,7 @@
               "properties": {
                 "dscp": {
                   "type": "integer",
+                  "description": "DSCP value",
                   "title": "DSCP"
                 }
               },
@@ -5123,6 +5140,7 @@
               "properties": {
                 "dscp": {
                   "type": "integer",
+                  "description": "DSCP value",
                   "title": "DSCP"
                 }
               },
@@ -5138,6 +5156,7 @@
           "properties": {
             "enabled": {
               "type": "boolean",
+              "default": true,
               "title": "Enabled"
             },
             "threshold": {
@@ -5145,10 +5164,16 @@
               "properties": {
                 "offset_from_master": {
                   "type": "integer",
+                  "minimum": 0,
+                  "maximum": 1000000000,
+                  "description": "Offset value",
                   "title": "Offset From Master"
                 },
                 "mean_path_delay": {
                   "type": "integer",
+                  "minimum": 0,
+                  "maximum": 1000000000,
+                  "description": "Delay value",
                   "title": "Mean Path Delay"
                 },
                 "drop": {
@@ -5156,10 +5181,16 @@
                   "properties": {
                     "offset_from_master": {
                       "type": "integer",
+                      "minimum": 0,
+                      "maximum": 1000000000,
+                      "description": "Offset value",
                       "title": "Offset From Master"
                     },
                     "mean_path_delay": {
                       "type": "integer",
+                      "minimum": 0,
+                      "maximum": 1000000000,
+                      "description": "Delay value",
                       "title": "Mean Path Delay"
                     }
                   },
@@ -5178,14 +5209,20 @@
                   "properties": {
                     "announce": {
                       "type": "integer",
+                      "minimum": 2,
+                      "maximum": 255,
                       "title": "Announce"
                     },
                     "follow_up": {
                       "type": "integer",
+                      "minimum": 2,
+                      "maximum": 255,
                       "title": "Follow Up"
                     },
                     "sync": {
                       "type": "integer",
+                      "minimum": 2,
+                      "maximum": 255,
                       "title": "Sync"
                     }
                   },
@@ -5197,22 +5234,31 @@
                   "properties": {
                     "enabled": {
                       "type": "boolean",
+                      "default": false,
                       "title": "Enabled"
                     },
                     "announce": {
                       "type": "integer",
+                      "minimum": 2,
+                      "maximum": 255,
                       "title": "Announce"
                     },
                     "delay_resp": {
                       "type": "integer",
+                      "minimum": 2,
+                      "maximum": 255,
                       "title": "Delay Resp"
                     },
                     "follow_up": {
                       "type": "integer",
+                      "minimum": 2,
+                      "maximum": 255,
                       "title": "Follow Up"
                     },
                     "sync": {
                       "type": "integer",
+                      "minimum": 2,
+                      "maximum": 255,
                       "title": "Sync"
                     }
                   },

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -5067,7 +5067,6 @@
       "properties": {
         "mode": {
           "type": "string",
-          "description": "Mode value",
           "enum": [
             "boundary",
             "transparent"
@@ -5111,7 +5110,6 @@
           "type": "integer",
           "minimum": 1,
           "maximum": 254,
-          "description": "TTL value",
           "title": "TTL"
         },
         "domain": {
@@ -5128,7 +5126,6 @@
               "properties": {
                 "dscp": {
                   "type": "integer",
-                  "description": "DSCP value",
                   "title": "DSCP"
                 }
               },
@@ -5140,7 +5137,6 @@
               "properties": {
                 "dscp": {
                   "type": "integer",
-                  "description": "DSCP value",
                   "title": "DSCP"
                 }
               },
@@ -5166,14 +5162,12 @@
                   "type": "integer",
                   "minimum": 0,
                   "maximum": 1000000000,
-                  "description": "Offset value",
                   "title": "Offset From Master"
                 },
                 "mean_path_delay": {
                   "type": "integer",
                   "minimum": 0,
                   "maximum": 1000000000,
-                  "description": "Delay value",
                   "title": "Mean Path Delay"
                 },
                 "drop": {
@@ -5183,14 +5177,12 @@
                       "type": "integer",
                       "minimum": 0,
                       "maximum": 1000000000,
-                      "description": "Offset value",
                       "title": "Offset From Master"
                     },
                     "mean_path_delay": {
                       "type": "integer",
                       "minimum": 0,
                       "maximum": 1000000000,
-                      "description": "Delay value",
                       "title": "Mean Path Delay"
                     }
                   },

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -5234,7 +5234,6 @@
                   "properties": {
                     "enabled": {
                       "type": "boolean",
-                      "default": false,
                       "title": "Enabled"
                     },
                     "announce": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -5266,7 +5266,7 @@
         }
       },
       "additionalProperties": false,
-      "title": "Ptp"
+      "title": "PTP"
     },
     "qos": {
       "type": "object",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -3721,7 +3721,6 @@ keys:
                 keys:
                   enabled:
                     type: bool
-                    default: false
                   announce:
                     type: int
                     min: 2

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -3588,6 +3588,85 @@ keys:
                   Example: "permit 10.255.0.0/27 eq 32"'
   prompt:
     type: str
+  ptp:
+    type: dict
+    keys:
+      mode:
+        type: str
+      forward_unicast:
+        type: bool
+      clock_identity:
+        type: str
+      source:
+        type: dict
+        keys:
+          ip:
+            type: str
+      priority1:
+        type: int
+      priority2:
+        type: int
+      ttl:
+        type: int
+      domain:
+        type: int
+      message_type:
+        type: dict
+        keys:
+          general:
+            type: dict
+            keys:
+              dscp:
+                type: int
+          event:
+            type: dict
+            keys:
+              dscp:
+                type: int
+      monitor:
+        type: dict
+        keys:
+          enabled:
+            type: bool
+          threshold:
+            type: dict
+            keys:
+              offset_from_master:
+                type: int
+              mean_path_delay:
+                type: int
+              drop:
+                type: dict
+                keys:
+                  offset_from_master:
+                    type: int
+                  mean_path_delay:
+                    type: int
+          missing_message:
+            type: dict
+            keys:
+              intervals:
+                type: dict
+                keys:
+                  announce:
+                    type: int
+                  follow_up:
+                    type: int
+                  sync:
+                    type: int
+              sequence_ids:
+                type: dict
+                keys:
+                  enabled:
+                    type: bool
+                  announce:
+                    type: int
+                  delay_resp:
+                    type: int
+                  follow_up:
+                    type: int
+                  sync:
+                    type: int
   qos:
     type: dict
     keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -3593,7 +3593,6 @@ keys:
     keys:
       mode:
         type: str
-        description: Mode value
         valid_values:
         - boundary
         - transparent
@@ -3624,7 +3623,6 @@ keys:
         type: int
         min: 1
         max: 254
-        description: TTL value
         convert_types:
         - str
       domain:
@@ -3643,13 +3641,11 @@ keys:
                 type: int
                 convert_types:
                 - str
-                description: DSCP value
           event:
             type: dict
             keys:
               dscp:
                 type: int
-                description: DSCP value
                 convert_types:
                 - str
       monitor:
@@ -3665,14 +3661,12 @@ keys:
                 type: int
                 min: 0
                 max: 1000000000
-                description: Offset value
                 convert_types:
                 - str
               mean_path_delay:
                 type: int
                 min: 0
                 max: 1000000000
-                description: Delay value
                 convert_types:
                 - str
               drop:
@@ -3682,14 +3676,12 @@ keys:
                     type: int
                     min: 0
                     max: 1000000000
-                    description: Offset value
                     convert_types:
                     - str
                   mean_path_delay:
                     type: int
                     min: 0
                     max: 1000000000
-                    description: Delay value
                     convert_types:
                     - str
           missing_message:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -3593,23 +3593,46 @@ keys:
     keys:
       mode:
         type: str
+        description: Mode value
+        valid_values:
+        - boundary
+        - transparent
       forward_unicast:
         type: bool
       clock_identity:
         type: str
+        description: The clock-id in xx:xx:xx:xx:xx:xx format
       source:
         type: dict
         keys:
           ip:
+            description: Source IP
             type: str
       priority1:
         type: int
+        min: 0
+        max: 255
+        convert_types:
+        - str
       priority2:
         type: int
+        min: 0
+        max: 255
+        convert_types:
+        - str
       ttl:
         type: int
+        min: 1
+        max: 254
+        description: TTL value
+        convert_types:
+        - str
       domain:
         type: int
+        min: 0
+        max: 255
+        convert_types:
+        - str
       message_type:
         type: dict
         keys:
@@ -3618,30 +3641,57 @@ keys:
             keys:
               dscp:
                 type: int
+                convert_types:
+                - str
+                description: DSCP value
           event:
             type: dict
             keys:
               dscp:
                 type: int
+                description: DSCP value
+                convert_types:
+                - str
       monitor:
         type: dict
         keys:
           enabled:
             type: bool
+            default: true
           threshold:
             type: dict
             keys:
               offset_from_master:
                 type: int
+                min: 0
+                max: 1000000000
+                description: Offset value
+                convert_types:
+                - str
               mean_path_delay:
                 type: int
+                min: 0
+                max: 1000000000
+                description: Delay value
+                convert_types:
+                - str
               drop:
                 type: dict
                 keys:
                   offset_from_master:
                     type: int
+                    min: 0
+                    max: 1000000000
+                    description: Offset value
+                    convert_types:
+                    - str
                   mean_path_delay:
                     type: int
+                    min: 0
+                    max: 1000000000
+                    description: Delay value
+                    convert_types:
+                    - str
           missing_message:
             type: dict
             keys:
@@ -3650,23 +3700,52 @@ keys:
                 keys:
                   announce:
                     type: int
+                    min: 2
+                    max: 255
+                    convert_types:
+                    - str
                   follow_up:
                     type: int
+                    min: 2
+                    max: 255
+                    convert_types:
+                    - str
                   sync:
                     type: int
+                    min: 2
+                    max: 255
+                    convert_types:
+                    - str
               sequence_ids:
                 type: dict
                 keys:
                   enabled:
                     type: bool
+                    default: false
                   announce:
                     type: int
+                    min: 2
+                    max: 255
+                    convert_types:
+                    - str
                   delay_resp:
                     type: int
+                    min: 2
+                    max: 255
+                    convert_types:
+                    - str
                   follow_up:
                     type: int
+                    min: 2
+                    max: 255
+                    convert_types:
+                    - str
                   sync:
                     type: int
+                    min: 2
+                    max: 255
+                    convert_types:
+                    - str
   qos:
     type: dict
     keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ptp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ptp.schema.yml
@@ -8,7 +8,6 @@ keys:
     keys:
       mode:
         type: str
-        description: Mode value
         valid_values:
         - boundary
         - transparent
@@ -39,7 +38,6 @@ keys:
         type: int
         min: 1
         max: 254
-        description: TTL value
         convert_types:
         - str
       domain:
@@ -58,13 +56,11 @@ keys:
                 type: int
                 convert_types:
                 - str
-                description: DSCP value
           event:
             type: dict
             keys:
               dscp:
                 type: int
-                description: DSCP value
                 convert_types:
                 - str
       monitor:
@@ -80,14 +76,12 @@ keys:
                 type: int
                 min: 0
                 max: 1000000000
-                description: Offset value
                 convert_types:
                 - str
               mean_path_delay:
                 type: int
                 min: 0
                 max: 1000000000
-                description: Delay value
                 convert_types:
                 - str
               drop:
@@ -97,14 +91,12 @@ keys:
                     type: int
                     min: 0
                     max: 1000000000
-                    description: Offset value
                     convert_types:
                     - str
                   mean_path_delay:
                     type: int
                     min: 0
                     max: 1000000000
-                    description: Delay value
                     convert_types:
                     - str
           missing_message:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ptp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ptp.schema.yml
@@ -136,7 +136,6 @@ keys:
                 keys:
                   enabled:
                     type: bool
-                    default: false
                   announce:
                     type: int
                     min: 2

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ptp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ptp.schema.yml
@@ -1,0 +1,84 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  ptp:
+    type: dict
+    keys:
+      mode:
+        type: str
+      forward_unicast:
+        type: bool
+      clock_identity:
+        type: str
+      source:
+        type: dict
+        keys:
+          ip:
+            type: str
+      priority1:
+        type: int
+      priority2:
+        type: int
+      ttl:
+        type: int
+      domain:
+        type: int
+      message_type:
+        type: dict
+        keys:
+          general:
+            type: dict
+            keys:
+              dscp:
+                type: int
+          event:
+            type: dict
+            keys:
+              dscp:
+                type: int
+      monitor:
+        type: dict
+        keys:
+          enabled:
+            type: bool
+          threshold:
+            type: dict
+            keys:
+              offset_from_master:
+                type: int
+              mean_path_delay:
+                type: int
+              drop:
+                type: dict
+                keys:
+                  offset_from_master:
+                    type: int
+                  mean_path_delay:
+                    type: int
+          missing_message:
+            type: dict
+            keys:
+              intervals:
+                type: dict
+                keys:
+                  announce:
+                    type: int
+                  follow_up:
+                    type: int
+                  sync:
+                    type: int
+              sequence_ids:
+                type: dict
+                keys:
+                  enabled:
+                    type: bool
+                  announce:
+                    type: int
+                  delay_resp:
+                    type: int
+                  follow_up:
+                    type: int
+                  sync:
+                    type: int

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ptp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ptp.schema.yml
@@ -8,23 +8,46 @@ keys:
     keys:
       mode:
         type: str
+        description: Mode value
+        valid_values:
+        - boundary
+        - transparent
       forward_unicast:
         type: bool
       clock_identity:
         type: str
+        description: The clock-id in xx:xx:xx:xx:xx:xx format
       source:
         type: dict
         keys:
           ip:
+            description: Source IP
             type: str
       priority1:
         type: int
+        min: 0
+        max: 255
+        convert_types:
+        - str
       priority2:
         type: int
+        min: 0
+        max: 255
+        convert_types:
+        - str
       ttl:
         type: int
+        min: 1
+        max: 254
+        description: TTL value
+        convert_types:
+        - str
       domain:
         type: int
+        min: 0
+        max: 255
+        convert_types:
+        - str
       message_type:
         type: dict
         keys:
@@ -33,30 +56,57 @@ keys:
             keys:
               dscp:
                 type: int
+                convert_types:
+                - str
+                description: DSCP value
           event:
             type: dict
             keys:
               dscp:
                 type: int
+                description: DSCP value
+                convert_types:
+                - str
       monitor:
         type: dict
         keys:
           enabled:
             type: bool
+            default: true
           threshold:
             type: dict
             keys:
               offset_from_master:
                 type: int
+                min: 0
+                max: 1000000000
+                description: Offset value
+                convert_types:
+                - str
               mean_path_delay:
                 type: int
+                min: 0
+                max: 1000000000
+                description: Delay value
+                convert_types:
+                - str
               drop:
                 type: dict
                 keys:
                   offset_from_master:
                     type: int
+                    min: 0
+                    max: 1000000000
+                    description: Offset value
+                    convert_types:
+                    - str
                   mean_path_delay:
                     type: int
+                    min: 0
+                    max: 1000000000
+                    description: Delay value
+                    convert_types:
+                    - str
           missing_message:
             type: dict
             keys:
@@ -65,20 +115,49 @@ keys:
                 keys:
                   announce:
                     type: int
+                    min: 2
+                    max: 255
+                    convert_types:
+                    - str
                   follow_up:
                     type: int
+                    min: 2
+                    max: 255
+                    convert_types:
+                    - str
                   sync:
                     type: int
+                    min: 2
+                    max: 255
+                    convert_types:
+                    - str
               sequence_ids:
                 type: dict
                 keys:
                   enabled:
                     type: bool
+                    default: false
                   announce:
                     type: int
+                    min: 2
+                    max: 255
+                    convert_types:
+                    - str
                   delay_resp:
                     type: int
+                    min: 2
+                    max: 255
+                    convert_types:
+                    - str
                   follow_up:
                     type: int
+                    min: 2
+                    max: 255
+                    convert_types:
+                    - str
                   sync:
                     type: int
+                    min: 2
+                    max: 255
+                    convert_types:
+                    - str


### PR DESCRIPTION
## Add schema for data model

<!-- Use this PR Title: Feat(eos_cli_config_gen): Add schema for < data_model_key > -->

## Checklist

### Contributor Checklist

- [x] Create schema fragment matching data model described in README.md and README_v4.0.md
  - README.md is most complete with all keys. README_v4.0 includes partial data models after conversion to lists.
  - Schema fragment path is `roles/eos_cli_config_gen/schemas/schema_fragments/<data_model_key>.schema.yml`.
  - Copy line 1-5 from another schema (comments and outer type:dict).
  - Refer to [schema documentation](https://avd.sh/en/devel/docs/input-variable-validation-BETA.html) for syntax and/or use YAML Lint plugin from Redhat in VSCode.
  - Use `convert_types` on value that could be mixed type or misinterpreted like integers and numeric strings.
- [x] If the data model has been converted from wildcard dicts:
  - Add `convert_types: ['dict']` to the schema.
  - Remove `convert_dicts` from the `templates/eos/<>.j2` and `templates/documentation/<>.j2` templates.
- [x] Run `molecule converge -s build_schemas_and_docs` to update schema and documentation.
- [x] Test by running `molecule converge -s eos_cli_config_gen` and verify no errors or changes to generated configs/docs.

### Reviewer Checklist

- Reviewer 1: Carl
  - [ ] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2: Claus
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
