### PR TITLE
Doc(plugins): Fix inconsistency in the configlet_build_config.rst.md

### DIFF
--- a/ansible_collections/arista/avd/plugins/modules/configlet_build_config.py
+++ b/ansible_collections/arista/avd/plugins/modules/configlet_build_config.py
@@ -55,7 +55,7 @@ EXAMPLES = r"""
   tags: [build, provision]
   configlet_build_config:
     configlet_dir: '/path/to/configlets/folder/'
-    configlet_prefix: 'AVD_'
+    configlet_prefix: 'AVD'
     configlet_extension: 'cfg'
 """
 
@@ -75,16 +75,16 @@ except ImportError:
     YAML_IMP_ERR = traceback.format_exc()
 
 
-def get_configlet(src_folder="", prefix="AVD", extension="cfg"):
+def get_configlet(src_folder, prefix, extension="cfg"):
     """
     Get available configlets to deploy to CVP.
 
     Parameters
     ----------
-    src_folder : str, optional
+    src_folder : str
         Path where to find configlet, by default ""
-    prefix : str, optional
-        Prefix to append to configlet name, by default 'AVD'
+    prefix : str
+        Prefix to append to configlet name
     extension : str, optional
         File extension to lookup configlet file, by default 'cfg'
 
@@ -93,6 +93,9 @@ def get_configlet(src_folder="", prefix="AVD", extension="cfg"):
     dict
         Dictionary of configlets found in source folder.
     """
+    if src_folder is None:
+        src_folder = ""
+
     src_configlets = glob.glob(src_folder + "/*." + extension)
     configlets = {}
     for file in src_configlets:


### PR DESCRIPTION
## Change Summary

* Make the prefix parameter optional with AVD default as it is behaving.
* Fix the markdown file for the module.

## Related Issue(s)

Fixes #1956

## Component(s) name

`arista.avd.plugins`

## How to test


let molecule run

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
