### PR TITLE
Feat(eos_cli_config_gen, eos_designs): Support Track BFD in static routes

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ipv6-static-routes.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ipv6-static-routes.md
@@ -94,6 +94,8 @@ interface Management1
 | default | 2a01:cb04:4e6:d400::/64 | 2a01:cb04:4e6:d100::1 | vlan101 | 200 | 666 | RT-TO-FAKE-DB-ZONE | 100 |
 | customer01 | 2a01:cb04:4e6:a300::/64 | 2a01:cb04:4e6:100::1 | vlan101 | 1 | - | - | - |
 | customer01 | 2a01:cb04:4e6:a400::/64 | 2a01:cb04:4e6:100::1 | vlan101 | 201 | 667 | RT-TO-FAKE-DMZ | - |
+| customer01 | 2b01:cb04:4e6:a400::/64 | 2a01:cb04:4e6:102::1 (tracked with BFD) | vlan102 | 201 | 102 | Track-BFD | 100 |
+| customer01 | 2c01:cb04:4e6:a400::/64 | - | vlan102 | 201 | 102 | No-Track-BFD | - |
 
 ### Static Routes Device Configuration
 
@@ -104,6 +106,8 @@ ipv6 route 2a01:cb04:4e6:d400::/64 Vlan101 2a01:cb04:4e6:d100::1 200 tag 666 nam
 ipv6 route 2a01:cb04:4e6:d400::/64 Vlan101 2a01:cb04:4e6:d100::1 200 tag 666 name RT-TO-FAKE-DB-ZONE metric 100
 ipv6 route vrf customer01 2a01:cb04:4e6:a300::/64 Vlan101 2a01:cb04:4e6:100::1
 ipv6 route vrf customer01 2a01:cb04:4e6:a400::/64 Vlan101 2a01:cb04:4e6:100::1 201 tag 667 name RT-TO-FAKE-DMZ
+ipv6 route vrf customer01 2b01:cb04:4e6:a400::/64 Vlan102 2a01:cb04:4e6:102::1 track bfd 201 tag 102 name Track-BFD metric 100
+ipv6 route vrf customer01 2c01:cb04:4e6:a400::/64 Vlan102 201 tag 102 name No-Track-BFD
 ```
 
 # Multicast

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/static-routes.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/static-routes.md
@@ -95,6 +95,8 @@ interface Management1
 | customer01 | 1.2.2.0/24 | 10.1.2.1 | vlan101 | 201 | 667 | RT-TO-FAKE-DMZ | - |
 | APP | 10.3.4.0/24 | 1.2.3.4 | - | 1 | - | - | - |
 | APP | 10.3.5.0/24 | - | Null0 | 1 | - | - | - |
+| customer01 | 10.3.6.0/24 | 11.2.1.1 (tracked with BFD) | Ethernet40 | 100 | 1000 | Track-BFD | 300 |
+| customer01 | 10.3.7.0/24 | - | Ethernet41 | 100 | 1000 | No-Track-BFD | 300 |
 
 ### Static Routes Device Configuration
 
@@ -106,6 +108,8 @@ ip route vrf customer01 1.2.1.0/24 Vlan202 10.1.2.1
 ip route vrf customer01 1.2.2.0/24 Vlan101 10.1.2.1 201 tag 667 name RT-TO-FAKE-DMZ
 ip route vrf APP 10.3.4.0/24 1.2.3.4
 ip route vrf APP 10.3.5.0/24 Null0
+ip route vrf customer01 10.3.6.0/24 Ethernet40 11.2.1.1 track bfd 100 tag 1000 name Track-BFD metric 300
+ip route vrf customer01 10.3.7.0/24 Ethernet41 100 tag 1000 name No-Track-BFD metric 300
 ```
 
 # Multicast

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ipv6-static-routes.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ipv6-static-routes.cfg
@@ -17,5 +17,7 @@ ipv6 route 2a01:cb04:4e6:d400::/64 Vlan101 2a01:cb04:4e6:d100::1 200 tag 666 nam
 ipv6 route 2a01:cb04:4e6:d400::/64 Vlan101 2a01:cb04:4e6:d100::1 200 tag 666 name RT-TO-FAKE-DB-ZONE metric 100
 ipv6 route vrf customer01 2a01:cb04:4e6:a300::/64 Vlan101 2a01:cb04:4e6:100::1
 ipv6 route vrf customer01 2a01:cb04:4e6:a400::/64 Vlan101 2a01:cb04:4e6:100::1 201 tag 667 name RT-TO-FAKE-DMZ
