### PR TITLE
Fix(eos_cli_config_gen): Render LLDP commands on ethernet_interfaces also for port-channel members (#2386)

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
@@ -192,6 +192,8 @@ interface Ethernet18
 interface Ethernet50
    description SRV-POD03_Eth1
    channel-group 5 mode active
+   no lldp transmit
+   no lldp receive
 ```
 
 ## Port-Channel Interfaces

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
@@ -377,6 +377,8 @@ interface Ethernet18
 interface Ethernet50
    description SRV-POD03_Eth1
    channel-group 5 mode active
+   no lldp transmit
+   no lldp receive
 !
 interface Management1
    description oob_management

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
@@ -387,6 +387,9 @@ ethernet_interfaces:
     channel_group:
       id: 5
       mode: "active"
+    lldp:
+      receive: false
+      transmit: false
 
   Ethernet8:
     peer: DC1-LEAF1B

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -354,6 +354,15 @@ interface {{ ethernet_interface.name }}
    lacp port-priority {{ ethernet_interface.lacp_port_priority }}
 {%         endif %}
 {%     endif %}
+{%     if ethernet_interface.lldp.transmit is arista.avd.defined(false) %}
+   no lldp transmit
+{%     endif %}
+{%     if ethernet_interface.lldp.receive is arista.avd.defined(false) %}
+   no lldp receive
+{%     endif %}
+{%     if ethernet_interface.lldp.ztp_vlan is arista.avd.defined %}
+   lldp tlv transmit ztp vlan {{ ethernet_interface.lldp.ztp_vlan }}
+{%     endif %}
 {%     if print_ethernet is arista.avd.defined(true) %}
 {%         if ethernet_interface.mpls.ldp.igp_sync is arista.avd.defined(true) %}
    mpls ldp igp sync
@@ -362,15 +371,6 @@ interface {{ ethernet_interface.name }}
    mpls ldp interface
 {%         elif ethernet_interface.mpls.ldp.interface is arista.avd.defined(false) %}
    no mpls ldp interface
-{%         endif %}
-{%         if ethernet_interface.lldp.transmit is arista.avd.defined(false) %}
-   no lldp transmit
-{%         endif %}
-{%         if ethernet_interface.lldp.receive is arista.avd.defined(false) %}
-   no lldp receive
-{%         endif %}
-{%         if ethernet_interface.lldp.ztp_vlan is arista.avd.defined %}
-   lldp tlv transmit ztp vlan {{ ethernet_interface.lldp.ztp_vlan }}
 {%         endif %}
 {%         if ethernet_interface.access_group_in is arista.avd.defined %}
    ip access-group {{ ethernet_interface.access_group_in }} in


### PR DESCRIPTION
Cherry-pick of #2386 for 3.8 release