### PR TITLE
Feat(eos_cli_config_gen): Add graceful-restart support for router_bgp

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
@@ -94,8 +94,6 @@ interface Management1
 | BGP Tuning |
 | ---------- |
 | no bgp default ipv4-unicast |
-| graceful-restart restart-time 300 |
-| graceful-restart |
 | bgp bestpath d-path |
 | update wait-for-convergence |
 | update wait-install |
@@ -158,12 +156,14 @@ interface Management1
 router bgp 65101
    router-id 192.168.255.3
    distance bgp 20 200 200
+   graceful-restart restart-time 555
+   graceful-restart stalepath-time 666
+   graceful-restart
+   graceful-restart-helper restart-time 555
    maximum-paths 32 ecmp 32
    update wait-for-convergence
    update wait-install
    no bgp default ipv4-unicast
-   graceful-restart restart-time 300
-   graceful-restart
    bgp bestpath d-path
    bgp listen range 10.10.10.0/24 peer-group my-peer-group1 peer-filter my-peer-filter
    bgp listen range 12.10.10.0/24 peer-id include router-id peer-group my-peer-group3 remote-as 65444

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
@@ -159,7 +159,7 @@ router bgp 65101
    graceful-restart restart-time 555
    graceful-restart stalepath-time 666
    graceful-restart
-   graceful-restart-helper restart-time 555
+   graceful-restart-helper restart-time 888
    maximum-paths 32 ecmp 32
    update wait-for-convergence
    update wait-install

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-base.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-base.cfg
@@ -18,7 +18,7 @@ router bgp 65101
    graceful-restart restart-time 555
    graceful-restart stalepath-time 666
    graceful-restart
-   graceful-restart-helper restart-time 555
+   graceful-restart-helper restart-time 888
    maximum-paths 32 ecmp 32
    update wait-for-convergence
    update wait-install

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-base.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-base.cfg
@@ -15,12 +15,14 @@ interface Management1
 router bgp 65101
    router-id 192.168.255.3
    distance bgp 20 200 200
+   graceful-restart restart-time 555
+   graceful-restart stalepath-time 666
+   graceful-restart
+   graceful-restart-helper restart-time 555
    maximum-paths 32 ecmp 32
    update wait-for-convergence
    update wait-install
    no bgp default ipv4-unicast
-   graceful-restart restart-time 300
-   graceful-restart
    bgp bestpath d-path
    bgp listen range 10.10.10.0/24 peer-group my-peer-group1 peer-filter my-peer-filter
    bgp listen range 12.10.10.0/24 peer-id include router-id peer-group my-peer-group3 remote-as 65444

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-base.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-base.yml
@@ -8,13 +8,19 @@ router_bgp:
     external_routes: 20
     internal_routes: 200
     local_routes: 200
+  graceful_restart:
+    enabled: true
+    restart_time: 555
+    stalepath_time: 666
+  graceful_restart_helper:
+    enabled: true
+    restart_time: 888
+    long_lived: true
   maximum_paths:
     paths: 32
     ecmp: 32
   bgp_defaults:
     - no bgp default ipv4-unicast
-    - graceful-restart restart-time 300
-    - graceful-restart
   bgp:
     bestpath:
       d_path: true

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -2889,6 +2889,8 @@ router_bgp:
     enabled: < true | false >
     restart_time: < 1-3600 >
     stalepath_time: < 1-3600 >
+  # graceful-restart-help long-lived and restart-time are mutually exclusive in CLI
+  # restart-time will take precedence if both are configured.
   graceful_restart_helper:
     enabled: < true | false >
     restart_time: < 1-100000000>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -2885,6 +2885,14 @@ router_bgp:
     external_routes: < 1-255 >
     internal_routes: < 1-255 >
     local_routes: < 1-255 >
+  graceful_restart:
+    enabled: < true | false >
+    restart_time: < 1-3600 >
+    stalepath_time: < 1-3600 >
+  graceful_restart_helper:
+    enabled: < true | false >
+    restart_time: < 1-100000000>
+    long_lived: < true | false >
   maximum_paths:
     paths: < 1-600 >
     ecmp: < 1-600 >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
@@ -2540,6 +2540,14 @@ router_bgp:
     external_routes: < 1-255 >
     internal_routes: < 1-255 >
     local_routes: < 1-255 >
+  graceful_restart:
+    enabled: < true | false >
+    restart_time: < 1-3600 >
+    stalepath_time: < 1-3600 >
+  graceful_restart_helper:
+    enabled: < true | false >
+    restart_time: < 1-100000000>
+    long_lived: < true | false >
   maximum_paths:
     paths: < 1-600 >
     ecmp: < 1-600 >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
