### PR TITLE
Fix(eos_designs): Handle overlapping VLAN names for l2vlans and vlan-aware-bundles

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L2LEAF1A.cfg
@@ -36,7 +36,7 @@ vlan 8
    name MULTICAST_ENABLED_8
 !
 vlan 9
-   name MULTICAST_ENABLED_8
+   name MULTICAST_ENABLED_9
 !
 vlan 110
    name MULTICAST_ENABLED_110

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF1A.cfg
@@ -64,7 +64,7 @@ vlan 8
    name MULTICAST_ENABLED_8
 !
 vlan 9
-   name MULTICAST_ENABLED_8
+   name MULTICAST_ENABLED_9
 !
 vlan 110
    name MULTICAST_ENABLED_110
@@ -861,6 +861,13 @@ router bgp 65101
       vlan 3-4
    !
    vlan-aware-bundle MULTICAST_ENABLED_8
+      rd 192.168.255.3:10008
+      route-target both 10008:10008
+      redistribute igmp
+      redistribute learned
+      vlan 8
+   !
+   vlan-aware-bundle MULTICAST_ENABLED_9
       rd 192.168.255.3:10009
       route-target both 10009:10009
       redistribute igmp

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF1B.cfg
@@ -64,7 +64,7 @@ vlan 8
    name MULTICAST_ENABLED_8
 !
 vlan 9
-   name MULTICAST_ENABLED_8
+   name MULTICAST_ENABLED_9
 !
 vlan 110
    name MULTICAST_ENABLED_110
@@ -861,6 +861,13 @@ router bgp 65101
       vlan 3-4
    !
    vlan-aware-bundle MULTICAST_ENABLED_8
+      rd 192.168.255.4:10008
+      route-target both 10008:10008
+      redistribute igmp
+      redistribute learned
+      vlan 8
+   !
+   vlan-aware-bundle MULTICAST_ENABLED_9
       rd 192.168.255.4:10009
       route-target both 10009:10009
       redistribute igmp

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF2A.cfg
@@ -64,7 +64,7 @@ vlan 8
    name MULTICAST_ENABLED_8
 !
 vlan 9
-   name MULTICAST_ENABLED_8
+   name MULTICAST_ENABLED_9
 !
 vlan 110
    name MULTICAST_ENABLED_110

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF3A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF3A.cfg
@@ -62,7 +62,7 @@ vlan 8
    name MULTICAST_ENABLED_8
 !
 vlan 9
-   name MULTICAST_ENABLED_8
+   name MULTICAST_ENABLED_9
 !
 vlan 110
    name MULTICAST_ENABLED_110

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF3B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF3B.cfg
@@ -62,7 +62,7 @@ vlan 8
    name MULTICAST_ENABLED_8
 !
 vlan 9
-   name MULTICAST_ENABLED_8
+   name MULTICAST_ENABLED_9
 !
 vlan 110
    name MULTICAST_ENABLED_110

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_false.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_false.cfg
@@ -76,6 +76,15 @@ vlan 161
 vlan 162
    name l2vlan_with_no_tags
 !
+vlan 163
+   name overlapping_name
+!
+vlan 164
+   name overlapping_name
+!
+vlan 165
+   name overlapping_name
+!
 vlan 210
    name Tenant_B_OP_Zone_1
 !
@@ -350,6 +359,9 @@ interface Vxlan1
    vxlan vlan 160 vni 10160
    vxlan vlan 161 vni 10161
    vxlan vlan 162 vni 10162
+   vxlan vlan 163 vni 10163
+   vxlan vlan 164 vni 10164
+   vxlan vlan 165 vni 10165
    vxlan vlan 210 vni 20210
    vxlan vlan 211 vni 20211
    vxlan vlan 250 vni 20250
@@ -429,6 +441,12 @@ router bgp 101
       route-target both 20162:20162
       redistribute learned
       vlan 162
+   !
+   vlan-aware-bundle overlapping_name
+      rd 192.168.255.109:20163
+      route-target both 20163:20163
+      redistribute learned
+      vlan 163-165
    !
    vlan-aware-bundle Tenant_A_APP_Zone
       rd 192.168.255.109:12

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_true.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_true.cfg
@@ -76,6 +76,15 @@ vlan 161
 vlan 162
    name l2vlan_with_no_tags
 !
+vlan 163
+   name overlapping_name
+!
+vlan 164
+   name overlapping_name
+!
+vlan 165
+   name overlapping_name
+!
 vlan 210
    name Tenant_B_OP_Zone_1
 !
@@ -146,6 +155,9 @@ interface Vxlan1
    vxlan vlan 160 vni 10160
    vxlan vlan 161 vni 10161
    vxlan vlan 162 vni 10162
+   vxlan vlan 163 vni 10163
+   vxlan vlan 164 vni 10164
+   vxlan vlan 165 vni 10165
    vxlan vlan 210 vni 20210
    vxlan vlan 211 vni 20211
    vxlan vlan 250 vni 20250
@@ -196,6 +208,12 @@ router bgp 101
       route-target both 20162:20162
       redistribute learned
       vlan 162
+   !
+   vlan-aware-bundle overlapping_name
+      rd 192.168.255.109:20163
+      route-target both 20163:20163
+      redistribute learned
+      vlan 163-165
    !
    vlan-aware-bundle Tenant_A_APP_Zone
       rd 192.168.255.109:12

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_default.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_default.cfg
@@ -76,6 +76,15 @@ vlan 161
 vlan 162
    name l2vlan_with_no_tags
 !
