### PR TITLE
Refactor(eos_validate_state): Improve performance by delagation asserts to localhost

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/bgp_check.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/bgp_check.yml
@@ -10,6 +10,7 @@
     - bgp_check
 
 - name: Validate ArBGP is configured and operating
+  delegate_to: localhost
   assert:
     that:
       - ip_route_summary.stdout_lines[0][0] | regex_search('multi-agent')
@@ -34,6 +35,7 @@
     - bgp_check
 
 - name: Validate ip bgp neighbors peer state
+  delegate_to: localhost
   assert:
     that:
       - bgp_summary.stdout[0].vrfs.default.peers[bgp_neighbor.ip_address].peerState == 'Established'
@@ -50,6 +52,7 @@
     - bgp_check
 
 - name: Validate bgp evpn neighbors peer state
+  delegate_to: localhost
   assert:
     that:
       - bgp_summary.stdout[1].vrfs.default.peers[bgp_neighbor.ip_address].peerState == 'Established'

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/hardware.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/hardware.yml
@@ -10,6 +10,7 @@
     - hardware
 
 - name: Validate power supplies status
+  delegate_to: localhost
   assert:
     that:
       - "powerSupply.value.state in {{ accepted_pwr_supply_states }}"
@@ -31,6 +32,7 @@
     - hardware
 
 - name: Validate fan status (power supplies)
+  delegate_to: localhost
   assert:
     that:
       - "powerSupplySlot.status in {{ accepted_fan_states }}"
@@ -45,6 +47,7 @@
     - hardware
 
 - name: Validate fan status (fan tray)
+  delegate_to: localhost
   assert:
     that:
       - "fanTraySlot.status in {{ accepted_fan_states }}"
@@ -67,6 +70,7 @@
     - hardware
 
 - name: Validate system temperature
+  delegate_to: localhost
   assert:
     that:
       - environment_temperature.stdout[0].systemStatus == 'temperatureOk'
@@ -85,6 +89,7 @@
     - hardware
 
 - name: Validate transceivers manufacturers
+  delegate_to: localhost
   assert:
     that:
       - "xcvrSlot.value.mfgName in {{ accepted_xcvr_manufacturers }}"

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/interface_state.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/interface_state.yml
@@ -11,6 +11,7 @@
     - interfaces_state
 
 - name: Validate Ethernet interfaces state