@@ -2544,6 +2544,8 @@ router_bgp:
     enabled: < true | false >
     restart_time: < 1-3600 >
     stalepath_time: < 1-3600 >
+  # graceful-restart-help long-lived and restart-time are mutually exclusive in CLI
+  # restart-time will take precedence if both are configured.
   graceful_restart_helper:
     enabled: < true | false >
     restart_time: < 1-100000000>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -3139,6 +3139,14 @@ router_bfd:
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;external_routes</samp>](## "router_bgp.distance.external_routes") | Integer |  |  | Min: 1<br>Max: 255 |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;internal_routes</samp>](## "router_bgp.distance.internal_routes") | Integer |  |  | Min: 1<br>Max: 255 |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;local_routes</samp>](## "router_bgp.distance.local_routes") | Integer |  |  | Min: 1<br>Max: 255 |  |
+| [<samp>&nbsp;&nbsp;graceful_restart</samp>](## "router_bgp.graceful_restart") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "router_bgp.graceful_restart.enabled") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;restart_time</samp>](## "router_bgp.graceful_restart.restart_time") | Integer |  |  | Min: 1<br>Max: 3600 | Number of seconds |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;stalepath_time</samp>](## "router_bgp.graceful_restart.stalepath_time") | Integer |  |  | Min: 1<br>Max: 3600 | Number of seconds |
+| [<samp>&nbsp;&nbsp;graceful_restart_helper</samp>](## "router_bgp.graceful_restart_helper") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "router_bgp.graceful_restart_helper.enabled") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;restart_time</samp>](## "router_bgp.graceful_restart_helper.restart_time") | Integer |  |  | Min: 1<br>Max: 100000000 | Number of seconds |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;long_lived</samp>](## "router_bgp.graceful_restart_helper.long_lived") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;maximum_paths</samp>](## "router_bgp.maximum_paths") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;paths</samp>](## "router_bgp.maximum_paths.paths") | Integer |  |  | Min: 1<br>Max: 600 |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ecmp</samp>](## "router_bgp.maximum_paths.ecmp") | Integer |  |  | Min: 1<br>Max: 600 |  |
@@ -3558,6 +3566,14 @@ router_bgp:
     external_routes: <int>
     internal_routes: <int>
     local_routes: <int>
+  graceful_restart:
+    enabled: <bool>
+    restart_time: <int>
+    stalepath_time: <int>
+  graceful_restart_helper:
+    enabled: <bool>
+    restart_time: <int>
+    long_lived: <bool>
   maximum_paths:
     paths: <int>
     ecmp: <int>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -3145,8 +3145,8 @@ router_bfd:
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;stalepath_time</samp>](## "router_bgp.graceful_restart.stalepath_time") | Integer |  |  | Min: 1<br>Max: 3600 | Number of seconds |
 | [<samp>&nbsp;&nbsp;graceful_restart_helper</samp>](## "router_bgp.graceful_restart_helper") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "router_bgp.graceful_restart_helper.enabled") | Boolean |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;restart_time</samp>](## "router_bgp.graceful_restart_helper.restart_time") | Integer |  |  | Min: 1<br>Max: 100000000 | Number of seconds |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;long_lived</samp>](## "router_bgp.graceful_restart_helper.long_lived") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;restart_time</samp>](## "router_bgp.graceful_restart_helper.restart_time") | Integer |  |  | Min: 1<br>Max: 100000000 | Number of seconds<br>graceful-restart-help long-lived and restart-time are mutually exclusive in CLI.<br>restart-time will take precedence if both are configured.<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;long_lived</samp>](## "router_bgp.graceful_restart_helper.long_lived") | Boolean |  |  |  | graceful-restart-help long-lived and restart-time are mutually exclusive in CLI.<br>restart-time will take precedence if both are configured.<br> |
 | [<samp>&nbsp;&nbsp;maximum_paths</samp>](## "router_bgp.maximum_paths") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;paths</samp>](## "router_bgp.maximum_paths.paths") | Integer |  |  | Min: 1<br>Max: 600 |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ecmp</samp>](## "router_bgp.maximum_paths.ecmp") | Integer |  |  | Min: 1<br>Max: 600 |  |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -5655,6 +5655,53 @@
           "additionalProperties": false,
           "title": "Distance"
         },
+        "graceful_restart": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "title": "Enabled"
+            },
+            "restart_time": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 3600,
+              "description": "Number of seconds",
+              "title": "Restart Time"
+            },
+            "stalepath_time": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 3600,
+              "description": "Number of seconds",
+              "title": "Stalepath Time"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Graceful Restart"
+        },
+        "graceful_restart_helper": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "title": "Enabled"
+            },
+            "restart_time": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100000000,
+              "description": "Number of seconds",
+              "title": "Restart Time"
+            },
+            "long_lived": {
+              "type": "boolean",
+              "title": "Long Lived"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Graceful Restart Helper"
+        },
         "maximum_paths": {
           "type": "object",
           "properties": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -5691,11 +5691,12 @@
               "type": "integer",
               "minimum": 1,
               "maximum": 100000000,
-              "description": "Number of seconds",
+              "description": "Number of seconds\ngraceful-restart-help long-lived and restart-time are mutually exclusive in CLI.\nrestart-time will take precedence if both are configured.\n",
               "title": "Restart Time"
             },
             "long_lived": {
               "type": "boolean",
+              "description": "graceful-restart-help long-lived and restart-time are mutually exclusive in CLI.\nrestart-time will take precedence if both are configured.\n",
               "title": "Long Lived"
             }
           },

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -4035,9 +4035,22 @@ keys:
             - str
             min: 1
             max: 100000000
