### PR TITLE
Feat(eos_cli_config_gen): Support access-lists & options on rp addresses

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-pim-sparse-mode.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-pim-sparse-mode.md
@@ -116,7 +116,7 @@ BFD enabled: True
 | VRF Name | Rendezvous Point Address | Group Address | Access Lists | Priority | Hashmask | Override |
 | -------- | ------------------------ | ------------- | ------------ | -------- | -------- | -------- |
 | MCAST_VRF1 | 10.238.2.161 | 239.12.22.12/32, 239.12.22.13/32, 239.12.22.14/32 | - | - | - | - |
-| MCAST_VRF2_ALL_GROUPS | 10.238.3.161 | - | - | - | - | - |
+| MCAST_VRF2_ALL_GROUPS | 10.238.3.161 | - | - | - | 30 | - |
 | Test_RP_ACL | 10.238.4.161 | - | RP_ACL | - | - | - |
 | Test_RP_ACL | 10.238.4.161 | - | RP_ACL2 | 20 | 30 | True |
 
@@ -147,7 +147,7 @@ router pim sparse-mode
    !
    vrf MCAST_VRF2_ALL_GROUPS
       ipv4
-         rp address 10.238.3.161
+         rp address 10.238.3.161 hashmask 30
    !
    vrf Test_RP_ACL
       ipv4

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-pim-sparse-mode.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-pim-sparse-mode.md
@@ -95,9 +95,9 @@ BFD enabled: True
 
 ##### IP Rendezvous Information
 
-| Rendezvous Point Address | Group Address |
-| ------------------------ | ------------- |
-| 10.238.1.161 | 239.12.12.12/32, 239.12.12.13/32, 239.12.12.14/32, 239.12.12.16/32, 239.12.12.20/32, 239.12.12.21/32 |
+| Rendezvous Point Address | Group Address | Access Lists | Priority | Hashmask | Override |
+| ------------------------ | ------------- | ------------ | -------- | -------- | -------- |
+| 10.238.1.161 | 239.12.12.12/32, 239.12.12.13/32, 239.12.12.14/32, 239.12.12.16/32, 239.12.12.20/32, 239.12.12.21/32 | RP_ACL, RP_ACL2 | 20 | - | - |
 
 ##### IP Anycast Information
 
@@ -111,11 +111,14 @@ BFD enabled: True
 | -------- | ----------- |
 | MCAST_VRF1 | True |
 | MCAST_VRF2_ALL_GROUPS | False |
+| Test_RP_ACL | False |
 
-| VRF Name | Rendezvous Point Address | Group Address |
-| -------- | ------------------------ | ------------- |
-| MCAST_VRF1 | 10.238.2.161 | 239.12.22.12/32, 239.12.22.13/32, 239.12.22.14/32 |
-| MCAST_VRF2_ALL_GROUPS | 10.238.3.161 | - |
+| VRF Name | Rendezvous Point Address | Group Address | Access Lists | Priority | Hashmask | Override |
+| -------- | ------------------------ | ------------- | ------------ | -------- | -------- | -------- |
+| MCAST_VRF1 | 10.238.2.161 | 239.12.22.12/32, 239.12.22.13/32, 239.12.22.14/32 | - | - | - | - |
+| MCAST_VRF2_ALL_GROUPS | 10.238.3.161 | - | - | - | - | - |
+| Test_RP_ACL | 10.238.4.161 | - | RP_ACL | - | - | - |
+| Test_RP_ACL | 10.238.4.161 | - | RP_ACL2 | 20 | 30 | True |
 
 #### Router Multicast Device Configuration
 
@@ -124,12 +127,14 @@ BFD enabled: True
 router pim sparse-mode
    ipv4
       bfd
-      rp address 10.238.1.161 239.12.12.12/32
-      rp address 10.238.1.161 239.12.12.13/32
-      rp address 10.238.1.161 239.12.12.14/32
-      rp address 10.238.1.161 239.12.12.16/32
-      rp address 10.238.1.161 239.12.12.20/32
-      rp address 10.238.1.161 239.12.12.21/32
+         rp address 10.238.1.161 239.12.12.12/32 priority 20
+         rp address 10.238.1.161 239.12.12.13/32 priority 20
+         rp address 10.238.1.161 239.12.12.14/32 priority 20
+         rp address 10.238.1.161 239.12.12.16/32 priority 20
+         rp address 10.238.1.161 239.12.12.20/32 priority 20
+         rp address 10.238.1.161 239.12.12.21/32 priority 20
+         rp address 10.238.1.161 access-list RP_ACL priority 20
+         rp address 10.238.1.161 access-list RP_ACL2 priority 20
       anycast-rp 10.38.1.161 10.50.64.16 register-count 15
       ssm range standard
    !
@@ -143,6 +148,11 @@ router pim sparse-mode
    vrf MCAST_VRF2_ALL_GROUPS
       ipv4
          rp address 10.238.3.161
