### PR TITLE
Fix(eos_validate_state): Handle missing  interfaces, MLAG and BGP peers

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/bgp_check.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/bgp_check.yml
@@ -38,8 +38,8 @@
   delegate_to: localhost
   assert:
     that:
-      - bgp_summary.stdout[0].vrfs.default.peers[bgp_neighbor.ip_address].peerState == 'Established'
-    fail_msg: "Session state {{ bgp_summary.stdout[0].vrfs.default.peers[bgp_neighbor.ip_address].peerState | replace('\"','') }}"
+      - bgp_summary.stdout[0].vrfs.default.peers[bgp_neighbor.ip_address].peerState | arista.avd.default('Not configured') == 'Established'
+    fail_msg: "Session state {{ bgp_summary.stdout[0].vrfs.default.peers[bgp_neighbor.ip_address].peerState | arista.avd.default('Not configured') | replace('\"','') }}"
     quiet: yes
   loop: "{{ router_bgp.neighbors | arista.avd.default({}) | arista.avd.convert_dicts('ip_address') }}"
   loop_control:
@@ -55,8 +55,8 @@
   delegate_to: localhost
   assert:
     that:
-      - bgp_summary.stdout[1].vrfs.default.peers[bgp_neighbor.ip_address].peerState == 'Established'
-    fail_msg: "Session state {{ bgp_summary.stdout[1].vrfs.default.peers[bgp_neighbor.ip_address].peerState | replace('\"','') }}"
+      - bgp_summary.stdout[1].vrfs.default.peers[bgp_neighbor.ip_address].peerState | arista.avd.default('Not configured') == 'Established'
+    fail_msg: "Session state: {{ bgp_summary.stdout[1].vrfs.default.peers[bgp_neighbor.ip_address].peerState | arista.avd.default('Not configured') | replace('\"','') }}"
     quiet: yes
   loop: "{{ router_bgp.neighbors | arista.avd.default({}) | arista.avd.convert_dicts('ip_address') }}"
   loop_control:

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/interface_state.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/interface_state.yml
@@ -14,17 +14,17 @@
   delegate_to: localhost
   assert:
     that:
-      ( interfaces_state.stdout[0].interfaceDescriptions[ethernet_interface.name].interfaceStatus == 'up' and
-      interfaces_state.stdout[0].interfaceDescriptions[ethernet_interface.name].lineProtocolStatus == 'up' and
+      ( interfaces_state.stdout[0].interfaceDescriptions[ethernet_interface.name].interfaceStatus | arista.avd.default('Not present') == 'up' and
+      interfaces_state.stdout[0].interfaceDescriptions[ethernet_interface.name].lineProtocolStatus | arista.avd.default('Not present') == 'up' and
       not ethernet_interface.shutdown
       ) or
-      ( interfaces_state.stdout[0].interfaceDescriptions[ethernet_interface.name].interfaceStatus == 'adminDown' and
-      interfaces_state.stdout[0].interfaceDescriptions[ethernet_interface.name].lineProtocolStatus != 'up' and
+      ( interfaces_state.stdout[0].interfaceDescriptions[ethernet_interface.name].interfaceStatus | arista.avd.default('Not present') == 'adminDown' and
+      interfaces_state.stdout[0].interfaceDescriptions[ethernet_interface.name].lineProtocolStatus | arista.avd.default('Not present') != 'up' and
       ethernet_interface.shutdown
       )
     fail_msg: "Interface shutdown: {{ ethernet_interface.shutdown | replace('\"','') }} -
-      interface status: {{ interfaces_state.stdout[0].interfaceDescriptions[ethernet_interface.name].interfaceStatus | replace('\"','') }} -
-      line protocol status: {{ interfaces_state.stdout[0].interfaceDescriptions[ethernet_interface.name].lineProtocolStatus | replace('\"','') }}"
+      interface status: {{ interfaces_state.stdout[0].interfaceDescriptions[ethernet_interface.name].interfaceStatus | arista.avd.default('Not present') | replace('\"','') }} -
+      line protocol status: {{ interfaces_state.stdout[0].interfaceDescriptions[ethernet_interface.name].lineProtocolStatus | arista.avd.default('Not present') | replace('\"','') }}"
     quiet: true
   loop: "{{ ethernet_interfaces | arista.avd.default({}) | arista.avd.convert_dicts('name') }}"
   loop_control:
@@ -38,17 +38,17 @@
   delegate_to: localhost
   assert:
     that:
-      ( interfaces_state.stdout[0].interfaceDescriptions[port_channel_interface.name].interfaceStatus == 'up' and
-      interfaces_state.stdout[0].interfaceDescriptions[port_channel_interface.name].lineProtocolStatus == 'up' and
+      ( interfaces_state.stdout[0].interfaceDescriptions[port_channel_interface.name].interfaceStatus | arista.avd.default('Not configured') == 'up' and
+      interfaces_state.stdout[0].interfaceDescriptions[port_channel_interface.name].lineProtocolStatus | arista.avd.default('Not configured') == 'up' and
       not port_channel_interface.shutdown
       ) or
-      ( interfaces_state.stdout[0].interfaceDescriptions[port_channel_interface.name].interfaceStatus == 'adminDown' and
-      interfaces_state.stdout[0].interfaceDescriptions[port_channel_interface.name].lineProtocolStatus != 'up' and
+      ( interfaces_state.stdout[0].interfaceDescriptions[port_channel_interface.name].interfaceStatus | arista.avd.default('Not configured') == 'adminDown' and
+      interfaces_state.stdout[0].interfaceDescriptions[port_channel_interface.name].lineProtocolStatus | arista.avd.default('Not configured') != 'up' and
       port_channel_interface.shutdown
       )
     fail_msg: "Interface shutdown: {{ port_channel_interface.shutdown | replace('\"','') }} -
-      interface status: {{ interfaces_state.stdout[0].interfaceDescriptions[port_channel_interface.name].interfaceStatus | replace('\"','') }} -
-      line protocol status: {{ interfaces_state.stdout[0].interfaceDescriptions[port_channel_interface.name].lineProtocolStatus | replace('\"','') }}"
+      interface status: {{ interfaces_state.stdout[0].interfaceDescriptions[port_channel_interface.name].interfaceStatus | arista.avd.default('Not configured') | replace('\"','') }} -
+      line protocol status: {{ interfaces_state.stdout[0].interfaceDescriptions[port_channel_interface.name].lineProtocolStatus | arista.avd.default('Not configured') | replace('\"','') }}"
     quiet: true
   loop: "{{ port_channel_interfaces | arista.avd.default({}) | arista.avd.convert_dicts('name') }}"
   loop_control:
@@ -62,17 +62,17 @@
   delegate_to: localhost
   assert:
     that:
-      ( interfaces_state.stdout[0].interfaceDescriptions[vlan_interface.name].interfaceStatus == 'up' and
-      interfaces_state.stdout[0].interfaceDescriptions[vlan_interface.name].lineProtocolStatus == 'up' and
+      ( interfaces_state.stdout[0].interfaceDescriptions[vlan_interface.name].interfaceStatus | arista.avd.default('Not configured') == 'up' and
+      interfaces_state.stdout[0].interfaceDescriptions[vlan_interface.name].lineProtocolStatus | arista.avd.default('Not configured') == 'up' and
       not vlan_interface.shutdown
       ) or
-      ( interfaces_state.stdout[0].interfaceDescriptions[vlan_interface.name].interfaceStatus == 'adminDown' and
-      interfaces_state.stdout[0].interfaceDescriptions[vlan_interface.name].lineProtocolStatus != 'up' and
+      ( interfaces_state.stdout[0].interfaceDescriptions[vlan_interface.name].interfaceStatus | arista.avd.default('Not configured') == 'adminDown' and
+      interfaces_state.stdout[0].interfaceDescriptions[vlan_interface.name].lineProtocolStatus | arista.avd.default('Not configured') != 'up' and
       vlan_interface.shutdown
       )
     fail_msg: "Interface shutdown: {{ vlan_interface.shutdown | replace('\"','') }} -
-      interface status: {{ interfaces_state.stdout[0].interfaceDescriptions[vlan_interface.name].interfaceStatus | replace('\"','') }} -
-      line protocol status: {{ interfaces_state.stdout[0].interfaceDescriptions[vlan_interface.name].lineProtocolStatus | replace('\"','') }}"
+      interface status: {{ interfaces_state.stdout[0].interfaceDescriptions[vlan_interface.name].interfaceStatus | arista.avd.default('Not configured') | replace('\"','') }} -
+      line protocol status: {{ interfaces_state.stdout[0].interfaceDescriptions[vlan_interface.name].lineProtocolStatus | arista.avd.default('Not configured') | replace('\"','') }}"
     quiet: true
   loop: "{{ vlan_interfaces| arista.avd.default({}) | arista.avd.convert_dicts('name') }}"
   loop_control:
@@ -86,10 +86,10 @@
   delegate_to: localhost
   assert:
     that:
-      - interfaces_state.stdout[0].interfaceDescriptions.Vxlan1.interfaceStatus == 'up'
-      - interfaces_state.stdout[0].interfaceDescriptions.Vxlan1.lineProtocolStatus == 'up'
-    fail_msg: "Interface status: {{ interfaces_state.stdout[0].interfaceDescriptions.Vxlan1.interfaceStatus | replace('\"','') }} -
-      line protocol status: {{ interfaces_state.stdout[0].interfaceDescriptions.Vxlan1.lineProtocolStatus | replace('\"','') }}"
+      - interfaces_state.stdout[0].interfaceDescriptions.Vxlan1.interfaceStatus | arista.avd.default('Not configured') == 'up'
+      - interfaces_state.stdout[0].interfaceDescriptions.Vxlan1.lineProtocolStatus | arista.avd.default('Not configured') == 'up'
+    fail_msg: "Interface status: {{ interfaces_state.stdout[0].interfaceDescriptions.Vxlan1.interfaceStatus | arista.avd.default('Not configured') | replace('\"','') }} -
+      line protocol status: {{ interfaces_state.stdout[0].interfaceDescriptions.Vxlan1.lineProtocolStatus | arista.avd.default('Not configured') | replace('\"','') }}"
     quiet: true
   ignore_errors: "{{ eos_validate_state_validation_mode_loose }}"
   when: (vxlan_interface.Vxlan1 is arista.avd.defined)
@@ -101,10 +101,10 @@
   delegate_to: localhost
   assert:
     that:
-      - interfaces_state.stdout[0].interfaceDescriptions[loopback_interface.name].interfaceStatus == 'up'
-      - interfaces_state.stdout[0].interfaceDescriptions[loopback_interface.name].lineProtocolStatus == 'up'
-    fail_msg: "Interface status: {{ interfaces_state.stdout[0].interfaceDescriptions[loopback_interface.name].interfaceStatus | replace('\"','') }} -
-      line protocol status: {{ interfaces_state.stdout[0].interfaceDescriptions[loopback_interface.name].lineProtocolStatus | replace('\"','') }}"
+      - interfaces_state.stdout[0].interfaceDescriptions[loopback_interface.name].interfaceStatus | arista.avd.default('Not configured') == 'up'
+      - interfaces_state.stdout[0].interfaceDescriptions[loopback_interface.name].lineProtocolStatus | arista.avd.default('Not configured') == 'up'
+    fail_msg: "Interface status: {{ interfaces_state.stdout[0].interfaceDescriptions[loopback_interface.name].interfaceStatus | arista.avd.default('Not configured') | replace('\"','') }} -
+      line protocol status: {{ interfaces_state.stdout[0].interfaceDescriptions[loopback_interface.name].lineProtocolStatus | arista.avd.default('Not configured') | replace('\"','') }}"
     quiet: true
   loop: "{{ loopback_interfaces | arista.avd.default({}) | arista.avd.convert_dicts('name') }}"
   loop_control:

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/mlag.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/mlag.yml
@@ -13,9 +13,9 @@
   delegate_to: localhost
   assert:
     that:
-      - mlag_state.stdout[0].state == 'active'
-      - mlag_state.stdout[0].negStatus == 'connected'
-    fail_msg: "State: {{ mlag_state.stdout[0].state| replace('\"','')  }} - negotiation_status: {{ mlag_state.stdout[0].negStatus| replace('\"','')  }}"
+      - mlag_state.stdout[0].state | arista.avd.default('Not configured') == 'active'
+      - mlag_state.stdout[0].negStatus | arista.avd.default('Not configured') == 'connected'
+    fail_msg: "State: {{ mlag_state.stdout[0].state | arista.avd.default('Not configured') | replace('\"','')  }} - Negotiation_status: {{ mlag_state.stdout[0].negStatus | arista.avd.default('Not configured') | replace('\"','')  }}"
     quiet: true
   ignore_errors: "{{ eos_validate_state_validation_mode_loose }}"
   register: mlag_state_results


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Handle missing  interfaces, MLAG and BGP peers

## Related Issue(s)

Fixes #2259

## Component(s) name

`arista.avd.eos_validate_state`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

Added default values for state information collected from devices. Previously we were blindly expecting every interface to be configured and showing up in the outputs. This resulted in "undefined" errors in Ansible, and those errors showed up directly in the report.

With this change we will show `Not configured` for logical entities like loopbacks, vxlan, mlag, bgp peers and `Not present` for physical ethernet interfaces.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Tested with avd-quickstart-containerlab by deploying the clab but _not_ pushing any config. Then running the validate_state.

Before the change we had a lot of Ansible undefined errors in the report. After the change the report is not clearly stating `Not configured`/`Not present` as applicable.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