-            description: Number of seconds
+            description: 'Number of seconds
+
+              graceful-restart-help long-lived and restart-time are mutually exclusive
+              in CLI.
+
+              restart-time will take precedence if both are configured.
+
+              '
           long_lived:
             type: bool
+            description: 'graceful-restart-help long-lived and restart-time are mutually
+              exclusive in CLI.
+
+              restart-time will take precedence if both are configured.
+
+              '
       maximum_paths:
         type: dict
         keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -4005,6 +4005,39 @@ keys:
             - str
             min: 1
             max: 255
+      graceful_restart:
+        type: dict
+        keys:
+          enabled:
+            type: bool
+          restart_time:
+            type: int
+            convert_types:
+            - str
+            min: 1
+            max: 3600
+            description: Number of seconds
+          stalepath_time:
+            type: int
+            convert_types:
+            - str
+            min: 1
+            max: 3600
+            description: Number of seconds
+      graceful_restart_helper:
+        type: dict
+        keys:
+          enabled:
+            type: bool
+          restart_time:
+            type: int
+            convert_types:
+            - str
+            min: 1
+            max: 100000000
+            description: Number of seconds
+          long_lived:
+            type: bool
       maximum_paths:
         type: dict
         keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_bgp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_bgp.schema.yml
@@ -35,6 +35,39 @@ keys:
               - str
             min: 1
             max: 255
+      graceful_restart:
+        type: dict
+        keys:
+          enabled:
+            type: bool
+          restart_time:
+            type: int
+            convert_types:
+              - str
+            min: 1
+            max: 3600
+            description: Number of seconds
+          stalepath_time:
+            type: int
+            convert_types:
+              - str
+            min: 1
+            max: 3600
+            description: Number of seconds
+      graceful_restart_helper:
+        type: dict
+        keys:
+          enabled:
+            type: bool
+          restart_time:
+            type: int
+            convert_types:
+              - str
+            min: 1
+            max: 100000000
+            description: Number of seconds
+          long_lived:
+            type: bool
       maximum_paths:
         type: dict
         keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_bgp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_bgp.schema.yml
@@ -65,9 +65,15 @@ keys:
               - str
             min: 1
             max: 100000000
-            description: Number of seconds
+            description: |
+              Number of seconds
+              graceful-restart-help long-lived and restart-time are mutually exclusive in CLI.
+              restart-time will take precedence if both are configured.
           long_lived:
             type: bool
+            description: |
+              graceful-restart-help long-lived and restart-time are mutually exclusive in CLI.
+              restart-time will take precedence if both are configured.
       maximum_paths:
         type: dict
         keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -12,6 +12,34 @@ router bgp {{ router_bgp.as }}
 {%         endif %}
    {{ distance_cli }}
 {%     endif %}
