### PR TITLE
Refactor(eos_designs): Use natural_sort instead of sorted everywhere (#2384)

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf1a.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf1a.yml
@@ -227,8 +227,8 @@ vlans:
     name: l2vlan110_with_trunk_groups
   200:
     trunk_groups:
-    - TRUNK_GROUP_TESTS_L2LEAF1
     - trunk-group-tests-l2leaf3
+    - TRUNK_GROUP_TESTS_L2LEAF1
     - TG_200
     - TG_NOT_MATCHING_ANY_SERVERS
     - MLAG
@@ -236,8 +236,8 @@ vlans:
     name: svi200_with_trunk_groups
   210:
     trunk_groups:
-    - TRUNK_GROUP_TESTS_L2LEAF1
     - trunk-group-tests-l2leaf3
+    - TRUNK_GROUP_TESTS_L2LEAF1
     - TG_200
     - TG_NOT_MATCHING_ANY_SERVERS
     - MLAG

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf1b.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf1b.yml
@@ -223,15 +223,15 @@ vlans:
     name: l2vlan110_with_trunk_groups
   200:
     trunk_groups:
-    - TRUNK_GROUP_TESTS_L2LEAF1
     - trunk-group-tests-l2leaf3
+    - TRUNK_GROUP_TESTS_L2LEAF1
     - CUSTOM_MLAG_TG_NAME
     tenant: TRUNK_GROUP_TESTS
     name: svi200_with_trunk_groups
   210:
     trunk_groups:
-    - TRUNK_GROUP_TESTS_L2LEAF1
     - trunk-group-tests-l2leaf3
+    - TRUNK_GROUP_TESTS_L2LEAF1
     - CUSTOM_MLAG_TG_NAME
     tenant: TRUNK_GROUP_TESTS
     name: l2vlan210_with_trunk_groups

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/overlay/route_maps.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/overlay/route_maps.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from functools import cached_property
 
+from ansible_collections.arista.avd.plugins.filter.natural_sort import natural_sort
+
 from .utils import UtilsMixin
 
 
@@ -29,7 +31,7 @@ class RouteMapsMixin(UtilsMixin):
 
         if self._overlay_routing_protocol == "ebgp":
             if self._evpn_prevent_readvertise_to_server is True:
-                remote_asns = sorted(list(set(self._evpn_route_servers[route_server].get("bgp_as") for route_server in self._evpn_route_servers)))
+                remote_asns = natural_sort(set(self._evpn_route_servers[route_server].get("bgp_as") for route_server in self._evpn_route_servers))
                 for remote_asn in remote_asns:
                     route_map_name = f"RM-EVPN-FILTER-AS{ remote_asn }"
                     route_maps[route_map_name] = {

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/vlans.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/vlans.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from functools import cached_property
 
+from ansible_collections.arista.avd.plugins.filter.natural_sort import natural_sort
 from ansible_collections.arista.avd.plugins.filter.range_expand import range_expand
 
 from .utils import UtilsMixin
@@ -30,7 +31,7 @@ class VlansMixin(UtilsMixin):
                 vlans.setdefault(int(vlan), {"trunk_groups": []})["trunk_groups"].extend(vlan_trunk_group["trunk_groups"])
 
         for vlan, vlan_dict in vlans.items():
-            vlan_dict["trunk_groups"] = sorted(list(set(vlan_dict["trunk_groups"])))
+            vlan_dict["trunk_groups"] = natural_sort(set(vlan_dict["trunk_groups"]))
 
         if vlans:
             return vlans


### PR DESCRIPTION
Cherry-pick of #2384 for 3.8 release