### PR TITLE
Feat(eos_designs): Add support for multiple descriptions for l3_interfaces

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1A.cfg
@@ -136,7 +136,7 @@ interface Ethernet10
    ip address 10.10.30.10/24
 !
 interface Ethernet11
-   description Single description preferred over descriptions
+   description DC1-BL1A descriptions preferred over global description
    no shutdown
    mtu 9000
    no switchport

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1A.cfg
@@ -127,6 +127,22 @@ interface Ethernet9
    vrf Tenant_L3_VRF_Zone
    ip address 10.10.20.20/24
 !
+interface Ethernet10
+   description test-DC1-BL1A
+   no shutdown
+   mtu 9000
+   no switchport
+   vrf Tenant_L3_VRF_Zone
+   ip address 10.10.30.10/24
+!
+interface Ethernet11
+   description Single description preferred over descriptions
+   no shutdown
+   mtu 9000
+   no switchport
+   vrf Tenant_L3_VRF_Zone
+   ip address 10.10.30.10/24
+!
 interface Ethernet4000
    description My test
    no shutdown

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1A.cfg
@@ -136,7 +136,7 @@ interface Ethernet10
    ip address 10.10.30.10/24
 !
 interface Ethernet11
-   description DC1-BL1A descriptions preferred over global description
+   description DC1-BL1A descriptions preferred over single description
    no shutdown
    mtu 9000
    no switchport

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1B.cfg
@@ -118,6 +118,22 @@ interface Ethernet9
    vrf Tenant_L3_VRF_Zone
    ip address 10.10.40.20/24
 !
+interface Ethernet10
+   description test-DC1-BL1B
+   no shutdown
+   mtu 9000
+   no switchport
+   vrf Tenant_L3_VRF_Zone
+   ip address 10.10.40.20/24
+!
+interface Ethernet11
+   description Single description preferred over descriptions
+   no shutdown
+   mtu 9000
+   no switchport
+   vrf Tenant_L3_VRF_Zone
+   ip address 10.10.40.20/24
+!
 interface Ethernet4000
    description My second test
    no shutdown

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1B.cfg
@@ -127,7 +127,7 @@ interface Ethernet10
    ip address 10.10.40.20/24
 !
 interface Ethernet11
-   description Single description preferred over descriptions
+   description DC1-BL1B descriptions preferred over global description
    no shutdown
    mtu 9000
    no switchport

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1B.cfg
@@ -127,7 +127,7 @@ interface Ethernet10
    ip address 10.10.40.20/24
 !
 interface Ethernet11
-   description DC1-BL1B descriptions preferred over global description
+   description DC1-BL1B descriptions preferred over single description
    no shutdown
    mtu 9000
    no switchport

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1A.yml
@@ -455,7 +455,7 @@ ethernet_interfaces:
     ip_address: 10.10.30.10/24
     mtu: 9000
     shutdown: false
-    description: Single description preferred over descriptions
+    description: DC1-BL1A descriptions preferred over global description
     type: routed
     vrf: Tenant_L3_VRF_Zone
   Ethernet4000:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1A.yml
@@ -442,6 +442,22 @@ ethernet_interfaces:
     description: test
     type: routed
     vrf: Tenant_L3_VRF_Zone
+  Ethernet10:
+    peer_type: l3_interface
+    ip_address: 10.10.30.10/24
+    mtu: 9000
+    shutdown: false
+    description: test-DC1-BL1A
+    type: routed
+    vrf: Tenant_L3_VRF_Zone
+  Ethernet11:
+    peer_type: l3_interface
+    ip_address: 10.10.30.10/24
+    mtu: 9000
+    shutdown: false
+    description: Single description preferred over descriptions
+    type: routed
+    vrf: Tenant_L3_VRF_Zone
   Ethernet4000:
     description: My test
     ip_address: 10.3.2.1/21

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1A.yml
@@ -455,7 +455,7 @@ ethernet_interfaces:
     ip_address: 10.10.30.10/24
     mtu: 9000
     shutdown: false
-    description: DC1-BL1A descriptions preferred over global description
+    description: DC1-BL1A descriptions preferred over single description
     type: routed
     vrf: Tenant_L3_VRF_Zone
   Ethernet4000:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1B.yml
@@ -429,7 +429,7 @@ ethernet_interfaces:
     ip_address: 10.10.40.20/24
     mtu: 9000
     shutdown: false
-    description: DC1-BL1B descriptions preferred over global description
+    description: DC1-BL1B descriptions preferred over single description
     type: routed
     vrf: Tenant_L3_VRF_Zone
   Ethernet4000:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1B.yml