+ipv6 route vrf customer01 2b01:cb04:4e6:a400::/64 Vlan102 2a01:cb04:4e6:102::1 track bfd 201 tag 102 name Track-BFD metric 100
+ipv6 route vrf customer01 2c01:cb04:4e6:a400::/64 Vlan102 201 tag 102 name No-Track-BFD
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/static-routes.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/static-routes.cfg
@@ -18,5 +18,7 @@ ip route vrf customer01 1.2.1.0/24 Vlan202 10.1.2.1
 ip route vrf customer01 1.2.2.0/24 Vlan101 10.1.2.1 201 tag 667 name RT-TO-FAKE-DMZ
 ip route vrf APP 10.3.4.0/24 1.2.3.4
 ip route vrf APP 10.3.5.0/24 Null0
+ip route vrf customer01 10.3.6.0/24 Ethernet40 11.2.1.1 track bfd 100 tag 1000 name Track-BFD metric 300
+ip route vrf customer01 10.3.7.0/24 Ethernet41 100 tag 1000 name No-Track-BFD metric 300
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ipv6-static-routes.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ipv6-static-routes.yml
@@ -35,3 +35,22 @@ ipv6_static_routes:
     distance: 201
     tag: 667
     name: RT-TO-FAKE-DMZ
+
+  - vrf: customer01
+    destination_address_prefix: 2b01:cb04:4e6:a400::/64
+    interface: vlan102
+    gateway: 2a01:cb04:4e6:102::1
+    track_bfd: true
+    distance: 201
+    tag: 102
+    metric: 100
+    name: Track-BFD
+
+  - vrf: customer01
+    destination_address_prefix: 2c01:cb04:4e6:a400::/64
+    interface: vlan102
+    # Negative test case - Tacking should not be enabled
+    track_bfd: true
+    distance: 201
+    tag: 102
+    name: No-Track-BFD

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/static-routes.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/static-routes.yml
@@ -34,3 +34,23 @@ static_routes:
   - destination_address_prefix: 10.3.5.0/24
     vrf: APP
     interface: Null0
+
+  - vrf: customer01
+    destination_address_prefix: 10.3.6.0/24
+    interface: Ethernet40
+    gateway: 11.2.1.1
+    track_bfd: true
+    tag: 1000
+    name: Track-BFD
+    distance: 100
+    metric: 300
+
+  - vrf: customer01
+    destination_address_prefix: 10.3.7.0/24
+    interface: Ethernet41
+    # Negative test case - Tacking should not be enabled
+    track_bfd: true
+    tag: 1000
+    name: No-Track-BFD
+    distance: 100
+    metric: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2A.cfg
@@ -598,9 +598,11 @@ ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
 !
 ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 ip route vrf Tenant_D_OP_Zone 0.0.0.0/0 10.3.11.4
+ip route vrf Tenant_D_OP_Zone 1.1.1.0/24 10.3.11.4 track bfd name Track-bfd-network-services
 ip route vrf Tenant_D_OP_Zone 10.3.11.0/24 Vlan411 name VARP
 !
 ipv6 route vrf Tenant_D_OP_Zone ::/0 2001:db8:311::4 name IPv6-test-2
