### PR TITLE
Feat(plugins): Make 'dest' optional on 'validate_and_template'

### DIFF
--- a/ansible_collections/arista/avd/plugins/README.md
+++ b/ansible_collections/arista/avd/plugins/README.md
@@ -634,13 +634,15 @@ For Markdown files the plugin can also run `md_toc` on the output before writing
 The module is used in `eos_cli_config_gen` for generating configuration and documentation outputs. By combining conversion, validation
 and template generation in a single tasks, we can avoid Ansible's variable precendence from interfering with the converted vars.
 
+If `dest` is not set, the template output will be returned under the `output` key in the result.
+
 The module arguments are:
 
 ```yaml
   # Path to Jinja2 Template file | Required
   template: <str>
 
-  # Destination path. The rendered template will be written to this file | Required
+  # Destination path. The rendered template will be written to this file | Optional
   dest: <str>
 
   # File mode for dest file | Optional

--- a/ansible_collections/arista/avd/plugins/action/validate_and_template.py
+++ b/ansible_collections/arista/avd/plugins/action/validate_and_template.py
@@ -33,7 +33,7 @@ class ActionModule(ActionBase):
         validation_mode = self._task.args.get("validation_mode")
 
         dest = self._task.args.get("dest")
-        if dest is not None and not isinstance(self.dest, str):
+        if dest is not None and not isinstance(dest, str):
             raise AnsibleActionFail("The argument 'dest' must be a string if set")
 
         self.add_md_toc = self._task.args.get("add_md_toc", False)

--- a/ansible_collections/arista/avd/plugins/action/validate_and_template.py
+++ b/ansible_collections/arista/avd/plugins/action/validate_and_template.py
@@ -23,17 +23,18 @@ class ActionModule(ActionBase):
             self.templatefile = self._task.args["template"]
             if not isinstance(self.templatefile, str):
                 raise AnsibleActionFail("The argument 'template' must be a string")
-            self.dest = self._task.args["dest"]
-            if not isinstance(self.dest, str):
-                raise AnsibleActionFail("The argument 'dest' must be a string")
             schema = self._task.args["schema"]
             if not isinstance(schema, dict):
                 raise AnsibleActionFail("The argument 'schema' must be a dict")
         else:
-            raise AnsibleActionFail("The arguments 'template', 'dest' and 'schema' must be set")
+            raise AnsibleActionFail("The arguments 'template' and 'schema' must be set")
 
         conversion_mode = self._task.args.get("conversion_mode")
         validation_mode = self._task.args.get("validation_mode")
+
+        dest = self._task.args.get("dest")
+        if dest is not None and not isinstance(self.dest, str):
+            raise AnsibleActionFail("The argument 'dest' must be a string if set")
 
         self.add_md_toc = self._task.args.get("add_md_toc", False)
         if not isinstance(self.add_md_toc, bool):
@@ -55,11 +56,11 @@ class ActionModule(ActionBase):
         # Template to file
         # Update result from Ansible "copy" operation (setting 'changed' flag accordingly)
         if not result.get("failed"):
-            result.update(self.template(task_vars))
+            result.update(self.template(task_vars, dest))
 
         return result
 
-    def template(self, task_vars):
+    def template(self, task_vars, dest):
         # Get updated templar instance to be passed along to our simplified "templater"
         templar = get_templar(self, task_vars)
 
@@ -67,19 +68,23 @@ class ActionModule(ActionBase):
         if self.add_md_toc:
             output = add_md_toc(output, skip_lines=self.md_toc_skip_lines)
 
-        write_file_result = self.write_file(output, task_vars)
+        if dest is None:
+            # Return dict with template output in 'output' key for fileless operation
+            return {"output": output}
+
+        write_file_result = self.write_file(output, dest, task_vars)
 
         # Return result with the result from the copy operation
         return write_file_result
 
-    def write_file(self, content, task_vars):
+    def write_file(self, content, dest, task_vars):
         """
         This function implements the Ansible 'copy' action_module, to benefit from Ansible builtin functionality like 'changed'.
         Reuse task data
         """
         new_task = self._task.copy()
         new_task.args = {
-            "dest": self.dest,
+            "dest": dest,
             "mode": self._task.args.get("mode"),
             "content": content,
         }


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Make 'dest' optional on 'validate_and_template'

## Related Issue(s)

Required for running AVD components in readonly environments, pulling output configs from registered vars.

## Component(s) name

`arista.avd.validate_and_template`

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
