### PR TITLE
Fix(eos_designs): Replace sorted with natural_sort in overlay/utils.py

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1B.cfg
@@ -248,7 +248,10 @@ router bgp 65105
    neighbor UNDERLAY-PEERS maximum-routes 12000
    neighbor 1.1.1.1 peer group EVPN-OVERLAY-CORE
    neighbor 1.1.1.1 remote-as 65555
-   neighbor 1.1.1.1 description MY_EVPN_GW_USER_DEFINED
+   neighbor 1.1.1.1 description MY_EVPN_GW1_USER_DEFINED
+   neighbor 2.2.2.2 peer group EVPN-OVERLAY-CORE
+   neighbor 2.2.2.2 remote-as 65555
+   neighbor 2.2.2.2 description MY_EVPN_GW2_USER_DEFINED
    neighbor 172.31.254.192 peer group UNDERLAY-PEERS
    neighbor 172.31.254.192 remote-as 65001
    neighbor 172.31.254.192 description DC1-SPINE1_Ethernet23

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1B.yml
@@ -72,7 +72,11 @@ router_bgp:
       remote_as: '65001'
     1.1.1.1:
       peer_group: EVPN-OVERLAY-CORE
-      description: MY_EVPN_GW_USER_DEFINED
+      description: MY_EVPN_GW1_USER_DEFINED
+      remote_as: '65555'
+    2.2.2.2:
+      peer_group: EVPN-OVERLAY-CORE
+      description: MY_EVPN_GW2_USER_DEFINED
       remote_as: '65555'
   address_family_evpn:
     neighbor_default:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_FABRIC.yml
@@ -187,8 +187,11 @@ l3leaf:
           uplink_switch_interfaces: [ Ethernet23, Ethernet23, Ethernet23, Ethernet23 ]
           evpn_gateway:
             remote_peers:
-              - hostname: "MY_EVPN_GW_USER_DEFINED"
+              - hostname: "MY_EVPN_GW1_USER_DEFINED"
                 ip_address: 1.1.1.1
+                bgp_as: 65555
+              - hostname: "MY_EVPN_GW2_USER_DEFINED"
+                ip_address: 2.2.2.2
                 bgp_as: 65555
             evpn_l2:
               enabled: true

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/overlay/utils.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/overlay/utils.py
@@ -54,7 +54,7 @@ class UtilsMixin:
 
         evpn_gateway_remote_peers = {}
 
-        for gw_remote_peer_dict in natural_sort(get(self._hostvars, "switch.evpn_gateway_remote_peers", default=[])):
+        for gw_remote_peer_dict in natural_sort(get(self._hostvars, "switch.evpn_gateway_remote_peers", default=[]), sort_key="hostname"):
             # These remote gw can be outside of the inventory
             gw_remote_peer = gw_remote_peer_dict["hostname"]
             peer_facts = self._get_peer_facts(gw_remote_peer, required=False)

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/overlay/utils.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/overlay/utils.py
@@ -54,7 +54,7 @@ class UtilsMixin:
 
         evpn_gateway_remote_peers = {}
 
-        for gw_remote_peer_dict in sorted(get(self._hostvars, "switch.evpn_gateway_remote_peers", default=[])):
+        for gw_remote_peer_dict in natural_sort(get(self._hostvars, "switch.evpn_gateway_remote_peers", default=[])):
             # These remote gw can be outside of the inventory
             gw_remote_peer = gw_remote_peer_dict["hostname"]
             peer_facts = self._get_peer_facts(gw_remote_peer, required=False)
@@ -115,7 +115,7 @@ class UtilsMixin:
 
         evpn_route_servers = {}
 
-        for route_server in sorted(get(self._hostvars, "switch.evpn_route_servers", default=[])):
+        for route_server in natural_sort(get(self._hostvars, "switch.evpn_route_servers", default=[])):
             peer_facts = self._get_peer_facts(route_server)
             if not peer_facts or peer_facts.get("evpn_role") != "server":
                 continue
@@ -228,7 +228,7 @@ class UtilsMixin:
 
         mpls_route_reflectors = {}
 
-        for route_reflector in sorted(get(self._hostvars, "switch.mpls_route_reflectors", default=[])):
+        for route_reflector in natural_sort(get(self._hostvars, "switch.mpls_route_reflectors", default=[])):
             if route_reflector == self._hostname:
                 continue
 
@@ -247,7 +247,7 @@ class UtilsMixin:
 
         mpls_rr_peers = {}
 
-        for route_reflector in sorted(get(self._hostvars, "switch.mpls_route_reflectors", default=[])):
+        for route_reflector in natural_sort(get(self._hostvars, "switch.mpls_route_reflectors", default=[])):
             if route_reflector == self._hostname:
                 continue
 


### PR DESCRIPTION
## Change Summary

The current code was trying to compare to dictionaries using built-in python `sorted` which could not handle it. 
`sorted` has been replaced with AVD `natural_sort` which can handle it/
It was not caught during refactoring because there was no example of multiple evpn_gateway remote_peers.

## Related Issue(s)

Fixes #2373

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

Replace `sorted` with `natural_sort` in `ansible_collections/arista/avd/roles/eos_designs/python_modules/overlay/utils.py`

## How to test

molecule

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