+ipv6 route vrf Tenant_D_OP_Zone 2001:dba::/32 2001:db8:310::1 track bfd name Track-bfd-network-services
 !
 route-map RM-CONN-2-BGP permit 10
    match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2B.cfg
@@ -562,6 +562,7 @@ ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
 !
 ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 ip route vrf Tenant_D_OP_Zone 0.0.0.0/0 10.3.11.4
+ip route vrf Tenant_D_OP_Zone 1.1.1.0/24 10.3.11.4 track bfd name Track-bfd-network-services
 ip route vrf Tenant_D_OP_Zone 10.3.11.0/24 Vlan411 name VARP
 !
 ipv6 route vrf Tenant_D_OP_Zone ::/0 2001:db8:311::4 name IPv6-test-2

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
@@ -287,6 +287,11 @@ static_routes:
 - destination_address_prefix: 0.0.0.0/0
   gateway: 10.3.11.4
   vrf: Tenant_D_OP_Zone
+- destination_address_prefix: 1.1.1.0/24
+  gateway: 10.3.11.4
+  track_bfd: true
+  name: Track-bfd-network-services
+  vrf: Tenant_D_OP_Zone
 - destination_address_prefix: 10.3.11.0/24
   vrf: Tenant_D_OP_Zone
   name: VARP
@@ -1045,6 +1050,11 @@ ipv6_static_routes:
 - destination_address_prefix: ::/0
   gateway: 2001:db8:311::4
   name: IPv6-test-2
+  vrf: Tenant_D_OP_Zone
+- destination_address_prefix: 2001:dba::/32
+  gateway: 2001:db8:310::1
+  name: Track-bfd-network-services
+  track_bfd: true
   vrf: Tenant_D_OP_Zone
 router_ospf:
   process_ids:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
@@ -287,6 +287,11 @@ static_routes:
 - destination_address_prefix: 0.0.0.0/0
   gateway: 10.3.11.4
   vrf: Tenant_D_OP_Zone
+- destination_address_prefix: 1.1.1.0/24
+  gateway: 10.3.11.4
+  track_bfd: true
+  name: Track-bfd-network-services
+  vrf: Tenant_D_OP_Zone
 - destination_address_prefix: 10.3.11.0/24
   vrf: Tenant_D_OP_Zone
   name: VARP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_D.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_D.yml
@@ -67,6 +67,11 @@ Tenant_D:
         - destination_address_prefix: 0.0.0.0/0
           gateway: "10.3.11.4"
           nodes: [ DC1-LEAF2A, DC1-LEAF2B ]
+        - destination_address_prefix: 1.1.1.0/24
+          gateway: "10.3.11.4"
+          nodes: [ DC1-LEAF2A, DC1-LEAF2B ]
+          track_bfd: true
+          name: Track-bfd-network-services
       ipv6_static_routes:
         - destination_address_prefix: ::/0
           gateway: 2001:db8:311::4
@@ -80,6 +85,11 @@ Tenant_D:
           gateway: 2001:db8:310::1
           name: IPv6-test-1
           nodes: [ DC1-LEAF1A ]
+        - destination_address_prefix: 2001:dba::/32
+          gateway: 2001:db8:310::1
+          name: Track-bfd-network-services
+          track_bfd: true
+          nodes: [ DC1-LEAF2A ]
     Tenant_D_WAN_Zone:
       ipv6_routing: false
       vrf_vni: 41

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -3634,6 +3634,7 @@ ipv6_static_routes:
     destination_address_prefix: < IPv6_network/Mask >
     interface: < interface >
     gateway: < IPv6_address >
+    track_bfd: < boolean >
     distance: < 1-255 >
     tag: < 0-4294967295 >
     name: < description >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -3617,6 +3617,7 @@ static_routes:
     destination_address_prefix: < IPv4_network/Mask >
     interface: < interface >
     gateway: < IPv4_address >