+   !
+   vrf Test_RP_ACL
+      ipv4
+         rp address 10.238.4.161 access-list RP_ACL
+         rp address 10.238.4.161 access-list RP_ACL2 priority 20 hashmask 30 override
 ```
 
 # Filters

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-pim-sparse-mode.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-pim-sparse-mode.md
@@ -127,14 +127,14 @@ BFD enabled: True
 router pim sparse-mode
    ipv4
       bfd
-         rp address 10.238.1.161 239.12.12.12/32 priority 20
-         rp address 10.238.1.161 239.12.12.13/32 priority 20
-         rp address 10.238.1.161 239.12.12.14/32 priority 20
-         rp address 10.238.1.161 239.12.12.16/32 priority 20
-         rp address 10.238.1.161 239.12.12.20/32 priority 20
-         rp address 10.238.1.161 239.12.12.21/32 priority 20
-         rp address 10.238.1.161 access-list RP_ACL priority 20
-         rp address 10.238.1.161 access-list RP_ACL2 priority 20
+      rp address 10.238.1.161 239.12.12.12/32 priority 20
+      rp address 10.238.1.161 239.12.12.13/32 priority 20
+      rp address 10.238.1.161 239.12.12.14/32 priority 20
+      rp address 10.238.1.161 239.12.12.16/32 priority 20
+      rp address 10.238.1.161 239.12.12.20/32 priority 20
+      rp address 10.238.1.161 239.12.12.21/32 priority 20
+      rp address 10.238.1.161 access-list RP_ACL priority 20
+      rp address 10.238.1.161 access-list RP_ACL2 priority 20
       anycast-rp 10.38.1.161 10.50.64.16 register-count 15
       ssm range standard
    !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-pim-sparse-mode.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-pim-sparse-mode.cfg
@@ -15,14 +15,14 @@ interface Management1
 router pim sparse-mode
    ipv4
       bfd
-         rp address 10.238.1.161 239.12.12.12/32 priority 20
-         rp address 10.238.1.161 239.12.12.13/32 priority 20
-         rp address 10.238.1.161 239.12.12.14/32 priority 20
-         rp address 10.238.1.161 239.12.12.16/32 priority 20
-         rp address 10.238.1.161 239.12.12.20/32 priority 20
-         rp address 10.238.1.161 239.12.12.21/32 priority 20
-         rp address 10.238.1.161 access-list RP_ACL priority 20
-         rp address 10.238.1.161 access-list RP_ACL2 priority 20
+      rp address 10.238.1.161 239.12.12.12/32 priority 20
+      rp address 10.238.1.161 239.12.12.13/32 priority 20
+      rp address 10.238.1.161 239.12.12.14/32 priority 20
+      rp address 10.238.1.161 239.12.12.16/32 priority 20
+      rp address 10.238.1.161 239.12.12.20/32 priority 20
+      rp address 10.238.1.161 239.12.12.21/32 priority 20
+      rp address 10.238.1.161 access-list RP_ACL priority 20
+      rp address 10.238.1.161 access-list RP_ACL2 priority 20
       anycast-rp 10.38.1.161 10.50.64.16 register-count 15
       ssm range standard
    !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-pim-sparse-mode.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-pim-sparse-mode.cfg
@@ -34,5 +34,10 @@ router pim sparse-mode
    vrf MCAST_VRF2_ALL_GROUPS
       ipv4
          rp address 10.238.3.161
+   !
+   vrf Test_RP_ACL
+      ipv4
+         rp address 10.238.4.161 access-list RP_ACL priority 20 hashmask 30 override
+         rp address 10.238.4.161 access-list RP_ACL2
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-pim-sparse-mode.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-pim-sparse-mode.cfg
@@ -15,12 +15,14 @@ interface Management1
 router pim sparse-mode
    ipv4
       bfd
-      rp address 10.238.1.161 239.12.12.12/32
-      rp address 10.238.1.161 239.12.12.13/32
-      rp address 10.238.1.161 239.12.12.14/32
-      rp address 10.238.1.161 239.12.12.16/32
-      rp address 10.238.1.161 239.12.12.20/32
-      rp address 10.238.1.161 239.12.12.21/32
+         rp address 10.238.1.161 239.12.12.12/32 priority 20
+         rp address 10.238.1.161 239.12.12.13/32 priority 20
+         rp address 10.238.1.161 239.12.12.14/32 priority 20
+         rp address 10.238.1.161 239.12.12.16/32 priority 20
+         rp address 10.238.1.161 239.12.12.20/32 priority 20
+         rp address 10.238.1.161 239.12.12.21/32 priority 20
+         rp address 10.238.1.161 access-list RP_ACL priority 20
+         rp address 10.238.1.161 access-list RP_ACL2 priority 20
       anycast-rp 10.38.1.161 10.50.64.16 register-count 15
       ssm range standard
    !
@@ -37,7 +39,7 @@ router pim sparse-mode
    !
    vrf Test_RP_ACL
       ipv4
-         rp address 10.238.4.161 access-list RP_ACL priority 20 hashmask 30 override
-         rp address 10.238.4.161 access-list RP_ACL2
+         rp address 10.238.4.161 access-list RP_ACL
+         rp address 10.238.4.161 access-list RP_ACL2 priority 20 hashmask 30 override
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-pim-sparse-mode.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-pim-sparse-mode.cfg
@@ -35,7 +35,7 @@ router pim sparse-mode
    !
    vrf MCAST_VRF2_ALL_GROUPS
       ipv4
-         rp address 10.238.3.161
+         rp address 10.238.3.161 hashmask 30
    !
    vrf Test_RP_ACL
       ipv4

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-pim-sparse-mode.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-pim-sparse-mode.yml
@@ -36,6 +36,7 @@ router_pim_sparse_mode:
       ipv4:
         rp_addresses:
           - address: 10.238.3.161
+            hashmask: 30
     - name: Test_RP_ACL
       ipv4:
         rp_addresses:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-pim-sparse-mode.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-pim-sparse-mode.yml
@@ -12,6 +12,10 @@ router_pim_sparse_mode:
           239.12.12.16/32:
           239.12.12.20/32:
           239.12.12.21/32:
+        access_lists:
+          - RP_ACL
+          - RP_ACL2
+        priority: 20
     anycast_rps:
       10.38.1.161:
         other_anycast_rp_addresses:
@@ -37,8 +41,10 @@ router_pim_sparse_mode:
         rp_addresses:
           - address: 10.238.4.161
             access_lists:
-              - access_list: RP_ACL
-                priority: 20
-                hashmask: 30
-                override: True
-              - access_list: RP_ACL2
+              - RP_ACL
+          - address: 10.238.4.161
+            access_lists:
+              - RP_ACL2
+            priority: 20
+            hashmask: 30
+            override: True

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-pim-sparse-mode.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-pim-sparse-mode.yml
@@ -32,3 +32,13 @@ router_pim_sparse_mode:
       ipv4:
         rp_addresses:
           - address: 10.238.3.161
+    - name: Test_RP_ACL
+      ipv4:
+        rp_addresses:
+          - address: 10.238.4.161
+            access_lists:
+              - access_list: RP_ACL
+                priority: 20
+                hashmask: 30
+                override: True
+              - access_list: RP_ACL2

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/router-pim-sparse-mode.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/router-pim-sparse-mode.md
@@ -95,9 +95,9 @@ BFD enabled: False
 
 ##### IP Rendezvous Information
 
-| Rendezvous Point Address | Group Address |
-| ------------------------ | ------------- |
-| 10.238.1.161 | 239.12.12.12/32, 239.12.12.13/32, 239.12.12.14/32, 239.12.12.16/32, 239.12.12.20/32, 239.12.12.21/32 |
+| Rendezvous Point Address | Group Address | Access Lists | Priority | Hashmask | Override |
+| ------------------------ | ------------- | ------------ | -------- | -------- | -------- |
+| 10.238.1.161 | 239.12.12.12/32, 239.12.12.13/32, 239.12.12.14/32, 239.12.12.16/32, 239.12.12.20/32, 239.12.12.21/32 | - | - | - | - |
 
 ##### IP Anycast Information
 
@@ -112,10 +112,10 @@ BFD enabled: False
 | MCAST_VRF1 | False |
 | MCAST_VRF2_ALL_GROUPS | False |
 
-| VRF Name | Rendezvous Point Address | Group Address |
-| -------- | ------------------------ | ------------- |
-| MCAST_VRF1 | 10.238.2.161 | 239.12.22.12/32, 239.12.22.13/32, 239.12.22.14/32 |
-| MCAST_VRF2_ALL_GROUPS | 10.238.3.161 | - |
+| VRF Name | Rendezvous Point Address | Group Address | Access Lists | Priority | Hashmask | Override |
+| -------- | ------------------------ | ------------- | ------------ | -------- | -------- | -------- |
+| MCAST_VRF1 | 10.238.2.161 | 239.12.22.12/32, 239.12.22.13/32, 239.12.22.14/32 | - | - | - | - |
+| MCAST_VRF2_ALL_GROUPS | 10.238.3.161 | - | - | - | - | - |
 
 #### Router Multicast Device Configuration
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -2196,8 +2196,8 @@ router_pim_sparse_mode:
               - < group_prefix_2/mask >
             access_lists:
               - access_list: < access_list_name >
-                priority: < int >
-                hashmask: < int >
+                priority: < 0-255 >
+                hashmask: < 0-32 >
                 override: < bool >
 ```
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -2179,6 +2179,11 @@ router_pim_sparse_mode:
         groups:
           < group_prefix_1/mask >:
           < group_prefix_2/mask >:
+        access_lists:
+          - < access_list_name >
+        priority: < 0-255 >
+        hashmask: < 0-32 >
+        override: < true | false >
       < rp_address_2 >:
     anycast_rps:
       < anycast_rp_address_1 >:
@@ -2195,10 +2200,10 @@ router_pim_sparse_mode:
               - < group_prefix_1/mask >
               - < group_prefix_2/mask >
             access_lists:
-              - access_list: < access_list_name >
-                priority: < 0-255 >
-                hashmask: < 0-32 >
-                override: < bool >
+              - < access_list_name >
+            priority: < 0-255 >
+            hashmask: < 0-32 >
+            override: < true | false >
 ```
 
 ### Monitoring

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -2194,6 +2194,11 @@ router_pim_sparse_mode:
             groups:
               - < group_prefix_1/mask >
               - < group_prefix_2/mask >
+            access_lists:
+              - access_list: < access_list_name >
+                priority: < int >
+                hashmask: < int >
+                override: < bool >
 ```
 
 ### Monitoring

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -5470,11 +5470,6 @@ router_ospf:
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- address</samp>](## "router_pim_sparse_mode.ipv4.rp_addresses.[].address") | String | Required, Unique |  |  | RP Address |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;groups</samp>](## "router_pim_sparse_mode.ipv4.rp_addresses.[].groups") | List, items: String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "router_pim_sparse_mode.ipv4.rp_addresses.[].groups.[].&lt;str&gt;") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;access_lists</samp>](## "router_pim_sparse_mode.ipv4.rp_addresses.[].access_lists") | List, items: Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- access_list</samp>](## "router_pim_sparse_mode.ipv4.rp_addresses.[].access_lists.[].access_list") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;priority</samp>](## "router_pim_sparse_mode.ipv4.rp_addresses.[].access_lists.[].priority") | Integer |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hashmask</samp>](## "router_pim_sparse_mode.ipv4.rp_addresses.[].access_lists.[].hashmask") | Integer |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;override</samp>](## "router_pim_sparse_mode.ipv4.rp_addresses.[].access_lists.[].override") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;anycast_rps</samp>](## "router_pim_sparse_mode.ipv4.anycast_rps") | List, items: Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- address</samp>](## "router_pim_sparse_mode.ipv4.anycast_rps.[].address") | String | Required, Unique |  |  | Anycast RP Address |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;other_anycast_rp_addresses</samp>](## "router_pim_sparse_mode.ipv4.anycast_rps.[].other_anycast_rp_addresses") | List, items: Dictionary |  |  |  |  |
@@ -5488,6 +5483,11 @@ router_ospf:
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- address</samp>](## "router_pim_sparse_mode.vrfs.[].ipv4.rp_addresses.[].address") | String |  |  |  | RP Address |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;groups</samp>](## "router_pim_sparse_mode.vrfs.[].ipv4.rp_addresses.[].groups") | List, items: String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "router_pim_sparse_mode.vrfs.[].ipv4.rp_addresses.[].groups.[].&lt;str&gt;") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;access_lists</samp>](## "router_pim_sparse_mode.vrfs.[].ipv4.rp_addresses.[].access_lists") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- access_list</samp>](## "router_pim_sparse_mode.vrfs.[].ipv4.rp_addresses.[].access_lists.[].access_list") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;priority</samp>](## "router_pim_sparse_mode.vrfs.[].ipv4.rp_addresses.[].access_lists.[].priority") | Integer |  |  | Min: 0<br>Max: 255 |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hashmask</samp>](## "router_pim_sparse_mode.vrfs.[].ipv4.rp_addresses.[].access_lists.[].hashmask") | Integer |  |  | Min: 0<br>Max: 32 |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;override</samp>](## "router_pim_sparse_mode.vrfs.[].ipv4.rp_addresses.[].access_lists.[].override") | Boolean |  |  |  |  |
 
 ### YAML
 
@@ -5500,11 +5500,6 @@ router_pim_sparse_mode:
       - address: <str>
         groups:
           - <str>
-        access_lists:
-          - access_list: <str>
-            priority: <int>
-            hashmask: <int>
-            override: <bool>
     anycast_rps:
       - address: <str>
         other_anycast_rp_addresses:
@@ -5518,6 +5513,11 @@ router_pim_sparse_mode:
           - address: <str>
             groups:
               - <str>
+            access_lists:
+              - access_list: <str>
+                priority: <int>
+                hashmask: <int>
+                override: <bool>
 ```
 
 ## Router Traffic Engineering

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -5470,6 +5470,11 @@ router_ospf:
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- address</samp>](## "router_pim_sparse_mode.ipv4.rp_addresses.[].address") | String | Required, Unique |  |  | RP Address |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;groups</samp>](## "router_pim_sparse_mode.ipv4.rp_addresses.[].groups") | List, items: String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "router_pim_sparse_mode.ipv4.rp_addresses.[].groups.[].&lt;str&gt;") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;access_lists</samp>](## "router_pim_sparse_mode.ipv4.rp_addresses.[].access_lists") | List, items: Dictionary |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- access_list</samp>](## "router_pim_sparse_mode.ipv4.rp_addresses.[].access_lists.[].access_list") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;priority</samp>](## "router_pim_sparse_mode.ipv4.rp_addresses.[].access_lists.[].priority") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hashmask</samp>](## "router_pim_sparse_mode.ipv4.rp_addresses.[].access_lists.[].hashmask") | Integer |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;override</samp>](## "router_pim_sparse_mode.ipv4.rp_addresses.[].access_lists.[].override") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;anycast_rps</samp>](## "router_pim_sparse_mode.ipv4.anycast_rps") | List, items: Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- address</samp>](## "router_pim_sparse_mode.ipv4.anycast_rps.[].address") | String | Required, Unique |  |  | Anycast RP Address |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;other_anycast_rp_addresses</samp>](## "router_pim_sparse_mode.ipv4.anycast_rps.[].other_anycast_rp_addresses") | List, items: Dictionary |  |  |  |  |
@@ -5495,6 +5500,11 @@ router_pim_sparse_mode:
       - address: <str>
         groups:
           - <str>
+        access_lists:
+          - access_list: <str>
+            priority: <int>
+            hashmask: <int>
+            override: <bool>
     anycast_rps:
       - address: <str>
         other_anycast_rp_addresses:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -5470,6 +5470,11 @@ router_ospf:
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- address</samp>](## "router_pim_sparse_mode.ipv4.rp_addresses.[].address") | String | Required, Unique |  |  | RP Address |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;groups</samp>](## "router_pim_sparse_mode.ipv4.rp_addresses.[].groups") | List, items: String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "router_pim_sparse_mode.ipv4.rp_addresses.[].groups.[].&lt;str&gt;") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;access_lists</samp>](## "router_pim_sparse_mode.ipv4.rp_addresses.[].access_lists") | List, items: String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "router_pim_sparse_mode.ipv4.rp_addresses.[].access_lists.[].&lt;str&gt;") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;priority</samp>](## "router_pim_sparse_mode.ipv4.rp_addresses.[].priority") | Integer |  |  | Min: 0<br>Max: 255 |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hashmask</samp>](## "router_pim_sparse_mode.ipv4.rp_addresses.[].hashmask") | Integer |  |  | Min: 0<br>Max: 32 |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;override</samp>](## "router_pim_sparse_mode.ipv4.rp_addresses.[].override") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;anycast_rps</samp>](## "router_pim_sparse_mode.ipv4.anycast_rps") | List, items: Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- address</samp>](## "router_pim_sparse_mode.ipv4.anycast_rps.[].address") | String | Required, Unique |  |  | Anycast RP Address |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;other_anycast_rp_addresses</samp>](## "router_pim_sparse_mode.ipv4.anycast_rps.[].other_anycast_rp_addresses") | List, items: Dictionary |  |  |  |  |
@@ -5480,14 +5485,14 @@ router_ospf:
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4</samp>](## "router_pim_sparse_mode.vrfs.[].ipv4") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bfd</samp>](## "router_pim_sparse_mode.vrfs.[].ipv4.bfd") | Boolean |  |  |  | Enable/Disable BFD |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rp_addresses</samp>](## "router_pim_sparse_mode.vrfs.[].ipv4.rp_addresses") | List, items: Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- address</samp>](## "router_pim_sparse_mode.vrfs.[].ipv4.rp_addresses.[].address") | String |  |  |  | RP Address |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- address</samp>](## "router_pim_sparse_mode.vrfs.[].ipv4.rp_addresses.[].address") | String | Required |  |  | RP Address |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;groups</samp>](## "router_pim_sparse_mode.vrfs.[].ipv4.rp_addresses.[].groups") | List, items: String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "router_pim_sparse_mode.vrfs.[].ipv4.rp_addresses.[].groups.[].&lt;str&gt;") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;access_lists</samp>](## "router_pim_sparse_mode.vrfs.[].ipv4.rp_addresses.[].access_lists") | List, items: Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- access_list</samp>](## "router_pim_sparse_mode.vrfs.[].ipv4.rp_addresses.[].access_lists.[].access_list") | String |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;priority</samp>](## "router_pim_sparse_mode.vrfs.[].ipv4.rp_addresses.[].access_lists.[].priority") | Integer |  |  | Min: 0<br>Max: 255 |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hashmask</samp>](## "router_pim_sparse_mode.vrfs.[].ipv4.rp_addresses.[].access_lists.[].hashmask") | Integer |  |  | Min: 0<br>Max: 32 |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;override</samp>](## "router_pim_sparse_mode.vrfs.[].ipv4.rp_addresses.[].access_lists.[].override") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;access_lists</samp>](## "router_pim_sparse_mode.vrfs.[].ipv4.rp_addresses.[].access_lists") | List, items: String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "router_pim_sparse_mode.vrfs.[].ipv4.rp_addresses.[].access_lists.[].&lt;str&gt;") | String |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;priority</samp>](## "router_pim_sparse_mode.vrfs.[].ipv4.rp_addresses.[].priority") | Integer |  |  | Min: 0<br>Max: 255 |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hashmask</samp>](## "router_pim_sparse_mode.vrfs.[].ipv4.rp_addresses.[].hashmask") | Integer |  |  | Min: 0<br>Max: 32 |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;override</samp>](## "router_pim_sparse_mode.vrfs.[].ipv4.rp_addresses.[].override") | Boolean |  |  |  |  |
 
 ### YAML
 
@@ -5500,6 +5505,11 @@ router_pim_sparse_mode:
       - address: <str>
         groups:
           - <str>
+        access_lists:
+          - <str>
+        priority: <int>
+        hashmask: <int>
+        override: <bool>
     anycast_rps:
       - address: <str>
         other_anycast_rp_addresses:
@@ -5514,10 +5524,10 @@ router_pim_sparse_mode:
             groups:
               - <str>
             access_lists:
-              - access_list: <str>
-                priority: <int>
-                hashmask: <int>
-                override: <bool>
+              - <str>
+            priority: <int>
+            hashmask: <int>
+            override: <bool>
 ```
 
 ## Router Traffic Engineering

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -12203,6 +12203,29 @@
                       "type": "string"
                     },
                     "title": "Groups"