+vlan 163
+   name overlapping_name
+!
+vlan 164
+   name overlapping_name
+!
+vlan 165
+   name overlapping_name
+!
 vlan 210
    name Tenant_B_OP_Zone_1
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_fabric.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_fabric.cfg
@@ -76,6 +76,15 @@ vlan 161
 vlan 162
    name l2vlan_with_no_tags
 !
+vlan 163
+   name overlapping_name
+!
+vlan 164
+   name overlapping_name
+!
+vlan 165
+   name overlapping_name
+!
 vlan 210
    name Tenant_B_OP_Zone_1
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_host.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_host.cfg
@@ -78,6 +78,15 @@ vlan 161
 vlan 162
    name l2vlan_with_no_tags
 !
+vlan 163
+   name overlapping_name
+!
+vlan 164
+   name overlapping_name
+!
+vlan 165
+   name overlapping_name
+!
 vlan 210
    name Tenant_B_OP_Zone_1
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_platform.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_platform.cfg
@@ -78,6 +78,15 @@ vlan 161
 vlan 162
    name l2vlan_with_no_tags
 !
+vlan 163
+   name overlapping_name
+!
+vlan 164
+   name overlapping_name
+!
+vlan 165
+   name overlapping_name
+!
 vlan 210
    name Tenant_B_OP_Zone_1
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-CL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-CL1A.yml
@@ -125,6 +125,15 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: 120-121
+    Tenant_A_NFS:
+      tenant: Tenant_A
+      rd: 192.168.255.18:20161
+      route_targets:
+        both:
+        - 20161:20161
+      redistribute_routes:
+      - learned
+      vlan: '161'
     Tenant_A_VMOTION:
       tenant: Tenant_A
       rd: 192.168.255.18:20160
@@ -134,15 +143,6 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: '160'
-    Tenant_A_NFS:
-      tenant: Tenant_A
-      rd: 192.168.255.18:20161
-      route_targets:
-        both:
-        - 20161:20161
-      redistribute_routes:
-      - learned
-      vlan: 161
     Tenant_B_OP_Zone:
       rd: 192.168.255.18:20
       route_targets:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-CL1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-CL1B.yml
@@ -125,6 +125,15 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: 120-121
+    Tenant_A_NFS:
+      tenant: Tenant_A
+      rd: 192.168.255.19:20161
+      route_targets:
+        both:
+        - 20161:20161
+      redistribute_routes:
+      - learned
+      vlan: '161'
     Tenant_A_VMOTION:
       tenant: Tenant_A
       rd: 192.168.255.19:20160
@@ -134,15 +143,6 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: '160'
-    Tenant_A_NFS:
-      tenant: Tenant_A
-      rd: 192.168.255.19:20161
-      route_targets:
-        both:
-        - 20161:20161
-      redistribute_routes:
-      - learned
-      vlan: 161
     Tenant_B_OP_Zone:
       rd: 192.168.255.19:20
       route_targets:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
@@ -230,6 +230,15 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: 120-121
+    Tenant_A_NFS:
+      tenant: Tenant_A
+      rd: 65001:20161
+      route_targets:
+        both:
+        - 100000:20161
+      redistribute_routes:
+      - learned
+      vlan: '161'
     Tenant_A_VMOTION:
       tenant: Tenant_A
       rd: 65001:20160
@@ -239,15 +248,6 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: '160'
-    Tenant_A_NFS:
-      tenant: Tenant_A
-      rd: 65001:20161
-      route_targets:
-        both:
-        - 100000:20161
-      redistribute_routes:
-      - learned
-      vlan: 161
     Tenant_B_OP_Zone:
       rd: '65001:20'
       route_targets:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
@@ -230,6 +230,15 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: 120-121
+    Tenant_A_NFS:
+      tenant: Tenant_A
+      rd: 65001:20161
+      route_targets:
+        both:
+        - 100000:20161
+      redistribute_routes:
+      - learned
+      vlan: '161'
     Tenant_A_VMOTION:
       tenant: Tenant_A
       rd: 65001:20160
@@ -239,15 +248,6 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: '160'
-    Tenant_A_NFS:
-      tenant: Tenant_A
-      rd: 65001:20161
-      route_targets:
-        both:
-        - 100000:20161
-      redistribute_routes:
-      - learned
-      vlan: 161
     Tenant_B_OP_Zone:
       rd: '65001:20'
       route_targets:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3A.yml
@@ -263,6 +263,15 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: 120-121
+    Tenant_A_NFS:
+      tenant: Tenant_A
+      rd: 65103:20161
+      route_targets:
+        both:
+        - 20161:20161
+      redistribute_routes:
+      - learned
+      vlan: '161'
     Tenant_A_VMOTION:
       tenant: Tenant_A
       rd: 65103:20160
@@ -272,15 +281,6 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: '160'
-    Tenant_A_NFS:
-      tenant: Tenant_A
-      rd: 65103:20161
-      route_targets:
-        both:
-        - 20161:20161
-      redistribute_routes:
-      - learned
-      vlan: 161
     Tenant_B_OP_Zone:
       rd: '65103:20'
       route_targets:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3B.yml
@@ -263,6 +263,15 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: 120-121
+    Tenant_A_NFS:
+      tenant: Tenant_A
+      rd: 65103:20161
+      route_targets:
+        both:
+        - 20161:20161
+      redistribute_routes:
+      - learned
+      vlan: '161'
     Tenant_A_VMOTION:
       tenant: Tenant_A
       rd: 65103:20160
