### PR TITLE
Feat(eos_cli_config_gen): Add arp learning bridged

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-l2-vpn.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-l2-vpn.md
@@ -95,23 +95,26 @@ interface Management1
 
 ## Router L2 VPN Summary
 
-   Neighbor discovery router solicitation VTEP flooding is disabled.
+   ARP learning bridged is enabled.
 
-   Virtual router neighbor advertisement VTEP flooding is disabled.
+   VXLAN ARP Proxying is disabled for IPv4 addresses defined in the prefix-list pl-router-l2-vpn.
 
    Selective ARP is enabled.
 
-   VXLAN ARP Proxying is disabled for IPv4 addresses defined in the prefix-list pl-router-l2-vpn.
+   Neighbor discovery router solicitation VTEP flooding is disabled.
+
+   Virtual router neighbor advertisement VTEP flooding is disabled.
 
 ## Router L2 VPN Device Configuration
 
 ```eos
 !
 router l2-vpn
+   arp learning bridged
+   arp proxy prefix-list pl-router-l2-vpn
+   arp selective-install
    nd rs flooding disabled
    virtual-router neighbor advertisement flooding disabled
-   arp selective-install
-   arp proxy prefix-list pl-router-l2-vpn
 ```
 
 # Quality Of Service

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-l2-vpn.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-l2-vpn.md
@@ -95,15 +95,15 @@ interface Management1
 
 ## Router L2 VPN Summary
 
-   ARP learning bridged is enabled.
+- ARP learning bridged is enabled.
 
-   VXLAN ARP Proxying is disabled for IPv4 addresses defined in the prefix-list pl-router-l2-vpn.
+- VXLAN ARP Proxying is disabled for IPv4 addresses defined in the prefix-list pl-router-l2-vpn.
 
-   Selective ARP is enabled.
+- Selective ARP is enabled.
 
-   Neighbor discovery router solicitation VTEP flooding is disabled.
+- Neighbor discovery router solicitation VTEP flooding is disabled.
 
-   Virtual router neighbor advertisement VTEP flooding is disabled.
+- Virtual router neighbor advertisement VTEP flooding is disabled.
 
 ## Router L2 VPN Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-l2-vpn.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-l2-vpn.cfg
@@ -5,10 +5,11 @@ transceiver qsfp default-mode 4x10G
 hostname router-l2-vpn
 !
 router l2-vpn
+   arp learning bridged
+   arp proxy prefix-list pl-router-l2-vpn
+   arp selective-install
    nd rs flooding disabled
    virtual-router neighbor advertisement flooding disabled
-   arp selective-install
-   arp proxy prefix-list pl-router-l2-vpn
 !
 no enable password
 no aaa root

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-l2-vpn.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-l2-vpn.yml
@@ -6,3 +6,4 @@ router_l2_vpn:
   arp_selective_install: true
   arp_proxy:
     prefix_list: "pl-router-l2-vpn"
+  arp_learning_bridged: true

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/router-l2-vpn.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/router-l2-vpn.md
@@ -95,23 +95,23 @@ interface Management1
 
 ## Router L2 VPN Summary
 
-   Neighbor discovery router solicitation VTEP flooding is disabled.
-
-   Virtual router neighbor advertisement VTEP flooding is disabled.
+   VXLAN ARP Proxying is disabled for IPv4 addresses defined in the prefix-list pl-router-l2-vpn.
 
    Selective ARP is enabled.
 
-   VXLAN ARP Proxying is disabled for IPv4 addresses defined in the prefix-list pl-router-l2-vpn.
+   Neighbor discovery router solicitation VTEP flooding is disabled.
+
+   Virtual router neighbor advertisement VTEP flooding is disabled.
 
 ## Router L2 VPN Device Configuration
 
 ```eos
 !
 router l2-vpn
+   arp proxy prefix-list pl-router-l2-vpn
+   arp selective-install
    nd rs flooding disabled
    virtual-router neighbor advertisement flooding disabled
-   arp selective-install
-   arp proxy prefix-list pl-router-l2-vpn
 ```
 
 # Quality Of Service

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/router-l2-vpn.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/router-l2-vpn.md
@@ -95,13 +95,13 @@ interface Management1
 
 ## Router L2 VPN Summary
 