+  delegate_to: localhost
   assert:
     that:
       ( interfaces_state.stdout[0].interfaceDescriptions[ethernet_interface.name].interfaceStatus == 'up' and
@@ -34,6 +35,7 @@
     - interfaces_state
 
 - name: Validate Port-Channel interfaces state
+  delegate_to: localhost
   assert:
     that:
       ( interfaces_state.stdout[0].interfaceDescriptions[port_channel_interface.name].interfaceStatus == 'up' and
@@ -57,6 +59,7 @@
     - interfaces_state
 
 - name: Validate Vlan interfaces state
+  delegate_to: localhost
   assert:
     that:
       ( interfaces_state.stdout[0].interfaceDescriptions[vlan_interface.name].interfaceStatus == 'up' and
@@ -80,6 +83,7 @@
     - interfaces_state
 
 - name: Validate Vxlan interfaces state
+  delegate_to: localhost
   assert:
     that:
       - interfaces_state.stdout[0].interfaceDescriptions.Vxlan1.interfaceStatus == 'up'
@@ -94,6 +98,7 @@
     - interfaces_state
 
 - name: Validate Loopback interfaces state
+  delegate_to: localhost
   assert:
     that:
       - interfaces_state.stdout[0].interfaceDescriptions[loopback_interface.name].interfaceStatus == 'up'

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/ip_reachability.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/ip_reachability.yml
@@ -24,6 +24,7 @@
     - ip_reachability
 
 - name: Validate ip reachability (directly connected interfaces)
+  delegate_to: localhost
   assert:
     that:
       - ip_reachability_test.stdout[0] | regex_search('1 received')

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/lldp_topology_fqdn.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/lldp_topology_fqdn.yml
@@ -11,6 +11,7 @@
     - lldp_topology
 
 - name: Validate lldp topology when there is a domain name
+  delegate_to: localhost
   assert:
     that:
       - lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.name].lldpNeighborInfo[0] is defined

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/lldp_topology_no_fqdn.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/lldp_topology_no_fqdn.yml
@@ -11,6 +11,7 @@
     - lldp_topology
 
 - name: Validate lldp topology when there is no domain name
+  delegate_to: localhost
   assert:
     that:
       - lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.name].lldpNeighborInfo[0] is defined

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/loopback_reachability.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/loopback_reachability.yml
@@ -19,6 +19,7 @@
     - loopback0_reachability
 
 - name: Validate ip reachability between devices (loopback0 <-> loopback0)
+  delegate_to: localhost
   assert:
     that:
       - loopback0_reachability_test.stdout[0] | regex_search("1 received")
@@ -44,6 +45,7 @@
     - optional
 
 - name: Validate ip reachability from Inband Management to loopback0 in fabric
+  delegate_to: localhost
   assert:
     that:
       - inb_mgmt_loopback0_reachability_test.stdout[0] | regex_search('1 received')

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/main.yml
@@ -1,5 +1,6 @@
 ---
 - name: "Collection {{ ansible_collection_name }} version {{ version }}{{ ('(git ' ~ git_tag ~ ')') if git_tag }} loaded from {{ collection_path }}"
+  delegate_to: localhost
   tags: [always, avd_version]
   set_fact:
     avd_collection_version: version
@@ -60,6 +61,7 @@
     - hardware
 
 - name: Display device platform and release information
+  delegate_to: localhost
   debug:
     msg: "The device {{ inventory_hostname }} is a {{ eos_version.stdout_lines.0.modelName }} model running EOS version {{ eos_version.stdout_lines.0.version }}"
   tags:

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/mlag.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/mlag.yml
@@ -10,6 +10,7 @@
     - mlag
 
 - name: Validate mlag status
+  delegate_to: localhost
   assert:
     that:
       - mlag_state.stdout[0].state == 'active'

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/ntp.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/ntp.yml
@@ -10,6 +10,7 @@
     - ntp
 
 - name: Validate ntp status
+  delegate_to: localhost
   assert:
     that:
       - ntp_status.stdout[0] | regex_search('synchronised to NTP server')

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/reload_cause.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/reload_cause.yml
@@ -12,6 +12,7 @@
     - never
 
 - name: validate reload cause
+  delegate_to: localhost
   assert:
     that: reload_cause.stdout_lines[0][2] == 'Reload requested by the user.'
     fail_msg: "{{ reload_cause.stdout_lines[0][2] | replace('\"','') }}"

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/routing_table.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/routing_table.yml
@@ -15,6 +15,7 @@
     - routing_table
 
 - name: Validate VTEP IP is in routing table
+  delegate_to: localhost
   assert:
     that:
       - vtep_reachability_test['stdout'][0] | regex_search(vtep_reachability_test.vtep_ip)
@@ -45,6 +46,7 @@
     - routing_table
 
 - name: Validate lo0 is in routing table
+  delegate_to: localhost
   assert:
     that:
       - routing_table_loopback0_test['stdout'][0] | regex_search(routing_table_loopback0_test.loopback0_address)


### PR DESCRIPTION
## Change Summary

Improve performance by delagation asserts to localhost

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.avd.eos_validate_state`

## Proposed changes

For all `assert` statements in task leverage `delegate_to: localhost`
This significantly increases the performance by 50%, as seen in the ATD test environment:

**Results with this PR**:

```
Tuesday 22 November 2022  20:57:14 +0000 (0:00:00.869)       0:01:03.744 ****** 
=============================================================================== 
eos_validate_state ----------------------------------------------------- 62.82s
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
total ------------------------------------------------------------------ 62.82s
Tuesday 22 November 2022  20:57:14 +0000 (0:00:00.870)       0:01:03.744 ****** 
=============================================================================== 
arista.avd.eos_validate_state : Gather ip reachability state between devices (loopback0 <-> loopback0) --------------------------------------------------------------------------------- 9.71s
arista.avd.eos_validate_state : Gather ip reachability state (directly connected interfaces) ------------------------------------------------------------------------------------------- 6.97s
arista.avd.eos_validate_state : run show ip route lo0 ---------------------------------------------------------------------------------------------------------------------------------- 6.21s
arista.avd.eos_validate_state : Gather ntp status -------------------------------------------------------------------------------------------------------------------------------------- 4.27s
arista.avd.eos_validate_state : Gather EOS platform and version details ---------------------------------------------------------------------------------------------------------------- 3.80s
arista.avd.eos_validate_state : Gather interfaces state -------------------------------------------------------------------------------------------------------------------------------- 2.63s
arista.avd.eos_validate_state : Gather bgp summary (ip and evpn) ----------------------------------------------------------------------------------------------------------------------- 2.37s
arista.avd.eos_validate_state : run show ip route VTEP IP ------------------------------------------------------------------------------------------------------------------------------ 2.37s
arista.avd.eos_validate_state : Gather ip route summary and ArBGP state ---------------------------------------------------------------------------------------------------------------- 2.14s
arista.avd.eos_validate_state : Gather lldp topology ----------------------------------------------------------------------------------------------------------------------------------- 2.05s
arista.avd.eos_validate_state : Generate variables for testing ------------------------------------------------------------------------------------------------------------------------- 1.78s
arista.avd.eos_validate_state : Gather mlag status ------------------------------------------------------------------------------------------------------------------------------------- 1.26s
arista.avd.eos_validate_state : Create Validation report - CSV ------------------------------------------------------------------------------------------------------------------------- 1.04s
arista.avd.eos_validate_state : Generate Results (Set eos_validate_state_report) ------------------------------------------------------------------------------------------------------- 0.90s
arista.avd.eos_validate_state : Collection arista.avd version 3.7.0(git v3.4.0) loaded from /home/coder/project/labfiles/arista-ansible/ansible-cvp/ansible_collections ---------------- 0.89s
arista.avd.eos_validate_state : Create Validation report - Markdown -------------------------------------------------------------------------------------------------------------------- 0.87s
arista.avd.eos_validate_state : Validate lldp topology when there is a domain name ----------------------------------------------------------------------------------------------------- 0.86s
arista.avd.eos_validate_state : Validate Ethernet interfaces state --------------------------------------------------------------------------------------------------------------------- 0.59s
arista.avd.eos_validate_state : Validate ip bgp neighbors peer state ------------------------------------------------------------------------------------------------------------------- 0.59s
arista.avd.eos_validate_state : Create required output directories if not present ------------------------------------------------------------------------------------------------------ 0.58s
Playbook run took 0 days, 0 hours, 1 minutes, 3 seconds
```

**Results with devel**

```
Tuesday 22 November 2022  21:01:48 +0000 (0:00:01.339)       0:02:09.752 ****** 
=============================================================================== 
eos_validate_state ---------------------------------------------------- 128.75s
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
total ----------------------------------------------------------------- 128.75s
Tuesday 22 November 2022  21:01:48 +0000 (0:00:01.339)       0:02:09.751 ****** 
=============================================================================== 
arista.avd.eos_validate_state : Gather ip reachability state between devices (loopback0 <-> loopback0) -------------------------------------------------------------------------------- 10.53s
arista.avd.eos_validate_state : Validate Ethernet interfaces state -------------------------------------------------------------------------------------------------------------------- 10.25s
arista.avd.eos_validate_state : Validate lldp topology when there is a domain name ----------------------------------------------------------------------------------------------------- 8.11s
arista.avd.eos_validate_state : Gather ip reachability state (directly connected interfaces) ------------------------------------------------------------------------------------------- 7.69s
arista.avd.eos_validate_state : run show ip route lo0 ---------------------------------------------------------------------------------------------------------------------------------- 7.26s
arista.avd.eos_validate_state : Validate ip bgp neighbors peer state ------------------------------------------------------------------------------------------------------------------- 6.07s
arista.avd.eos_validate_state : Validate ip reachability between devices (loopback0 <-> loopback0) ------------------------------------------------------------------------------------- 5.62s
arista.avd.eos_validate_state : Validate lo0 is in routing table ----------------------------------------------------------------------------------------------------------------------- 5.56s
arista.avd.eos_validate_state : Validate bgp evpn neighbors peer state ----------------------------------------------------------------------------------------------------------------- 4.86s
arista.avd.eos_validate_state : Validate Loopback interfaces state --------------------------------------------------------------------------------------------------------------------- 4.56s
arista.avd.eos_validate_state : Validate Vlan interfaces state ------------------------------------------------------------------------------------------------------------------------- 4.32s
arista.avd.eos_validate_state : Gather ntp status -------------------------------------------------------------------------------------------------------------------------------------- 3.93s
arista.avd.eos_validate_state : Validate ip reachability (directly connected interfaces) ----------------------------------------------------------------------------------------------- 3.82s
arista.avd.eos_validate_state : Gather EOS platform and version details ---------------------------------------------------------------------------------------------------------------- 3.69s
arista.avd.eos_validate_state : Validate Port-Channel interfaces state ----------------------------------------------------------------------------------------------------------------- 2.83s
arista.avd.eos_validate_state : Gather bgp summary (ip and evpn) ----------------------------------------------------------------------------------------------------------------------- 2.60s
arista.avd.eos_validate_state : run show ip route VTEP IP ------------------------------------------------------------------------------------------------------------------------------ 2.52s
arista.avd.eos_validate_state : Gather lldp topology ----------------------------------------------------------------------------------------------------------------------------------- 2.52s
arista.avd.eos_validate_state : Gather ip route summary and ArBGP state ---------------------------------------------------------------------------------------------------------------- 2.24s
arista.avd.eos_validate_state : Gather interfaces state -------------------------------------------------------------------------------------------------------------------------------- 2.22s
Playbook run took 0 days, 0 hours, 2 minutes, 9 seconds
```


## How to test

Run eos_validate state against topology.

## Checklist

### Repository Checklist

- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
