### PR TITLE
Feat(eos_designs): Add schema validation to eos_designs action plugins

### DIFF
--- a/ansible_collections/arista/avd/plugins/action/eos_designs_facts.py
+++ b/ansible_collections/arista/avd/plugins/action/eos_designs_facts.py
@@ -96,7 +96,7 @@ class ActionModule(ActionBase):
 
         return result
 
-    def get_all_hostvars(self, fabric_hosts, hostvars: object, default_vars: dict):
+    def get_all_hostvars(self, fabric_hosts: list, hostvars: object, default_vars: dict):
         """
         Fetch hostvars for all hosts and perform data conversion & validation
 

--- a/ansible_collections/arista/avd/plugins/action/eos_designs_facts.py
+++ b/ansible_collections/arista/avd/plugins/action/eos_designs_facts.py
@@ -116,7 +116,7 @@ class ActionModule(ActionBase):
             hostname2 : dict | None
             ...
         bool
-            Did validation fail for one or more of the hosts
+            True if validation failed for one or more of the hosts
         """
         # Load schema tools once with empty host.
         avdschematools = AvdSchemaTools(self._schema, "", display, self._conversion_mode, self._validation_mode)
@@ -128,6 +128,7 @@ class ActionModule(ActionBase):
             all_hostvars[host] = ChainMap({}, hostvars.get(host), default_vars)
 
             # Set correct hostname and perform conversion and validation
+            avdschematools.hostname = host
             result = avdschematools.convert_and_validate_data(all_hostvars[host])
             failed = failed or result.get("failed", False)
 

--- a/ansible_collections/arista/avd/plugins/action/eos_designs_facts.py
+++ b/ansible_collections/arista/avd/plugins/action/eos_designs_facts.py
@@ -7,10 +7,11 @@ import pstats
 from collections import ChainMap
 
 from ansible.errors import AnsibleActionFail
-from ansible.plugins.action import ActionBase
+from ansible.plugins.action import ActionBase, display
 
 from ansible_collections.arista.avd.plugins.plugin_utils.eos_designs_facts import EosDesignsFacts
 from ansible_collections.arista.avd.plugins.plugin_utils.errors import AristaAvdMissingVariableError
+from ansible_collections.arista.avd.plugins.plugin_utils.schema.avdschematools import AvdSchemaTools
 from ansible_collections.arista.avd.plugins.plugin_utils.utils import get_templar
 
 
@@ -27,8 +28,13 @@ class ActionModule(ActionBase):
             profiler = cProfile.Profile()
             profiler.enable()
 
-        set_avd_switch_facts = self._task.args.get("avd_switch_facts", False)
+        self._schema = self._task.args.get("schema")
+        if not isinstance(self._schema, dict):
+            raise AnsibleActionFail("The argument 'schema' must be set as a dict")
+
         self.template_output = self._task.args.get("template_output", False)
+        self._conversion_mode = self._task.args.get("conversion_mode")
+        self._validation_mode = self._task.args.get("validation_mode")
 
         groups = task_vars.get("groups", {})
         fabric_name = self._templar.template(task_vars.get("fabric_name", ""))
@@ -49,35 +55,39 @@ class ActionModule(ActionBase):
         # Caveat: Since we load default vars only once, it will be templated based on the vars of the random host triggering this task
         #         This should not be too bad, since all hosts are within the same fabric - hence they should also use the same "design"
         default_vars = self._templar.template(self._task._role.get_default_vars())
+        all_hostvars, failed = self.get_all_hostvars(fabric_hosts, hostvars, default_vars)
+        if failed:
+            # Stop here if any of the devices failed input data validation
+            result["failed"] = True
+            return result
 
         # Get updated templar instance to be passed along to our simplified "templater"
         self.templar = get_templar(self, task_vars)
 
