### PR TITLE
Feat(plugins): Add password type to metaschema + validator (bgp only)

### DIFF
--- a/ansible_collections/arista/avd/docs/input-variable-validation-BETA.md
+++ b/ansible_collections/arista/avd/docs/input-variable-validation-BETA.md
@@ -253,7 +253,7 @@ The meta-schema does not allow for other keys to be set in the schema.
 | <samp>convert_types</samp> | List, items: String | | | | List of types to auto-convert from.<br>For type `password`, auto-conversion is supported from `int` |
 | <samp>max_length</samp> | Integer | | | | Maximum length |
 | <samp>min_length</samp> | Integer | | | | Minimum length |
-| <samp>password_type</samp> | String True | | | Enum ['bgp'] | The type of the password, currently only 'bgp' is supported |
+| <samp>password_type</samp> | String | True | | | Enum ['bgp'] | The type of the password, currently only 'bgp' is supported |
 | <samp>password_key_field</samp> | String | True | | | The field in the dict to use as key for the password.<br>It will only worked with keys in the same dictionary.|
 | <samp>display_name</samp> | String | | | Regex Pattern: `"^[^\n]+$"` | Free text display name for forms and documentation (single line) |
 | <samp>description</samp> | String | | | Minimum Length: 1 | Free text description for forms and documentation (multi line) |

--- a/ansible_collections/arista/avd/docs/input-variable-validation-BETA.md
+++ b/ansible_collections/arista/avd/docs/input-variable-validation-BETA.md
@@ -244,3 +244,23 @@ The meta-schema does not allow for other keys to be set in the schema.
 | <samp>&nbsp;&nbsp;table</samp> | String | | | | Setting 'table' will allow for custom grouping of schema fields in the documentation.<br>By default each root key has it's own table. By setting the same table-value on multiple keys, they will be merged to a single table.<br>If 'table' is set on a 'child' key, all parent keys are automatically included in the table.<br>If 'table' is set on a parent key, all child keys will be included in the same table.<br>It is *not* possible to override 'table' on a child key, if set on the parent. |
 
 The meta-schema does not allow for other keys to be set in the schema.
+
+### Schema Options for type `password` (Password)
+
+| Key | Type | Required | Default | Value Restrictions | Description |
+| ----| ---- | -------- | ------- | ------------------ | ----------- |
+| <samp>type</samp> | String | True | | Valid Values:<br>- `"str"` | Type of variable using the Python short names for each type.<br>`str` for String |
+| <samp>convert_types</samp> | List, items: String | | | | List of types to auto-convert from.<br>For type `password`, auto-conversion is supported from `int` |
+| <samp>max_length</samp> | Integer | | | | Maximum length |
+| <samp>min_length</samp> | Integer | | | | Minimum length |
+| <samp>password_type</samp> | String True | | | Enum ['bgp'] | The type of the password, currently only 'bgp' is supported |
+| <samp>password_key_field</samp> | String | True | | | The field in the dict to use as key for the password.<br>It will only worked with keys in the same dictionary.|
+| <samp>display_name</samp> | String | | | Regex Pattern: `"^[^\n]+$"` | Free text display name for forms and documentation (single line) |
+| <samp>description</samp> | String | | | Minimum Length: 1 | Free text description for forms and documentation (multi line) |
+| <samp>required</samp> | Boolean | | | | Set if variable is required |
+| <samp>$ref</samp> | String | | | | Reference to Sub Schema using JSON Schema resolver<br>Example '#/keys/mykey' will resolve the schema for 'mykey' under the root dictionary of the current schema |
+| <samp>documentation_options</samp> | Dictionary | | | | Special options used for generating documentation |
+| <samp>&nbsp;&nbsp;filename</samp> | String | | "Input Variables" | | Setting 'filename' will allow for custom grouping of schema tables in the documentation.<br>By default all tables will be part of the same 'default.md' file. By setting 'filename' the tables for one or more keys can be moved to separate file.<br>If 'filename' is set on a parent key, all child keys will be included in the same file.<br>It is *not* possible to override 'filename' on a child key, if set on the parent. |
+| <samp>&nbsp;&nbsp;table</samp> | String | | | | Setting 'table' will allow for custom grouping of schema fields in the documentation.<br>By default each root key has it's own table. By setting the same table-value on multiple keys, they will be merged to a single table.<br>If 'table' is set on a 'child' key, all parent keys are automatically included in the table.<br>If 'table' is set on a parent key, all child keys will be included in the same table.<br>It is *not* possible to override 'table' on a child key, if set on the parent. |
+
+The meta-schema does not allow for other keys to be set in the schema.