+    track_bfd: < boolean >
     distance: < 1-255 >
     tag: < 0-4294967295 >
     name: < description >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -2090,7 +2090,7 @@ ipv6_standard_access_lists:
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;destination_address_prefix</samp>](## "ipv6_static_routes.[].destination_address_prefix") | String |  |  |  | IPv6 Network/Mask |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;interface</samp>](## "ipv6_static_routes.[].interface") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;gateway</samp>](## "ipv6_static_routes.[].gateway") | String |  |  |  | IPv6 Address |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;track_bfd</samp>](## "ipv6_static_routes.[].track_bfd") | Boolean |  |  |  | Track this route using BFD |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;track_bfd</samp>](## "ipv6_static_routes.[].track_bfd") | Boolean |  |  |  | Track next-hop using BFD |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;distance</samp>](## "ipv6_static_routes.[].distance") | Integer |  |  | Min: 1<br>Max: 255 |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;tag</samp>](## "ipv6_static_routes.[].tag") | Integer |  |  | Min: 0<br>Max: 4294967295 |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "ipv6_static_routes.[].name") | String |  |  |  | Description |
@@ -5792,7 +5792,7 @@ standard_access_lists:
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;destination_address_prefix</samp>](## "static_routes.[].destination_address_prefix") | String |  |  |  | IPv4_network/Mask |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;interface</samp>](## "static_routes.[].interface") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;gateway</samp>](## "static_routes.[].gateway") | String |  |  |  | IPv4 Address |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;track_bfd</samp>](## "static_routes.[].track_bfd") | Boolean |  |  |  | Track this route using BFD |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;track_bfd</samp>](## "static_routes.[].track_bfd") | Boolean |  |  |  | Track next-hop using BFD |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;distance</samp>](## "static_routes.[].distance") | Integer |  |  | Min: 1<br>Max: 255 |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;tag</samp>](## "static_routes.[].tag") | Integer |  |  | Min: 0<br>Max: 4294967295 |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "static_routes.[].name") | String |  |  |  | Description |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -2090,6 +2090,7 @@ ipv6_standard_access_lists:
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;destination_address_prefix</samp>](## "ipv6_static_routes.[].destination_address_prefix") | String |  |  |  | IPv6 Network/Mask |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;interface</samp>](## "ipv6_static_routes.[].interface") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;gateway</samp>](## "ipv6_static_routes.[].gateway") | String |  |  |  | IPv6 Address |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;track_bfd</samp>](## "ipv6_static_routes.[].track_bfd") | Boolean |  |  |  | Track this route using BFD |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;distance</samp>](## "ipv6_static_routes.[].distance") | Integer |  |  | Min: 1<br>Max: 255 |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;tag</samp>](## "ipv6_static_routes.[].tag") | Integer |  |  | Min: 0<br>Max: 4294967295 |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "ipv6_static_routes.[].name") | String |  |  |  | Description |
@@ -2103,6 +2104,7 @@ ipv6_static_routes:
     destination_address_prefix: <str>
     interface: <str>
     gateway: <str>
+    track_bfd: <bool>
     distance: <int>
     tag: <int>
     name: <str>
@@ -5790,6 +5792,7 @@ standard_access_lists:
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;destination_address_prefix</samp>](## "static_routes.[].destination_address_prefix") | String |  |  |  | IPv4_network/Mask |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;interface</samp>](## "static_routes.[].interface") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;gateway</samp>](## "static_routes.[].gateway") | String |  |  |  | IPv4 Address |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;track_bfd</samp>](## "static_routes.[].track_bfd") | Boolean |  |  |  | Track this route using BFD |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;distance</samp>](## "static_routes.[].distance") | Integer |  |  | Min: 1<br>Max: 255 |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;tag</samp>](## "static_routes.[].tag") | Integer |  |  | Min: 0<br>Max: 4294967295 |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "static_routes.[].name") | String |  |  |  | Description |
@@ -5803,6 +5806,7 @@ static_routes:
     destination_address_prefix: <str>
     interface: <str>
     gateway: <str>
+    track_bfd: <bool>
     distance: <int>
     tag: <int>
     name: <str>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -3867,7 +3867,7 @@
           },
           "track_bfd": {
             "type": "boolean",
-            "description": "Track this route using BFD",
+            "description": "Track next-hop using BFD",
             "title": "Track BFD"
           },
           "distance": {
@@ -12902,7 +12902,7 @@
           },
           "track_bfd": {
             "type": "boolean",
-            "description": "Track this route using BFD",
+            "description": "Track next-hop using BFD",
             "title": "Track BFD"
           },
           "distance": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -3865,6 +3865,11 @@
             "description": "IPv6 Address",
             "title": "Gateway"
           },