@@ -272,15 +281,6 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: '160'
-    Tenant_A_NFS:
-      tenant: Tenant_A
-      rd: 65103:20161
-      route_targets:
-        both:
-        - 20161:20161
-      redistribute_routes:
-      - learned
-      vlan: 161
     Tenant_B_OP_Zone:
       rd: '65103:20'
       route_targets:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1_UNDEPLOYED_LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1_UNDEPLOYED_LEAF1A.yml
@@ -263,6 +263,15 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: 120-121
+    Tenant_A_NFS:
+      tenant: Tenant_A
+      rd: 192.168.255.21:20161
+      route_targets:
+        both:
+        - 20161:20161
+      redistribute_routes:
+      - learned
+      vlan: '161'
     Tenant_A_VMOTION:
       tenant: Tenant_A
       rd: 192.168.255.21:20160
@@ -272,15 +281,6 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: '160'
-    Tenant_A_NFS:
-      tenant: Tenant_A
-      rd: 192.168.255.21:20161
-      route_targets:
-        both:
-        - 20161:20161
-      redistribute_routes:
-      - learned
-      vlan: 161
     Tenant_B_OP_Zone:
       rd: 192.168.255.21:20
       route_targets:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1_UNDEPLOYED_LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1_UNDEPLOYED_LEAF1B.yml
@@ -263,6 +263,15 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: 120-121
+    Tenant_A_NFS:
+      tenant: Tenant_A
+      rd: 192.168.255.22:20161
+      route_targets:
+        both:
+        - 20161:20161
+      redistribute_routes:
+      - learned
+      vlan: '161'
     Tenant_A_VMOTION:
       tenant: Tenant_A
       rd: 192.168.255.22:20160
@@ -272,15 +281,6 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: '160'
-    Tenant_A_NFS:
-      tenant: Tenant_A
-      rd: 192.168.255.22:20161
-      route_targets:
-        both:
-        - 20161:20161
-      redistribute_routes:
-      - learned
-      vlan: 161
     Tenant_B_OP_Zone:
       rd: 192.168.255.22:20
       route_targets:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L2LEAF1A.yml
@@ -106,7 +106,7 @@ vlans:
     name: MULTICAST_ENABLED_8
   9:
     tenant: Tenant_B
-    name: MULTICAST_ENABLED_8
+    name: MULTICAST_ENABLED_9
   330:
     tenant: Tenant_C
     name: L3_MULTICAST_DISABLED_330

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF1A.yml
@@ -326,7 +326,7 @@ router_bgp:
         - 10256:10256
       redistribute_routes:
       - learned
-      vlan: 256
+      vlan: '256'
     MULTICAST_ENABLED_257:
       tenant: Tenant_A
       rd: 192.168.255.3:10257
@@ -336,7 +336,7 @@ router_bgp:
       redistribute_routes:
       - learned
       - igmp
-      vlan: 257
+      vlan: '257'
     MULTICAST_ENABLED_4092:
       tenant: Tenant_A
       rd: 192.168.255.3:14092
@@ -346,7 +346,7 @@ router_bgp:
       redistribute_routes:
       - learned
       - igmp
-      vlan: 4092
+      vlan: '4092'
     MULTICAST_DISABLED_5_6:
       rd: 192.168.255.3:22
       route_targets:
@@ -381,8 +381,18 @@ router_bgp:
         - 10007:10007
       redistribute_routes:
       - learned
-      vlan: 7
+      vlan: '7'
     MULTICAST_ENABLED_8:
+      tenant: Tenant_B
+      rd: 192.168.255.3:10008
+      route_targets:
+        both:
+        - 10008:10008
+      redistribute_routes:
+      - learned
+      - igmp
+      vlan: '8'
+    MULTICAST_ENABLED_9:
       tenant: Tenant_B
       rd: 192.168.255.3:10009
       route_targets:
@@ -391,7 +401,7 @@ router_bgp:
       redistribute_routes:
       - learned
       - igmp
-      vlan: 9
+      vlan: '9'
     TEN_C_L3_MULTICAST_DISABLED_330_331:
       rd: 192.168.255.3:33
       route_targets:
@@ -667,7 +677,7 @@ vlans:
     name: MULTICAST_ENABLED_8
   9:
     tenant: Tenant_B
-    name: MULTICAST_ENABLED_8
+    name: MULTICAST_ENABLED_9
   330:
     tenant: Tenant_C
     name: L3_MULTICAST_DISABLED_330

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF1B.yml
@@ -326,7 +326,7 @@ router_bgp:
         - 10256:10256
       redistribute_routes:
       - learned
-      vlan: 256
+      vlan: '256'
     MULTICAST_ENABLED_257:
       tenant: Tenant_A
       rd: 192.168.255.4:10257
@@ -336,7 +336,7 @@ router_bgp:
       redistribute_routes:
       - learned
       - igmp
-      vlan: 257
+      vlan: '257'
     MULTICAST_ENABLED_4092:
       tenant: Tenant_A
       rd: 192.168.255.4:14092
@@ -346,7 +346,7 @@ router_bgp:
       redistribute_routes:
       - learned
       - igmp
-      vlan: 4092
+      vlan: '4092'
     MULTICAST_DISABLED_5_6:
       rd: 192.168.255.4:22
       route_targets:
@@ -381,8 +381,18 @@ router_bgp:
         - 10007:10007
       redistribute_routes:
       - learned
