### PR TITLE
Doc(eos_cli_config_gen): Add LACP to key_to_display_name plugin

### DIFF
--- a/ansible_collections/arista/avd/plugins/plugin_utils/schema/key_to_display_name.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/schema/key_to_display_name.py
@@ -28,6 +28,7 @@ WORDLIST = {
     "ipv6": "IPv6",
     "is": "IS",
     "isis": "ISIS",
+    "lacp": "LACP",
     "lag": "LAG",
     "ldp": "LDP",
     "lfa": "LFA",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -1631,7 +1631,7 @@ ipv6_static_routes:
 ipv6_unicast_routing: <bool>
 ```
 
-## Lacp
+## LACP
 
 ### Description
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -2560,7 +2560,7 @@
         }
       },
       "additionalProperties": false,
-      "title": "Lacp"
+      "title": "LACP"
     },
     "link_tracking_groups": {
       "type": "array",


### PR DESCRIPTION
## Change Summary

Update key to display name to include lacp - LACP

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