@@ -429,7 +429,7 @@ ethernet_interfaces:
     ip_address: 10.10.40.20/24
     mtu: 9000
     shutdown: false
-    description: Single description preferred over descriptions
+    description: DC1-BL1B descriptions preferred over global description
     type: routed
     vrf: Tenant_L3_VRF_Zone
   Ethernet4000:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1B.yml
@@ -416,6 +416,22 @@ ethernet_interfaces:
     description: test
     type: routed
     vrf: Tenant_L3_VRF_Zone
+  Ethernet10:
+    peer_type: l3_interface
+    ip_address: 10.10.40.20/24
+    mtu: 9000
+    shutdown: false
+    description: test-DC1-BL1B
+    type: routed
+    vrf: Tenant_L3_VRF_Zone
+  Ethernet11:
+    peer_type: l3_interface
+    ip_address: 10.10.40.20/24
+    mtu: 9000
+    shutdown: false
+    description: Single description preferred over descriptions
+    type: routed
+    vrf: Tenant_L3_VRF_Zone
   Ethernet4000:
     description: My second test
     ip_address: 10.1.2.3/12

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_A.yml
@@ -202,12 +202,25 @@ Tenant_A:
     Tenant_L3_VRF_Zone:
       vrf_vni: 15
       l3_interfaces:
-        - interfaces: [ Ethernet8, Ethernet9, Ethernet8, Ethernet9 ]
+        - interfaces: [Ethernet8, Ethernet9, Ethernet8, Ethernet9]
           ip_addresses: [10.10.10.10/24, 10.10.20.20/24, 10.10.30.10/24, 10.10.40.20/24]
           nodes: [DC1-BL1A, DC1-BL1A, DC1-BL1B, DC1-BL1B]
           mtu: 9000
           enabled: True
           description: "test"
+        - interfaces: [Ethernet10, Ethernet10]
+          ip_addresses: [10.10.30.10/24, 10.10.40.20/24]
+          nodes: [DC1-BL1A, DC1-BL1B]
+          mtu: 9000
+          enabled: True
+          descriptions: ["test-DC1-BL1A", "test-DC1-BL1B"]
+        - interfaces: [Ethernet11, Ethernet11]
+          ip_addresses: [10.10.30.10/24, 10.10.40.20/24]
+          nodes: [DC1-BL1A, DC1-BL1B]
+          mtu: 9000
+          enabled: True
+          description: "Single description preferred over descriptions"
+          descriptions: ["test-DC1-BL1A", "test-DC1-BL1B"]
     Tenant_OSPF:
       vrf_id: 30
       ospf:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_A.yml
@@ -220,7 +220,7 @@ Tenant_A:
           mtu: 9000
           enabled: True
           description: "Single description"
-          descriptions: ["DC1-BL1A descriptions preferred over global description", "DC1-BL1B descriptions preferred over global description"]
+          descriptions: ["DC1-BL1A descriptions preferred over single description", "DC1-BL1B descriptions preferred over single description"]
           # no description nor desciptions is tested in Tenant_OSPF below
     Tenant_OSPF:
       vrf_id: 30

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_A.yml
@@ -219,8 +219,9 @@ Tenant_A:
           nodes: [DC1-BL1A, DC1-BL1B]
           mtu: 9000
           enabled: True
-          description: "Single description preferred over descriptions"
-          descriptions: ["test-DC1-BL1A", "test-DC1-BL1B"]
+          description: "Single description"
+          descriptions: ["DC1-BL1A descriptions preferred over global description", "DC1-BL1B descriptions preferred over global description"]
+          # no description nor desciptions is tested in Tenant_OSPF below
     Tenant_OSPF:
       vrf_id: 30
       ospf:

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/network-services-v4.0.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/network-services-v4.0.md
@@ -324,7 +324,7 @@ svi_profiles:
             ip_addresses: [ <IPv4_address/Mask>, <IPv4_address/Mask>, <IPv4_address/Mask> ]
             nodes: [ < node_1 >, < node_2 >, < node_1 > ]
             description: < description >
-            # if description is set then descriptions is ignored for backward-compatibility
+            # `descriptions` has precedence over `description`
             descriptions: [ <description1>, <description2>, description3> ]
             enabled: < true | false >
             mtu: < mtu >

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/network-services-v4.0.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/network-services-v4.0.md
@@ -318,12 +318,14 @@ svi_profiles:
             ip_address_virtual: < IPv4_address/Mask >
 
         # List of L3 interfaces | Optional.