-      vlan: 7
+      vlan: '7'
     MULTICAST_ENABLED_8:
+      tenant: Tenant_B
+      rd: 192.168.255.4:10008
+      route_targets:
+        both:
+        - 10008:10008
+      redistribute_routes:
+      - learned
+      - igmp
+      vlan: '8'
+    MULTICAST_ENABLED_9:
       tenant: Tenant_B
       rd: 192.168.255.4:10009
       route_targets:
@@ -391,7 +401,7 @@ router_bgp:
       redistribute_routes:
       - learned
       - igmp
-      vlan: 9
+      vlan: '9'
     TEN_C_L3_MULTICAST_DISABLED_330_331:
       rd: 192.168.255.4:33
       route_targets:
@@ -667,7 +677,7 @@ vlans:
     name: MULTICAST_ENABLED_8
   9:
     tenant: Tenant_B
-    name: MULTICAST_ENABLED_8
+    name: MULTICAST_ENABLED_9
   330:
     tenant: Tenant_C
     name: L3_MULTICAST_DISABLED_330

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF2A.yml
@@ -749,7 +749,7 @@ vlans:
     name: MULTICAST_ENABLED_8
   9:
     tenant: Tenant_B
-    name: MULTICAST_ENABLED_8
+    name: MULTICAST_ENABLED_9
   330:
     tenant: Tenant_C
     name: L3_MULTICAST_DISABLED_330

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF3A.yml
@@ -781,7 +781,7 @@ vlans:
     name: MULTICAST_ENABLED_8
   9:
     tenant: Tenant_B
-    name: MULTICAST_ENABLED_8
+    name: MULTICAST_ENABLED_9
   330:
     tenant: Tenant_C
     name: L3_MULTICAST_DISABLED_330

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF3B.yml
@@ -781,7 +781,7 @@ vlans:
     name: MULTICAST_ENABLED_8
   9:
     tenant: Tenant_B
-    name: MULTICAST_ENABLED_8
+    name: MULTICAST_ENABLED_9
   330:
     tenant: Tenant_C
     name: L3_MULTICAST_DISABLED_330

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_false.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_false.yml
@@ -211,6 +211,15 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: 120-121
+    Tenant_A_NFS:
+      tenant: Tenant_A
+      rd: 192.168.255.109:20161
+      route_targets:
+        both:
+        - 20161:20161
+      redistribute_routes:
+      - learned
+      vlan: '161'
     Tenant_A_VMOTION:
       tenant: Tenant_A
       rd: 192.168.255.109:20160
@@ -220,15 +229,6 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: '160'
-    Tenant_A_NFS:
-      tenant: Tenant_A
-      rd: 192.168.255.109:20161
-      route_targets:
-        both:
-        - 20161:20161
-      redistribute_routes:
-      - learned
-      vlan: 161
     l2vlan_with_no_tags:
       tenant: Tenant_A
       rd: 192.168.255.109:20162
@@ -237,7 +237,16 @@ router_bgp:
         - 20162:20162
       redistribute_routes:
       - learned
-      vlan: 162
+      vlan: '162'
+    overlapping_name:
+      tenant: Tenant_A
+      rd: 192.168.255.109:20163
+      route_targets:
+        both:
+        - 20163:20163
+      redistribute_routes:
+      - learned
+      vlan: 163-165
     Tenant_B_OP_Zone:
       rd: 192.168.255.109:20
       route_targets:
@@ -452,6 +461,15 @@ vlans:
   162:
     tenant: Tenant_A
     name: l2vlan_with_no_tags
+  163:
+    tenant: Tenant_A
+    name: overlapping_name
+  164:
+    tenant: Tenant_A
+    name: overlapping_name
+  165:
+    tenant: Tenant_A
+    name: overlapping_name
   210:
     tenant: Tenant_B
     name: Tenant_B_OP_Zone_1
@@ -780,6 +798,12 @@ vxlan_interface:
           vni: 10161
         162:
           vni: 10162
+        163:
+          vni: 10163
+        164:
+          vni: 10164
+        165:
+          vni: 10165
         210:
           vni: 20210
         211:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_true.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_true.yml
@@ -76,6 +76,15 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: 120-121
+    Tenant_A_NFS:
+      tenant: Tenant_A
+      rd: 192.168.255.109:20161
+      route_targets:
+        both:
+        - 20161:20161
+      redistribute_routes:
+      - learned
+      vlan: '161'
     Tenant_A_VMOTION:
       tenant: Tenant_A
       rd: 192.168.255.109:20160
@@ -85,15 +94,6 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: '160'
-    Tenant_A_NFS:
-      tenant: Tenant_A
-      rd: 192.168.255.109:20161
-      route_targets:
-        both:
-        - 20161:20161
-      redistribute_routes:
-      - learned
-      vlan: 161
     l2vlan_with_no_tags:
       tenant: Tenant_A
       rd: 192.168.255.109:20162
@@ -102,7 +102,16 @@ router_bgp:
         - 20162:20162
       redistribute_routes:
       - learned
-      vlan: 162
+      vlan: '162'
+    overlapping_name:
+      tenant: Tenant_A
+      rd: 192.168.255.109:20163
+      route_targets:
+        both:
+        - 20163:20163
+      redistribute_routes:
+      - learned
+      vlan: 163-165
     Tenant_B_OP_Zone:
       rd: 192.168.255.109:20
       route_targets:
@@ -272,6 +281,15 @@ vlans:
   162:
     tenant: Tenant_A
     name: l2vlan_with_no_tags
