### PR TITLE
Feat(eos_cli_config_gen): Source-interface for management cvx

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-cvx.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-cvx.md
@@ -60,6 +60,7 @@ management cvx
    server host 10.90.224.188
    server host 10.90.224.189
    server host leaf1.atd.lab
+   source-interface loopback0
 ```
 
 # Authentication

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/management-cvx.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/management-cvx.cfg
@@ -17,5 +17,6 @@ management cvx
    server host 10.90.224.188
    server host 10.90.224.189
    server host leaf1.atd.lab
+   source-interface loopback0
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/management-cvx.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/management-cvx.yml
@@ -5,3 +5,4 @@ management_cvx:
   - 10.90.224.188
   - 10.90.224.189
   - leaf1.atd.lab
+  source_interface: loopback0

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1941,6 +1941,7 @@ management_cvx:
   server_hosts:
     - < IP | hostname >
     - < IP | hostname >
+  source_interface: < interface name >
 ```
 
 #### Management Defaults

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -2134,6 +2134,7 @@ management_console:
 | [<samp>&nbsp;&nbsp;shutdown</samp>](## "management_cvx.shutdown") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;server_hosts</samp>](## "management_cvx.server_hosts") | List, items: String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "management_cvx.server_hosts.[].&lt;str&gt;") | String |  |  |  | IP or hostname |
+| [<samp>&nbsp;&nbsp;source_interface</samp>](## "management_cvx.source_interface") | String |  |  |  | interface name |
 
 ### YAML
 
@@ -2142,6 +2143,7 @@ management_cvx:
   shutdown: <bool>
   server_hosts:
     - <str>
+  source_interface: <str>
 ```
 
 ## Management Defaults

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -2134,7 +2134,7 @@ management_console:
 | [<samp>&nbsp;&nbsp;shutdown</samp>](## "management_cvx.shutdown") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;server_hosts</samp>](## "management_cvx.server_hosts") | List, items: String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "management_cvx.server_hosts.[].&lt;str&gt;") | String |  |  |  | IP or hostname |
-| [<samp>&nbsp;&nbsp;source_interface</samp>](## "management_cvx.source_interface") | String |  |  |  | interface name |
+| [<samp>&nbsp;&nbsp;source_interface</samp>](## "management_cvx.source_interface") | String |  |  |  | Interface name |
 
 ### YAML
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -3626,6 +3626,11 @@
             "description": "IP or hostname"
           },
           "title": "Server Hosts"
+        },
+        "source_interface": {
+          "type": "string",
+          "description": "interface name",
+          "title": "Source Interface"
         }
       },
       "additionalProperties": false,

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -3629,7 +3629,7 @@
         },
         "source_interface": {
           "type": "string",
-          "description": "interface name",
+          "description": "Interface name",
           "title": "Source Interface"
         }
       },

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -2672,7 +2672,7 @@ keys:
           description: IP or hostname
       source_interface:
         type: str
-        description: interface name
+        description: Interface name
   management_defaults:
     type: dict
     keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -2670,6 +2670,9 @@ keys:
         items:
           type: str
           description: IP or hostname
+      source_interface:
+        type: str
+        description: interface name
   management_defaults:
     type: dict
     keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_cvx.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_cvx.schema.yml
@@ -15,4 +15,4 @@ keys:
           description: IP or hostname
       source_interface:
         type: str
-        description: interface name
+        description: Interface name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_cvx.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_cvx.schema.yml
@@ -13,3 +13,6 @@ keys:
         items:
           type: str
           description: IP or hostname
+      source_interface:
+        type: str
+        description: interface name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-cvx.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-cvx.j2
@@ -10,4 +10,7 @@ management cvx
 {%     for server_host in management_cvx.server_hosts | arista.avd.natural_sort %}
    server host {{ server_host }}
 {%     endfor %}
+{%     if management_cvx.source_interface is arista.avd.defined %}
+   source-interface {{ management_cvx.source_interface }}
+{%     endif %}
 {% endif %}


### PR DESCRIPTION
## Change Summary
Added `source-interface` command for management-cvx

## Related Issue(s)

Fixes #2075 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Data model:
```
management_cvx:
  shutdown: false
  server_hosts:
  - 10.90.224.188
  - 10.90.224.189
  - leaf1.atd.lab
  source_interface: loopback0
```

Config:
```
management cvx
   no shutdown
   server host 10.90.224.188
   server host 10.90.224.189
   server host leaf1.atd.lab
   source-interface loopback0
!
```

## How to test
`molecule converge --scenario-name eos_cli_config_gen -- --limit management-cvx`

## Checklist

### User Checklist

- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
