### PR TITLE
Feat(eos_cli_config_gen): Fix macsec template

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mac-security-eth-po-entropy.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mac-security-eth-po-entropy.md
@@ -235,7 +235,7 @@ mac security
       cipher aes128-gcm
       key 1234a 7 025756085F535976
       key 1234c 7 10195F4C5144405A fallback
-      mka session key-server priority 100
+      mka key-server priority 100
       mka session rekey-period 30
       sci
       l2-protocol lldp bypass unauthorized

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/mac-security-eth-po-entropy.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/mac-security-eth-po-entropy.cfg
@@ -10,7 +10,7 @@ mac security
       cipher aes128-gcm
       key 1234a 7 025756085F535976
       key 1234c 7 10195F4C5144405A fallback
-      mka session key-server priority 100
+      mka key-server priority 100
       mka session rekey-period 30
       sci
       l2-protocol lldp bypass unauthorized

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/mac-security.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/mac-security.j2
@@ -24,7 +24,7 @@ mac security
 {%             endif %}
 {%         endfor %}
 {%         if profile.mka.key_server_priority is arista.avd.defined %}
-      mka session key-server priority {{ profile.mka.key_server_priority }}
+      mka key-server priority {{ profile.mka.key_server_priority }}
 {%         endif %}
 {%         if profile.mka.session.rekey_period is arista.avd.defined %}
       mka session rekey-period {{ profile.mka.session.rekey_period }}


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->

## Related Issue(s)

Related to #2285 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->
* Fix for the macsec commands added in #2286 

key-server priority is defined directly under macsec profile, not under profile session

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
See molecule tests

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-
