### PR TITLE
Fix: File permissions for documentation and schema tasks

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/tasks/build-documentation.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/tasks/build-documentation.yml
@@ -24,6 +24,7 @@
   template:
     src: avd_schema_documentation.j2
     dest: "{{ role_documentation_dir ~ '/' ~ documentation_file.filename ~ '.md'  }}"
+    mode: 0664
   loop: "{{ role_documentation_schema }}"
   loop_control:
     loop_var: documentation_file

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/tasks/build-schemas.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/tasks/build-schemas.yml
@@ -21,6 +21,7 @@
   ansible.builtin.copy:
     content: "{{ query('ansible.builtin.file', *schema_files) | map('from_yaml') | ansible.builtin.combine(recursive=True) | to_nice_yaml(indent=2, sort_keys=false) }}"
     dest: "{{ role_schema_path }}"
+    mode: 0664
   vars:
     schema_files: "{{ query('ansible.builtin.fileglob', role_schema_fragments_glob) | arista.avd.natural_sort }}"
 
@@ -30,3 +31,4 @@
   ansible.builtin.copy:
     content: "{{ lookup('ansible.builtin.file', role_schema_path) | from_yaml | arista.avd.convert_schema(type='jsonschema') | to_nice_json(indent=2, sort_keys=false) }}"
     dest: "{{ role_schema_json_schema_path }}"
+    mode: 0664

--- a/ansible_collections/arista/avd/roles/eos_designs/tasks/build-documentation.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/tasks/build-documentation.yml
@@ -24,6 +24,7 @@
   template:
     src: avd_schema_documentation.j2
     dest: "{{ role_documentation_dir ~ '/' ~ documentation_file.filename ~ '.md'  }}"
+    mode: 0664
   loop: "{{ role_documentation_schema }}"
   loop_control:
     loop_var: documentation_file

--- a/ansible_collections/arista/avd/roles/eos_designs/tasks/build-schemas.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/tasks/build-schemas.yml
@@ -21,6 +21,7 @@
   ansible.builtin.copy:
     content: "{{ query('ansible.builtin.file', *schema_files) | map('from_yaml') | ansible.builtin.combine(recursive=True) | to_nice_yaml(indent=2) }}"
     dest: "{{ role_schema_path }}"
+    mode: 0664
   vars:
     schema_files: "{{ query('ansible.builtin.fileglob', role_schema_fragments_glob) | arista.avd.natural_sort }}"
 
@@ -30,3 +31,4 @@
   ansible.builtin.copy:
     content: "{{ lookup('ansible.builtin.file', role_schema_path) | from_yaml | arista.avd.convert_schema(type='jsonschema') | to_nice_json(indent=2, sort_keys=false) }}"
     dest: "{{ role_schema_json_schema_path }}"
+    mode: 0664


### PR DESCRIPTION
## Change Summary

Fix `risky-file-permissions: File permissions unset or incorrect` as reported by galaxy-importer

## Component(s) name

- `arista.avd.eos_designs`
- `arista.avd.eos_cli_config_gen`

## Proposed changes
Set file permissions on all tasks to `mode: 0664`

## How to test

Run `ansible-avd/make galaxy-importer`      

## Checklist

### Repository Checklist

- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