-        if set_avd_switch_facts:
-            avd_overlay_peers = {}
-            avd_topology_peers = {}
-            avd_switch_facts_instances = self.create_avd_switch_facts_instances(fabric_hosts, hostvars, default_vars)
+        avd_overlay_peers = {}
+        avd_topology_peers = {}
+        avd_switch_facts_instances = self.create_avd_switch_facts_instances(fabric_hosts, all_hostvars)
+        avd_switch_facts = self.render_avd_switch_facts(avd_switch_facts_instances)
 
-            avd_switch_facts = self.render_avd_switch_facts(avd_switch_facts_instances)
+        for host in fabric_hosts:
+            host_evpn_route_servers = avd_switch_facts[host]["switch"].get("evpn_route_servers", [])
+            for peer in host_evpn_route_servers:
+                avd_overlay_peers.setdefault(peer, []).append(host)
 
-            for host in fabric_hosts:
-                host_evpn_route_servers = avd_switch_facts[host]["switch"].get("evpn_route_servers", [])
-                for peer in host_evpn_route_servers:
-                    avd_overlay_peers.setdefault(peer, []).append(host)
+            host_mpls_route_reflectors = avd_switch_facts[host]["switch"].get("mpls_route_reflectors", [])
+            for peer in host_mpls_route_reflectors:
+                avd_overlay_peers.setdefault(peer, []).append(host)
 
-                host_mpls_route_reflectors = avd_switch_facts[host]["switch"].get("mpls_route_reflectors", [])
-                for peer in host_mpls_route_reflectors:
-                    avd_overlay_peers.setdefault(peer, []).append(host)
+            host_topology_peers = avd_switch_facts[host]["switch"].get("uplink_peers", [])
 
-                host_topology_peers = avd_switch_facts[host]["switch"].get("uplink_peers", [])
+            for peer in host_topology_peers:
+                avd_topology_peers.setdefault(peer, []).append(host)
 
-                for peer in host_topology_peers:
-                    avd_topology_peers.setdefault(peer, []).append(host)
-
-            result["ansible_facts"] = {}
-            result["ansible_facts"]["avd_switch_facts"] = avd_switch_facts
-            result["ansible_facts"]["avd_overlay_peers"] = avd_overlay_peers
-            result["ansible_facts"]["avd_topology_peers"] = avd_topology_peers
+        result["ansible_facts"] = {
+            "avd_switch_facts": avd_switch_facts,
+            "avd_overlay_peers": avd_overlay_peers,
+            "avd_topology_peers": avd_topology_peers,
+        }
 
         if cprofile_file:
             profiler.disable()
@@ -86,9 +96,9 @@ class ActionModule(ActionBase):
 
         return result
 
-    def create_avd_switch_facts_instances(self, fabric_hosts: list, hostvars: object, default_vars: dict):
+    def get_all_hostvars(self, fabric_hosts, hostvars: object, default_vars: dict):
         """
-        Create "avd_switch_facts_instances" dictionary
+        Fetch hostvars for all hosts and perform data conversion & validation
 
         Parameters
         ----------
@@ -96,6 +106,44 @@ class ActionModule(ActionBase):
             List of hostnames
         hostvars : object
             Ansible "hostvars" object
+        default_vars : dict
+            Default variables shared between all fabric_hosts
+
+        Returns
+        -------
+        dict
+            hostname1 : dict | None
+            hostname2 : dict | None
+            ...
+        bool
+            Did validation fail for one or more of the hosts
+        """
+        # Load schema tools once with empty host.
+        avdschematools = AvdSchemaTools(self._schema, "", display, self._conversion_mode, self._validation_mode)
+
+        all_hostvars = {}
+        failed = False
+        for host in fabric_hosts:
+            # Using ChainMap to avoid copying data between defaults, hostvars and local template_vars
+            all_hostvars[host] = ChainMap({}, hostvars.get(host), default_vars)
+
+            # Set correct hostname and perform conversion and validation
+            result = avdschematools.convert_and_validate_data(all_hostvars[host])
+            failed = failed or result.get("failed", False)
+
+        return all_hostvars, failed
+
+    def create_avd_switch_facts_instances(self, fabric_hosts: list, all_hostvars: dict):
+        """
+        Create "avd_switch_facts_instances" dictionary
+
+        Parameters
+        ----------
+        fabric_hosts : list
+            List of hostnames
+        all_hostvars : dict
+            hostname1 : dict
+            hostname2 : dict
         default_vars : dict
             Default variables shared between all fabric_hosts
 
@@ -110,8 +158,7 @@ class ActionModule(ActionBase):
         """
         avd_switch_facts = {}
         for host in fabric_hosts:
