### PR TITLE
Feat(eos_cli_config_gen): Add schema for management_api_gnmi

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/management-gnmi.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/management-gnmi.yml
@@ -1,6 +1,6 @@
 management_api_gnmi:
   enable_vrfs:
-    MGMT:
+    - name: MGMT
       access_group: ACL-GNMI
-    MONITORING:
+    - name: MONITORING
   octa:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
@@ -1725,9 +1725,9 @@ ip_http_client_source_interfaces:
 ```yaml
 management_api_gnmi:
   enable_vrfs:
-    < vrf_name_1 >:
+    - name: < vrf_name_1 >
       access_group: < Standard IPv4 ACL name >
-    < vrf_name_2 >:
+    - name: < vrf_name_2 >
       access_group: < Standard IPv4 ACL name >
   octa:
 ```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -2080,6 +2080,44 @@ maintenance:
           - <str>
 ```
 
+## Management API Gnmi
+
+### Variables
+
+| Variable | Type | Required | Default | Value Restrictions | Description |
+| -------- | ---- | -------- | ------- | ------------------ | ----------- |
+| [<samp>management_api_gnmi</samp>](## "management_api_gnmi") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;provider</samp>](## "management_api_gnmi.provider") | String |  | eos-native |  |  |
+| [<samp>&nbsp;&nbsp;transport</samp>](## "management_api_gnmi.transport") | Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;grpc</samp>](## "management_api_gnmi.transport.grpc") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "management_api_gnmi.transport.grpc.[].name") | String |  |  |  | Transport name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ssl_profile</samp>](## "management_api_gnmi.transport.grpc.[].ssl_profile") | String |  |  |  | SSL profile name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "management_api_gnmi.transport.grpc.[].vrf") | String |  |  |  | VRF name is optional |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;notification_timestamp</samp>](## "management_api_gnmi.transport.grpc.[].notification_timestamp") | String |  |  | Valid Values:<br>- send-time<br>- last-change-time | Per the GNMI specification, the default timestamp field of a notification message is set to be<br>the time at which the value of the underlying data source changes or when the reported event takes place.<br>In order to facilitate integration in legacy environments oriented around polling style operations,<br>an option to support overriding the timestamp field to the send-time is available from EOS 4.27.0F.<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ip_access_group</samp>](## "management_api_gnmi.transport.grpc.[].ip_access_group") | String |  |  |  | ACL name |
+| [<samp>&nbsp;&nbsp;enable_vrfs</samp>](## "management_api_gnmi.enable_vrfs") | List, items: Dictionary |  |  |  | Enable VRFs will be deprecated in AVD v4.0.<br>These should not be mixed with the new keys above.<br> |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "management_api_gnmi.enable_vrfs.[].name") | String | Required, Unique |  |  | VRF name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;access_group</samp>](## "management_api_gnmi.enable_vrfs.[].access_group") | String |  |  |  | Standard IPv4 ACL name |
+| [<samp>&nbsp;&nbsp;octa</samp>](## "management_api_gnmi.octa") | Dictionary |  |  |  | Octa key will be deprecated in AVD v4.0.<br>These should not be mixed with the new keys above.<br>Octa activates `eos-native` provider and it is the only provider currently supported by EOS. |
+
+### YAML
+
+```yaml
+management_api_gnmi:
+  provider: <str>
+  transport:
+    grpc:
+      - name: <str>
+        ssl_profile: <str>
+        vrf: <str>
+        notification_timestamp: <str>
+        ip_access_group: <str>
+  enable_vrfs:
+    - name: <str>
+      access_group: <str>
+  octa:
+```
+
 ## Management API HTTP
 
 ### Variables

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -3539,6 +3539,93 @@
       },
       "additionalProperties": false
     },
+    "management_api_gnmi": {
+      "type": "object",
+      "properties": {
+        "provider": {
+          "type": "string",
+          "default": "eos-native",
+          "title": "Provider"
+        },
+        "transport": {
+          "type": "object",
+          "properties": {
+            "grpc": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "Transport name",
+                    "title": "Name"
+                  },
+                  "ssl_profile": {
+                    "type": "string",
+                    "description": "SSL profile name",
+                    "title": "SSL Profile"
+                  },
+                  "vrf": {
+                    "type": "string",
+                    "description": "VRF name is optional",
+                    "title": "VRF"
+                  },
+                  "notification_timestamp": {
+                    "type": "string",
+                    "enum": [
+                      "send-time",
+                      "last-change-time"
+                    ],
+                    "description": "Per the GNMI specification, the default timestamp field of a notification message is set to be\nthe time at which the value of the underlying data source changes or when the reported event takes place.\nIn order to facilitate integration in legacy environments oriented around polling style operations,\nan option to support overriding the timestamp field to the send-time is available from EOS 4.27.0F.\n",
+                    "title": "Notification Timestamp"
+                  },
+                  "ip_access_group": {
+                    "type": "string",
+                    "description": "ACL name",
+                    "title": "IP Access Group"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "title": "Grpc"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Transport"
+        },
+        "enable_vrfs": {
+          "type": "array",
+          "description": "Enable VRFs will be deprecated in AVD v4.0.\nThese should not be mixed with the new keys above.\n",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "VRF name",
+                "title": "Name"
+              },
+              "access_group": {
+                "type": "string",
+                "description": "Standard IPv4 ACL name",
+                "title": "Access Group"
+              }
+            },
+            "additionalProperties": false,
+            "required": [
+              "name"
+            ]
+          },
+          "title": "Enable VRFs"
+        },
+        "octa": {
+          "type": "object",
+          "description": "Octa key will be deprecated in AVD v4.0.\nThese should not be mixed with the new keys above.\nOcta activates `eos-native` provider and it is the only provider currently supported by EOS.",
+          "title": "Octa"
+        }
+      },
+      "additionalProperties": false,
+      "title": "Management API Gnmi"
+    },
     "management_api_http": {
       "type": "object",
       "properties": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -2631,6 +2631,77 @@ keys:
                   items:
                     type: str
                     description: Name of Interface Group
+  management_api_gnmi:
+    type: dict
+    keys:
+      provider:
+        type: str
+        default: eos-native
+      transport:
+        type: dict
+        keys:
+          grpc:
+            type: list
+            items:
+              type: dict
+              keys:
+                name:
+                  type: str
+                  description: Transport name
+                ssl_profile:
+                  type: str
+                  description: SSL profile name
+                vrf:
+                  type: str
+                  description: VRF name is optional
+                notification_timestamp:
+                  type: str
+                  valid_values:
+                  - send-time
+                  - last-change-time
+                  description: 'Per the GNMI specification, the default timestamp
+                    field of a notification message is set to be
+
+                    the time at which the value of the underlying data source changes
+                    or when the reported event takes place.
+
+                    In order to facilitate integration in legacy environments oriented
+                    around polling style operations,
+
+                    an option to support overriding the timestamp field to the send-time
+                    is available from EOS 4.27.0F.
+
+                    '
+                ip_access_group:
+                  type: str
+                  description: ACL name
+      enable_vrfs:
+        type: list
+        primary_key: name
+        convert_types:
+        - dict
+        description: 'Enable VRFs will be deprecated in AVD v4.0.
+
+          These should not be mixed with the new keys above.
+
+          '
+        items:
+          type: dict
+          keys:
+            name:
+              type: str
+              description: VRF name
+            access_group:
+              type: str
+              description: Standard IPv4 ACL name
+      octa:
+        type: dict
+        description: 'Octa key will be deprecated in AVD v4.0.
+
+          These should not be mixed with the new keys above.
+
+          Octa activates `eos-native` provider and it is the only provider currently
+          supported by EOS.'
   management_api_http:
     type: dict
     keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_api_gnmi.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_api_gnmi.schema.yml
@@ -1,0 +1,62 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  management_api_gnmi:
+    type: dict
+    keys:
+      provider:
+        type: str
+        default: eos-native
+      transport:
+        type: dict
+        keys:
+          grpc:
+            type: list
+            items:
+              type: dict
+              keys:
+                name:
+                  type: str
+                  description: Transport name
+                ssl_profile:
+                  type: str
+                  description: SSL profile name
+                vrf:
+                  type: str
+                  description: VRF name is optional
+                notification_timestamp:
+                  type: str
+                  valid_values: ["send-time", "last-change-time"]
+                  description: |
+                    Per the GNMI specification, the default timestamp field of a notification message is set to be
+                    the time at which the value of the underlying data source changes or when the reported event takes place.
+                    In order to facilitate integration in legacy environments oriented around polling style operations,
+                    an option to support overriding the timestamp field to the send-time is available from EOS 4.27.0F.
+                ip_access_group:
+                  type: str
+                  description: ACL name
+      enable_vrfs:
+        type: list
+        primary_key: name
+        convert_types:
+          - dict
+        description: |
+          Enable VRFs will be deprecated in AVD v4.0.
+          These should not be mixed with the new keys above.
+        items:
+          type: dict
+          keys:
+            name:
+              type: str
+              description: VRF name
+            access_group:
+              type: str
+              description: Standard IPv4 ACL name
+      octa:
+        type: dict
+        description: |
+          Octa key will be deprecated in AVD v4.0.
+          These should not be mixed with the new keys above.
+          Octa activates `eos-native` provider and it is the only provider currently supported by EOS.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-api-gnmi.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-api-gnmi.j2
@@ -15,7 +15,7 @@
 | VRF with GNMI | OCTA |
 | ------------- | ---- |
 {%         for vrf in management_api_gnmi.enable_vrfs | arista.avd.natural_sort %}
-| {{ vrf }} | {{ octa }} |
+| {{ vrf.name }} | {{ octa }} |
 {%         endfor %}
 {%     endif %}
 {# new table view using the new flags #}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-api-gnmi.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-api-gnmi.j2
@@ -3,14 +3,14 @@
 !
 management api gnmi
 {%     for vrf in management_api_gnmi.enable_vrfs | arista.avd.natural_sort %}
-{%         if vrf == 'default' %}
+{%         if vrf.name == 'default' %}
    transport grpc default
 {%         else %}
-   transport grpc {{ vrf }}
-{%             if management_api_gnmi.enable_vrfs[vrf].access_group is arista.avd.defined %}
-      ip access-group {{ management_api_gnmi.enable_vrfs[vrf].access_group }}
+   transport grpc {{ vrf.name }}
+{%             if vrf.access_group is arista.avd.defined %}
+      ip access-group {{ vrf.access_group }}
 {%             endif %}
-      vrf {{ vrf }}
+      vrf {{ vrf.name }}
 {%         endif %}
 {%     endfor %}
 {%     if management_api_gnmi.octa is defined %}


### PR DESCRIPTION
## Add schema for data model

<!-- Use this PR Title: Feat(eos_cli_config_gen): Add schema for < data_model_key > -->

## Checklist

### Contributor Checklist

- [x] Create schema fragment matching data model described in README.md and README_v4.0.md
  - README.md is most complete with all keys. README_v4.0 includes partial data models after conversion to lists.
  - Schema fragment path is `roles/eos_cli_config_gen/schemas/schema_fragments/<data_model_key>.schema.yml`.
  - Copy line 1-5 from another schema (comments and outer type:dict).
  - Refer to [schema documentation](https://avd.sh/en/devel/docs/input-variable-validation-BETA.html) for syntax and/or use YAML Lint plugin from Redhat in VSCode.
  - Use `convert_types` on value that could be mixed type or misinterpreted like integers and numeric strings.
- [x] If the data model has been converted from wildcard dicts:
  - Add `convert_types: ['dict']` to the schema.
  - Remove `convert_dicts` from the `templates/eos/<>.j2` and `templates/documentation/<>.j2` templates.
- [x] Run `molecule converge -s build_schemas_and_docs` to update schema and documentation.
- [x] Test by running `molecule converge -s eos_cli_config_gen` and verify no errors or changes to generated configs/docs.

### Reviewer Checklist

- Reviewer 1:
  - [ ] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [ ] Verify that `convert_dicts` has been removed from templates as applicable.
  - [ ] Verify no changes to configs/docs on any molecule scenario
  - [ ] Verify that CI pass

- Reviewer 2:
  - [ ] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [ ] Verify that `convert_dicts` has been removed from templates as applicable.
  - [ ] Verify no changes to configs/docs on any molecule scenario
  - [ ] Verify that CI pass