-   VXLAN ARP Proxying is disabled for IPv4 addresses defined in the prefix-list pl-router-l2-vpn.
+- VXLAN ARP Proxying is disabled for IPv4 addresses defined in the prefix-list pl-router-l2-vpn.
 
-   Selective ARP is enabled.
+- Selective ARP is enabled.
 
-   Neighbor discovery router solicitation VTEP flooding is disabled.
+- Neighbor discovery router solicitation VTEP flooding is disabled.
 
-   Virtual router neighbor advertisement VTEP flooding is disabled.
+- Virtual router neighbor advertisement VTEP flooding is disabled.
 
 ## Router L2 VPN Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/router-l2-vpn.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/router-l2-vpn.cfg
@@ -5,10 +5,10 @@ transceiver qsfp default-mode 4x10G
 hostname router-l2-vpn
 !
 router l2-vpn
+   arp proxy prefix-list pl-router-l2-vpn
+   arp selective-install
    nd rs flooding disabled
    virtual-router neighbor advertisement flooding disabled
-   arp selective-install
-   arp proxy prefix-list pl-router-l2-vpn
 !
 no enable password
 no aaa root

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -3684,11 +3684,12 @@ vrfs:
 
 ```yaml
 router_l2_vpn:
-  nd_rs_flooding_disabled: < true | false >
-  virtual_router_nd_ra_flooding_disabled: < true | false >
-  arp_selective_install: < true | false >
+  arp_learning_bridged: < true | false >
   arp_proxy:
     prefix_list: < prefix_list_name >
+  arp_selective_install: < true | false >
+  nd_rs_flooding_disabled: < true | false >
+  virtual_router_nd_ra_flooding_disabled: < true | false >
 ```
 
 ### Router MSDP

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -5131,21 +5131,23 @@ router_isis:
 | Variable | Type | Required | Default | Value Restrictions | Description |
 | -------- | ---- | -------- | ------- | ------------------ | ----------- |
 | [<samp>router_l2_vpn</samp>](## "router_l2_vpn") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;nd_rs_flooding_disabled</samp>](## "router_l2_vpn.nd_rs_flooding_disabled") | Boolean |  |  |  |  |
-| [<samp>&nbsp;&nbsp;virtual_router_nd_ra_flooding_disabled</samp>](## "router_l2_vpn.virtual_router_nd_ra_flooding_disabled") | Boolean |  |  |  |  |
-| [<samp>&nbsp;&nbsp;arp_selective_install</samp>](## "router_l2_vpn.arp_selective_install") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;arp_learning_bridged</samp>](## "router_l2_vpn.arp_learning_bridged") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;arp_proxy</samp>](## "router_l2_vpn.arp_proxy") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;prefix_list</samp>](## "router_l2_vpn.arp_proxy.prefix_list") | String |  |  |  | Prefix-list Name |
+| [<samp>&nbsp;&nbsp;arp_selective_install</samp>](## "router_l2_vpn.arp_selective_install") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;nd_rs_flooding_disabled</samp>](## "router_l2_vpn.nd_rs_flooding_disabled") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;virtual_router_nd_ra_flooding_disabled</samp>](## "router_l2_vpn.virtual_router_nd_ra_flooding_disabled") | Boolean |  |  |  |  |
 
 ### YAML
 
 ```yaml
 router_l2_vpn:
-  nd_rs_flooding_disabled: <bool>
-  virtual_router_nd_ra_flooding_disabled: <bool>
-  arp_selective_install: <bool>
+  arp_learning_bridged: <bool>
   arp_proxy:
     prefix_list: <str>
+  arp_selective_install: <bool>
+  nd_rs_flooding_disabled: <bool>
+  virtual_router_nd_ra_flooding_disabled: <bool>
 ```
 
 ## Router Msdp

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -11252,17 +11252,9 @@
     "router_l2_vpn": {
       "type": "object",
       "properties": {
-        "nd_rs_flooding_disabled": {
+        "arp_learning_bridged": {
           "type": "boolean",
-          "title": "ND RS Flooding Disabled"
-        },
-        "virtual_router_nd_ra_flooding_disabled": {
-          "type": "boolean",
-          "title": "Virtual Router ND RA Flooding Disabled"
-        },
-        "arp_selective_install": {
-          "type": "boolean",
-          "title": "ARP Selective Install"
+          "title": "ARP Learning Bridged"
         },
         "arp_proxy": {
           "type": "object",
@@ -11275,6 +11267,18 @@
           },
           "additionalProperties": false,
           "title": "ARP Proxy"
+        },
+        "arp_selective_install": {
+          "type": "boolean",
+          "title": "ARP Selective Install"
+        },
+        "nd_rs_flooding_disabled": {
+          "type": "boolean",
+          "title": "ND RS Flooding Disabled"
+        },
+        "virtual_router_nd_ra_flooding_disabled": {
+          "type": "boolean",
+          "title": "Virtual Router ND RA Flooding Disabled"
         }
       },
       "additionalProperties": false,

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -7668,11 +7668,7 @@ keys:
   router_l2_vpn:
     type: dict
     keys:
-      nd_rs_flooding_disabled:
-        type: bool
-      virtual_router_nd_ra_flooding_disabled:
-        type: bool
-      arp_selective_install:
+      arp_learning_bridged:
         type: bool
       arp_proxy:
         type: dict
@@ -7680,6 +7676,12 @@ keys:
           prefix_list:
             type: str
             description: Prefix-list Name
+      arp_selective_install:
+        type: bool
+      nd_rs_flooding_disabled:
+        type: bool
+      virtual_router_nd_ra_flooding_disabled:
+        type: bool
   router_msdp:
     type: dict
     keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_l2_vpn.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_l2_vpn.schema.yml
@@ -6,11 +6,7 @@ keys:
   router_l2_vpn:
     type: dict
     keys:
-      nd_rs_flooding_disabled:
-        type: bool
-      virtual_router_nd_ra_flooding_disabled:
-        type: bool
-      arp_selective_install:
+      arp_learning_bridged:
         type: bool
       arp_proxy:
         type: dict
@@ -18,3 +14,9 @@ keys:
           prefix_list:
             type: str
             description: Prefix-list Name
+      arp_selective_install:
+        type: bool
+      nd_rs_flooding_disabled:
+        type: bool
+      virtual_router_nd_ra_flooding_disabled:
+        type: bool

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-l2-vpn.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-l2-vpn.j2
@@ -6,23 +6,23 @@
 ## Router L2 VPN Summary
 {%     if router_l2_vpn.arp_learning_bridged is arista.avd.defined(true) %}
 
-   ARP learning bridged is enabled.
+- ARP learning bridged is enabled.
 {%     endif %}
 {%     if router_l2_vpn.arp_proxy.prefix_list is arista.avd.defined %}
 
-   VXLAN ARP Proxying is disabled for IPv4 addresses defined in the prefix-list {{ router_l2_vpn.arp_proxy.prefix_list }}.
+- VXLAN ARP Proxying is disabled for IPv4 addresses defined in the prefix-list {{ router_l2_vpn.arp_proxy.prefix_list }}.
 {%     endif %}
 {%     if router_l2_vpn.arp_selective_install is arista.avd.defined(true) %}
 
-   Selective ARP is enabled.
+- Selective ARP is enabled.
 {%     endif %}
 {%     if router_l2_vpn.nd_rs_flooding_disabled is arista.avd.defined(true) %}
 
-   Neighbor discovery router solicitation VTEP flooding is disabled.
+- Neighbor discovery router solicitation VTEP flooding is disabled.
 {%     endif %}
 {%     if router_l2_vpn.virtual_router_nd_ra_flooding_disabled is arista.avd.defined(true) %}
 
-   Virtual router neighbor advertisement VTEP flooding is disabled.
+- Virtual router neighbor advertisement VTEP flooding is disabled.
 {%     endif %}
 
 ## Router L2 VPN Device Configuration

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-l2-vpn.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-l2-vpn.j2
@@ -4,6 +4,18 @@
 # Router L2 VPN
 
 ## Router L2 VPN Summary
+{%     if router_l2_vpn.arp_learning_bridged is arista.avd.defined(true) %}
+
+   ARP learning bridged is enabled.
+{%     endif %}
+{%     if router_l2_vpn.arp_proxy.prefix_list is arista.avd.defined %}
+
+   VXLAN ARP Proxying is disabled for IPv4 addresses defined in the prefix-list {{ router_l2_vpn.arp_proxy.prefix_list }}.
+{%     endif %}
+{%     if router_l2_vpn.arp_selective_install is arista.avd.defined(true) %}
+
+   Selective ARP is enabled.
+{%     endif %}
 {%     if router_l2_vpn.nd_rs_flooding_disabled is arista.avd.defined(true) %}
 
    Neighbor discovery router solicitation VTEP flooding is disabled.
@@ -11,14 +23,6 @@
 {%     if router_l2_vpn.virtual_router_nd_ra_flooding_disabled is arista.avd.defined(true) %}
 
    Virtual router neighbor advertisement VTEP flooding is disabled.
-{%     endif %}
-{%     if router_l2_vpn.arp_selective_install is arista.avd.defined(true) %}
-
-   Selective ARP is enabled.
-{%     endif %}
-{%     if router_l2_vpn.arp_proxy.prefix_list is arista.avd.defined %}
-
-   VXLAN ARP Proxying is disabled for IPv4 addresses defined in the prefix-list {{ router_l2_vpn.arp_proxy.prefix_list }}.
 {%     endif %}
 
 ## Router L2 VPN Device Configuration

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-l2-vpn.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-l2-vpn.j2
@@ -2,16 +2,19 @@
 {% if router_l2_vpn is arista.avd.defined %}
 !
 router l2-vpn
+{%     if router_l2_vpn.arp_learning_bridged is arista.avd.defined(true) %}
+   arp learning bridged
+{%     endif %}
+{%     if router_l2_vpn.arp_proxy.prefix_list is arista.avd.defined %}
+   arp proxy prefix-list {{ router_l2_vpn.arp_proxy.prefix_list }}
+{%     endif %}
+{%     if router_l2_vpn.arp_selective_install is arista.avd.defined(true) %}
+   arp selective-install
+{%     endif %}
 {%     if router_l2_vpn.nd_rs_flooding_disabled is arista.avd.defined(true) %}
    nd rs flooding disabled
 {%     endif %}
 {%     if router_l2_vpn.virtual_router_nd_ra_flooding_disabled is arista.avd.defined(true) %}
    virtual-router neighbor advertisement flooding disabled
-{%     endif %}
-{%     if router_l2_vpn.arp_selective_install is arista.avd.defined(true) %}
-   arp selective-install
-{%     endif %}
-{%     if router_l2_vpn.arp_proxy.prefix_list is arista.avd.defined %}
-   arp proxy prefix-list {{ router_l2_vpn.arp_proxy.prefix_list }}
 {%     endif %}
 {% endif %}


### PR DESCRIPTION
## Change Summary

Added the knob for "arp learning bridged" as well as refactored the order as per EOS cli.

<img width="415" alt="image" src="https://user-images.githubusercontent.com/88734745/211069080-fd9e1f6c-17c8-48e9-afa9-f7952ded200a.png">

## Related Issue(s)

Fixes #2370 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

```yaml
router_l2_vpn:
  arp_learning_bridged: < true | false >
```

## How to test

molecule converge -s eos_cli_config_gen -- --limit router-l2-vpn
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
