### PR TITLE
Fix(eos_designs): Python import error for AristaAvdMissingVariableError

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/core_interfaces/utils.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/core_interfaces/utils.py
@@ -6,8 +6,9 @@ from ipaddress import ip_network
 from itertools import islice
 
 from ansible_collections.arista.avd.plugins.filter.convert_dicts import convert_dicts
+from ansible_collections.arista.avd.plugins.plugin_utils.errors import AristaAvdMissingVariableError
 from ansible_collections.arista.avd.plugins.plugin_utils.merge import merge
-from ansible_collections.arista.avd.plugins.plugin_utils.utils import AristaAvdMissingVariableError, default, get, get_item
+from ansible_collections.arista.avd.plugins.plugin_utils.utils import default, get, get_item
 from ansible_collections.arista.avd.roles.eos_designs.python_modules.interface_descriptions import AvdInterfaceDescriptions
 from ansible_collections.arista.avd.roles.eos_designs.python_modules.ip_addressing import AvdIpAddressing
 


### PR DESCRIPTION
## Change Summary

Update import for AristaAvdMissingVariableError

## Component(s) name

`arista.avd.eos_designs`

## How to test

All Molecule pass

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