+  163:
+    tenant: Tenant_A
+    name: overlapping_name
+  164:
+    tenant: Tenant_A
+    name: overlapping_name
+  165:
+    tenant: Tenant_A
+    name: overlapping_name
   210:
     tenant: Tenant_B
     name: Tenant_B_OP_Zone_1
@@ -353,6 +371,12 @@ vxlan_interface:
           vni: 10161
         162:
           vni: 10162
+        163:
+          vni: 10163
+        164:
+          vni: 10164
+        165:
+          vni: 10165
         210:
           vni: 20210
         211:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_default.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_default.yml
@@ -99,6 +99,15 @@ vlans:
   162:
     tenant: Tenant_A
     name: l2vlan_with_no_tags
+  163:
+    tenant: Tenant_A
+    name: overlapping_name
+  164:
+    tenant: Tenant_A
+    name: overlapping_name
+  165:
+    tenant: Tenant_A
+    name: overlapping_name
   210:
     tenant: Tenant_B
     name: Tenant_B_OP_Zone_1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_fabric.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_fabric.yml
@@ -99,6 +99,15 @@ vlans:
   162:
     tenant: Tenant_A
     name: l2vlan_with_no_tags
+  163:
+    tenant: Tenant_A
+    name: overlapping_name
+  164:
+    tenant: Tenant_A
+    name: overlapping_name
+  165:
+    tenant: Tenant_A
+    name: overlapping_name
   210:
     tenant: Tenant_B
     name: Tenant_B_OP_Zone_1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_host.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_host.yml
@@ -105,6 +105,15 @@ vlans:
   162:
     tenant: Tenant_A
     name: l2vlan_with_no_tags
+  163:
+    tenant: Tenant_A
+    name: overlapping_name
+  164:
+    tenant: Tenant_A
+    name: overlapping_name
+  165:
+    tenant: Tenant_A
+    name: overlapping_name
   210:
     tenant: Tenant_B
     name: Tenant_B_OP_Zone_1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_platform.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_platform.yml
@@ -105,6 +105,15 @@ vlans:
   162:
     tenant: Tenant_A
     name: l2vlan_with_no_tags
+  163:
+    tenant: Tenant_A
+    name: overlapping_name
+  164:
+    tenant: Tenant_A
+    name: overlapping_name
+  165:
+    tenant: Tenant_A
+    name: overlapping_name
   210:
     tenant: Tenant_B
     name: Tenant_B_OP_Zone_1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_A.yml
@@ -255,3 +255,9 @@ Tenant_A:
     162:
       name: l2vlan_with_no_tags
       # No "tags" defined - should render on switches with tag "all" or no tags
+    163:
+      name: overlapping_name
+    164:
+      name: overlapping_name
+    165:
+      name: overlapping_name

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/EVPN_MULTICAST_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/EVPN_MULTICAST_TESTS.yml
@@ -208,7 +208,7 @@ tenants:
         evpn_l2_multicast:
           enabled: true
       9:
-        name: "MULTICAST_ENABLED_8"
+        name: "MULTICAST_ENABLED_9"
         tags: ['test_l2']
         evpn_l2_multicast:
           enabled: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-CL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-CL1A.yml
@@ -125,6 +125,15 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: 120-121
+    Tenant_A_NFS:
+      tenant: Tenant_A
+      rd: 192.168.255.18:20161
+      route_targets:
+        both:
+        - 20161:20161
+      redistribute_routes:
+      - learned
+      vlan: '161'
     Tenant_A_VMOTION:
       tenant: Tenant_A
       rd: 192.168.255.18:20160
@@ -134,15 +143,6 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: '160'
-    Tenant_A_NFS:
-      tenant: Tenant_A
-      rd: 192.168.255.18:20161
-      route_targets:
-        both:
-        - 20161:20161
-      redistribute_routes:
-      - learned
-      vlan: 161
     Tenant_B_OP_Zone:
       rd: 192.168.255.18:20
       route_targets:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-CL1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-CL1B.yml
@@ -125,6 +125,15 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: 120-121
+    Tenant_A_NFS:
+      tenant: Tenant_A
+      rd: 192.168.255.19:20161
+      route_targets:
+        both:
+        - 20161:20161
+      redistribute_routes:
+      - learned
+      vlan: '161'
     Tenant_A_VMOTION:
       tenant: Tenant_A
       rd: 192.168.255.19:20160
@@ -134,15 +143,6 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: '160'
-    Tenant_A_NFS:
-      tenant: Tenant_A
-      rd: 192.168.255.19:20161
-      route_targets:
-        both:
-        - 20161:20161
-      redistribute_routes:
-      - learned
-      vlan: 161
     Tenant_B_OP_Zone:
       rd: 192.168.255.19:20
       route_targets:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-LEAF2A.yml
@@ -176,6 +176,15 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: 120-121
+    Tenant_A_NFS:
+      tenant: Tenant_A
+      rd: 65001:20161
+      route_targets:
+        both:
+        - 100000:20161
+      redistribute_routes:
+      - learned
+      vlan: '161'
     Tenant_A_VMOTION:
       tenant: Tenant_A
       rd: 65001:20160
@@ -185,15 +194,6 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: '160'
-    Tenant_A_NFS:
-      tenant: Tenant_A
-      rd: 65001:20161
-      route_targets:
-        both:
-        - 100000:20161
-      redistribute_routes:
-      - learned
-      vlan: 161
     Tenant_B_OP_Zone:
       rd: '65001:20'
       route_targets:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-LEAF2B.yml