+                  },
+                  "access_lists": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Access Lists"
+                  },
+                  "priority": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 255,
+                    "title": "Priority"
+                  },
+                  "hashmask": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 32,
+                    "title": "Hashmask"
+                  },
+                  "override": {
+                    "type": "boolean",
+                    "title": "Override"
                   }
                 },
                 "required": [
@@ -12294,34 +12317,30 @@
                         "access_lists": {
                           "type": "array",
                           "items": {
-                            "type": "object",
-                            "properties": {
-                              "access_list": {
-                                "type": "string",
-                                "title": "Access List"
-                              },
-                              "priority": {
-                                "type": "integer",
-                                "minimum": 0,
-                                "maximum": 255,
-                                "title": "Priority"
-                              },
-                              "hashmask": {
-                                "type": "integer",
-                                "minimum": 0,
-                                "maximum": 32,
-                                "title": "Hashmask"
-                              },
-                              "override": {
-                                "type": "boolean",
-                                "title": "Override"
-                              }
-                            },
-                            "additionalProperties": false
+                            "type": "string"
                           },
                           "title": "Access Lists"
+                        },
+                        "priority": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "maximum": 255,
+                          "title": "Priority"
+                        },
+                        "hashmask": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "maximum": 32,
+                          "title": "Hashmask"
+                        },
+                        "override": {
+                          "type": "boolean",
+                          "title": "Override"
                         }
                       },
