### PR TITLE
Fix(eos_snapshot): eos snapshot produces incorrect json and yaml output

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_snapshot/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_snapshot/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
 # tasks file for eos_snapshot
 - name: "Collection {{ ansible_collection_name }} version {{ version }}{{ ('(git ' ~ git_tag ~ ')') if git_tag }} loaded from {{ collection_path }}"
+  delegate_to: localhost
   tags: [always, avd_version]
   set_fact:
     avd_collection_version: version
@@ -13,16 +14,17 @@
   failed_when: false
 
 - name: Create required output directories if not present
+  delegate_to: localhost
   file:
     path: "{{ item }}"
     state: directory
     mode: 0775
   loop:
     - "{{ snapshots_backup_dir }}"
-  delegate_to: localhost
   run_once: true
 
 - name: Create output directory for each EOS device
+  delegate_to: localhost
   file:
     path: "{{ snapshots_backup_dir }}/{{ inventory_hostname }}"
     state: directory
@@ -36,7 +38,19 @@
   failed_when: false
   register: cli_output
 
+- name: run show commands on remote EOS devices with json output
+  eos_command:
+    commands:
+      - command: "{{ item }}"
+        output: json
+  with_items: "{{ commands_list }}"
+  failed_when: false
+  register: cli_output_json
+  when: ("'json' in output_format") or
+        ("'yaml' in output_format")
+
 - name: save collected commands in text files
+  delegate_to: localhost
   template:
     src: device_text_command.j2
     dest: "{{ snapshots_backup_dir }}/{{ inventory_hostname }}/{{ item.item | replace('/', '_') }}.txt"
@@ -45,20 +59,20 @@
   when: "'text' in output_format"
 
 - name: Generate json report for fabric
+  delegate_to: localhost
   template:
     src: fabric_json_output.j2
     dest: "{{ snapshots_backup_dir }}/report.json"
     mode: 0664
-  delegate_to: localhost
   run_once: true
   when: "'json' in output_format"
 
 - name: Generate yaml report for fabric
+  delegate_to: localhost
   template:
     src: fabric_yaml_output.j2
     dest: "{{ snapshots_backup_dir }}/report.yaml"
     mode: 0664
-  delegate_to: localhost
   run_once: true
   when: "'yaml' in output_format"
 

--- a/ansible_collections/arista/avd/roles/eos_snapshot/tasks/markdown.yml
+++ b/ansible_collections/arista/avd/roles/eos_snapshot/tasks/markdown.yml
@@ -1,10 +1,12 @@
 - name: Create md_fragments directory for each EOS device
+  delegate_to: localhost
   file:
     path: "{{ snapshots_backup_dir }}/{{ inventory_hostname }}/md_fragments"
     state: directory
     mode: 0775
 
 - name: save collected commands in md files
+  delegate_to: localhost
   template:
     src: md_report.j2
     dest: "{{ snapshots_backup_dir }}/{{ inventory_hostname }}/md_fragments/{{ item.item | replace('/', '_') }}.md"
@@ -12,18 +14,21 @@
   loop: "{{ cli_output.results }}"
 
 - name: generate table of content report
+  delegate_to: localhost
   template:
     src: md_table_of_content.j2
     dest: "{{ snapshots_backup_dir }}/{{ inventory_hostname }}/md_fragments/0_table_of_content.md"
     mode: 0664
 
 - name: Assembling md_fragments
+  delegate_to: localhost
   assemble:
     src: "{{ snapshots_backup_dir }}/{{ inventory_hostname }}/md_fragments"
     dest: "{{ snapshots_backup_dir }}/{{ inventory_hostname }}/report.md"
     mode: 0664
 
 - name: Delete md_fragments directory for each EOS device
+  delegate_to: localhost
   file:
     path: "{{ snapshots_backup_dir }}/{{ inventory_hostname }}/md_fragments"
     state: absent