@@ -176,6 +176,15 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: 120-121
+    Tenant_A_NFS:
+      tenant: Tenant_A
+      rd: 65001:20161
+      route_targets:
+        both:
+        - 100000:20161
+      redistribute_routes:
+      - learned
+      vlan: '161'
     Tenant_A_VMOTION:
       tenant: Tenant_A
       rd: 65001:20160
@@ -185,15 +194,6 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: '160'
-    Tenant_A_NFS:
-      tenant: Tenant_A
-      rd: 65001:20161
-      route_targets:
-        both:
-        - 100000:20161
-      redistribute_routes:
-      - learned
-      vlan: 161
     Tenant_B_OP_Zone:
       rd: '65001:20'
       route_targets:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SVC3A.yml
@@ -263,6 +263,15 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: 120-121
+    Tenant_A_NFS:
+      tenant: Tenant_A
+      rd: 65103:20161
+      route_targets:
+        both:
+        - 20161:20161
+      redistribute_routes:
+      - learned
+      vlan: '161'
     Tenant_A_VMOTION:
       tenant: Tenant_A
       rd: 65103:20160
@@ -272,15 +281,6 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: '160'
-    Tenant_A_NFS:
-      tenant: Tenant_A
-      rd: 65103:20161
-      route_targets:
-        both:
-        - 20161:20161
-      redistribute_routes:
-      - learned
-      vlan: 161
     Tenant_B_OP_Zone:
       rd: '65103:20'
       route_targets:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SVC3B.yml
@@ -263,6 +263,15 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: 120-121
+    Tenant_A_NFS:
+      tenant: Tenant_A
+      rd: 65103:20161
+      route_targets:
+        both:
+        - 20161:20161
+      redistribute_routes:
+      - learned
+      vlan: '161'
     Tenant_A_VMOTION:
       tenant: Tenant_A
       rd: 65103:20160
@@ -272,15 +281,6 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: '160'
-    Tenant_A_NFS:
-      tenant: Tenant_A
-      rd: 65103:20161
-      route_targets:
-        both:
-        - 20161:20161
-      redistribute_routes:
-      - learned
-      vlan: 161
     Tenant_B_OP_Zone:
       rd: '65103:20'
       route_targets:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/evpn_services_l2_only_false.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/evpn_services_l2_only_false.yml
@@ -187,6 +187,15 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: 120-121
+    Tenant_A_NFS:
+      tenant: Tenant_A
+      rd: 192.168.255.109:20161
+      route_targets:
+        both:
+        - 20161:20161
+      redistribute_routes:
+      - learned
+      vlan: '161'
     Tenant_A_VMOTION:
       tenant: Tenant_A
       rd: 192.168.255.109:20160
@@ -196,15 +205,6 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: '160'
-    Tenant_A_NFS:
-      tenant: Tenant_A
-      rd: 192.168.255.109:20161
-      route_targets:
-        both:
-        - 20161:20161
-      redistribute_routes:
-      - learned
-      vlan: 161
     l2vlan_with_no_tags:
       tenant: Tenant_A
       rd: 192.168.255.109:20162
@@ -213,7 +213,7 @@ router_bgp:
         - 20162:20162
       redistribute_routes:
       - learned
-      vlan: 162
+      vlan: '162'
     Tenant_B_OP_Zone:
       rd: 192.168.255.109:20
       route_targets:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/evpn_services_l2_only_true.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/evpn_services_l2_only_true.yml
@@ -76,6 +76,15 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: 120-121
+    Tenant_A_NFS:
+      tenant: Tenant_A
+      rd: 192.168.255.109:20161
+      route_targets:
+        both:
+        - 20161:20161
+      redistribute_routes:
+      - learned
+      vlan: '161'
     Tenant_A_VMOTION:
       tenant: Tenant_A
       rd: 192.168.255.109:20160
@@ -85,15 +94,6 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: '160'
-    Tenant_A_NFS:
-      tenant: Tenant_A
-      rd: 192.168.255.109:20161
-      route_targets:
-        both:
-        - 20161:20161
-      redistribute_routes:
-      - learned
-      vlan: 161
     l2vlan_with_no_tags:
       tenant: Tenant_A
       rd: 192.168.255.109:20162
@@ -102,7 +102,7 @@ router_bgp:
         - 20162:20162
       redistribute_routes:
       - learned
-      vlan: 162
+      vlan: '162'
     Tenant_B_OP_Zone:
       rd: 192.168.255.109:20
       route_targets:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -175,6 +175,24 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: 120-124
+    Tenant_A_FTP:
+      tenant: Tenant_A
+      rd: 192.168.255.10:10162
+      route_targets:
+        both:
+        - 10162:10162
+      redistribute_routes:
+      - learned
+      vlan: '162'
+    Tenant_A_NFS:
+      tenant: Tenant_A
+      rd: 192.168.255.10:10161
+      route_targets:
+        both:
+        - 10161:10161
+      redistribute_routes:
+      - learned
+      vlan: '161'
     Tenant_A_VMOTION:
       tenant: Tenant_A
       rd: 192.168.255.10:10160