-        # This will create IP routed interface inside VRF. Length of interfaces, nodes and ip_addresses must match.
+        # This will create IP routed interface inside VRF. Length of interfaces, nodes and ip_addresses and descriptions (if used) must match.
         l3_interfaces:
           - interfaces: [ <interface_name1>, <interface_name2>, <interface_name3> ]
             ip_addresses: [ <IPv4_address/Mask>, <IPv4_address/Mask>, <IPv4_address/Mask> ]
             nodes: [ < node_1 >, < node_2 >, < node_1 > ]
             description: < description >
+            # if description is set then descriptions is ignored for backward-compatibility
+            descriptions: [ <description1>, <description2>, description3> ]
             enabled: < true | false >
             mtu: < mtu >
             # EOS CLI rendered directly on the Ethernet interface in the final EOS configuration

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
@@ -387,12 +387,14 @@ mac_address_table:
             ipv6_address_virtual: < IPv6_address/Mask >
 
         # List of L3 interfaces | Optional.
-        # This will create IP routed interface inside VRF. Length of interfaces, nodes and ip_addresses must match.
+        # This will create IP routed interface inside VRF. Length of interfaces, nodes and ip_addresses and descriptions (if used) must match.
         l3_interfaces:
           - interfaces: [ <interface_name1>, <interface_name2>, <interface_name3> ]
             ip_addresses: [ <IPv4_address/Mask>, <IPv4_address/Mask>, <IPv4_address/Mask> ]
             nodes: [ < node_1 >, < node_2 >, < node_1 > ]
             description: < description >
+            # if description is set then descriptions is ignored for backward-compatibility
+            descriptions: [ <description1>, <description2>, description3> ]
             enabled: < true | false >
             mtu: < mtu >
             # EOS CLI rendered directly on the Ethernet interface in the final EOS configuration

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
@@ -393,7 +393,7 @@ mac_address_table:
             ip_addresses: [ <IPv4_address/Mask>, <IPv4_address/Mask>, <IPv4_address/Mask> ]
             nodes: [ < node_1 >, < node_2 >, < node_1 > ]
             description: < description >
-            # if description is set then descriptions is ignored for backward-compatibility
+            # `descriptions` has precedence over `description`
             descriptions: [ <description1>, <description2>, description3> ]
             enabled: < true | false >
             mtu: < mtu >

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/ethernet_interfaces.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/ethernet_interfaces.py
@@ -53,10 +53,11 @@ class EthernetInterfacesMixin(UtilsMixin):
                                 continue
 
                             interface_name = str(l3_interface["interfaces"][node_index])
-                            interface_description = l3_interface.get("description")
-                            # if 'description' is set, it is preferred
-                            if (interface_descriptions := l3_interface.get("descriptions")) is not None and interface_description is None:
+                            # if 'descriptions' is set, it is preferred
+                            if (interface_descriptions := l3_interface.get("descriptions")) is not None:
                                 interface_description = interface_descriptions[node_index]
+                            else:
+                                interface_description = l3_interface.get("description")
                             interface = {
                                 "peer_type": "l3_interface",
                                 "ip_address": l3_interface["ip_addresses"][node_index],


### PR DESCRIPTION
## Change Summary

Add the ability to have a list of descriptions for l3_interfaces

## Related Issue(s)

Fixes #2236

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

### Documentation

The code checks for the presence of `descriptions` and make sure the length of the list is as long as the list of `interfaces`. If so each interface is assigned the description at the same index in the `descriptions` table.
`descriptions` takes precedence over the existing `description`

```diff
-        # This will create IP routed interface inside VRF. Length of interfaces, nodes and ip_addresses must match.
+        # This will create IP routed interface inside VRF. Length of interfaces, nodes and ip_addresses and descriptions (if used) must match.
         l3_interfaces:
           - interfaces: [ <interface_name1>, <interface_name2>, <interface_name3> ]
             ip_addresses: [ <IPv4_address/Mask>, <IPv4_address/Mask>, <IPv4_address/Mask> ]
             nodes: [ < node_1 >, < node_2 >, < node_1 > ]
             description: < description >
+            # `descriptions` has precedence over `description`
+            descriptions: [ <description1>, <description2>, description3> ]
             enabled: < true | false >
             mtu: < mtu >
             # EOS CLI rendered directly on the Ethernet interface in the final EOS configuration
```

## How to test

molecule in `eos_designs_unit_test`

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