--- a/ansible_collections/arista/avd/roles/eos_snapshot/templates/fabric_json_output.j2
+++ b/ansible_collections/arista/avd/roles/eos_snapshot/templates/fabric_json_output.j2
@@ -5,7 +5,7 @@
         "{{ node }}": {
 {%     for command in commands_list %}
             "{{ command | replace(" ","_") }}":
-                {{ hostvars[node].cli_output.results[0].stdout[0] | to_nice_json | indent(12) }}
+                {{ hostvars[node].cli_output_json.results[loop.index0].stdout[0] | to_nice_json | indent(12) }}
 {%-        if not loop.last %}
 ,
 {%         else %}

--- a/ansible_collections/arista/avd/roles/eos_snapshot/templates/fabric_yaml_output.j2
+++ b/ansible_collections/arista/avd/roles/eos_snapshot/templates/fabric_yaml_output.j2
@@ -3,6 +3,6 @@ devices:
   {{ node }}:
 {%     for command in commands_list %}
     "{{ command }}":
-      {{ hostvars[node].cli_output.results[0].stdout[0] | to_nice_yaml(indent=2) | trim | indent(6) }}
+      {{ hostvars[node].cli_output_json.results[loop.index0].stdout[0] | to_nice_yaml(indent=2) | trim | indent(6) }}
 {%     endfor %}
 {% endfor %}


### PR DESCRIPTION
## Change Summary

- Fix issue in json and yaml templates to loop over commands
- Collect commands in json format when json or yaml output is selected to generate accurate output data
- Add delegate to localhost to applicable task to increase performance.

## Related Issue(s)

Fixes #2394

## Component(s) name

`arista.avd.eos_snapshot`

## Proposed changes

- For loop with loop.index in json and yaml templates
- Added new task to gather commands in json format
- Added `delegate_to: localhost` to all applicable task

In my testing with ATD environment, even though we collect commands twice, because of `delegate_to: localhost` we improve overall performance:

**Before:**

```
Monday 16 January 2023  20:00:18 +0000 (0:00:02.692)       0:01:01.214 ******** 
=============================================================================== 
eos_snapshot ----------------------------------------------------------- 60.25s
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
total ------------------------------------------------------------------ 60.25s
Monday 16 January 2023  20:00:18 +0000 (0:00:02.692)       0:01:01.213 ******** 
=============================================================================== 
arista.avd.eos_snapshot : save collected commands in text files --------------------- 14.33s
arista.avd.eos_snapshot : save collected commands in md files ----------------------- 14.32s
arista.avd.eos_snapshot : run show commands on remote EOS devices ------------------- 11.88s
arista.avd.eos_snapshot : generate table of content report --------------------------- 3.16s
arista.avd.eos_snapshot : Create output directory for each EOS device ---------------- 2.80s
arista.avd.eos_snapshot : Assembling md_fragments ------------------------------------ 2.79s
arista.avd.eos_snapshot : Delete md_fragments directory for each EOS device ---------- 2.69s
arista.avd.eos_snapshot : Create md_fragments directory for each EOS device ---------- 2.64s
arista.avd.eos_snapshot : Generate yaml report for fabric ---------------------------- 1.40s
arista.avd.eos_snapshot : Generate json report for fabric ---------------------------- 1.38s
arista.avd.eos_snapshot : Create required output directories if not present ---------- 0.56s
arista.avd.eos_snapshot : Generate markdown report for fabric ------------------------ 0.28s
Playbook run took 0 days, 0 hours, 1 minutes, 1 seconds
```
**After:**

```
Monday 16 January 2023  19:50:00 +0000 (0:00:00.763)       0:00:44.578 ******** 
=============================================================================== 
eos_snapshot ----------------------------------------------------------- 43.63s
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
total ------------------------------------------------------------------ 43.63s
Monday 16 January 2023  19:50:00 +0000 (0:00:00.763)       0:00:44.577 ******** 
=============================================================================== 
arista.avd.eos_snapshot : run show commands on remote EOS devices ------------------- 11.89s
arista.avd.eos_snapshot : run show commands on remote EOS devices with json output -- 10.22s
arista.avd.eos_snapshot : save collected commands in text files ---------------------- 6.49s
arista.avd.eos_snapshot : save collected commands in md files ------------------------ 5.91s
arista.avd.eos_snapshot : Generate json report for fabric ---------------------------- 1.58s
arista.avd.eos_snapshot : Generate yaml report for fabric ---------------------------- 1.52s
arista.avd.eos_snapshot : generate table of content report --------------------------- 1.27s
arista.avd.eos_snapshot : Assembling md_fragments ------------------------------------ 0.85s
arista.avd.eos_snapshot : Create md_fragments directory for each EOS device ---------- 0.77s
arista.avd.eos_snapshot : Delete md_fragments directory for each EOS device ---------- 0.76s
arista.avd.eos_snapshot : Create output directory for each EOS device ---------------- 0.69s
arista.avd.eos_snapshot : Create required output directories if not present ---------- 0.48s
arista.avd.eos_snapshot : Generate markdown report for fabric ------------------------ 0.26s
Playbook run took 0 days, 0 hours, 0 minutes, 44 seconds
```
went from 60 seconds to 45 seconds to complete the playbook.

## How to test

Tested with ATD environment

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
