### PR TITLE
Fix(eos_cli_config_gen): Add convert_types to router ospf area id schema

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-ospf.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-ospf.md
@@ -244,7 +244,7 @@ interface Vlan24
 | Process ID | Area | Area Type | Filter Networks | Filter Prefix List | Additional Options |
 | ---------- | ---- | --------- | --------------- | ------------------ | ------------------ |
 | 200 | 0.0.0.2 | normal | 1.1.1.0/24, 2.2.2.0/24 | - |  |
-| 200 | 0.0.0.3 | normal | - | PL-OSPF-FILTERING |  |
+| 200 | 3 | normal | - | PL-OSPF-FILTERING |  |
 | 600 | 0.0.0.1 | normal | - | - |  |
 | 600 | 0.0.10.11 | stub | - | - | no-summary |
 | 600 | 0.0.20.20 | nssa | - | - |  |
@@ -309,7 +309,7 @@ router ospf 200 vrf ospf_zone
    router-id 192.168.254.1
    area 0.0.0.2 filter 1.1.1.0/24
    area 0.0.0.2 filter 2.2.2.0/24
-   area 0.0.0.3 filter prefix-list PL-OSPF-FILTERING
+   area 3 filter prefix-list PL-OSPF-FILTERING
    max-lsa 5
    timers lsa rx min interval 100
    default-information originate always

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-ospf.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-ospf.cfg
@@ -79,7 +79,7 @@ router ospf 200 vrf ospf_zone
    router-id 192.168.254.1
    area 0.0.0.2 filter 1.1.1.0/24
    area 0.0.0.2 filter 2.2.2.0/24
-   area 0.0.0.3 filter prefix-list PL-OSPF-FILTERING
+   area 3 filter prefix-list PL-OSPF-FILTERING
    max-lsa 5
    timers lsa rx min interval 100
    default-information originate always

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-ospf.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-ospf.yml
@@ -80,7 +80,7 @@ router_ospf:
             networks:
               - 1.1.1.0/24
               - 2.2.2.0/24
-        '0.0.0.3':
+        3:
           filter:
             prefix_list: PL-OSPF-FILTERING
       max_metric: # not expected to produce config. Just here to test proper variable checks.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -8173,6 +8173,8 @@ keys:
                 keys:
                   id:
                     type: str
+                    convert_types:
+                    - int
                   filter:
                     type: dict
                     keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_ospf.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_ospf.schema.yml
@@ -198,6 +198,8 @@ keys:
                 keys:
                   id:
                     type: str
+                    convert_types:
+                      - int
                   filter:
                     type: dict
                     keys:


### PR DESCRIPTION
## Change Summary

The `router_ospf > areas` expects the area to be input as a string (i.e. "0.0.0.2"), and if an user inputs the area number as an integer, it gets the following error message:

```
[WARNING]: b"[leaf1]: 'Validation Error: router_ospf.process_ids[0].areas[0].id': 2 is not of type 'str'"  
```

The EOS CLI will let users input the ospf area in both format, so to avoid this error and allow users to input the area as an integer or string, we need to check and convert from `int` to `str` if that's the case. 

## Related Issue(s)

N/A

## Component(s) name

`arista.avd.eso_cli_config_gen`

## Proposed changes

This is the current `router_ospf` area schema: 

```yml
            areas:
              type: list
              primary_key: id
              convert_types:
                - dict
              items:
                type: dict
                keys:
                  id:
                    type: str
```
Proposed new schema: 

```yml
            areas:
              type: list
              primary_key: id
              convert_types:
                - dict
              items:
                type: dict
                keys:
                  id:
                    type: str
                    convert_types:
                      - int
```

## How to test

`molecule converge -s eos_cli_config_gen`

## Checklist

### User Checklist

- N/A

### Repository Checklist

- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