@@ -184,24 +202,6 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: '160'
-    Tenant_A_NFS:
-      tenant: Tenant_A
-      rd: 192.168.255.10:10161
-      route_targets:
-        both:
-        - 10161:10161
-      redistribute_routes:
-      - learned
-      vlan: 161
-    Tenant_A_FTP:
-      tenant: Tenant_A
-      rd: 192.168.255.10:10162
-      route_targets:
-        both:
-        - 10162:10162
-      redistribute_routes:
-      - learned
-      vlan: 162
     Tenant_B_OP_Zone:
       rd: 192.168.255.10:20
       route_targets:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -175,6 +175,24 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: 120-124
+    Tenant_A_FTP:
+      tenant: Tenant_A
+      rd: 192.168.255.11:10162
+      route_targets:
+        both:
+        - 10162:10162
+      redistribute_routes:
+      - learned
+      vlan: '162'
+    Tenant_A_NFS:
+      tenant: Tenant_A
+      rd: 192.168.255.11:10161
+      route_targets:
+        both:
+        - 10161:10161
+      redistribute_routes:
+      - learned
+      vlan: '161'
     Tenant_A_VMOTION:
       tenant: Tenant_A
       rd: 192.168.255.11:10160
@@ -184,24 +202,6 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: '160'
-    Tenant_A_NFS:
-      tenant: Tenant_A
-      rd: 192.168.255.11:10161
-      route_targets:
-        both:
-        - 10161:10161
-      redistribute_routes:
-      - learned
-      vlan: 161
-    Tenant_A_FTP:
-      tenant: Tenant_A
-      rd: 192.168.255.11:10162
-      route_targets:
-        both:
-        - 10162:10162
-      redistribute_routes:
-      - learned
-      vlan: 162
     Tenant_B_OP_Zone:
       rd: 192.168.255.11:20
       route_targets:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -263,6 +263,24 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: 120-124
+    Tenant_A_FTP:
+      tenant: Tenant_A
+      rd: 192.168.255.12:10162
+      route_targets:
+        both:
+        - 10162:10162
+      redistribute_routes:
+      - learned
+      vlan: '162'
+    Tenant_A_NFS:
+      tenant: Tenant_A
+      rd: 192.168.255.12:10161
+      route_targets:
+        both:
+        - 10161:10161
+      redistribute_routes:
+      - learned
+      vlan: '161'
     Tenant_A_VMOTION:
       tenant: Tenant_A
       rd: 192.168.255.12:10160
@@ -272,24 +290,6 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: '160'
-    Tenant_A_NFS:
-      tenant: Tenant_A
-      rd: 192.168.255.12:10161
-      route_targets:
-        both:
-        - 10161:10161
-      redistribute_routes:
-      - learned
-      vlan: 161
-    Tenant_A_FTP:
-      tenant: Tenant_A
-      rd: 192.168.255.12:10162
-      route_targets:
-        both:
-        - 10162:10162
-      redistribute_routes:
-      - learned
-      vlan: 162
     Tenant_B_OP_Zone:
       rd: 192.168.255.12:20
       route_targets:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -263,6 +263,24 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: 120-124
+    Tenant_A_FTP:
+      tenant: Tenant_A
+      rd: 192.168.255.13:10162
+      route_targets:
+        both:
+        - 10162:10162
+      redistribute_routes:
+      - learned
+      vlan: '162'
+    Tenant_A_NFS:
+      tenant: Tenant_A
+      rd: 192.168.255.13:10161
+      route_targets:
+        both:
+        - 10161:10161
+      redistribute_routes:
+      - learned
+      vlan: '161'
     Tenant_A_VMOTION:
       tenant: Tenant_A
       rd: 192.168.255.13:10160
@@ -272,24 +290,6 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: '160'
-    Tenant_A_NFS:
-      tenant: Tenant_A
-      rd: 192.168.255.13:10161
-      route_targets:
-        both:
-        - 10161:10161
-      redistribute_routes:
-      - learned
-      vlan: 161
-    Tenant_A_FTP:
-      tenant: Tenant_A
-      rd: 192.168.255.13:10162
-      route_targets:
-        both:
-        - 10162:10162
-      redistribute_routes:
-      - learned
-      vlan: 162
     Tenant_B_OP_Zone:
       rd: 192.168.255.13:20
       route_targets:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -225,6 +225,15 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: 120-121
+    Tenant_A_NFS:
+      tenant: Tenant_A
+      rd: 192.168.255.6:10161
+      route_targets:
+        both:
+        - 10161:10161
+      redistribute_routes:
+      - learned
+      vlan: '161'
     Tenant_A_VMOTION:
       tenant: Tenant_A
       rd: 192.168.255.6:10160
@@ -234,15 +243,6 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: '160'
-    Tenant_A_NFS:
-      tenant: Tenant_A
-      rd: 192.168.255.6:10161
-      route_targets:
-        both:
-        - 10161:10161
-      redistribute_routes:
-      - learned
-      vlan: 161
     Tenant_B_OP_Zone:
       rd: 192.168.255.6:20
       route_targets:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -225,6 +225,15 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: 120-121
+    Tenant_A_NFS:
+      tenant: Tenant_A
+      rd: 192.168.255.7:10161
+      route_targets:
+        both:
+        - 10161:10161
+      redistribute_routes:
+      - learned
+      vlan: '161'
     Tenant_A_VMOTION:
       tenant: Tenant_A
       rd: 192.168.255.7:10160
@@ -234,15 +243,6 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: '160'
-    Tenant_A_NFS:
-      tenant: Tenant_A
-      rd: 192.168.255.7:10161
-      route_targets:
-        both:
-        - 10161:10161
-      redistribute_routes:
-      - learned
-      vlan: 161
     Tenant_B_OP_Zone:
       rd: 192.168.255.7:20
       route_targets:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF3A.yml
