### PR TITLE
Fix: Logging buffered default level not required (#2364)

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/logging-minimal.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/logging-minimal.md
@@ -57,6 +57,7 @@ interface Management1
 | -----| ----- |
 | Console | informational |
 | Monitor | debugging |
+| Buffer | - |
 
 **Syslog facility value:** syslog
 
@@ -64,6 +65,7 @@ interface Management1
 
 ```eos
 !
+logging buffered 64000
 logging console informational
 logging monitor debugging
 logging facility syslog

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/logging-minimal.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/logging-minimal.cfg
@@ -2,6 +2,7 @@
 !
 transceiver qsfp default-mode 4x10G
 !
+logging buffered 64000
 logging console informational
 logging monitor debugging
 logging facility syslog

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/logging-minimal.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/logging-minimal.yml
@@ -3,3 +3,5 @@ logging:
   console: informational
   monitor: debugging
   facility: syslog
+  buffered:
+    size: 64000

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/logging.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/logging.j2
@@ -3,12 +3,14 @@
 !
 {%     if logging.buffered.level is arista.avd.defined('disabled') %}
 no logging buffered
-{%     elif logging.buffered.level is arista.avd.defined %}
+{%     elif logging.buffered.size is arista.avd.defined or logging.buffered.level is arista.avd.defined %}
 {%         set logging_buffered_cli = "logging buffered" %}
 {%         if logging.buffered.size is arista.avd.defined %}
 {%             set logging_buffered_cli = logging_buffered_cli ~ " " ~ logging.buffered.size %}
 {%         endif %}
-{%         set logging_buffered_cli = logging_buffered_cli ~ " " ~ logging.buffered.level %}
+{%         if logging.buffered.level is arista.avd.defined  %}
+{%             set logging_buffered_cli = logging_buffered_cli ~ " " ~ logging.buffered.level %}
+{%         endif %}
 {{ logging_buffered_cli }}
 {%     endif %}
 {%     if logging.trap is arista.avd.defined('disabled') %}


### PR DESCRIPTION
Cherry-pick of https://github.com/aristanetworks/ansible-avd/pull/2364 for 3.8 release