-            # Using ChainMap to avoid copying data between defaults, hostvars and local template_vars
-            host_hostvars = ChainMap({}, hostvars.get(host), default_vars)
+            host_hostvars = all_hostvars[host]
             avd_switch_facts[host] = {}
             # Add reference to dict "avd_switch_facts".
             # This is used to access EosDesignsFacts objects of other switches during rendering of one switch.

--- a/ansible_collections/arista/avd/plugins/action/yaml_templates_to_facts.py
+++ b/ansible_collections/arista/avd/plugins/action/yaml_templates_to_facts.py
@@ -10,12 +10,13 @@ from datetime import datetime
 import yaml
 from ansible.errors import AnsibleActionFail
 from ansible.parsing.yaml.dumper import AnsibleDumper
-from ansible.plugins.action import ActionBase
+from ansible.plugins.action import ActionBase, display
 from ansible.utils.vars import isidentifier
 
 from ansible_collections.arista.avd.plugins.plugin_utils.avdfacts import AvdFacts
 from ansible_collections.arista.avd.plugins.plugin_utils.errors import AristaAvdMissingVariableError
 from ansible_collections.arista.avd.plugins.plugin_utils.merge import merge
+from ansible_collections.arista.avd.plugins.plugin_utils.schema.avdschematools import AvdSchemaTools
 from ansible_collections.arista.avd.plugins.plugin_utils.strip_empties import strip_null_from_data
 from ansible_collections.arista.avd.plugins.plugin_utils.utils import get_templar, load_python_class
 from ansible_collections.arista.avd.plugins.plugin_utils.utils import template as templater
@@ -44,27 +45,28 @@ class ActionModule(ActionBase):
                 n = self._templar.template(n)
                 if not isidentifier(n):
                     raise AnsibleActionFail(
-                        f"The argument 'root_key' value of '{n}' is not valid. Keys must start with a letter or underscore character,                          "
-                        "                   and contain only letters, numbers and underscores."
+                        f"The argument 'root_key' value of '{n}' is not valid. Keys must start with a letter or underscore character, "
+                        "and contain only letters, numbers and underscores."
                     )
                 root_key = n
 
-            if "templates" in self._task.args:
-                t = self._task.args.get("templates")
-                if isinstance(t, list):
-                    template_list = t
-                else:
-                    raise AnsibleActionFail("The argument 'templates' is not a list")
-            else:
-                raise AnsibleActionFail("The argument 'templates' must be set")
+            template_list = self._task.args.get("templates")
+            if not isinstance(template_list, list):
+                raise AnsibleActionFail("The argument 'templates' must be set as a list")
 
-            dest = self._task.args.get("dest", False)
+            schema = self._task.args.get("schema")
+            if not isinstance(schema, dict):
+                raise AnsibleActionFail("The argument 'schema' must be set as a dict")
+
+            self.dest = self._task.args.get("dest", False)
             template_output = self._task.args.get("template_output", False)
             debug = self._task.args.get("debug", False)
             remove_avd_switch_facts = self._task.args.get("remove_avd_switch_facts", False)
+            conversion_mode = self._task.args.get("conversion_mode")
+            validation_mode = self._task.args.get("validation_mode")
 
         else:
-            raise AnsibleActionFail("The argument 'templates' must be set")
+            raise AnsibleActionFail("Required arguments 'templates' and 'schema' are not set on yaml_templates_to_facts")
 
         # Read ansible variables and perform templating to support inline jinja
         for var in task_vars:
@@ -76,6 +78,14 @@ class ActionModule(ActionBase):
                     task_vars[var] = self._templar.template(task_vars[var], fail_on_undefined=False)
                 except Exception as e:
                     raise AnsibleActionFail(f"Exception during templating of task_var '{var}'") from e
+
+        # Load schema tools and perform conversion and validation
+        hostname = task_vars["inventory_hostname"]
+        avdschematools = AvdSchemaTools(schema, hostname, display, conversion_mode, validation_mode)
+        result.update(avdschematools.convert_and_validate_data(task_vars))
+        if result.get("failed"):
+            # Input data validation failed so return errors.
+            return result
 
         # Get updated templar instance to be passed along to our simplified "templater"
         self.templar = get_templar(self, task_vars)
@@ -179,13 +189,13 @@ class ActionModule(ActionBase):
                 avd_yaml_templates_to_facts_debug.append(debug_item)
 
         # If the argument 'dest' is set, write the output data to a file.
-        if dest:
+        if self.dest:
             if debug:
-                debug_item = {"action": "dest", "dest": dest, "timestamps": {"write_file": datetime.now()}}
+                debug_item = {"action": "dest", "dest": self.dest, "timestamps": {"write_file": datetime.now()}}
 
             # Depending on the file suffix of 'dest' (default: 'json') we will format the data to yaml or just write the output data directly.
             # The Copy module used in 'write_file' will convert the output data to json automatically.
-            if dest.split(".")[-1] in ["yml", "yaml"]:
+            if self.dest.split(".")[-1] in ["yml", "yaml"]:
                 write_file_result = self.write_file(yaml.dump(output, Dumper=AnsibleDumper, indent=2, sort_keys=False, width=130), task_vars)
             else:
                 write_file_result = self.write_file(output, task_vars)
@@ -221,15 +231,16 @@ class ActionModule(ActionBase):
         return result
 
     def write_file(self, content, task_vars):
-        # The write_file function is implementing the Ansible 'copy' action_module, to benefit from Ansible builtin functionality like 'changed'.
-        # Reuse task data
+        """
+        This function implements the Ansible 'copy' action_module, to benefit from Ansible builtin functionality like 'changed'.
+        Reuse task data
+        """
         new_task = self._task.copy()