+                      "required": [
+                        "address"
+                      ],
                       "additionalProperties": false
                     },
                     "title": "RP Addresses"

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -12203,32 +12203,6 @@
                       "type": "string"
                     },
                     "title": "Groups"
-                  },
-                  "access_lists": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "access_list": {
-                          "type": "string",
-                          "title": "Access List"
-                        },
-                        "priority": {
-                          "type": "integer",
-                          "title": "Priority"
-                        },
-                        "hashmask": {
-                          "type": "integer",
-                          "title": "Hashmask"
-                        },
-                        "override": {
-                          "type": "boolean",
-                          "title": "Override"
-                        }
-                      },
-                      "additionalProperties": false
-                    },
-                    "title": "Access Lists"
                   }
                 },
                 "required": [
@@ -12316,6 +12290,36 @@
                             "type": "string"
                           },
                           "title": "Groups"
+                        },
+                        "access_lists": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "access_list": {
+                                "type": "string",
+                                "title": "Access List"
+                              },
+                              "priority": {
+                                "type": "integer",
+                                "minimum": 0,
+                                "maximum": 255,
+                                "title": "Priority"
+                              },
+                              "hashmask": {
+                                "type": "integer",
+                                "minimum": 0,
+                                "maximum": 32,
+                                "title": "Hashmask"
+                              },
+                              "override": {
+                                "type": "boolean",
+                                "title": "Override"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "title": "Access Lists"
                         }
                       },
                       "additionalProperties": false

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -12203,6 +12203,32 @@
                       "type": "string"
                     },
                     "title": "Groups"