--- a/ansible_collections/arista/avd/plugins/plugin_utils/bgp_utils.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/bgp_utils.py
@@ -218,7 +218,8 @@ def cbc_check_password(key: bytes, data: bytes) -> bool:
     It does not return the password but only raise an error if the passowrd cannot be decrypted
     """
     try:
-        cbc_decrypt(key, data)
-        return True
+        # It is possible that if only one character is changed towards the end of the encrypting string
+        # cbc_decrypt will succeed - hence this test
+        return cbc_encrypt(key, cbc_decrypt(key, data)) == data
     except Exception:
         return False

--- a/ansible_collections/arista/avd/plugins/plugin_utils/bgp_utils.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/bgp_utils.py
@@ -215,7 +215,7 @@ def cbc_decrypt(key: bytes, data: bytes) -> bytes:
 def cbc_check_password(key: bytes, data: bytes) -> bool:
     """
     This function is used to verify if an encrypted password is decryptable.
-    It does not return the password but only raise an error if the passowrd cannot be decrypted
+    It does not return the password but only raise an error if the password cannot be decrypted
     """
     try:
         # It is possible that if only one character is changed towards the end of the encrypting string

--- a/ansible_collections/arista/avd/plugins/plugin_utils/schema/avd_meta_schema.json
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/schema/avd_meta_schema.json
@@ -263,6 +263,48 @@
                     "additionalProperties": false
                 },
                 {
+                    "required": [ "type", "password_type", "password_key_field" ],
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "enum": [
+                                "password"
+                            ]
+                        },
+                        "convert_types": {
+                            "type": "array",
+                            "description": "List of types to auto-convert from.\nFor 'password' auto-conversion is supported from 'int'",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "int"
+                                ]
+                            }
+                        },
+                        "max_length": {
+                            "type": "number"
+                        },
+                        "min_length": {
+                            "type": "number"
+                        },
+                        "password_type": {
+                            "type": "string",
+                            "description": "The type of the password, currently only 'bgp' is supported",
+                            "enum": ["bgp"]
+                        },
+                        "password_key_field": {
+                            "type": "string",
+                            "description": "The field in the dict to use as key for the password.\nIt will only worked with keys in the same dictionary."
+                        },
+                        "display_name": { "$ref": "#/$def/display_name" },
+                        "description": { "$ref": "#/$def/description" },
+                        "required": { "$ref": "#/$def/required" },
+                        "$ref": { "$ref": "#/$def/$ref" },
+                        "documentation_options": { "$ref": "#/$def/documentation_options" }
+                    },
+                    "additionalProperties": false
+                },
+                {
                     "required": [ "$ref" ],
                     "properties": {
                         "$ref": { "$ref": "#/$def/$ref" }

--- a/ansible_collections/arista/avd/plugins/plugin_utils/schema/avdtodocumentationschemaconverter.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/schema/avdtodocumentationschemaconverter.py
@@ -228,7 +228,7 @@ class AvdToDocumentationSchemaConverter:
             "bool": "Boolean",
             "dict": "Dictionary",
             "list": "List",
-            "password": "String",
+            "password": "Password",
         }
         schema_type = schema.get("type")
         if not schema_type:

--- a/ansible_collections/arista/avd/plugins/plugin_utils/schema/avdtodocumentationschemaconverter.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/schema/avdtodocumentationschemaconverter.py
@@ -228,6 +228,7 @@ class AvdToDocumentationSchemaConverter:
             "bool": "Boolean",
             "dict": "Dictionary",
             "list": "List",
+            "password": "String",
         }
         schema_type = schema.get("type")
         if not schema_type:

--- a/ansible_collections/arista/avd/plugins/plugin_utils/schema/avdtojsonschemaconverter.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/schema/avdtojsonschemaconverter.py
@@ -67,6 +67,7 @@ class AvdToJsonSchemaConverter:
             "bool": "boolean",
             "list": "array",
             "dict": "object",
+            "password": "string",
         }
         return {"type": TYPE_MAP[type]}
 

--- a/ansible_collections/arista/avd/plugins/plugin_utils/schema/avdvalidator.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/schema/avdvalidator.py
@@ -10,7 +10,7 @@ import os
 
 from ansible_collections.arista.avd.plugins.plugin_utils.bgp_utils import cbc_check_password
 from ansible_collections.arista.avd.plugins.plugin_utils.errors import AristaAvdMissingVariableError
-from ansible_collections.arista.avd.plugins.plugin_utils.utils import get_all
+from ansible_collections.arista.avd.plugins.plugin_utils.utils import get, get_all
 
 try:
     import jsonschema
@@ -114,14 +114,8 @@ def _keys_validator(validator, keys: dict, instance: dict, schema: dict):
             childschema.setdefault("valid_values", []).extend(get_all(instance, childschema["dynamic_valid_values"]))
 
         # Validation of passwords
-        if childschema.get("password_type") and childschema.get("password_key_field"):
-            try:
-                password_type = childschema.get("password_type")
-                password_key_field = childschema.get("password_key_field")
-                password_key = get_all(instance, password_key_field, required=True)[0]
-                yield from _password_validator(validator, password_type, password_key, instance, schema)
-            except AristaAvdMissingVariableError:
-                yield jsonschema.ValidationError(f"A value is required for '{password_key_field}' to validate the '{key}'.")
+        if childschema["type"] == "password":
+            yield from _password_validator(validator, parent=instance, key=key, instance=instance[key], schema=childschema)
 
         # Perform regular validation of the child schema.
         yield from validator.descend(
@@ -173,25 +167,31 @@ def _is_dict(validator, instance):
     return isinstance(instance, (dict, ChainMap))
 
 
-def _password_validator(validator, password_type: str, password_key: str, instance: dict, schema: dict):
+def _password_validator(validator, parent: dict, key: str, instance: str, schema: dict):
     """
     This function validates if password is a valid password for the given password_type
 
     The schema validates that the password_type is a valid one so no check is run on this method
     """
-    password = instance["password"]
-    if not validator.is_type(password, "password"):
+    if not validator.is_type(instance, "password"):
         return
 
-    if password_type == "bgp":
-        if password_key is None:
-            yield jsonschema.ValidationError("password_key is missing")
-        else:
-            b_key = bytes(f"{password_key}_passwd", encoding="utf-8")
-            b_password = bytes(password, encoding="utf-8")
+    password_type = schema.get("password_type")
 
-            if not cbc_check_password(b_key, b_password):
-                yield jsonschema.ValidationError(f"BGP password {password} is not valid for password_key {password_key}")
+    if password_type == "bgp":
+        password_key_field = schema.get("password_key_field")
+
+        try:
+            password_key = get(parent, password_key_field, required=True)
+        except AristaAvdMissingVariableError:
+            yield jsonschema.ValidationError(f"A value is required for '{password_key_field}' to validate the password_key '{key}'.")
+            return
+
+        b_key = bytes(f"{password_key}_passwd", encoding="UTF-8")
+        b_password = bytes(instance, encoding="UTF-8")
+
+        if not cbc_check_password(b_key, b_password):
+            yield jsonschema.ValidationError(f"Value in BGP key {key} is not valid for password_key {password_key}")
 
 
 """

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -4154,7 +4154,7 @@ router_bfd:
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bfd</samp>](## "router_bgp.peer_groups.[].bfd") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ebgp_multihop</samp>](## "router_bgp.peer_groups.[].ebgp_multihop") | Integer |  |  | Min: 1<br>Max: 255 | Time-to-live in range of hops |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;next_hop_self</samp>](## "router_bgp.peer_groups.[].next_hop_self") | Boolean |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;password</samp>](## "router_bgp.peer_groups.[].password") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;password</samp>](## "router_bgp.peer_groups.[].password") | Password |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;default_originate</samp>](## "router_bgp.peer_groups.[].default_originate") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "router_bgp.peer_groups.[].default_originate.enabled") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;always</samp>](## "router_bgp.peer_groups.[].default_originate.always") | Boolean |  |  |  |  |
@@ -4454,7 +4454,7 @@ router_bfd:
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- ip_address</samp>](## "router_bgp.vrfs.[].neighbors.[].ip_address") | String | Required, Unique |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;peer_group</samp>](## "router_bgp.vrfs.[].neighbors.[].peer_group") | String |  |  |  | Peer-group name |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;remote_as</samp>](## "router_bgp.vrfs.[].neighbors.[].remote_as") | String |  |  |  | BGP AS <1-4294967295> or AS number in asdot notation <1-65535>.<0-65535> |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;password</samp>](## "router_bgp.vrfs.[].neighbors.[].password") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;password</samp>](## "router_bgp.vrfs.[].neighbors.[].password") | Password |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;remove_private_as</samp>](## "router_bgp.vrfs.[].neighbors.[].remove_private_as") | Dictionary |  |  |  | Remove private AS numbers in outbound AS path |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "router_bgp.vrfs.[].neighbors.[].remove_private_as.enabled") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;all</samp>](## "router_bgp.vrfs.[].neighbors.[].remove_private_as.all") | Boolean |  |  |  |  |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -4585,7 +4585,7 @@ router_bgp:
       bfd: <bool>
       ebgp_multihop: <int>
       next_hop_self: <bool>
-      password: <str>
+      password: <password>
       default_originate:
         enabled: <bool>
         always: <bool>
@@ -4885,7 +4885,7 @@ router_bgp:
         - ip_address: <str>
           peer_group: <str>
           remote_as: <str>
-          password: <str>
+          password: <password>
           remove_private_as:
             enabled: <bool>
             all: <bool>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -6089,7 +6089,9 @@ keys:
             next_hop_self:
               type: bool
             password:
-              type: str
+              type: password
+              password_type: bgp
+              password_key_field: name
             default_originate:
               type: dict
               keys:
@@ -7172,7 +7174,9 @@ keys:
                     convert_types:
                     - int
                   password:
-                    type: str
+                    type: password
+                    password_type: bgp
+                    password_key_field: ip_address
                   remove_private_as:
                     type: dict
                     description: Remove private AS numbers in outbound AS path

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_bgp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_bgp.schema.yml
@@ -209,7 +209,9 @@ keys:
             next_hop_self:
               type: bool
             password:
-              type: str
+              type: password
+              password_type: bgp
+              password_key_field: name
             default_originate:
               type: dict
               keys:
@@ -1264,7 +1266,9 @@ keys:
                     convert_types:
                       - int
                   password:
-                    type: str
+                    type: password
+                    password_type: bgp
+                    password_key_field: ip_address
                   remove_private_as:
                     type: dict
                     description: Remove private AS numbers in outbound AS path

--- a/ansible_collections/arista/avd/tests/unit/plugins/plugin_utils/schema/conftest.py
+++ b/ansible_collections/arista/avd/tests/unit/plugins/plugin_utils/schema/conftest.py
@@ -1,0 +1,33 @@
+"""
+conftest.py file for schema testing
+"""
+
+import pytest
+
+from ansible_collections.arista.avd.plugins.plugin_utils.schema.avdschema import AvdSchema
+from ansible_collections.arista.avd.plugins.plugin_utils.schema.avdschemaresolver import AvdSchemaResolver
+from ansible_collections.arista.avd.plugins.plugin_utils.schema.avdvalidator import AvdValidator
+
+
+@pytest.fixture
+def avdvalidator_factory():
+    def factory(schema):
+        return AvdValidator(schema)
+
+    return factory
+
+
+@pytest.fixture
+def avdschema_factory():
+    def factory(schema):
+        return AvdSchema(schema)
+
+    return factory
+
+
+@pytest.fixture
+def avdschemaresolver_factory():
+    def factory(schema):
+        return AvdSchemaResolver(schema)
+
+    return factory

--- a/ansible_collections/arista/avd/tests/unit/plugins/plugin_utils/schema/test_avdvalidator.py
+++ b/ansible_collections/arista/avd/tests/unit/plugins/plugin_utils/schema/test_avdvalidator.py
@@ -18,12 +18,12 @@ PASSWORD_VALIDATOR_SCHEMA_BGP_TYPE = {
 PASSWORD_VALIDATOR_SCHEMA_BGP_TYPE_UNKNOWN_FIELD = {
     "type": "dict",
     "keys": {
-        "password": {"type": "str", "description": "BGP password", "password_type": "bgp", "password_key_field": "neighbor_ip_address"},
+        "password": {"type": "password", "description": "BGP password", "password_type": "bgp", "password_key_field": "neighbor_ip_address"},
         "neighbor_ip": {"type": "str", "description": "The neighbor IP"},
     },
 }
 
-# TODO - fow now just verify that the correct validator is unhappy - should verify on the error messahe probably
+# TODO - fow now just verify that the correct validator is unhappy - should verify on the error message probably
 PASSWORD_VALIDATOR_PARAMS = [
     pytest.param({"password": True, "neighbor_ip": "42.42.42.42"}, PASSWORD_VALIDATOR_SCHEMA_BGP_TYPE, ["type"], id="wrong_type"),
     pytest.param({"password": "3QGcqpU2YTwKh2jVQ4Vj/A==", "neighbor_ip": "42.42.42.42"}, PASSWORD_VALIDATOR_SCHEMA_BGP_TYPE, [], id="valid_password"),

--- a/ansible_collections/arista/avd/tests/unit/plugins/plugin_utils/schema/test_avdvalidator.py
+++ b/ansible_collections/arista/avd/tests/unit/plugins/plugin_utils/schema/test_avdvalidator.py
@@ -1,0 +1,47 @@
+"""
+Test file for plugins/plugin_utils/schema/avdvalidator.py
+"""
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import pytest
+
+# TODO this only covers type 7
+PASSWORD_VALIDATOR_SCHEMA_BGP_TYPE = {
+    "type": "dict",
+    "keys": {
+        "password": {"type": "password", "description": "BGP password", "password_type": "bgp", "password_key_field": "neighbor_ip"},
+        "neighbor_ip": {"type": "str", "description": "The neighbor IP"},
+    },
+}
+PASSWORD_VALIDATOR_SCHEMA_BGP_TYPE_UNKNOWN_FIELD = {
+    "type": "dict",
+    "keys": {
+        "password": {"type": "str", "description": "BGP password", "password_type": "bgp", "password_key_field": "neighbor_ip_address"},
+        "neighbor_ip": {"type": "str", "description": "The neighbor IP"},
+    },
+}
+
+# TODO - fow now just verify that the correct validator is unhappy - should verify on the error messahe probably
+PASSWORD_VALIDATOR_PARAMS = [
+    pytest.param({"password": True, "neighbor_ip": "42.42.42.42"}, PASSWORD_VALIDATOR_SCHEMA_BGP_TYPE, ["type"], id="wrong_type"),
+    pytest.param({"password": "3QGcqpU2YTwKh2jVQ4Vj/A==", "neighbor_ip": "42.42.42.42"}, PASSWORD_VALIDATOR_SCHEMA_BGP_TYPE, [], id="valid_password"),
+    pytest.param({"password": "toto", "neighbor_ip": "42.42.42.42"}, PASSWORD_VALIDATOR_SCHEMA_BGP_TYPE, ["keys"], id="invalid_password"),
+    pytest.param({"password": "toto"}, PASSWORD_VALIDATOR_SCHEMA_BGP_TYPE_UNKNOWN_FIELD, ["keys"], id="unkown_password_key_field"),
+]
+
+
+@pytest.mark.parametrize("instance, schema, expected_errors", PASSWORD_VALIDATOR_PARAMS)
+def test__password_validator(avdvalidator_factory, instance, schema, expected_errors):
+    """
+    Tests to verify the behavior of the _password_validator
+
+    For the expected validation errors, for now the test only check that the correct validator triggered the error.
+    """
+    avdvalidator = avdvalidator_factory(schema)
+    errors = list(avdvalidator.iter_errors(instance))
+    print(errors)
+    assert len(expected_errors) == len(errors)
+    for index, error in enumerate(sorted(errors, key=lambda x: x.validator)):
+        assert error.validator == expected_errors[index]


### PR DESCRIPTION
## Change Summary

Add the capability in the schema to validate BGP passwords

Requires #2385 

## Related Issue(s)

Fixes #1770

## Component(s) name

`arista.avd.eos_cli_config_gen`
`arista.avd.plugins`

## Proposed changes

* Add a password type to the metaschema
* use the type in eos_cli_config_gen for BGP password for neighbors and peer-groups

## How to test

molecule

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
