### PR TITLE
Fix(eos_cli_config_gen): Update Schema for OSPF maximum paths from 32 to 128

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -3517,7 +3517,7 @@ router_ospf:
           default_information_originate:
             metric: < Integer 1-65535 > # Value of the route metric
             metric_type: < 1 | 2 > # OSPF metric type
-      maximum_paths: < Integer 1-64 >
+      maximum_paths: < Integer 1-128 >
       max_metric:
         router_lsa:
           external_lsa:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -3517,7 +3517,7 @@ router_ospf:
           default_information_originate:
             metric: < Integer 1-65535 > # Value of the route metric
             metric_type: < 1 | 2 > # OSPF metric type
-      maximum_paths: < Integer 1-32 >
+      maximum_paths: < Integer 1-64 >
       max_metric:
         router_lsa:
           external_lsa:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -5375,7 +5375,7 @@ router_multicast:
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;default_information_originate</samp>](## "router_ospf.process_ids.[].areas.[].default_information_originate") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;metric</samp>](## "router_ospf.process_ids.[].areas.[].default_information_originate.metric") | Integer |  |  | Min: 1<br>Max: 65535 | Metric for default route |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;metric_type</samp>](## "router_ospf.process_ids.[].areas.[].default_information_originate.metric_type") | Integer |  |  | Valid Values:<br>- 1<br>- 2 | OSPF metric type for default route |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;maximum_paths</samp>](## "router_ospf.process_ids.[].maximum_paths") | Integer |  |  | Min: 1<br>Max: 32 |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;maximum_paths</samp>](## "router_ospf.process_ids.[].maximum_paths") | Integer |  |  | Min: 1<br>Max: 64 |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;max_metric</samp>](## "router_ospf.process_ids.[].max_metric") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;router_lsa</samp>](## "router_ospf.process_ids.[].max_metric.router_lsa") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;external_lsa</samp>](## "router_ospf.process_ids.[].max_metric.router_lsa.external_lsa") | Dictionary |  |  |  |  |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -5375,7 +5375,7 @@ router_multicast:
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;default_information_originate</samp>](## "router_ospf.process_ids.[].areas.[].default_information_originate") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;metric</samp>](## "router_ospf.process_ids.[].areas.[].default_information_originate.metric") | Integer |  |  | Min: 1<br>Max: 65535 | Metric for default route |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;metric_type</samp>](## "router_ospf.process_ids.[].areas.[].default_information_originate.metric_type") | Integer |  |  | Valid Values:<br>- 1<br>- 2 | OSPF metric type for default route |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;maximum_paths</samp>](## "router_ospf.process_ids.[].maximum_paths") | Integer |  |  | Min: 1<br>Max: 64 |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;maximum_paths</samp>](## "router_ospf.process_ids.[].maximum_paths") | Integer |  |  | Min: 1<br>Max: 128 |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;max_metric</samp>](## "router_ospf.process_ids.[].max_metric") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;router_lsa</samp>](## "router_ospf.process_ids.[].max_metric.router_lsa") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;external_lsa</samp>](## "router_ospf.process_ids.[].max_metric.router_lsa.external_lsa") | Dictionary |  |  |  |  |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -12113,7 +12113,7 @@
               "maximum_paths": {
                 "type": "integer",
                 "minimum": 1,
-                "maximum": 32,
+                "maximum": 64,
                 "title": "Maximum Paths"
               },
               "max_metric": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -12113,7 +12113,7 @@
               "maximum_paths": {
                 "type": "integer",
                 "minimum": 1,
-                "maximum": 64,
+                "maximum": 128,
                 "title": "Maximum Paths"
               },
               "max_metric": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -338,9 +338,9 @@ keys:
                   Example: "deny ip any any"'
   aliases:
     type: str
-    description: "Multi-line string with one or more alias commands.\n\nExample:\n\n```yaml\naliases:
-      |\n  alias wr copy running-config startup-config\n  alias siib show ip interface
-      brief\n```"
+    description: "Multi-line string with one or more alias commands.\n\nExample:\n\
+      \n```yaml\naliases: |\n  alias wr copy running-config startup-config\n  alias\
+      \ siib show ip interface brief\n```"
   arp:
     type: dict
     keys:
@@ -540,14 +540,14 @@ keys:
   custom_templates:
     type: list
     display_name: Extensibility with Custom Templates
-    description: "- Custom templates can be added below the playbook directory.\n-
-      If a location above the directory is desired, a symbolic link can be used.\n-
-      Example under the `playbooks` directory create symbolic link with the following
-      command:\n\n  ```bash\n  ln -s ../../shared_repo/custom_avd_templates/ ./custom_avd_templates\n
-      \ ```\n\n- The output will be rendered at the end of the configuration.\n- The
-      order of custom templates in the list can be important if they overlap.\n- It
-      is recommenended to use a `!` delimiter at the top of each custom template.\n\nAdd
-      `custom_templates` to group/host variables:\n"
+    description: "- Custom templates can be added below the playbook directory.\n\
+      - If a location above the directory is desired, a symbolic link can be used.\n\
+      - Example under the `playbooks` directory create symbolic link with the following\
+      \ command:\n\n  ```bash\n  ln -s ../../shared_repo/custom_avd_templates/ ./custom_avd_templates\n\
+      \  ```\n\n- The output will be rendered at the end of the configuration.\n-\
+      \ The order of custom templates in the list can be important if they overlap.\n\
+      - It is recommenended to use a `!` delimiter at the top of each custom template.\n\
+      \nAdd `custom_templates` to group/host variables:\n"
     items:
       type: str
       description: Template relative path below playbook directory
@@ -588,12 +588,12 @@ keys:
                 type: bool
   daemon_terminattr:
     type: dict
-    description: "You can either provide a list of IPs/FQDNs to target on-premise
-      Cloudvision cluster or use DNS name for your Cloudvision as a Service instance.\nStreaming
-      to multiple clusters both on-prem and cloud service is supported.\n> Note For
-      TerminAttr version recommendation and EOS compatibility matrix, please refer
-      to the latest TerminAttr Release Notes\n  which always contain the latest recommended
-      versions and minimum required versions per EOS release.\n"
+    description: "You can either provide a list of IPs/FQDNs to target on-premise\
+      \ Cloudvision cluster or use DNS name for your Cloudvision as a Service instance.\n\
+      Streaming to multiple clusters both on-prem and cloud service is supported.\n\
+      > Note For TerminAttr version recommendation and EOS compatibility matrix, please\
+      \ refer to the latest TerminAttr Release Notes\n  which always contain the latest\
+      \ recommended versions and minimum required versions per EOS release.\n"
     keys:
       cvaddrs:
         type: list
@@ -2364,15 +2364,15 @@ keys:
     convert_types:
     - dict
     display_name: IP Community Lists
-    description: "AVD supports 2 different data models for community lists:\n\n- The
-      legacy `community_lists` data model that can be used for compatibility with
-      the existing deployments.\n- The improved `ip_community_lists` data model.\n\nBoth
-      data models can coexist without conflicts, as different keys are used: `community_lists`
-      vs `ip_community_lists`.\nCommunity list names must be unique.\n\nThe improved
-      data model has a better design documented below:\n\ncommunities and regexp MUST
-      not be configured together in the same entry\npossible community strings are
-      (case insensitive):\n - GSHUT\n - internet\n - local-as\n - no-advertise\n -
-      no-export\n - <1-4294967040>\n - aa:nn\n"
+    description: "AVD supports 2 different data models for community lists:\n\n- The\
+      \ legacy `community_lists` data model that can be used for compatibility with\
+      \ the existing deployments.\n- The improved `ip_community_lists` data model.\n\
+      \nBoth data models can coexist without conflicts, as different keys are used:\
+      \ `community_lists` vs `ip_community_lists`.\nCommunity list names must be unique.\n\
+      \nThe improved data model has a better design documented below:\n\ncommunities\
+      \ and regexp MUST not be configured together in the same entry\npossible community\
+      \ strings are (case insensitive):\n - GSHUT\n - internet\n - local-as\n - no-advertise\n\
+      \ - no-export\n - <1-4294967040>\n - aa:nn\n"
     items:
       type: dict
       keys:
@@ -3791,8 +3791,8 @@ keys:
               type: str
             tls_versions:
               type: str
-              description: "List of allowed TLS versions as string\nExamples:\n  -
-                \"1.0\"\n  - \"1.0 1.1\"\n"
+              description: "List of allowed TLS versions as string\nExamples:\n  -\
+                \ \"1.0\"\n  - \"1.0 1.1\"\n"
               convert_types:
               - float
             cipher_list:
@@ -4190,12 +4190,12 @@ keys:
               type: str
         rate_limit_per_ingress_chip:
           type: str
-          description: "Ratelimit and unit as string.\nExamples:\n  \"100000 bps\"\n
-            \ \"100 kbps\"\n  \"10 mbps\"\n"
+          description: "Ratelimit and unit as string.\nExamples:\n  \"100000 bps\"\
+            \n  \"100 kbps\"\n  \"10 mbps\"\n"
         rate_limit_per_egress_chip:
           type: str
-          description: "Ratelimit and unit as string.\nExamples:\n  \"100000 bps\"\n
-            \ \"100 kbps\"\n  \"10 mbps\"\n"
+          description: "Ratelimit and unit as string.\nExamples:\n  \"100000 bps\"\
+            \n  \"100 kbps\"\n  \"10 mbps\"\n"
         sample:
           type: int
           convert_types:
@@ -8222,7 +8222,7 @@ keys:
               convert_types:
               - str
               min: 1
-              max: 32
+              max: 64
             max_metric:
               type: dict
               keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -338,9 +338,9 @@ keys:
                   Example: "deny ip any any"'
   aliases:
     type: str
-    description: "Multi-line string with one or more alias commands.\n\nExample:\n\
-      \n```yaml\naliases: |\n  alias wr copy running-config startup-config\n  alias\
-      \ siib show ip interface brief\n```"
+    description: "Multi-line string with one or more alias commands.\n\nExample:\n\n```yaml\naliases:
+      |\n  alias wr copy running-config startup-config\n  alias siib show ip interface
+      brief\n```"
   arp:
     type: dict
     keys:
@@ -540,14 +540,14 @@ keys:
   custom_templates:
     type: list
     display_name: Extensibility with Custom Templates
-    description: "- Custom templates can be added below the playbook directory.\n\
-      - If a location above the directory is desired, a symbolic link can be used.\n\
-      - Example under the `playbooks` directory create symbolic link with the following\
-      \ command:\n\n  ```bash\n  ln -s ../../shared_repo/custom_avd_templates/ ./custom_avd_templates\n\
-      \  ```\n\n- The output will be rendered at the end of the configuration.\n-\
-      \ The order of custom templates in the list can be important if they overlap.\n\
-      - It is recommenended to use a `!` delimiter at the top of each custom template.\n\
-      \nAdd `custom_templates` to group/host variables:\n"
+    description: "- Custom templates can be added below the playbook directory.\n-
+      If a location above the directory is desired, a symbolic link can be used.\n-
+      Example under the `playbooks` directory create symbolic link with the following
+      command:\n\n  ```bash\n  ln -s ../../shared_repo/custom_avd_templates/ ./custom_avd_templates\n
+      \ ```\n\n- The output will be rendered at the end of the configuration.\n- The
+      order of custom templates in the list can be important if they overlap.\n- It
+      is recommenended to use a `!` delimiter at the top of each custom template.\n\nAdd
+      `custom_templates` to group/host variables:\n"
     items:
       type: str
       description: Template relative path below playbook directory
@@ -588,12 +588,12 @@ keys:
                 type: bool
   daemon_terminattr:
     type: dict
-    description: "You can either provide a list of IPs/FQDNs to target on-premise\
-      \ Cloudvision cluster or use DNS name for your Cloudvision as a Service instance.\n\
-      Streaming to multiple clusters both on-prem and cloud service is supported.\n\
-      > Note For TerminAttr version recommendation and EOS compatibility matrix, please\
-      \ refer to the latest TerminAttr Release Notes\n  which always contain the latest\
-      \ recommended versions and minimum required versions per EOS release.\n"
+    description: "You can either provide a list of IPs/FQDNs to target on-premise
+      Cloudvision cluster or use DNS name for your Cloudvision as a Service instance.\nStreaming
+      to multiple clusters both on-prem and cloud service is supported.\n> Note For
+      TerminAttr version recommendation and EOS compatibility matrix, please refer
+      to the latest TerminAttr Release Notes\n  which always contain the latest recommended
+      versions and minimum required versions per EOS release.\n"
     keys:
       cvaddrs:
         type: list
@@ -2364,15 +2364,15 @@ keys:
     convert_types:
     - dict
     display_name: IP Community Lists
-    description: "AVD supports 2 different data models for community lists:\n\n- The\
-      \ legacy `community_lists` data model that can be used for compatibility with\
-      \ the existing deployments.\n- The improved `ip_community_lists` data model.\n\
-      \nBoth data models can coexist without conflicts, as different keys are used:\
-      \ `community_lists` vs `ip_community_lists`.\nCommunity list names must be unique.\n\
-      \nThe improved data model has a better design documented below:\n\ncommunities\
-      \ and regexp MUST not be configured together in the same entry\npossible community\
-      \ strings are (case insensitive):\n - GSHUT\n - internet\n - local-as\n - no-advertise\n\
-      \ - no-export\n - <1-4294967040>\n - aa:nn\n"
+    description: "AVD supports 2 different data models for community lists:\n\n- The
+      legacy `community_lists` data model that can be used for compatibility with
+      the existing deployments.\n- The improved `ip_community_lists` data model.\n\nBoth
+      data models can coexist without conflicts, as different keys are used: `community_lists`
+      vs `ip_community_lists`.\nCommunity list names must be unique.\n\nThe improved
+      data model has a better design documented below:\n\ncommunities and regexp MUST
+      not be configured together in the same entry\npossible community strings are
+      (case insensitive):\n - GSHUT\n - internet\n - local-as\n - no-advertise\n -
+      no-export\n - <1-4294967040>\n - aa:nn\n"
     items:
       type: dict
       keys:
@@ -3791,8 +3791,8 @@ keys:
               type: str
             tls_versions:
               type: str
-              description: "List of allowed TLS versions as string\nExamples:\n  -\
-                \ \"1.0\"\n  - \"1.0 1.1\"\n"
+              description: "List of allowed TLS versions as string\nExamples:\n  -
+                \"1.0\"\n  - \"1.0 1.1\"\n"
               convert_types:
               - float
             cipher_list:
@@ -4190,12 +4190,12 @@ keys:
               type: str
         rate_limit_per_ingress_chip:
           type: str
-          description: "Ratelimit and unit as string.\nExamples:\n  \"100000 bps\"\
-            \n  \"100 kbps\"\n  \"10 mbps\"\n"
+          description: "Ratelimit and unit as string.\nExamples:\n  \"100000 bps\"\n
+            \ \"100 kbps\"\n  \"10 mbps\"\n"
         rate_limit_per_egress_chip:
           type: str
-          description: "Ratelimit and unit as string.\nExamples:\n  \"100000 bps\"\
-            \n  \"100 kbps\"\n  \"10 mbps\"\n"
+          description: "Ratelimit and unit as string.\nExamples:\n  \"100000 bps\"\n
+            \ \"100 kbps\"\n  \"10 mbps\"\n"
         sample:
           type: int
           convert_types:
@@ -8222,7 +8222,7 @@ keys:
               convert_types:
               - str
               min: 1
-              max: 64
+              max: 128
             max_metric:
               type: dict
               keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_ospf.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_ospf.schema.yml
@@ -240,7 +240,7 @@ keys:
               convert_types:
                 - str
               min: 1
-              max: 64
+              max: 128
             max_metric:
               type: dict
               keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_ospf.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_ospf.schema.yml
@@ -240,7 +240,7 @@ keys:
               convert_types:
                 - str
               min: 1
-              max: 32
+              max: 64
             max_metric:
               type: dict
               keys:


### PR DESCRIPTION
## Change Summary

OSPF maximum paths from 32 to 128

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Checklist


### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