+                  },
+                  "access_lists": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "access_list": {
+                          "type": "string",
+                          "title": "Access List"
+                        },
+                        "priority": {
+                          "type": "integer",
+                          "title": "Priority"
+                        },
+                        "hashmask": {
+                          "type": "integer",
+                          "title": "Hashmask"
+                        },
+                        "override": {
+                          "type": "boolean",
+                          "title": "Override"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "title": "Access Lists"
                   }
                 },
                 "required": [

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -8282,6 +8282,20 @@ keys:
                   - dict
                   items:
                     type: str
+                access_lists:
+                  type: list
+                  items:
+                    type: str
+                priority:
+                  type: int
+                  min: 0
+                  max: 255
+                hashmask:
+                  type: int
+                  min: 0
+                  max: 32
+                override:
+                  type: bool
           anycast_rps:
             type: list
             primary_key: address
@@ -8332,6 +8346,7 @@ keys:
                       address:
                         type: str
                         description: RP Address
+                        required: true
                       groups:
                         type: list
                         items:
@@ -8339,20 +8354,17 @@ keys:
                       access_lists:
                         type: list
                         items:
-                          type: dict
-                          keys:
-                            access_list:
-                              type: str
-                            priority:
-                              type: int
-                              min: 0
-                              max: 255
-                            hashmask:
-                              type: int
-                              min: 0
-                              max: 32
-                            override:
-                              type: bool
+                          type: str
+                      priority:
+                        type: int
+                        min: 0
+                        max: 255
+                      hashmask:
+                        type: int
+                        min: 0
+                        max: 32
+                      override:
+                        type: bool
   router_traffic_engineering:
     type: dict
     keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -8282,6 +8282,19 @@ keys:
                   - dict
                   items:
                     type: str
+                access_lists:
+                  type: list
+                  items:
+                    type: dict
+                    keys:
+                      access_list:
+                        type: str
+                      priority:
+                        type: int
+                      hashmask:
+                        type: int
+                      override:
+                        type: bool
           anycast_rps:
             type: list
             primary_key: address

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -8282,19 +8282,6 @@ keys:
                   - dict
                   items:
                     type: str
-                access_lists:
-                  type: list
-                  items:
-                    type: dict
-                    keys:
-                      access_list:
-                        type: str
-                      priority:
-                        type: int
-                      hashmask:
-                        type: int
-                      override:
-                        type: bool
           anycast_rps:
             type: list
             primary_key: address
@@ -8349,6 +8336,23 @@ keys:
                         type: list
                         items:
                           type: str
+                      access_lists:
+                        type: list
+                        items:
+                          type: dict
+                          keys:
+                            access_list:
+                              type: str
+                            priority:
+                              type: int
+                              min: 0
+                              max: 255
+                            hashmask:
+                              type: int
+                              min: 0
+                              max: 32
+                            override:
+                              type: bool
   router_traffic_engineering:
     type: dict
     keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_pim_sparse_mode.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_pim_sparse_mode.schema.yml
@@ -33,19 +33,6 @@ keys:
                   - dict
                   items:
                     type: str
-                access_lists:
-                  type: list
-                  items:
-                    type: dict
-                    keys:
-                      access_list:
-                        type: str
-                      priority:
-                        type: int
-                      hashmask:
-                        type: int
-                      override:
-                        type: bool
           anycast_rps:
             type: list
             primary_key: address
@@ -100,3 +87,20 @@ keys:
                         type: list
                         items:
                           type: str
+                      access_lists:
+                        type: list
+                        items:
+                          type: dict
+                          keys:
+                            access_list:
+                              type: str
+                            priority:
+                              type: int
+                              min: 0
+                              max: 255
+                            hashmask:
+                              type: int
+                              min: 0
+                              max: 32
+                            override:
+                              type: bool

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_pim_sparse_mode.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_pim_sparse_mode.schema.yml
@@ -33,6 +33,20 @@ keys:
                   - dict
                   items:
                     type: str
+                access_lists:
+                  type: list
+                  items:
+                    type: str
+                priority:
+                  type: int
+                  min: 0
+                  max: 255
+                hashmask:
+                  type: int
+                  min: 0
+                  max: 32
+                override:
+                  type: bool
           anycast_rps:
             type: list
             primary_key: address
@@ -83,6 +97,7 @@ keys:
                       address:
                         type: str
                         description: RP Address
+                        required: true
                       groups:
                         type: list
                         items:
@@ -90,17 +105,14 @@ keys:
                       access_lists:
                         type: list
                         items:
-                          type: dict
-                          keys:
-                            access_list:
-                              type: str
-                            priority:
-                              type: int
-                              min: 0
-                              max: 255
-                            hashmask:
-                              type: int
-                              min: 0
-                              max: 32
-                            override:
-                              type: bool
+                          type: str
+                      priority:
+                        type: int
+                        min: 0
+                        max: 255
+                      hashmask:
+                        type: int
+                        min: 0
+                        max: 32
+                      override:
+                        type: bool

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_pim_sparse_mode.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_pim_sparse_mode.schema.yml
@@ -17,6 +17,10 @@ keys:
             description: IPv4 Prefix associated with SSM
           rp_addresses:
             type: list
+            # This primary_key is inserted to support conversion from wildcard dicts,
+            # but it also stops the user from defining the same RP address multiple times,
+            # which should be allowed. When wildcard dict support is finally removed,
+            # this primary_key should also be removed. TODO: AVD5.0
             primary_key: address
             convert_types:
             - dict

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_pim_sparse_mode.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_pim_sparse_mode.schema.yml
@@ -33,6 +33,19 @@ keys:
                   - dict
                   items:
                     type: str
+                access_lists:
+                  type: list
+                  items:
+                    type: dict
+                    keys:
+                      access_list:
+                        type: str
+                      priority:
+                        type: int
+                      hashmask:
+                        type: int
+                      override:
+                        type: bool
           anycast_rps:
             type: list
             primary_key: address

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-pim-sparse-mode.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-pim-sparse-mode.j2
@@ -11,11 +11,15 @@ BFD enabled: {{ router_pim_sparse_mode.ipv4.bfd | arista.avd.default(false) }}
 
 ##### IP Rendezvous Information
 
-| Rendezvous Point Address | Group Address |
-| ------------------------ | ------------- |
+| Rendezvous Point Address | Group Address | Access Lists | Priority | Hashmask | Override |
+| ------------------------ | ------------- | ------------ | -------- | -------- | -------- |
 {%             for rp_address in router_pim_sparse_mode.ipv4.rp_addresses | arista.avd.natural_sort('address') %}
 {%                 set rp_groups = rp_address.groups | arista.avd.default(['-']) | join(', ') %}
-| {{ rp_address.address }} | {{ rp_groups }} |
+{%                 set access_lists = rp_address.access_lists | arista.avd.default(['-']) | join(', ') %}
+{%                 set priority = rp_address.priority | arista.avd.default('-') %}
+{%                 set hashmask = rp_address.hashmask | arista.avd.default('-') %}
+{%                 set override = rp_address.override | arista.avd.default('-') %}
+| {{ rp_address.address }} | {{ rp_groups }} | {{ access_lists }} | {{ priority }} | {{ hashmask }} | {{ override }} |
 {%             endfor %}
 {%         endif %}
 {%         if router_pim_sparse_mode.ipv4.anycast_rps is arista.avd.defined %}
@@ -42,13 +46,17 @@ BFD enabled: {{ router_pim_sparse_mode.ipv4.bfd | arista.avd.default(false) }}
 | {{ vrf.name }} | {{ vrf.ipv4.bfd | arista.avd.default(false) }} |
 {%         endfor %}
 
-| VRF Name | Rendezvous Point Address | Group Address |
-| -------- | ------------------------ | ------------- |
+| VRF Name | Rendezvous Point Address | Group Address | Access Lists | Priority | Hashmask | Override |
+| -------- | ------------------------ | ------------- | ------------ | -------- | -------- | -------- |
 {%         for vrf in router_pim_sparse_mode.vrfs | arista.avd.natural_sort('name') %}
 {%             if vrf.ipv4.rp_addresses is arista.avd.defined %}
 {%                 for rp_address in vrf.ipv4.rp_addresses | arista.avd.natural_sort('address') %}
 {%                     set rp_groups = rp_address.groups | arista.avd.default(['-']) | join(', ') %}
-| {{ vrf.name }} | {{ rp_address.address }} | {{ rp_groups }} |
+{%                     set access_lists = rp_address.access_lists | arista.avd.default(['-']) | join(', ') %}
+{%                     set priority = rp_address.priority | arista.avd.default('-') %}
+{%                     set hashmask = rp_address.hashmask | arista.avd.default('-') %}
+{%                     set override = rp_address.override | arista.avd.default('-') %}
+| {{ vrf.name }} | {{ rp_address.address }} | {{ rp_groups }} | {{ access_lists }} | {{ priority }} | {{ hashmask }} | {{ override }} |
 {%                 endfor %}
 {%             endif %}
 {%         endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-pim-sparse-mode.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-pim-sparse-mode.j2
@@ -42,6 +42,20 @@ router pim sparse-mode
 {%                     for group in rp_address.groups | arista.avd.natural_sort %}
          rp address {{ rp_address.address }} {{ group }}
 {%                     endfor %}
+{%                 elif rp_address.access_lists is arista.avd.defined %}
+{%                     for access_list in rp_address.access_lists | arista.avd.natural_sort('access_list') %}
+{%                         set rp_acl_cli = "rp address " ~ rp_address.address ~ " access-list " ~ access_list.access_list %}
+{%                         if access_list.priority is arista.avd.defined %}
+{%                             set rp_acl_cli = rp_acl_cli ~ " priority " ~ access_list.priority %}
+{%                         endif %}
+{%                         if access_list.hashmask is arista.avd.defined %}
+{%                             set rp_acl_cli = rp_acl_cli ~ " hashmask " ~ access_list.hashmask %}
+{%                         endif %}
+{%                         if access_list.override is arista.avd.defined(true) %}
+{%                             set rp_acl_cli = rp_acl_cli ~ " override" %}
+{%                         endif %}
+         {{ rp_acl_cli }}
+{%                     endfor %}
 {%                 else %}
          rp address {{ rp_address.address }}
 {%                 endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-pim-sparse-mode.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-pim-sparse-mode.j2
@@ -21,16 +21,16 @@ router pim sparse-mode
 {%             if rp_address.groups is arista.avd.defined or rp_address.access_lists is arista.avd.defined %}
 {%                 if rp_address.groups is arista.avd.defined %}
 {%                     for group in rp_address.groups | arista.avd.natural_sort %}
-         rp address {{ rp_address.address }} {{ group }}{{ rp_options_cli }}
+      rp address {{ rp_address.address }} {{ group }}{{ rp_options_cli }}
 {%                     endfor %}
 {%                 endif %}
 {%                 if rp_address.access_lists is arista.avd.defined %}
 {%                     for access_list in rp_address.access_lists | arista.avd.natural_sort %}
-         rp address {{ rp_address.address }} access-list {{ access_list }}{{ rp_options_cli }}
+      rp address {{ rp_address.address }} access-list {{ access_list }}{{ rp_options_cli }}
 {%                     endfor %}
 {%                 endif %}
 {%             else %}
-         rp address {{ rp_address.address }}{{ rp_options_cli }}
+      rp address {{ rp_address.address }}{{ rp_options_cli }}
 {%             endif %}
 {%         endfor %}
 {%         for anycast_rp in router_pim_sparse_mode.ipv4.anycast_rps | arista.avd.natural_sort('address') %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-pim-sparse-mode.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-pim-sparse-mode.j2
@@ -8,12 +8,29 @@ router pim sparse-mode
       bfd
 {%         endif %}
 {%         for rp_address in router_pim_sparse_mode.ipv4.rp_addresses | arista.avd.natural_sort('address') %}
-{%             if rp_address.groups is arista.avd.defined %}
-{%                 for group in rp_address.groups | arista.avd.natural_sort %}
-      rp address {{ rp_address.address }} {{ group }}
-{%                 endfor %}
+{%             set rp_options_cli = "" %}
+{%             if rp_address.priority is arista.avd.defined %}
+{%                 set rp_options_cli = rp_options_cli ~ " priority " ~ rp_address.priority %}
+{%             endif %}
+{%             if rp_address.hashmask is arista.avd.defined %}
+{%                 set rp_options_cli = rp_options_cli ~ " hashmask " ~ rp_address.hashmask %}
+{%             endif %}
+{%             if rp_address.override is arista.avd.defined(true) %}
+{%                 set rp_options_cli = rp_options_cli ~ " override" %}
+{%             endif %}
+{%             if rp_address.groups is arista.avd.defined or rp_address.access_lists is arista.avd.defined %}
+{%                 if rp_address.groups is arista.avd.defined %}
+{%                     for group in rp_address.groups | arista.avd.natural_sort %}
+         rp address {{ rp_address.address }} {{ group }}{{ rp_options_cli }}
+{%                     endfor %}
+{%                 endif %}
+{%                 if rp_address.access_lists is arista.avd.defined %}
+{%                     for access_list in rp_address.access_lists | arista.avd.natural_sort %}
+         rp address {{ rp_address.address }} access-list {{ access_list }}{{ rp_options_cli }}
+{%                     endfor %}
+{%                 endif %}
 {%             else %}
-      rp address {{ rp_address.address }}
+         rp address {{ rp_address.address }}{{ rp_options_cli }}
 {%             endif %}
 {%         endfor %}
 {%         for anycast_rp in router_pim_sparse_mode.ipv4.anycast_rps | arista.avd.natural_sort('address') %}
@@ -38,26 +55,29 @@ router pim sparse-mode
          bfd
 {%             endif %}
 {%             for rp_address in vrf.ipv4.rp_addresses | arista.avd.natural_sort('address') %}
-{%                 if rp_address.groups is arista.avd.defined %}
-{%                     for group in rp_address.groups | arista.avd.natural_sort %}
-         rp address {{ rp_address.address }} {{ group }}
-{%                     endfor %}
-{%                 elif rp_address.access_lists is arista.avd.defined %}
-{%                     for access_list in rp_address.access_lists | arista.avd.natural_sort('access_list') %}
-{%                         set rp_acl_cli = "rp address " ~ rp_address.address ~ " access-list " ~ access_list.access_list %}
-{%                         if access_list.priority is arista.avd.defined %}
-{%                             set rp_acl_cli = rp_acl_cli ~ " priority " ~ access_list.priority %}
-{%                         endif %}
-{%                         if access_list.hashmask is arista.avd.defined %}
-{%                             set rp_acl_cli = rp_acl_cli ~ " hashmask " ~ access_list.hashmask %}
-{%                         endif %}
-{%                         if access_list.override is arista.avd.defined(true) %}
-{%                             set rp_acl_cli = rp_acl_cli ~ " override" %}
-{%                         endif %}
-         {{ rp_acl_cli }}
-{%                     endfor %}
+{%                 set rp_options_cli = "" %}
+{%                 if rp_address.priority is arista.avd.defined %}
+{%                     set rp_options_cli = rp_options_cli ~ " priority " ~ rp_address.priority %}
+{%                 endif %}
+{%                 if rp_address.hashmask is arista.avd.defined %}
+{%                     set rp_options_cli = rp_options_cli ~ " hashmask " ~ rp_address.hashmask %}
+{%                 endif %}
+{%                 if rp_address.override is arista.avd.defined(true) %}
+{%                     set rp_options_cli = rp_options_cli ~ " override" %}
+{%                 endif %}
+{%                 if rp_address.groups is arista.avd.defined or rp_address.access_lists is arista.avd.defined %}
+{%                     if rp_address.groups is arista.avd.defined %}
+{%                         for group in rp_address.groups | arista.avd.natural_sort %}
+         rp address {{ rp_address.address }} {{ group }}{{ rp_options_cli }}
+{%                         endfor %}
+{%                     endif %}
+{%                     if rp_address.access_lists is arista.avd.defined %}
+{%                         for access_list in rp_address.access_lists | arista.avd.natural_sort %}
+         rp address {{ rp_address.address }} access-list {{ access_list }}{{ rp_options_cli }}
+{%                         endfor %}
+{%                     endif %}
 {%                 else %}
-         rp address {{ rp_address.address }}
+         rp address {{ rp_address.address }}{{ rp_options_cli }}
 {%                 endif %}
 {%             endfor %}
 {%         endif %}


### PR DESCRIPTION
## Change Summary

Support Access-lists, priority, hashmask, override on rp addresses

## Related Issue(s)

Fixes #2353 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

```yaml
router_pim_sparse_mode:
  rp_addresses:
    - address: < rp_address_1 >
      access_lists:
        - < access_list_name >
      priority: < 0-255 >
      hashmask: < 0-32 >
      override: < bool >
  vrfs:
    - name: < vrf_name >
      ipv4:
        rp_addresses:
          - address: < rp_address_1 >
            access_lists:
              - < access_list_name >
            priority: < 0-255 >
            hashmask: < 0-32 >
            override: < bool >
```

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
