### PR TITLE
Feat(eos_designs): Adding 7020R to plattform settings

### DIFF
--- a/ansible_collections/arista/avd/plugins/README.md
+++ b/ansible_collections/arista/avd/plugins/README.md
@@ -297,7 +297,7 @@ platform_settings:
     reload_delay:
       mlag: 300
       non_mlag: 330
-  - platforms: [ 7280R, 7280R2, 7500R, 7500R2 ]
+  - platforms: [ 7280R, 7280R2, 7500R, 7500R2, 7020R ]
     tcam_profile: vxlan-routing
     lag_hardware_only: true
     reload_delay:

--- a/ansible_collections/arista/avd/roles/eos_designs/defaults/main/default-platform-settings.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/defaults/main/default-platform-settings.yml
@@ -18,7 +18,7 @@ default_platform_settings:
     feature_support:
       # "queue-monitor length notify" is only valid for R-Series so should be disabled on default platform.
       queue_monitor_length_notify: false
-  - platforms: ['7280R', '7280R2']
+  - platforms: ['7280R', '7280R2', '7020R']
     tcam_profile: vxlan-routing
     lag_hardware_only: true
     reload_delay:

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/platform-settings-v4.0.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/platform-settings-v4.0.md
@@ -54,7 +54,7 @@ platform_settings:
     feature_support:
       # "queue-monitor length notify" is only valid for R-Series so should be disabled on default platform.
       queue_monitor_length_notify: false
-  - platforms: [ '7280R', '7280R2' ]
+  - platforms: [ '7280R', '7280R2', '7020R' ]
     tcam_profile: vxlan-routing
     lag_hardware_only: true
     reload_delay:

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/platform-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/platform-settings.md
@@ -62,7 +62,7 @@ default_platform_settings:
       non_mlag: 330
     feature_support:
       queue_monitor_length_notify: false
-  - platforms: ['7280R', '7280R2']
+  - platforms: ['7280R', '7280R2', '7020R']
     tcam_profile: vxlan-routing
     lag_hardware_only: true
     reload_delay:


### PR DESCRIPTION
## Change Summary

Adding 7020R models to plattform settings of 7280R to reflect the need of specific 'vxlan-routing' hardware tcam profile.

## Related Issue(s)

Fixes  #2352

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

## How to test
Set 7020R as Node plattform and design & cli_conf should render the correct tcam profile requirement
## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been rebased from devel before I start
- [X] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [X] My change requires a change to the documentation and documentation have been updated accordingly.
- [X] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