-
-        # remove 'yaml_templates_to_facts' options (except 'dest' which will be reused):
-        for remove in ("root_key", "templates", "template_output", "debug", "remove_avd_switch_facts"):
-            new_task.args.pop(remove, None)
-
-        new_task.args["content"] = content
+        new_task.args = {
+            "dest": self.dest,
+            "mode": self._task.args.get("mode"),
+            "content": content,
+        }
 
         copy_action = self._shared_loader_obj.action_loader.get(
             "ansible.legacy.copy",

--- a/ansible_collections/arista/avd/plugins/modules/eos_designs_facts.py
+++ b/ansible_collections/arista/avd/plugins/modules/eos_designs_facts.py
@@ -47,7 +47,7 @@ options:
       - Run data conversion in either "warning", "info", "debug", "quiet" or "disabled" mode.
       - Conversion will perform type conversion of input variables as defined in the schema.
       - Conversion is intended to help the user to identify minor issues with the input data, while still allowing the data to be validated.
-      - During conversion, messages will generated with information about the host(s) and key(s) which required conversion.
+      - During conversion, messages will be generated with information about the host(s) and key(s) which required conversion.
       - conversion_mode:disabled means that conversion will not run.
       - conversion_mode:warning will produce warning messages.
       - conversion_mode:info will produce regular log messages.
@@ -61,7 +61,7 @@ options:
     description:
       - Run validation in either "error", "warning", "info", "debug" or "disabled" mode.
       - Validation will validate the input variables according to the schema.
-      - During validation, messages will generated with information about the host(s) and key(s) which failed validation.
+      - During validation, messages will be generated with information about the host(s) and key(s) which failed validation.
       - validation_mode:disabled means that validation will not run.
       - validation_mode:error will produce error messages and fail the task.
       - validation_mode:warning will produce warning messages.

--- a/ansible_collections/arista/avd/plugins/modules/eos_designs_facts.py
+++ b/ansible_collections/arista/avd/plugins/modules/eos_designs_facts.py
@@ -30,13 +30,47 @@ description:
     so all devices can lookup values of any other device without using the slower `hostvars`.
   - The facts can also be copied to the "root" `switch` in a task run per-device (see example below)
   - The module is used in `arista.avd.eos_designs` to set facts for devices, which are then used by jinja templates
-    in `arista.avd.eos_designs` to generate the `structured_configuration`.
+    and python module in `arista.avd.eos_designs` to generate the `structured_configuration`.
 options:
-  avd_switch_facts:
+  schema:
+    description: Schema conforming to "AVD Meta Schema"
+    required: true
+    type: dict
+  template_output:
     description: |
-      - Calculate and set 'avd_switch_facts.<devices>.switch', 'avd_overlay_peers' and 'avd_topology_peers' facts
-    required: False
+      If true the output data will be run through another jinja2 rendering before returning.
+      This is to resolve any input values with inline jinja using variables/facts set by the input templates.
+    required: false
     type: bool
+  conversion_mode:
+    description:
+      - Run data conversion in either "warning", "info", "debug", "quiet" or "disabled" mode.
+      - Conversion will perform type conversion of input variables as defined in the schema.
+      - Conversion is intended to help the user to identify minor issues with the input data, while still allowing the data to be validated.
+      - During conversion, messages will generated with information about the host(s) and key(s) which required conversion.
+      - conversion_mode:disabled means that conversion will not run.
+      - conversion_mode:warning will produce warning messages.
+      - conversion_mode:info will produce regular log messages.
+      - conversion_mode:debug will produce hidden messages viewable with -v.
+      - conversion_mode:quiet will not produce any messages.
+    required: false
+    default: "debug"
+    type: str
+    choices: [ "warning", "info", "debug", "quiet", "disabled" ]
+  validation_mode:
+    description:
+      - Run validation in either "error", "warning", "info", "debug" or "disabled" mode.
+      - Validation will validate the input variables according to the schema.
+      - During validation, messages will generated with information about the host(s) and key(s) which failed validation.
+      - validation_mode:disabled means that validation will not run.
+      - validation_mode:error will produce error messages and fail the task.
+      - validation_mode:warning will produce warning messages.
+      - validation_mode:info will produce regular log messages.
+      - validation_mode:debug will produce hidden messages viewable with -v.
+    required: false
+    default: "warning"
+    type: str
+    choices: [ "error", "warning", "info", "debug", "disabled" ]
 """
 
 EXAMPLES = r"""
@@ -46,4 +80,11 @@ EXAMPLES = r"""
     avd_switch_facts: True
   check_mode: False
   run_once: True
+
+- name: Set eos_designs facts per device
+  tags: [build, provision, facts]
+  ansible.builtin.set_fact:
+    switch: "{{ avd_switch_facts[inventory_hostname].switch }}"
+  delegate_to: localhost
+  changed_when: false
 """

--- a/ansible_collections/arista/avd/plugins/modules/validate_and_template.py
+++ b/ansible_collections/arista/avd/plugins/modules/validate_and_template.py
@@ -53,7 +53,7 @@ options:
     required: false
   conversion_mode:
     description:
-      - Run data conversion in either "warning", "info", "debug" or "disabled" mode.
+      - Run data conversion in either "warning", "info", "debug", "quiet" or "disabled" mode.
       - Conversion will perform type conversion of input variables as defined in the schema.
       - Conversion is intended to help the user to identify minor issues with the input data, while still allowing the data to be validated.
       - During conversion, messages will generated with information about the host(s) and key(s) which required conversion.
@@ -61,10 +61,11 @@ options:
       - conversion_mode:warning will produce warning messages.
       - conversion_mode:info will produce regular log messages.
       - conversion_mode:debug will produce hidden messages viewable with -v.
+      - conversion_mode:quiet will not produce any messages.
     required: false
     default: "debug"
     type: str
-    choices: [ "warning", "info", "debug", "disabled" ]
+    choices: [ "warning", "info", "debug", "quiet", "disabled" ]
   validation_mode:
     description:
       - Run validation in either "error", "warning", "info", "debug" or "disabled" mode.

--- a/ansible_collections/arista/avd/plugins/modules/yaml_templates_to_facts.py
+++ b/ansible_collections/arista/avd/plugins/modules/yaml_templates_to_facts.py
@@ -82,7 +82,7 @@ options:
     required: false
     type: str
   mode:
-    description: File mode for dest file.
+    description: File mode (ex. 0664) for dest file. See 'ansible.builtin.copy' module for details.
     required: false
     type: str
   template_output:
@@ -96,7 +96,7 @@ options:
       - Run data conversion in either "warning", "info", "debug", "quiet" or "disabled" mode.
       - Conversion will perform type conversion of input variables as defined in the schema.
       - Conversion is intended to help the user to identify minor issues with the input data, while still allowing the data to be validated.
-      - During conversion, messages will generated with information about the host(s) and key(s) which required conversion.
+      - During conversion, messages will be generated with information about the host(s) and key(s) which required conversion.
       - conversion_mode:disabled means that conversion will not run.
       - conversion_mode:warning will produce warning messages.
       - conversion_mode:info will produce regular log messages.
@@ -110,7 +110,7 @@ options:
     description:
       - Run validation in either "error", "warning", "info", "debug" or "disabled" mode.
       - Validation will validate the input variables according to the schema.
-      - During validation, messages will generated with information about the host(s) and key(s) which failed validation.
+      - During validation, messages will be generated with information about the host(s) and key(s) which failed validation.
       - validation_mode:disabled means that validation will not run.
       - validation_mode:error will produce error messages and fail the task.
       - validation_mode:warning will produce warning messages.

--- a/ansible_collections/arista/avd/plugins/modules/yaml_templates_to_facts.py
+++ b/ansible_collections/arista/avd/plugins/modules/yaml_templates_to_facts.py
@@ -28,7 +28,7 @@ options:
     type: str
   schema:
     description: Schema conforming to "AVD Meta Schema"
-    required: true
+    required: false
     type: dict
   templates:
     description: List of dicts for Jinja templates to be run.

--- a/ansible_collections/arista/avd/plugins/modules/yaml_templates_to_facts.py
+++ b/ansible_collections/arista/avd/plugins/modules/yaml_templates_to_facts.py
@@ -26,6 +26,10 @@ options:
     description: Root key under which the facts will be defined. If not set the facts well be set directly on root level.
     required: false
     type: str
+  schema:
+    description: Schema conforming to "AVD Meta Schema"
+    required: true
+    type: dict
   templates:
     description: List of dicts for Jinja templates to be run.
     required: true
@@ -77,12 +81,45 @@ options:
       Autodetects data format based on file suffix. '.yml', '.yaml' -> YAML, default -> JSON
     required: false
     type: str
+  mode:
+    description: File mode for dest file.
+    required: false
+    type: str
   template_output:
     description: |
       If true the output data will be run through another jinja2 rendering before returning.
       This is to resolve any input values with inline jinja using variables/facts set by the input templates.
     required: false
     type: bool
+  conversion_mode:
+    description:
+      - Run data conversion in either "warning", "info", "debug", "quiet" or "disabled" mode.
+      - Conversion will perform type conversion of input variables as defined in the schema.
+      - Conversion is intended to help the user to identify minor issues with the input data, while still allowing the data to be validated.
+      - During conversion, messages will generated with information about the host(s) and key(s) which required conversion.
+      - conversion_mode:disabled means that conversion will not run.
+      - conversion_mode:warning will produce warning messages.
+      - conversion_mode:info will produce regular log messages.
+      - conversion_mode:debug will produce hidden messages viewable with -v.
+      - conversion_mode:quiet will not produce any messages.
+    required: false
+    default: "debug"
+    type: str
+    choices: [ "warning", "info", "debug", "quiet", "disabled" ]
+  validation_mode:
+    description:
+      - Run validation in either "error", "warning", "info", "debug" or "disabled" mode.
+      - Validation will validate the input variables according to the schema.
+      - During validation, messages will generated with information about the host(s) and key(s) which failed validation.
+      - validation_mode:disabled means that validation will not run.
+      - validation_mode:error will produce error messages and fail the task.
+      - validation_mode:warning will produce warning messages.
+      - validation_mode:info will produce regular log messages.
+      - validation_mode:debug will produce hidden messages viewable with -v.
+    required: false
+    default: "warning"
+    type: str
+    choices: [ "error", "warning", "info", "debug", "disabled" ]
 """
 
 EXAMPLES = r"""

--- a/ansible_collections/arista/avd/plugins/plugin_utils/schema/avdschematools.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/schema/avdschematools.py
@@ -74,6 +74,8 @@ class AvdSchemaTools:
         exceptions = self.avdschema.convert(data)
         if conversion_counter := self.handle_validation_exceptions(exceptions, self.conversion_mode):
             result_messages.append(f"{conversion_counter} data conversions done to conform to schema.")
+            if self.conversion_mode == "debug":
+                result_messages.append("Run with -v to see details")
 
         return result_messages
 
@@ -90,6 +92,8 @@ class AvdSchemaTools:
         exceptions = self.avdschema.validate(data)
         if validation_counter := self.handle_validation_exceptions(exceptions, self.validation_mode):
             result_messages.append(f"{validation_counter} errors found during schema validation of input vars.")
+            if self.validation_mode == "debug":
+                result_messages.append("Run with -v to see details")
 
         return result_messages
 

--- a/ansible_collections/arista/avd/roles/eos_designs/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/tasks/main.yml
@@ -29,6 +29,9 @@
     avd_switch_facts: true
     #cprofile_file: "eos_designs_facts.prof"
     template_output: true
+    schema: "{{ lookup('ansible.builtin.file', role_schema_path) | from_yaml }}"
+    conversion_mode: "{{ avd_data_conversion_mode }}"
+    validation_mode: "{{ avd_data_validation_mode }}"
   check_mode: false
   run_once: true
 
@@ -55,6 +58,9 @@
     dest: "{{ structured_dir }}/{{ inventory_hostname }}.{{ avd_structured_config_file_format }}"
     #cprofile_file: "structured-{{inventory_hostname}}.prof"
     template_output: true
+    schema: "{{ lookup('ansible.builtin.file', role_schema_path) | from_yaml }}"
+    conversion_mode: "{{ avd_data_conversion_mode }}"
+    validation_mode: "{{ avd_data_validation_mode }}"
   delegate_to: localhost
   check_mode: false
   register: structured_config


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Add schema validation to eos_designs action plugins

## Component(s) name

`arista.avd.eos_designs_facts`
`arista.avd.yaml_templates_to_facts`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

- Add input variable conversion and validation using common libs to EOS Designs action plugins.
- Update documentation

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Since we don't have any schemas yet, I tested locally with some draft schemas.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