+          "track_bfd": {
+            "type": "boolean",
+            "description": "Track this route using BFD",
+            "title": "Track BFD"
+          },
           "distance": {
             "type": "integer",
             "minimum": 1,
@@ -12894,6 +12899,11 @@
             "type": "string",
             "description": "IPv4 Address",
             "title": "Gateway"
+          },
+          "track_bfd": {
+            "type": "boolean",
+            "description": "Track this route using BFD",
+            "title": "Track BFD"
           },
           "distance": {
             "type": "integer",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -2816,6 +2816,9 @@ keys:
         gateway:
           type: str
           description: IPv6 Address
+        track_bfd:
+          type: bool
+          description: Track this route using BFD
         distance:
           type: int
           convert_types:
@@ -8734,6 +8737,9 @@ keys:
         gateway:
           type: str
           description: IPv4 Address
+        track_bfd:
+          type: bool
+          description: Track this route using BFD
         distance:
           type: int
           convert_types:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -2818,7 +2818,7 @@ keys:
           description: IPv6 Address
         track_bfd:
           type: bool
-          description: Track this route using BFD
+          description: Track next-hop using BFD
         distance:
           type: int
           convert_types:
@@ -8739,7 +8739,7 @@ keys:
           description: IPv4 Address
         track_bfd:
           type: bool
-          description: Track this route using BFD
+          description: Track next-hop using BFD
         distance:
           type: int
           convert_types:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ipv6_static_routes.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ipv6_static_routes.schema.yml
@@ -20,7 +20,7 @@ keys:
           description: IPv6 Address
         track_bfd:
           type: bool
-          description: Track this route using BFD
+          description: Track next-hop using BFD
         distance:
           type: int
           convert_types:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ipv6_static_routes.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ipv6_static_routes.schema.yml
@@ -18,6 +18,9 @@ keys:
         gateway:
           type: str
           description: IPv6 Address
+        track_bfd:
+          type: bool
+          description: Track this route using BFD
         distance:
           type: int
           convert_types:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/static_routes.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/static_routes.schema.yml
@@ -19,6 +19,9 @@ keys:
         gateway:
           type: str
           description: IPv4 Address
+        track_bfd:
+          type: bool
+          description: Track this route using BFD
         distance:
           type: int
           convert_types:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/static_routes.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/static_routes.schema.yml
@@ -21,7 +21,7 @@ keys:
           description: IPv4 Address
         track_bfd:
           type: bool
-          description: Track this route using BFD
+          description: Track next-hop using BFD
         distance:
           type: int
           convert_types:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ipv6-static-routes.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ipv6-static-routes.j2
@@ -8,7 +8,14 @@
 | --- | ------------------ | ----------------------- | ------------------- | ----------------------------- | ----------------- | ----------------------------- | -------------- |
 {%     for static_route in ipv6_static_routes %}
 {%         set vrf = static_route.vrf | arista.avd.default('default') %}
-{%         set gateway = static_route.gateway | arista.avd.default('-') %}
+{%         if static_route.gateway is arista.avd.defined %}
+{%             set gateway = static_route.gateway %}
+{%             if static_route.track_bfd is arista.avd.defined(true) %}
+{%                 set gateway = gateway ~ " (tracked with BFD)" %}
+{%             endif %}
+{%         else %}
+{%             set gateway = "-" %}
+{%         endif %}
 {%         set interface = static_route.interface | arista.avd.default('-') %}
 {%         set distance = static_route.distance | arista.avd.default('1') %}
 {%         set tag = static_route.tag | arista.avd.default('-') %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/static-routes.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/static-routes.j2
@@ -8,7 +8,14 @@
 | --- | ------------------ | ----------------------- | ------------------- | ----------------------------- | ----------------- | ----------------------------- | -------------- |
 {%     for static_route in static_routes %}
 {%         set vrf = static_route.vrf | arista.avd.default('default') %}
-{%         set gateway = static_route.gateway | arista.avd.default('-') %}
+{%         if static_route.gateway is arista.avd.defined %}
+{%             set gateway = static_route.gateway %}
+{%             if static_route.track_bfd is arista.avd.defined(true) %}
+{%                 set gateway = gateway ~ " (tracked with BFD)" %}
+{%             endif %}
+{%         else %}
+{%             set gateway = "-" %}
+{%         endif %}
 {%         set interface = static_route.interface | arista.avd.default('-') %}
 {%         set distance = static_route.distance | arista.avd.default('1') %}
 {%         set tag = static_route.tag | arista.avd.default('-') %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ipv6-static-routes.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ipv6-static-routes.j2
@@ -16,6 +16,9 @@
 {%         endif %}
 {%         if ipv6_static_route.gateway is arista.avd.defined %}
 {%             set ipv6_static_route_cli = ipv6_static_route_cli ~ " " ~ ipv6_static_route.gateway %}
+{%             if ipv6_static_route.track_bfd is arista.avd.defined(true) %}
+{%                 set ipv6_static_route_cli = ipv6_static_route_cli ~ " track bfd" %}
+{%             endif %}
 {%         endif %}
 {%         if ipv6_static_route.distance is arista.avd.defined %}
 {%             set ipv6_static_route_cli = ipv6_static_route_cli ~ " " ~ ipv6_static_route.distance %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/static-routes.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/static-routes.j2
@@ -14,6 +14,9 @@
 {%         endif %}
 {%         if static_route.gateway is arista.avd.defined %}
 {%             set static_route_cli = static_route_cli ~ " " ~ static_route.gateway %}
+{%             if static_route.track_bfd is arista.avd.defined(true) %}
+{%                 set static_route_cli = static_route_cli ~ " track bfd" %}
+{%             endif %}
 {%         endif %}
 {%         if static_route.distance is arista.avd.defined %}
 {%             set static_route_cli = static_route_cli ~ " " ~ static_route.distance %}

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
@@ -430,6 +430,7 @@ mac_address_table:
         static_routes:
           - destination_address_prefix: < IPv4_address/Mask >
             gateway: < IPv4_address >
+            track_bfd: < boolean >
             distance: < 1-255 >
             tag: < 0-4294967295 >
             name: < description >
@@ -440,6 +441,7 @@ mac_address_table:
         ipv6_static_routes:
           - destination_address_prefix: < IPv6_address/Mask >
             gateway: < IPv6_address >
+            track_bfd: < boolean >
             distance: < 1-255 >
             tag: < 0-4294967295 >
             name: < description >


### PR DESCRIPTION
## Change Summary

Support Track BFD in static routes.

## Component(s) name

`arista.avd.eos_cli_config_gen`, `arista.avd.eos_designs`

## Proposed changes

```
static_routes:
  - track_bfd: < boolean >
ipv6_static_routes:
  - track_bfd: < boolean >
```
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

## How to test

molecule converge -s eos_cli_config_gen -- --limit static-routes

molecule converge -s eos_cli_config_gen -- --limit ipv6-static-routes

molecule converge -s eos_designs_unit_tests

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