@@ -207,6 +207,15 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: 120-121
+    Tenant_A_NFS:
+      tenant: Tenant_A
+      rd: 192.168.255.12:10161
+      route_targets:
+        both:
+        - 10161:10161
+      redistribute_routes:
+      - learned
+      vlan: '161'
     Tenant_A_VMOTION:
       tenant: Tenant_A
       rd: 192.168.255.12:10160
@@ -216,15 +225,6 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: '160'
-    Tenant_A_NFS:
-      tenant: Tenant_A
-      rd: 192.168.255.12:10161
-      route_targets:
-        both:
-        - 10161:10161
-      redistribute_routes:
-      - learned
-      vlan: 161
     Tenant_B_OP_Zone:
       rd: 192.168.255.12:20
       route_targets:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF3B.yml
@@ -207,6 +207,15 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: 120-121
+    Tenant_A_NFS:
+      tenant: Tenant_A
+      rd: 192.168.255.13:10161
+      route_targets:
+        both:
+        - 10161:10161
+      redistribute_routes:
+      - learned
+      vlan: '161'
     Tenant_A_VMOTION:
       tenant: Tenant_A
       rd: 192.168.255.13:10160
@@ -216,15 +225,6 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: '160'
-    Tenant_A_NFS:
-      tenant: Tenant_A
-      rd: 192.168.255.13:10161
-      route_targets:
-        both:
-        - 10161:10161
-      redistribute_routes:
-      - learned
-      vlan: 161
     Tenant_B_OP_Zone:
       rd: 192.168.255.13:20
       route_targets:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF4A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF4A.yml
@@ -207,6 +207,15 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: 120-121
+    Tenant_A_NFS:
+      tenant: Tenant_A
+      rd: 192.168.255.14:10161
+      route_targets:
+        both:
+        - 10161:10161
+      redistribute_routes:
+      - learned
+      vlan: '161'
     Tenant_A_VMOTION:
       tenant: Tenant_A
       rd: 192.168.255.14:10160
@@ -216,15 +225,6 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: '160'
-    Tenant_A_NFS:
-      tenant: Tenant_A
-      rd: 192.168.255.14:10161
-      route_targets:
-        both:
-        - 10161:10161
-      redistribute_routes:
-      - learned
-      vlan: 161
     Tenant_B_OP_Zone:
       rd: 192.168.255.14:20
       route_targets:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF4B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF4B.yml
@@ -207,6 +207,15 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: 120-121
+    Tenant_A_NFS:
+      tenant: Tenant_A
+      rd: 192.168.255.15:10161
+      route_targets:
+        both:
+        - 10161:10161
+      redistribute_routes:
+      - learned
+      vlan: '161'
     Tenant_A_VMOTION:
       tenant: Tenant_A
       rd: 192.168.255.15:10160
@@ -216,15 +225,6 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: '160'
-    Tenant_A_NFS:
-      tenant: Tenant_A
-      rd: 192.168.255.15:10161
-      route_targets:
-        both:
-        - 10161:10161
-      redistribute_routes:
-      - learned
-      vlan: 161
     Tenant_B_OP_Zone:
       rd: 192.168.255.15:20
       route_targets:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -284,6 +284,15 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: 120-121
+    Tenant_A_NFS:
+      tenant: Tenant_A
+      rd: 192.168.255.8:10161
+      route_targets:
+        both:
+        - 10161:10161
+      redistribute_routes:
+      - learned
+      vlan: '161'
     Tenant_A_VMOTION:
       tenant: Tenant_A
       rd: 192.168.255.8:10160
@@ -293,15 +302,6 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: '160'
-    Tenant_A_NFS:
-      tenant: Tenant_A
-      rd: 192.168.255.8:10161
-      route_targets:
-        both:
-        - 10161:10161
-      redistribute_routes:
-      - learned
-      vlan: 161
     Tenant_B_OP_Zone:
       rd: 192.168.255.8:20
       route_targets:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -284,6 +284,15 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: 120-121
+    Tenant_A_NFS:
+      tenant: Tenant_A
+      rd: 192.168.255.9:10161
+      route_targets:
+        both:
+        - 10161:10161
+      redistribute_routes:
+      - learned
+      vlan: '161'
     Tenant_A_VMOTION:
       tenant: Tenant_A
       rd: 192.168.255.9:10160
@@ -293,15 +302,6 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: '160'
-    Tenant_A_NFS:
-      tenant: Tenant_A
-      rd: 192.168.255.9:10161
-      route_targets:
-        both:
-        - 10161:10161
-      redistribute_routes:
-      - learned
-      vlan: 161
     Tenant_B_OP_Zone:
       rd: 192.168.255.9:20
       route_targets:

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
@@ -617,6 +617,8 @@ mac_address_table:
         rt_override: < 1-16777215 | default -> vni_override >
 
         # VLAN name | Required
+        # For EVPN vlan-aware-bundles the VLAN name is also used as the bundle name for l2vlans.
+        # If the same name is used on multiple VLANs they will be added to the same bundle.
         name: < description >
 
         # Tags leveraged for network services filtering. | Optional


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Handle overlapping VLAN names for l2vlans and vlan-aware-bundles

## Related Issue(s)

Fixes #2387 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

- Add molecule test with overlapping vlan names
- Fix logic to add all vlans with the same name to the same bundle
- Fix typo in multicast molecule (duplicate vlan name), since it got triggered by this fix.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