+{# the ordering of graceful-restart commands in the CLI is as follow
+   graceful-restart restart-time 300
+   graceful-restart stalepath-time 42
+   graceful-restart
+
+   but when disabling graceful-restart using no graceful-restart, stalepath-time stays
+   hence the convoluted Jinja template
+#}
+{%     if router_bgp.graceful_restart.enabled is arista.avd.defined(true) and router_bgp.graceful_restart.restart_time is arista.avd.defined %}
+   graceful-restart restart-time {{ router_bgp.graceful_restart.restart_time }}
+{%     endif %}
+{%     if router_bgp.graceful_restart.stalepath_time is arista.avd.defined %}
+   graceful-restart stalepath-time {{ router_bgp.graceful_restart.stalepath_time }}
+{%     endif %}
+{%     if router_bgp.graceful_restart.enabled is arista.avd.defined(true) %}
+   graceful-restart
+{%     endif %}
+{%     if router_bgp.graceful_restart_helper.enabled is arista.avd.defined(false) %}
+   no graceful-restart-helper
+{%     elif router_bgp.graceful_restart_helper.enabled is arista.avd.defined(true) %}
+{# graceful-restart-help long-lived and restart-time are mutually exclusive in CLI #}
+{# restart-time will win in this case #}
+{%         if router_bgp.graceful_restart.restart_time is arista.avd.defined %}
+   graceful-restart-helper restart-time {{ router_bgp.graceful_restart.restart_time }}
+{%         elif router_bgp.graceful_restart.long_lived is arista.avd.defined(true) %}
+   graceful-restart-helper long-lived
+{%         endif %}
+{%     endif %}
 {%     if router_bgp.maximum_paths.paths is arista.avd.defined %}
 {%         set paths_cli = "maximum-paths " ~ router_bgp.maximum_paths.paths %}
 {%         if router_bgp.maximum_paths.ecmp is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -34,9 +34,9 @@ router bgp {{ router_bgp.as }}
 {%     elif router_bgp.graceful_restart_helper.enabled is arista.avd.defined(true) %}
 {# graceful-restart-help long-lived and restart-time are mutually exclusive in CLI #}
 {# restart-time will win in this case #}
-{%         if router_bgp.graceful_restart.restart_time is arista.avd.defined %}
-   graceful-restart-helper restart-time {{ router_bgp.graceful_restart.restart_time }}
-{%         elif router_bgp.graceful_restart.long_lived is arista.avd.defined(true) %}
+{%         if router_bgp.graceful_restart_helper.restart_time is arista.avd.defined %}
+   graceful-restart-helper restart-time {{ router_bgp.graceful_restart_helper.restart_time }}
+{%         elif router_bgp.graceful_restart_helper.long_lived is arista.avd.defined(true) %}
    graceful-restart-helper long-lived
 {%         endif %}
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -12,14 +12,6 @@ router bgp {{ router_bgp.as }}
 {%         endif %}
    {{ distance_cli }}
 {%     endif %}
-{# the ordering of graceful-restart commands in the CLI is as follow
-   graceful-restart restart-time 300
-   graceful-restart stalepath-time 42
-   graceful-restart
-
-   but when disabling graceful-restart using no graceful-restart, stalepath-time stays
-   hence the convoluted Jinja template
-#}
 {%     if router_bgp.graceful_restart.enabled is arista.avd.defined(true) and router_bgp.graceful_restart.restart_time is arista.avd.defined %}
    graceful-restart restart-time {{ router_bgp.graceful_restart.restart_time }}
 {%     endif %}
@@ -32,8 +24,6 @@ router bgp {{ router_bgp.as }}
 {%     if router_bgp.graceful_restart_helper.enabled is arista.avd.defined(false) %}
    no graceful-restart-helper
 {%     elif router_bgp.graceful_restart_helper.enabled is arista.avd.defined(true) %}
-{# graceful-restart-help long-lived and restart-time are mutually exclusive in CLI #}
-{# restart-time will win in this case #}
 {%         if router_bgp.graceful_restart_helper.restart_time is arista.avd.defined %}
    graceful-restart-helper restart-time {{ router_bgp.graceful_restart_helper.restart_time }}
 {%         elif router_bgp.graceful_restart_helper.long_lived is arista.avd.defined(true) %}


### PR DESCRIPTION
## Change Summary

Add graceful-restart and graceful-restart-helper support at top BGP level

* Missing device documentation template updates
* Need to verify on the issue if it should be implemented at other levels

## Related Issue(s)

Fixes #2265 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Adding the following keys to the `router_bgp` schema:

```
  graceful_restart:
    enabled: < true | false >
    restart_time: < 1-3600 >
    stalepath_time: < 1-3600 >
  graceful_restart_helper:
    enabled: < true | false >
    restart_time: < 1-100000000>
    long_lived: < true | false >
```

Based on the following output (only including top level options in the fist commit for this PR):

```
DC1-LEAF1A(config-router-bgp)#show cli commands | grep graceful
[no|default] graceful-restart
[no|default] graceful-restart ( restart-time | stalepath-time ) SECONDS
[no|default] graceful-restart-helper [ ( restart-time RESTART_TIME ) ] [ long-lived ]
[no|default] neighbor ( GROUP | IP_PEER | IP6_PEER | IP6_LL_PEER ) graceful-restart [ disabled ]
[no|default] neighbor ( GROUP | IP_PEER | IP6_PEER | IP6_LL_PEER ) graceful-restart-helper [ ( restart-time RESTART_TIME ) ] [ long-lived ] [ disabled ]
```

## How to test

Adding molecule tests

**NOTE:** for now the test does not cover every single cases as only one host is being used.

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
