### PR TITLE
Feat(eos_designs, eos_cli_config_gen)!: Remove default "switchport" and remove logic from eos_cli_config_gen

### DIFF
--- a/ansible_collections/arista/avd/docs/porting-guides/4.x.x.md
+++ b/ansible_collections/arista/avd/docs/porting-guides/4.x.x.md
@@ -220,6 +220,49 @@ tenants:
 
 ## Changes to role `arista.avd.eos_cli_config_gen`
 
+### Remove default "type: switched" from ethernet_interfaces and port_channel_interfaces
+
+The change has been incorporated into `eos_designs` so action is only required when defining new interfaces
+with `structured_config`, `custom_structured_configuration_` or when using `eos_cli_config_gen` directly.
+
+With AVD 4.0.0 there is no longer a default value for `type` under `ethernet_interfaces` and `port_channel_interfaces`.
+
+Example input:
+
+```yaml
+ethernet_interfaces:
+  - name: Ethernet2
+    vlans: 10
+    mode: trunk
+```
+
+Previous output:
+
+```eos
+interface Ethernet2
+   switchport
+   switchport mode trunk
+   switchport trunk allowed vlans 10
+```
+
+AVD version 4.0.0 output:
+
+```eos
+interface Ethernet2
+   switchport mode trunk
+   switchport trunk allowed vlans 10
+```
+
+To retain the previous configuration, the interface definition must be updated like this:
+
+```yaml
+ethernet_interfaces:
+  - name: Ethernet2
+    type: switched
+    vlans: 10
+    mode: trunk
+```
+
 ### New model for `hardware_counters.features`
 
 The `hardware_counters.features` model has been improved to allow more options.

--- a/ansible_collections/arista/avd/docs/porting-guides/4.x.x.md
+++ b/ansible_collections/arista/avd/docs/porting-guides/4.x.x.md
@@ -220,49 +220,6 @@ tenants:
 
 ## Changes to role `arista.avd.eos_cli_config_gen`
 
-### Remove default "type: switched" from ethernet_interfaces and port_channel_interfaces
-
-The change has been incorporated into `eos_designs` so action is only required when defining new interfaces
-with `structured_config`, `custom_structured_configuration_` or when using `eos_cli_config_gen` directly.
-
-With AVD 4.0.0 there is no longer a default value for `type` under `ethernet_interfaces` and `port_channel_interfaces`.
-
-Example input:
-
-```yaml
-ethernet_interfaces:
-  - name: Ethernet2
-    vlans: 10
-    mode: trunk
-```
-
-Previous output:
-
-```eos
-interface Ethernet2
-   switchport
-   switchport mode trunk
-   switchport trunk allowed vlans 10
-```
-
-AVD version 4.0.0 output:
-
-```eos
-interface Ethernet2
-   switchport mode trunk
-   switchport trunk allowed vlans 10
-```
-
-To retain the previous configuration, the interface definition must be updated like this:
-
-```yaml
-ethernet_interfaces:
-  - name: Ethernet2
-    type: switched
-    vlans: 10
-    mode: trunk
-```
-
 ### New model for `hardware_counters.features`
 
 The `hardware_counters.features` model has been improved to allow more options.

--- a/ansible_collections/arista/avd/docs/porting-guides/4.x.x.md
+++ b/ansible_collections/arista/avd/docs/porting-guides/4.x.x.md
@@ -220,6 +220,56 @@ tenants:
 
 ## Changes to role `arista.avd.eos_cli_config_gen`
 
+### Non port-channel related config is no longer ignored on port-channel member ethernet_interfaces
+
+The change has been incorporated into `eos_designs` so action is only required when defining new interfaces
+with `structured_config`, `custom_structured_configuration_` or when using `eos_cli_config_gen` directly.
+
+With AVD 4.0.0 port-channel member interfaces defined under `ethernet_interfaces` will no longer ignore the
+`type` setting which defaults to `switched`. Other switchport or IP related features are also no longer ignored.
+
+For interfaces with LACP fallback, this may be the intended behavior, and this is the reason for this change.
+
+Example input:
+
+```yaml
+ethernet_interfaces:
+  - name: Ethernet2
+    channel_group:
+      id: 2
+      mode: active
+    mode: access    # <--- These are just examples of "other configurations"
+    vlans: 123      # <--- that were previously ignored.
+```
+
+Previous output:
+
+```eos
+interface Ethernet2
+   channel-group 2 mode active
+```
+
+AVD version 4.0.0 output:
+
+```eos
+interface Ethernet2
+   switchport
+   switchport mode access
+   switchport access vlan 123
+   channel-group 2 mode active
+```
+
+To retain the previous configuration, the interface definition must be updated like this:
+
+```yaml
+ethernet_interfaces:
+  - name: Ethernet2
+    type: port-channel-member
+    channel_group:
+      id: 2
+      mode: active
+```
+
 ### New model for `hardware_counters.features`
 
 The `hardware_counters.features` model has been improved to allow more options.

--- a/ansible_collections/arista/avd/docs/release-notes/4.x.x.md
+++ b/ansible_collections/arista/avd/docs/release-notes/4.x.x.md
@@ -19,6 +19,22 @@
 Breaking changes may require modifications to the inventory or playbook. See the [Porting guide for AVD 4.x.x](../porting-guides/4.x.x.md)
 for details.
 
+#### Remove default "type: switched" from ethernet_interfaces and port_channel_interfaces in eos_cli_config_gen
+
+The change has been incorporated into `eos_designs` so action is only required when defining new interfaces
+with `structured_config`, `custom_structured_configuration_` or when using `eos_cli_config_gen` directly.
+
+When defining `ethernet_interfaces` and `port_channel_interfaces` the `eos_cli_config_gen` role previously
+had `type: switched` as default value for all interfaces, which resulted in `eos_cli_config_gen` rendering
+`switchport` on all interfaces, unless specifically set to `type: routed` or similar.
+
+The previous default value lead to conflicts for port-channel members as well as conflicts when the global
+EOS default interface mode had been changed to `no switchport`.
+
+With AVD 4.0.0 there is no longer a default value for `type` under `ethernet_interfaces` and `port_channel_interfaces`.
+
+See details in the [Porting guide for AVD 4.x.x](../porting-guides/4.x.x.md#remove-default-type-switched-from-ethernet_interfaces-and-port_channel_interfaces).
+
 #### Change upper case CVP roles and module vars to lower case
 
 Potentially breaking in rare cases where custom logic relies on the registered vars or content of files.

--- a/ansible_collections/arista/avd/docs/release-notes/4.x.x.md
+++ b/ansible_collections/arista/avd/docs/release-notes/4.x.x.md
@@ -19,22 +19,6 @@
 Breaking changes may require modifications to the inventory or playbook. See the [Porting guide for AVD 4.x.x](../porting-guides/4.x.x.md)
 for details.
 
-#### Remove default "type: switched" from ethernet_interfaces and port_channel_interfaces in eos_cli_config_gen
-
-The change has been incorporated into `eos_designs` so action is only required when defining new interfaces
-with `structured_config`, `custom_structured_configuration_` or when using `eos_cli_config_gen` directly.
-
-When defining `ethernet_interfaces` and `port_channel_interfaces` the `eos_cli_config_gen` role previously
-had `type: switched` as default value for all interfaces, which resulted in `eos_cli_config_gen` rendering
-`switchport` on all interfaces, unless specifically set to `type: routed` or similar.
-
-The previous default value lead to conflicts for port-channel members as well as conflicts when the global
-EOS default interface mode had been changed to `no switchport`.
-
-With AVD 4.0.0 there is no longer a default value for `type` under `ethernet_interfaces` and `port_channel_interfaces`.
-
-See details in the [Porting guide for AVD 4.x.x](../porting-guides/4.x.x.md#remove-default-type-switched-from-ethernet_interfaces-and-port_channel_interfaces).
-
 #### Change upper case CVP roles and module vars to lower case
 
 Potentially breaking in rare cases where custom logic relies on the registered vars or content of files.

--- a/ansible_collections/arista/avd/docs/release-notes/4.x.x.md
+++ b/ansible_collections/arista/avd/docs/release-notes/4.x.x.md
@@ -19,6 +19,18 @@
 Breaking changes may require modifications to the inventory or playbook. See the [Porting guide for AVD 4.x.x](../porting-guides/4.x.x.md)
 for details.
 
+#### Non port-channel related config is no longer ignored on port-channel member ethernet_interfaces
+
+The change has been incorporated into `eos_designs` so action is only required when defining new interfaces
+with `structured_config`, `custom_structured_configuration_` or when using `eos_cli_config_gen` directly.
+
+With AVD 4.0.0 port-channel member interfaces defined under `ethernet_interfaces` will no longer ignore the
+`type` setting which defaults to `switched`. Other switchport or IP related features are also no longer ignored.
+
+For interfaces with LACP fallback, this may be the intended behavior, and this is the reason for this change.
+
+See details in the [Porting guide for AVD 4.x.x](../porting-guides/4.x.x.md#non-port-channel-related-config-is-no-longer-ignored-on-port-channel-member-ethernet_interfaces).
+
 #### Change upper case CVP roles and module vars to lower case
 
 Potentially breaking in rare cases where custom logic relies on the registered vars or content of files.

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF1A.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF1A.yml
@@ -95,7 +95,6 @@ ethernet_interfaces:
   peer_interface: Ethernet53
   peer_type: mlag_peer
   description: MLAG_PEER_LEAF1B_Ethernet53
-  type: switched
   shutdown: false
   channel_group:
     id: 53
@@ -105,7 +104,6 @@ ethernet_interfaces:
   peer_interface: Ethernet54
   peer_type: mlag_peer
   description: MLAG_PEER_LEAF1B_Ethernet54
-  type: switched
   shutdown: false
   channel_group:
     id: 53
@@ -116,7 +114,6 @@ ethernet_interfaces:
   peer_type: l3spine
   description: SPINE1_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 51
     mode: active
@@ -125,8 +122,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -156,8 +153,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -187,8 +184,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -218,8 +215,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -249,8 +246,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -280,8 +277,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -311,8 +308,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -342,8 +339,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -373,8 +370,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -404,8 +401,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -435,8 +432,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -466,8 +463,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -497,8 +494,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -528,8 +525,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -559,8 +556,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -590,8 +587,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -621,8 +618,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -652,8 +649,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -683,8 +680,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -714,8 +711,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -745,8 +742,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -776,8 +773,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -807,8 +804,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -838,8 +835,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -869,8 +866,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -900,8 +897,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -931,8 +928,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -962,8 +959,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -993,8 +990,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -1024,8 +1021,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -1055,8 +1052,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -1086,8 +1083,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -1117,8 +1114,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -1148,8 +1145,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -1179,8 +1176,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -1210,8 +1207,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -1241,8 +1238,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -1272,8 +1269,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -1303,8 +1300,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -1334,8 +1331,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -1365,8 +1362,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -1396,8 +1393,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -1427,8 +1424,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -1458,8 +1455,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -1489,8 +1486,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -1520,8 +1517,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -1551,8 +1548,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -1582,8 +1579,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF1A.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF1A.yml
@@ -95,6 +95,7 @@ ethernet_interfaces:
   peer_interface: Ethernet53
   peer_type: mlag_peer
   description: MLAG_PEER_LEAF1B_Ethernet53
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 53
@@ -104,6 +105,7 @@ ethernet_interfaces:
   peer_interface: Ethernet54
   peer_type: mlag_peer
   description: MLAG_PEER_LEAF1B_Ethernet54
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 53
@@ -114,6 +116,7 @@ ethernet_interfaces:
   peer_type: l3spine
   description: SPINE1_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 51
     mode: active

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF1B.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF1B.yml
@@ -95,6 +95,7 @@ ethernet_interfaces:
   peer_interface: Ethernet53
   peer_type: mlag_peer
   description: MLAG_PEER_LEAF1A_Ethernet53
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 53
@@ -104,6 +105,7 @@ ethernet_interfaces:
   peer_interface: Ethernet54
   peer_type: mlag_peer
   description: MLAG_PEER_LEAF1A_Ethernet54
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 53
@@ -114,6 +116,7 @@ ethernet_interfaces:
   peer_type: l3spine
   description: SPINE2_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 51
     mode: active

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF1B.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF1B.yml
@@ -95,7 +95,6 @@ ethernet_interfaces:
   peer_interface: Ethernet53
   peer_type: mlag_peer
   description: MLAG_PEER_LEAF1A_Ethernet53
-  type: switched
   shutdown: false
   channel_group:
     id: 53
@@ -105,7 +104,6 @@ ethernet_interfaces:
   peer_interface: Ethernet54
   peer_type: mlag_peer
   description: MLAG_PEER_LEAF1A_Ethernet54
-  type: switched
   shutdown: false
   channel_group:
     id: 53
@@ -116,7 +114,6 @@ ethernet_interfaces:
   peer_type: l3spine
   description: SPINE2_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 51
     mode: active
@@ -125,8 +122,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -156,8 +153,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -187,8 +184,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -218,8 +215,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -249,8 +246,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -280,8 +277,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -311,8 +308,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -342,8 +339,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -373,8 +370,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -404,8 +401,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -435,8 +432,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -466,8 +463,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -497,8 +494,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -528,8 +525,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -559,8 +556,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -590,8 +587,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -621,8 +618,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -652,8 +649,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -683,8 +680,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -714,8 +711,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -745,8 +742,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -776,8 +773,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -807,8 +804,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -838,8 +835,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -869,8 +866,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -900,8 +897,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -931,8 +928,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -962,8 +959,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -993,8 +990,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -1024,8 +1021,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -1055,8 +1052,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -1086,8 +1083,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -1117,8 +1114,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -1148,8 +1145,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -1179,8 +1176,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -1210,8 +1207,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -1241,8 +1238,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -1272,8 +1269,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -1303,8 +1300,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -1334,8 +1331,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -1365,8 +1362,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -1396,8 +1393,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -1427,8 +1424,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -1458,8 +1455,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -1489,8 +1486,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -1520,8 +1517,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -1551,8 +1548,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge
@@ -1582,8 +1579,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 110
   spanning_tree_portfast: edge

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF2A.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF2A.yml
@@ -54,7 +54,6 @@ ethernet_interfaces:
   peer_type: l3spine
   description: SPINE1_Ethernet49/1
   shutdown: false
-  type: switched
   channel_group:
     id: 11
     mode: active
@@ -64,7 +63,6 @@ ethernet_interfaces:
   peer_type: l3spine
   description: SPINE2_Ethernet49/1
   shutdown: false
-  type: switched
   channel_group:
     id: 11
     mode: active
@@ -73,8 +71,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -104,8 +102,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -135,8 +133,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -166,8 +164,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -197,8 +195,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -228,8 +226,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -259,8 +257,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -290,8 +288,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -321,8 +319,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -352,8 +350,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -383,8 +381,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -414,8 +412,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -445,8 +443,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -476,8 +474,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -507,8 +505,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -538,8 +536,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -569,8 +567,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -600,8 +598,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -631,8 +629,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -662,8 +660,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -693,8 +691,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -724,8 +722,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -755,8 +753,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -786,8 +784,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -817,8 +815,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -848,8 +846,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -879,8 +877,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -910,8 +908,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -941,8 +939,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -972,8 +970,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -1003,8 +1001,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -1034,8 +1032,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -1065,8 +1063,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -1096,8 +1094,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -1127,8 +1125,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -1158,8 +1156,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -1189,8 +1187,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -1220,8 +1218,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -1251,8 +1249,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -1282,8 +1280,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -1313,8 +1311,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -1344,8 +1342,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -1375,8 +1373,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -1406,8 +1404,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -1437,8 +1435,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -1468,8 +1466,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -1499,8 +1497,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -1530,8 +1528,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -1561,8 +1559,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -1592,8 +1590,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -1623,8 +1621,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -1654,8 +1652,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -1685,8 +1683,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -1716,8 +1714,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -1747,8 +1745,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -1778,8 +1776,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -1809,8 +1807,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -1840,8 +1838,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -1871,8 +1869,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -1902,8 +1900,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -1933,8 +1931,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -1964,8 +1962,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -1995,8 +1993,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -2026,8 +2024,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -2057,8 +2055,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -2088,8 +2086,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -2119,8 +2117,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -2150,8 +2148,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -2181,8 +2179,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -2212,8 +2210,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -2243,8 +2241,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -2274,8 +2272,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -2305,8 +2303,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -2336,8 +2334,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -2367,8 +2365,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -2398,8 +2396,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -2429,8 +2427,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -2460,8 +2458,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -2491,8 +2489,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -2522,8 +2520,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -2553,8 +2551,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -2584,8 +2582,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -2615,8 +2613,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -2646,8 +2644,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -2677,8 +2675,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -2708,8 +2706,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -2739,8 +2737,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -2770,8 +2768,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -2801,8 +2799,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -2832,8 +2830,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -2863,8 +2861,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -2894,8 +2892,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -2925,8 +2923,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -2956,8 +2954,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -2987,8 +2985,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -3018,8 +3016,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -3049,8 +3047,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -3080,8 +3078,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -3111,8 +3109,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -3142,8 +3140,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -3173,8 +3171,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -3204,8 +3202,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -3235,8 +3233,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -3266,8 +3264,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -3297,8 +3295,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -3328,8 +3326,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -3359,8 +3357,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -3390,8 +3388,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -3421,8 +3419,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -3452,8 +3450,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -3483,8 +3481,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -3514,8 +3512,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -3545,8 +3543,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -3576,8 +3574,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -3607,8 +3605,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -3638,8 +3636,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -3669,8 +3667,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -3700,8 +3698,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -3731,8 +3729,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -3762,8 +3760,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -3793,8 +3791,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -3824,8 +3822,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -3855,8 +3853,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -3886,8 +3884,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -3917,8 +3915,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -3948,8 +3946,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -3979,8 +3977,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -4010,8 +4008,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -4041,8 +4039,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -4072,8 +4070,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -4103,8 +4101,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -4134,8 +4132,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -4165,8 +4163,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -4196,8 +4194,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -4227,8 +4225,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -4258,8 +4256,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -4289,8 +4287,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -4320,8 +4318,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -4351,8 +4349,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -4382,8 +4380,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -4413,8 +4411,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -4444,8 +4442,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -4475,8 +4473,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -4506,8 +4504,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -4537,8 +4535,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -4568,8 +4566,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -4599,8 +4597,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -4630,8 +4628,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -4661,8 +4659,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -4692,8 +4690,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -4723,8 +4721,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -4754,8 +4752,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -4785,8 +4783,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -4816,8 +4814,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -4847,8 +4845,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -4878,8 +4876,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -4909,8 +4907,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -4940,8 +4938,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -4971,8 +4969,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -5002,8 +5000,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -5033,8 +5031,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -5064,8 +5062,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -5095,8 +5093,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -5126,8 +5124,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -5157,8 +5155,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -5188,8 +5186,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -5219,8 +5217,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -5250,8 +5248,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -5281,8 +5279,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -5312,8 +5310,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -5343,8 +5341,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -5374,8 +5372,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -5405,8 +5403,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -5436,8 +5434,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -5467,8 +5465,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -5498,8 +5496,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -5529,8 +5527,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -5560,8 +5558,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -5591,8 +5589,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -5622,8 +5620,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -5653,8 +5651,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -5684,8 +5682,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -5715,8 +5713,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -5746,8 +5744,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -5777,8 +5775,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -5808,8 +5806,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -5839,8 +5837,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -5870,8 +5868,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -5901,8 +5899,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -5932,8 +5930,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -5963,8 +5961,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -5994,8 +5992,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -6025,8 +6023,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -6056,8 +6054,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -6087,8 +6085,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -6118,8 +6116,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -6149,8 +6147,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -6180,8 +6178,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -6211,8 +6209,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -6242,8 +6240,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -6273,8 +6271,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -6304,8 +6302,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -6335,8 +6333,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -6366,8 +6364,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -6397,8 +6395,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -6428,8 +6426,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -6459,8 +6457,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -6490,8 +6488,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -6521,8 +6519,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -6552,8 +6550,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -6583,8 +6581,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -6614,8 +6612,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -6645,8 +6643,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -6676,8 +6674,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -6707,8 +6705,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -6738,8 +6736,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -6769,8 +6767,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -6800,8 +6798,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -6831,8 +6829,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -6862,8 +6860,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -6893,8 +6891,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -6924,8 +6922,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -6955,8 +6953,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -6986,8 +6984,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -7017,8 +7015,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -7048,8 +7046,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -7079,8 +7077,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -7110,8 +7108,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -7141,8 +7139,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -7172,8 +7170,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -7203,8 +7201,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -7234,8 +7232,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -7265,8 +7263,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -7296,8 +7294,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -7327,8 +7325,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -7358,8 +7356,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -7389,8 +7387,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -7420,8 +7418,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -7451,8 +7449,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge
@@ -7482,8 +7480,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 210
   spanning_tree_portfast: edge

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF2A.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF2A.yml
@@ -54,6 +54,7 @@ ethernet_interfaces:
   peer_type: l3spine
   description: SPINE1_Ethernet49/1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 11
     mode: active
@@ -63,6 +64,7 @@ ethernet_interfaces:
   peer_type: l3spine
   description: SPINE2_Ethernet49/1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 11
     mode: active

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3A.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3A.yml
@@ -116,6 +116,7 @@ ethernet_interfaces:
   peer_interface: Ethernet98/3
   peer_type: mlag_peer
   description: MLAG_PEER_LEAF3B_Ethernet98/3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 983
@@ -125,6 +126,7 @@ ethernet_interfaces:
   peer_interface: Ethernet98/4
   peer_type: mlag_peer
   description: MLAG_PEER_LEAF3B_Ethernet98/4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 983
@@ -135,6 +137,7 @@ ethernet_interfaces:
   peer_type: l3spine
   description: SPINE1_Ethernet50/1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 971
     mode: active
@@ -144,6 +147,7 @@ ethernet_interfaces:
   peer_type: l3spine
   description: SPINE2_Ethernet50/1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 971
     mode: active
@@ -153,6 +157,7 @@ ethernet_interfaces:
   peer_type: leaf
   description: LEAF3C_Ethernet97/1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 973
     mode: active
@@ -162,6 +167,7 @@ ethernet_interfaces:
   peer_type: leaf
   description: LEAF3D_Ethernet97/1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 974
     mode: active
@@ -171,6 +177,7 @@ ethernet_interfaces:
   peer_type: leaf
   description: LEAF3E_Ethernet97/1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 981
     mode: active

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3A.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3A.yml
@@ -116,7 +116,6 @@ ethernet_interfaces:
   peer_interface: Ethernet98/3
   peer_type: mlag_peer
   description: MLAG_PEER_LEAF3B_Ethernet98/3
-  type: switched
   shutdown: false
   channel_group:
     id: 983
@@ -126,7 +125,6 @@ ethernet_interfaces:
   peer_interface: Ethernet98/4
   peer_type: mlag_peer
   description: MLAG_PEER_LEAF3B_Ethernet98/4
-  type: switched
   shutdown: false
   channel_group:
     id: 983
@@ -137,7 +135,6 @@ ethernet_interfaces:
   peer_type: l3spine
   description: SPINE1_Ethernet50/1
   shutdown: false
-  type: switched
   channel_group:
     id: 971
     mode: active
@@ -147,7 +144,6 @@ ethernet_interfaces:
   peer_type: l3spine
   description: SPINE2_Ethernet50/1
   shutdown: false
-  type: switched
   channel_group:
     id: 971
     mode: active
@@ -157,7 +153,6 @@ ethernet_interfaces:
   peer_type: leaf
   description: LEAF3C_Ethernet97/1
   shutdown: false
-  type: switched
   channel_group:
     id: 973
     mode: active
@@ -167,7 +162,6 @@ ethernet_interfaces:
   peer_type: leaf
   description: LEAF3D_Ethernet97/1
   shutdown: false
-  type: switched
   channel_group:
     id: 974
     mode: active
@@ -177,7 +171,6 @@ ethernet_interfaces:
   peer_type: leaf
   description: LEAF3E_Ethernet97/1
   shutdown: false
-  type: switched
   channel_group:
     id: 981
     mode: active
@@ -186,8 +179,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -217,8 +210,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -248,8 +241,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -279,8 +272,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -310,8 +303,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -341,8 +334,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -372,8 +365,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -403,8 +396,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -434,8 +427,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -465,8 +458,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -496,8 +489,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -527,8 +520,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -558,8 +551,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -589,8 +582,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -620,8 +613,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -651,8 +644,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -682,8 +675,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -713,8 +706,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -744,8 +737,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -775,8 +768,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -806,8 +799,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -837,8 +830,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -868,8 +861,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -899,8 +892,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -930,8 +923,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -961,8 +954,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -992,8 +985,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1023,8 +1016,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1054,8 +1047,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1085,8 +1078,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1116,8 +1109,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1147,8 +1140,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1178,8 +1171,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1209,8 +1202,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1240,8 +1233,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1271,8 +1264,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1302,8 +1295,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1333,8 +1326,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1364,8 +1357,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1395,8 +1388,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1426,8 +1419,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1457,8 +1450,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1488,8 +1481,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1519,8 +1512,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1550,8 +1543,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1581,8 +1574,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1612,8 +1605,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1643,8 +1636,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1674,8 +1667,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1705,8 +1698,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1736,8 +1729,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1767,8 +1760,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1798,8 +1791,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1829,8 +1822,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1860,8 +1853,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1891,8 +1884,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1922,8 +1915,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1953,8 +1946,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1984,8 +1977,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2015,8 +2008,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2046,8 +2039,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2077,8 +2070,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2108,8 +2101,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2139,8 +2132,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2170,8 +2163,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2201,8 +2194,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2232,8 +2225,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2263,8 +2256,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2294,8 +2287,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2325,8 +2318,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2356,8 +2349,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2387,8 +2380,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2418,8 +2411,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2449,8 +2442,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2480,8 +2473,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2511,8 +2504,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2542,8 +2535,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2573,8 +2566,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2604,8 +2597,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2635,8 +2628,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2666,8 +2659,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2697,8 +2690,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2728,8 +2721,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2759,8 +2752,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2790,8 +2783,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2821,8 +2814,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2852,8 +2845,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2883,8 +2876,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2914,8 +2907,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2945,8 +2938,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2976,8 +2969,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -3007,8 +3000,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -3038,8 +3031,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -3069,8 +3062,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -3100,8 +3093,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -3131,8 +3124,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3B.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3B.yml
@@ -116,7 +116,6 @@ ethernet_interfaces:
   peer_interface: Ethernet98/3
   peer_type: mlag_peer
   description: MLAG_PEER_LEAF3A_Ethernet98/3
-  type: switched
   shutdown: false
   channel_group:
     id: 983
@@ -126,7 +125,6 @@ ethernet_interfaces:
   peer_interface: Ethernet98/4
   peer_type: mlag_peer
   description: MLAG_PEER_LEAF3A_Ethernet98/4
-  type: switched
   shutdown: false
   channel_group:
     id: 983
@@ -137,7 +135,6 @@ ethernet_interfaces:
   peer_type: l3spine
   description: SPINE1_Ethernet51/1
   shutdown: false
-  type: switched
   channel_group:
     id: 971
     mode: active
@@ -147,7 +144,6 @@ ethernet_interfaces:
   peer_type: l3spine
   description: SPINE2_Ethernet51/1
   shutdown: false
-  type: switched
   channel_group:
     id: 971
     mode: active
@@ -157,7 +153,6 @@ ethernet_interfaces:
   peer_type: leaf
   description: LEAF3C_Ethernet97/2
   shutdown: false
-  type: switched
   channel_group:
     id: 973
     mode: active
@@ -167,7 +162,6 @@ ethernet_interfaces:
   peer_type: leaf
   description: LEAF3D_Ethernet97/2
   shutdown: false
-  type: switched
   channel_group:
     id: 974
     mode: active
@@ -177,7 +171,6 @@ ethernet_interfaces:
   peer_type: leaf
   description: LEAF3E_Ethernet97/2
   shutdown: false
-  type: switched
   channel_group:
     id: 981
     mode: active
@@ -186,8 +179,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -217,8 +210,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -248,8 +241,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -279,8 +272,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -310,8 +303,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -341,8 +334,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -372,8 +365,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -403,8 +396,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -434,8 +427,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -465,8 +458,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -496,8 +489,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -527,8 +520,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -558,8 +551,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -589,8 +582,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -620,8 +613,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -651,8 +644,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -682,8 +675,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -713,8 +706,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -744,8 +737,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -775,8 +768,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -806,8 +799,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -837,8 +830,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -868,8 +861,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -899,8 +892,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -930,8 +923,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -961,8 +954,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -992,8 +985,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1023,8 +1016,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1054,8 +1047,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1085,8 +1078,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1116,8 +1109,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1147,8 +1140,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1178,8 +1171,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1209,8 +1202,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1240,8 +1233,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1271,8 +1264,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1302,8 +1295,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1333,8 +1326,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1364,8 +1357,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1395,8 +1388,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1426,8 +1419,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1457,8 +1450,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1488,8 +1481,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1519,8 +1512,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1550,8 +1543,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1581,8 +1574,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1612,8 +1605,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1643,8 +1636,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1674,8 +1667,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1705,8 +1698,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1736,8 +1729,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1767,8 +1760,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1798,8 +1791,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1829,8 +1822,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1860,8 +1853,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1891,8 +1884,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1922,8 +1915,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1953,8 +1946,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1984,8 +1977,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2015,8 +2008,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2046,8 +2039,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2077,8 +2070,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2108,8 +2101,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2139,8 +2132,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2170,8 +2163,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2201,8 +2194,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2232,8 +2225,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2263,8 +2256,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2294,8 +2287,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2325,8 +2318,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2356,8 +2349,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2387,8 +2380,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2418,8 +2411,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2449,8 +2442,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2480,8 +2473,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2511,8 +2504,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2542,8 +2535,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2573,8 +2566,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2604,8 +2597,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2635,8 +2628,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2666,8 +2659,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2697,8 +2690,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2728,8 +2721,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2759,8 +2752,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2790,8 +2783,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2821,8 +2814,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2852,8 +2845,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2883,8 +2876,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2914,8 +2907,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2945,8 +2938,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2976,8 +2969,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -3007,8 +3000,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -3038,8 +3031,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -3069,8 +3062,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -3100,8 +3093,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -3131,8 +3124,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3B.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3B.yml
@@ -116,6 +116,7 @@ ethernet_interfaces:
   peer_interface: Ethernet98/3
   peer_type: mlag_peer
   description: MLAG_PEER_LEAF3A_Ethernet98/3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 983
@@ -125,6 +126,7 @@ ethernet_interfaces:
   peer_interface: Ethernet98/4
   peer_type: mlag_peer
   description: MLAG_PEER_LEAF3A_Ethernet98/4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 983
@@ -135,6 +137,7 @@ ethernet_interfaces:
   peer_type: l3spine
   description: SPINE1_Ethernet51/1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 971
     mode: active
@@ -144,6 +147,7 @@ ethernet_interfaces:
   peer_type: l3spine
   description: SPINE2_Ethernet51/1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 971
     mode: active
@@ -153,6 +157,7 @@ ethernet_interfaces:
   peer_type: leaf
   description: LEAF3C_Ethernet97/2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 973
     mode: active
@@ -162,6 +167,7 @@ ethernet_interfaces:
   peer_type: leaf
   description: LEAF3D_Ethernet97/2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 974
     mode: active
@@ -171,6 +177,7 @@ ethernet_interfaces:
   peer_type: leaf
   description: LEAF3E_Ethernet97/2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 981
     mode: active

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3C.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3C.yml
@@ -54,7 +54,6 @@ ethernet_interfaces:
   peer_type: leaf
   description: LEAF3A_Ethernet97/3
   shutdown: false
-  type: switched
   channel_group:
     id: 971
     mode: active
@@ -64,7 +63,6 @@ ethernet_interfaces:
   peer_type: leaf
   description: LEAF3B_Ethernet97/3
   shutdown: false
-  type: switched
   channel_group:
     id: 971
     mode: active
@@ -73,8 +71,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -104,8 +102,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -135,8 +133,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -166,8 +164,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -197,8 +195,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -228,8 +226,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -259,8 +257,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -290,8 +288,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -321,8 +319,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -352,8 +350,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -383,8 +381,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -414,8 +412,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -445,8 +443,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -476,8 +474,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -507,8 +505,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -538,8 +536,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -569,8 +567,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -600,8 +598,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -631,8 +629,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -662,8 +660,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -693,8 +691,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -724,8 +722,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -755,8 +753,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -786,8 +784,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -817,8 +815,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -848,8 +846,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -879,8 +877,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -910,8 +908,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -941,8 +939,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -972,8 +970,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1003,8 +1001,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1034,8 +1032,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1065,8 +1063,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1096,8 +1094,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1127,8 +1125,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1158,8 +1156,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1189,8 +1187,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1220,8 +1218,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1251,8 +1249,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1282,8 +1280,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1313,8 +1311,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1344,8 +1342,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1375,8 +1373,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1406,8 +1404,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1437,8 +1435,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1468,8 +1466,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1499,8 +1497,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1530,8 +1528,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1561,8 +1559,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1592,8 +1590,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1623,8 +1621,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1654,8 +1652,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1685,8 +1683,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1716,8 +1714,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1747,8 +1745,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1778,8 +1776,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1809,8 +1807,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1840,8 +1838,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1871,8 +1869,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1902,8 +1900,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1933,8 +1931,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1964,8 +1962,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1995,8 +1993,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2026,8 +2024,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2057,8 +2055,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2088,8 +2086,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2119,8 +2117,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2150,8 +2148,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2181,8 +2179,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2212,8 +2210,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2243,8 +2241,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2274,8 +2272,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2305,8 +2303,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2336,8 +2334,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2367,8 +2365,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2398,8 +2396,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2429,8 +2427,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2460,8 +2458,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2491,8 +2489,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2522,8 +2520,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2553,8 +2551,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2584,8 +2582,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2615,8 +2613,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2646,8 +2644,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2677,8 +2675,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2708,8 +2706,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2739,8 +2737,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2770,8 +2768,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2801,8 +2799,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2832,8 +2830,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2863,8 +2861,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2894,8 +2892,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2925,8 +2923,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2956,8 +2954,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2987,8 +2985,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -3018,8 +3016,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3C.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3C.yml
@@ -54,6 +54,7 @@ ethernet_interfaces:
   peer_type: leaf
   description: LEAF3A_Ethernet97/3
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 971
     mode: active
@@ -63,6 +64,7 @@ ethernet_interfaces:
   peer_type: leaf
   description: LEAF3B_Ethernet97/3
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 971
     mode: active

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3D.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3D.yml
@@ -54,6 +54,7 @@ ethernet_interfaces:
   peer_type: leaf
   description: LEAF3A_Ethernet97/4
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 971
     mode: active
@@ -63,6 +64,7 @@ ethernet_interfaces:
   peer_type: leaf
   description: LEAF3B_Ethernet97/4
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 971
     mode: active

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3D.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3D.yml
@@ -54,7 +54,6 @@ ethernet_interfaces:
   peer_type: leaf
   description: LEAF3A_Ethernet97/4
   shutdown: false
-  type: switched
   channel_group:
     id: 971
     mode: active
@@ -64,7 +63,6 @@ ethernet_interfaces:
   peer_type: leaf
   description: LEAF3B_Ethernet97/4
   shutdown: false
-  type: switched
   channel_group:
     id: 971
     mode: active
@@ -73,8 +71,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -104,8 +102,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -135,8 +133,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -166,8 +164,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -197,8 +195,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -228,8 +226,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -259,8 +257,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -290,8 +288,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -321,8 +319,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -352,8 +350,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -383,8 +381,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -414,8 +412,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -445,8 +443,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -476,8 +474,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -507,8 +505,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -538,8 +536,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -569,8 +567,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -600,8 +598,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -631,8 +629,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -662,8 +660,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -693,8 +691,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -724,8 +722,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -755,8 +753,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -786,8 +784,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -817,8 +815,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -848,8 +846,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -879,8 +877,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -910,8 +908,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -941,8 +939,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -972,8 +970,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1003,8 +1001,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1034,8 +1032,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1065,8 +1063,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1096,8 +1094,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1127,8 +1125,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1158,8 +1156,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1189,8 +1187,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1220,8 +1218,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1251,8 +1249,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1282,8 +1280,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1313,8 +1311,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1344,8 +1342,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1375,8 +1373,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1406,8 +1404,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1437,8 +1435,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1468,8 +1466,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1499,8 +1497,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1530,8 +1528,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1561,8 +1559,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1592,8 +1590,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1623,8 +1621,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1654,8 +1652,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1685,8 +1683,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1716,8 +1714,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1747,8 +1745,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1778,8 +1776,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1809,8 +1807,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1840,8 +1838,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1871,8 +1869,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1902,8 +1900,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1933,8 +1931,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1964,8 +1962,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1995,8 +1993,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2026,8 +2024,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2057,8 +2055,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2088,8 +2086,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2119,8 +2117,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2150,8 +2148,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2181,8 +2179,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2212,8 +2210,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2243,8 +2241,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2274,8 +2272,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2305,8 +2303,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2336,8 +2334,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2367,8 +2365,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2398,8 +2396,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2429,8 +2427,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2460,8 +2458,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2491,8 +2489,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2522,8 +2520,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2553,8 +2551,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2584,8 +2582,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2615,8 +2613,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2646,8 +2644,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2677,8 +2675,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2708,8 +2706,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2739,8 +2737,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2770,8 +2768,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2801,8 +2799,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2832,8 +2830,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2863,8 +2861,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2894,8 +2892,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2925,8 +2923,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2956,8 +2954,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2987,8 +2985,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -3018,8 +3016,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3E.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3E.yml
@@ -54,7 +54,6 @@ ethernet_interfaces:
   peer_type: leaf
   description: LEAF3A_Ethernet98/1
   shutdown: false
-  type: switched
   channel_group:
     id: 971
     mode: active
@@ -64,7 +63,6 @@ ethernet_interfaces:
   peer_type: leaf
   description: LEAF3B_Ethernet98/1
   shutdown: false
-  type: switched
   channel_group:
     id: 971
     mode: active
@@ -73,8 +71,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -104,8 +102,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -135,8 +133,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -166,8 +164,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -197,8 +195,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -228,8 +226,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -259,8 +257,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -290,8 +288,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -321,8 +319,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -352,8 +350,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -383,8 +381,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -414,8 +412,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -445,8 +443,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -476,8 +474,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -507,8 +505,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -538,8 +536,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -569,8 +567,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -600,8 +598,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -631,8 +629,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -662,8 +660,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -693,8 +691,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -724,8 +722,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -755,8 +753,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -786,8 +784,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -817,8 +815,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -848,8 +846,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -879,8 +877,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -910,8 +908,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -941,8 +939,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -972,8 +970,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1003,8 +1001,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1034,8 +1032,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1065,8 +1063,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1096,8 +1094,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1127,8 +1125,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1158,8 +1156,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1189,8 +1187,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1220,8 +1218,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1251,8 +1249,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1282,8 +1280,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1313,8 +1311,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1344,8 +1342,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1375,8 +1373,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1406,8 +1404,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1437,8 +1435,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1468,8 +1466,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1499,8 +1497,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1530,8 +1528,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1561,8 +1559,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1592,8 +1590,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1623,8 +1621,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1654,8 +1652,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1685,8 +1683,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1716,8 +1714,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1747,8 +1745,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1778,8 +1776,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1809,8 +1807,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1840,8 +1838,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1871,8 +1869,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1902,8 +1900,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1933,8 +1931,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1964,8 +1962,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -1995,8 +1993,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2026,8 +2024,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2057,8 +2055,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2088,8 +2086,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2119,8 +2117,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2150,8 +2148,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2181,8 +2179,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2212,8 +2210,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2243,8 +2241,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2274,8 +2272,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2305,8 +2303,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2336,8 +2334,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2367,8 +2365,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2398,8 +2396,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2429,8 +2427,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2460,8 +2458,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2491,8 +2489,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2522,8 +2520,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2553,8 +2551,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2584,8 +2582,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2615,8 +2613,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2646,8 +2644,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2677,8 +2675,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2708,8 +2706,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2739,8 +2737,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2770,8 +2768,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2801,8 +2799,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2832,8 +2830,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2863,8 +2861,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2894,8 +2892,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2925,8 +2923,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2956,8 +2954,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -2987,8 +2985,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge
@@ -3018,8 +3016,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   native_vlan: 310
   spanning_tree_portfast: edge

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3E.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3E.yml
@@ -54,6 +54,7 @@ ethernet_interfaces:
   peer_type: leaf
   description: LEAF3A_Ethernet98/1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 971
     mode: active
@@ -63,6 +64,7 @@ ethernet_interfaces:
   peer_type: leaf
   description: LEAF3B_Ethernet98/1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 971
     mode: active

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/SPINE1.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/SPINE1.yml
@@ -223,6 +223,7 @@ ethernet_interfaces:
   peer_interface: Ethernet55/1
   peer_type: mlag_peer
   description: MLAG_PEER_SPINE2_Ethernet55/1
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 551
@@ -232,6 +233,7 @@ ethernet_interfaces:
   peer_interface: Ethernet56/1
   peer_type: mlag_peer
   description: MLAG_PEER_SPINE2_Ethernet56/1
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 551
@@ -242,6 +244,7 @@ ethernet_interfaces:
   peer_type: leaf
   description: LEAF1A_Ethernet51
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -251,6 +254,7 @@ ethernet_interfaces:
   peer_type: leaf
   description: LEAF2A_Ethernet1/1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 491
     mode: active
@@ -260,6 +264,7 @@ ethernet_interfaces:
   peer_type: leaf
   description: LEAF3A_Ethernet97/1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 501
     mode: active
@@ -269,6 +274,7 @@ ethernet_interfaces:
   peer_type: leaf
   description: LEAF3B_Ethernet97/1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 501
     mode: active

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/SPINE1.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/SPINE1.yml
@@ -223,7 +223,6 @@ ethernet_interfaces:
   peer_interface: Ethernet55/1
   peer_type: mlag_peer
   description: MLAG_PEER_SPINE2_Ethernet55/1
-  type: switched
   shutdown: false
   channel_group:
     id: 551
@@ -233,7 +232,6 @@ ethernet_interfaces:
   peer_interface: Ethernet56/1
   peer_type: mlag_peer
   description: MLAG_PEER_SPINE2_Ethernet56/1
-  type: switched
   shutdown: false
   channel_group:
     id: 551
@@ -244,7 +242,6 @@ ethernet_interfaces:
   peer_type: leaf
   description: LEAF1A_Ethernet51
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -254,7 +251,6 @@ ethernet_interfaces:
   peer_type: leaf
   description: LEAF2A_Ethernet1/1
   shutdown: false
-  type: switched
   channel_group:
     id: 491
     mode: active
@@ -264,7 +260,6 @@ ethernet_interfaces:
   peer_type: leaf
   description: LEAF3A_Ethernet97/1
   shutdown: false
-  type: switched
   channel_group:
     id: 501
     mode: active
@@ -274,7 +269,6 @@ ethernet_interfaces:
   peer_type: leaf
   description: LEAF3B_Ethernet97/1
   shutdown: false
-  type: switched
   channel_group:
     id: 501
     mode: active

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/SPINE2.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/SPINE2.yml
@@ -223,7 +223,6 @@ ethernet_interfaces:
   peer_interface: Ethernet55/1
   peer_type: mlag_peer
   description: MLAG_PEER_SPINE1_Ethernet55/1
-  type: switched
   shutdown: false
   channel_group:
     id: 551
@@ -233,7 +232,6 @@ ethernet_interfaces:
   peer_interface: Ethernet56/1
   peer_type: mlag_peer
   description: MLAG_PEER_SPINE1_Ethernet56/1
-  type: switched
   shutdown: false
   channel_group:
     id: 551
@@ -244,7 +242,6 @@ ethernet_interfaces:
   peer_type: leaf
   description: LEAF1B_Ethernet51
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -254,7 +251,6 @@ ethernet_interfaces:
   peer_type: leaf
   description: LEAF2A_Ethernet1/3
   shutdown: false
-  type: switched
   channel_group:
     id: 491
     mode: active
@@ -264,7 +260,6 @@ ethernet_interfaces:
   peer_type: leaf
   description: LEAF3A_Ethernet97/2
   shutdown: false
-  type: switched
   channel_group:
     id: 501
     mode: active
@@ -274,7 +269,6 @@ ethernet_interfaces:
   peer_type: leaf
   description: LEAF3B_Ethernet97/2
   shutdown: false
-  type: switched
   channel_group:
     id: 501
     mode: active

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/SPINE2.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/SPINE2.yml
@@ -223,6 +223,7 @@ ethernet_interfaces:
   peer_interface: Ethernet55/1
   peer_type: mlag_peer
   description: MLAG_PEER_SPINE1_Ethernet55/1
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 551
@@ -232,6 +233,7 @@ ethernet_interfaces:
   peer_interface: Ethernet56/1
   peer_type: mlag_peer
   description: MLAG_PEER_SPINE1_Ethernet56/1
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 551
@@ -242,6 +244,7 @@ ethernet_interfaces:
   peer_type: leaf
   description: LEAF1B_Ethernet51
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -251,6 +254,7 @@ ethernet_interfaces:
   peer_type: leaf
   description: LEAF2A_Ethernet1/3
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 491
     mode: active
@@ -260,6 +264,7 @@ ethernet_interfaces:
   peer_type: leaf
   description: LEAF3A_Ethernet97/2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 501
     mode: active
@@ -269,6 +274,7 @@ ethernet_interfaces:
   peer_type: leaf
   description: LEAF3B_Ethernet97/2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 501
     mode: active

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf1a.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf1a.yml
@@ -319,6 +319,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_dc1-leaf1b_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -328,6 +329,7 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_dc1-leaf1b_Ethernet4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -356,6 +358,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-LEAF1C_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 8
     mode: active
@@ -365,6 +368,7 @@ ethernet_interfaces:
   peer_type: server
   description: dc1-leaf1-server1_PCI1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 5
     mode: active

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf1a.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf1a.yml
@@ -319,7 +319,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_dc1-leaf1b_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -329,7 +328,6 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_dc1-leaf1b_Ethernet4
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -358,7 +356,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-LEAF1C_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 8
     mode: active
@@ -367,12 +364,7 @@ ethernet_interfaces:
   peer_interface: PCI1
   peer_type: server
   description: dc1-leaf1-server1_PCI1
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 11-12,21-22
-  native_vlan: 4092
-  spanning_tree_portfast: edge
   channel_group:
     id: 5
     mode: active

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf1b.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf1b.yml
@@ -319,7 +319,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_dc1-leaf1a_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -329,7 +328,6 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_dc1-leaf1a_Ethernet4
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -358,7 +356,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-LEAF1C_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 8
     mode: active
@@ -367,12 +364,7 @@ ethernet_interfaces:
   peer_interface: PCI2
   peer_type: server
   description: dc1-leaf1-server1_PCI2
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 11-12,21-22
-  native_vlan: 4092
-  spanning_tree_portfast: edge
   channel_group:
     id: 5
     mode: active

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf1b.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf1b.yml
@@ -319,6 +319,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_dc1-leaf1a_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -328,6 +329,7 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_dc1-leaf1a_Ethernet4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -356,6 +358,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-LEAF1C_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 8
     mode: active
@@ -365,6 +368,7 @@ ethernet_interfaces:
   peer_type: server
   description: dc1-leaf1-server1_PCI2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 5
     mode: active

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf1c.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf1c.yml
@@ -44,6 +44,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF1A_Ethernet8
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -53,6 +54,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF1B_Ethernet8
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf1c.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf1c.yml
@@ -44,7 +44,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF1A_Ethernet8
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -54,7 +53,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF1B_Ethernet8
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -63,8 +61,8 @@ ethernet_interfaces:
   peer_interface: iLO
   peer_type: server
   description: dc1-leaf1-server1_iLO
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '11'
   spanning_tree_portfast: edge

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf2a.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf2a.yml
@@ -379,6 +379,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_dc1-leaf2b_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -388,6 +389,7 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_dc1-leaf2b_Ethernet4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -416,6 +418,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-LEAF2C_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 8
     mode: active
@@ -434,6 +437,7 @@ ethernet_interfaces:
   peer_type: server
   description: dc1-leaf2-server1_PCI1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 5
     mode: active

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf2a.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf2a.yml
@@ -379,7 +379,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_dc1-leaf2b_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -389,7 +388,6 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_dc1-leaf2b_Ethernet4
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -418,7 +416,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-LEAF2C_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 8
     mode: active
@@ -436,12 +433,7 @@ ethernet_interfaces:
   peer_interface: PCI1
   peer_type: server
   description: dc1-leaf2-server1_PCI1
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 11-12,21-22
-  native_vlan: 4092
-  spanning_tree_portfast: edge
   channel_group:
     id: 5
     mode: active

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf2b.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf2b.yml
@@ -379,7 +379,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_dc1-leaf2a_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -389,7 +388,6 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_dc1-leaf2a_Ethernet4
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -418,7 +416,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-LEAF2C_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 8
     mode: active
@@ -436,12 +433,7 @@ ethernet_interfaces:
   peer_interface: PCI2
   peer_type: server
   description: dc1-leaf2-server1_PCI2
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 11-12,21-22
-  native_vlan: 4092
-  spanning_tree_portfast: edge
   channel_group:
     id: 5
     mode: active

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf2b.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf2b.yml
@@ -379,6 +379,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_dc1-leaf2a_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -388,6 +389,7 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_dc1-leaf2a_Ethernet4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -416,6 +418,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-LEAF2C_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 8
     mode: active
@@ -434,6 +437,7 @@ ethernet_interfaces:
   peer_type: server
   description: dc1-leaf2-server1_PCI2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 5
     mode: active

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf2c.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf2c.yml
@@ -44,6 +44,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF2A_Ethernet8
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -53,6 +54,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF2B_Ethernet8
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf2c.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf2c.yml
@@ -44,7 +44,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF2A_Ethernet8
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -54,7 +53,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF2B_Ethernet8
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -63,8 +61,8 @@ ethernet_interfaces:
   peer_interface: iLO
   peer_type: server
   description: dc1-leaf2-server1_iLO
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '11'
   spanning_tree_portfast: edge

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf1a.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf1a.yml
@@ -319,6 +319,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_dc2-leaf1b_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -328,6 +329,7 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_dc2-leaf1b_Ethernet4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -356,6 +358,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC2-LEAF1C_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 8
     mode: active
@@ -365,6 +368,7 @@ ethernet_interfaces:
   peer_type: server
   description: dc2-leaf1-server1_PCI1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 5
     mode: active

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf1a.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf1a.yml
@@ -319,7 +319,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_dc2-leaf1b_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -329,7 +328,6 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_dc2-leaf1b_Ethernet4
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -358,7 +356,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC2-LEAF1C_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 8
     mode: active
@@ -367,12 +364,7 @@ ethernet_interfaces:
   peer_interface: PCI1
   peer_type: server
   description: dc2-leaf1-server1_PCI1
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 11-12,21-22
-  native_vlan: 4092
-  spanning_tree_portfast: edge
   channel_group:
     id: 5
     mode: active

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf1b.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf1b.yml
@@ -319,7 +319,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_dc2-leaf1a_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -329,7 +328,6 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_dc2-leaf1a_Ethernet4
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -358,7 +356,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC2-LEAF1C_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 8
     mode: active
@@ -367,12 +364,7 @@ ethernet_interfaces:
   peer_interface: PCI2
   peer_type: server
   description: dc2-leaf1-server1_PCI2
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 11-12,21-22
-  native_vlan: 4092
-  spanning_tree_portfast: edge
   channel_group:
     id: 5
     mode: active

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf1b.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf1b.yml
@@ -319,6 +319,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_dc2-leaf1a_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -328,6 +329,7 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_dc2-leaf1a_Ethernet4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -356,6 +358,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC2-LEAF1C_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 8
     mode: active
@@ -365,6 +368,7 @@ ethernet_interfaces:
   peer_type: server
   description: dc2-leaf1-server1_PCI2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 5
     mode: active

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf1c.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf1c.yml
@@ -44,6 +44,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC2-LEAF1A_Ethernet8
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -53,6 +54,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC2-LEAF1B_Ethernet8
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf1c.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf1c.yml
@@ -44,7 +44,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC2-LEAF1A_Ethernet8
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -54,7 +53,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC2-LEAF1B_Ethernet8
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -63,8 +61,8 @@ ethernet_interfaces:
   peer_interface: iLO
   peer_type: server
   description: dc2-leaf1-server1_iLO
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '11'
   spanning_tree_portfast: edge

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf2a.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf2a.yml
@@ -379,6 +379,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_dc2-leaf2b_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -388,6 +389,7 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_dc2-leaf2b_Ethernet4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -416,6 +418,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC2-LEAF2C_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 8
     mode: active
@@ -434,6 +437,7 @@ ethernet_interfaces:
   peer_type: server
   description: dc2-leaf2-server1_PCI1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 5
     mode: active

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf2a.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf2a.yml
@@ -379,7 +379,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_dc2-leaf2b_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -389,7 +388,6 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_dc2-leaf2b_Ethernet4
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -418,7 +416,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC2-LEAF2C_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 8
     mode: active
@@ -436,12 +433,7 @@ ethernet_interfaces:
   peer_interface: PCI1
   peer_type: server
   description: dc2-leaf2-server1_PCI1
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 11-12,21-22
-  native_vlan: 4092
-  spanning_tree_portfast: edge
   channel_group:
     id: 5
     mode: active

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf2b.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf2b.yml
@@ -379,7 +379,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_dc2-leaf2a_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -389,7 +388,6 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_dc2-leaf2a_Ethernet4
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -418,7 +416,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC2-LEAF2C_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 8
     mode: active
@@ -436,12 +433,7 @@ ethernet_interfaces:
   peer_interface: PCI2
   peer_type: server
   description: dc2-leaf2-server1_PCI2
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 11-12,21-22
-  native_vlan: 4092
-  spanning_tree_portfast: edge
   channel_group:
     id: 5
     mode: active

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf2b.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf2b.yml
@@ -379,6 +379,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_dc2-leaf2a_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -388,6 +389,7 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_dc2-leaf2a_Ethernet4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -416,6 +418,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC2-LEAF2C_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 8
     mode: active
@@ -434,6 +437,7 @@ ethernet_interfaces:
   peer_type: server
   description: dc2-leaf2-server1_PCI2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 5
     mode: active

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf2c.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf2c.yml
@@ -44,7 +44,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC2-LEAF2A_Ethernet8
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -54,7 +53,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC2-LEAF2B_Ethernet8
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -63,8 +61,8 @@ ethernet_interfaces:
   peer_interface: iLO
   peer_type: server
   description: dc2-leaf2-server1_iLO
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '11'
   spanning_tree_portfast: edge

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf2c.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf2c.yml
@@ -44,6 +44,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC2-LEAF2A_Ethernet8
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -53,6 +54,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC2-LEAF2B_Ethernet8
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/fabric/DC1_FABRIC-documentation.md
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/fabric/DC1_FABRIC-documentation.md
@@ -101,8 +101,8 @@
 
 | Name | Port | Fabric Device | Fabric Port | Description | Shutdown | Type | Mode | VLANs | Profile |
 | ---- | ---- | ------------- | ------------| ----------- | -------- | ---- | ---- | ----- | ------- |
-| FIREWALL | Eth1 | SPINE1 | Ethernet5 | FIREWALL_Eth1 | False | switched | trunk | 10,20,30 | PP-FIREWALL |
-| FIREWALL | Eth2 | SPINE2 | Ethernet5 | FIREWALL_Eth2 | False | switched | trunk | 10,20,30 | PP-FIREWALL |
+| FIREWALL | Eth1 | SPINE1 | Ethernet5 | FIREWALL_Eth1 | False | - | - | - | PP-FIREWALL |
+| FIREWALL | Eth2 | SPINE2 | Ethernet5 | FIREWALL_Eth2 | False | - | - | - | PP-FIREWALL |
 
 ### Servers
 

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/fabric/DC1_FABRIC-documentation.md
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/fabric/DC1_FABRIC-documentation.md
@@ -101,8 +101,8 @@
 
 | Name | Port | Fabric Device | Fabric Port | Description | Shutdown | Type | Mode | VLANs | Profile |
 | ---- | ---- | ------------- | ------------| ----------- | -------- | ---- | ---- | ----- | ------- |
-| FIREWALL | Eth1 | SPINE1 | Ethernet5 | FIREWALL_Eth1 | False | - | - | - | PP-FIREWALL |
-| FIREWALL | Eth2 | SPINE2 | Ethernet5 | FIREWALL_Eth2 | False | - | - | - | PP-FIREWALL |
+| FIREWALL | Eth1 | SPINE1 | Ethernet5 | FIREWALL_Eth1 | False | switched | trunk | 10,20,30 | PP-FIREWALL |
+| FIREWALL | Eth2 | SPINE2 | Ethernet5 | FIREWALL_Eth2 | False | switched | trunk | 10,20,30 | PP-FIREWALL |
 
 ### Servers
 

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF1.yml
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF1.yml
@@ -84,6 +84,7 @@ ethernet_interfaces:
   peer_interface: Ethernet47
   peer_type: mlag_peer
   description: MLAG_PEER_LEAF2_Ethernet47
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 47
@@ -93,6 +94,7 @@ ethernet_interfaces:
   peer_interface: Ethernet48
   peer_type: mlag_peer
   description: MLAG_PEER_LEAF2_Ethernet48
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 47
@@ -103,6 +105,7 @@ ethernet_interfaces:
   peer_type: spine
   description: SPINE1_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -112,6 +115,7 @@ ethernet_interfaces:
   peer_type: spine
   description: SPINE2_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF1.yml
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF1.yml
@@ -84,7 +84,6 @@ ethernet_interfaces:
   peer_interface: Ethernet47
   peer_type: mlag_peer
   description: MLAG_PEER_LEAF2_Ethernet47
-  type: switched
   shutdown: false
   channel_group:
     id: 47
@@ -94,7 +93,6 @@ ethernet_interfaces:
   peer_interface: Ethernet48
   peer_type: mlag_peer
   description: MLAG_PEER_LEAF2_Ethernet48
-  type: switched
   shutdown: false
   channel_group:
     id: 47
@@ -105,7 +103,6 @@ ethernet_interfaces:
   peer_type: spine
   description: SPINE1_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -115,7 +112,6 @@ ethernet_interfaces:
   peer_type: spine
   description: SPINE2_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -125,8 +121,8 @@ ethernet_interfaces:
   peer_type: server
   port_profile: PP-BLUE
   description: HostA_Eth1
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '10'
   spanning_tree_portfast: edge

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF2.yml
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF2.yml
@@ -84,6 +84,7 @@ ethernet_interfaces:
   peer_interface: Ethernet47
   peer_type: mlag_peer
   description: MLAG_PEER_LEAF1_Ethernet47
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 47
@@ -93,6 +94,7 @@ ethernet_interfaces:
   peer_interface: Ethernet48
   peer_type: mlag_peer
   description: MLAG_PEER_LEAF1_Ethernet48
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 47
@@ -103,6 +105,7 @@ ethernet_interfaces:
   peer_type: spine
   description: SPINE1_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -112,6 +115,7 @@ ethernet_interfaces:
   peer_type: spine
   description: SPINE2_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF2.yml
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF2.yml
@@ -84,7 +84,6 @@ ethernet_interfaces:
   peer_interface: Ethernet47
   peer_type: mlag_peer
   description: MLAG_PEER_LEAF1_Ethernet47
-  type: switched
   shutdown: false
   channel_group:
     id: 47
@@ -94,7 +93,6 @@ ethernet_interfaces:
   peer_interface: Ethernet48
   peer_type: mlag_peer
   description: MLAG_PEER_LEAF1_Ethernet48
-  type: switched
   shutdown: false
   channel_group:
     id: 47
@@ -105,7 +103,6 @@ ethernet_interfaces:
   peer_type: spine
   description: SPINE1_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -115,7 +112,6 @@ ethernet_interfaces:
   peer_type: spine
   description: SPINE2_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -125,8 +121,8 @@ ethernet_interfaces:
   peer_type: server
   port_profile: PP-GREEN
   description: HostB_Eth1
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '20'
   spanning_tree_portfast: edge

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF3.yml
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF3.yml
@@ -84,7 +84,6 @@ ethernet_interfaces:
   peer_interface: Ethernet47
   peer_type: mlag_peer
   description: MLAG_PEER_LEAF4_Ethernet47
-  type: switched
   shutdown: false
   channel_group:
     id: 47
@@ -94,7 +93,6 @@ ethernet_interfaces:
   peer_interface: Ethernet48
   peer_type: mlag_peer
   description: MLAG_PEER_LEAF4_Ethernet48
-  type: switched
   shutdown: false
   channel_group:
     id: 47
@@ -105,7 +103,6 @@ ethernet_interfaces:
   peer_type: spine
   description: SPINE1_Ethernet3
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -115,7 +112,6 @@ ethernet_interfaces:
   peer_type: spine
   description: SPINE2_Ethernet3
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -125,8 +121,8 @@ ethernet_interfaces:
   peer_type: server
   port_profile: PP-BLUE
   description: HostC_Eth1
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '10'
   spanning_tree_portfast: edge

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF3.yml
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF3.yml
@@ -84,6 +84,7 @@ ethernet_interfaces:
   peer_interface: Ethernet47
   peer_type: mlag_peer
   description: MLAG_PEER_LEAF4_Ethernet47
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 47
@@ -93,6 +94,7 @@ ethernet_interfaces:
   peer_interface: Ethernet48
   peer_type: mlag_peer
   description: MLAG_PEER_LEAF4_Ethernet48
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 47
@@ -103,6 +105,7 @@ ethernet_interfaces:
   peer_type: spine
   description: SPINE1_Ethernet3
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -112,6 +115,7 @@ ethernet_interfaces:
   peer_type: spine
   description: SPINE2_Ethernet3
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF4.yml
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF4.yml
@@ -84,6 +84,7 @@ ethernet_interfaces:
   peer_interface: Ethernet47
   peer_type: mlag_peer
   description: MLAG_PEER_LEAF3_Ethernet47
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 47
@@ -93,6 +94,7 @@ ethernet_interfaces:
   peer_interface: Ethernet48
   peer_type: mlag_peer
   description: MLAG_PEER_LEAF3_Ethernet48
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 47
@@ -103,6 +105,7 @@ ethernet_interfaces:
   peer_type: spine
   description: SPINE1_Ethernet4
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -112,6 +115,7 @@ ethernet_interfaces:
   peer_type: spine
   description: SPINE2_Ethernet4
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF4.yml
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF4.yml
@@ -84,7 +84,6 @@ ethernet_interfaces:
   peer_interface: Ethernet47
   peer_type: mlag_peer
   description: MLAG_PEER_LEAF3_Ethernet47
-  type: switched
   shutdown: false
   channel_group:
     id: 47
@@ -94,7 +93,6 @@ ethernet_interfaces:
   peer_interface: Ethernet48
   peer_type: mlag_peer
   description: MLAG_PEER_LEAF3_Ethernet48
-  type: switched
   shutdown: false
   channel_group:
     id: 47
@@ -105,7 +103,6 @@ ethernet_interfaces:
   peer_type: spine
   description: SPINE1_Ethernet4
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -115,7 +112,6 @@ ethernet_interfaces:
   peer_type: spine
   description: SPINE2_Ethernet4
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -125,8 +121,8 @@ ethernet_interfaces:
   peer_type: server
   port_profile: PP-ORANGE
   description: Host2_Eth1
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '30'
   spanning_tree_portfast: edge

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/SPINE1.yml
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/SPINE1.yml
@@ -101,6 +101,7 @@ ethernet_interfaces:
   peer_interface: Ethernet47
   peer_type: mlag_peer
   description: MLAG_PEER_SPINE2_Ethernet47
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 47
@@ -110,6 +111,7 @@ ethernet_interfaces:
   peer_interface: Ethernet48
   peer_type: mlag_peer
   description: MLAG_PEER_SPINE2_Ethernet48
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 47
@@ -120,6 +122,7 @@ ethernet_interfaces:
   peer_type: leaf
   description: LEAF1_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -129,6 +132,7 @@ ethernet_interfaces:
   peer_type: leaf
   description: LEAF2_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -138,6 +142,7 @@ ethernet_interfaces:
   peer_type: leaf
   description: LEAF3_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 3
     mode: active
@@ -147,6 +152,7 @@ ethernet_interfaces:
   peer_type: leaf
   description: LEAF4_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 3
     mode: active
@@ -157,6 +163,7 @@ ethernet_interfaces:
   port_profile: PP-FIREWALL
   description: FIREWALL_Eth1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 5
     mode: active

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/SPINE1.yml
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/SPINE1.yml
@@ -101,7 +101,6 @@ ethernet_interfaces:
   peer_interface: Ethernet47
   peer_type: mlag_peer
   description: MLAG_PEER_SPINE2_Ethernet47
-  type: switched
   shutdown: false
   channel_group:
     id: 47
@@ -111,7 +110,6 @@ ethernet_interfaces:
   peer_interface: Ethernet48
   peer_type: mlag_peer
   description: MLAG_PEER_SPINE2_Ethernet48
-  type: switched
   shutdown: false
   channel_group:
     id: 47
@@ -122,7 +120,6 @@ ethernet_interfaces:
   peer_type: leaf
   description: LEAF1_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -132,7 +129,6 @@ ethernet_interfaces:
   peer_type: leaf
   description: LEAF2_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -142,7 +138,6 @@ ethernet_interfaces:
   peer_type: leaf
   description: LEAF3_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 3
     mode: active
@@ -152,7 +147,6 @@ ethernet_interfaces:
   peer_type: leaf
   description: LEAF4_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 3
     mode: active
@@ -162,10 +156,7 @@ ethernet_interfaces:
   peer_type: firewall
   port_profile: PP-FIREWALL
   description: FIREWALL_Eth1
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 10,20,30
   channel_group:
     id: 5
     mode: active

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/SPINE2.yml
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/SPINE2.yml
@@ -101,7 +101,6 @@ ethernet_interfaces:
   peer_interface: Ethernet47
   peer_type: mlag_peer
   description: MLAG_PEER_SPINE1_Ethernet47
-  type: switched
   shutdown: false
   channel_group:
     id: 47
@@ -111,7 +110,6 @@ ethernet_interfaces:
   peer_interface: Ethernet48
   peer_type: mlag_peer
   description: MLAG_PEER_SPINE1_Ethernet48
-  type: switched
   shutdown: false
   channel_group:
     id: 47
@@ -122,7 +120,6 @@ ethernet_interfaces:
   peer_type: leaf
   description: LEAF1_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -132,7 +129,6 @@ ethernet_interfaces:
   peer_type: leaf
   description: LEAF2_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -142,7 +138,6 @@ ethernet_interfaces:
   peer_type: leaf
   description: LEAF3_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 3
     mode: active
@@ -152,7 +147,6 @@ ethernet_interfaces:
   peer_type: leaf
   description: LEAF4_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 3
     mode: active
@@ -162,10 +156,7 @@ ethernet_interfaces:
   peer_type: firewall
   port_profile: PP-FIREWALL
   description: FIREWALL_Eth2
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 10,20,30
   channel_group:
     id: 5
     mode: active

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/SPINE2.yml
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/SPINE2.yml
@@ -101,6 +101,7 @@ ethernet_interfaces:
   peer_interface: Ethernet47
   peer_type: mlag_peer
   description: MLAG_PEER_SPINE1_Ethernet47
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 47
@@ -110,6 +111,7 @@ ethernet_interfaces:
   peer_interface: Ethernet48
   peer_type: mlag_peer
   description: MLAG_PEER_SPINE1_Ethernet48
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 47
@@ -120,6 +122,7 @@ ethernet_interfaces:
   peer_type: leaf
   description: LEAF1_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -129,6 +132,7 @@ ethernet_interfaces:
   peer_type: leaf
   description: LEAF2_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -138,6 +142,7 @@ ethernet_interfaces:
   peer_type: leaf
   description: LEAF3_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 3
     mode: active
@@ -147,6 +152,7 @@ ethernet_interfaces:
   peer_type: leaf
   description: LEAF4_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 3
     mode: active
@@ -157,6 +163,7 @@ ethernet_interfaces:
   port_profile: PP-FIREWALL
   description: FIREWALL_Eth2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 5
     mode: active

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf1a.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf1a.yml
@@ -319,6 +319,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_dc1-leaf1b_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -328,6 +329,7 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_dc1-leaf1b_Ethernet4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -356,6 +358,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-LEAF1C_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 8
     mode: active
@@ -365,6 +368,7 @@ ethernet_interfaces:
   peer_type: server
   description: dc1-leaf1-server1_PCI1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 5
     mode: active

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf1a.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf1a.yml
@@ -319,7 +319,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_dc1-leaf1b_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -329,7 +328,6 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_dc1-leaf1b_Ethernet4
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -358,7 +356,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-LEAF1C_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 8
     mode: active
@@ -367,12 +364,7 @@ ethernet_interfaces:
   peer_interface: PCI1
   peer_type: server
   description: dc1-leaf1-server1_PCI1
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 11-12,21-22
-  native_vlan: 4092
-  spanning_tree_portfast: edge
   channel_group:
     id: 5
     mode: active

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf1b.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf1b.yml
@@ -319,7 +319,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_dc1-leaf1a_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -329,7 +328,6 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_dc1-leaf1a_Ethernet4
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -358,7 +356,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-LEAF1C_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 8
     mode: active
@@ -367,12 +364,7 @@ ethernet_interfaces:
   peer_interface: PCI2
   peer_type: server
   description: dc1-leaf1-server1_PCI2
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 11-12,21-22
-  native_vlan: 4092
-  spanning_tree_portfast: edge
   channel_group:
     id: 5
     mode: active

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf1b.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf1b.yml
@@ -319,6 +319,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_dc1-leaf1a_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -328,6 +329,7 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_dc1-leaf1a_Ethernet4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -356,6 +358,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-LEAF1C_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 8
     mode: active
@@ -365,6 +368,7 @@ ethernet_interfaces:
   peer_type: server
   description: dc1-leaf1-server1_PCI2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 5
     mode: active

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf1c.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf1c.yml
@@ -44,6 +44,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF1A_Ethernet8
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -53,6 +54,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF1B_Ethernet8
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf1c.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf1c.yml
@@ -44,7 +44,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF1A_Ethernet8
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -54,7 +53,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF1B_Ethernet8
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -63,8 +61,8 @@ ethernet_interfaces:
   peer_interface: iLO
   peer_type: server
   description: dc1-leaf1-server1_iLO
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '11'
   spanning_tree_portfast: edge

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf2a.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf2a.yml
@@ -319,7 +319,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_dc1-leaf2b_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -329,7 +328,6 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_dc1-leaf2b_Ethernet4
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -358,7 +356,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-LEAF2C_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 8
     mode: active
@@ -367,12 +364,7 @@ ethernet_interfaces:
   peer_interface: PCI1
   peer_type: server
   description: dc1-leaf2-server1_PCI1
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 11-12,21-22
-  native_vlan: 4092
-  spanning_tree_portfast: edge
   channel_group:
     id: 5
     mode: active

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf2a.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf2a.yml
@@ -319,6 +319,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_dc1-leaf2b_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -328,6 +329,7 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_dc1-leaf2b_Ethernet4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -356,6 +358,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-LEAF2C_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 8
     mode: active
@@ -365,6 +368,7 @@ ethernet_interfaces:
   peer_type: server
   description: dc1-leaf2-server1_PCI1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 5
     mode: active

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf2b.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf2b.yml
@@ -319,6 +319,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_dc1-leaf2a_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -328,6 +329,7 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_dc1-leaf2a_Ethernet4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -356,6 +358,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-LEAF2C_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 8
     mode: active
@@ -365,6 +368,7 @@ ethernet_interfaces:
   peer_type: server
   description: dc1-leaf2-server1_PCI2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 5
     mode: active

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf2b.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf2b.yml
@@ -319,7 +319,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_dc1-leaf2a_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -329,7 +328,6 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_dc1-leaf2a_Ethernet4
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -358,7 +356,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-LEAF2C_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 8
     mode: active
@@ -367,12 +364,7 @@ ethernet_interfaces:
   peer_interface: PCI2
   peer_type: server
   description: dc1-leaf2-server1_PCI2
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 11-12,21-22
-  native_vlan: 4092
-  spanning_tree_portfast: edge
   channel_group:
     id: 5
     mode: active

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf2c.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf2c.yml
@@ -44,6 +44,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF2A_Ethernet8
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -53,6 +54,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF2B_Ethernet8
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf2c.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf2c.yml
@@ -44,7 +44,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF2A_Ethernet8
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -54,7 +53,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF2B_Ethernet8
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -63,8 +61,8 @@ ethernet_interfaces:
   peer_interface: iLO
   peer_type: server
   description: dc1-leaf2-server1_iLO
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '11'
   spanning_tree_portfast: edge

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
@@ -77,7 +77,6 @@ sFlow is disabled.
 | Interface | Description | Mode | VLANs | Native VLAN | Trunk Group | Channel-Group |
 | --------- | ----------- | ---- | ----- | ----------- | ----------- | ------------- |
 | Ethernet2 |  SRV-POD02_Eth1 | trunk | 110-111,210-211 | - | - | - |
-| Ethernet4 |  Molecule IPv6 | access | - | - | - | - |
 | Ethernet6 |  SRV-POD02_Eth1 | trunk | 110-111,210-211 | - | - | - |
 | Ethernet7 |  Molecule L2 | access | - | - | - | - |
 | Ethernet11 |  interface_in_mode_access_accepting_tagged_LACP | access | 200 | - | - | - |
@@ -119,7 +118,6 @@ sFlow is disabled.
 | Ethernet52 |  SFlow Interface Testing - SFlow ingress and egress unmodified enabled | access | - | - | - | - |
 | Ethernet53 |  SFlow Interface Testing - SFlow ingress and egress disabled | access | - | - | - | - |
 | Ethernet54 |  SFlow Interface Testing - SFlow ingress and egress unmodified disabled | access | - | - | - | - |
-| Ethernet55 |  DHCPv6 Relay Testing | access | - | - | - | - |
 | Ethernet56 |  Interface with poe commands and limit in class | access | - | - | - | - |
 | Ethernet57 |  Interface with poe commands and limit in watts | access | - | - | - | - |
 | Ethernet58 |  Interface with poe disabled and no other poe keys | access | - | - | - | - |
@@ -243,9 +241,9 @@ sFlow is disabled.
 | Interface | Description | Type | Channel Group | IPv6 Address | VRF | MTU | Shutdown | ND RA Disabled | Managed Config Flag | IPv6 ACL In | IPv6 ACL Out |
 | --------- | ----------- | ---- | --------------| ------------ | --- | --- | -------- | -------------- | -------------------| ----------- | ------------ |
 | Ethernet3 | P2P_LINK_TO_DC1-SPINE2_Ethernet2 | routed | - | 2002:ABDC::1/64 | default | 1500 | - | - | - | - | - |
-| Ethernet4 | Molecule IPv6 | switchport | - | 2020::2020/64 | default | 9100 | True | True | True | IPv6_ACL_IN | IPv6_ACL_OUT |
+| Ethernet4 | Molecule IPv6 | routed | - | 2020::2020/64 | default | 9100 | True | True | True | IPv6_ACL_IN | IPv6_ACL_OUT |
 | Ethernet8.101 | to WAN-ISP-01 Ethernet2.101 - VRF-C1 | l3dot1q | - | 2002:ABDC::1/64 | default | - | - | - | - | - | - |
-| Ethernet55 | DHCPv6 Relay Testing | switchport | - | a0::1/64 | default | - | False | - | - | - | - |
+| Ethernet55 | DHCPv6 Relay Testing | - | - | a0::1/64 | default | - | False | - | - | - | - |
 
 ##### ISIS
 
@@ -344,7 +342,7 @@ interface Ethernet4
    description Molecule IPv6
    shutdown
    mtu 9100
-   switchport
+   no switchport
    snmp trap link-change
    ipv6 enable
    ipv6 address 2020::2020/64
@@ -763,7 +761,6 @@ interface Ethernet54
 interface Ethernet55
    description DHCPv6 Relay Testing
    no shutdown
-   switchport
    ipv6 address a0::1/64
    ipv6 dhcp relay destination a0::2 link-address a0::3
    ipv6 dhcp relay destination a0::4 vrf TEST local-interface Loopback55 link-address a0::5

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
@@ -243,7 +243,7 @@ sFlow is disabled.
 | Ethernet3 | P2P_LINK_TO_DC1-SPINE2_Ethernet2 | routed | - | 2002:ABDC::1/64 | default | 1500 | - | - | - | - | - |
 | Ethernet4 | Molecule IPv6 | routed | - | 2020::2020/64 | default | 9100 | True | True | True | IPv6_ACL_IN | IPv6_ACL_OUT |
 | Ethernet8.101 | to WAN-ISP-01 Ethernet2.101 - VRF-C1 | l3dot1q | - | 2002:ABDC::1/64 | default | - | - | - | - | - | - |
-| Ethernet55 | DHCPv6 Relay Testing | - | - | a0::1/64 | default | - | False | - | - | - | - |
+| Ethernet55 | DHCPv6 Relay Testing | routed | - | a0::1/64 | default | - | False | - | - | - | - |
 
 ##### ISIS
 
@@ -761,6 +761,7 @@ interface Ethernet54
 interface Ethernet55
    description DHCPv6 Relay Testing
    no shutdown
+   no switchport
    ipv6 address a0::1/64
    ipv6 dhcp relay destination a0::2 link-address a0::3
    ipv6 dhcp relay destination a0::4 vrf TEST local-interface Loopback55 link-address a0::5

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
@@ -212,8 +212,6 @@ interface Ethernet50
 | Port-Channel20 | Po_in_mode_access_accepting_tagged_LACP_frames | switched | access | 200 | - | - | - | - | - | - |
 | Port-Channel50 | SRV-POD03_PortChanne1 | switched | trunk | 1-4000 | - | - | - | - | - | 0000:0000:0303:0202:0101 |
 | Port-Channel51 | ipv6_prefix | switched | trunk | 1-500 | - | - | - | - | - | - |
-| Port-Channel100.101 | IFL for TENANT01 | switched | access | - | - | - | - | - | - | - |
-| Port-Channel100.102 | IFL for TENANT02 | switched | access | - | - | - | - | - | - | - |
 | Port-Channel101 | PVLAN Promiscuous Access - only one secondary | switched | access | 110 | - | - | - | - | - | - |
 | Port-Channel102 | PVLAN Promiscuous Trunk - vlan translation out | switched | trunk | 110-112 | - | - | - | - | - | - |
 | Port-Channel103 | PVLAN Secondary Trunk | switched | trunk | 110-112 | - | - | - | - | - | - |
@@ -476,14 +474,12 @@ interface Port-Channel100.101
    description IFL for TENANT01
    logging event link-status
    mtu 1500
-   switchport
    ip address 10.1.1.3/31
 !
 interface Port-Channel100.102
    description IFL for TENANT02
    no logging event link-status
    mtu 1500
-   switchport
    vrf C2
    ip address 10.1.2.3/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
@@ -232,6 +232,8 @@ interface Ethernet50
 | Interface | Description | Type | Vlan ID | Dot1q VLAN Tag |
 | --------- | ----------- | -----| ------- | -------------- |
 | Port-Channel8.101 | to Dev02 Port-Channel8.101 - VRF-C1 | l3dot1q | - | 101 |
+| Port-Channel100.101 | IFL for TENANT01 | l3dot1q | - | 101 |
+| Port-Channel100.102 | IFL for TENANT02 | l3dot1q | - | 102 |
 
 ##### Flexible Encapsulation Interfaces
 
@@ -296,6 +298,8 @@ interface Ethernet50
 | Port-Channel9 | - | routed | - | 10.9.2.3/31 | default | - | - | - | - |
 | Port-Channel17 | PBR Description | routed | - | 192.0.2.3/31 | default | - | - | - | - |
 | Port-Channel99 | MCAST | routed | - | 192.0.2.10/31 | default | - | - | - | - |
+| Port-Channel100.101 | IFL for TENANT01 | routed | - | 10.1.1.3/31 | default | 1500 | - | - | - |
+| Port-Channel100.102 | IFL for TENANT02 | routed | - | 10.1.2.3/31 | C2 | 1500 | - | - | - |
 | Port-Channel113 | interface_with_mpls_enabled | routed | - | 172.31.128.9/31 | default | - | - | - | - |
 | Port-Channel114 | interface_with_mpls_disabled | routed | - | 172.31.128.10/31 | default | - | - | - | - |
 
@@ -474,12 +478,14 @@ interface Port-Channel100.101
    description IFL for TENANT01
    logging event link-status
    mtu 1500
+   encapsulation dot1q vlan 101
    ip address 10.1.1.3/31
 !
 interface Port-Channel100.102
    description IFL for TENANT02
    no logging event link-status
    mtu 1500
+   encapsulation dot1q vlan 102
    vrf C2
    ip address 10.1.2.3/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis-new.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis-new.md
@@ -49,6 +49,7 @@ interface Management1
 
 | Interface | Description | Mode | VLANs | Native VLAN | Trunk Group | Channel-Group |
 | --------- | ----------- | ---- | ----- | ----------- | ----------- | ------------- |
+| Ethernet3 | MLAG_PEER_EAPI-LEAF1B_Ethernet3 | *access | *- | *- | *- | 3 |
 
 *Inherited from Port-Channel Interface
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis-new.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis-new.md
@@ -49,7 +49,6 @@ interface Management1
 
 | Interface | Description | Mode | VLANs | Native VLAN | Trunk Group | Channel-Group |
 | --------- | ----------- | ---- | ----- | ----------- | ----------- | ------------- |
-| Ethernet3 | MLAG_PEER_EAPI-LEAF1B_Ethernet3 | *access | *- | *- | *- | 3 |
 
 *Inherited from Port-Channel Interface
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis.md
@@ -50,6 +50,7 @@ interface Management1
 
 | Interface | Description | Mode | VLANs | Native VLAN | Trunk Group | Channel-Group |
 | --------- | ----------- | ---- | ----- | ----------- | ----------- | ------------- |
+| Ethernet3 | MLAG_PEER_EAPI-LEAF1B_Ethernet3 | *access | *- | *- | *- | 3 |
 
 *Inherited from Port-Channel Interface
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis.md
@@ -50,7 +50,6 @@ interface Management1
 
 | Interface | Description | Mode | VLANs | Native VLAN | Trunk Group | Channel-Group |
 | --------- | ----------- | ---- | ----- | ----------- | ----------- | ------------- |
-| Ethernet3 | MLAG_PEER_EAPI-LEAF1B_Ethernet3 | *access | *- | *- | *- | 3 |
 
 *Inherited from Port-Channel Interface
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
@@ -58,7 +58,7 @@ interface Ethernet4
    description Molecule IPv6
    shutdown
    mtu 9100
-   switchport
+   no switchport
    snmp trap link-change
    ipv6 enable
    ipv6 address 2020::2020/64
@@ -477,7 +477,6 @@ interface Ethernet54
 interface Ethernet55
    description DHCPv6 Relay Testing
    no shutdown
-   switchport
    ipv6 address a0::1/64
    ipv6 dhcp relay destination a0::2 link-address a0::3
    ipv6 dhcp relay destination a0::4 vrf TEST local-interface Loopback55 link-address a0::5

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
@@ -477,6 +477,7 @@ interface Ethernet54
 interface Ethernet55
    description DHCPv6 Relay Testing
    no shutdown
+   no switchport
    ipv6 address a0::1/64
    ipv6 dhcp relay destination a0::2 link-address a0::3
    ipv6 dhcp relay destination a0::4 vrf TEST local-interface Loopback55 link-address a0::5

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
@@ -148,14 +148,12 @@ interface Port-Channel100.101
    description IFL for TENANT01
    logging event link-status
    mtu 1500
-   switchport
    ip address 10.1.1.3/31
 !
 interface Port-Channel100.102
    description IFL for TENANT02
    no logging event link-status
    mtu 1500
-   switchport
    vrf C2
    ip address 10.1.2.3/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
@@ -148,12 +148,14 @@ interface Port-Channel100.101
    description IFL for TENANT01
    logging event link-status
    mtu 1500
+   encapsulation dot1q vlan 101
    ip address 10.1.1.3/31
 !
 interface Port-Channel100.102
    description IFL for TENANT02
    no logging event link-status
    mtu 1500
+   encapsulation dot1q vlan 102
    vrf C2
    ip address 10.1.2.3/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/address-locking.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/address-locking.yml
@@ -17,20 +17,17 @@ address_locking:
 
 ethernet_interfaces:
   - name: Ethernet1
-    type: switched
     description: Address Locking Interface Testing 1
     address_locking:
       ipv4: true
 
   - name: Ethernet2
-    type: switched
     description: Address Locking Interface Testing 2
     address_locking:
       ipv4: true
       ipv6: true
 
   - name: Ethernet3
-    type: switched
     description: Address Locking Interface Testing 3
     address_locking:
       ipv4: false

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/address-locking.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/address-locking.yml
@@ -17,17 +17,20 @@ address_locking:
 
 ethernet_interfaces:
   - name: Ethernet1
+    type: switched
     description: Address Locking Interface Testing 1
     address_locking:
       ipv4: true
 
   - name: Ethernet2
+    type: switched
     description: Address Locking Interface Testing 2
     address_locking:
       ipv4: true
       ipv6: true
 
   - name: Ethernet3
+    type: switched
     description: Address Locking Interface Testing 3
     address_locking:
       ipv4: false

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
@@ -31,7 +31,6 @@ ethernet_interfaces:
       EOF
 
   - name: Ethernet2
-    type: switched
     peer: SRV-POD03
     peer_interface: Eth1
     peer_type: server
@@ -280,7 +279,6 @@ ethernet_interfaces:
       vlan: 70
 
   - name: Ethernet14
-    type: switched
     logging:
       event:
         link_status: true
@@ -292,14 +290,12 @@ ethernet_interfaces:
     vlans: 110-111,210-211
 
   - name: Ethernet15
-    type: switched
     description: PVLAN Promiscuous Access - only one secondary
     mode: access
     vlans: 110
     pvlan_mapping: 111
 
   - name: Ethernet16
-    type: switched
     description: PVLAN Promiscuous Trunk - vlan translation out
     mode: trunk
     vlans: 110-112
@@ -309,7 +305,6 @@ ethernet_interfaces:
         to: 110
 
   - name: Ethernet17
-    type: switched
     description: PVLAN Secondary Trunk
     mode: trunk
     vlans: 110-112
@@ -325,7 +320,6 @@ ethernet_interfaces:
         input: MyLANServicePolicy
 
   - name: Ethernet19
-    type: switched
     description: Switched port with no LLDP rx/tx
     mode: access
     vlans: 110
@@ -341,7 +335,6 @@ ethernet_interfaces:
       receive: false
 
   - name: Ethernet21
-    type: switched
     description: 200MBit/s shape
     qos:
       trust: disabled
@@ -349,26 +342,22 @@ ethernet_interfaces:
       rate: "200000 kbps"
 
   - name: Ethernet22
-    type: switched
     description: 10% shape
     shape:
       rate: "10 percent"
 
   - name: Ethernet23
-    type: switched
     description: Error-correction encoding
     error_correction_encoding:
       fire_code: true
       reed_solomon: true
 
   - name: Ethernet24
-    type: switched
     description: Disable error-correction encoding
     error_correction_encoding:
       enabled: false
 
   - name: Ethernet25
-    type: switched
     description: Molecule MAC
     mac_access_group_in: MAC_ACL_IN
     mac_access_group_out: MAC_ACL_OUT
@@ -431,7 +420,6 @@ ethernet_interfaces:
         client: true
 
   - name: Ethernet27
-    type: switched
     description: EVPN-Vxlan single-active redundancy
     evpn_ethernet_segment:
       identifier: "0000:0000:0000:0102:0304"
@@ -445,7 +433,6 @@ ethernet_interfaces:
         candidate_reachability_required: true
 
   - name: Ethernet28
-    type: switched
     description: EVPN-MPLS multihoming
     evpn_ethernet_segment:
       identifier: "0000:0000:0000:0102:0305"
@@ -455,41 +442,35 @@ ethernet_interfaces:
         tunnel_flood_filter_time: 100
 
   - name: Ethernet29
-    type: switched
     description: DOT1X Testing - auto phone true
     dot1x:
       port_control: auto
       port_control_force_authorized_phone: true
 
   - name: Ethernet30
-    type: switched
     description: DOT1X Testing - force-authorized phone false
     dot1x:
       port_control: force-authorized
       port_control_force_authorized_phone: false
 
   - name: Ethernet31
-    type: switched
     description: DOT1X Testing - force-unauthorized - no phone
     dot1x:
       port_control: force-unauthorized
 
   - name: Ethernet32
-    type: switched
     description: DOT1X Testing - auto reauthentication
     dot1x:
       port_control: auto
       reauthentication: true
 
   - name: Ethernet33
-    type: switched
     description: DOT1X Testing - pae mode authenticator
     dot1x:
       pae:
         mode: authenticator
 
   - name: Ethernet34
-    type: switched
     description: DOT1X Testing - authentication_failure allow
     dot1x:
       authentication_failure:
@@ -497,28 +478,24 @@ ethernet_interfaces:
         allow_vlan: 800
 
   - name: Ethernet35
-    type: switched
     description: DOT1X Testing - authentication_failure drop
     dot1x:
       authentication_failure:
         action: drop
 
   - name: Ethernet36
-    type: switched
     description: DOT1X Testing - host-mode single-host
     dot1x:
       host_mode:
         mode: single-host
 
   - name: Ethernet37
-    type: switched
     description: DOT1X Testing - host-mode multi-host
     dot1x:
       host_mode:
         mode: multi-host
 
   - name: Ethernet38
-    type: switched
     description: DOT1X Testing - host-mode multi-host authenticated
     dot1x:
       host_mode:
@@ -526,7 +503,6 @@ ethernet_interfaces:
         multi_host_authenticated: true
 
   - name: Ethernet39
-    type: switched
     description: DOT1X Testing - mac_based_authentication host-mode common true
     dot1x:
       mac_based_authentication:
@@ -534,7 +510,6 @@ ethernet_interfaces:
         host_mode_common: true
 
   - name: Ethernet40
-    type: switched
     description: DOT1X Testing - mac_based_authentication always
     dot1x:
       mac_based_authentication:
@@ -542,7 +517,6 @@ ethernet_interfaces:
         always: true
 
   - name: Ethernet41
-    type: switched
     description: DOT1X Testing - mac_based_authentication always and host-mode common
     dot1x:
       mac_based_authentication:
@@ -551,14 +525,12 @@ ethernet_interfaces:
         host_mode_common: true
 
   - name: Ethernet42
-    type: switched
     description: DOT1X Testing - mac_based_authentication
     dot1x:
       mac_based_authentication:
         enabled: true
 
   - name: Ethernet43
-    type: switched
     description: DOT1X Testing - timeout values
     dot1x:
       timeout:
@@ -569,7 +541,6 @@ ethernet_interfaces:
         tx_period: 6
 
   - name: Ethernet44
-    type: switched
     description: DOT1X Testing - reauthorization_request_limit
     dot1x:
       reauthorization_request_limit: 3
@@ -577,7 +548,6 @@ ethernet_interfaces:
         disabled: true
 
   - name: Ethernet45
-    type: switched
     description: DOT1X Testing - all features
     dot1x:
       port_control: auto
@@ -606,7 +576,6 @@ ethernet_interfaces:
       reauthorization_request_limit: 2
 
   - name: Ethernet46
-    type: switched
     description: native-vlan-tag-precedence
     native_vlan_tag: true
     native_vlan: 100
@@ -633,20 +602,17 @@ ethernet_interfaces:
 
   - name: Ethernet50
     description: SFlow Interface Testing - SFlow ingress enabled
-    type: switched
     sflow:
       enable: true
 
   - name: Ethernet51
     description: SFlow Interface Testing - SFlow egress enabled
-    type: switched
     sflow:
       egress:
         enable: true
 
   - name: Ethernet52
     description: SFlow Interface Testing - SFlow ingress and egress unmodified enabled
-    type: switched
     sflow:
       enable: true
       egress:
@@ -654,7 +620,6 @@ ethernet_interfaces:
 
   - name: Ethernet53
     description: SFlow Interface Testing - SFlow ingress and egress disabled
-    type: switched
     sflow:
       enable: false
       egress:
@@ -662,7 +627,6 @@ ethernet_interfaces:
 
   - name: Ethernet54
     description: SFlow Interface Testing - SFlow ingress and egress unmodified disabled
-    type: switched
     sflow:
       enable: false
       egress:
@@ -683,7 +647,6 @@ ethernet_interfaces:
 
   - name: Ethernet56
     description: Interface with poe commands and limit in class
-    type: switched
     poe:
       priority: low
       reboot:
@@ -700,7 +663,6 @@ ethernet_interfaces:
 
   - name: Ethernet57
     description: Interface with poe commands and limit in watts
-    type: switched
     poe:
       disabled: false
       priority: critical
@@ -718,13 +680,11 @@ ethernet_interfaces:
 
   - name: Ethernet58
     description: Interface with poe disabled and no other poe keys
-    type: switched
     poe:
       disabled: true
 
   - name: Ethernet60
     description: IP NAT Testing
-    type: switched
     ip_nat:
       destination:
         dynamic:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
@@ -723,6 +723,7 @@ ethernet_interfaces:
 
   - name: Ethernet60
     description: IP NAT Testing
+    type: switched
     ip_nat:
       destination:
         dynamic:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
@@ -31,6 +31,7 @@ ethernet_interfaces:
       EOF
 
   - name: Ethernet2
+    type: switched
     peer: SRV-POD03
     peer_interface: Eth1
     peer_type: server
@@ -94,6 +95,7 @@ ethernet_interfaces:
     spanning_tree_guard: root
 
   - name: Ethernet4
+    type: routed
     description: Molecule IPv6
     shutdown: true
     mtu: 9100
@@ -149,6 +151,7 @@ ethernet_interfaces:
     spanning_tree_guard: loop
 
   - name: Ethernet6
+    type: switched
     logging:
       event:
         link_status: true
@@ -277,6 +280,7 @@ ethernet_interfaces:
       vlan: 70
 
   - name: Ethernet14
+    type: switched
     logging:
       event:
         link_status: true
@@ -288,12 +292,14 @@ ethernet_interfaces:
     vlans: 110-111,210-211
 
   - name: Ethernet15
+    type: switched
     description: PVLAN Promiscuous Access - only one secondary
     mode: access
     vlans: 110
     pvlan_mapping: 111
 
   - name: Ethernet16
+    type: switched
     description: PVLAN Promiscuous Trunk - vlan translation out
     mode: trunk
     vlans: 110-112
@@ -303,6 +309,7 @@ ethernet_interfaces:
         to: 110
 
   - name: Ethernet17
+    type: switched
     description: PVLAN Secondary Trunk
     mode: trunk
     vlans: 110-112
@@ -318,6 +325,7 @@ ethernet_interfaces:
         input: MyLANServicePolicy
 
   - name: Ethernet19
+    type: switched
     description: Switched port with no LLDP rx/tx
     mode: access
     vlans: 110
@@ -333,6 +341,7 @@ ethernet_interfaces:
       receive: false
 
   - name: Ethernet21
+    type: switched
     description: 200MBit/s shape
     qos:
       trust: disabled
@@ -340,22 +349,26 @@ ethernet_interfaces:
       rate: "200000 kbps"
 
   - name: Ethernet22
+    type: switched
     description: 10% shape
     shape:
       rate: "10 percent"
 
   - name: Ethernet23
+    type: switched
     description: Error-correction encoding
     error_correction_encoding:
       fire_code: true
       reed_solomon: true
 
   - name: Ethernet24
+    type: switched
     description: Disable error-correction encoding
     error_correction_encoding:
       enabled: false
 
   - name: Ethernet25
+    type: switched
     description: Molecule MAC
     mac_access_group_in: MAC_ACL_IN
     mac_access_group_out: MAC_ACL_OUT
@@ -418,6 +431,7 @@ ethernet_interfaces:
         client: true
 
   - name: Ethernet27
+    type: switched
     description: EVPN-Vxlan single-active redundancy
     evpn_ethernet_segment:
       identifier: "0000:0000:0000:0102:0304"
@@ -431,6 +445,7 @@ ethernet_interfaces:
         candidate_reachability_required: true
 
   - name: Ethernet28
+    type: switched
     description: EVPN-MPLS multihoming
     evpn_ethernet_segment:
       identifier: "0000:0000:0000:0102:0305"
@@ -440,35 +455,41 @@ ethernet_interfaces:
         tunnel_flood_filter_time: 100
 
   - name: Ethernet29
+    type: switched
     description: DOT1X Testing - auto phone true
     dot1x:
       port_control: auto
       port_control_force_authorized_phone: true
 
   - name: Ethernet30
+    type: switched
     description: DOT1X Testing - force-authorized phone false
     dot1x:
       port_control: force-authorized
       port_control_force_authorized_phone: false
 
   - name: Ethernet31
+    type: switched
     description: DOT1X Testing - force-unauthorized - no phone
     dot1x:
       port_control: force-unauthorized
 
   - name: Ethernet32
+    type: switched
     description: DOT1X Testing - auto reauthentication
     dot1x:
       port_control: auto
       reauthentication: true
 
   - name: Ethernet33
+    type: switched
     description: DOT1X Testing - pae mode authenticator
     dot1x:
       pae:
         mode: authenticator
 
   - name: Ethernet34
+    type: switched
     description: DOT1X Testing - authentication_failure allow
     dot1x:
       authentication_failure:
@@ -476,24 +497,28 @@ ethernet_interfaces:
         allow_vlan: 800
 
   - name: Ethernet35
+    type: switched
     description: DOT1X Testing - authentication_failure drop
     dot1x:
       authentication_failure:
         action: drop
 
   - name: Ethernet36
+    type: switched
     description: DOT1X Testing - host-mode single-host
     dot1x:
       host_mode:
         mode: single-host
 
   - name: Ethernet37
+    type: switched
     description: DOT1X Testing - host-mode multi-host
     dot1x:
       host_mode:
         mode: multi-host
 
   - name: Ethernet38
+    type: switched
     description: DOT1X Testing - host-mode multi-host authenticated
     dot1x:
       host_mode:
@@ -501,6 +526,7 @@ ethernet_interfaces:
         multi_host_authenticated: true
 
   - name: Ethernet39
+    type: switched
     description: DOT1X Testing - mac_based_authentication host-mode common true
     dot1x:
       mac_based_authentication:
@@ -508,6 +534,7 @@ ethernet_interfaces:
         host_mode_common: true
 
   - name: Ethernet40
+    type: switched
     description: DOT1X Testing - mac_based_authentication always
     dot1x:
       mac_based_authentication:
@@ -515,6 +542,7 @@ ethernet_interfaces:
         always: true
 
   - name: Ethernet41
+    type: switched
     description: DOT1X Testing - mac_based_authentication always and host-mode common
     dot1x:
       mac_based_authentication:
@@ -523,12 +551,14 @@ ethernet_interfaces:
         host_mode_common: true
 
   - name: Ethernet42
+    type: switched
     description: DOT1X Testing - mac_based_authentication
     dot1x:
       mac_based_authentication:
         enabled: true
 
   - name: Ethernet43
+    type: switched
     description: DOT1X Testing - timeout values
     dot1x:
       timeout:
@@ -539,6 +569,7 @@ ethernet_interfaces:
         tx_period: 6
 
   - name: Ethernet44
+    type: switched
     description: DOT1X Testing - reauthorization_request_limit
     dot1x:
       reauthorization_request_limit: 3
@@ -546,6 +577,7 @@ ethernet_interfaces:
         disabled: true
 
   - name: Ethernet45
+    type: switched
     description: DOT1X Testing - all features
     dot1x:
       port_control: auto
@@ -574,6 +606,7 @@ ethernet_interfaces:
       reauthorization_request_limit: 2
 
   - name: Ethernet46
+    type: switched
     description: native-vlan-tag-precedence
     native_vlan_tag: true
     native_vlan: 100
@@ -600,17 +633,20 @@ ethernet_interfaces:
 
   - name: Ethernet50
     description: SFlow Interface Testing - SFlow ingress enabled
+    type: switched
     sflow:
       enable: true
 
   - name: Ethernet51
     description: SFlow Interface Testing - SFlow egress enabled
+    type: switched
     sflow:
       egress:
         enable: true
 
   - name: Ethernet52
     description: SFlow Interface Testing - SFlow ingress and egress unmodified enabled
+    type: switched
     sflow:
       enable: true
       egress:
@@ -618,6 +654,7 @@ ethernet_interfaces:
 
   - name: Ethernet53
     description: SFlow Interface Testing - SFlow ingress and egress disabled
+    type: switched
     sflow:
       enable: false
       egress:
@@ -625,6 +662,7 @@ ethernet_interfaces:
 
   - name: Ethernet54
     description: SFlow Interface Testing - SFlow ingress and egress unmodified disabled
+    type: switched
     sflow:
       enable: false
       egress:
@@ -644,6 +682,7 @@ ethernet_interfaces:
 
   - name: Ethernet56
     description: Interface with poe commands and limit in class
+    type: switched
     poe:
       priority: low
       reboot:
@@ -660,6 +699,7 @@ ethernet_interfaces:
 
   - name: Ethernet57
     description: Interface with poe commands and limit in watts
+    type: switched
     poe:
       disabled: false
       priority: critical
@@ -677,6 +717,7 @@ ethernet_interfaces:
 
   - name: Ethernet58
     description: Interface with poe disabled and no other poe keys
+    type: switched
     poe:
       disabled: true
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
@@ -670,6 +670,7 @@ ethernet_interfaces:
 
   - name: Ethernet55
     description: DHCPv6 Relay Testing
+    type: routed
     shutdown: false
     ipv6_address: a0::1/64
     ipv6_dhcp_relay_destinations:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/flow-tracking.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/flow-tracking.yml
@@ -47,16 +47,20 @@ flow_trackings:
 
 ethernet_interfaces:
   - name: Ethernet40
+    type: switched
     flow_tracker:
       sampled: T2
   - name: Ethernet41
+    type: switched
     flow_tracker:
       sampled: T3
   - name: Ethernet42
+    type: switched
     flow_tracker:
       sampled: T3
 
 port_channel_interfaces:
   - name: Port-Channel42
+    type: switched
     flow_tracker:
       sampled: T3

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/flow-tracking.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/flow-tracking.yml
@@ -47,20 +47,16 @@ flow_trackings:
 
 ethernet_interfaces:
   - name: Ethernet40
-    type: switched
     flow_tracker:
       sampled: T2
   - name: Ethernet41
-    type: switched
     flow_tracker:
       sampled: T3
   - name: Ethernet42
-    type: switched
     flow_tracker:
       sampled: T3
 
 port_channel_interfaces:
   - name: Port-Channel42
-    type: switched
     flow_tracker:
       sampled: T3

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/l2-protocol-forwarding.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/l2-protocol-forwarding.yml
@@ -65,13 +65,11 @@ l2_protocol:
 ethernet_interfaces:
   - name: Ethernet1
     description: L2PF test
-    type: switched
     l2_protocol:
       forwarding_profile: TEST1
 
 port_channel_interfaces:
   - name: Port-Channel1
     description: L2PF test
-    type: switched
     l2_protocol:
       forwarding_profile: TEST2

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/l2-protocol-forwarding.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/l2-protocol-forwarding.yml
@@ -65,11 +65,13 @@ l2_protocol:
 ethernet_interfaces:
   - name: Ethernet1
     description: L2PF test
+    type: switched
     l2_protocol:
       forwarding_profile: TEST1
 
 port_channel_interfaces:
   - name: Port-Channel1
     description: L2PF test
+    type: switched
     l2_protocol:
       forwarding_profile: TEST2

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/lldp.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/lldp.yml
@@ -20,7 +20,6 @@ ethernet_interfaces:
       receive: false
 
   - name: Ethernet2
-    type: switched
     description: Switched port with no LLDP rx/tx
     mode: access
     vlans: 110

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/lldp.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/lldp.yml
@@ -20,6 +20,7 @@ ethernet_interfaces:
       receive: false
 
   - name: Ethernet2
+    type: switched
     description: Switched port with no LLDP rx/tx
     mode: access
     vlans: 110
@@ -28,6 +29,7 @@ ethernet_interfaces:
       receive: true
 
   - name: Ethernet3
+    type: switched
     description: No special LLDP settings
     mode: access
     vlans: 110

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/mac-security-eth-po-entropy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/mac-security-eth-po-entropy.yml
@@ -48,6 +48,7 @@ port_channel_interfaces:
 # Children interfaces
 ethernet_interfaces:
   - name: Ethernet3
+    type: port-channel-member
     peer: DC1-AGG01
     peer_interface: Ethernet3
     peer_type: l3leaf

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/mac-security-eth-po-entropy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/mac-security-eth-po-entropy.yml
@@ -40,6 +40,7 @@ management_security:
 ### L2 portchannel
 port_channel_interfaces:
   - name: Port-Channel3
+    type: switched
     description: L2-PORT
     vlans: 1-5
     mode: trunk

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
@@ -2,6 +2,7 @@
 ### Port-Channel Interfaces ###
 port_channel_interfaces:
   - name: Port-Channel5
+    type: switched
     description: DC1_L2LEAF1_Po1
     vlans: 110,201
     link_tracking_groups:
@@ -27,6 +28,7 @@ port_channel_interfaces:
       EOF
 
   - name: Port-Channel15
+    type: switched
     description: DC1_L2LEAF3_Po1
     vlans: 110,201
     link_tracking_groups:
@@ -37,6 +39,7 @@ port_channel_interfaces:
     spanning_tree_guard: loop
 
   - name: Port-Channel16
+    type: switched
     description: DC1_L2LEAF4_Po1
     vlans: 110,201
     mode: trunk
@@ -45,6 +48,7 @@ port_channel_interfaces:
     spanning_tree_guard: disabled
 
   - name: Port-Channel3
+    type: switched
     description: MLAG_PEER_DC1-LEAF1B_Po3
     vlans: "2-4094"
     mode: trunk
@@ -56,6 +60,7 @@ port_channel_interfaces:
       - MLAG
 
   - name: Port-Channel10
+    type: switched
     description: SRV01_bond0
     vlans: 2-3000
     mode: trunk
@@ -66,6 +71,7 @@ port_channel_interfaces:
       rate: 50 percent
 
   - name: Port-Channel50
+    type: switched
     description: SRV-POD03_PortChanne1
     vlans: 1-4000
     mode: trunk
@@ -75,6 +81,7 @@ port_channel_interfaces:
     lacp_id: 0303.0202.0101
 
   - name: Port-Channel51
+    type: switched
     description: ipv6_prefix
     vlans: 1-500
     mode: trunk
@@ -145,6 +152,7 @@ port_channel_interfaces:
       vlan: 70
 
   - name: Port-Channel13
+    type: switched
     description: EVPN-Vxlan single-active redundancy
     evpn_ethernet_segment:
       redundancy: single-active
@@ -158,6 +166,7 @@ port_channel_interfaces:
       route_target: "00:00:01:02:03:04"
 
   - name: Port-Channel14
+    type: switched
     description: EVPN-MPLS multihoming
     evpn_ethernet_segment:
       identifier: "0000:0000:0000:0102:0305"
@@ -184,6 +193,7 @@ port_channel_interfaces:
         sparse_mode: true
 
   - name: Port-Channel101
+    type: switched
     description: PVLAN Promiscuous Access - only one secondary
     mode: access
     vlans: 110
@@ -192,6 +202,7 @@ port_channel_interfaces:
       trust: disabled
 
   - name: Port-Channel102
+    type: switched
     description: PVLAN Promiscuous Trunk - vlan translation out
     mode: trunk
     vlans: 110-112
@@ -201,12 +212,14 @@ port_channel_interfaces:
         to: 110
 
   - name: Port-Channel103
+    type: switched
     description: PVLAN Secondary Trunk
     mode: trunk
     vlans: 110-112
     trunk_private_vlan_secondary: true
 
   - name: Port-Channel104
+    type: switched
     description: LACP fallback individual
     mode: trunk
     vlans: 112
@@ -214,26 +227,31 @@ port_channel_interfaces:
     lacp_fallback_mode: individual
 
   - name: Port-Channel105
+    type: switched
     description: bpdu disabled
     spanning_tree_bpduguard: disabled
     spanning_tree_bpdufilter: disabled
 
   - name: Port-Channel106
+    type: switched
     description: bpdu enabled
     spanning_tree_bpduguard: enabled
     spanning_tree_bpdufilter: enabled
 
   - name: Port-Channel107
+    type: switched
     description: bpdu true
     spanning_tree_bpduguard: true
     spanning_tree_bpdufilter: true
 
   - name: Port-Channel108
+    type: switched
     description: bpdu false
     spanning_tree_bpduguard: false # No config should be rendered for this case
     spanning_tree_bpdufilter: false # No config should be rendered for this case
 
   - name: Port-Channel109
+    type: switched
     description: Molecule ACLs
     mode: access
     vlans: 110
@@ -319,6 +337,7 @@ port_channel_interfaces:
     lacp_id: 0303.0202.0101
 
   - name: Port-Channel112
+    type: switched
     description: LACP fallback individual
     mode: trunk
     vlans: 112
@@ -345,6 +364,7 @@ port_channel_interfaces:
         interface: false
 
   - name: Port-Channel115
+    type: switched
     description: native-vlan-tag-precedence
     native_vlan_tag: true
     native_vlan: 100
@@ -448,8 +468,6 @@ ethernet_interfaces:
     peer_interface: Eth1
     peer_type: server
     description: SRV-POD03_Eth1
-    mode: trunk
-    vlans: 1-4000
     channel_group:
       id: 5
       mode: "active"
@@ -513,6 +531,7 @@ ethernet_interfaces:
       mode: active
 
   - name: Ethernet10/4
+    type: switched
     description: LAG Member LACP fallback
     channel_group:
       id: 104
@@ -543,6 +562,7 @@ ethernet_interfaces:
       mode: active
 
   - name: Ethernet11/2
+    type: switched
     description: LAG Member LACP fallback LLDP ZTP VLAN
     channel_group:
       id: 112

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
@@ -2,7 +2,6 @@
 ### Port-Channel Interfaces ###
 port_channel_interfaces:
   - name: Port-Channel5
-    type: switched
     description: DC1_L2LEAF1_Po1
     vlans: 110,201
     link_tracking_groups:
@@ -28,7 +27,6 @@ port_channel_interfaces:
       EOF
 
   - name: Port-Channel15
-    type: switched
     description: DC1_L2LEAF3_Po1
     vlans: 110,201
     link_tracking_groups:
@@ -39,7 +37,6 @@ port_channel_interfaces:
     spanning_tree_guard: loop
 
   - name: Port-Channel16
-    type: switched
     description: DC1_L2LEAF4_Po1
     vlans: 110,201
     mode: trunk
@@ -48,7 +45,6 @@ port_channel_interfaces:
     spanning_tree_guard: disabled
 
   - name: Port-Channel3
-    type: switched
     description: MLAG_PEER_DC1-LEAF1B_Po3
     vlans: "2-4094"
     mode: trunk
@@ -60,7 +56,6 @@ port_channel_interfaces:
       - MLAG
 
   - name: Port-Channel10
-    type: switched
     description: SRV01_bond0
     vlans: 2-3000
     mode: trunk
@@ -71,7 +66,6 @@ port_channel_interfaces:
       rate: 50 percent
 
   - name: Port-Channel50
-    type: switched
     description: SRV-POD03_PortChanne1
     vlans: 1-4000
     mode: trunk
@@ -81,7 +75,6 @@ port_channel_interfaces:
     lacp_id: 0303.0202.0101
 
   - name: Port-Channel51
-    type: switched
     description: ipv6_prefix
     vlans: 1-500
     mode: trunk
@@ -97,6 +90,7 @@ port_channel_interfaces:
       event:
         link_status: true
   - name: Port-Channel100.101
+    type: l3dot1q
     logging:
       event:
         link_status: true
@@ -105,6 +99,7 @@ port_channel_interfaces:
     ip_address: 10.1.1.3/31
     encapsulation_dot1q_vlan: 101
   - name: Port-Channel100.102
+    type: l3dot1q
     logging:
       event:
         link_status: false
@@ -152,7 +147,6 @@ port_channel_interfaces:
       vlan: 70
 
   - name: Port-Channel13
-    type: switched
     description: EVPN-Vxlan single-active redundancy
     evpn_ethernet_segment:
       redundancy: single-active
@@ -166,7 +160,6 @@ port_channel_interfaces:
       route_target: "00:00:01:02:03:04"
 
   - name: Port-Channel14
-    type: switched
     description: EVPN-MPLS multihoming
     evpn_ethernet_segment:
       identifier: "0000:0000:0000:0102:0305"
@@ -193,7 +186,6 @@ port_channel_interfaces:
         sparse_mode: true
 
   - name: Port-Channel101
-    type: switched
     description: PVLAN Promiscuous Access - only one secondary
     mode: access
     vlans: 110
@@ -202,7 +194,6 @@ port_channel_interfaces:
       trust: disabled
 
   - name: Port-Channel102
-    type: switched
     description: PVLAN Promiscuous Trunk - vlan translation out
     mode: trunk
     vlans: 110-112
@@ -212,14 +203,12 @@ port_channel_interfaces:
         to: 110
 
   - name: Port-Channel103
-    type: switched
     description: PVLAN Secondary Trunk
     mode: trunk
     vlans: 110-112
     trunk_private_vlan_secondary: true
 
   - name: Port-Channel104
-    type: switched
     description: LACP fallback individual
     mode: trunk
     vlans: 112
@@ -227,31 +216,26 @@ port_channel_interfaces:
     lacp_fallback_mode: individual
 
   - name: Port-Channel105
-    type: switched
     description: bpdu disabled
     spanning_tree_bpduguard: disabled
     spanning_tree_bpdufilter: disabled
 
   - name: Port-Channel106
-    type: switched
     description: bpdu enabled
     spanning_tree_bpduguard: enabled
     spanning_tree_bpdufilter: enabled
 
   - name: Port-Channel107
-    type: switched
     description: bpdu true
     spanning_tree_bpduguard: true
     spanning_tree_bpdufilter: true
 
   - name: Port-Channel108
-    type: switched
     description: bpdu false
     spanning_tree_bpduguard: false # No config should be rendered for this case
     spanning_tree_bpdufilter: false # No config should be rendered for this case
 
   - name: Port-Channel109
-    type: switched
     description: Molecule ACLs
     mode: access
     vlans: 110
@@ -337,7 +321,6 @@ port_channel_interfaces:
     lacp_id: 0303.0202.0101
 
   - name: Port-Channel112
-    type: switched
     description: LACP fallback individual
     mode: trunk
     vlans: 112
@@ -364,7 +347,6 @@ port_channel_interfaces:
         interface: false
 
   - name: Port-Channel115
-    type: switched
     description: native-vlan-tag-precedence
     native_vlan_tag: true
     native_vlan: 100
@@ -414,7 +396,6 @@ port_channel_interfaces:
 
   - name: Port-Channel130
     description: IP NAT Testing
-    type: switched
     ip_nat:
       destination:
         dynamic:
@@ -435,6 +416,7 @@ port_channel_interfaces:
 # Children interfaces
 ethernet_interfaces:
   - name: Ethernet5
+    type: port-channel-member
     peer: DC1-AGG01
     peer_interface: Ethernet1
     peer_type: l2leaf
@@ -447,6 +429,7 @@ ethernet_interfaces:
         override: 100gbase-ar4
 
   - name: Ethernet3
+    type: port-channel-member
     peer: DC1-LEAF1B
     peer_interface: Ethernet3
     peer_type: mlag_peer
@@ -456,6 +439,7 @@ ethernet_interfaces:
       mode: active
 
   - name: Ethernet4
+    type: port-channel-member
     peer: DC1-LEAF1B
     peer_interface: Ethernet4
     peer_type: mlag_peer
@@ -465,6 +449,7 @@ ethernet_interfaces:
       mode: active
 
   - name: Ethernet50
+    type: port-channel-member
     peer: SRV-POD03
     peer_interface: Eth1
     peer_type: server
@@ -477,6 +462,7 @@ ethernet_interfaces:
       transmit: false
 
   - name: Ethernet8
+    type: port-channel-member
     peer: DC1-LEAF1B
     peer_interface: Ethernet4
     description: MLAG_PEER_DC1-LEAF1B_Ethernet8
@@ -485,6 +471,7 @@ ethernet_interfaces:
       mode: active
 
   - name: Ethernet15
+    type: port-channel-member
     peer: DC1-AGG03
     peer_interface: Ethernet1
     peer_type: l2leaf
@@ -497,6 +484,7 @@ ethernet_interfaces:
       multiplier: 30
 
   - name: Ethernet16
+    type: port-channel-member
     peer: DC1-AGG04
     peer_interface: Ethernet1
     peer_type: l2leaf
@@ -508,24 +496,28 @@ ethernet_interfaces:
       mode: normal
 
   - name: Ethernet17
+    type: port-channel-member
     description: LAG Member
     channel_group:
       id: 17
       mode: active
 
   - name: Ethernet10/1
+    type: port-channel-member
     description: LAG Member
     channel_group:
       id: 101
       mode: active
 
   - name: Ethernet10/2
+    type: port-channel-member
     description: LAG Member
     channel_group:
       id: 102
       mode: active
 
   - name: Ethernet10/3
+    type: port-channel-member
     description: LAG Member
     channel_group:
       id: 103
@@ -542,18 +534,21 @@ ethernet_interfaces:
     spanning_tree_portfast: edge
 
   - name: Ethernet18
+    type: port-channel-member
     description: LAG Member
     channel_group:
       id: 109
       mode: active
 
   - name: Ethernet10/10
+    type: port-channel-member
     description: isis_port_channel_member
     channel_group:
       id: 110
       mode: active
 
   - name: Ethernet11/1
+    type: port-channel-member
     description: LAG Member with error_correction
     error_correction_encoding:
       fire_code: true
@@ -563,7 +558,6 @@ ethernet_interfaces:
       mode: active
 
   - name: Ethernet11/2
-    type: switched
     description: LAG Member LACP fallback LLDP ZTP VLAN
     channel_group:
       id: 112

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
@@ -414,6 +414,7 @@ port_channel_interfaces:
 
   - name: Port-Channel130
     description: IP NAT Testing
+    type: switched
     ip_nat:
       destination:
         dynamic:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ptp.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ptp.yml
@@ -91,6 +91,7 @@ ethernet_interfaces:
       transport: ipv4
 # port-channel interfaces
   - name: Ethernet5
+    type: port-channel-member
     peer: DC1-AGG01
     peer_interface: Ethernet1
     peer_type: l2leaf

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ptp.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ptp.yml
@@ -38,6 +38,7 @@ ptp:
 # port-channels
 port_channel_interfaces:
   - name: Port-Channel5
+    type: switched
     description: DC1_L2LEAF1_Po1
     vlans: 110,201
     mode: trunk

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/qos.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/qos.yml
@@ -135,6 +135,7 @@ ethernet_interfaces:
       cos: 2
 
   - name: Ethernet3
+    type: port-channel-member
     peer: DC1-LEAF1B
     peer_interface: Ethernet3
     peer_type: mlag_peer
@@ -144,6 +145,7 @@ ethernet_interfaces:
       mode: active
 
   - name: Ethernet4
+    type: port-channel-member
     peer: DC1-LEAF1B
     peer_interface: Ethernet4
     peer_type: mlag_peer

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/qos.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/qos.yml
@@ -122,6 +122,7 @@ ethernet_interfaces:
       dscp: 48
 
   - name: Ethernet6
+    type: switched
     peer: SRV-POD02
     peer_interface: Eth1
     peer_type: server
@@ -152,6 +153,7 @@ ethernet_interfaces:
       mode: active
 
   - name: Ethernet7
+    type: switched
     peer: SRV-POD03
     peer_interface: Eth1
     peer_type: server
@@ -163,6 +165,7 @@ ethernet_interfaces:
 ### Port-Channel Interfaces ###
 port_channel_interfaces:
   - name: Port-Channel3
+    type: switched
     description: MLAG_PEER_DC1-LEAF1B_Po3
     vlans: "2-4094"
     mode: trunk

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-isis-new.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-isis-new.yml
@@ -82,6 +82,7 @@ ethernet_interfaces:
     isis_metric: 50
     isis_network_point_to_point: true
   - name: Ethernet3
+    type: port-channel-member
     peer: EAPI-LEAF1B
     peer_interface: Ethernet3
     peer_type: mlag_peer

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-isis.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-isis.yml
@@ -48,6 +48,7 @@ ethernet_interfaces:
     isis_network_point_to_point: true
     isis_circuit_type: level-1-2
   - name: Ethernet3
+    type: port-channel-member
     peer: EAPI-LEAF1B
     peer_interface: Ethernet3
     peer_type: mlag_peer
@@ -56,18 +57,21 @@ ethernet_interfaces:
       id: 3
       mode: active
   - name: Ethernet4
+    type: port-channel-member
     peer: DC1-LEAF1B
     peer_interface: Ethernet4
     channel_group:
       id: 4
       mode: active
   - name: Ethernet5
+    type: port-channel-member
     peer: DC1-LEAF1B
     peer_interface: Ethernet5
     channel_group:
       id: 5
       mode: active
   - name: Ethernet6
+    type: port-channel-member
     peer: DC1-LEAF1B
     peer_interface: Ethernet6
     channel_group:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/inventory/host_vars/host1/ethernet-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/inventory/host_vars/host1/ethernet-interfaces.yml
@@ -71,6 +71,5 @@ ethernet_interfaces:
         unmatched: true
   Ethernet31:
     description: DOT1X Testing - force-unauthorized - no phone
-    type: switched
     dot1x:
       port_control: force-unauthorized

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/inventory/host_vars/host1/ethernet-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/inventory/host_vars/host1/ethernet-interfaces.yml
@@ -71,5 +71,6 @@ ethernet_interfaces:
         unmatched: true
   Ethernet31:
     description: DOT1X Testing - force-unauthorized - no phone
+    type: switched
     dot1x:
       port_control: force-unauthorized

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/inventory/host_vars/host1/port-channel-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/inventory/host_vars/host1/port-channel-interfaces.yml
@@ -32,6 +32,7 @@ port_channel_interfaces:
 
   Port-Channel51:
     description: ipv6_prefix
+    type: switched
     vlans: 1-500
     mode: trunk
     # Testing ipv6_nd_prefixes as dict of dict

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/inventory/host_vars/host1/port-channel-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/inventory/host_vars/host1/port-channel-interfaces.yml
@@ -7,7 +7,6 @@ port_channel_interfaces:
   # Testing deprecated esi and rt variables on port-channel interfaces/subinterfaces
   Port-Channel1:
     description: SRV01_bond0
-    type: switched
     vlans: 2-3000
     mode: trunk
     esi: 0000:0000:0404:0404:0303
@@ -33,7 +32,6 @@ port_channel_interfaces:
 
   Port-Channel51:
     description: ipv6_prefix
-    type: switched
     vlans: 1-500
     mode: trunk
     # Testing ipv6_nd_prefixes as dict of dict

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/inventory/host_vars/host1/port-channel-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/inventory/host_vars/host1/port-channel-interfaces.yml
@@ -7,6 +7,7 @@ port_channel_interfaces:
   # Testing deprecated esi and rt variables on port-channel interfaces/subinterfaces
   Port-Channel1:
     description: SRV01_bond0
+    type: switched
     vlans: 2-3000
     mode: trunk
     esi: 0000:0000:0404:0404:0303

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-BL1A.yml
@@ -332,7 +332,6 @@ ethernet_interfaces:
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-BL1B_Ethernet5
-  type: switched
   shutdown: false
   channel_group:
     id: 5
@@ -342,7 +341,6 @@ ethernet_interfaces:
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-BL1B_Ethernet6
-  type: switched
   shutdown: false
   channel_group:
     id: 5

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-BL1A.yml
@@ -332,6 +332,7 @@ ethernet_interfaces:
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-BL1B_Ethernet5
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 5
@@ -341,6 +342,7 @@ ethernet_interfaces:
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-BL1B_Ethernet6
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 5

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-BL1B.yml
@@ -332,7 +332,6 @@ ethernet_interfaces:
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-BL1A_Ethernet5
-  type: switched
   shutdown: false
   channel_group:
     id: 5
@@ -342,7 +341,6 @@ ethernet_interfaces:
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-BL1A_Ethernet6
-  type: switched
   shutdown: false
   channel_group:
     id: 5

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-BL1B.yml
@@ -332,6 +332,7 @@ ethernet_interfaces:
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-BL1A_Ethernet5
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 5
@@ -341,6 +342,7 @@ ethernet_interfaces:
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-BL1A_Ethernet6
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 5

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -59,6 +59,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF2A_Ethernet7
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -68,6 +69,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF2B_Ethernet7
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -59,7 +59,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF2A_Ethernet7
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -69,7 +68,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF2B_Ethernet7
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -133,7 +133,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2B_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -143,7 +142,6 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2B_Ethernet4
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -154,7 +152,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-SVC3A_Ethernet7
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -164,7 +161,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-SVC3B_Ethernet7
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -133,6 +133,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2B_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -142,6 +143,7 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2B_Ethernet4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -152,6 +154,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-SVC3A_Ethernet7
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -161,6 +164,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-SVC3B_Ethernet7
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -133,7 +133,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2A_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -143,7 +142,6 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2A_Ethernet4
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -154,7 +152,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-SVC3A_Ethernet8
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -164,7 +161,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-SVC3B_Ethernet8
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -133,6 +133,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2A_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -142,6 +143,7 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2A_Ethernet4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -152,6 +154,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-SVC3A_Ethernet8
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -161,6 +164,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-SVC3B_Ethernet8
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF1A.yml
@@ -215,8 +215,8 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A_B
   description: server02_SINGLE_NODE_TRUNK_Eth1
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk
   vlans: 110-111,210-211
 - name: Ethernet7
@@ -225,8 +225,8 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A
   description: server02_SINGLE_NODE_Eth1
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '110'
 loopback_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF2A.yml
@@ -580,6 +580,7 @@ ethernet_interfaces:
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF2B_Ethernet5
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 5
@@ -589,6 +590,7 @@ ethernet_interfaces:
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF2B_Ethernet6
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 5
@@ -635,6 +637,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF1A_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 7
     mode: active
@@ -645,6 +648,7 @@ ethernet_interfaces:
   port_profile: TENANT_B
   description: server01_MLAG_Eth2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 10
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF2A.yml
@@ -580,7 +580,6 @@ ethernet_interfaces:
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF2B_Ethernet5
-  type: switched
   shutdown: false
   channel_group:
     id: 5
@@ -590,7 +589,6 @@ ethernet_interfaces:
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF2B_Ethernet6
-  type: switched
   shutdown: false
   channel_group:
     id: 5
@@ -637,7 +635,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF1A_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 7
     mode: active
@@ -647,10 +644,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_B
   description: server01_MLAG_Eth2
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 210-211
   channel_group:
     id: 10
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF2B.yml
@@ -580,7 +580,6 @@ ethernet_interfaces:
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF2A_Ethernet5
-  type: switched
   shutdown: false
   channel_group:
     id: 5
@@ -590,7 +589,6 @@ ethernet_interfaces:
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF2A_Ethernet6
-  type: switched
   shutdown: false
   channel_group:
     id: 5
@@ -637,7 +635,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF1A_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 7
     mode: active
@@ -647,10 +644,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_B
   description: server01_MLAG_Eth3
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 210-211
   channel_group:
     id: 10
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF2B.yml
@@ -580,6 +580,7 @@ ethernet_interfaces:
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF2A_Ethernet5
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 5
@@ -589,6 +590,7 @@ ethernet_interfaces:
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF2A_Ethernet6
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 5
@@ -635,6 +637,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF1A_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 7
     mode: active
@@ -645,6 +648,7 @@ ethernet_interfaces:
   port_profile: TENANT_B
   description: server01_MLAG_Eth3
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 10
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SVC3A.yml
@@ -739,6 +739,7 @@ ethernet_interfaces:
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-SVC3B_Ethernet5
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 5
@@ -748,6 +749,7 @@ ethernet_interfaces:
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-SVC3B_Ethernet6
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 5
@@ -794,6 +796,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF2A_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 7
     mode: active
@@ -803,6 +806,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF2B_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 7
     mode: active
@@ -813,6 +817,7 @@ ethernet_interfaces:
   port_profile: TENANT_A_B
   description: server03_ESI_Eth1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 10
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SVC3A.yml
@@ -739,7 +739,6 @@ ethernet_interfaces:
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-SVC3B_Ethernet5
-  type: switched
   shutdown: false
   channel_group:
     id: 5
@@ -749,7 +748,6 @@ ethernet_interfaces:
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-SVC3B_Ethernet6
-  type: switched
   shutdown: false
   channel_group:
     id: 5
@@ -796,7 +794,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF2A_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 7
     mode: active
@@ -806,7 +803,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF2B_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 7
     mode: active
@@ -816,10 +812,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A_B
   description: server03_ESI_Eth1
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 110-111,210-211
   channel_group:
     id: 10
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SVC3B.yml
@@ -729,7 +729,6 @@ ethernet_interfaces:
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-SVC3A_Ethernet5
-  type: switched
   shutdown: false
   channel_group:
     id: 5
@@ -739,7 +738,6 @@ ethernet_interfaces:
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-SVC3A_Ethernet6
-  type: switched
   shutdown: false
   channel_group:
     id: 5
@@ -786,7 +784,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF2A_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 7
     mode: active
@@ -796,7 +793,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF2B_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 7
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SVC3B.yml
@@ -729,6 +729,7 @@ ethernet_interfaces:
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-SVC3A_Ethernet5
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 5
@@ -738,6 +739,7 @@ ethernet_interfaces:
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-SVC3A_Ethernet6
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 5
@@ -784,6 +786,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF2A_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 7
     mode: active
@@ -793,6 +796,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF2B_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 7
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-LEAF1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-LEAF1.yml
@@ -22,6 +22,7 @@ ethernet_interfaces:
   peer_type: l3spine
   description: BGP-SPINE1_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -31,6 +32,7 @@ ethernet_interfaces:
   peer_type: l3spine
   description: BGP-SPINE2_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-LEAF1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-LEAF1.yml
@@ -22,7 +22,6 @@ ethernet_interfaces:
   peer_type: l3spine
   description: BGP-SPINE1_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -32,7 +31,6 @@ ethernet_interfaces:
   peer_type: l3spine
   description: BGP-SPINE2_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -40,16 +38,16 @@ ethernet_interfaces:
   peer: Endpoint
   peer_type: network_port
   description: Endpoint
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
 - name: Ethernet11
   peer: Endpoint
   peer_type: network_port
   description: Endpoint
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
 port_channel_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-LEAF2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-LEAF2.yml
@@ -22,7 +22,6 @@ ethernet_interfaces:
   peer_type: l3spine
   description: BGP-SPINE1_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -32,7 +31,6 @@ ethernet_interfaces:
   peer_type: l3spine
   description: BGP-SPINE2_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -40,16 +38,16 @@ ethernet_interfaces:
   peer: Endpoint
   peer_type: network_port
   description: Endpoint
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
 - name: Ethernet11
   peer: Endpoint
   peer_type: network_port
   description: Endpoint
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
 port_channel_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-LEAF2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-LEAF2.yml
@@ -22,6 +22,7 @@ ethernet_interfaces:
   peer_type: l3spine
   description: BGP-SPINE1_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -31,6 +32,7 @@ ethernet_interfaces:
   peer_type: l3spine
   description: BGP-SPINE2_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-SPINE1.yml
@@ -103,7 +103,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_BGP-SPINE2_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -113,7 +112,6 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_BGP-SPINE2_Ethernet4
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -124,7 +122,6 @@ ethernet_interfaces:
   peer_type: leaf
   description: BGP-LEAF1_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -134,7 +131,6 @@ ethernet_interfaces:
   peer_type: leaf
   description: BGP-LEAF2_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 2
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-SPINE1.yml
@@ -103,6 +103,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_BGP-SPINE2_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -112,6 +113,7 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_BGP-SPINE2_Ethernet4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -122,6 +124,7 @@ ethernet_interfaces:
   peer_type: leaf
   description: BGP-LEAF1_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -131,6 +134,7 @@ ethernet_interfaces:
   peer_type: leaf
   description: BGP-LEAF2_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 2
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-SPINE2.yml
@@ -107,6 +107,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_BGP-SPINE1_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -116,6 +117,7 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_BGP-SPINE1_Ethernet4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -126,6 +128,7 @@ ethernet_interfaces:
   peer_type: leaf
   description: BGP-LEAF1_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -135,6 +138,7 @@ ethernet_interfaces:
   peer_type: leaf
   description: BGP-LEAF2_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 2
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-SPINE2.yml
@@ -107,7 +107,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_BGP-SPINE1_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -117,7 +116,6 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_BGP-SPINE1_Ethernet4
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -128,7 +126,6 @@ ethernet_interfaces:
   peer_type: leaf
   description: BGP-LEAF1_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -138,7 +135,6 @@ ethernet_interfaces:
   peer_type: leaf
   description: BGP-LEAF2_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 2
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/ISIS-LEAF1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/ISIS-LEAF1.yml
@@ -30,7 +30,6 @@ ethernet_interfaces:
   peer_type: l3spine
   description: ISIS-SPINE1_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/ISIS-LEAF1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/ISIS-LEAF1.yml
@@ -30,6 +30,7 @@ ethernet_interfaces:
   peer_type: l3spine
   description: ISIS-SPINE1_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/ISIS-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/ISIS-SPINE1.yml
@@ -34,7 +34,6 @@ ethernet_interfaces:
   peer_type: leaf
   description: ISIS-LEAF1_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -42,8 +41,8 @@ ethernet_interfaces:
   peer: Endpoint
   peer_type: network_port
   description: Endpoint
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '110'
 port_channel_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/ISIS-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/ISIS-SPINE1.yml
@@ -34,6 +34,7 @@ ethernet_interfaces:
   peer_type: leaf
   description: ISIS-LEAF1_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/L2ONLY-LEAF1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/L2ONLY-LEAF1.yml
@@ -22,7 +22,6 @@ ethernet_interfaces:
   peer_type: spine
   description: L2ONLY-SPINE1_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -32,7 +31,6 @@ ethernet_interfaces:
   peer_type: spine
   description: L2ONLY-SPINE2_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -40,16 +38,16 @@ ethernet_interfaces:
   peer: Endpoint
   peer_type: network_port
   description: Endpoint
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
 - name: Ethernet11
   peer: Endpoint
   peer_type: network_port
   description: Endpoint
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
 port_channel_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/L2ONLY-LEAF1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/L2ONLY-LEAF1.yml
@@ -22,6 +22,7 @@ ethernet_interfaces:
   peer_type: spine
   description: L2ONLY-SPINE1_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -31,6 +32,7 @@ ethernet_interfaces:
   peer_type: spine
   description: L2ONLY-SPINE2_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/L2ONLY-LEAF2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/L2ONLY-LEAF2.yml
@@ -22,6 +22,7 @@ ethernet_interfaces:
   peer_type: spine
   description: L2ONLY-SPINE1_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -31,6 +32,7 @@ ethernet_interfaces:
   peer_type: spine
   description: L2ONLY-SPINE2_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/L2ONLY-LEAF2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/L2ONLY-LEAF2.yml
@@ -22,7 +22,6 @@ ethernet_interfaces:
   peer_type: spine
   description: L2ONLY-SPINE1_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -32,7 +31,6 @@ ethernet_interfaces:
   peer_type: spine
   description: L2ONLY-SPINE2_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -40,16 +38,16 @@ ethernet_interfaces:
   peer: Endpoint
   peer_type: network_port
   description: Endpoint
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
 - name: Ethernet11
   peer: Endpoint
   peer_type: network_port
   description: Endpoint
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
 port_channel_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/L2ONLY-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/L2ONLY-SPINE1.yml
@@ -63,7 +63,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_L2ONLY-SPINE2_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -73,7 +72,6 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_L2ONLY-SPINE2_Ethernet4
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -84,7 +82,6 @@ ethernet_interfaces:
   peer_type: leaf
   description: L2ONLY-LEAF1_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -94,7 +91,6 @@ ethernet_interfaces:
   peer_type: leaf
   description: L2ONLY-LEAF2_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 2
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/L2ONLY-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/L2ONLY-SPINE1.yml
@@ -63,6 +63,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_L2ONLY-SPINE2_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -72,6 +73,7 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_L2ONLY-SPINE2_Ethernet4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -82,6 +84,7 @@ ethernet_interfaces:
   peer_type: leaf
   description: L2ONLY-LEAF1_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -91,6 +94,7 @@ ethernet_interfaces:
   peer_type: leaf
   description: L2ONLY-LEAF2_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 2
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/L2ONLY-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/L2ONLY-SPINE2.yml
@@ -63,6 +63,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_L2ONLY-SPINE1_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -72,6 +73,7 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_L2ONLY-SPINE1_Ethernet4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -82,6 +84,7 @@ ethernet_interfaces:
   peer_type: leaf
   description: L2ONLY-LEAF1_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -91,6 +94,7 @@ ethernet_interfaces:
   peer_type: leaf
   description: L2ONLY-LEAF2_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 2
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/L2ONLY-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/L2ONLY-SPINE2.yml
@@ -63,7 +63,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_L2ONLY-SPINE1_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -73,7 +72,6 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_L2ONLY-SPINE1_Ethernet4
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -84,7 +82,6 @@ ethernet_interfaces:
   peer_type: leaf
   description: L2ONLY-LEAF1_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -94,7 +91,6 @@ ethernet_interfaces:
   peer_type: leaf
   description: L2ONLY-LEAF2_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 2
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-LEAF1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-LEAF1.yml
@@ -22,6 +22,7 @@ ethernet_interfaces:
   peer_type: l3spine
   description: OSPF-SPINE1_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -31,6 +32,7 @@ ethernet_interfaces:
   peer_type: l3spine
   description: OSPF-SPINE2_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-LEAF1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-LEAF1.yml
@@ -22,7 +22,6 @@ ethernet_interfaces:
   peer_type: l3spine
   description: OSPF-SPINE1_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -32,7 +31,6 @@ ethernet_interfaces:
   peer_type: l3spine
   description: OSPF-SPINE2_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -40,16 +38,16 @@ ethernet_interfaces:
   peer: Endpoint
   peer_type: network_port
   description: Endpoint
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
 - name: Ethernet11
   peer: Endpoint
   peer_type: network_port
   description: Endpoint
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
 port_channel_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-LEAF2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-LEAF2.yml
@@ -22,7 +22,6 @@ ethernet_interfaces:
   peer_type: l3spine
   description: OSPF-SPINE1_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -32,7 +31,6 @@ ethernet_interfaces:
   peer_type: l3spine
   description: OSPF-SPINE2_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -40,16 +38,16 @@ ethernet_interfaces:
   peer: Endpoint
   peer_type: network_port
   description: Endpoint
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
 - name: Ethernet11
   peer: Endpoint
   peer_type: network_port
   description: Endpoint
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
 port_channel_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-LEAF2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-LEAF2.yml
@@ -22,6 +22,7 @@ ethernet_interfaces:
   peer_type: l3spine
   description: OSPF-SPINE1_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -31,6 +32,7 @@ ethernet_interfaces:
   peer_type: l3spine
   description: OSPF-SPINE2_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-SPINE1.yml
@@ -71,7 +71,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_OSPF-SPINE2_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -81,7 +80,6 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_OSPF-SPINE2_Ethernet4
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -92,7 +90,6 @@ ethernet_interfaces:
   peer_type: leaf
   description: OSPF-LEAF1_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -102,7 +99,6 @@ ethernet_interfaces:
   peer_type: leaf
   description: OSPF-LEAF2_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 2
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-SPINE1.yml
@@ -71,6 +71,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_OSPF-SPINE2_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -80,6 +81,7 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_OSPF-SPINE2_Ethernet4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -90,6 +92,7 @@ ethernet_interfaces:
   peer_type: leaf
   description: OSPF-LEAF1_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -99,6 +102,7 @@ ethernet_interfaces:
   peer_type: leaf
   description: OSPF-LEAF2_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 2
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-SPINE2.yml
@@ -74,7 +74,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_OSPF-SPINE1_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -84,7 +83,6 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_OSPF-SPINE1_Ethernet4
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -95,7 +93,6 @@ ethernet_interfaces:
   peer_type: leaf
   description: OSPF-LEAF1_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -105,7 +102,6 @@ ethernet_interfaces:
   peer_type: leaf
   description: OSPF-LEAF2_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 2
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-SPINE2.yml
@@ -74,6 +74,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_OSPF-SPINE1_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -83,6 +84,7 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_OSPF-SPINE1_Ethernet4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -93,6 +95,7 @@ ethernet_interfaces:
   peer_type: leaf
   description: OSPF-LEAF1_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -102,6 +105,7 @@ ethernet_interfaces:
   peer_type: leaf
   description: OSPF-LEAF2_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 2
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER1.md
@@ -246,10 +246,12 @@ interface Ethernet2
 !
 interface Ethernet3
    no shutdown
+   switchport
    channel-group 3 mode active
 !
 interface Ethernet4
    no shutdown
+   switchport
    channel-group 3 mode active
 !
 interface Ethernet6

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER2.md
@@ -245,10 +245,12 @@ interface Ethernet2
 !
 interface Ethernet3
    no shutdown
+   switchport
    channel-group 3 mode active
 !
 interface Ethernet4
    no shutdown
+   switchport
    channel-group 3 mode active
 !
 interface Ethernet5

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-LER1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-LER1.md
@@ -234,10 +234,12 @@ interface Ethernet1
 !
 interface Ethernet4
    no shutdown
+   switchport
    channel-group 4 mode active
 !
 interface Ethernet5
    no shutdown
+   switchport
    channel-group 4 mode active
 !
 interface Ethernet6

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE1-LER1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE1-LER1.cfg
@@ -137,10 +137,12 @@ interface Ethernet2
 !
 interface Ethernet3
    no shutdown
+   switchport
    channel-group 3 mode active
 !
 interface Ethernet4
    no shutdown
+   switchport
    channel-group 3 mode active
 !
 interface Ethernet6

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE1-LER2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE1-LER2.cfg
@@ -139,10 +139,12 @@ interface Ethernet2
 !
 interface Ethernet3
    no shutdown
+   switchport
    channel-group 3 mode active
 !
 interface Ethernet4
    no shutdown
+   switchport
    channel-group 3 mode active
 !
 interface Ethernet5

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE2-LER1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE2-LER1.cfg
@@ -101,10 +101,12 @@ interface Ethernet1
 !
 interface Ethernet4
    no shutdown
+   switchport
    channel-group 4 mode active
 !
 interface Ethernet5
    no shutdown
+   switchport
    channel-group 4 mode active
 !
 interface Ethernet6

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LER1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LER1.yml
@@ -246,11 +246,7 @@ ethernet_interfaces:
   peer_type: cpe
   port_profile: TENANT_A_WAN_SERVICE_10
   description: CPE_TENANT_A_SITE1_Ethernet1
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: '10'
-  spanning_tree_portfast: edge
   channel_group:
     id: 8
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LER1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LER1.yml
@@ -247,6 +247,7 @@ ethernet_interfaces:
   port_profile: TENANT_A_WAN_SERVICE_10
   description: CPE_TENANT_A_SITE1_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 8
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LER2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LER2.yml
@@ -282,11 +282,7 @@ ethernet_interfaces:
   peer_type: cpe
   port_profile: TENANT_A_WAN_SERVICE_10
   description: CPE_TENANT_A_SITE1_Ethernet2
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: '10'
-  spanning_tree_portfast: edge
   channel_group:
     id: 8
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LER2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LER2.yml
@@ -283,6 +283,7 @@ ethernet_interfaces:
   port_profile: TENANT_A_WAN_SERVICE_10
   description: CPE_TENANT_A_SITE1_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 8
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE2-LER1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE2-LER1.yml
@@ -266,6 +266,7 @@ ethernet_interfaces:
       igp_sync: true
   speed: forced 40gfull
 - name: Ethernet11
+  type: port-channel-member
   peer: SITE2-LSR2
   peer_interface: Port-Channel12
   peer_type: p

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE2-LER1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE2-LER1.yml
@@ -281,8 +281,8 @@ ethernet_interfaces:
   peer_type: cpe
   port_profile: TENANT_A_WAN_SERVICE_10
   description: CPE_TENANT_A_SITE2_eth0
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk
   vlans: '10'
   spanning_tree_portfast: edge

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE2-LSR2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE2-LSR2.yml
@@ -103,6 +103,7 @@ ethernet_interfaces:
       igp_sync: true
   speed: forced 40gfull
 - name: Ethernet12
+  type: port-channel-member
   peer: SITE2-LER1
   peer_interface: Port-Channel11
   peer_type: pe
@@ -113,6 +114,7 @@ ethernet_interfaces:
     mode: active
   speed: forced 40gfull
 - name: Ethernet13
+  type: port-channel-member
   peer: SITE2-LER1
   peer_interface: Port-Channel11
   peer_type: pe

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/fabric/TWODC_5STAGE_CLOS-documentation.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/fabric/TWODC_5STAGE_CLOS-documentation.md
@@ -255,14 +255,14 @@
 
 | Name | Port | Fabric Device | Fabric Port | Description | Shutdown | Type | Mode | VLANs | Profile |
 | ---- | ---- | ------------- | ------------| ----------- | -------- | ---- | ---- | ----- | ------- |
-| server-1 | Eth2 | DC1-POD1-LEAF2B | Ethernet16 | server-1_Eth2 | False | switched | access | 110 | TENANT_A |
-| server-1 | Eth4 | DC1-POD1-LEAF2B | Ethernet17 | Set using structured_config on server adapter | False | switched | access | 110 | TENANT_A |
-| server-1 | Eth6 | DC1-POD1-LEAF2B | Ethernet18 | server-1_Eth6 | False | switched | access | 110 | NESTED_TENANT_A |
-| server-1 | Eth8 | DC1-POD1-LEAF2B | Ethernet19 | server-1_Eth8 | False | switched | access | 110 | NESTED_TENANT_A |
-| server-1 | Eth1 | DC1.POD1.LEAF2A | Ethernet16 | server-1_Eth1 | False | switched | access | 110 | TENANT_A |
-| server-1 | Eth3 | DC1.POD1.LEAF2A | Ethernet17 | Set using structured_config on server adapter | False | switched | access | 110 | TENANT_A |
-| server-1 | Eth5 | DC1.POD1.LEAF2A | Ethernet18 | server-1_Eth5 | False | switched | access | 110 | NESTED_TENANT_A |
-| server-1 | Eth7 | DC1.POD1.LEAF2A | Ethernet19 | server-1_Eth7 | False | switched | access | 110 | NESTED_TENANT_A |
+| server-1 | Eth2 | DC1-POD1-LEAF2B | Ethernet16 | server-1_Eth2 | False | - | - | - | TENANT_A |
+| server-1 | Eth4 | DC1-POD1-LEAF2B | Ethernet17 | Set using structured_config on server adapter | False | - | - | - | TENANT_A |
+| server-1 | Eth6 | DC1-POD1-LEAF2B | Ethernet18 | server-1_Eth6 | False | - | - | - | NESTED_TENANT_A |
+| server-1 | Eth8 | DC1-POD1-LEAF2B | Ethernet19 | server-1_Eth8 | False | - | - | - | NESTED_TENANT_A |
+| server-1 | Eth1 | DC1.POD1.LEAF2A | Ethernet16 | server-1_Eth1 | False | - | - | - | TENANT_A |
+| server-1 | Eth3 | DC1.POD1.LEAF2A | Ethernet17 | Set using structured_config on server adapter | False | - | - | - | TENANT_A |
+| server-1 | Eth5 | DC1.POD1.LEAF2A | Ethernet18 | server-1_Eth5 | False | - | - | - | NESTED_TENANT_A |
+| server-1 | Eth7 | DC1.POD1.LEAF2A | Ethernet19 | server-1_Eth7 | False | - | - | - | NESTED_TENANT_A |
 
 ### Port Profiles
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/fabric/TWODC_5STAGE_CLOS-documentation.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/fabric/TWODC_5STAGE_CLOS-documentation.md
@@ -255,14 +255,14 @@
 
 | Name | Port | Fabric Device | Fabric Port | Description | Shutdown | Type | Mode | VLANs | Profile |
 | ---- | ---- | ------------- | ------------| ----------- | -------- | ---- | ---- | ----- | ------- |
-| server-1 | Eth2 | DC1-POD1-LEAF2B | Ethernet16 | server-1_Eth2 | False | - | - | - | TENANT_A |
-| server-1 | Eth4 | DC1-POD1-LEAF2B | Ethernet17 | Set using structured_config on server adapter | False | - | - | - | TENANT_A |
-| server-1 | Eth6 | DC1-POD1-LEAF2B | Ethernet18 | server-1_Eth6 | False | - | - | - | NESTED_TENANT_A |
-| server-1 | Eth8 | DC1-POD1-LEAF2B | Ethernet19 | server-1_Eth8 | False | - | - | - | NESTED_TENANT_A |
-| server-1 | Eth1 | DC1.POD1.LEAF2A | Ethernet16 | server-1_Eth1 | False | - | - | - | TENANT_A |
-| server-1 | Eth3 | DC1.POD1.LEAF2A | Ethernet17 | Set using structured_config on server adapter | False | - | - | - | TENANT_A |
-| server-1 | Eth5 | DC1.POD1.LEAF2A | Ethernet18 | server-1_Eth5 | False | - | - | - | NESTED_TENANT_A |
-| server-1 | Eth7 | DC1.POD1.LEAF2A | Ethernet19 | server-1_Eth7 | False | - | - | - | NESTED_TENANT_A |
+| server-1 | Eth2 | DC1-POD1-LEAF2B | Ethernet16 | server-1_Eth2 | False | switched | access | 110 | TENANT_A |
+| server-1 | Eth4 | DC1-POD1-LEAF2B | Ethernet17 | Set using structured_config on server adapter | False | switched | access | 110 | TENANT_A |
+| server-1 | Eth6 | DC1-POD1-LEAF2B | Ethernet18 | server-1_Eth6 | False | switched | access | 110 | NESTED_TENANT_A |
+| server-1 | Eth8 | DC1-POD1-LEAF2B | Ethernet19 | server-1_Eth8 | False | switched | access | 110 | NESTED_TENANT_A |
+| server-1 | Eth1 | DC1.POD1.LEAF2A | Ethernet16 | server-1_Eth1 | False | switched | access | 110 | TENANT_A |
+| server-1 | Eth3 | DC1.POD1.LEAF2A | Ethernet17 | Set using structured_config on server adapter | False | switched | access | 110 | TENANT_A |
+| server-1 | Eth5 | DC1.POD1.LEAF2A | Ethernet18 | server-1_Eth5 | False | switched | access | 110 | NESTED_TENANT_A |
+| server-1 | Eth7 | DC1.POD1.LEAF2A | Ethernet19 | server-1_Eth7 | False | switched | access | 110 | NESTED_TENANT_A |
 
 ### Port Profiles
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF1A.yml
@@ -38,7 +38,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-POD1-LEAF1A_Ethernet3
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF1A.yml
@@ -38,6 +38,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-POD1-LEAF1A_Ethernet3
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF2A.yml
@@ -103,7 +103,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-POD1-L2LEAF2B_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -113,7 +112,6 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-POD1-L2LEAF2B_Ethernet4
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -124,7 +122,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1.POD1.LEAF2A_Ethernet3
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -134,7 +131,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-POD1-LEAF2B_Ethernet3
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF2A.yml
@@ -103,6 +103,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-POD1-L2LEAF2B_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -112,6 +113,7 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-POD1-L2LEAF2B_Ethernet4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -122,6 +124,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1.POD1.LEAF2A_Ethernet3
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -131,6 +134,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-POD1-LEAF2B_Ethernet3
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF2B.yml
@@ -118,7 +118,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-POD1-L2LEAF2A_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -128,7 +127,6 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-POD1-L2LEAF2A_Ethernet4
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -139,7 +137,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1.POD1.LEAF2A_Ethernet4
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -149,7 +146,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-POD1-LEAF2B_Ethernet4
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF2B.yml
@@ -118,6 +118,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-POD1-L2LEAF2A_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -127,6 +128,7 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-POD1-L2LEAF2A_Ethernet4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -137,6 +139,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1.POD1.LEAF2A_Ethernet4
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -146,6 +149,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-POD1-LEAF2B_Ethernet4
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF1A.yml
@@ -150,7 +150,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-POD1-L2LEAF1A_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 3
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF1A.yml
@@ -150,6 +150,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-POD1-L2LEAF1A_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 3
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2B.yml
@@ -529,6 +529,7 @@ ethernet_interfaces:
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1.POD1.LEAF2A_Ethernet5
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 5
@@ -538,6 +539,7 @@ ethernet_interfaces:
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1.POD1.LEAF2A_Ethernet6
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 5
@@ -576,6 +578,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-POD1-L2LEAF2A_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 3
     mode: active
@@ -585,6 +588,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-POD1-L2LEAF2B_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 3
     mode: active
@@ -641,6 +645,7 @@ ethernet_interfaces:
     EOF
 
     '
+  type: port-channel-member
   channel_group:
     id: 16
     mode: active
@@ -658,6 +663,7 @@ ethernet_interfaces:
     EOF
 
     '
+  type: port-channel-member
   channel_group:
     id: 17
     mode: active
@@ -675,6 +681,7 @@ ethernet_interfaces:
     EOF
 
     '
+  type: port-channel-member
   channel_group:
     id: 18
     mode: active
@@ -692,6 +699,7 @@ ethernet_interfaces:
     EOF
 
     '
+  type: port-channel-member
   channel_group:
     id: 19
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2B.yml
@@ -529,7 +529,6 @@ ethernet_interfaces:
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1.POD1.LEAF2A_Ethernet5
-  type: switched
   shutdown: false
   channel_group:
     id: 5
@@ -539,7 +538,6 @@ ethernet_interfaces:
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1.POD1.LEAF2A_Ethernet6
-  type: switched
   shutdown: false
   channel_group:
     id: 5
@@ -578,7 +576,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-POD1-L2LEAF2A_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 3
     mode: active
@@ -588,7 +585,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-POD1-L2LEAF2B_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 3
     mode: active
@@ -637,11 +633,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A
   description: server-1_Eth2
-  type: switched
   shutdown: false
-  mode: access
-  vlans: '110'
-  service_profile: bar
   eos_cli: 'comment
 
     Comment created from raw_eos_cli under profile TENANT_A
@@ -658,11 +650,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A
   description: Set using structured_config on server adapter
-  type: switched
   shutdown: false
-  mode: access
-  vlans: '110'
-  service_profile: foo
   eos_cli: 'comment
 
     Comment created from raw_eos_cli under adapter for switch Eth17
@@ -679,11 +667,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: NESTED_TENANT_A
   description: server-1_Eth6
-  type: switched
   shutdown: false
-  mode: access
-  vlans: '110'
-  service_profile: foo
   eos_cli: 'comment
 
     Comment created from raw_eos_cli under profile NESTED_TENANT_A
@@ -700,11 +684,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: NESTED_TENANT_A
   description: server-1_Eth8
-  type: switched
   shutdown: false
-  mode: access
-  vlans: '110'
-  service_profile: foo
   eos_cli: 'comment
 
     Comment created from raw_eos_cli under profile NESTED_TENANT_A

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1.POD1.LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1.POD1.LEAF2A.yml
@@ -489,6 +489,7 @@ ethernet_interfaces:
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-POD1-LEAF2B_Ethernet5
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 5
@@ -498,6 +499,7 @@ ethernet_interfaces:
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-POD1-LEAF2B_Ethernet6
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 5
@@ -536,6 +538,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-POD1-L2LEAF2A_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 3
     mode: active
@@ -545,6 +548,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-POD1-L2LEAF2B_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 3
     mode: active
@@ -599,6 +603,7 @@ ethernet_interfaces:
     EOF
 
     '
+  type: port-channel-member
   channel_group:
     id: 16
     mode: active
@@ -616,6 +621,7 @@ ethernet_interfaces:
     EOF
 
     '
+  type: port-channel-member
   channel_group:
     id: 17
     mode: active
@@ -633,6 +639,7 @@ ethernet_interfaces:
     EOF
 
     '
+  type: port-channel-member
   channel_group:
     id: 18
     mode: active
@@ -650,6 +657,7 @@ ethernet_interfaces:
     EOF
 
     '
+  type: port-channel-member
   channel_group:
     id: 19
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1.POD1.LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1.POD1.LEAF2A.yml
@@ -489,7 +489,6 @@ ethernet_interfaces:
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-POD1-LEAF2B_Ethernet5
-  type: switched
   shutdown: false
   channel_group:
     id: 5
@@ -499,7 +498,6 @@ ethernet_interfaces:
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-POD1-LEAF2B_Ethernet6
-  type: switched
   shutdown: false
   channel_group:
     id: 5
@@ -538,7 +536,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-POD1-L2LEAF2A_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 3
     mode: active
@@ -548,7 +545,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-POD1-L2LEAF2B_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 3
     mode: active
@@ -595,11 +591,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A
   description: server-1_Eth1
-  type: switched
   shutdown: false
-  mode: access
-  vlans: '110'
-  service_profile: bar
   eos_cli: 'comment
 
     Comment created from raw_eos_cli under profile TENANT_A
@@ -616,11 +608,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A
   description: Set using structured_config on server adapter
-  type: switched
   shutdown: false
-  mode: access
-  vlans: '110'
-  service_profile: foo
   eos_cli: 'comment
 
     Comment created from raw_eos_cli under adapter for switch Eth17
@@ -637,11 +625,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: NESTED_TENANT_A
   description: server-1_Eth5
-  type: switched
   shutdown: false
-  mode: access
-  vlans: '110'
-  service_profile: foo
   eos_cli: 'comment
 
     Comment created from raw_eos_cli under profile NESTED_TENANT_A
@@ -658,11 +642,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: NESTED_TENANT_A
   description: server-1_Eth7
-  type: switched
   shutdown: false
-  mode: access
-  vlans: '110'
-  service_profile: foo
   eos_cli: 'comment
 
     Comment created from raw_eos_cli under profile NESTED_TENANT_A

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-L2LEAF1A.yml
@@ -54,6 +54,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC2-POD1-LEAF1A_Ethernet3
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-L2LEAF1A.yml
@@ -54,7 +54,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC2-POD1-LEAF1A_Ethernet3
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-L2LEAF2A.yml
@@ -54,6 +54,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC2-POD1-LEAF2A_Ethernet3
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-L2LEAF2A.yml
@@ -54,7 +54,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC2-POD1-LEAF2A_Ethernet3
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-LEAF1A.yml
@@ -225,6 +225,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC2-POD1-L2LEAF1A_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 3
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-LEAF1A.yml
@@ -225,7 +225,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC2-POD1-L2LEAF1A_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 3
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-LEAF2A.yml
@@ -120,6 +120,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC2-POD1-L2LEAF2A_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 3
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-LEAF2A.yml
@@ -120,7 +120,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC2-POD1-L2LEAF2A_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 3
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ignore-custom-keys-in-data-models.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ignore-custom-keys-in-data-models.cfg
@@ -14,7 +14,6 @@ no aaa root
 vrf instance MGMT
 !
 interface Ethernet1
-   switchport
 no ip routing vrf MGMT
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ignore-custom-keys-in-data-models.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ignore-custom-keys-in-data-models.cfg
@@ -14,6 +14,7 @@ no aaa root
 vrf instance MGMT
 !
 interface Ethernet1
+   switchport
 no ip routing vrf MGMT
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF3A.yml
@@ -115,6 +115,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_AUTO_BGP_ASN_LEAF3B_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -124,6 +125,7 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_AUTO_BGP_ASN_LEAF3B_Ethernet4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF3A.yml
@@ -115,7 +115,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_AUTO_BGP_ASN_LEAF3B_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -125,7 +124,6 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_AUTO_BGP_ASN_LEAF3B_Ethernet4
-  type: switched
   shutdown: false
   channel_group:
     id: 3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF3B.yml
@@ -115,7 +115,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_AUTO_BGP_ASN_LEAF3A_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -125,7 +124,6 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_AUTO_BGP_ASN_LEAF3A_Ethernet4
-  type: switched
   shutdown: false
   channel_group:
     id: 3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF3B.yml
@@ -115,6 +115,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_AUTO_BGP_ASN_LEAF3A_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -124,6 +125,7 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_AUTO_BGP_ASN_LEAF3A_Ethernet4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF4A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF4A.yml
@@ -115,7 +115,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_AUTO_BGP_ASN_LEAF4B_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -125,7 +124,6 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_AUTO_BGP_ASN_LEAF4B_Ethernet4
-  type: switched
   shutdown: false
   channel_group:
     id: 3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF4A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF4A.yml
@@ -115,6 +115,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_AUTO_BGP_ASN_LEAF4B_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -124,6 +125,7 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_AUTO_BGP_ASN_LEAF4B_Ethernet4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF4B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF4B.yml
@@ -115,7 +115,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_AUTO_BGP_ASN_LEAF4A_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -125,7 +124,6 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_AUTO_BGP_ASN_LEAF4A_Ethernet4
-  type: switched
   shutdown: false
   channel_group:
     id: 3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF4B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF4B.yml
@@ -115,6 +115,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_AUTO_BGP_ASN_LEAF4A_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -124,6 +125,7 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_AUTO_BGP_ASN_LEAF4A_Ethernet4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF7A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF7A.yml
@@ -115,6 +115,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_AUTO_BGP_ASN_LEAF7B_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -124,6 +125,7 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_AUTO_BGP_ASN_LEAF7B_Ethernet4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF7A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF7A.yml
@@ -115,7 +115,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_AUTO_BGP_ASN_LEAF7B_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -125,7 +124,6 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_AUTO_BGP_ASN_LEAF7B_Ethernet4
-  type: switched
   shutdown: false
   channel_group:
     id: 3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF7B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF7B.yml
@@ -115,6 +115,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_AUTO_BGP_ASN_LEAF7A_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -124,6 +125,7 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_AUTO_BGP_ASN_LEAF7A_Ethernet4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF7B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF7B.yml
@@ -115,7 +115,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_AUTO_BGP_ASN_LEAF7A_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -125,7 +124,6 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_AUTO_BGP_ASN_LEAF7A_Ethernet4
-  type: switched
   shutdown: false
   channel_group:
     id: 3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-PYTHON_MODULES-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-PYTHON_MODULES-L3LEAF1A.yml
@@ -171,7 +171,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: TEST_CUSTOM_PREFIX_MLAG_PEER_CUSTOM-PYTHON_MODULES-L3LEAF1B_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -181,7 +180,6 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: TEST_CUSTOM_PREFIX_MLAG_PEER_CUSTOM-PYTHON_MODULES-L3LEAF1B_Ethernet4
-  type: switched
   shutdown: false
   channel_group:
     id: 3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-PYTHON_MODULES-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-PYTHON_MODULES-L3LEAF1A.yml
@@ -171,6 +171,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: TEST_CUSTOM_PREFIX_MLAG_PEER_CUSTOM-PYTHON_MODULES-L3LEAF1B_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -180,6 +181,7 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: TEST_CUSTOM_PREFIX_MLAG_PEER_CUSTOM-PYTHON_MODULES-L3LEAF1B_Ethernet4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-PYTHON_MODULES-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-PYTHON_MODULES-L3LEAF1B.yml
@@ -171,7 +171,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: TEST_CUSTOM_PREFIX_MLAG_PEER_CUSTOM-PYTHON_MODULES-L3LEAF1A_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -181,7 +180,6 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: TEST_CUSTOM_PREFIX_MLAG_PEER_CUSTOM-PYTHON_MODULES-L3LEAF1A_Ethernet4
-  type: switched
   shutdown: false
   channel_group:
     id: 3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-PYTHON_MODULES-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-PYTHON_MODULES-L3LEAF1B.yml
@@ -171,6 +171,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: TEST_CUSTOM_PREFIX_MLAG_PEER_CUSTOM-PYTHON_MODULES-L3LEAF1A_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -180,6 +181,7 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: TEST_CUSTOM_PREFIX_MLAG_PEER_CUSTOM-PYTHON_MODULES-L3LEAF1A_Ethernet4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-TEMPLATES-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-TEMPLATES-L3LEAF1A.yml
@@ -171,7 +171,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: TEST_CUSTOM_PREFIX_MLAG_PEER_CUSTOM-TEMPLATES-L3LEAF1B_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -181,7 +180,6 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: TEST_CUSTOM_PREFIX_MLAG_PEER_CUSTOM-TEMPLATES-L3LEAF1B_Ethernet4
-  type: switched
   shutdown: false
   channel_group:
     id: 3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-TEMPLATES-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-TEMPLATES-L3LEAF1A.yml
@@ -171,6 +171,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: TEST_CUSTOM_PREFIX_MLAG_PEER_CUSTOM-TEMPLATES-L3LEAF1B_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -180,6 +181,7 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: TEST_CUSTOM_PREFIX_MLAG_PEER_CUSTOM-TEMPLATES-L3LEAF1B_Ethernet4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-TEMPLATES-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-TEMPLATES-L3LEAF1B.yml
@@ -171,7 +171,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: TEST_CUSTOM_PREFIX_MLAG_PEER_CUSTOM-TEMPLATES-L3LEAF1A_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -181,7 +180,6 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: TEST_CUSTOM_PREFIX_MLAG_PEER_CUSTOM-TEMPLATES-L3LEAF1A_Ethernet4
-  type: switched
   shutdown: false
   channel_group:
     id: 3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-TEMPLATES-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-TEMPLATES-L3LEAF1B.yml
@@ -171,6 +171,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: TEST_CUSTOM_PREFIX_MLAG_PEER_CUSTOM-TEMPLATES-L3LEAF1A_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -180,6 +181,7 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: TEST_CUSTOM_PREFIX_MLAG_PEER_CUSTOM-TEMPLATES-L3LEAF1A_Ethernet4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-CL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-CL1A.yml
@@ -331,7 +331,6 @@ ethernet_interfaces:
   peer_interface: Ethernet1/15/1
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-CL1B_Ethernet1/15/1
-  type: switched
   shutdown: false
   channel_group:
     id: 1151
@@ -342,7 +341,6 @@ ethernet_interfaces:
   peer_interface: Ethernet1/16/1
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-CL1B_Ethernet1/16/1
-  type: switched
   shutdown: false
   channel_group:
     id: 1151

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-CL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-CL1A.yml
@@ -331,6 +331,7 @@ ethernet_interfaces:
   peer_interface: Ethernet1/15/1
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-CL1B_Ethernet1/15/1
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 1151
@@ -341,6 +342,7 @@ ethernet_interfaces:
   peer_interface: Ethernet1/16/1
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-CL1B_Ethernet1/16/1
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 1151

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-CL1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-CL1B.yml
@@ -332,6 +332,7 @@ ethernet_interfaces:
   peer_interface: Ethernet1/31/1
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-CL1A_Ethernet1/31/1
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 1311
@@ -342,6 +343,7 @@ ethernet_interfaces:
   peer_interface: Ethernet1/32/1
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-CL1A_Ethernet1/32/1
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 1311

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-CL1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-CL1B.yml
@@ -332,7 +332,6 @@ ethernet_interfaces:
   peer_interface: Ethernet1/31/1
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-CL1A_Ethernet1/31/1
-  type: switched
   shutdown: false
   channel_group:
     id: 1311
@@ -343,7 +342,6 @@ ethernet_interfaces:
   peer_interface: Ethernet1/32/1
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-CL1A_Ethernet1/32/1
-  type: switched
   shutdown: false
   channel_group:
     id: 1311

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -122,7 +122,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF1B_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -133,7 +132,6 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF1B_Ethernet4
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -146,7 +144,6 @@ ethernet_interfaces:
   description: DC1-LEAF2A_Ethernet7
   speed: forced 10000
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -157,7 +154,6 @@ ethernet_interfaces:
   description: DC1-LEAF2B_Ethernet7
   speed: forced 10000
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -122,6 +122,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF1B_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -132,6 +133,7 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF1B_Ethernet4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -144,6 +146,7 @@ ethernet_interfaces:
   description: DC1-LEAF2A_Ethernet7
   speed: forced 10000
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -154,6 +157,7 @@ ethernet_interfaces:
   description: DC1-LEAF2B_Ethernet7
   speed: forced 10000
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF1B.yml
@@ -122,6 +122,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF1A_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -132,6 +133,7 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF1A_Ethernet4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -144,6 +146,7 @@ ethernet_interfaces:
   description: DC1-LEAF2A_Ethernet8
   speed: forced 10000
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -154,6 +157,7 @@ ethernet_interfaces:
   description: DC1-LEAF2B_Ethernet8
   speed: forced 10000
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF1B.yml
@@ -122,7 +122,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF1A_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -133,7 +132,6 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF1A_Ethernet4
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -146,7 +144,6 @@ ethernet_interfaces:
   description: DC1-LEAF2A_Ethernet8
   speed: forced 10000
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -157,7 +154,6 @@ ethernet_interfaces:
   description: DC1-LEAF2B_Ethernet8
   speed: forced 10000
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -149,7 +149,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2B_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -159,7 +158,6 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2B_Ethernet4
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -170,7 +168,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-SVC3A_Ethernet7
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -180,7 +177,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-SVC3B_Ethernet7
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -149,6 +149,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2B_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -158,6 +159,7 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2B_Ethernet4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -168,6 +170,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-SVC3A_Ethernet7
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -177,6 +180,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-SVC3B_Ethernet7
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -149,7 +149,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2A_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -159,7 +158,6 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2A_Ethernet4
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -170,7 +168,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-SVC3A_Ethernet8
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -180,7 +177,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-SVC3B_Ethernet8
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -149,6 +149,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2A_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -158,6 +159,7 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2A_Ethernet4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -168,6 +170,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-SVC3A_Ethernet8
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -177,6 +180,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-SVC3B_Ethernet8
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF3A.yml
@@ -66,6 +66,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF2A_Ethernet9
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -75,6 +76,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF2B_Ethernet9
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF3A.yml
@@ -66,7 +66,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF2A_Ethernet9
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -76,7 +75,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF2B_Ethernet9
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF4A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF4A.yml
@@ -66,6 +66,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF2A_Ethernet13
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -75,6 +76,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF2B_Ethernet13
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF4A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF4A.yml
@@ -66,7 +66,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF2A_Ethernet13
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -76,7 +75,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF2B_Ethernet13
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF1A.yml
@@ -293,9 +293,9 @@ ethernet_interfaces:
   peer_type: server
   port_profile: ALL_WITH_SECURITY
   description: server02_SINGLE_NODE_TRUNK_Eth1
-  l2_mtu: 8000
-  type: switched
   shutdown: false
+  type: switched
+  l2_mtu: 8000
   mode: trunk
   vlans: 1-4094
   spanning_tree_portfast: edge
@@ -307,8 +307,8 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A
   description: server02_SINGLE_NODE_Eth1
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '110'
 loopback_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
@@ -427,7 +427,6 @@ ethernet_interfaces:
   description: DC1-L2LEAF1A_Ethernet1
   speed: forced 10000
   shutdown: false
-  type: switched
   channel_group:
     id: 7
     mode: active
@@ -438,7 +437,6 @@ ethernet_interfaces:
   description: DC1-L2LEAF1B_Ethernet1
   speed: forced 10000
   shutdown: false
-  type: switched
   channel_group:
     id: 7
     mode: active
@@ -448,7 +446,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF3A_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 9
     mode: active
@@ -458,7 +455,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF4A_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 13
     mode: active
@@ -468,7 +464,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1.L2LEAF5A_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 141
     mode: active
@@ -478,7 +473,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1.L2LEAF5B_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 141
     mode: active
@@ -584,12 +578,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_B
   description: server01_MLAG_Eth2
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 210-211
-  spanning_tree_bpdufilter: disabled
-  spanning_tree_bpduguard: disabled
   channel_group:
     id: 10
     mode: active
@@ -599,13 +588,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A_MTU
   description: server01_MTU_PROFILE_MLAG_Eth4
-  mtu: 1600
-  type: switched
   shutdown: false
-  mode: access
-  vlans: '110'
-  spanning_tree_bpdufilter: enabled
-  spanning_tree_bpduguard: enabled
   channel_group:
     id: 11
     mode: active
@@ -614,11 +597,7 @@ ethernet_interfaces:
   peer_interface: Eth6
   peer_type: server
   description: server01_MTU_ADAPTOR_MLAG_Eth6
-  mtu: 1601
-  type: switched
   shutdown: false
-  spanning_tree_bpdufilter: 'True'
-  spanning_tree_bpduguard: 'True'
   channel_group:
     id: 12
     mode: active
@@ -628,10 +607,7 @@ ethernet_interfaces:
   peer_type: firewall
   port_profile: TENANT_A_B
   description: FIREWALL01_E0
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 110-111,210-211
   channel_group:
     id: 20
     mode: active
@@ -641,8 +617,8 @@ ethernet_interfaces:
   peer_type: router
   port_profile: TENANT_A
   description: ROUTER01_Eth0
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '110'
 - name: Ethernet24
@@ -650,8 +626,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: DOT1X_PORT_PROFILE
   description: PC
-  type: switched
   shutdown: false
+  type: switched
   dot1x:
     port_control: auto
     reauthentication: true
@@ -674,8 +650,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: DOT1X_PORT_PROFILE
   description: PC
-  type: switched
   shutdown: false
+  type: switched
   dot1x:
     port_control: auto
     reauthentication: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
@@ -427,6 +427,7 @@ ethernet_interfaces:
   description: DC1-L2LEAF1A_Ethernet1
   speed: forced 10000
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 7
     mode: active
@@ -437,6 +438,7 @@ ethernet_interfaces:
   description: DC1-L2LEAF1B_Ethernet1
   speed: forced 10000
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 7
     mode: active
@@ -446,6 +448,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF3A_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 9
     mode: active
@@ -455,6 +458,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF4A_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 13
     mode: active
@@ -464,6 +468,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1.L2LEAF5A_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 141
     mode: active
@@ -473,6 +478,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1.L2LEAF5B_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 141
     mode: active
@@ -579,6 +585,7 @@ ethernet_interfaces:
   port_profile: TENANT_B
   description: server01_MLAG_Eth2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 10
     mode: active
@@ -589,6 +596,7 @@ ethernet_interfaces:
   port_profile: TENANT_A_MTU
   description: server01_MTU_PROFILE_MLAG_Eth4
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 11
     mode: active
@@ -598,6 +606,7 @@ ethernet_interfaces:
   peer_type: server
   description: server01_MTU_ADAPTOR_MLAG_Eth6
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 12
     mode: active
@@ -608,6 +617,7 @@ ethernet_interfaces:
   port_profile: TENANT_A_B
   description: FIREWALL01_E0
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 20
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
@@ -427,6 +427,7 @@ ethernet_interfaces:
   description: DC1-L2LEAF1A_Ethernet2
   speed: forced 10000
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 7
     mode: active
@@ -437,6 +438,7 @@ ethernet_interfaces:
   description: DC1-L2LEAF1B_Ethernet2
   speed: forced 10000
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 7
     mode: active
@@ -446,6 +448,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF3A_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 9
     mode: active
@@ -455,6 +458,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF4A_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 13
     mode: active
@@ -464,6 +468,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1.L2LEAF5A_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 141
     mode: active
@@ -473,6 +478,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1.L2LEAF5B_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 141
     mode: active
@@ -571,6 +577,7 @@ ethernet_interfaces:
   port_profile: TENANT_B
   description: server01_MLAG_Eth3
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 10
     mode: active
@@ -581,6 +588,7 @@ ethernet_interfaces:
   port_profile: TENANT_A_MTU
   description: server01_MTU_PROFILE_MLAG_Eth5
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 11
     mode: active
@@ -590,6 +598,7 @@ ethernet_interfaces:
   peer_type: server
   description: server01_MTU_ADAPTOR_MLAG_Eth7
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 12
     mode: active
@@ -600,6 +609,7 @@ ethernet_interfaces:
   port_profile: TENANT_A_B
   description: FIREWALL01_E1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 20
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
@@ -427,7 +427,6 @@ ethernet_interfaces:
   description: DC1-L2LEAF1A_Ethernet2
   speed: forced 10000
   shutdown: false
-  type: switched
   channel_group:
     id: 7
     mode: active
@@ -438,7 +437,6 @@ ethernet_interfaces:
   description: DC1-L2LEAF1B_Ethernet2
   speed: forced 10000
   shutdown: false
-  type: switched
   channel_group:
     id: 7
     mode: active
@@ -448,7 +446,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF3A_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 9
     mode: active
@@ -458,7 +455,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF4A_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 13
     mode: active
@@ -468,7 +464,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1.L2LEAF5A_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 141
     mode: active
@@ -478,7 +473,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1.L2LEAF5B_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 141
     mode: active
@@ -576,12 +570,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_B
   description: server01_MLAG_Eth3
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 210-211
-  spanning_tree_bpdufilter: disabled
-  spanning_tree_bpduguard: disabled
   channel_group:
     id: 10
     mode: active
@@ -591,13 +580,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A_MTU
   description: server01_MTU_PROFILE_MLAG_Eth5
-  mtu: 1600
-  type: switched
   shutdown: false
-  mode: access
-  vlans: '110'
-  spanning_tree_bpdufilter: enabled
-  spanning_tree_bpduguard: enabled
   channel_group:
     id: 11
     mode: active
@@ -606,11 +589,7 @@ ethernet_interfaces:
   peer_interface: Eth7
   peer_type: server
   description: server01_MTU_ADAPTOR_MLAG_Eth7
-  mtu: 1601
-  type: switched
   shutdown: false
-  spanning_tree_bpdufilter: 'True'
-  spanning_tree_bpduguard: 'True'
   channel_group:
     id: 12
     mode: active
@@ -620,10 +599,7 @@ ethernet_interfaces:
   peer_type: firewall
   port_profile: TENANT_A_B
   description: FIREWALL01_E1
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 110-111,210-211
   channel_group:
     id: 20
     mode: active
@@ -633,8 +609,8 @@ ethernet_interfaces:
   peer_type: router
   port_profile: TENANT_A
   description: ROUTER01_Eth1
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '110'
 port_channel_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3A.yml
@@ -992,6 +992,7 @@ ethernet_interfaces:
   peer_interface: Ethernet53/1
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-SVC3B_Ethernet53/1
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 2000
@@ -1002,6 +1003,7 @@ ethernet_interfaces:
   peer_interface: Ethernet54/1
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-SVC3B_Ethernet54/1
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 2000
@@ -1013,6 +1015,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF2A_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 7
     mode: active
@@ -1022,6 +1025,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF2B_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 7
     mode: active
@@ -1072,6 +1076,7 @@ ethernet_interfaces:
   port_profile: TENANT_A_B
   description: server03_ESI_Eth1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 10
     mode: active
@@ -1161,6 +1166,7 @@ ethernet_interfaces:
   port_profile: ALL_WITH_SECURITY_PORT_CHANNEL
   description: server07_inherit_all_from_profile_port_channel_Eth1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 14
     mode: active
@@ -1170,6 +1176,7 @@ ethernet_interfaces:
   peer_type: server
   description: server08_no_profile_port_channel_Eth1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 15
     mode: 'on'
@@ -1206,6 +1213,7 @@ ethernet_interfaces:
   peer_type: server
   description: server10_no_profile_port_channel_lacp_fallback_Eth1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 17
     mode: passive
@@ -1217,6 +1225,7 @@ ethernet_interfaces:
   port_profile: ALL_WITH_SECURITY_PORT_CHANNEL_LACP_FALLBACK
   description: server11_inherit_profile_port_channel_lacp_fallback_Eth1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 18
     mode: active
@@ -1228,6 +1237,7 @@ ethernet_interfaces:
   port_profile: NESTED_PORT_PROFILE
   description: server12_inherit_nested_profile_port_channel_lacp_fallback_Eth1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 19
     mode: active
@@ -1259,6 +1269,7 @@ ethernet_interfaces:
   port_profile: TENANT_A
   description: server15_port_channel_with_disabled_phy_interfaces_Eth1
   shutdown: true
+  type: port-channel-member
   channel_group:
     id: 22
     mode: active
@@ -1269,6 +1280,7 @@ ethernet_interfaces:
   port_profile: TENANT_A
   description: server16_port_channel_with_disabled_port_channel_Eth1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 23
     mode: active
@@ -1279,6 +1291,7 @@ ethernet_interfaces:
   port_profile: TENANT_A
   description: server17_port_channel_with_disabled_phy_and_po_interfaces_Eth1
   shutdown: true
+  type: port-channel-member
   channel_group:
     id: 24
     mode: active
@@ -1299,6 +1312,7 @@ ethernet_interfaces:
   port_profile: TENANT_A
   description: server18_monitoring_session_source_po_Eth3
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 27
     mode: active
@@ -1333,6 +1347,7 @@ ethernet_interfaces:
   port_profile: TENANT_A
   description: server21_monitoring_session_destination_po_Eth1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 42
     mode: active
@@ -1343,6 +1358,7 @@ ethernet_interfaces:
   port_profile: TENANT_A
   description: server22_port_channel_with_custom_id_Eth1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1291
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3A.yml
@@ -992,7 +992,6 @@ ethernet_interfaces:
   peer_interface: Ethernet53/1
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-SVC3B_Ethernet53/1
-  type: switched
   shutdown: false
   channel_group:
     id: 2000
@@ -1003,7 +1002,6 @@ ethernet_interfaces:
   peer_interface: Ethernet54/1
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-SVC3B_Ethernet54/1
-  type: switched
   shutdown: false
   channel_group:
     id: 2000
@@ -1015,7 +1013,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF2A_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 7
     mode: active
@@ -1025,7 +1022,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF2B_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 7
     mode: active
@@ -1075,10 +1071,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A_B
   description: server03_ESI_Eth1
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 110-111,210-211
   channel_group:
     id: 10
     mode: active
@@ -1088,9 +1081,9 @@ ethernet_interfaces:
   peer_type: server
   port_profile: ALL_WITH_SECURITY
   description: server04_inherit_all_from_profile_Eth1
-  l2_mtu: 8000
-  type: switched
   shutdown: false
+  type: switched
+  l2_mtu: 8000
   mode: trunk
   vlans: 1-4094
   spanning_tree_portfast: edge
@@ -1114,8 +1107,8 @@ ethernet_interfaces:
   peer_interface: Eth1
   peer_type: server
   description: server05_no_profile_Eth1
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk
   vlans: 1-4094
   spanning_tree_portfast: edge
@@ -1140,9 +1133,9 @@ ethernet_interfaces:
   peer_type: server
   port_profile: ALL_WITH_SECURITY
   description: server06_override_profile_Eth1
-  l2_mtu: 8000
-  type: switched
   shutdown: false
+  type: switched
+  l2_mtu: 8000
   mode: access
   vlans: '210'
   spanning_tree_portfast: network
@@ -1167,27 +1160,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: ALL_WITH_SECURITY_PORT_CHANNEL
   description: server07_inherit_all_from_profile_port_channel_Eth1
-  l2_mtu: 8000
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 1-4094
-  spanning_tree_portfast: edge
-  spanning_tree_bpdufilter: enabled
-  spanning_tree_bpduguard: enabled
-  storm_control:
-    all:
-      level: '10'
-      unit: percent
-    broadcast:
-      level: '100'
-      unit: pps
-    multicast:
-      level: '1'
-      unit: percent
-    unknown_unicast:
-      level: '2'
-      unit: percent
   channel_group:
     id: 14
     mode: active
@@ -1196,26 +1169,7 @@ ethernet_interfaces:
   peer_interface: Eth1
   peer_type: server
   description: server08_no_profile_port_channel_Eth1
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 1-4094
-  spanning_tree_portfast: edge
-  spanning_tree_bpdufilter: 'True'
-  spanning_tree_bpduguard: disabled
-  storm_control:
-    all:
-      level: '10'
-      unit: percent
-    broadcast:
-      level: '100'
-      unit: pps
-    multicast:
-      level: '1'
-      unit: percent
-    unknown_unicast:
-      level: '2'
-      unit: percent
   channel_group:
     id: 15
     mode: 'on'
@@ -1225,9 +1179,9 @@ ethernet_interfaces:
   peer_type: server
   port_profile: ALL_WITH_SECURITY_PORT_CHANNEL
   description: server09_override_profile_no_port_channel_Eth1
-  l2_mtu: 8000
-  type: switched
   shutdown: false
+  type: switched
+  l2_mtu: 8000
   mode: access
   vlans: '210'
   spanning_tree_portfast: network
@@ -1251,26 +1205,7 @@ ethernet_interfaces:
   peer_interface: Eth1
   peer_type: server
   description: server10_no_profile_port_channel_lacp_fallback_Eth1
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 1-4094
-  spanning_tree_portfast: edge
-  spanning_tree_bpdufilter: 'True'
-  spanning_tree_bpduguard: disabled
-  storm_control:
-    all:
-      level: '10'
-      unit: percent
-    broadcast:
-      level: '100'
-      unit: pps
-    multicast:
-      level: '1'
-      unit: percent
-    unknown_unicast:
-      level: '2'
-      unit: percent
   channel_group:
     id: 17
     mode: passive
@@ -1281,27 +1216,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: ALL_WITH_SECURITY_PORT_CHANNEL_LACP_FALLBACK
   description: server11_inherit_profile_port_channel_lacp_fallback_Eth1
-  l2_mtu: 8000
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 1-4094
-  spanning_tree_portfast: edge
-  spanning_tree_bpdufilter: 'True'
-  spanning_tree_bpduguard: 'True'
-  storm_control:
-    all:
-      level: '10'
-      unit: percent
-    broadcast:
-      level: '100'
-      unit: pps
-    multicast:
-      level: '1'
-      unit: percent
-    unknown_unicast:
-      level: '2'
-      unit: percent
   channel_group:
     id: 18
     mode: active
@@ -1312,27 +1227,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: NESTED_PORT_PROFILE
   description: server12_inherit_nested_profile_port_channel_lacp_fallback_Eth1
-  l2_mtu: 8000
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 1-4094
-  spanning_tree_portfast: edge
-  spanning_tree_bpdufilter: 'True'
-  spanning_tree_bpduguard: 'True'
-  storm_control:
-    all:
-      level: '10'
-      unit: percent
-    broadcast:
-      level: '100'
-      unit: pps
-    multicast:
-      level: '1'
-      unit: percent
-    unknown_unicast:
-      level: '2'
-      unit: percent
   channel_group:
     id: 19
     mode: active
@@ -1343,8 +1238,8 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A
   description: server13_disabled_interfaces_Eth1
-  type: switched
   shutdown: true
+  type: switched
   mode: access
   vlans: '110'
 - name: Ethernet21
@@ -1353,8 +1248,8 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A
   description: server14_explicitly_enabled_interfaces_Eth1
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '110'
 - name: Ethernet22
@@ -1363,10 +1258,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A
   description: server15_port_channel_with_disabled_phy_interfaces_Eth1
-  type: switched
   shutdown: true
-  mode: access
-  vlans: '110'
   channel_group:
     id: 22
     mode: active
@@ -1376,10 +1268,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A
   description: server16_port_channel_with_disabled_port_channel_Eth1
-  type: switched
   shutdown: false
-  mode: access
-  vlans: '110'
   channel_group:
     id: 23
     mode: active
@@ -1389,10 +1278,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A
   description: server17_port_channel_with_disabled_phy_and_po_interfaces_Eth1
-  type: switched
   shutdown: true
-  mode: access
-  vlans: '110'
   channel_group:
     id: 24
     mode: active
@@ -1402,8 +1288,8 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A
   description: server18_monitoring_session_source_phys_interfaces_Eth1
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '110'
 - name: Ethernet27
@@ -1412,10 +1298,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A
   description: server18_monitoring_session_source_po_Eth3
-  type: switched
   shutdown: false
-  mode: access
-  vlans: '110'
   channel_group:
     id: 27
     mode: active
@@ -1425,8 +1308,8 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A
   description: server18_monitoring_session_source_phys_interface_Eth5
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '110'
 - name: Ethernet26
@@ -1434,25 +1317,22 @@ ethernet_interfaces:
   peer_interface: Eth1
   peer_type: server
   description: server19_monitoring_session_destination_phys_Eth1
-  type: switched
   shutdown: false
+  type: switched
 - name: Ethernet40
   peer: server20_monitoring_session_destination_phys
   peer_interface: Eth1
   peer_type: server
   description: server20_monitoring_session_destination_phys_Eth1
-  type: switched
   shutdown: false
+  type: switched
 - name: Ethernet42
   peer: server21_monitoring_session_destination_po
   peer_interface: Eth1
   peer_type: server
   port_profile: TENANT_A
   description: server21_monitoring_session_destination_po_Eth1
-  type: switched
   shutdown: false
-  mode: access
-  vlans: '110'
   channel_group:
     id: 42
     mode: active
@@ -1462,10 +1342,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A
   description: server22_port_channel_with_custom_id_Eth1
-  type: switched
   shutdown: false
-  mode: access
-  vlans: '110'
   channel_group:
     id: 1291
     mode: active
@@ -1475,8 +1352,8 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A
   description: server23_phone_int_1
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk phone
   vlans: '110'
 - name: Ethernet31

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3A.yml
@@ -1378,10 +1378,8 @@ ethernet_interfaces:
   peer_type: server
   port_profile: PORT_CHANNEL_LACP_TIMER
   description: server24_port_channel_lacp_timer_profile_Eth1
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 1-4094
+  type: port-channel-member
   channel_group:
     id: 31
     mode: active
@@ -1393,8 +1391,8 @@ ethernet_interfaces:
   peer_interface: Eth1
   peer_type: server
   description: server25_port_channel_lacp_timer_Eth1
-  type: switched
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 32
     mode: active
@@ -1407,10 +1405,8 @@ ethernet_interfaces:
   peer_type: server
   port_profile: PORT_CHANNEL_LACP_TIMER_NORMAL
   description: server26_port_channel_lacp_timer_profile_Eth1
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 1-4094
+  type: port-channel-member
   channel_group:
     id: 33
     mode: active
@@ -1422,8 +1418,8 @@ ethernet_interfaces:
   peer_interface: Eth1
   peer_type: server
   description: server27_port_channel_lacp_timer_Eth1
-  type: switched
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 34
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3B.yml
@@ -982,6 +982,7 @@ ethernet_interfaces:
   peer_interface: Ethernet53/1
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-SVC3A_Ethernet53/1
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 2000
@@ -992,6 +993,7 @@ ethernet_interfaces:
   peer_interface: Ethernet54/1
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-SVC3A_Ethernet54/1
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 2000
@@ -1003,6 +1005,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF2A_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 7
     mode: active
@@ -1012,6 +1015,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF2B_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 7
     mode: active
@@ -1141,6 +1145,7 @@ ethernet_interfaces:
   port_profile: ALL_WITH_SECURITY_PORT_CHANNEL
   description: server07_inherit_all_from_profile_port_channel_Eth2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 14
     mode: active
@@ -1150,6 +1155,7 @@ ethernet_interfaces:
   peer_type: server
   description: server08_no_profile_port_channel_Eth2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 15
     mode: 'on'
@@ -1186,6 +1192,7 @@ ethernet_interfaces:
   peer_type: server
   description: server10_no_profile_port_channel_lacp_fallback_Eth2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 17
     mode: passive
@@ -1197,6 +1204,7 @@ ethernet_interfaces:
   port_profile: ALL_WITH_SECURITY_PORT_CHANNEL_LACP_FALLBACK
   description: server11_inherit_profile_port_channel_lacp_fallback_Eth2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 18
     mode: active
@@ -1208,6 +1216,7 @@ ethernet_interfaces:
   port_profile: NESTED_PORT_PROFILE
   description: server12_inherit_nested_profile_port_channel_lacp_fallback_Eth2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 19
     mode: active
@@ -1239,6 +1248,7 @@ ethernet_interfaces:
   port_profile: TENANT_A
   description: server15_port_channel_with_disabled_phy_interfaces_Eth2
   shutdown: true
+  type: port-channel-member
   channel_group:
     id: 22
     mode: active
@@ -1249,6 +1259,7 @@ ethernet_interfaces:
   port_profile: TENANT_A
   description: server16_port_channel_with_disabled_port_channel_Eth2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 23
     mode: active
@@ -1259,6 +1270,7 @@ ethernet_interfaces:
   port_profile: TENANT_A
   description: server17_port_channel_with_disabled_phy_and_po_interfaces_Eth2
   shutdown: true
+  type: port-channel-member
   channel_group:
     id: 24
     mode: active
@@ -1279,6 +1291,7 @@ ethernet_interfaces:
   port_profile: TENANT_A
   description: server18_monitoring_session_source_po_Eth4
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 27
     mode: active
@@ -1296,6 +1309,7 @@ ethernet_interfaces:
   port_profile: TENANT_A
   description: server21_monitoring_session_destination_po_Eth2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 42
     mode: active
@@ -1306,6 +1320,7 @@ ethernet_interfaces:
   port_profile: TENANT_A
   description: server22_port_channel_with_custom_id_Eth2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1291
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3B.yml
@@ -982,7 +982,6 @@ ethernet_interfaces:
   peer_interface: Ethernet53/1
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-SVC3A_Ethernet53/1
-  type: switched
   shutdown: false
   channel_group:
     id: 2000
@@ -993,7 +992,6 @@ ethernet_interfaces:
   peer_interface: Ethernet54/1
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-SVC3A_Ethernet54/1
-  type: switched
   shutdown: false
   channel_group:
     id: 2000
@@ -1005,7 +1003,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF2A_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 7
     mode: active
@@ -1015,7 +1012,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF2B_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 7
     mode: active
@@ -1065,9 +1061,9 @@ ethernet_interfaces:
   peer_type: server
   port_profile: ALL_WITH_SECURITY
   description: server04_inherit_all_from_profile_Eth2
-  l2_mtu: 8000
-  type: switched
   shutdown: false
+  type: switched
+  l2_mtu: 8000
   mode: trunk
   vlans: 1-4094
   spanning_tree_portfast: edge
@@ -1091,8 +1087,8 @@ ethernet_interfaces:
   peer_interface: Eth2
   peer_type: server
   description: server05_no_profile_Eth2
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk
   vlans: 1-4094
   spanning_tree_portfast: edge
@@ -1117,9 +1113,9 @@ ethernet_interfaces:
   peer_type: server
   port_profile: ALL_WITH_SECURITY
   description: server06_override_profile_Eth2
-  l2_mtu: 8000
-  type: switched
   shutdown: false
+  type: switched
+  l2_mtu: 8000
   mode: access
   vlans: '210'
   spanning_tree_portfast: network
@@ -1144,27 +1140,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: ALL_WITH_SECURITY_PORT_CHANNEL
   description: server07_inherit_all_from_profile_port_channel_Eth2
-  l2_mtu: 8000
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 1-4094
-  spanning_tree_portfast: edge
-  spanning_tree_bpdufilter: enabled
-  spanning_tree_bpduguard: enabled
-  storm_control:
-    all:
-      level: '10'
-      unit: percent
-    broadcast:
-      level: '100'
-      unit: pps
-    multicast:
-      level: '1'
-      unit: percent
-    unknown_unicast:
-      level: '2'
-      unit: percent
   channel_group:
     id: 14
     mode: active
@@ -1173,26 +1149,7 @@ ethernet_interfaces:
   peer_interface: Eth2
   peer_type: server
   description: server08_no_profile_port_channel_Eth2
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 1-4094
-  spanning_tree_portfast: edge
-  spanning_tree_bpdufilter: 'True'
-  spanning_tree_bpduguard: disabled
-  storm_control:
-    all:
-      level: '10'
-      unit: percent
-    broadcast:
-      level: '100'
-      unit: pps
-    multicast:
-      level: '1'
-      unit: percent
-    unknown_unicast:
-      level: '2'
-      unit: percent
   channel_group:
     id: 15
     mode: 'on'
@@ -1202,9 +1159,9 @@ ethernet_interfaces:
   peer_type: server
   port_profile: ALL_WITH_SECURITY_PORT_CHANNEL
   description: server09_override_profile_no_port_channel_Eth2
-  l2_mtu: 8000
-  type: switched
   shutdown: false
+  type: switched
+  l2_mtu: 8000
   mode: access
   vlans: '210'
   spanning_tree_portfast: network
@@ -1228,26 +1185,7 @@ ethernet_interfaces:
   peer_interface: Eth2
   peer_type: server
   description: server10_no_profile_port_channel_lacp_fallback_Eth2
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 1-4094
-  spanning_tree_portfast: edge
-  spanning_tree_bpdufilter: 'True'
-  spanning_tree_bpduguard: disabled
-  storm_control:
-    all:
-      level: '10'
-      unit: percent
-    broadcast:
-      level: '100'
-      unit: pps
-    multicast:
-      level: '1'
-      unit: percent
-    unknown_unicast:
-      level: '2'
-      unit: percent
   channel_group:
     id: 17
     mode: passive
@@ -1258,27 +1196,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: ALL_WITH_SECURITY_PORT_CHANNEL_LACP_FALLBACK
   description: server11_inherit_profile_port_channel_lacp_fallback_Eth2
-  l2_mtu: 8000
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 1-4094
-  spanning_tree_portfast: edge
-  spanning_tree_bpdufilter: 'True'
-  spanning_tree_bpduguard: 'True'
-  storm_control:
-    all:
-      level: '10'
-      unit: percent
-    broadcast:
-      level: '100'
-      unit: pps
-    multicast:
-      level: '1'
-      unit: percent
-    unknown_unicast:
-      level: '2'
-      unit: percent
   channel_group:
     id: 18
     mode: active
@@ -1289,27 +1207,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: NESTED_PORT_PROFILE
   description: server12_inherit_nested_profile_port_channel_lacp_fallback_Eth2
-  l2_mtu: 8000
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 1-4094
-  spanning_tree_portfast: edge
-  spanning_tree_bpdufilter: 'True'
-  spanning_tree_bpduguard: 'True'
-  storm_control:
-    all:
-      level: '10'
-      unit: percent
-    broadcast:
-      level: '100'
-      unit: pps
-    multicast:
-      level: '1'
-      unit: percent
-    unknown_unicast:
-      level: '2'
-      unit: percent
   channel_group:
     id: 19
     mode: active
@@ -1320,8 +1218,8 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A
   description: server13_disabled_interfaces_Eth2
-  type: switched
   shutdown: true
+  type: switched
   mode: access
   vlans: '110'
 - name: Ethernet21
@@ -1330,8 +1228,8 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A
   description: server14_explicitly_enabled_interfaces_Eth2
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '110'
 - name: Ethernet22
@@ -1340,10 +1238,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A
   description: server15_port_channel_with_disabled_phy_interfaces_Eth2
-  type: switched
   shutdown: true
-  mode: access
-  vlans: '110'
   channel_group:
     id: 22
     mode: active
@@ -1353,10 +1248,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A
   description: server16_port_channel_with_disabled_port_channel_Eth2
-  type: switched
   shutdown: false
-  mode: access
-  vlans: '110'
   channel_group:
     id: 23
     mode: active
@@ -1366,10 +1258,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A
   description: server17_port_channel_with_disabled_phy_and_po_interfaces_Eth2
-  type: switched
   shutdown: true
-  mode: access
-  vlans: '110'
   channel_group:
     id: 24
     mode: active
@@ -1379,8 +1268,8 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A
   description: server18_monitoring_session_source_phys_interfaces_Eth2
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '110'
 - name: Ethernet27
@@ -1389,10 +1278,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A
   description: server18_monitoring_session_source_po_Eth4
-  type: switched
   shutdown: false
-  mode: access
-  vlans: '110'
   channel_group:
     id: 27
     mode: active
@@ -1401,18 +1287,15 @@ ethernet_interfaces:
   peer_interface: Eth2
   peer_type: server
   description: server19_monitoring_session_destination_phys_Eth2
-  type: switched
   shutdown: false
+  type: switched
 - name: Ethernet42
   peer: server21_monitoring_session_destination_po
   peer_interface: Eth2
   peer_type: server
   port_profile: TENANT_A
   description: server21_monitoring_session_destination_po_Eth2
-  type: switched
   shutdown: false
-  mode: access
-  vlans: '110'
   channel_group:
     id: 42
     mode: active
@@ -1422,10 +1305,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A
   description: server22_port_channel_with_custom_id_Eth2
-  type: switched
   shutdown: false
-  mode: access
-  vlans: '110'
   channel_group:
     id: 1291
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3B.yml
@@ -1330,10 +1330,8 @@ ethernet_interfaces:
   peer_type: server
   port_profile: PORT_CHANNEL_LACP_TIMER
   description: server24_port_channel_lacp_timer_profile_Eth2
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 1-4094
+  type: port-channel-member
   channel_group:
     id: 31
     mode: active
@@ -1345,8 +1343,8 @@ ethernet_interfaces:
   peer_interface: Eth2
   peer_type: server
   description: server25_port_channel_lacp_timer_Eth2
-  type: switched
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 32
     mode: active
@@ -1359,10 +1357,8 @@ ethernet_interfaces:
   peer_type: server
   port_profile: PORT_CHANNEL_LACP_TIMER_NORMAL
   description: server26_port_channel_lacp_timer_profile_Eth2
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 1-4094
+  type: port-channel-member
   channel_group:
     id: 33
     mode: active
@@ -1374,8 +1370,8 @@ ethernet_interfaces:
   peer_interface: Eth2
   peer_type: server
   description: server27_port_channel_lacp_timer_Eth2
-  type: switched
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 34
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1.L2LEAF5A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1.L2LEAF5A.yml
@@ -122,6 +122,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_DC1.L2LEAF5B_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -131,6 +132,7 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_DC1.L2LEAF5B_Ethernet4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -141,6 +143,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF2A_Ethernet14/1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -150,6 +153,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF2B_Ethernet14/1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1.L2LEAF5A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1.L2LEAF5A.yml
@@ -122,7 +122,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_DC1.L2LEAF5B_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -132,7 +131,6 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_DC1.L2LEAF5B_Ethernet4
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -143,7 +141,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF2A_Ethernet14/1
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -153,7 +150,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF2B_Ethernet14/1
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1.L2LEAF5B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1.L2LEAF5B.yml
@@ -122,6 +122,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_DC1.L2LEAF5A_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -131,6 +132,7 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_DC1.L2LEAF5A_Ethernet4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -141,6 +143,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF2A_Ethernet15/1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -150,6 +153,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF2B_Ethernet15/1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1.L2LEAF5B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1.L2LEAF5B.yml
@@ -122,7 +122,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_DC1.L2LEAF5A_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -132,7 +131,6 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_DC1.L2LEAF5A_Ethernet4
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -143,7 +141,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF2A_Ethernet15/1
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -153,7 +150,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF2B_Ethernet15/1
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1_UNDEPLOYED_LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1_UNDEPLOYED_LEAF1A.yml
@@ -801,7 +801,6 @@ ethernet_interfaces:
   peer_interface: Ethernet57/1
   peer_type: mlag_peer
   description: MLAG_PEER_DC1_UNDEPLOYED_LEAF1B_Ethernet57/1
-  type: switched
   shutdown: false
   channel_group:
     id: 571
@@ -812,7 +811,6 @@ ethernet_interfaces:
   peer_interface: Ethernet58/1
   peer_type: mlag_peer
   description: MLAG_PEER_DC1_UNDEPLOYED_LEAF1B_Ethernet58/1
-  type: switched
   shutdown: false
   channel_group:
     id: 571

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1_UNDEPLOYED_LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1_UNDEPLOYED_LEAF1A.yml
@@ -801,6 +801,7 @@ ethernet_interfaces:
   peer_interface: Ethernet57/1
   peer_type: mlag_peer
   description: MLAG_PEER_DC1_UNDEPLOYED_LEAF1B_Ethernet57/1
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 571
@@ -811,6 +812,7 @@ ethernet_interfaces:
   peer_interface: Ethernet58/1
   peer_type: mlag_peer
   description: MLAG_PEER_DC1_UNDEPLOYED_LEAF1B_Ethernet58/1
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 571

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1_UNDEPLOYED_LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1_UNDEPLOYED_LEAF1B.yml
@@ -801,7 +801,6 @@ ethernet_interfaces:
   peer_interface: Ethernet57/1
   peer_type: mlag_peer
   description: MLAG_PEER_DC1_UNDEPLOYED_LEAF1A_Ethernet57/1
-  type: switched
   shutdown: false
   channel_group:
     id: 571
@@ -812,7 +811,6 @@ ethernet_interfaces:
   peer_interface: Ethernet58/1
   peer_type: mlag_peer
   description: MLAG_PEER_DC1_UNDEPLOYED_LEAF1A_Ethernet58/1
-  type: switched
   shutdown: false
   channel_group:
     id: 571

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1_UNDEPLOYED_LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1_UNDEPLOYED_LEAF1B.yml
@@ -801,6 +801,7 @@ ethernet_interfaces:
   peer_interface: Ethernet57/1
   peer_type: mlag_peer
   description: MLAG_PEER_DC1_UNDEPLOYED_LEAF1A_Ethernet57/1
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 571
@@ -811,6 +812,7 @@ ethernet_interfaces:
   peer_interface: Ethernet58/1
   peer_type: mlag_peer
   description: MLAG_PEER_DC1_UNDEPLOYED_LEAF1A_Ethernet58/1
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 571

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L2LEAF1A.yml
@@ -30,6 +30,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: EVPN-MULTICAST-L3LEAF1A_Ethernet6
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -39,6 +40,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: EVPN-MULTICAST-L3LEAF1B_Ethernet6
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L2LEAF1A.yml
@@ -30,7 +30,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: EVPN-MULTICAST-L3LEAF1A_Ethernet6
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -40,7 +39,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: EVPN-MULTICAST-L3LEAF1B_Ethernet6
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF1A.yml
@@ -1199,6 +1199,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_EVPN-MULTICAST-L3LEAF1B_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -1208,6 +1209,7 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_EVPN-MULTICAST-L3LEAF1B_Ethernet4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -1230,6 +1232,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: EVPN-MULTICAST-L2LEAF1A_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 6
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF1A.yml
@@ -1199,7 +1199,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_EVPN-MULTICAST-L3LEAF1B_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -1209,7 +1208,6 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_EVPN-MULTICAST-L3LEAF1B_Ethernet4
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -1232,7 +1230,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: EVPN-MULTICAST-L2LEAF1A_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 6
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF1B.yml
@@ -1199,6 +1199,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_EVPN-MULTICAST-L3LEAF1A_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -1208,6 +1209,7 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_EVPN-MULTICAST-L3LEAF1A_Ethernet4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -1230,6 +1232,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: EVPN-MULTICAST-L2LEAF1A_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 6
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF1B.yml
@@ -1199,7 +1199,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_EVPN-MULTICAST-L3LEAF1A_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -1209,7 +1208,6 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_EVPN-MULTICAST-L3LEAF1A_Ethernet4
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -1232,7 +1230,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: EVPN-MULTICAST-L2LEAF1A_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 6
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/IGMP-QUERIER-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/IGMP-QUERIER-L2LEAF1A.yml
@@ -30,7 +30,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: IGMP-QUERIER-L3LEAF1A_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/IGMP-QUERIER-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/IGMP-QUERIER-L2LEAF1A.yml
@@ -30,6 +30,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: IGMP-QUERIER-L3LEAF1A_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/IGMP-QUERIER-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/IGMP-QUERIER-L3LEAF1A.yml
@@ -253,6 +253,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: IGMP-QUERIER-L2LEAF1A_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/IGMP-QUERIER-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/IGMP-QUERIER-L3LEAF1A.yml
@@ -253,7 +253,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: IGMP-QUERIER-L2LEAF1A_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-L2LEAF1A.yml
@@ -69,6 +69,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: MH-LEAF2A_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-L2LEAF1A.yml
@@ -69,7 +69,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: MH-LEAF2A_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -78,8 +77,8 @@ ethernet_interfaces:
   peer_interface: Eth1
   peer_type: server
   description: server02_Eth1
-  type: switched
   shutdown: false
+  type: switched
   link_tracking_groups:
   - name: l2leaf-server02
     direction: downstream

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF1A.yml
@@ -156,6 +156,7 @@ ethernet_interfaces:
   port_profile: Tenant_X
   description: server01_ES1_Eth1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 10
     mode: active
@@ -166,6 +167,7 @@ ethernet_interfaces:
   port_profile: Tenant_X
   description: server03_AUTO_ESI_Eth1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 12
     mode: active
@@ -176,6 +178,7 @@ ethernet_interfaces:
   port_profile: Tenant_ESI_Auto
   description: server04_AUTO_ESI_Profile_Eth1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 13
     mode: active
@@ -186,6 +189,7 @@ ethernet_interfaces:
   port_profile: Tenant_ESI_Auto
   description: server05_AUTO_ESI_Profile_Override_Eth1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 14
     mode: active
@@ -196,6 +200,7 @@ ethernet_interfaces:
   port_profile: Tenant_X_Trunk_Auto
   description: server06_Single_Active_Port_Channel_Eth1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 15
     mode: active
@@ -206,6 +211,7 @@ ethernet_interfaces:
   port_profile: Tenant_X_Trunk
   description: server07_Single_Active_Port_Channel_Manual_DF_Eth1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 16
     mode: active
@@ -266,6 +272,7 @@ ethernet_interfaces:
   port_profile: Tenant_X_Trunk
   description: server11_Single_Active_Port_Channel_Manual_DF_Dont_Preempt_Eth1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 20
     mode: active
@@ -294,6 +301,7 @@ ethernet_interfaces:
   port_profile: Tenant_X_Trunk
   description: server13_Single_Active_Port_Channel_Manual_DF_Dont_Preempt_modulus_Eth1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 22
     mode: active
@@ -319,6 +327,7 @@ ethernet_interfaces:
   peer_type: router
   description: ROUTER02_WITH_SUBIF_Eth1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 11
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF1A.yml
@@ -155,10 +155,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: Tenant_X
   description: server01_ES1_Eth1
-  type: switched
   shutdown: false
-  mode: access
-  vlans: '310'
   channel_group:
     id: 10
     mode: active
@@ -168,10 +165,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: Tenant_X
   description: server03_AUTO_ESI_Eth1
-  type: switched
   shutdown: false
-  mode: access
-  vlans: '310'
   channel_group:
     id: 12
     mode: active
@@ -181,10 +175,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: Tenant_ESI_Auto
   description: server04_AUTO_ESI_Profile_Eth1
-  type: switched
   shutdown: false
-  mode: access
-  vlans: '310'
   channel_group:
     id: 13
     mode: active
@@ -194,10 +185,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: Tenant_ESI_Auto
   description: server05_AUTO_ESI_Profile_Override_Eth1
-  type: switched
   shutdown: false
-  mode: access
-  vlans: '310'
   channel_group:
     id: 14
     mode: active
@@ -207,10 +195,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: Tenant_X_Trunk_Auto
   description: server06_Single_Active_Port_Channel_Eth1
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: '310'
   channel_group:
     id: 15
     mode: active
@@ -220,10 +205,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: Tenant_X_Trunk
   description: server07_Single_Active_Port_Channel_Manual_DF_Eth1
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: '310'
   channel_group:
     id: 16
     mode: active
@@ -233,8 +215,8 @@ ethernet_interfaces:
   peer_type: server
   port_profile: Tenant_X_Trunk_Auto_Eth
   description: server08_Single_Active_Ethernet_Eth1
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk
   vlans: '310'
   evpn_ethernet_segment:
@@ -250,8 +232,8 @@ ethernet_interfaces:
   peer_type: server
   port_profile: Tenant_X_Trunk
   description: server09_All_Active_Ethernet_Eth1
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk
   vlans: '310'
   evpn_ethernet_segment:
@@ -266,8 +248,8 @@ ethernet_interfaces:
   peer_type: server
   port_profile: Tenant_X_Trunk
   description: server10_Single_Active_Ethernet_Manual_DF_Eth1
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk
   vlans: '310'
   evpn_ethernet_segment:
@@ -283,10 +265,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: Tenant_X_Trunk
   description: server11_Single_Active_Port_Channel_Manual_DF_Dont_Preempt_Eth1
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: '310'
   channel_group:
     id: 20
     mode: active
@@ -296,8 +275,8 @@ ethernet_interfaces:
   peer_type: server
   port_profile: Tenant_X_Trunk
   description: server12_Single_Active_Ethernet_Manual_DF_Dont_Preempt_Eth1
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk
   vlans: '310'
   evpn_ethernet_segment:
@@ -314,10 +293,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: Tenant_X_Trunk
   description: server13_Single_Active_Port_Channel_Manual_DF_Dont_Preempt_modulus_Eth1
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: '310'
   channel_group:
     id: 22
     mode: active
@@ -327,8 +303,8 @@ ethernet_interfaces:
   peer_type: server
   port_profile: Tenant_X_Trunk
   description: server14_Single_Active_Ethernet_Manual_DF_Dont_Preempt_modulus_Eth1
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk
   vlans: '310'
   evpn_ethernet_segment:
@@ -342,7 +318,6 @@ ethernet_interfaces:
   peer_interface: Eth1
   peer_type: router
   description: ROUTER02_WITH_SUBIF_Eth1
-  type: switched
   shutdown: false
   channel_group:
     id: 11

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF1B.yml
@@ -156,6 +156,7 @@ ethernet_interfaces:
   port_profile: Tenant_X
   description: server01_ES1_Eth2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 10
     mode: active
@@ -166,6 +167,7 @@ ethernet_interfaces:
   port_profile: Tenant_X
   description: server03_AUTO_ESI_Eth2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 12
     mode: active
@@ -176,6 +178,7 @@ ethernet_interfaces:
   port_profile: Tenant_ESI_Auto
   description: server04_AUTO_ESI_Profile_Eth2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 13
     mode: active
@@ -186,6 +189,7 @@ ethernet_interfaces:
   port_profile: Tenant_ESI_Auto
   description: server05_AUTO_ESI_Profile_Override_Eth2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 14
     mode: active
@@ -196,6 +200,7 @@ ethernet_interfaces:
   port_profile: Tenant_X_Trunk_Auto
   description: server06_Single_Active_Port_Channel_Eth2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 15
     mode: active
@@ -206,6 +211,7 @@ ethernet_interfaces:
   port_profile: Tenant_X_Trunk
   description: server07_Single_Active_Port_Channel_Manual_DF_Eth2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 16
     mode: active
@@ -266,6 +272,7 @@ ethernet_interfaces:
   port_profile: Tenant_X_Trunk
   description: server11_Single_Active_Port_Channel_Manual_DF_Dont_Preempt_Eth2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 20
     mode: active
@@ -294,6 +301,7 @@ ethernet_interfaces:
   port_profile: Tenant_X_Trunk
   description: server13_Single_Active_Port_Channel_Manual_DF_Dont_Preempt_modulus_Eth2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 22
     mode: active
@@ -319,6 +327,7 @@ ethernet_interfaces:
   peer_type: router
   description: ROUTER02_WITH_SUBIF_Eth2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 11
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF1B.yml
@@ -155,10 +155,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: Tenant_X
   description: server01_ES1_Eth2
-  type: switched
   shutdown: false
-  mode: access
-  vlans: '310'
   channel_group:
     id: 10
     mode: active
@@ -168,10 +165,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: Tenant_X
   description: server03_AUTO_ESI_Eth2
-  type: switched
   shutdown: false
-  mode: access
-  vlans: '310'
   channel_group:
     id: 12
     mode: active
@@ -181,10 +175,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: Tenant_ESI_Auto
   description: server04_AUTO_ESI_Profile_Eth2
-  type: switched
   shutdown: false
-  mode: access
-  vlans: '310'
   channel_group:
     id: 13
     mode: active
@@ -194,10 +185,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: Tenant_ESI_Auto
   description: server05_AUTO_ESI_Profile_Override_Eth2
-  type: switched
   shutdown: false
-  mode: access
-  vlans: '310'
   channel_group:
     id: 14
     mode: active
@@ -207,10 +195,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: Tenant_X_Trunk_Auto
   description: server06_Single_Active_Port_Channel_Eth2
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: '310'
   channel_group:
     id: 15
     mode: active
@@ -220,10 +205,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: Tenant_X_Trunk
   description: server07_Single_Active_Port_Channel_Manual_DF_Eth2
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: '310'
   channel_group:
     id: 16
     mode: active
@@ -233,8 +215,8 @@ ethernet_interfaces:
   peer_type: server
   port_profile: Tenant_X_Trunk_Auto_Eth
   description: server08_Single_Active_Ethernet_Eth2
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk
   vlans: '310'
   evpn_ethernet_segment:
@@ -250,8 +232,8 @@ ethernet_interfaces:
   peer_type: server
   port_profile: Tenant_X_Trunk
   description: server09_All_Active_Ethernet_Eth2
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk
   vlans: '310'
   evpn_ethernet_segment:
@@ -266,8 +248,8 @@ ethernet_interfaces:
   peer_type: server
   port_profile: Tenant_X_Trunk
   description: server10_Single_Active_Ethernet_Manual_DF_Eth2
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk
   vlans: '310'
   evpn_ethernet_segment:
@@ -283,10 +265,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: Tenant_X_Trunk
   description: server11_Single_Active_Port_Channel_Manual_DF_Dont_Preempt_Eth2
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: '310'
   channel_group:
     id: 20
     mode: active
@@ -296,8 +275,8 @@ ethernet_interfaces:
   peer_type: server
   port_profile: Tenant_X_Trunk
   description: server12_Single_Active_Ethernet_Manual_DF_Dont_Preempt_Eth2
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk
   vlans: '310'
   evpn_ethernet_segment:
@@ -314,10 +293,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: Tenant_X_Trunk
   description: server13_Single_Active_Port_Channel_Manual_DF_Dont_Preempt_modulus_Eth2
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: '310'
   channel_group:
     id: 22
     mode: active
@@ -327,8 +303,8 @@ ethernet_interfaces:
   peer_type: server
   port_profile: Tenant_X_Trunk
   description: server14_Single_Active_Ethernet_Manual_DF_Dont_Preempt_modulus_Eth2
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk
   vlans: '310'
   evpn_ethernet_segment:
@@ -342,7 +318,6 @@ ethernet_interfaces:
   peer_interface: Eth2
   peer_type: router
   description: ROUTER02_WITH_SUBIF_Eth2
-  type: switched
   shutdown: false
   channel_group:
     id: 11

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF2A.yml
@@ -180,6 +180,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: MH-L2LEAF1A_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 2
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF2A.yml
@@ -180,7 +180,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: MH-L2LEAF1A_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 2
     mode: active
@@ -190,8 +189,8 @@ ethernet_interfaces:
   peer_type: router
   port_profile: Tenant_X_LT
   description: ROUTER01_Eth1
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '310'
   link_tracking_groups:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG-OSPF-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG-OSPF-L3LEAF1A.yml
@@ -120,6 +120,7 @@ ethernet_interfaces:
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_MLAG-OSPF-L3LEAF1B_Ethernet5
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 5
@@ -129,6 +130,7 @@ ethernet_interfaces:
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_MLAG-OSPF-L3LEAF1B_Ethernet6
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 5

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG-OSPF-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG-OSPF-L3LEAF1A.yml
@@ -120,7 +120,6 @@ ethernet_interfaces:
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_MLAG-OSPF-L3LEAF1B_Ethernet5
-  type: switched
   shutdown: false
   channel_group:
     id: 5
@@ -130,7 +129,6 @@ ethernet_interfaces:
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_MLAG-OSPF-L3LEAF1B_Ethernet6
-  type: switched
   shutdown: false
   channel_group:
     id: 5

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG-OSPF-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG-OSPF-L3LEAF1B.yml
@@ -120,6 +120,7 @@ ethernet_interfaces:
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_MLAG-OSPF-L3LEAF1A_Ethernet5
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 5
@@ -129,6 +130,7 @@ ethernet_interfaces:
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_MLAG-OSPF-L3LEAF1A_Ethernet6
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 5

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG-OSPF-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG-OSPF-L3LEAF1B.yml
@@ -120,7 +120,6 @@ ethernet_interfaces:
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_MLAG-OSPF-L3LEAF1A_Ethernet5
-  type: switched
   shutdown: false
   channel_group:
     id: 5
@@ -130,7 +129,6 @@ ethernet_interfaces:
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_MLAG-OSPF-L3LEAF1A_Ethernet6
-  type: switched
   shutdown: false
   channel_group:
     id: 5

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3A.yml
@@ -129,6 +129,7 @@ ethernet_interfaces:
   peer_interface: Eth1
   peer_type: mlag_peer
   description: MLAG_PEER_OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3B_Eth1
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 1
@@ -138,6 +139,7 @@ ethernet_interfaces:
   peer_interface: Eth2
   peer_type: mlag_peer
   description: MLAG_PEER_OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3B_Eth2
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3A.yml
@@ -129,7 +129,6 @@ ethernet_interfaces:
   peer_interface: Eth1
   peer_type: mlag_peer
   description: MLAG_PEER_OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3B_Eth1
-  type: switched
   shutdown: false
   channel_group:
     id: 1
@@ -139,7 +138,6 @@ ethernet_interfaces:
   peer_interface: Eth2
   peer_type: mlag_peer
   description: MLAG_PEER_OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3B_Eth2
-  type: switched
   shutdown: false
   channel_group:
     id: 1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3B.yml
@@ -129,7 +129,6 @@ ethernet_interfaces:
   peer_interface: Eth1
   peer_type: mlag_peer
   description: MLAG_PEER_OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3A_Eth1
-  type: switched
   shutdown: false
   channel_group:
     id: 1
@@ -139,7 +138,6 @@ ethernet_interfaces:
   peer_interface: Eth2
   peer_type: mlag_peer
   description: MLAG_PEER_OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3A_Eth2
-  type: switched
   shutdown: false
   channel_group:
     id: 1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3B.yml
@@ -129,6 +129,7 @@ ethernet_interfaces:
   peer_interface: Eth1
   peer_type: mlag_peer
   description: MLAG_PEER_OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3A_Eth1
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 1
@@ -138,6 +139,7 @@ ethernet_interfaces:
   peer_interface: Eth2
   peer_type: mlag_peer
   description: MLAG_PEER_OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3A_Eth2
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L2LEAF1A.yml
@@ -30,7 +30,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: UNDERLAY-MULTICAST-L3LEAF1A_Ethernet6
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L2LEAF1A.yml
@@ -30,6 +30,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: UNDERLAY-MULTICAST-L3LEAF1A_Ethernet6
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF1A.yml
@@ -138,7 +138,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_UNDERLAY-MULTICAST-L3LEAF1B_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -148,7 +147,6 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_UNDERLAY-MULTICAST-L3LEAF1B_Ethernet4
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -180,7 +178,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: UNDERLAY-MULTICAST-L2LEAF1A_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 6
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF1A.yml
@@ -138,6 +138,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_UNDERLAY-MULTICAST-L3LEAF1B_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -147,6 +148,7 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_UNDERLAY-MULTICAST-L3LEAF1B_Ethernet4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -178,6 +180,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: UNDERLAY-MULTICAST-L2LEAF1A_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 6
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF1B.yml
@@ -131,6 +131,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_UNDERLAY-MULTICAST-L3LEAF1A_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -140,6 +141,7 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_UNDERLAY-MULTICAST-L3LEAF1A_Ethernet4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF1B.yml
@@ -131,7 +131,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_UNDERLAY-MULTICAST-L3LEAF1A_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -141,7 +140,6 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_UNDERLAY-MULTICAST-L3LEAF1A_Ethernet4
-  type: switched
   shutdown: false
   channel_group:
     id: 3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF2A.yml
@@ -121,7 +121,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_UNDERLAY-MULTICAST-L3LEAF2B_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -131,7 +130,6 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_UNDERLAY-MULTICAST-L3LEAF2B_Ethernet4
-  type: switched
   shutdown: false
   channel_group:
     id: 3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF2A.yml
@@ -121,6 +121,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_UNDERLAY-MULTICAST-L3LEAF2B_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -130,6 +131,7 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_UNDERLAY-MULTICAST-L3LEAF2B_Ethernet4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF2B.yml
@@ -121,7 +121,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_UNDERLAY-MULTICAST-L3LEAF2A_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -131,7 +130,6 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_UNDERLAY-MULTICAST-L3LEAF2A_Ethernet4
-  type: switched
   shutdown: false
   channel_group:
     id: 3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF2B.yml
@@ -121,6 +121,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_UNDERLAY-MULTICAST-L3LEAF2A_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -130,6 +131,7 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_UNDERLAY-MULTICAST-L3LEAF2A_Ethernet4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1A.yml
@@ -76,6 +76,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1B_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -85,6 +86,7 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1B_Ethernet4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -95,6 +97,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1A_Ethernet5
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -104,6 +107,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1B_Ethernet5
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1A.yml
@@ -76,7 +76,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1B_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -86,7 +85,6 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1B_Ethernet4
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -97,7 +95,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1A_Ethernet5
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -107,7 +104,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1B_Ethernet5
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1B.yml
@@ -76,7 +76,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1A_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -86,7 +85,6 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1A_Ethernet4
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -97,7 +95,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1A_Ethernet6
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -107,7 +104,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1B_Ethernet6
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1B.yml
@@ -76,6 +76,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1A_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -85,6 +86,7 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1A_Ethernet4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -95,6 +97,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1A_Ethernet6
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -104,6 +107,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1B_Ethernet6
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1A.yml
@@ -137,7 +137,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1B_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -147,7 +146,6 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1B_Ethernet4
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -170,7 +168,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1A_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 5
     mode: active
@@ -180,7 +177,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1B_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 5
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1A.yml
@@ -137,6 +137,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1B_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -146,6 +147,7 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1B_Ethernet4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -168,6 +170,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1A_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 5
     mode: active
@@ -177,6 +180,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1B_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 5
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1B.yml
@@ -137,7 +137,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1A_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -147,7 +146,6 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1A_Ethernet4
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -170,7 +168,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1A_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 5
     mode: active
@@ -180,7 +177,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1B_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 5
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1B.yml
@@ -137,6 +137,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1A_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -146,6 +147,7 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1A_Ethernet4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -168,6 +170,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1A_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 5
     mode: active
@@ -177,6 +180,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1B_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 5
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-structured-config-1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-structured-config-1.yml
@@ -99,6 +99,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_bgp-peer-groups-structured-config-2_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-structured-config-1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-structured-config-1.yml
@@ -99,7 +99,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_bgp-peer-groups-structured-config-2_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-structured-config-2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-structured-config-2.yml
@@ -116,7 +116,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_bgp-peer-groups-structured-config-1_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-structured-config-2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-structured-config-2.yml
@@ -116,6 +116,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_bgp-peer-groups-structured-config-1_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/connected_endpoints.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/connected_endpoints.yml
@@ -18,13 +18,12 @@ ethernet_interfaces:
   peer: OLD_SW-1/4
   peer_type: server
   description: PHYSICAL_PORT_DESCRIPTION
-  type: switched
   shutdown: false
+  type: switched
 - name: Ethernet5
   peer: OLD_SW-1/5
   peer_type: server
   description: OLD_SW-1/5
-  type: switched
   shutdown: false
   channel_group:
     id: 5
@@ -33,7 +32,6 @@ ethernet_interfaces:
   peer: OLD_SW-1/5
   peer_type: server
   description: OLD_SW-1/5
-  type: switched
   shutdown: false
   channel_group:
     id: 5
@@ -42,7 +40,6 @@ ethernet_interfaces:
   peer: OLD_SW-1/6
   peer_type: server
   description: PHYSICAL_PORT_DESCRIPTION
-  type: switched
   shutdown: false
   channel_group:
     id: 7
@@ -51,7 +48,6 @@ ethernet_interfaces:
   peer: OLD_SW-1/6
   peer_type: server
   description: PHYSICAL_PORT_DESCRIPTION
-  type: switched
   shutdown: false
   channel_group:
     id: 7

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/connected_endpoints.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/connected_endpoints.yml
@@ -25,6 +25,7 @@ ethernet_interfaces:
   peer_type: server
   description: OLD_SW-1/5
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 5
     mode: active
@@ -33,6 +34,7 @@ ethernet_interfaces:
   peer_type: server
   description: OLD_SW-1/5
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 5
     mode: active
@@ -41,6 +43,7 @@ ethernet_interfaces:
   peer_type: server
   description: PHYSICAL_PORT_DESCRIPTION
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 7
     mode: active
@@ -49,6 +52,7 @@ ethernet_interfaces:
   peer_type: server
   description: PHYSICAL_PORT_DESCRIPTION
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 7
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/core-1-isis-sr-ldp.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/core-1-isis-sr-ldp.yml
@@ -217,6 +217,7 @@ ethernet_interfaces:
       igp_sync: true
   speed: forced 1000full
 - name: Ethernet12
+  type: port-channel-member
   peer: core-2-ospf-ldp
   peer_interface: Port-Channel12
   peer_type: core_router
@@ -227,6 +228,7 @@ ethernet_interfaces:
     mode: active
   speed: forced 1000full
 - name: Ethernet13
+  type: port-channel-member
   peer: core-2-ospf-ldp
   peer_interface: Port-Channel12
   peer_type: core_router

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/core-2-ospf-ldp.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/core-2-ospf-ldp.yml
@@ -172,6 +172,7 @@ ethernet_interfaces:
       igp_sync: true
   speed: forced 1000full
 - name: Ethernet12
+  type: port-channel-member
   peer: core-1-isis-sr-ldp
   peer_interface: Port-Channel12
   peer_type: core_router
@@ -182,6 +183,7 @@ ethernet_interfaces:
     mode: active
   speed: forced 1000full
 - name: Ethernet13
+  type: port-channel-member
   peer: core-1-isis-sr-ldp
   peer_interface: Port-Channel12
   peer_type: core_router

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/filter.only_vlans_in_use.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/filter.only_vlans_in_use.yml
@@ -30,7 +30,7 @@ ethernet_interfaces:
   peer_interface: Nic1
   peer_type: server
   description: testserver_Nic1
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk
   vlans: 1-2

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ignore-custom-keys-in-data-models.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ignore-custom-keys-in-data-models.yml
@@ -17,6 +17,5 @@ _custom_key2:
 - custom_value2
 ethernet_interfaces:
 - name: Ethernet1
-  type: switched
   _custom_key3:
     custom_dict3: custom_value3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ignore-custom-keys-in-data-models.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ignore-custom-keys-in-data-models.yml
@@ -17,5 +17,6 @@ _custom_key2:
 - custom_value2
 ethernet_interfaces:
 - name: Ethernet1
+  type: switched
   _custom_key3:
     custom_dict3: custom_value3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/l3_edge_bgp.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/l3_edge_bgp.yml
@@ -117,6 +117,7 @@ ethernet_interfaces:
   mtu: 9000
   ip_address: 192.168.0.6/31
 - name: Ethernet5
+  type: port-channel-member
   peer: peer5
   peer_interface: Port-Channel5
   peer_type: other
@@ -126,6 +127,7 @@ ethernet_interfaces:
     id: 5
     mode: active
 - name: Ethernet6
+  type: port-channel-member
   peer: peer5
   peer_interface: Port-Channel5
   peer_type: other
@@ -135,6 +137,7 @@ ethernet_interfaces:
     id: 5
     mode: active
 - name: Ethernet7
+  type: port-channel-member
   peer: peer6
   peer_interface: Port-Channel7
   peer_type: other
@@ -144,6 +147,7 @@ ethernet_interfaces:
     id: 7
     mode: active
 - name: Ethernet8
+  type: port-channel-member
   peer: peer6
   peer_interface: Port-Channel7
   peer_type: other

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/network-ports-tests-2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/network-ports-tests-2.yml
@@ -71,6 +71,7 @@ ethernet_interfaces:
   peer_interface: Ethernet10/1
   peer_type: mlag_peer
   description: MLAG_PEER_network-ports-tests.1_Ethernet10/1
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 101
@@ -81,6 +82,7 @@ ethernet_interfaces:
   port_profile: ap_with_port_channel
   description: AP1 with port_channel
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -90,6 +92,7 @@ ethernet_interfaces:
   port_profile: ap_with_port_channel
   description: AP1 with port_channel
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 2
     mode: active
@@ -648,6 +651,7 @@ ethernet_interfaces:
   peer_type: network_port
   description: Checking port-channels
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 42
     mode: active
@@ -656,6 +660,7 @@ ethernet_interfaces:
   peer_type: network_port
   description: Checking port-channels
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 42
     mode: active
@@ -664,6 +669,7 @@ ethernet_interfaces:
   peer_type: network_port
   description: Checking port-channels
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 42
     mode: active
@@ -672,6 +678,7 @@ ethernet_interfaces:
   peer_type: network_port
   description: Checking port-channels
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 42
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/network-ports-tests-2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/network-ports-tests-2.yml
@@ -71,7 +71,6 @@ ethernet_interfaces:
   peer_interface: Ethernet10/1
   peer_type: mlag_peer
   description: MLAG_PEER_network-ports-tests.1_Ethernet10/1
-  type: switched
   shutdown: false
   channel_group:
     id: 101
@@ -81,12 +80,7 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: ap_with_port_channel
   description: AP1 with port_channel
-  type: switched
   shutdown: false
-  mode: access
-  vlans: '101'
-  spanning_tree_portfast: edge
-  spanning_tree_bpdufilter: enabled
   channel_group:
     id: 1
     mode: active
@@ -95,12 +89,7 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: ap_with_port_channel
   description: AP1 with port_channel
-  type: switched
   shutdown: false
-  mode: access
-  vlans: '101'
-  spanning_tree_portfast: edge
-  spanning_tree_bpdufilter: enabled
   channel_group:
     id: 2
     mode: active
@@ -109,8 +98,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -120,8 +109,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -131,8 +120,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -142,8 +131,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -153,8 +142,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -164,8 +153,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -175,8 +164,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -186,8 +175,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -197,8 +186,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -208,8 +197,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -219,8 +208,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -230,8 +219,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -241,8 +230,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -252,8 +241,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -263,8 +252,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -274,8 +263,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -285,8 +274,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -296,8 +285,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -307,8 +296,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -318,8 +307,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -329,8 +318,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -340,8 +329,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -351,8 +340,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -362,8 +351,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -373,8 +362,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -384,8 +373,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -395,8 +384,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -406,8 +395,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -417,8 +406,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -428,8 +417,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -439,8 +428,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -450,8 +439,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -461,8 +450,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -472,8 +461,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -483,8 +472,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -494,8 +483,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -505,8 +494,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -516,8 +505,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -527,8 +516,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -538,8 +527,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -549,8 +538,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -560,8 +549,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -571,8 +560,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -582,8 +571,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -593,8 +582,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -604,8 +593,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -615,8 +604,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -626,8 +615,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -637,8 +626,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -648,8 +637,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -658,7 +647,6 @@ ethernet_interfaces:
   peer: Checking port-channels
   peer_type: network_port
   description: Checking port-channels
-  type: switched
   shutdown: false
   channel_group:
     id: 42
@@ -667,7 +655,6 @@ ethernet_interfaces:
   peer: Checking port-channels
   peer_type: network_port
   description: Checking port-channels
-  type: switched
   shutdown: false
   channel_group:
     id: 42
@@ -676,7 +663,6 @@ ethernet_interfaces:
   peer: Checking port-channels
   peer_type: network_port
   description: Checking port-channels
-  type: switched
   shutdown: false
   channel_group:
     id: 42
@@ -685,7 +671,6 @@ ethernet_interfaces:
   peer: Checking port-channels
   peer_type: network_port
   description: Checking port-channels
-  type: switched
   shutdown: false
   channel_group:
     id: 42

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/network-ports-tests.1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/network-ports-tests.1.yml
@@ -51,7 +51,6 @@ ethernet_interfaces:
   peer_interface: Ethernet10/1
   peer_type: mlag_peer
   description: MLAG_PEER_network-ports-tests-2_Ethernet10/1
-  type: switched
   shutdown: false
   channel_group:
     id: 101
@@ -61,8 +60,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -72,8 +71,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -83,8 +82,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -94,8 +93,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -105,8 +104,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -116,8 +115,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -127,8 +126,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -138,8 +137,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -149,8 +148,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -160,8 +159,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -171,8 +170,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -182,8 +181,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -193,8 +192,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -204,8 +203,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -215,8 +214,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -226,8 +225,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -237,8 +236,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -248,8 +247,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -259,8 +258,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -270,8 +269,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -281,8 +280,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -292,8 +291,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -303,8 +302,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -314,8 +313,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -325,8 +324,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -336,8 +335,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -347,8 +346,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -358,8 +357,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -369,8 +368,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -380,8 +379,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -391,8 +390,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -402,8 +401,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -413,8 +412,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -424,8 +423,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -435,8 +434,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -446,8 +445,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -457,8 +456,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -468,8 +467,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -479,8 +478,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -490,8 +489,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -501,8 +500,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -512,8 +511,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -523,8 +522,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -534,8 +533,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -545,8 +544,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -556,8 +555,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -567,8 +566,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -578,8 +577,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -589,8 +588,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -600,8 +599,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -611,8 +610,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -622,8 +621,8 @@ ethernet_interfaces:
   peer_type: network_port
   port_profile: pc
   description: PCs
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '100'
   spanning_tree_portfast: edge
@@ -632,14 +631,14 @@ ethernet_interfaces:
   peer: 'N: blah'
   peer_type: network_port
   description: 'N: blah'
-  type: switched
   shutdown: false
+  type: switched
 - name: Ethernet6
   peer: 'N: blah'
   peer_type: network_port
   description: 'N: blah'
-  type: switched
   shutdown: false
+  type: switched
 mlag_configuration:
   domain_id: mlag
   local_interface: Vlan4094

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/network-ports-tests.1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/network-ports-tests.1.yml
@@ -51,6 +51,7 @@ ethernet_interfaces:
   peer_interface: Ethernet10/1
   peer_type: mlag_peer
   description: MLAG_PEER_network-ports-tests-2_Ethernet10/1
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 101

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-leaf1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-leaf1.yml
@@ -159,8 +159,8 @@ ethernet_interfaces:
   peer_interface: eth1
   peer_type: server
   description: bmca-endpoint_eth1
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '11'
   ptp:
@@ -177,8 +177,8 @@ ethernet_interfaces:
   peer_interface: PCI1
   peer_type: server
   description: video-endpoint_PCI1
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '11'
   spanning_tree_portfast: edge
@@ -197,8 +197,8 @@ ethernet_interfaces:
   peer_interface: eth3
   peer_type: server
   description: Endpoint-with-specific-PTP-profile_eth3
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '11'
   ptp:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-leaf2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-leaf2.yml
@@ -172,8 +172,8 @@ ethernet_interfaces:
   peer_interface: PCI2
   peer_type: server
   description: video-endpoint_PCI2
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '11'
   spanning_tree_portfast: edge

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l2leaf1a.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l2leaf1a.yml
@@ -122,6 +122,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_trunk-group-tests-l2leaf1b_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -131,6 +132,7 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_trunk-group-tests-l2leaf1b_Ethernet4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -141,6 +143,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: TRUNK-GROUP-TESTS-L3LEAF1A_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -150,6 +153,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: TRUNK-GROUP-TESTS-L3LEAF1B_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -159,6 +163,7 @@ ethernet_interfaces:
   peer_type: server
   description: server_with_tg_300_Nic3
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 13
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l2leaf1a.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l2leaf1a.yml
@@ -122,7 +122,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_trunk-group-tests-l2leaf1b_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -132,7 +131,6 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_trunk-group-tests-l2leaf1b_Ethernet4
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -143,7 +141,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: TRUNK-GROUP-TESTS-L3LEAF1A_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -153,7 +150,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: TRUNK-GROUP-TESTS-L3LEAF1B_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -162,12 +158,7 @@ ethernet_interfaces:
   peer_interface: Nic3
   peer_type: server
   description: server_with_tg_300_Nic3
-  type: switched
   shutdown: false
-  mode: trunk
-  trunk_groups:
-  - TG_NOT_MATCHING_ANY_VLANS
-  - TG_300
   channel_group:
     id: 13
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l2leaf1b.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l2leaf1b.yml
@@ -114,6 +114,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_trunk-group-tests-l2leaf1a_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -123,6 +124,7 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_trunk-group-tests-l2leaf1a_Ethernet4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -133,6 +135,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: TRUNK-GROUP-TESTS-L3LEAF1A_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -142,6 +145,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: TRUNK-GROUP-TESTS-L3LEAF1B_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -162,6 +166,7 @@ ethernet_interfaces:
   peer_type: server
   description: server_with_tg_300_Nic4
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 13
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l2leaf1b.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l2leaf1b.yml
@@ -114,7 +114,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_trunk-group-tests-l2leaf1a_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -124,7 +123,6 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_trunk-group-tests-l2leaf1a_Ethernet4
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -135,7 +133,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: TRUNK-GROUP-TESTS-L3LEAF1A_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -145,7 +142,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: TRUNK-GROUP-TESTS-L3LEAF1B_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -154,8 +150,8 @@ ethernet_interfaces:
   peer_interface: Nic1
   peer_type: server
   description: server_with_tg_200_Nic1
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk
   trunk_groups:
   - TG_NOT_MATCHING_ANY_VLANS
@@ -165,12 +161,7 @@ ethernet_interfaces:
   peer_interface: Nic4
   peer_type: server
   description: server_with_tg_300_Nic4
-  type: switched
   shutdown: false
-  mode: trunk
-  trunk_groups:
-  - TG_NOT_MATCHING_ANY_VLANS
-  - TG_300
   channel_group:
     id: 13
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l2leaf3.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l2leaf3.yml
@@ -22,6 +22,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: TRUNK-GROUP-TESTS-L3LEAF1A_Ethernet5
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -31,6 +32,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: TRUNK-GROUP-TESTS-L3LEAF1B_Ethernet5
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l2leaf3.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l2leaf3.yml
@@ -22,7 +22,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: TRUNK-GROUP-TESTS-L3LEAF1A_Ethernet5
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -32,7 +31,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: TRUNK-GROUP-TESTS-L3LEAF1B_Ethernet5
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -41,8 +39,8 @@ ethernet_interfaces:
   peer_interface: Nic2
   peer_type: server
   description: server_with_tg_200_Nic2
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk
   trunk_groups:
   - TG_NOT_MATCHING_ANY_VLANS

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l2leaf4.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l2leaf4.yml
@@ -22,6 +22,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: TRUNK-GROUP-TESTS-L3LEAF2A_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -31,6 +32,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: TRUNK-GROUP-TESTS-L3LEAF2B_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l2leaf4.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l2leaf4.yml
@@ -22,7 +22,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: TRUNK-GROUP-TESTS-L3LEAF2A_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -32,7 +31,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: TRUNK-GROUP-TESTS-L3LEAF2B_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -41,8 +39,8 @@ ethernet_interfaces:
   peer_interface: Nic3
   peer_type: server
   description: server_with_tg_200_Nic3
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk
   trunk_groups:
   - TG_NOT_MATCHING_ANY_VLANS

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf1a.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf1a.yml
@@ -427,6 +427,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_trunk-group-tests-l3leaf1b_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -436,6 +437,7 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_trunk-group-tests-l3leaf1b_Ethernet4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -446,6 +448,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: TRUNK-GROUP-TESTS-L2LEAF1A_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -455,6 +458,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: TRUNK-GROUP-TESTS-L2LEAF1B_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -464,6 +468,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: TRUNK-GROUP-TESTS-L2LEAF3_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 5
     mode: active
@@ -484,6 +489,7 @@ ethernet_interfaces:
   peer_type: server
   description: server_with_tg_300_Nic1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 13
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf1a.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf1a.yml
@@ -427,7 +427,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_trunk-group-tests-l3leaf1b_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -437,7 +436,6 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_trunk-group-tests-l3leaf1b_Ethernet4
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -448,7 +446,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: TRUNK-GROUP-TESTS-L2LEAF1A_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -458,7 +455,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: TRUNK-GROUP-TESTS-L2LEAF1B_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -468,7 +464,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: TRUNK-GROUP-TESTS-L2LEAF3_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 5
     mode: active
@@ -477,8 +472,8 @@ ethernet_interfaces:
   peer_interface: Nic1
   peer_type: server
   description: server_with_tg_100_Nic1
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk
   trunk_groups:
   - TG_NOT_MATCHING_ANY_VLANS
@@ -488,12 +483,7 @@ ethernet_interfaces:
   peer_interface: Nic1
   peer_type: server
   description: server_with_tg_300_Nic1
-  type: switched
   shutdown: false
-  mode: trunk
-  trunk_groups:
-  - TG_NOT_MATCHING_ANY_VLANS
-  - TG_300
   channel_group:
     id: 13
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf1b.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf1b.yml
@@ -415,7 +415,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_trunk-group-tests-l3leaf1a_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -425,7 +424,6 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_trunk-group-tests-l3leaf1a_Ethernet4
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -436,7 +434,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: TRUNK-GROUP-TESTS-L2LEAF1A_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -446,7 +443,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: TRUNK-GROUP-TESTS-L2LEAF1B_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -456,7 +452,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: TRUNK-GROUP-TESTS-L2LEAF3_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 5
     mode: active
@@ -465,12 +460,7 @@ ethernet_interfaces:
   peer_interface: Nic2
   peer_type: server
   description: server_with_tg_300_Nic2
-  type: switched
   shutdown: false
-  mode: trunk
-  trunk_groups:
-  - TG_NOT_MATCHING_ANY_VLANS
-  - TG_300
   channel_group:
     id: 13
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf1b.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf1b.yml
@@ -415,6 +415,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_trunk-group-tests-l3leaf1a_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -424,6 +425,7 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_trunk-group-tests-l3leaf1a_Ethernet4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -434,6 +436,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: TRUNK-GROUP-TESTS-L2LEAF1A_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -443,6 +446,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: TRUNK-GROUP-TESTS-L2LEAF1B_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -452,6 +456,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: TRUNK-GROUP-TESTS-L2LEAF3_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 5
     mode: active
@@ -461,6 +466,7 @@ ethernet_interfaces:
   peer_type: server
   description: server_with_tg_300_Nic2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 13
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf2a.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf2a.yml
@@ -185,7 +185,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_trunk-group-tests-l3leaf2b_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -195,7 +194,6 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_trunk-group-tests-l3leaf2b_Ethernet4
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -206,7 +204,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: TRUNK-GROUP-TESTS-L2LEAF4_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf2a.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf2a.yml
@@ -185,6 +185,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_trunk-group-tests-l3leaf2b_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -194,6 +195,7 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_trunk-group-tests-l3leaf2b_Ethernet4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -204,6 +206,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: TRUNK-GROUP-TESTS-L2LEAF4_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf2b.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf2b.yml
@@ -180,7 +180,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_trunk-group-tests-l3leaf2a_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -190,7 +189,6 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_trunk-group-tests-l3leaf2a_Ethernet4
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -201,7 +199,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: TRUNK-GROUP-TESTS-L2LEAF4_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf2b.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf2b.yml
@@ -180,6 +180,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_trunk-group-tests-l3leaf2a_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -189,6 +190,7 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_trunk-group-tests-l3leaf2a_Ethernet4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -199,6 +201,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: TRUNK-GROUP-TESTS-L2LEAF4_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink-native-vlan-child.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink-native-vlan-child.yml
@@ -25,7 +25,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: UPLINK-NATIVE-VLAN-PARENT_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 2
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink-native-vlan-child.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink-native-vlan-child.yml
@@ -25,6 +25,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: UPLINK-NATIVE-VLAN-PARENT_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 2
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink-native-vlan-grandparent.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink-native-vlan-grandparent.yml
@@ -18,7 +18,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: UPLINK-NATIVE-VLAN-PARENT_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink-native-vlan-grandparent.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink-native-vlan-grandparent.yml
@@ -18,6 +18,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: UPLINK-NATIVE-VLAN-PARENT_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink-native-vlan-parent.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink-native-vlan-parent.yml
@@ -25,7 +25,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: UPLINK-NATIVE-VLAN-GRANDPARENT_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -35,7 +34,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: UPLINK-NATIVE-VLAN-CHILD_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 2
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink-native-vlan-parent.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink-native-vlan-parent.yml
@@ -25,6 +25,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: UPLINK-NATIVE-VLAN-GRANDPARENT_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -34,6 +35,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: UPLINK-NATIVE-VLAN-CHILD_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 2
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/ignore-custom-keys-in-data-models.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/ignore-custom-keys-in-data-models.yml
@@ -13,6 +13,5 @@ l2leaf:
       _custom_key2: [custom_value2]
       ethernet_interfaces:
         - name: "Ethernet1"
-          type: switched
           _custom_key3:
             custom_dict3: custom_value3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/ignore-custom-keys-in-data-models.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/ignore-custom-keys-in-data-models.yml
@@ -13,5 +13,6 @@ l2leaf:
       _custom_key2: [custom_value2]
       ethernet_interfaces:
         - name: "Ethernet1"
+          type: switched
           _custom_key3:
             custom_dict3: custom_value3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -117,6 +117,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF2A_Ethernet7
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -126,6 +127,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF2B_Ethernet7
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -117,7 +117,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF2A_Ethernet7
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -127,7 +126,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF2B_Ethernet7
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-L2LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-L2LEAF1B.yml
@@ -117,6 +117,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF2A_Ethernet8
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -126,6 +127,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF2B_Ethernet8
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-L2LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-L2LEAF1B.yml
@@ -117,7 +117,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF2A_Ethernet8
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -127,7 +126,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF2B_Ethernet8
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -144,7 +144,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-SVC3A_Ethernet7
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -154,7 +153,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-SVC3B_Ethernet7
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -144,6 +144,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-SVC3A_Ethernet7
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -153,6 +154,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-SVC3B_Ethernet7
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -144,6 +144,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-SVC3A_Ethernet8
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -153,6 +154,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-SVC3B_Ethernet8
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -144,7 +144,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-SVC3A_Ethernet8
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -154,7 +153,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-SVC3B_Ethernet8
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-L2LEAF3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-L2LEAF3A.yml
@@ -65,7 +65,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF2A_Ethernet9
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -75,7 +74,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF2B_Ethernet9
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-L2LEAF3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-L2LEAF3A.yml
@@ -65,6 +65,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF2A_Ethernet9
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -74,6 +75,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF2B_Ethernet9
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-L2LEAF4A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-L2LEAF4A.yml
@@ -65,7 +65,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF2A_Ethernet13
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -75,7 +74,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF2B_Ethernet13
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-L2LEAF4A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-L2LEAF4A.yml
@@ -65,6 +65,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF2A_Ethernet13
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -74,6 +75,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF2B_Ethernet13
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-L2LEAF5A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-L2LEAF5A.yml
@@ -117,7 +117,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF2A_Ethernet14
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -127,7 +126,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF2B_Ethernet14
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-L2LEAF5A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-L2LEAF5A.yml
@@ -117,6 +117,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF2A_Ethernet14
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -126,6 +127,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF2B_Ethernet14
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-L2LEAF5B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-L2LEAF5B.yml
@@ -117,7 +117,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF2A_Ethernet15
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -127,7 +126,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF2B_Ethernet15
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-L2LEAF5B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-L2LEAF5B.yml
@@ -117,6 +117,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF2A_Ethernet15
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -126,6 +127,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF2B_Ethernet15
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-LEAF1A.yml
@@ -239,9 +239,9 @@ ethernet_interfaces:
   peer_type: server
   port_profile: ALL_WITH_SECURITY
   description: server02_SINGLE_NODE_TRUNK_Eth1
-  l2_mtu: 8000
-  type: switched
   shutdown: false
+  type: switched
+  l2_mtu: 8000
   mode: trunk
   vlans: 1-4094
   spanning_tree_portfast: edge
@@ -266,8 +266,8 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A
   description: server02_SINGLE_NODE_Eth1
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '110'
 loopback_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-LEAF2A.yml
@@ -366,6 +366,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF1A_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 7
     mode: active
@@ -375,6 +376,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF1B_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 7
     mode: active
@@ -384,6 +386,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF3A_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 9
     mode: active
@@ -393,6 +396,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF4A_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 13
     mode: active
@@ -402,6 +406,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF5A_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 14
     mode: active
@@ -411,6 +416,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF5B_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 14
     mode: active
@@ -421,6 +427,7 @@ ethernet_interfaces:
   port_profile: TENANT_B
   description: server01_MLAG_Eth2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 10
     mode: active
@@ -431,6 +438,7 @@ ethernet_interfaces:
   port_profile: TENANT_A_MTU
   description: server01_MTU_PROFILE_MLAG_Eth4
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 11
     mode: active
@@ -440,6 +448,7 @@ ethernet_interfaces:
   peer_type: server
   description: server01_MTU_ADAPTOR_MLAG_Eth6
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 12
     mode: active
@@ -450,6 +459,7 @@ ethernet_interfaces:
   port_profile: TENANT_A_B
   description: FIREWALL01_E0
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 20
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-LEAF2A.yml
@@ -366,7 +366,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF1A_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 7
     mode: active
@@ -376,7 +375,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF1B_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 7
     mode: active
@@ -386,7 +384,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF3A_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 9
     mode: active
@@ -396,7 +393,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF4A_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 13
     mode: active
@@ -406,7 +402,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF5A_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 14
     mode: active
@@ -416,7 +411,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF5B_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 14
     mode: active
@@ -426,12 +420,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_B
   description: server01_MLAG_Eth2
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 210-211
-  spanning_tree_bpdufilter: disabled
-  spanning_tree_bpduguard: disabled
   channel_group:
     id: 10
     mode: active
@@ -441,13 +430,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A_MTU
   description: server01_MTU_PROFILE_MLAG_Eth4
-  mtu: 1600
-  type: switched
   shutdown: false
-  mode: access
-  vlans: '110'
-  spanning_tree_bpdufilter: enabled
-  spanning_tree_bpduguard: enabled
   channel_group:
     id: 11
     mode: active
@@ -456,11 +439,7 @@ ethernet_interfaces:
   peer_interface: Eth6
   peer_type: server
   description: server01_MTU_ADAPTOR_MLAG_Eth6
-  mtu: 1601
-  type: switched
   shutdown: false
-  spanning_tree_bpdufilter: 'True'
-  spanning_tree_bpduguard: 'True'
   channel_group:
     id: 12
     mode: active
@@ -470,10 +449,7 @@ ethernet_interfaces:
   peer_type: firewall
   port_profile: TENANT_A_B
   description: FIREWALL01_E0
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 110-111,210-211
   channel_group:
     id: 20
     mode: active
@@ -483,8 +459,8 @@ ethernet_interfaces:
   peer_type: router
   port_profile: TENANT_A
   description: ROUTER01_Eth0
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '110'
 port_channel_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-LEAF2B.yml
@@ -366,7 +366,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF1A_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 7
     mode: active
@@ -376,7 +375,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF1B_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 7
     mode: active
@@ -386,7 +384,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF3A_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 9
     mode: active
@@ -396,7 +393,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF4A_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 13
     mode: active
@@ -406,7 +402,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF5A_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 14
     mode: active
@@ -416,7 +411,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF5B_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 14
     mode: active
@@ -426,12 +420,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_B
   description: server01_MLAG_Eth3
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 210-211
-  spanning_tree_bpdufilter: disabled
-  spanning_tree_bpduguard: disabled
   channel_group:
     id: 10
     mode: active
@@ -441,13 +430,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A_MTU
   description: server01_MTU_PROFILE_MLAG_Eth5
-  mtu: 1600
-  type: switched
   shutdown: false
-  mode: access
-  vlans: '110'
-  spanning_tree_bpdufilter: enabled
-  spanning_tree_bpduguard: enabled
   channel_group:
     id: 11
     mode: active
@@ -456,11 +439,7 @@ ethernet_interfaces:
   peer_interface: Eth7
   peer_type: server
   description: server01_MTU_ADAPTOR_MLAG_Eth7
-  mtu: 1601
-  type: switched
   shutdown: false
-  spanning_tree_bpdufilter: 'True'
-  spanning_tree_bpduguard: 'True'
   channel_group:
     id: 12
     mode: active
@@ -470,10 +449,7 @@ ethernet_interfaces:
   peer_type: firewall
   port_profile: TENANT_A_B
   description: FIREWALL01_E1
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 110-111,210-211
   channel_group:
     id: 20
     mode: active
@@ -483,8 +459,8 @@ ethernet_interfaces:
   peer_type: router
   port_profile: TENANT_A
   description: ROUTER01_Eth1
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '110'
 port_channel_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-LEAF2B.yml
@@ -366,6 +366,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF1A_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 7
     mode: active
@@ -375,6 +376,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF1B_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 7
     mode: active
@@ -384,6 +386,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF3A_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 9
     mode: active
@@ -393,6 +396,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF4A_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 13
     mode: active
@@ -402,6 +406,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF5A_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 14
     mode: active
@@ -411,6 +416,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF5B_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 14
     mode: active
@@ -421,6 +427,7 @@ ethernet_interfaces:
   port_profile: TENANT_B
   description: server01_MLAG_Eth3
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 10
     mode: active
@@ -431,6 +438,7 @@ ethernet_interfaces:
   port_profile: TENANT_A_MTU
   description: server01_MTU_PROFILE_MLAG_Eth5
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 11
     mode: active
@@ -440,6 +448,7 @@ ethernet_interfaces:
   peer_type: server
   description: server01_MTU_ADAPTOR_MLAG_Eth7
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 12
     mode: active
@@ -450,6 +459,7 @@ ethernet_interfaces:
   port_profile: TENANT_A_B
   description: FIREWALL01_E1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 20
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SVC3A.yml
@@ -998,7 +998,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF2A_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 7
     mode: active
@@ -1008,7 +1007,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF2B_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 7
     mode: active
@@ -1018,10 +1016,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A_B
   description: server03_ESI_Eth1
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 110-111,210-211
   channel_group:
     id: 10
     mode: active
@@ -1031,9 +1026,9 @@ ethernet_interfaces:
   peer_type: server
   port_profile: ALL_WITH_SECURITY
   description: server04_inherit_all_from_profile_Eth1
-  l2_mtu: 8000
-  type: switched
   shutdown: false
+  type: switched
+  l2_mtu: 8000
   mode: trunk
   vlans: 1-4094
   spanning_tree_portfast: edge
@@ -1057,8 +1052,8 @@ ethernet_interfaces:
   peer_interface: Eth1
   peer_type: server
   description: server05_no_profile_Eth1
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk
   vlans: 1-4094
   spanning_tree_portfast: edge
@@ -1083,9 +1078,9 @@ ethernet_interfaces:
   peer_type: server
   port_profile: ALL_WITH_SECURITY
   description: server06_override_profile_Eth1
-  l2_mtu: 8000
-  type: switched
   shutdown: false
+  type: switched
+  l2_mtu: 8000
   mode: access
   vlans: '210'
   spanning_tree_portfast: network
@@ -1110,27 +1105,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: ALL_WITH_SECURITY_PORT_CHANNEL
   description: server07_inherit_all_from_profile_port_channel_Eth1
-  l2_mtu: 8000
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 1-4094
-  spanning_tree_portfast: edge
-  spanning_tree_bpdufilter: enabled
-  spanning_tree_bpduguard: enabled
-  storm_control:
-    all:
-      level: '10'
-      unit: percent
-    broadcast:
-      level: '100'
-      unit: pps
-    multicast:
-      level: '1'
-      unit: percent
-    unknown_unicast:
-      level: '2'
-      unit: percent
   channel_group:
     id: 14
     mode: active
@@ -1139,26 +1114,7 @@ ethernet_interfaces:
   peer_interface: Eth1
   peer_type: server
   description: server08_no_profile_port_channel_Eth1
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 1-4094
-  spanning_tree_portfast: edge
-  spanning_tree_bpdufilter: 'True'
-  spanning_tree_bpduguard: disabled
-  storm_control:
-    all:
-      level: '10'
-      unit: percent
-    broadcast:
-      level: '100'
-      unit: pps
-    multicast:
-      level: '1'
-      unit: percent
-    unknown_unicast:
-      level: '2'
-      unit: percent
   channel_group:
     id: 15
     mode: 'on'
@@ -1168,9 +1124,9 @@ ethernet_interfaces:
   peer_type: server
   port_profile: ALL_WITH_SECURITY_PORT_CHANNEL
   description: server09_override_profile_no_port_channel_Eth1
-  l2_mtu: 8000
-  type: switched
   shutdown: false
+  type: switched
+  l2_mtu: 8000
   mode: access
   vlans: '210'
   spanning_tree_portfast: network
@@ -1194,26 +1150,7 @@ ethernet_interfaces:
   peer_interface: Eth1
   peer_type: server
   description: server10_no_profile_port_channel_lacp_fallback_Eth1
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 1-4094
-  spanning_tree_portfast: edge
-  spanning_tree_bpdufilter: 'True'
-  spanning_tree_bpduguard: disabled
-  storm_control:
-    all:
-      level: '10'
-      unit: percent
-    broadcast:
-      level: '100'
-      unit: pps
-    multicast:
-      level: '1'
-      unit: percent
-    unknown_unicast:
-      level: '2'
-      unit: percent
   channel_group:
     id: 17
     mode: active
@@ -1224,27 +1161,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: ALL_WITH_SECURITY_PORT_CHANNEL_LACP_FALLBACK
   description: server11_inherit_profile_port_channel_lacp_fallback_Eth1
-  l2_mtu: 8000
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 1-4094
-  spanning_tree_portfast: edge
-  spanning_tree_bpdufilter: 'True'
-  spanning_tree_bpduguard: 'True'
-  storm_control:
-    all:
-      level: '10'
-      unit: percent
-    broadcast:
-      level: '100'
-      unit: pps
-    multicast:
-      level: '1'
-      unit: percent
-    unknown_unicast:
-      level: '2'
-      unit: percent
   channel_group:
     id: 18
     mode: active
@@ -1255,27 +1172,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: NESTED_PORT_PROFILE
   description: server12_inherit_nested_profile_port_channel_lacp_fallback_Eth1
-  l2_mtu: 8000
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 1-4094
-  spanning_tree_portfast: edge
-  spanning_tree_bpdufilter: 'True'
-  spanning_tree_bpduguard: 'True'
-  storm_control:
-    all:
-      level: '10'
-      unit: percent
-    broadcast:
-      level: '100'
-      unit: pps
-    multicast:
-      level: '1'
-      unit: percent
-    unknown_unicast:
-      level: '2'
-      unit: percent
   channel_group:
     id: 19
     mode: active
@@ -1286,8 +1183,8 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A
   description: server13_disabled_interfaces_Eth1
-  type: switched
   shutdown: true
+  type: switched
   mode: access
   vlans: '110'
 - name: Ethernet21
@@ -1296,8 +1193,8 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A
   description: server14_explicitly_enabled_interfaces_Eth1
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '110'
 - name: Ethernet22
@@ -1306,10 +1203,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A
   description: server15_port_channel_with_disabled_phy_interfaces_Eth1
-  type: switched
   shutdown: true
-  mode: access
-  vlans: '110'
   channel_group:
     id: 22
     mode: active
@@ -1319,10 +1213,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A
   description: server16_port_channel_with_disabled_port_channel_Eth1
-  type: switched
   shutdown: false
-  mode: access
-  vlans: '110'
   channel_group:
     id: 23
     mode: active
@@ -1332,10 +1223,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A
   description: server17_port_channel_with_disabled_phy_and_po_interfaces_Eth1
-  type: switched
   shutdown: true
-  mode: access
-  vlans: '110'
   channel_group:
     id: 24
     mode: active
@@ -1345,8 +1233,8 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A
   description: server18_monitoring_session_source_phys_interfaces_Eth1
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '110'
 - name: Ethernet27
@@ -1355,10 +1243,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A
   description: server18_monitoring_session_source_po_Eth3
-  type: switched
   shutdown: false
-  mode: access
-  vlans: '110'
   channel_group:
     id: 27
     mode: active
@@ -1368,8 +1253,8 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A
   description: server18_monitoring_session_source_phys_interface_Eth5
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '110'
 - name: Ethernet26
@@ -1377,25 +1262,22 @@ ethernet_interfaces:
   peer_interface: Eth1
   peer_type: server
   description: server19_monitoring_session_destination_phys_Eth1
-  type: switched
   shutdown: false
+  type: switched
 - name: Ethernet40
   peer: server20_monitoring_session_destination_phys
   peer_interface: Eth1
   peer_type: server
   description: server20_monitoring_session_destination_phys_Eth1
-  type: switched
   shutdown: false
+  type: switched
 - name: Ethernet42
   peer: server21_monitoring_session_destination_po
   peer_interface: Eth1
   peer_type: server
   port_profile: TENANT_A
   description: server21_monitoring_session_destination_po_Eth1
-  type: switched
   shutdown: false
-  mode: access
-  vlans: '110'
   channel_group:
     id: 42
     mode: active
@@ -1405,10 +1287,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A
   description: server22_port_channel_with_custom_id_Eth1
-  type: switched
   shutdown: false
-  mode: access
-  vlans: '110'
   channel_group:
     id: 1291
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SVC3A.yml
@@ -998,6 +998,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF2A_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 7
     mode: active
@@ -1007,6 +1008,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF2B_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 7
     mode: active
@@ -1017,6 +1019,7 @@ ethernet_interfaces:
   port_profile: TENANT_A_B
   description: server03_ESI_Eth1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 10
     mode: active
@@ -1106,6 +1109,7 @@ ethernet_interfaces:
   port_profile: ALL_WITH_SECURITY_PORT_CHANNEL
   description: server07_inherit_all_from_profile_port_channel_Eth1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 14
     mode: active
@@ -1115,6 +1119,7 @@ ethernet_interfaces:
   peer_type: server
   description: server08_no_profile_port_channel_Eth1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 15
     mode: 'on'
@@ -1151,6 +1156,7 @@ ethernet_interfaces:
   peer_type: server
   description: server10_no_profile_port_channel_lacp_fallback_Eth1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 17
     mode: active
@@ -1162,6 +1168,7 @@ ethernet_interfaces:
   port_profile: ALL_WITH_SECURITY_PORT_CHANNEL_LACP_FALLBACK
   description: server11_inherit_profile_port_channel_lacp_fallback_Eth1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 18
     mode: active
@@ -1173,6 +1180,7 @@ ethernet_interfaces:
   port_profile: NESTED_PORT_PROFILE
   description: server12_inherit_nested_profile_port_channel_lacp_fallback_Eth1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 19
     mode: active
@@ -1204,6 +1212,7 @@ ethernet_interfaces:
   port_profile: TENANT_A
   description: server15_port_channel_with_disabled_phy_interfaces_Eth1
   shutdown: true
+  type: port-channel-member
   channel_group:
     id: 22
     mode: active
@@ -1214,6 +1223,7 @@ ethernet_interfaces:
   port_profile: TENANT_A
   description: server16_port_channel_with_disabled_port_channel_Eth1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 23
     mode: active
@@ -1224,6 +1234,7 @@ ethernet_interfaces:
   port_profile: TENANT_A
   description: server17_port_channel_with_disabled_phy_and_po_interfaces_Eth1
   shutdown: true
+  type: port-channel-member
   channel_group:
     id: 24
     mode: active
@@ -1244,6 +1255,7 @@ ethernet_interfaces:
   port_profile: TENANT_A
   description: server18_monitoring_session_source_po_Eth3
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 27
     mode: active
@@ -1278,6 +1290,7 @@ ethernet_interfaces:
   port_profile: TENANT_A
   description: server21_monitoring_session_destination_po_Eth1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 42
     mode: active
@@ -1288,6 +1301,7 @@ ethernet_interfaces:
   port_profile: TENANT_A
   description: server22_port_channel_with_custom_id_Eth1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1291
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SVC3B.yml
@@ -988,7 +988,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF2A_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 7
     mode: active
@@ -998,7 +997,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF2B_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 7
     mode: active
@@ -1008,9 +1006,9 @@ ethernet_interfaces:
   peer_type: server
   port_profile: ALL_WITH_SECURITY
   description: server04_inherit_all_from_profile_Eth2
-  l2_mtu: 8000
-  type: switched
   shutdown: false
+  type: switched
+  l2_mtu: 8000
   mode: trunk
   vlans: 1-4094
   spanning_tree_portfast: edge
@@ -1034,8 +1032,8 @@ ethernet_interfaces:
   peer_interface: Eth2
   peer_type: server
   description: server05_no_profile_Eth2
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk
   vlans: 1-4094
   spanning_tree_portfast: edge
@@ -1060,9 +1058,9 @@ ethernet_interfaces:
   peer_type: server
   port_profile: ALL_WITH_SECURITY
   description: server06_override_profile_Eth2
-  l2_mtu: 8000
-  type: switched
   shutdown: false
+  type: switched
+  l2_mtu: 8000
   mode: access
   vlans: '210'
   spanning_tree_portfast: network
@@ -1087,27 +1085,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: ALL_WITH_SECURITY_PORT_CHANNEL
   description: server07_inherit_all_from_profile_port_channel_Eth2
-  l2_mtu: 8000
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 1-4094
-  spanning_tree_portfast: edge
-  spanning_tree_bpdufilter: enabled
-  spanning_tree_bpduguard: enabled
-  storm_control:
-    all:
-      level: '10'
-      unit: percent
-    broadcast:
-      level: '100'
-      unit: pps
-    multicast:
-      level: '1'
-      unit: percent
-    unknown_unicast:
-      level: '2'
-      unit: percent
   channel_group:
     id: 14
     mode: active
@@ -1116,26 +1094,7 @@ ethernet_interfaces:
   peer_interface: Eth2
   peer_type: server
   description: server08_no_profile_port_channel_Eth2
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 1-4094
-  spanning_tree_portfast: edge
-  spanning_tree_bpdufilter: 'True'
-  spanning_tree_bpduguard: disabled
-  storm_control:
-    all:
-      level: '10'
-      unit: percent
-    broadcast:
-      level: '100'
-      unit: pps
-    multicast:
-      level: '1'
-      unit: percent
-    unknown_unicast:
-      level: '2'
-      unit: percent
   channel_group:
     id: 15
     mode: 'on'
@@ -1145,9 +1104,9 @@ ethernet_interfaces:
   peer_type: server
   port_profile: ALL_WITH_SECURITY_PORT_CHANNEL
   description: server09_override_profile_no_port_channel_Eth2
-  l2_mtu: 8000
-  type: switched
   shutdown: false
+  type: switched
+  l2_mtu: 8000
   mode: access
   vlans: '210'
   spanning_tree_portfast: network
@@ -1171,26 +1130,7 @@ ethernet_interfaces:
   peer_interface: Eth2
   peer_type: server
   description: server10_no_profile_port_channel_lacp_fallback_Eth2
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 1-4094
-  spanning_tree_portfast: edge
-  spanning_tree_bpdufilter: 'True'
-  spanning_tree_bpduguard: disabled
-  storm_control:
-    all:
-      level: '10'
-      unit: percent
-    broadcast:
-      level: '100'
-      unit: pps
-    multicast:
-      level: '1'
-      unit: percent
-    unknown_unicast:
-      level: '2'
-      unit: percent
   channel_group:
     id: 17
     mode: active
@@ -1201,27 +1141,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: ALL_WITH_SECURITY_PORT_CHANNEL_LACP_FALLBACK
   description: server11_inherit_profile_port_channel_lacp_fallback_Eth2
-  l2_mtu: 8000
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 1-4094
-  spanning_tree_portfast: edge
-  spanning_tree_bpdufilter: 'True'
-  spanning_tree_bpduguard: 'True'
-  storm_control:
-    all:
-      level: '10'
-      unit: percent
-    broadcast:
-      level: '100'
-      unit: pps
-    multicast:
-      level: '1'
-      unit: percent
-    unknown_unicast:
-      level: '2'
-      unit: percent
   channel_group:
     id: 18
     mode: active
@@ -1232,27 +1152,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: NESTED_PORT_PROFILE
   description: server12_inherit_nested_profile_port_channel_lacp_fallback_Eth2
-  l2_mtu: 8000
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 1-4094
-  spanning_tree_portfast: edge
-  spanning_tree_bpdufilter: 'True'
-  spanning_tree_bpduguard: 'True'
-  storm_control:
-    all:
-      level: '10'
-      unit: percent
-    broadcast:
-      level: '100'
-      unit: pps
-    multicast:
-      level: '1'
-      unit: percent
-    unknown_unicast:
-      level: '2'
-      unit: percent
   channel_group:
     id: 19
     mode: active
@@ -1263,8 +1163,8 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A
   description: server13_disabled_interfaces_Eth2
-  type: switched
   shutdown: true
+  type: switched
   mode: access
   vlans: '110'
 - name: Ethernet21
@@ -1273,8 +1173,8 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A
   description: server14_explicitly_enabled_interfaces_Eth2
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '110'
 - name: Ethernet22
@@ -1283,10 +1183,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A
   description: server15_port_channel_with_disabled_phy_interfaces_Eth2
-  type: switched
   shutdown: true
-  mode: access
-  vlans: '110'
   channel_group:
     id: 22
     mode: active
@@ -1296,10 +1193,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A
   description: server16_port_channel_with_disabled_port_channel_Eth2
-  type: switched
   shutdown: false
-  mode: access
-  vlans: '110'
   channel_group:
     id: 23
     mode: active
@@ -1309,10 +1203,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A
   description: server17_port_channel_with_disabled_phy_and_po_interfaces_Eth2
-  type: switched
   shutdown: true
-  mode: access
-  vlans: '110'
   channel_group:
     id: 24
     mode: active
@@ -1322,8 +1213,8 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A
   description: server18_monitoring_session_source_phys_interfaces_Eth2
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '110'
 - name: Ethernet27
@@ -1332,10 +1223,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A
   description: server18_monitoring_session_source_po_Eth4
-  type: switched
   shutdown: false
-  mode: access
-  vlans: '110'
   channel_group:
     id: 27
     mode: active
@@ -1344,18 +1232,15 @@ ethernet_interfaces:
   peer_interface: Eth2
   peer_type: server
   description: server19_monitoring_session_destination_phys_Eth2
-  type: switched
   shutdown: false
+  type: switched
 - name: Ethernet42
   peer: server21_monitoring_session_destination_po
   peer_interface: Eth2
   peer_type: server
   port_profile: TENANT_A
   description: server21_monitoring_session_destination_po_Eth2
-  type: switched
   shutdown: false
-  mode: access
-  vlans: '110'
   channel_group:
     id: 42
     mode: active
@@ -1365,10 +1250,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A
   description: server22_port_channel_with_custom_id_Eth2
-  type: switched
   shutdown: false
-  mode: access
-  vlans: '110'
   channel_group:
     id: 1291
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SVC3B.yml
@@ -988,6 +988,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF2A_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 7
     mode: active
@@ -997,6 +998,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF2B_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 7
     mode: active
@@ -1086,6 +1088,7 @@ ethernet_interfaces:
   port_profile: ALL_WITH_SECURITY_PORT_CHANNEL
   description: server07_inherit_all_from_profile_port_channel_Eth2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 14
     mode: active
@@ -1095,6 +1098,7 @@ ethernet_interfaces:
   peer_type: server
   description: server08_no_profile_port_channel_Eth2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 15
     mode: 'on'
@@ -1131,6 +1135,7 @@ ethernet_interfaces:
   peer_type: server
   description: server10_no_profile_port_channel_lacp_fallback_Eth2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 17
     mode: active
@@ -1142,6 +1147,7 @@ ethernet_interfaces:
   port_profile: ALL_WITH_SECURITY_PORT_CHANNEL_LACP_FALLBACK
   description: server11_inherit_profile_port_channel_lacp_fallback_Eth2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 18
     mode: active
@@ -1153,6 +1159,7 @@ ethernet_interfaces:
   port_profile: NESTED_PORT_PROFILE
   description: server12_inherit_nested_profile_port_channel_lacp_fallback_Eth2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 19
     mode: active
@@ -1184,6 +1191,7 @@ ethernet_interfaces:
   port_profile: TENANT_A
   description: server15_port_channel_with_disabled_phy_interfaces_Eth2
   shutdown: true
+  type: port-channel-member
   channel_group:
     id: 22
     mode: active
@@ -1194,6 +1202,7 @@ ethernet_interfaces:
   port_profile: TENANT_A
   description: server16_port_channel_with_disabled_port_channel_Eth2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 23
     mode: active
@@ -1204,6 +1213,7 @@ ethernet_interfaces:
   port_profile: TENANT_A
   description: server17_port_channel_with_disabled_phy_and_po_interfaces_Eth2
   shutdown: true
+  type: port-channel-member
   channel_group:
     id: 24
     mode: active
@@ -1224,6 +1234,7 @@ ethernet_interfaces:
   port_profile: TENANT_A
   description: server18_monitoring_session_source_po_Eth4
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 27
     mode: active
@@ -1241,6 +1252,7 @@ ethernet_interfaces:
   port_profile: TENANT_A
   description: server21_monitoring_session_destination_po_Eth2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 42
     mode: active
@@ -1251,6 +1263,7 @@ ethernet_interfaces:
   port_profile: TENANT_A
   description: server22_port_channel_with_custom_id_Eth2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1291
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/MH-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/MH-L2LEAF1A.yml
@@ -68,7 +68,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: MH-LEAF2A_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -77,8 +76,8 @@ ethernet_interfaces:
   peer_interface: Eth1
   peer_type: server
   description: server02_Eth1
-  type: switched
   shutdown: false
+  type: switched
   link_tracking_groups:
   - name: l2leaf-server02
     direction: downstream

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/MH-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/MH-L2LEAF1A.yml
@@ -68,6 +68,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: MH-LEAF2A_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/MH-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/MH-LEAF1A.yml
@@ -155,6 +155,7 @@ ethernet_interfaces:
   port_profile: Tenant_X
   description: server01_ES1_Eth1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 10
     mode: active
@@ -165,6 +166,7 @@ ethernet_interfaces:
   port_profile: Tenant_X
   description: server03_AUTO_ESI_Eth1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 12
     mode: active
@@ -174,6 +176,7 @@ ethernet_interfaces:
   peer_type: router
   description: ROUTER02_WITH_SUBIF_Eth1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 11
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/MH-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/MH-LEAF1A.yml
@@ -154,10 +154,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: Tenant_X
   description: server01_ES1_Eth1
-  type: switched
   shutdown: false
-  mode: access
-  vlans: '310'
   channel_group:
     id: 10
     mode: active
@@ -167,10 +164,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: Tenant_X
   description: server03_AUTO_ESI_Eth1
-  type: switched
   shutdown: false
-  mode: access
-  vlans: '310'
   channel_group:
     id: 12
     mode: active
@@ -179,7 +173,6 @@ ethernet_interfaces:
   peer_interface: Eth1
   peer_type: router
   description: ROUTER02_WITH_SUBIF_Eth1
-  type: switched
   shutdown: false
   channel_group:
     id: 11

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/MH-LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/MH-LEAF1B.yml
@@ -155,6 +155,7 @@ ethernet_interfaces:
   port_profile: Tenant_X
   description: server01_ES1_Eth2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 10
     mode: active
@@ -165,6 +166,7 @@ ethernet_interfaces:
   port_profile: Tenant_X
   description: server03_AUTO_ESI_Eth2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 12
     mode: active
@@ -174,6 +176,7 @@ ethernet_interfaces:
   peer_type: router
   description: ROUTER02_WITH_SUBIF_Eth2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 11
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/MH-LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/MH-LEAF1B.yml
@@ -154,10 +154,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: Tenant_X
   description: server01_ES1_Eth2
-  type: switched
   shutdown: false
-  mode: access
-  vlans: '310'
   channel_group:
     id: 10
     mode: active
@@ -167,10 +164,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: Tenant_X
   description: server03_AUTO_ESI_Eth2
-  type: switched
   shutdown: false
-  mode: access
-  vlans: '310'
   channel_group:
     id: 12
     mode: active
@@ -179,7 +173,6 @@ ethernet_interfaces:
   peer_interface: Eth2
   peer_type: router
   description: ROUTER02_WITH_SUBIF_Eth2
-  type: switched
   shutdown: false
   channel_group:
     id: 11

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/MH-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/MH-LEAF2A.yml
@@ -175,7 +175,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: MH-L2LEAF1A_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 2
     mode: active
@@ -185,8 +184,8 @@ ethernet_interfaces:
   peer_type: router
   port_profile: Tenant_X_LT
   description: ROUTER01_Eth1
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '310'
   link_tracking_groups:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/MH-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/MH-LEAF2A.yml
@@ -175,6 +175,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: MH-L2LEAF1A_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 2
     mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/core-1-isis-sr-ldp.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/core-1-isis-sr-ldp.yml
@@ -217,6 +217,7 @@ ethernet_interfaces:
       igp_sync: true
   speed: forced 1000full
 - name: Ethernet12
+  type: port-channel-member
   peer: core-2-ospf-ldp
   peer_interface: Port-Channel12
   peer_type: core_router
@@ -227,6 +228,7 @@ ethernet_interfaces:
     mode: active
   speed: forced 1000full
 - name: Ethernet13
+  type: port-channel-member
   peer: core-2-ospf-ldp
   peer_interface: Port-Channel12
   peer_type: core_router

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/core-2-ospf-ldp.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/core-2-ospf-ldp.yml
@@ -172,6 +172,7 @@ ethernet_interfaces:
       igp_sync: true
   speed: forced 1000full
 - name: Ethernet12
+  type: port-channel-member
   peer: core-1-isis-sr-ldp
   peer_interface: Port-Channel12
   peer_type: core_router
@@ -182,6 +183,7 @@ ethernet_interfaces:
     mode: active
   speed: forced 1000full
 - name: Ethernet13
+  type: port-channel-member
   peer: core-1-isis-sr-ldp
   peer_interface: Port-Channel12
   peer_type: core_router

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -130,6 +130,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF1B_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -139,6 +140,7 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF1B_Ethernet4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -149,6 +151,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: CUSTOM_DC1-LEAF2A_Ethernet7
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -158,6 +161,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: CUSTOM_DC1-LEAF2B_Ethernet7
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -130,7 +130,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF1B_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -140,7 +139,6 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF1B_Ethernet4
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -151,7 +149,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: CUSTOM_DC1-LEAF2A_Ethernet7
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -161,7 +158,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: CUSTOM_DC1-LEAF2B_Ethernet7
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1B.yml
@@ -130,6 +130,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF1A_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -139,6 +140,7 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF1A_Ethernet4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -149,6 +151,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: CUSTOM_DC1-LEAF2A_Ethernet8
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -158,6 +161,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: CUSTOM_DC1-LEAF2B_Ethernet8
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1B.yml
@@ -130,7 +130,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF1A_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -140,7 +139,6 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF1A_Ethernet4
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -151,7 +149,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: CUSTOM_DC1-LEAF2A_Ethernet8
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -161,7 +158,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: CUSTOM_DC1-LEAF2B_Ethernet8
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -157,6 +157,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2B_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -166,6 +167,7 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2B_Ethernet4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -176,6 +178,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: CUSTOM_DC1-SVC3A_Ethernet7
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -185,6 +188,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: CUSTOM_DC1-SVC3B_Ethernet7
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -157,7 +157,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2B_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -167,7 +166,6 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2B_Ethernet4
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -178,7 +176,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: CUSTOM_DC1-SVC3A_Ethernet7
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -188,7 +185,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: CUSTOM_DC1-SVC3B_Ethernet7
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -157,6 +157,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2A_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -166,6 +167,7 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2A_Ethernet4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -176,6 +178,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: CUSTOM_DC1-SVC3A_Ethernet8
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -185,6 +188,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: CUSTOM_DC1-SVC3B_Ethernet8
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -157,7 +157,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2A_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -167,7 +166,6 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2A_Ethernet4
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -178,7 +176,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: CUSTOM_DC1-SVC3A_Ethernet8
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -188,7 +185,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: CUSTOM_DC1-SVC3B_Ethernet8
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF3A.yml
@@ -65,6 +65,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: CUSTOM_DC1-LEAF2A_Ethernet9
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -74,6 +75,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: CUSTOM_DC1-LEAF2B_Ethernet9
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF3A.yml
@@ -65,7 +65,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: CUSTOM_DC1-LEAF2A_Ethernet9
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -75,7 +74,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: CUSTOM_DC1-LEAF2B_Ethernet9
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
@@ -230,9 +230,9 @@ ethernet_interfaces:
   peer_type: server
   port_profile: ALL_WITH_SECURITY
   description: CUSTOM_server02_SINGLE_NODE_TRUNK_Eth1
-  l2_mtu: 8000
-  type: switched
   shutdown: false
+  type: switched
+  l2_mtu: 8000
   mode: trunk
   vlans: 1-4094
   spanning_tree_portfast: edge
@@ -257,8 +257,8 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A
   description: CUSTOM_server02_SINGLE_NODE_Eth1
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '110'
 loopback_interfaces:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -374,6 +374,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: CUSTOM_DC1-L2LEAF1A_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 7
     mode: active
@@ -383,6 +384,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: CUSTOM_DC1-L2LEAF1B_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 7
     mode: active
@@ -392,6 +394,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: CUSTOM_DC1-L2LEAF3A_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 9
     mode: active
@@ -402,6 +405,7 @@ ethernet_interfaces:
   port_profile: TENANT_B
   description: CUSTOM_server01_MLAG_Eth2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 10
     mode: active
@@ -412,6 +416,7 @@ ethernet_interfaces:
   port_profile: TENANT_A_MTU
   description: CUSTOM_server01_MTU_PROFILE_MLAG_Eth4
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 11
     mode: active
@@ -421,6 +426,7 @@ ethernet_interfaces:
   peer_type: server
   description: CUSTOM_server01_MTU_ADAPTOR_MLAG_Eth6
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 12
     mode: active
@@ -430,6 +436,7 @@ ethernet_interfaces:
   peer_type: server
   description: CUSTOM_server01_MTU_ADAPTOR_MLAG_Eth8
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 12
     mode: active
@@ -440,6 +447,7 @@ ethernet_interfaces:
   port_profile: TENANT_A_B
   description: CUSTOM_FIREWALL01_E0
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 20
     mode: active

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -374,7 +374,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: CUSTOM_DC1-L2LEAF1A_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 7
     mode: active
@@ -384,7 +383,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: CUSTOM_DC1-L2LEAF1B_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 7
     mode: active
@@ -394,7 +392,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: CUSTOM_DC1-L2LEAF3A_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 9
     mode: active
@@ -404,10 +401,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_B
   description: CUSTOM_server01_MLAG_Eth2
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 210-211
   channel_group:
     id: 10
     mode: active
@@ -417,11 +411,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A_MTU
   description: CUSTOM_server01_MTU_PROFILE_MLAG_Eth4
-  mtu: 1600
-  type: switched
   shutdown: false
-  mode: access
-  vlans: '110'
   channel_group:
     id: 11
     mode: active
@@ -430,8 +420,6 @@ ethernet_interfaces:
   peer_interface: Eth6
   peer_type: server
   description: CUSTOM_server01_MTU_ADAPTOR_MLAG_Eth6
-  mtu: 1601
-  type: switched
   shutdown: false
   channel_group:
     id: 12
@@ -441,8 +429,6 @@ ethernet_interfaces:
   peer_interface: Eth8
   peer_type: server
   description: CUSTOM_server01_MTU_ADAPTOR_MLAG_Eth8
-  mtu: 1601
-  type: switched
   shutdown: false
   channel_group:
     id: 12
@@ -453,10 +439,7 @@ ethernet_interfaces:
   peer_type: firewall
   port_profile: TENANT_A_B
   description: CUSTOM_FIREWALL01_E0
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 110-111,210-211
   channel_group:
     id: 20
     mode: active
@@ -466,8 +449,8 @@ ethernet_interfaces:
   peer_type: router
   port_profile: TENANT_A
   description: CUSTOM_ROUTER01_Eth0
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '110'
 port_channel_interfaces:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -374,6 +374,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: CUSTOM_DC1-L2LEAF1A_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 7
     mode: active
@@ -383,6 +384,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: CUSTOM_DC1-L2LEAF1B_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 7
     mode: active
@@ -392,6 +394,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: CUSTOM_DC1-L2LEAF3A_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 9
     mode: active
@@ -402,6 +405,7 @@ ethernet_interfaces:
   port_profile: TENANT_B
   description: CUSTOM_server01_MLAG_Eth3
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 10
     mode: active
@@ -412,6 +416,7 @@ ethernet_interfaces:
   port_profile: TENANT_A_MTU
   description: CUSTOM_server01_MTU_PROFILE_MLAG_Eth5
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 11
     mode: active
@@ -421,6 +426,7 @@ ethernet_interfaces:
   peer_type: server
   description: CUSTOM_server01_MTU_ADAPTOR_MLAG_Eth7
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 12
     mode: active
@@ -430,6 +436,7 @@ ethernet_interfaces:
   peer_type: server
   description: CUSTOM_server01_MTU_ADAPTOR_MLAG_Eth9
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 12
     mode: active
@@ -440,6 +447,7 @@ ethernet_interfaces:
   port_profile: TENANT_A_B
   description: CUSTOM_FIREWALL01_E1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 20
     mode: active

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -374,7 +374,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: CUSTOM_DC1-L2LEAF1A_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 7
     mode: active
@@ -384,7 +383,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: CUSTOM_DC1-L2LEAF1B_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 7
     mode: active
@@ -394,7 +392,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: CUSTOM_DC1-L2LEAF3A_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 9
     mode: active
@@ -404,10 +401,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_B
   description: CUSTOM_server01_MLAG_Eth3
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 210-211
   channel_group:
     id: 10
     mode: active
@@ -417,11 +411,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A_MTU
   description: CUSTOM_server01_MTU_PROFILE_MLAG_Eth5
-  mtu: 1600
-  type: switched
   shutdown: false
-  mode: access
-  vlans: '110'
   channel_group:
     id: 11
     mode: active
@@ -430,8 +420,6 @@ ethernet_interfaces:
   peer_interface: Eth7
   peer_type: server
   description: CUSTOM_server01_MTU_ADAPTOR_MLAG_Eth7
-  mtu: 1601
-  type: switched
   shutdown: false
   channel_group:
     id: 12
@@ -441,8 +429,6 @@ ethernet_interfaces:
   peer_interface: Eth9
   peer_type: server
   description: CUSTOM_server01_MTU_ADAPTOR_MLAG_Eth9
-  mtu: 1601
-  type: switched
   shutdown: false
   channel_group:
     id: 12
@@ -453,10 +439,7 @@ ethernet_interfaces:
   peer_type: firewall
   port_profile: TENANT_A_B
   description: CUSTOM_FIREWALL01_E1
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 110-111,210-211
   channel_group:
     id: 20
     mode: active
@@ -466,8 +449,8 @@ ethernet_interfaces:
   peer_type: router
   port_profile: TENANT_A
   description: CUSTOM_ROUTER01_Eth1
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '110'
 port_channel_interfaces:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -948,7 +948,6 @@ ethernet_interfaces:
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: CUSTOM_MLAG_PEER_DC1-SVC3B_Ethernet5
-  type: switched
   shutdown: false
   channel_group:
     id: 5
@@ -958,7 +957,6 @@ ethernet_interfaces:
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: CUSTOM_MLAG_PEER_DC1-SVC3B_Ethernet6
-  type: switched
   shutdown: false
   channel_group:
     id: 5
@@ -969,7 +967,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: CUSTOM_DC1-L2LEAF2A_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 7
     mode: active
@@ -979,7 +976,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: CUSTOM_DC1-L2LEAF2B_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 7
     mode: active
@@ -1029,10 +1025,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A_B
   description: CUSTOM_server03_ESI_Eth1
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 110-111,210-211
   channel_group:
     id: 10
     mode: active
@@ -1042,9 +1035,9 @@ ethernet_interfaces:
   peer_type: server
   port_profile: ALL_WITH_SECURITY
   description: CUSTOM_server04_inherit_all_from_profile_Eth1
-  l2_mtu: 8000
-  type: switched
   shutdown: false
+  type: switched
+  l2_mtu: 8000
   mode: trunk
   vlans: 1-4094
   spanning_tree_portfast: edge
@@ -1068,8 +1061,8 @@ ethernet_interfaces:
   peer_interface: Eth1
   peer_type: server
   description: CUSTOM_server05_no_profile_Eth1
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk
   vlans: 1-4094
   spanning_tree_portfast: edge
@@ -1094,9 +1087,9 @@ ethernet_interfaces:
   peer_type: server
   port_profile: ALL_WITH_SECURITY
   description: CUSTOM_server06_override_profile_Eth1
-  l2_mtu: 8000
-  type: switched
   shutdown: false
+  type: switched
+  l2_mtu: 8000
   mode: access
   vlans: '210'
   spanning_tree_portfast: network
@@ -1121,27 +1114,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: ALL_WITH_SECURITY_PORT_CHANNEL
   description: CUSTOM_server07_inherit_all_from_profile_port_channel_Eth1
-  l2_mtu: 8000
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 1-4094
-  spanning_tree_portfast: edge
-  spanning_tree_bpdufilter: 'True'
-  spanning_tree_bpduguard: 'False'
-  storm_control:
-    all:
-      level: '10'
-      unit: percent
-    broadcast:
-      level: '100'
-      unit: pps
-    multicast:
-      level: '1'
-      unit: percent
-    unknown_unicast:
-      level: '2'
-      unit: percent
   channel_group:
     id: 14
     mode: active
@@ -1150,26 +1123,7 @@ ethernet_interfaces:
   peer_interface: Eth1
   peer_type: server
   description: CUSTOM_server08_no_profile_port_channel_Eth1
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 1-4094
-  spanning_tree_portfast: edge
-  spanning_tree_bpdufilter: 'True'
-  spanning_tree_bpduguard: 'False'
-  storm_control:
-    all:
-      level: '10'
-      unit: percent
-    broadcast:
-      level: '100'
-      unit: pps
-    multicast:
-      level: '1'
-      unit: percent
-    unknown_unicast:
-      level: '2'
-      unit: percent
   channel_group:
     id: 15
     mode: 'on'
@@ -1179,9 +1133,9 @@ ethernet_interfaces:
   peer_type: server
   port_profile: ALL_WITH_SECURITY_PORT_CHANNEL
   description: CUSTOM_server09_override_profile_no_port_channel_Eth1
-  l2_mtu: 8000
-  type: switched
   shutdown: false
+  type: switched
+  l2_mtu: 8000
   mode: access
   vlans: '210'
   spanning_tree_portfast: network
@@ -1205,26 +1159,7 @@ ethernet_interfaces:
   peer_interface: Eth1
   peer_type: server
   description: CUSTOM_server10_no_profile_port_channel_lacp_fallback_Eth1
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 1-4094
-  spanning_tree_portfast: edge
-  spanning_tree_bpdufilter: 'True'
-  spanning_tree_bpduguard: 'False'
-  storm_control:
-    all:
-      level: '10'
-      unit: percent
-    broadcast:
-      level: '100'
-      unit: pps
-    multicast:
-      level: '1'
-      unit: percent
-    unknown_unicast:
-      level: '2'
-      unit: percent
   channel_group:
     id: 17
     mode: active
@@ -1235,27 +1170,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: ALL_WITH_SECURITY_PORT_CHANNEL_LACP_FALLBACK
   description: CUSTOM_server11_inherit_profile_port_channel_lacp_fallback_Eth1
-  l2_mtu: 8000
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 1-4094
-  spanning_tree_portfast: edge
-  spanning_tree_bpdufilter: 'True'
-  spanning_tree_bpduguard: 'False'
-  storm_control:
-    all:
-      level: '10'
-      unit: percent
-    broadcast:
-      level: '100'
-      unit: pps
-    multicast:
-      level: '1'
-      unit: percent
-    unknown_unicast:
-      level: '2'
-      unit: percent
   channel_group:
     id: 18
     mode: active
@@ -1266,27 +1181,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: NESTED_PORT_PROFILE
   description: CUSTOM_server12_inherit_nested_profile_port_channel_lacp_fallback_Eth1
-  l2_mtu: 8000
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 1-4094
-  spanning_tree_portfast: edge
-  spanning_tree_bpdufilter: 'True'
-  spanning_tree_bpduguard: 'False'
-  storm_control:
-    all:
-      level: '10'
-      unit: percent
-    broadcast:
-      level: '100'
-      unit: pps
-    multicast:
-      level: '1'
-      unit: percent
-    unknown_unicast:
-      level: '2'
-      unit: percent
   channel_group:
     id: 19
     mode: active
@@ -1297,8 +1192,8 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A
   description: CUSTOM_server13_disabled_interfaces_Eth1
-  type: switched
   shutdown: true
+  type: switched
   mode: access
   vlans: '110'
 - name: Ethernet21
@@ -1307,8 +1202,8 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A
   description: CUSTOM_server14_explicitly_enabled_interfaces_Eth1
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '110'
 - name: Ethernet22
@@ -1317,10 +1212,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A
   description: CUSTOM_server15_port_channel_disabled_interfaces_Eth1
-  type: switched
   shutdown: true
-  mode: access
-  vlans: '110'
   channel_group:
     id: 22
     mode: active

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -948,6 +948,7 @@ ethernet_interfaces:
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: CUSTOM_MLAG_PEER_DC1-SVC3B_Ethernet5
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 5
@@ -957,6 +958,7 @@ ethernet_interfaces:
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: CUSTOM_MLAG_PEER_DC1-SVC3B_Ethernet6
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 5
@@ -967,6 +969,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: CUSTOM_DC1-L2LEAF2A_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 7
     mode: active
@@ -976,6 +979,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: CUSTOM_DC1-L2LEAF2B_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 7
     mode: active
@@ -1026,6 +1030,7 @@ ethernet_interfaces:
   port_profile: TENANT_A_B
   description: CUSTOM_server03_ESI_Eth1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 10
     mode: active
@@ -1115,6 +1120,7 @@ ethernet_interfaces:
   port_profile: ALL_WITH_SECURITY_PORT_CHANNEL
   description: CUSTOM_server07_inherit_all_from_profile_port_channel_Eth1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 14
     mode: active
@@ -1124,6 +1130,7 @@ ethernet_interfaces:
   peer_type: server
   description: CUSTOM_server08_no_profile_port_channel_Eth1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 15
     mode: 'on'
@@ -1160,6 +1167,7 @@ ethernet_interfaces:
   peer_type: server
   description: CUSTOM_server10_no_profile_port_channel_lacp_fallback_Eth1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 17
     mode: active
@@ -1171,6 +1179,7 @@ ethernet_interfaces:
   port_profile: ALL_WITH_SECURITY_PORT_CHANNEL_LACP_FALLBACK
   description: CUSTOM_server11_inherit_profile_port_channel_lacp_fallback_Eth1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 18
     mode: active
@@ -1182,6 +1191,7 @@ ethernet_interfaces:
   port_profile: NESTED_PORT_PROFILE
   description: CUSTOM_server12_inherit_nested_profile_port_channel_lacp_fallback_Eth1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 19
     mode: active
@@ -1213,6 +1223,7 @@ ethernet_interfaces:
   port_profile: TENANT_A
   description: CUSTOM_server15_port_channel_disabled_interfaces_Eth1
   shutdown: true
+  type: port-channel-member
   channel_group:
     id: 22
     mode: active

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -948,7 +948,6 @@ ethernet_interfaces:
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: CUSTOM_MLAG_PEER_DC1-SVC3A_Ethernet5
-  type: switched
   shutdown: false
   channel_group:
     id: 5
@@ -958,7 +957,6 @@ ethernet_interfaces:
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: CUSTOM_MLAG_PEER_DC1-SVC3A_Ethernet6
-  type: switched
   shutdown: false
   channel_group:
     id: 5
@@ -969,7 +967,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: CUSTOM_DC1-L2LEAF2A_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 7
     mode: active
@@ -979,7 +976,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: CUSTOM_DC1-L2LEAF2B_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 7
     mode: active
@@ -1029,10 +1025,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A_B
   description: CUSTOM_server03_ESI_Eth2
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 110-111,210-211
   channel_group:
     id: 10
     mode: active
@@ -1042,9 +1035,9 @@ ethernet_interfaces:
   peer_type: server
   port_profile: ALL_WITH_SECURITY
   description: CUSTOM_server04_inherit_all_from_profile_Eth2
-  l2_mtu: 8000
-  type: switched
   shutdown: false
+  type: switched
+  l2_mtu: 8000
   mode: trunk
   vlans: 1-4094
   spanning_tree_portfast: edge
@@ -1068,8 +1061,8 @@ ethernet_interfaces:
   peer_interface: Eth2
   peer_type: server
   description: CUSTOM_server05_no_profile_Eth2
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk
   vlans: 1-4094
   spanning_tree_portfast: edge
@@ -1094,9 +1087,9 @@ ethernet_interfaces:
   peer_type: server
   port_profile: ALL_WITH_SECURITY
   description: CUSTOM_server06_override_profile_Eth2
-  l2_mtu: 8000
-  type: switched
   shutdown: false
+  type: switched
+  l2_mtu: 8000
   mode: access
   vlans: '210'
   spanning_tree_portfast: network
@@ -1121,27 +1114,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: ALL_WITH_SECURITY_PORT_CHANNEL
   description: CUSTOM_server07_inherit_all_from_profile_port_channel_Eth2
-  l2_mtu: 8000
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 1-4094
-  spanning_tree_portfast: edge
-  spanning_tree_bpdufilter: 'True'
-  spanning_tree_bpduguard: 'False'
-  storm_control:
-    all:
-      level: '10'
-      unit: percent
-    broadcast:
-      level: '100'
-      unit: pps
-    multicast:
-      level: '1'
-      unit: percent
-    unknown_unicast:
-      level: '2'
-      unit: percent
   channel_group:
     id: 14
     mode: active
@@ -1150,26 +1123,7 @@ ethernet_interfaces:
   peer_interface: Eth2
   peer_type: server
   description: CUSTOM_server08_no_profile_port_channel_Eth2
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 1-4094
-  spanning_tree_portfast: edge
-  spanning_tree_bpdufilter: 'True'
-  spanning_tree_bpduguard: 'False'
-  storm_control:
-    all:
-      level: '10'
-      unit: percent
-    broadcast:
-      level: '100'
-      unit: pps
-    multicast:
-      level: '1'
-      unit: percent
-    unknown_unicast:
-      level: '2'
-      unit: percent
   channel_group:
     id: 15
     mode: 'on'
@@ -1179,9 +1133,9 @@ ethernet_interfaces:
   peer_type: server
   port_profile: ALL_WITH_SECURITY_PORT_CHANNEL
   description: CUSTOM_server09_override_profile_no_port_channel_Eth2
-  l2_mtu: 8000
-  type: switched
   shutdown: false
+  type: switched
+  l2_mtu: 8000
   mode: access
   vlans: '210'
   spanning_tree_portfast: network
@@ -1205,26 +1159,7 @@ ethernet_interfaces:
   peer_interface: Eth2
   peer_type: server
   description: CUSTOM_server10_no_profile_port_channel_lacp_fallback_Eth2
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 1-4094
-  spanning_tree_portfast: edge
-  spanning_tree_bpdufilter: 'True'
-  spanning_tree_bpduguard: 'False'
-  storm_control:
-    all:
-      level: '10'
-      unit: percent
-    broadcast:
-      level: '100'
-      unit: pps
-    multicast:
-      level: '1'
-      unit: percent
-    unknown_unicast:
-      level: '2'
-      unit: percent
   channel_group:
     id: 17
     mode: active
@@ -1235,27 +1170,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: ALL_WITH_SECURITY_PORT_CHANNEL_LACP_FALLBACK
   description: CUSTOM_server11_inherit_profile_port_channel_lacp_fallback_Eth2
-  l2_mtu: 8000
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 1-4094
-  spanning_tree_portfast: edge
-  spanning_tree_bpdufilter: 'True'
-  spanning_tree_bpduguard: 'False'
-  storm_control:
-    all:
-      level: '10'
-      unit: percent
-    broadcast:
-      level: '100'
-      unit: pps
-    multicast:
-      level: '1'
-      unit: percent
-    unknown_unicast:
-      level: '2'
-      unit: percent
   channel_group:
     id: 18
     mode: active
@@ -1266,27 +1181,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: NESTED_PORT_PROFILE
   description: CUSTOM_server12_inherit_nested_profile_port_channel_lacp_fallback_Eth2
-  l2_mtu: 8000
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 1-4094
-  spanning_tree_portfast: edge
-  spanning_tree_bpdufilter: 'True'
-  spanning_tree_bpduguard: 'False'
-  storm_control:
-    all:
-      level: '10'
-      unit: percent
-    broadcast:
-      level: '100'
-      unit: pps
-    multicast:
-      level: '1'
-      unit: percent
-    unknown_unicast:
-      level: '2'
-      unit: percent
   channel_group:
     id: 19
     mode: active
@@ -1297,8 +1192,8 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A
   description: CUSTOM_server13_disabled_interfaces_Eth2
-  type: switched
   shutdown: true
+  type: switched
   mode: access
   vlans: '110'
 - name: Ethernet21
@@ -1307,8 +1202,8 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A
   description: CUSTOM_server14_explicitly_enabled_interfaces_Eth2
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '110'
 - name: Ethernet22
@@ -1317,10 +1212,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A
   description: CUSTOM_server15_port_channel_disabled_interfaces_Eth2
-  type: switched
   shutdown: true
-  mode: access
-  vlans: '110'
   channel_group:
     id: 22
     mode: active

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -948,6 +948,7 @@ ethernet_interfaces:
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: CUSTOM_MLAG_PEER_DC1-SVC3A_Ethernet5
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 5
@@ -957,6 +958,7 @@ ethernet_interfaces:
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: CUSTOM_MLAG_PEER_DC1-SVC3A_Ethernet6
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 5
@@ -967,6 +969,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: CUSTOM_DC1-L2LEAF2A_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 7
     mode: active
@@ -976,6 +979,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: CUSTOM_DC1-L2LEAF2B_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 7
     mode: active
@@ -1026,6 +1030,7 @@ ethernet_interfaces:
   port_profile: TENANT_A_B
   description: CUSTOM_server03_ESI_Eth2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 10
     mode: active
@@ -1115,6 +1120,7 @@ ethernet_interfaces:
   port_profile: ALL_WITH_SECURITY_PORT_CHANNEL
   description: CUSTOM_server07_inherit_all_from_profile_port_channel_Eth2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 14
     mode: active
@@ -1124,6 +1130,7 @@ ethernet_interfaces:
   peer_type: server
   description: CUSTOM_server08_no_profile_port_channel_Eth2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 15
     mode: 'on'
@@ -1160,6 +1167,7 @@ ethernet_interfaces:
   peer_type: server
   description: CUSTOM_server10_no_profile_port_channel_lacp_fallback_Eth2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 17
     mode: active
@@ -1171,6 +1179,7 @@ ethernet_interfaces:
   port_profile: ALL_WITH_SECURITY_PORT_CHANNEL_LACP_FALLBACK
   description: CUSTOM_server11_inherit_profile_port_channel_lacp_fallback_Eth2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 18
     mode: active
@@ -1182,6 +1191,7 @@ ethernet_interfaces:
   port_profile: NESTED_PORT_PROFILE
   description: CUSTOM_server12_inherit_nested_profile_port_channel_lacp_fallback_Eth2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 19
     mode: active
@@ -1213,6 +1223,7 @@ ethernet_interfaces:
   port_profile: TENANT_A
   description: CUSTOM_server15_port_channel_disabled_interfaces_Eth2
   shutdown: true
+  type: port-channel-member
   channel_group:
     id: 22
     mode: active

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-BL1A.yml
@@ -129,6 +129,7 @@ ethernet_interfaces:
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-BL1B_Ethernet5
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 5
@@ -138,6 +139,7 @@ ethernet_interfaces:
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-BL1B_Ethernet6
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-BL1A.yml
@@ -129,7 +129,6 @@ ethernet_interfaces:
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-BL1B_Ethernet5
-  type: switched
   shutdown: false
   channel_group:
     id: 5
@@ -139,7 +138,6 @@ ethernet_interfaces:
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-BL1B_Ethernet6
-  type: switched
   shutdown: false
   channel_group:
     id: 5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-BL1B.yml
@@ -129,7 +129,6 @@ ethernet_interfaces:
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-BL1A_Ethernet5
-  type: switched
   shutdown: false
   channel_group:
     id: 5
@@ -139,7 +138,6 @@ ethernet_interfaces:
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-BL1A_Ethernet6
-  type: switched
   shutdown: false
   channel_group:
     id: 5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-BL1B.yml
@@ -129,6 +129,7 @@ ethernet_interfaces:
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-BL1A_Ethernet5
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 5
@@ -138,6 +139,7 @@ ethernet_interfaces:
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-BL1A_Ethernet6
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -59,6 +59,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF2A_Ethernet7
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -68,6 +69,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF2B_Ethernet7
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -59,7 +59,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF2A_Ethernet7
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -69,7 +68,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF2B_Ethernet7
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -88,6 +88,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2B_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -97,6 +98,7 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2B_Ethernet4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -107,6 +109,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-SVC3A_Ethernet7
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -116,6 +119,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-SVC3B_Ethernet7
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -88,7 +88,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2B_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -98,7 +97,6 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2B_Ethernet4
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -109,7 +107,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-SVC3A_Ethernet7
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -119,7 +116,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-SVC3B_Ethernet7
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -88,7 +88,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2A_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -98,7 +97,6 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2A_Ethernet4
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -109,7 +107,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-SVC3A_Ethernet8
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -119,7 +116,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-SVC3B_Ethernet8
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -88,6 +88,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2A_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -97,6 +98,7 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2A_Ethernet4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -107,6 +109,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-SVC3A_Ethernet8
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -116,6 +119,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-SVC3B_Ethernet8
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -136,7 +136,6 @@ ethernet_interfaces:
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF2B_Ethernet5
-  type: switched
   shutdown: false
   channel_group:
     id: 5
@@ -146,7 +145,6 @@ ethernet_interfaces:
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF2B_Ethernet6
-  type: switched
   shutdown: false
   channel_group:
     id: 5
@@ -209,7 +207,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF1A_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 7
     mode: active

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -136,6 +136,7 @@ ethernet_interfaces:
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF2B_Ethernet5
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 5
@@ -145,6 +146,7 @@ ethernet_interfaces:
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF2B_Ethernet6
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 5
@@ -207,6 +209,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF1A_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 7
     mode: active

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -136,6 +136,7 @@ ethernet_interfaces:
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF2A_Ethernet5
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 5
@@ -145,6 +146,7 @@ ethernet_interfaces:
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF2A_Ethernet6
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 5
@@ -207,6 +209,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF1A_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 7
     mode: active

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -136,7 +136,6 @@ ethernet_interfaces:
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF2A_Ethernet5
-  type: switched
   shutdown: false
   channel_group:
     id: 5
@@ -146,7 +145,6 @@ ethernet_interfaces:
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF2A_Ethernet6
-  type: switched
   shutdown: false
   channel_group:
     id: 5
@@ -209,7 +207,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF1A_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 7
     mode: active

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SVC3A.yml
@@ -126,7 +126,6 @@ ethernet_interfaces:
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-SVC3B_Ethernet5
-  type: switched
   shutdown: false
   channel_group:
     id: 5
@@ -136,7 +135,6 @@ ethernet_interfaces:
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-SVC3B_Ethernet6
-  type: switched
   shutdown: false
   channel_group:
     id: 5
@@ -199,7 +197,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF2A_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 7
     mode: active
@@ -209,7 +206,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF2B_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 7
     mode: active

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SVC3A.yml
@@ -126,6 +126,7 @@ ethernet_interfaces:
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-SVC3B_Ethernet5
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 5
@@ -135,6 +136,7 @@ ethernet_interfaces:
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-SVC3B_Ethernet6
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 5
@@ -197,6 +199,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF2A_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 7
     mode: active
@@ -206,6 +209,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF2B_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 7
     mode: active

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SVC3B.yml
@@ -126,7 +126,6 @@ ethernet_interfaces:
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-SVC3A_Ethernet5
-  type: switched
   shutdown: false
   channel_group:
     id: 5
@@ -136,7 +135,6 @@ ethernet_interfaces:
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-SVC3A_Ethernet6
-  type: switched
   shutdown: false
   channel_group:
     id: 5
@@ -199,7 +197,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF2A_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 7
     mode: active
@@ -209,7 +206,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF2B_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 7
     mode: active

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SVC3B.yml
@@ -126,6 +126,7 @@ ethernet_interfaces:
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-SVC3A_Ethernet5
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 5
@@ -135,6 +136,7 @@ ethernet_interfaces:
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-SVC3A_Ethernet6
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 5
@@ -197,6 +199,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF2A_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 7
     mode: active
@@ -206,6 +209,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF2B_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 7
     mode: active

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
@@ -140,6 +140,7 @@ ethernet_interfaces:
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-BL1B_Ethernet5
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 5
@@ -149,6 +150,7 @@ ethernet_interfaces:
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-BL1B_Ethernet6
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
@@ -140,7 +140,6 @@ ethernet_interfaces:
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-BL1B_Ethernet5
-  type: switched
   shutdown: false
   channel_group:
     id: 5
@@ -150,7 +149,6 @@ ethernet_interfaces:
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-BL1B_Ethernet6
-  type: switched
   shutdown: false
   channel_group:
     id: 5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
@@ -140,6 +140,7 @@ ethernet_interfaces:
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-BL1A_Ethernet5
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 5
@@ -149,6 +150,7 @@ ethernet_interfaces:
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-BL1A_Ethernet6
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
@@ -140,7 +140,6 @@ ethernet_interfaces:
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-BL1A_Ethernet5
-  type: switched
   shutdown: false
   channel_group:
     id: 5
@@ -150,7 +149,6 @@ ethernet_interfaces:
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-BL1A_Ethernet6
-  type: switched
   shutdown: false
   channel_group:
     id: 5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -59,6 +59,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF2A_Ethernet7
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -68,6 +69,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF2B_Ethernet7
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -59,7 +59,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF2A_Ethernet7
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -69,7 +68,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF2B_Ethernet7
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -91,7 +91,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2B_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -101,7 +100,6 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2B_Ethernet4
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -112,7 +110,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-SVC3A_Ethernet7
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -122,7 +119,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-SVC3B_Ethernet7
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -91,6 +91,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2B_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -100,6 +101,7 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2B_Ethernet4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -110,6 +112,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-SVC3A_Ethernet7
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -119,6 +122,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-SVC3B_Ethernet7
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -91,7 +91,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2A_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -101,7 +100,6 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2A_Ethernet4
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -112,7 +110,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-SVC3A_Ethernet8
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -122,7 +119,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-SVC3B_Ethernet8
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -91,6 +91,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2A_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -100,6 +101,7 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2A_Ethernet4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -110,6 +112,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-SVC3A_Ethernet8
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -119,6 +122,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-SVC3B_Ethernet8
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -212,7 +212,6 @@ ethernet_interfaces:
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF2B_Ethernet5
-  type: switched
   shutdown: false
   channel_group:
     id: 5
@@ -222,7 +221,6 @@ ethernet_interfaces:
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF2B_Ethernet6
-  type: switched
   shutdown: false
   channel_group:
     id: 5
@@ -277,7 +275,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF1A_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 7
     mode: active

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -212,6 +212,7 @@ ethernet_interfaces:
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF2B_Ethernet5
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 5
@@ -221,6 +222,7 @@ ethernet_interfaces:
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF2B_Ethernet6
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 5
@@ -275,6 +277,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF1A_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 7
     mode: active

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -212,7 +212,6 @@ ethernet_interfaces:
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF2A_Ethernet5
-  type: switched
   shutdown: false
   channel_group:
     id: 5
@@ -222,7 +221,6 @@ ethernet_interfaces:
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF2A_Ethernet6
-  type: switched
   shutdown: false
   channel_group:
     id: 5
@@ -277,7 +275,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF1A_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 7
     mode: active

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -212,6 +212,7 @@ ethernet_interfaces:
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF2A_Ethernet5
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 5
@@ -221,6 +222,7 @@ ethernet_interfaces:
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF2A_Ethernet6
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 5
@@ -275,6 +277,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF1A_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 7
     mode: active

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -202,6 +202,7 @@ ethernet_interfaces:
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-SVC3B_Ethernet5
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 5
@@ -211,6 +212,7 @@ ethernet_interfaces:
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-SVC3B_Ethernet6
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 5
@@ -265,6 +267,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF2A_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 7
     mode: active
@@ -274,6 +277,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF2B_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 7
     mode: active

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -202,7 +202,6 @@ ethernet_interfaces:
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-SVC3B_Ethernet5
-  type: switched
   shutdown: false
   channel_group:
     id: 5
@@ -212,7 +211,6 @@ ethernet_interfaces:
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-SVC3B_Ethernet6
-  type: switched
   shutdown: false
   channel_group:
     id: 5
@@ -267,7 +265,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF2A_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 7
     mode: active
@@ -277,7 +274,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF2B_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 7
     mode: active

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -202,7 +202,6 @@ ethernet_interfaces:
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-SVC3A_Ethernet5
-  type: switched
   shutdown: false
   channel_group:
     id: 5
@@ -212,7 +211,6 @@ ethernet_interfaces:
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-SVC3A_Ethernet6
-  type: switched
   shutdown: false
   channel_group:
     id: 5
@@ -267,7 +265,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF2A_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 7
     mode: active
@@ -277,7 +274,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF2B_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 7
     mode: active

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -202,6 +202,7 @@ ethernet_interfaces:
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-SVC3A_Ethernet5
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 5
@@ -211,6 +212,7 @@ ethernet_interfaces:
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-SVC3A_Ethernet6
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 5
@@ -265,6 +267,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF2A_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 7
     mode: active
@@ -274,6 +277,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF2B_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 7
     mode: active

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -59,6 +59,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF2A_Ethernet7
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -68,6 +69,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF2B_Ethernet7
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -59,7 +59,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF2A_Ethernet7
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -69,7 +68,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-LEAF2B_Ethernet7
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -139,6 +139,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2B_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -148,6 +149,7 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2B_Ethernet4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -158,6 +160,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-SVC3A_Ethernet7
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -167,6 +170,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-SVC3B_Ethernet7
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -139,7 +139,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2B_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -149,7 +148,6 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2B_Ethernet4
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -160,7 +158,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-SVC3A_Ethernet7
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -170,7 +167,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-SVC3B_Ethernet7
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -139,6 +139,7 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2A_Ethernet3
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -148,6 +149,7 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2A_Ethernet4
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 3
@@ -158,6 +160,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-SVC3A_Ethernet8
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active
@@ -167,6 +170,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-SVC3B_Ethernet8
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -139,7 +139,6 @@ ethernet_interfaces:
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2A_Ethernet3
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -149,7 +148,6 @@ ethernet_interfaces:
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2A_Ethernet4
-  type: switched
   shutdown: false
   channel_group:
     id: 3
@@ -160,7 +158,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-SVC3A_Ethernet8
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active
@@ -170,7 +167,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: DC1-SVC3B_Ethernet8
   shutdown: false
-  type: switched
   channel_group:
     id: 1
     mode: active

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
@@ -229,8 +229,8 @@ ethernet_interfaces:
   peer_type: server
   port_profile: ALL_WITH_SECURITY
   description: server02_SINGLE_NODE_TRUNK_Eth1
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk
   vlans: 1-4094
   spanning_tree_portfast: edge
@@ -255,8 +255,8 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A
   description: server02_SINGLE_NODE_Eth1
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '110'
 loopback_interfaces:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -647,7 +647,6 @@ ethernet_interfaces:
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF2B_Ethernet5
-  type: switched
   shutdown: false
   channel_group:
     id: 5
@@ -657,7 +656,6 @@ ethernet_interfaces:
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF2B_Ethernet6
-  type: switched
   shutdown: false
   channel_group:
     id: 5
@@ -704,7 +702,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF1A_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 7
     mode: active
@@ -714,10 +711,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_B
   description: server01_MLAG_Eth2
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 210-211
   channel_group:
     id: 10
     mode: active
@@ -727,11 +721,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A_MTU
   description: server01_MTU_PROFILE_MLAG_Eth4
-  mtu: 1600
-  type: switched
   shutdown: false
-  mode: access
-  vlans: '110'
   channel_group:
     id: 11
     mode: active
@@ -740,8 +730,6 @@ ethernet_interfaces:
   peer_interface: Eth6
   peer_type: server
   description: server01_MTU_ADAPTOR_MLAG_Eth6
-  mtu: 1601
-  type: switched
   shutdown: false
   channel_group:
     id: 12

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -647,6 +647,7 @@ ethernet_interfaces:
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF2B_Ethernet5
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 5
@@ -656,6 +657,7 @@ ethernet_interfaces:
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF2B_Ethernet6
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 5
@@ -702,6 +704,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF1A_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 7
     mode: active
@@ -712,6 +715,7 @@ ethernet_interfaces:
   port_profile: TENANT_B
   description: server01_MLAG_Eth2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 10
     mode: active
@@ -722,6 +726,7 @@ ethernet_interfaces:
   port_profile: TENANT_A_MTU
   description: server01_MTU_PROFILE_MLAG_Eth4
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 11
     mode: active
@@ -731,6 +736,7 @@ ethernet_interfaces:
   peer_type: server
   description: server01_MTU_ADAPTOR_MLAG_Eth6
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 12
     mode: active

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -647,6 +647,7 @@ ethernet_interfaces:
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF2A_Ethernet5
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 5
@@ -656,6 +657,7 @@ ethernet_interfaces:
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF2A_Ethernet6
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 5
@@ -702,6 +704,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF1A_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 7
     mode: active
@@ -712,6 +715,7 @@ ethernet_interfaces:
   port_profile: TENANT_B
   description: server01_MLAG_Eth3
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 10
     mode: active
@@ -722,6 +726,7 @@ ethernet_interfaces:
   port_profile: TENANT_A_MTU
   description: server01_MTU_PROFILE_MLAG_Eth5
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 11
     mode: active
@@ -731,6 +736,7 @@ ethernet_interfaces:
   peer_type: server
   description: server01_MTU_ADAPTOR_MLAG_Eth7
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 12
     mode: active

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -647,7 +647,6 @@ ethernet_interfaces:
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF2A_Ethernet5
-  type: switched
   shutdown: false
   channel_group:
     id: 5
@@ -657,7 +656,6 @@ ethernet_interfaces:
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF2A_Ethernet6
-  type: switched
   shutdown: false
   channel_group:
     id: 5
@@ -704,7 +702,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF1A_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 7
     mode: active
@@ -714,10 +711,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_B
   description: server01_MLAG_Eth3
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 210-211
   channel_group:
     id: 10
     mode: active
@@ -727,11 +721,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A_MTU
   description: server01_MTU_PROFILE_MLAG_Eth5
-  mtu: 1600
-  type: switched
   shutdown: false
-  mode: access
-  vlans: '110'
   channel_group:
     id: 11
     mode: active
@@ -740,8 +730,6 @@ ethernet_interfaces:
   peer_interface: Eth7
   peer_type: server
   description: server01_MTU_ADAPTOR_MLAG_Eth7
-  mtu: 1601
-  type: switched
   shutdown: false
   channel_group:
     id: 12

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF3A.yml
@@ -601,6 +601,7 @@ ethernet_interfaces:
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF3B_Ethernet5
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 5
@@ -610,6 +611,7 @@ ethernet_interfaces:
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF3B_Ethernet6
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF3A.yml
@@ -601,7 +601,6 @@ ethernet_interfaces:
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF3B_Ethernet5
-  type: switched
   shutdown: false
   channel_group:
     id: 5
@@ -611,7 +610,6 @@ ethernet_interfaces:
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF3B_Ethernet6
-  type: switched
   shutdown: false
   channel_group:
     id: 5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF3B.yml
@@ -601,6 +601,7 @@ ethernet_interfaces:
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF3A_Ethernet5
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 5
@@ -610,6 +611,7 @@ ethernet_interfaces:
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF3A_Ethernet6
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF3B.yml
@@ -601,7 +601,6 @@ ethernet_interfaces:
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF3A_Ethernet5
-  type: switched
   shutdown: false
   channel_group:
     id: 5
@@ -611,7 +610,6 @@ ethernet_interfaces:
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF3A_Ethernet6
-  type: switched
   shutdown: false
   channel_group:
     id: 5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF4A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF4A.yml
@@ -601,7 +601,6 @@ ethernet_interfaces:
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF4B_Ethernet5
-  type: switched
   shutdown: false
   channel_group:
     id: 5
@@ -611,7 +610,6 @@ ethernet_interfaces:
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF4B_Ethernet6
-  type: switched
   shutdown: false
   channel_group:
     id: 5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF4A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF4A.yml
@@ -601,6 +601,7 @@ ethernet_interfaces:
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF4B_Ethernet5
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 5
@@ -610,6 +611,7 @@ ethernet_interfaces:
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF4B_Ethernet6
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF4B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF4B.yml
@@ -601,6 +601,7 @@ ethernet_interfaces:
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF4A_Ethernet5
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 5
@@ -610,6 +611,7 @@ ethernet_interfaces:
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF4A_Ethernet6
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF4B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF4B.yml
@@ -601,7 +601,6 @@ ethernet_interfaces:
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF4A_Ethernet5
-  type: switched
   shutdown: false
   channel_group:
     id: 5
@@ -611,7 +610,6 @@ ethernet_interfaces:
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF4A_Ethernet6
-  type: switched
   shutdown: false
   channel_group:
     id: 5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -844,6 +844,7 @@ ethernet_interfaces:
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-SVC3B_Ethernet5
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 5
@@ -853,6 +854,7 @@ ethernet_interfaces:
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-SVC3B_Ethernet6
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 5
@@ -899,6 +901,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF2A_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 7
     mode: active
@@ -908,6 +911,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF2B_Ethernet1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 7
     mode: active
@@ -918,6 +922,7 @@ ethernet_interfaces:
   port_profile: TENANT_A_B
   description: server03_ESI_Eth1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 10
     mode: active
@@ -1005,6 +1010,7 @@ ethernet_interfaces:
   port_profile: ALL_WITH_SECURITY_PORT_CHANNEL
   description: server07_inherit_all_from_profile_port_channel_Eth1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 14
     mode: active
@@ -1014,6 +1020,7 @@ ethernet_interfaces:
   peer_type: server
   description: server08_no_profile_port_channel_Eth1
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 15
     mode: 'on'

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -844,7 +844,6 @@ ethernet_interfaces:
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-SVC3B_Ethernet5
-  type: switched
   shutdown: false
   channel_group:
     id: 5
@@ -854,7 +853,6 @@ ethernet_interfaces:
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-SVC3B_Ethernet6
-  type: switched
   shutdown: false
   channel_group:
     id: 5
@@ -901,7 +899,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF2A_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 7
     mode: active
@@ -911,7 +908,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF2B_Ethernet1
   shutdown: false
-  type: switched
   channel_group:
     id: 7
     mode: active
@@ -921,10 +917,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: TENANT_A_B
   description: server03_ESI_Eth1
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 110-111,210-211
   channel_group:
     id: 10
     mode: active
@@ -934,8 +927,8 @@ ethernet_interfaces:
   peer_type: server
   port_profile: ALL_WITH_SECURITY
   description: server04_inherit_all_from_profile_Eth1
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk
   vlans: 1-4094
   spanning_tree_portfast: edge
@@ -959,8 +952,8 @@ ethernet_interfaces:
   peer_interface: Eth1
   peer_type: server
   description: server05_no_profile_Eth1
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk
   vlans: 1-4094
   spanning_tree_portfast: edge
@@ -985,8 +978,8 @@ ethernet_interfaces:
   peer_type: server
   port_profile: ALL_WITH_SECURITY
   description: server06_override_profile_Eth1
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '210'
   spanning_tree_portfast: network
@@ -1011,26 +1004,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: ALL_WITH_SECURITY_PORT_CHANNEL
   description: server07_inherit_all_from_profile_port_channel_Eth1
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 1-4094
-  spanning_tree_portfast: edge
-  spanning_tree_bpdufilter: 'True'
-  spanning_tree_bpduguard: 'False'
-  storm_control:
-    all:
-      level: '10'
-      unit: percent
-    broadcast:
-      level: '100'
-      unit: pps
-    multicast:
-      level: '1'
-      unit: percent
-    unknown_unicast:
-      level: '2'
-      unit: percent
   channel_group:
     id: 14
     mode: active
@@ -1039,26 +1013,7 @@ ethernet_interfaces:
   peer_interface: Eth1
   peer_type: server
   description: server08_no_profile_port_channel_Eth1
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 1-4094
-  spanning_tree_portfast: edge
-  spanning_tree_bpdufilter: 'True'
-  spanning_tree_bpduguard: 'False'
-  storm_control:
-    all:
-      level: '10'
-      unit: percent
-    broadcast:
-      level: '100'
-      unit: pps
-    multicast:
-      level: '1'
-      unit: percent
-    unknown_unicast:
-      level: '2'
-      unit: percent
   channel_group:
     id: 15
     mode: 'on'
@@ -1068,8 +1023,8 @@ ethernet_interfaces:
   peer_type: server
   port_profile: ALL_WITH_SECURITY_PORT_CHANNEL
   description: server09_override_profile_no_port_channel_Eth1
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '210'
   spanning_tree_portfast: network

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -834,6 +834,7 @@ ethernet_interfaces:
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-SVC3A_Ethernet5
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 5
@@ -843,6 +844,7 @@ ethernet_interfaces:
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-SVC3A_Ethernet6
+  type: port-channel-member
   shutdown: false
   channel_group:
     id: 5
@@ -889,6 +891,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF2A_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 7
     mode: active
@@ -898,6 +901,7 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF2B_Ethernet2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 7
     mode: active
@@ -985,6 +989,7 @@ ethernet_interfaces:
   port_profile: ALL_WITH_SECURITY_PORT_CHANNEL
   description: server07_inherit_all_from_profile_port_channel_Eth2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 14
     mode: active
@@ -994,6 +999,7 @@ ethernet_interfaces:
   peer_type: server
   description: server08_no_profile_port_channel_Eth2
   shutdown: false
+  type: port-channel-member
   channel_group:
     id: 15
     mode: 'on'

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -834,7 +834,6 @@ ethernet_interfaces:
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-SVC3A_Ethernet5
-  type: switched
   shutdown: false
   channel_group:
     id: 5
@@ -844,7 +843,6 @@ ethernet_interfaces:
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-SVC3A_Ethernet6
-  type: switched
   shutdown: false
   channel_group:
     id: 5
@@ -891,7 +889,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF2A_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 7
     mode: active
@@ -901,7 +898,6 @@ ethernet_interfaces:
   peer_type: l2leaf
   description: DC1-L2LEAF2B_Ethernet2
   shutdown: false
-  type: switched
   channel_group:
     id: 7
     mode: active
@@ -911,8 +907,8 @@ ethernet_interfaces:
   peer_type: server
   port_profile: ALL_WITH_SECURITY
   description: server04_inherit_all_from_profile_Eth2
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk
   vlans: 1-4094
   spanning_tree_portfast: edge
@@ -936,8 +932,8 @@ ethernet_interfaces:
   peer_interface: Eth2
   peer_type: server
   description: server05_no_profile_Eth2
-  type: switched
   shutdown: false
+  type: switched
   mode: trunk
   vlans: 1-4094
   spanning_tree_portfast: edge
@@ -962,8 +958,8 @@ ethernet_interfaces:
   peer_type: server
   port_profile: ALL_WITH_SECURITY
   description: server06_override_profile_Eth2
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '210'
   spanning_tree_portfast: network
@@ -988,26 +984,7 @@ ethernet_interfaces:
   peer_type: server
   port_profile: ALL_WITH_SECURITY_PORT_CHANNEL
   description: server07_inherit_all_from_profile_port_channel_Eth2
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 1-4094
-  spanning_tree_portfast: edge
-  spanning_tree_bpdufilter: 'True'
-  spanning_tree_bpduguard: 'False'
-  storm_control:
-    all:
-      level: '10'
-      unit: percent
-    broadcast:
-      level: '100'
-      unit: pps
-    multicast:
-      level: '1'
-      unit: percent
-    unknown_unicast:
-      level: '2'
-      unit: percent
   channel_group:
     id: 14
     mode: active
@@ -1016,26 +993,7 @@ ethernet_interfaces:
   peer_interface: Eth2
   peer_type: server
   description: server08_no_profile_port_channel_Eth2
-  type: switched
   shutdown: false
-  mode: trunk
-  vlans: 1-4094
-  spanning_tree_portfast: edge
-  spanning_tree_bpdufilter: 'True'
-  spanning_tree_bpduguard: 'False'
-  storm_control:
-    all:
-      level: '10'
-      unit: percent
-    broadcast:
-      level: '100'
-      unit: pps
-    multicast:
-      level: '1'
-      unit: percent
-    unknown_unicast:
-      level: '2'
-      unit: percent
   channel_group:
     id: 15
     mode: 'on'
@@ -1045,8 +1003,8 @@ ethernet_interfaces:
   peer_type: server
   port_profile: ALL_WITH_SECURITY_PORT_CHANNEL
   description: server09_override_profile_no_port_channel_Eth2
-  type: switched
   shutdown: false
+  type: switched
   mode: access
   vlans: '210'
   spanning_tree_portfast: network

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/data_model/Interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/data_model/Interfaces.md
@@ -31,7 +31,7 @@ search:
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;forwarding_profile</samp>](## "ethernet_interfaces.[].l2_protocol.forwarding_profile") | String |  |  |  | L2 protocol forwarding profile |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trunk_groups</samp>](## "ethernet_interfaces.[].trunk_groups") | List, items: String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "ethernet_interfaces.[].trunk_groups.[].&lt;str&gt;") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;type</samp>](## "ethernet_interfaces.[].type") | String |  |  | Valid Values:<br>- routed<br>- switched<br>- l3dot1q<br>- l2dot1q | l3dot1q and l2dot1q are used for sub-interfaces<br>The parent interface should be defined as routed<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;type</samp>](## "ethernet_interfaces.[].type") | String |  |  | Valid Values:<br>- routed<br>- switched<br>- l3dot1q<br>- l2dot1q | l3dot1q and l2dot1q are used for sub-interfaces. The parent interface should be defined as routed.<br>Interface will not be listed in device documentation, unless "type" is set.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;snmp_trap_link_change</samp>](## "ethernet_interfaces.[].snmp_trap_link_change") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;address_locking</samp>](## "ethernet_interfaces.[].address_locking") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4</samp>](## "ethernet_interfaces.[].address_locking.ipv4") | Boolean |  |  |  | Enable address locking for IPv4 |
@@ -747,7 +747,7 @@ search:
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;l2_mtu</samp>](## "port_channel_interfaces.[].l2_mtu") | Integer |  |  |  | "l2_mtu" should only be defined for platforms supporting the "l2 mtu" CLI<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vlans</samp>](## "port_channel_interfaces.[].vlans") | String |  |  |  | List of switchport vlans as string<br>For a trunk port this would be a range like "1-200,300"<br>For an access port this would be a single vlan "123"<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;snmp_trap_link_change</samp>](## "port_channel_interfaces.[].snmp_trap_link_change") | Boolean |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;type</samp>](## "port_channel_interfaces.[].type") | String |  |  | Valid Values:<br>- routed<br>- switched<br>- l3dot1q<br>- l2dot1q | l3dot1q and l2dot1q are used for sub-interfaces<br>The parent interface should be defined as routed<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;type</samp>](## "port_channel_interfaces.[].type") | String |  |  | Valid Values:<br>- routed<br>- switched<br>- l3dot1q<br>- l2dot1q | l3dot1q and l2dot1q are used for sub-interfaces. The parent interface should be defined as routed.<br>Interface will not be listed in device documentation, unless "type" is set.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;encapsulation_dot1q_vlan</samp>](## "port_channel_interfaces.[].encapsulation_dot1q_vlan") | Integer |  |  |  | VLAN tag to configure on sub-interface |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "port_channel_interfaces.[].vrf") | String |  |  |  | VRF name |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;encapsulation_vlan</samp>](## "port_channel_interfaces.[].encapsulation_vlan") | Dictionary |  |  |  |  |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/data_model/Interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/data_model/Interfaces.md
@@ -31,7 +31,7 @@ search:
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;forwarding_profile</samp>](## "ethernet_interfaces.[].l2_protocol.forwarding_profile") | String |  |  |  | L2 protocol forwarding profile |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trunk_groups</samp>](## "ethernet_interfaces.[].trunk_groups") | List, items: String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "ethernet_interfaces.[].trunk_groups.[].&lt;str&gt;") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;type</samp>](## "ethernet_interfaces.[].type") | String |  |  | Valid Values:<br>- routed<br>- switched<br>- l3dot1q<br>- l2dot1q | l3dot1q and l2dot1q are used for sub-interfaces. The parent interface should be defined as routed.<br>Interface will not be listed in device documentation, unless "type" is set.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;type</samp>](## "ethernet_interfaces.[].type") | String |  |  | Valid Values:<br>- routed<br>- switched<br>- l3dot1q<br>- l2dot1q<br>- port-channel-member | l3dot1q and l2dot1q are used for sub-interfaces. The parent interface should be defined as routed.<br>Interface will not be listed in device documentation, unless "type" is set.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;snmp_trap_link_change</samp>](## "ethernet_interfaces.[].snmp_trap_link_change") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;address_locking</samp>](## "ethernet_interfaces.[].address_locking") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4</samp>](## "ethernet_interfaces.[].address_locking.ipv4") | Boolean |  |  |  | Enable address locking for IPv4 |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -1804,7 +1804,7 @@
               "l3dot1q",
               "l2dot1q"
             ],
-            "description": "l3dot1q and l2dot1q are used for sub-interfaces\nThe parent interface should be defined as routed\n",
+            "description": "l3dot1q and l2dot1q are used for sub-interfaces. The parent interface should be defined as routed.\nInterface will not be listed in device documentation, unless \"type\" is set.\n",
             "title": "Type"
           },
           "snmp_trap_link_change": {
@@ -8906,7 +8906,7 @@
               "l3dot1q",
               "l2dot1q"
             ],
-            "description": "l3dot1q and l2dot1q are used for sub-interfaces\nThe parent interface should be defined as routed\n",
+            "description": "l3dot1q and l2dot1q are used for sub-interfaces. The parent interface should be defined as routed.\nInterface will not be listed in device documentation, unless \"type\" is set.\n",
             "title": "Type"
           },
           "encapsulation_dot1q_vlan": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -1802,7 +1802,8 @@
               "routed",
               "switched",
               "l3dot1q",
-              "l2dot1q"
+              "l2dot1q",
+              "port-channel-member"
             ],
             "description": "l3dot1q and l2dot1q are used for sub-interfaces. The parent interface should be defined as routed.\nInterface will not be listed in device documentation, unless \"type\" is set.\n",
             "title": "Type"

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -1298,6 +1298,7 @@ keys:
           - switched
           - l3dot1q
           - l2dot1q
+          - port-channel-member
           description: 'l3dot1q and l2dot1q are used for sub-interfaces. The parent
             interface should be defined as routed.
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -1298,9 +1298,11 @@ keys:
           - switched
           - l3dot1q
           - l2dot1q
-          description: 'l3dot1q and l2dot1q are used for sub-interfaces
+          description: 'l3dot1q and l2dot1q are used for sub-interfaces. The parent
+            interface should be defined as routed.
 
-            The parent interface should be defined as routed
+            Interface will not be listed in device documentation, unless "type" is
+            set.
 
             '
         snmp_trap_link_change:
@@ -5624,9 +5626,11 @@ keys:
           - switched
           - l3dot1q
           - l2dot1q
-          description: 'l3dot1q and l2dot1q are used for sub-interfaces
+          description: 'l3dot1q and l2dot1q are used for sub-interfaces. The parent
+            interface should be defined as routed.
 
-            The parent interface should be defined as routed
+            Interface will not be listed in device documentation, unless "type" is
+            set.
 
             '
         encapsulation_dot1q_vlan:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ethernet_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ethernet_interfaces.schema.yml
@@ -89,8 +89,8 @@ keys:
           type: str
           valid_values: ["routed", "switched", "l3dot1q", "l2dot1q"]
           description: |
-            l3dot1q and l2dot1q are used for sub-interfaces
-            The parent interface should be defined as routed
+            l3dot1q and l2dot1q are used for sub-interfaces. The parent interface should be defined as routed.
+            Interface will not be listed in device documentation, unless "type" is set.
         snmp_trap_link_change:
           type: bool
         address_locking:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ethernet_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ethernet_interfaces.schema.yml
@@ -87,7 +87,7 @@ keys:
             type: str
         type:
           type: str
-          valid_values: ["routed", "switched", "l3dot1q", "l2dot1q"]
+          valid_values: ["routed", "switched", "l3dot1q", "l2dot1q", "port-channel-member"]
           description: |
             l3dot1q and l2dot1q are used for sub-interfaces. The parent interface should be defined as routed.
             Interface will not be listed in device documentation, unless "type" is set.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/port_channel_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/port_channel_interfaces.schema.yml
@@ -52,8 +52,8 @@ keys:
           - l3dot1q
           - l2dot1q
           description: |
-            l3dot1q and l2dot1q are used for sub-interfaces
-            The parent interface should be defined as routed
+            l3dot1q and l2dot1q are used for sub-interfaces. The parent interface should be defined as routed.
+            Interface will not be listed in device documentation, unless "type" is set.
         encapsulation_dot1q_vlan:
           type: int
           description: VLAN tag to configure on sub-interface

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ethernet-interfaces.j2
@@ -16,7 +16,7 @@
                                                                       arista.avd.convert_dicts('name') |
                                                                       selectattr('name', 'arista.avd.defined', port_channel_interface_name) |
                                                                       first %}
-{%             if port_channel_interface.type is not defined or port_channel_interface.type not in ['routed', 'l3dot1q', 'l2dot1q'] %}
+{%             if port_channel_interface.type is arista.avd.defined('switched') %}
 {%                 set description = ethernet_interface.description | arista.avd.default("-") %}
 {%                 set mode = port_channel_interface.mode | arista.avd.default("access") %}
 {%                 set vlans = port_channel_interface.vlans | arista.avd.default('-') %}
@@ -38,7 +38,7 @@
 {%                 endif %}
 | {{ ethernet_interface.name }} | {{ description }} | *{{ mode }} | *{{ vlans }} | *{{ native_vlan }} | *{{ l2.trunk_groups }} | {{ channel_group }} |
 {%             endif %}
-{%         elif ethernet_interface.type is not defined or ethernet_interface.type not in ['routed', 'l3dot1q', 'l2dot1q'] %}
+{%         elif ethernet_interface.type is arista.avd.defined('switched') %}
 {%             set description = ethernet_interface.description | arista.avd.default("-") %}
 {%             set mode = ethernet_interface.mode | arista.avd.default("access") %}
 {%             set vlans = ethernet_interface.vlans | arista.avd.default('-') %}
@@ -255,7 +255,7 @@
                                                                           first %}
 {%                 if port_channel_interface.ip_address is arista.avd.defined %}
 {%                     set description = ethernet_interface.description | arista.avd.default("-") %}
-{%                     set type = port_channel_interface.type | arista.avd.default("*switchport") %}
+{%                     set type = port_channel_interface.type | arista.avd.default("-") %}
 {%                     set channel_group = ethernet_interface.channel_group.id | arista.avd.default("-") %}
 {%                     set ip_address = port_channel_interface.ip_address | arista.avd.default("-") %}
 {%                     set vrf = port_channel_interface.vrf | arista.avd.default("*default") %}
@@ -268,7 +268,7 @@
 {%             else %}
 {%                 if ethernet_interface.ip_address is arista.avd.defined %}
 {%                     set description = ethernet_interface.description | arista.avd.default("-") %}
-{%                     set type = ethernet_interface.type | arista.avd.default("switchport") %}
+{%                     set type = ethernet_interface.type | arista.avd.default("-") %}
 {%                     set ip_address = ethernet_interface.ip_address | arista.avd.default("-") %}
 {%                     set vrf = ethernet_interface.vrf | arista.avd.default("default") %}
 {%                     set mtu = ethernet_interface.mtu | arista.avd.default("-") %}
@@ -322,7 +322,7 @@
                                                                           first %}
 {%                 if port_channel_interface.ipv6_address is arista.avd.defined or port_channel_interface.ipv6_enable is arista.avd.defined(true) %}
 {%                     set description = ethernet_interface.description | arista.avd.default("-") %}
-{%                     set type = port_channel_interface.type | arista.avd.default("switchport") %}
+{%                     set type = port_channel_interface.type | arista.avd.default("-") %}
 {%                     set channel_group = ethernet_interface.channel_group.id | arista.avd.default("-") %}
 {%                     set ipv6_address = port_channel_interface.ipv6_address | arista.avd.default("-") %}
 {%                     set vrf = port_channel_interface.vrf | arista.avd.default("default") %}
@@ -337,7 +337,7 @@
 {%             else %}
 {%                 if ethernet_interface.ipv6_address is arista.avd.defined or ethernet_interface.ipv6_enable is arista.avd.defined(true) %}
 {%                     set description = ethernet_interface.description | arista.avd.default("-") %}
-{%                     set type = ethernet_interface.type | arista.avd.default("switchport") %}
+{%                     set type = ethernet_interface.type | arista.avd.default("-") %}
 {%                     set ipv6_address = ethernet_interface.ipv6_address | arista.avd.default("-") %}
 {%                     set vrf = ethernet_interface.vrf | arista.avd.default("default") %}
 {%                     set mtu = ethernet_interface.mtu | arista.avd.default("-") %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ethernet-interfaces.j2
@@ -16,7 +16,7 @@
                                                                       arista.avd.convert_dicts('name') |
                                                                       selectattr('name', 'arista.avd.defined', port_channel_interface_name) |
                                                                       first %}
-{%             if port_channel_interface.type is arista.avd.defined('switched') %}
+{%             if port_channel_interface.type | arista.avd.default('switched') == 'switched' %}
 {%                 set description = ethernet_interface.description | arista.avd.default("-") %}
 {%                 set mode = port_channel_interface.mode | arista.avd.default("access") %}
 {%                 set vlans = port_channel_interface.vlans | arista.avd.default('-') %}
@@ -38,7 +38,7 @@
 {%                 endif %}
 | {{ ethernet_interface.name }} | {{ description }} | *{{ mode }} | *{{ vlans }} | *{{ native_vlan }} | *{{ l2.trunk_groups }} | {{ channel_group }} |
 {%             endif %}
-{%         elif ethernet_interface.type is arista.avd.defined('switched') %}
+{%         elif ethernet_interface.type | arista.avd.default('switched') == 'switched' %}
 {%             set description = ethernet_interface.description | arista.avd.default("-") %}
 {%             set mode = ethernet_interface.mode | arista.avd.default("access") %}
 {%             set vlans = ethernet_interface.vlans | arista.avd.default('-') %}
@@ -255,7 +255,7 @@
                                                                           first %}
 {%                 if port_channel_interface.ip_address is arista.avd.defined %}
 {%                     set description = ethernet_interface.description | arista.avd.default("-") %}
-{%                     set type = port_channel_interface.type | arista.avd.default("-") %}
+{%                     set type = port_channel_interface.type | arista.avd.default("*switchport") %}
 {%                     set channel_group = ethernet_interface.channel_group.id | arista.avd.default("-") %}
 {%                     set ip_address = port_channel_interface.ip_address | arista.avd.default("-") %}
 {%                     set vrf = port_channel_interface.vrf | arista.avd.default("*default") %}
@@ -268,7 +268,7 @@
 {%             else %}
 {%                 if ethernet_interface.ip_address is arista.avd.defined %}
 {%                     set description = ethernet_interface.description | arista.avd.default("-") %}
-{%                     set type = ethernet_interface.type | arista.avd.default("-") %}
+{%                     set type = ethernet_interface.type | arista.avd.default("switchport") %}
 {%                     set ip_address = ethernet_interface.ip_address | arista.avd.default("-") %}
 {%                     set vrf = ethernet_interface.vrf | arista.avd.default("default") %}
 {%                     set mtu = ethernet_interface.mtu | arista.avd.default("-") %}
@@ -322,7 +322,7 @@
                                                                           first %}
 {%                 if port_channel_interface.ipv6_address is arista.avd.defined or port_channel_interface.ipv6_enable is arista.avd.defined(true) %}
 {%                     set description = ethernet_interface.description | arista.avd.default("-") %}
-{%                     set type = port_channel_interface.type | arista.avd.default("-") %}
+{%                     set type = port_channel_interface.type | arista.avd.default("switchport") %}
 {%                     set channel_group = ethernet_interface.channel_group.id | arista.avd.default("-") %}
 {%                     set ipv6_address = port_channel_interface.ipv6_address | arista.avd.default("-") %}
 {%                     set vrf = port_channel_interface.vrf | arista.avd.default("default") %}
@@ -337,7 +337,7 @@
 {%             else %}
 {%                 if ethernet_interface.ipv6_address is arista.avd.defined or ethernet_interface.ipv6_enable is arista.avd.defined(true) %}
 {%                     set description = ethernet_interface.description | arista.avd.default("-") %}
-{%                     set type = ethernet_interface.type | arista.avd.default("-") %}
+{%                     set type = ethernet_interface.type | arista.avd.default("switchport") %}
 {%                     set ipv6_address = ethernet_interface.ipv6_address | arista.avd.default("-") %}
 {%                     set vrf = ethernet_interface.vrf | arista.avd.default("default") %}
 {%                     set mtu = ethernet_interface.mtu | arista.avd.default("-") %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/port-channel-interfaces.j2
@@ -10,9 +10,9 @@
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
 {%     for port_channel_interface in port_channel_interfaces | arista.avd.natural_sort('name') %}
-{%         if port_channel_interface.type is arista.avd.defined("switched") %}
+{%         if port_channel_interface.type | arista.avd.default("switched") == 'switched' %}
 {%             set description = port_channel_interface.description | arista.avd.default("-") %}
-{%             set type = port_channel_interface.type %}
+{%             set type = port_channel_interface.type | arista.avd.default("switched") %}
 {%             set mode = port_channel_interface.mode | arista.avd.default("access") %}
 {%             set vlans = port_channel_interface.vlans | arista.avd.default("-") %}
 {%             if  port_channel_interface.native_vlan_tag is arista.avd.defined(true) %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/port-channel-interfaces.j2
@@ -10,9 +10,9 @@
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
 {%     for port_channel_interface in port_channel_interfaces | arista.avd.natural_sort('name') %}
-{%         if port_channel_interface.type is not defined or port_channel_interface.type not in ['routed', 'l3dot1q', 'l2dot1q'] %}
+{%         if port_channel_interface.type is arista.avd.defined("switched") %}
 {%             set description = port_channel_interface.description | arista.avd.default("-") %}
-{%             set type = port_channel_interface.type | arista.avd.default("switched") %}
+{%             set type = port_channel_interface.type %}
 {%             set mode = port_channel_interface.mode | arista.avd.default("access") %}
 {%             set vlans = port_channel_interface.vlans | arista.avd.default("-") %}
 {%             if  port_channel_interface.native_vlan_tag is arista.avd.defined(true) %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -1,24 +1,10 @@
 {# eos - ethernet interfaces #}
 {% set POE_CLASS_MAP = {0: "15.40", 1: "4.00", 2: "7.00", 3: "15.40", 4: "30.00", 5: "45.00", 6: "60.00", 7: "75.00", 8: "90.00"} %}
 {% for ethernet_interface in ethernet_interfaces | arista.avd.natural_sort('name') %}
-{%     if ethernet_interface.channel_group.id is arista.avd.defined and ethernet_interface.channel_group.mode is arista.avd.defined %}
-{%         set port_channel_interface_name = 'Port-Channel' ~ ethernet_interface.channel_group.id %}
-{%         if port_channel_interfaces | arista.avd.default([]) |
-                                        arista.avd.convert_dicts('name') |
-                                        selectattr('name', 'arista.avd.defined', port_channel_interface_name) |
-                                        selectattr('lacp_fallback_mode', 'arista.avd.defined', 'individual') |
-                                        length > 0 %}
-{%             set print_ethernet = true %}
-{%         endif %}
-{%     else %}
-{%         set print_ethernet = true %}
-{%     endif %}
 !
 interface {{ ethernet_interface.name }}
-{%     if print_ethernet is arista.avd.defined(true) %}
-{%         if ethernet_interface.profile is arista.avd.defined %}
+{%     if ethernet_interface.profile is arista.avd.defined %}
    profile {{ ethernet_interface.profile }}
-{%         endif %}
 {%     endif %}
 {%     if ethernet_interface.description is arista.avd.defined %}
    description {{ ethernet_interface.description }}
@@ -31,10 +17,8 @@ interface {{ ethernet_interface.name }}
 {%     if ethernet_interface.load_interval is arista.avd.defined %}
    load-interval {{ ethernet_interface.load_interval }}
 {%     endif %}
-{%     if print_ethernet is arista.avd.defined(true) %}
-{%         if ethernet_interface.mtu is arista.avd.defined %}
+{%     if ethernet_interface.mtu is arista.avd.defined %}
    mtu {{ ethernet_interface.mtu }}
-{%         endif %}
 {%     endif %}
 {%     if ethernet_interface.logging.event is arista.avd.defined %}
 {%         if ethernet_interface.logging.event.link_status is arista.avd.defined(true) %}
@@ -58,18 +42,14 @@ interface {{ ethernet_interface.name }}
    no logging event storm-control
 {%         endif %}
 {%     endif %}
-{%     if print_ethernet is arista.avd.defined(true) %}
-{%         if ethernet_interface.flowcontrol.received is arista.avd.defined %}
+{%     if ethernet_interface.flowcontrol.received is arista.avd.defined %}
    flowcontrol receive {{ ethernet_interface.flowcontrol.received }}
-{%         endif %}
 {%     endif %}
 {%     if ethernet_interface.speed is arista.avd.defined %}
    speed {{ ethernet_interface.speed }}
 {%     endif %}
-{%     if print_ethernet is arista.avd.defined(true) %}
-{%         if ethernet_interface.l2_mtu is arista.avd.defined %}
+{%     if ethernet_interface.l2_mtu is arista.avd.defined %}
    l2 mtu {{ ethernet_interface.l2_mtu }}
-{%         endif %}
 {%     endif %}
 {%     if ethernet_interface.bgp.session_tracker is arista.avd.defined %}
    bgp session tracker {{ ethernet_interface.bgp.session_tracker }}
@@ -91,297 +71,295 @@ interface {{ ethernet_interface.name }}
    no error-correction encoding reed-solomon
 {%         endif %}
 {%     endif %}
-{%     if print_ethernet is arista.avd.defined(true) %}
-{%         if ethernet_interface.mode is arista.avd.defined('access') or ethernet_interface.mode is arista.avd.defined('dot1q-tunnel') %}
-{%             if ethernet_interface.vlans is arista.avd.defined %}
+{%     if ethernet_interface.mode is arista.avd.defined('access') or ethernet_interface.mode is arista.avd.defined('dot1q-tunnel') %}
+{%         if ethernet_interface.vlans is arista.avd.defined %}
    switchport access vlan {{ ethernet_interface.vlans }}
-{%             endif %}
 {%         endif %}
-{%         if ethernet_interface.mode is arista.avd.defined and ethernet_interface.mode in ['trunk', 'trunk phone'] %}
-{%             if ethernet_interface.native_vlan_tag is arista.avd.defined(true) %}
+{%     endif %}
+{%     if ethernet_interface.mode is arista.avd.defined and ethernet_interface.mode in ['trunk', 'trunk phone'] %}
+{%         if ethernet_interface.native_vlan_tag is arista.avd.defined(true) %}
    switchport trunk native vlan tag
-{%             elif ethernet_interface.native_vlan is arista.avd.defined %}
+{%         elif ethernet_interface.native_vlan is arista.avd.defined %}
    switchport trunk native vlan {{ ethernet_interface.native_vlan }}
-{%             endif %}
 {%         endif %}
-{%         if ethernet_interface.phone.vlan is arista.avd.defined %}
+{%     endif %}
+{%     if ethernet_interface.phone.vlan is arista.avd.defined %}
    switchport phone vlan {{ ethernet_interface.phone.vlan }}
-{%         endif %}
-{%         if ethernet_interface.phone.trunk is arista.avd.defined %}
+{%     endif %}
+{%     if ethernet_interface.phone.trunk is arista.avd.defined %}
    switchport phone trunk {{ ethernet_interface.phone.trunk }}
-{%         endif %}
-{%         for vlan_translation in ethernet_interface.vlan_translations | arista.avd.natural_sort %}
-{%             if vlan_translation.from is arista.avd.defined and vlan_translation.to is arista.avd.defined %}
-{%                 set vlan_translation_cli = 'switchport vlan translation' %}
-{%                 if vlan_translation.direction | arista.avd.default in ['in', 'out'] %}
-{%                     set vlan_translation_cli = vlan_translation_cli ~ ' ' ~ vlan_translation.direction %}
-{%                 endif %}
-{%                 set vlan_translation_cli = vlan_translation_cli ~ ' ' ~ vlan_translation.from %}
-{%                 set vlan_translation_cli = vlan_translation_cli ~ ' ' ~ vlan_translation.to %}
+{%     endif %}
+{%     for vlan_translation in ethernet_interface.vlan_translations | arista.avd.natural_sort %}
+{%         if vlan_translation.from is arista.avd.defined and vlan_translation.to is arista.avd.defined %}
+{%             set vlan_translation_cli = 'switchport vlan translation' %}
+{%             if vlan_translation.direction | arista.avd.default in ['in', 'out'] %}
+{%                 set vlan_translation_cli = vlan_translation_cli ~ ' ' ~ vlan_translation.direction %}
+{%             endif %}
+{%             set vlan_translation_cli = vlan_translation_cli ~ ' ' ~ vlan_translation.from %}
+{%             set vlan_translation_cli = vlan_translation_cli ~ ' ' ~ vlan_translation.to %}
    {{ vlan_translation_cli }}
-{%             endif %}
-{%         endfor %}
-{%         if ethernet_interface.mode is arista.avd.defined('trunk') %}
-{%             if ethernet_interface.vlans is arista.avd.defined %}
+{%         endif %}
+{%     endfor %}
+{%     if ethernet_interface.mode is arista.avd.defined('trunk') %}
+{%         if ethernet_interface.vlans is arista.avd.defined %}
    switchport trunk allowed vlan {{ ethernet_interface.vlans }}
-{%             endif %}
 {%         endif %}
-{%         if ethernet_interface.mode is arista.avd.defined %}
+{%     endif %}
+{%     if ethernet_interface.mode is arista.avd.defined %}
    switchport mode {{ ethernet_interface.mode }}
-{%         endif %}
-{%         for trunk_group in ethernet_interface.trunk_groups | arista.avd.natural_sort %}
+{%     endif %}
+{%     for trunk_group in ethernet_interface.trunk_groups | arista.avd.natural_sort %}
    switchport trunk group {{ trunk_group }}
-{%         endfor %}
-{%         if ethernet_interface.type is arista.avd.defined('routed') %}
+{%     endfor %}
+{%     if ethernet_interface.type is arista.avd.defined('routed') %}
    no switchport
-{%         elif ethernet_interface.type | arista.avd.default in ['l3dot1q', 'l2dot1q'] %}
-{%             if ethernet_interface.vlan_id is arista.avd.defined and
-                  ethernet_interface.type == 'l2dot1q' %}
+{%     elif ethernet_interface.type | arista.avd.default in ['l3dot1q', 'l2dot1q'] %}
+{%         if ethernet_interface.vlan_id is arista.avd.defined and
+               ethernet_interface.type == 'l2dot1q' %}
    vlan id {{ ethernet_interface.vlan_id }}
-{%             endif %}
-{%             if ethernet_interface.encapsulation_dot1q_vlan is arista.avd.defined %}
+{%         endif %}
+{%         if ethernet_interface.encapsulation_dot1q_vlan is arista.avd.defined %}
    encapsulation dot1q vlan {{ ethernet_interface.encapsulation_dot1q_vlan }}
-{%             elif ethernet_interface.encapsulation_vlan.client.dot1q.vlan is arista.avd.defined() %}
-{%                 set encapsulation_cli = "client dot1q " ~ ethernet_interface.encapsulation_vlan.client.dot1q.vlan %}
-{%                 if ethernet_interface.encapsulation_vlan.network.dot1q.vlan is arista.avd.defined() %}
-{%                     set encapsulation_cli = encapsulation_cli ~ " network dot1q " ~ ethernet_interface.encapsulation_vlan.network.dot1q.vlan %}
-{%                 elif ethernet_interface.encapsulation_vlan.network.client is arista.avd.defined(true) %}
-{%                     set encapsulation_cli = encapsulation_cli ~ " network client" %}
-{%                 endif %}
-{%             elif ethernet_interface.encapsulation_vlan.client.dot1q.inner is arista.avd.defined and ethernet_interface.encapsulation_vlan.client.dot1q.outer is arista.avd.defined %}
-{%                 set encapsulation_cli = "client dot1q outer " ~ ethernet_interface.encapsulation_vlan.client.dot1q.outer ~ " inner " ~ ethernet_interface.encapsulation_vlan.client.dot1q.inner %}
-{%                 if ethernet_interface.encapsulation_vlan.network.dot1q.inner is arista.avd.defined and ethernet_interface.encapsulation_vlan.network.dot1q.outer is arista.avd.defined %}
-{%                     set encapsulation_cli = encapsulation_cli ~ " network dot1q outer " ~ ethernet_interface.encapsulation_vlan.network.dot1q.inner ~ " inner " ~ ethernet_interface.encapsulation_vlan.network.dot1q.outer %}
-{%                 elif ethernet_interface.encapsulation_vlan.network.dot1q.client is arista.avd.defined(true) %}
-{%                     set encapsulation_cli = encapsulation_cli ~ " network client" %}
-{%                 endif %}
-{%             elif ethernet_interface.encapsulation_vlan.client.unmatched is arista.avd.defined(true) %}
-{%                 set encapsulation_cli = "client unmatched" %}
+{%         elif ethernet_interface.encapsulation_vlan.client.dot1q.vlan is arista.avd.defined() %}
+{%             set encapsulation_cli = "client dot1q " ~ ethernet_interface.encapsulation_vlan.client.dot1q.vlan %}
+{%             if ethernet_interface.encapsulation_vlan.network.dot1q.vlan is arista.avd.defined() %}
+{%                 set encapsulation_cli = encapsulation_cli ~ " network dot1q " ~ ethernet_interface.encapsulation_vlan.network.dot1q.vlan %}
+{%             elif ethernet_interface.encapsulation_vlan.network.client is arista.avd.defined(true) %}
+{%                 set encapsulation_cli = encapsulation_cli ~ " network client" %}
 {%             endif %}
-{%             if encapsulation_cli is arista.avd.defined %}
+{%         elif ethernet_interface.encapsulation_vlan.client.dot1q.inner is arista.avd.defined and ethernet_interface.encapsulation_vlan.client.dot1q.outer is arista.avd.defined %}
+{%             set encapsulation_cli = "client dot1q outer " ~ ethernet_interface.encapsulation_vlan.client.dot1q.outer ~ " inner " ~ ethernet_interface.encapsulation_vlan.client.dot1q.inner %}
+{%             if ethernet_interface.encapsulation_vlan.network.dot1q.inner is arista.avd.defined and ethernet_interface.encapsulation_vlan.network.dot1q.outer is arista.avd.defined %}
+{%                 set encapsulation_cli = encapsulation_cli ~ " network dot1q outer " ~ ethernet_interface.encapsulation_vlan.network.dot1q.inner ~ " inner " ~ ethernet_interface.encapsulation_vlan.network.dot1q.outer %}
+{%             elif ethernet_interface.encapsulation_vlan.network.dot1q.client is arista.avd.defined(true) %}
+{%                 set encapsulation_cli = encapsulation_cli ~ " network client" %}
+{%             endif %}
+{%         elif ethernet_interface.encapsulation_vlan.client.unmatched is arista.avd.defined(true) %}
+{%             set encapsulation_cli = "client unmatched" %}
+{%         endif %}
+{%         if encapsulation_cli is arista.avd.defined %}
    encapsulation vlan
       {{ encapsulation_cli }}
-{%             endif %}
-{%         else %}
+{%         endif %}
+{%     elif ethernet_interface.type is arista.avd.defined('switched') %}
    switchport
-{%         endif %}
-{%         if ethernet_interface.trunk_private_vlan_secondary is arista.avd.defined(true) %}
+{%     endif %}
+{%     if ethernet_interface.trunk_private_vlan_secondary is arista.avd.defined(true) %}
    switchport trunk private-vlan secondary
-{%         elif ethernet_interface.trunk_private_vlan_secondary is arista.avd.defined(false) %}
+{%     elif ethernet_interface.trunk_private_vlan_secondary is arista.avd.defined(false) %}
    no switchport trunk private-vlan secondary
-{%         endif %}
-{%         if ethernet_interface.pvlan_mapping is arista.avd.defined %}
+{%     endif %}
+{%     if ethernet_interface.pvlan_mapping is arista.avd.defined %}
    switchport pvlan mapping {{ ethernet_interface.pvlan_mapping }}
-{%         endif %}
-{%         if ethernet_interface.l2_protocol.encapsulation_dot1q_vlan is arista.avd.defined %}
+{%     endif %}
+{%     if ethernet_interface.l2_protocol.encapsulation_dot1q_vlan is arista.avd.defined %}
    l2-protocol encapsulation dot1q vlan {{ ethernet_interface.l2_protocol.encapsulation_dot1q_vlan }}
-{%         endif %}
-{%         if ethernet_interface.l2_protocol.forwarding_profile is arista.avd.defined %}
+{%     endif %}
+{%     if ethernet_interface.l2_protocol.forwarding_profile is arista.avd.defined %}
    l2-protocol forwarding profile {{ ethernet_interface.l2_protocol.forwarding_profile }}
-{%         endif %}
-{%         if ethernet_interface.flow_tracker.sampled is arista.avd.defined %}
+{%     endif %}
+{%     if ethernet_interface.flow_tracker.sampled is arista.avd.defined %}
    flow tracker sampled {{ ethernet_interface.flow_tracker.sampled }}
-{%         endif %}
-{%         if ethernet_interface.evpn_ethernet_segment is arista.avd.defined %}
+{%     endif %}
+{%     if ethernet_interface.evpn_ethernet_segment is arista.avd.defined %}
    evpn ethernet-segment
-{%             if ethernet_interface.evpn_ethernet_segment.identifier is arista.avd.defined %}
+{%         if ethernet_interface.evpn_ethernet_segment.identifier is arista.avd.defined %}
       identifier {{ ethernet_interface.evpn_ethernet_segment.identifier }}
-{%             endif %}
-{%             if ethernet_interface.evpn_ethernet_segment.redundancy is arista.avd.defined %}
+{%         endif %}
+{%         if ethernet_interface.evpn_ethernet_segment.redundancy is arista.avd.defined %}
       redundancy {{ ethernet_interface.evpn_ethernet_segment.redundancy }}
-{%             endif %}
-{%             if ethernet_interface.evpn_ethernet_segment.designated_forwarder_election is arista.avd.defined %}
-{%                 if ethernet_interface.evpn_ethernet_segment.designated_forwarder_election.algorithm is arista.avd.defined("modulus") %}
+{%         endif %}
+{%         if ethernet_interface.evpn_ethernet_segment.designated_forwarder_election is arista.avd.defined %}
+{%             if ethernet_interface.evpn_ethernet_segment.designated_forwarder_election.algorithm is arista.avd.defined("modulus") %}
       designated-forwarder election algorithm modulus
-{%                 elif ethernet_interface.evpn_ethernet_segment.designated_forwarder_election.algorithm is arista.avd.defined("preference") and ethernet_interface.evpn_ethernet_segment.designated_forwarder_election.preference_value is arista.avd.defined %}
-{%                     set dfe_algo_cli = "designated-forwarder election algorithm preference " ~ ethernet_interface.evpn_ethernet_segment.designated_forwarder_election.preference_value %}
-{%                     if ethernet_interface.evpn_ethernet_segment.designated_forwarder_election.dont_preempt is arista.avd.defined(true) %}
-{%                         set dfe_algo_cli = dfe_algo_cli ~ " dont-preempt" %}
-{%                     endif %}
+{%             elif ethernet_interface.evpn_ethernet_segment.designated_forwarder_election.algorithm is arista.avd.defined("preference") and ethernet_interface.evpn_ethernet_segment.designated_forwarder_election.preference_value is arista.avd.defined %}
+{%                 set dfe_algo_cli = "designated-forwarder election algorithm preference " ~ ethernet_interface.evpn_ethernet_segment.designated_forwarder_election.preference_value %}
+{%                 if ethernet_interface.evpn_ethernet_segment.designated_forwarder_election.dont_preempt is arista.avd.defined(true) %}
+{%                     set dfe_algo_cli = dfe_algo_cli ~ " dont-preempt" %}
+{%                 endif %}
       {{ dfe_algo_cli }}
+{%             endif %}
+{%             if ethernet_interface.evpn_ethernet_segment.designated_forwarder_election.hold_time is arista.avd.defined %}
+{%                 set dfe_hold_time_cli = "designated-forwarder election hold-time " ~ ethernet_interface.evpn_ethernet_segment.designated_forwarder_election.hold_time %}
+{%                 if ethernet_interface.evpn_ethernet_segment.designated_forwarder_election.subsequent_hold_time is arista.avd.defined %}
+{%                     set dfe_hold_time_cli = dfe_hold_time_cli ~ " subsequent-hold-time " ~ ethernet_interface.evpn_ethernet_segment.designated_forwarder_election.subsequent_hold_time %}
 {%                 endif %}
-{%                 if ethernet_interface.evpn_ethernet_segment.designated_forwarder_election.hold_time is arista.avd.defined %}
-{%                     set dfe_hold_time_cli = "designated-forwarder election hold-time " ~ ethernet_interface.evpn_ethernet_segment.designated_forwarder_election.hold_time %}
-{%                     if ethernet_interface.evpn_ethernet_segment.designated_forwarder_election.subsequent_hold_time is arista.avd.defined %}
-{%                         set dfe_hold_time_cli = dfe_hold_time_cli ~ " subsequent-hold-time " ~ ethernet_interface.evpn_ethernet_segment.designated_forwarder_election.subsequent_hold_time %}
-{%                     endif %}
       {{ dfe_hold_time_cli }}
-{%                 endif %}
-{%                 if ethernet_interface.evpn_ethernet_segment.designated_forwarder_election.candidate_reachability_required is arista.avd.defined(true) %}
+{%             endif %}
+{%             if ethernet_interface.evpn_ethernet_segment.designated_forwarder_election.candidate_reachability_required is arista.avd.defined(true) %}
       designated-forwarder election candidate reachability required
-{%                 elif ethernet_interface.evpn_ethernet_segment.designated_forwarder_election.candidate_reachability_required is arista.avd.defined(false) %}
+{%             elif ethernet_interface.evpn_ethernet_segment.designated_forwarder_election.candidate_reachability_required is arista.avd.defined(false) %}
       no designated-forwarder election candidate reachability required
-{%                 endif %}
 {%             endif %}
-{%             if ethernet_interface.evpn_ethernet_segment.mpls.tunnel_flood_filter_time is arista.avd.defined %}
+{%         endif %}
+{%         if ethernet_interface.evpn_ethernet_segment.mpls.tunnel_flood_filter_time is arista.avd.defined %}
       mpls tunnel flood filter time {{ ethernet_interface.evpn_ethernet_segment.mpls.tunnel_flood_filter_time }}
-{%             endif %}
-{%             if ethernet_interface.evpn_ethernet_segment.mpls.shared_index is arista.avd.defined %}
+{%         endif %}
+{%         if ethernet_interface.evpn_ethernet_segment.mpls.shared_index is arista.avd.defined %}
       mpls shared index {{ ethernet_interface.evpn_ethernet_segment.mpls.shared_index }}
-{%             endif %}
-{%             if ethernet_interface.evpn_ethernet_segment.route_target is arista.avd.defined %}
+{%         endif %}
+{%         if ethernet_interface.evpn_ethernet_segment.route_target is arista.avd.defined %}
       route-target import {{ ethernet_interface.evpn_ethernet_segment.route_target }}
-{%             endif %}
 {%         endif %}
-{%         if ethernet_interface.dot1x is arista.avd.defined %}
-{%             if ethernet_interface.dot1x.pae.mode is arista.avd.defined %}
+{%     endif %}
+{%     if ethernet_interface.dot1x is arista.avd.defined %}
+{%         if ethernet_interface.dot1x.pae.mode is arista.avd.defined %}
    dot1x pae {{ ethernet_interface.dot1x.pae.mode }}
-{%             endif %}
-{%             if ethernet_interface.dot1x.authentication_failure is arista.avd.defined %}
-{%                 if ethernet_interface.dot1x.authentication_failure.action is arista.avd.defined('allow') and
-                      ethernet_interface.dot1x.authentication_failure.allow_vlan is arista.avd.defined %}
+{%         endif %}
+{%         if ethernet_interface.dot1x.authentication_failure is arista.avd.defined %}
+{%             if ethernet_interface.dot1x.authentication_failure.action is arista.avd.defined('allow') and
+                  ethernet_interface.dot1x.authentication_failure.allow_vlan is arista.avd.defined %}
    dot1x authentication failure action traffic allow vlan {{ ethernet_interface.dot1x.authentication_failure.allow_vlan }}
-{%                 elif ethernet_interface.dot1x.authentication_failure.action is arista.avd.defined('drop') %}
+{%             elif ethernet_interface.dot1x.authentication_failure.action is arista.avd.defined('drop') %}
    dot1x authentication failure action traffic drop
-{%                 endif %}
 {%             endif %}
-{%             if ethernet_interface.dot1x.reauthentication is arista.avd.defined(true) %}
+{%         endif %}
+{%         if ethernet_interface.dot1x.reauthentication is arista.avd.defined(true) %}
    dot1x reauthentication
-{%             endif %}
-{%             if ethernet_interface.dot1x.port_control is arista.avd.defined %}
+{%         endif %}
+{%         if ethernet_interface.dot1x.port_control is arista.avd.defined %}
    dot1x port-control {{ ethernet_interface.dot1x.port_control }}
-{%             endif %}
-{%             if ethernet_interface.dot1x.port_control_force_authorized_phone is arista.avd.defined(true) %}
+{%         endif %}
+{%         if ethernet_interface.dot1x.port_control_force_authorized_phone is arista.avd.defined(true) %}
    dot1x port-control force-authorized phone
-{%             elif ethernet_interface.dot1x.port_control_force_authorized_phone is arista.avd.defined(false) %}
+{%         elif ethernet_interface.dot1x.port_control_force_authorized_phone is arista.avd.defined(false) %}
    no dot1x port-control force-authorized phone
-{%             endif %}
-{%             if ethernet_interface.dot1x.host_mode is arista.avd.defined %}
-{%                 if ethernet_interface.dot1x.host_mode.mode is arista.avd.defined('single-host') %}
+{%         endif %}
+{%         if ethernet_interface.dot1x.host_mode is arista.avd.defined %}
+{%             if ethernet_interface.dot1x.host_mode.mode is arista.avd.defined('single-host') %}
    dot1x host-mode single-host
-{%                 elif ethernet_interface.dot1x.host_mode.mode is arista.avd.defined('multi-host') %}
-{%                     set host_mode_cli = "dot1x host-mode multi-host" %}
-{%                     if ethernet_interface.dot1x.host_mode.multi_host_authenticated is arista.avd.defined(true) %}
-{%                         set host_mode_cli = host_mode_cli ~ " authenticated" %}
-{%                     endif %}
+{%             elif ethernet_interface.dot1x.host_mode.mode is arista.avd.defined('multi-host') %}
+{%                 set host_mode_cli = "dot1x host-mode multi-host" %}
+{%                 if ethernet_interface.dot1x.host_mode.multi_host_authenticated is arista.avd.defined(true) %}
+{%                     set host_mode_cli = host_mode_cli ~ " authenticated" %}
+{%                 endif %}
    {{ host_mode_cli }}
-{%                 endif %}
 {%             endif %}
-{%             if ethernet_interface.dot1x.mac_based_authentication.enabled is arista.avd.defined(true) %}
-{%                 if ethernet_interface.dot1x.mac_based_authentication.host_mode_common is arista.avd.defined(true) %}
+{%         endif %}
+{%         if ethernet_interface.dot1x.mac_based_authentication.enabled is arista.avd.defined(true) %}
+{%             if ethernet_interface.dot1x.mac_based_authentication.host_mode_common is arista.avd.defined(true) %}
    dot1x mac based authentication host-mode common
-{%                     if ethernet_interface.dot1x.mac_based_authentication.always is arista.avd.defined(true) %}
+{%                 if ethernet_interface.dot1x.mac_based_authentication.always is arista.avd.defined(true) %}
    dot1x mac based authentication always
-{%                     endif %}
-{%                 else %}
-{%                     set auth_cli = "dot1x mac based authentication" %}
-{%                     if ethernet_interface.dot1x.mac_based_authentication.always is arista.avd.defined(true) %}
-{%                         set auth_cli = auth_cli ~ " always" %}
-{%                     endif %}
+{%                 endif %}
+{%             else %}
+{%                 set auth_cli = "dot1x mac based authentication" %}
+{%                 if ethernet_interface.dot1x.mac_based_authentication.always is arista.avd.defined(true) %}
+{%                     set auth_cli = auth_cli ~ " always" %}
+{%                 endif %}
    {{ auth_cli }}
-{%                 endif %}
 {%             endif %}
-{%             if ethernet_interface.dot1x.timeout is arista.avd.defined %}
-{%                 if ethernet_interface.dot1x.timeout.quiet_period is arista.avd.defined %}
+{%         endif %}
+{%         if ethernet_interface.dot1x.timeout is arista.avd.defined %}
+{%             if ethernet_interface.dot1x.timeout.quiet_period is arista.avd.defined %}
    dot1x timeout quiet-period {{ ethernet_interface.dot1x.timeout.quiet_period }}
-{%                 endif %}
-{%                 if ethernet_interface.dot1x.timeout.reauth_timeout_ignore is arista.avd.defined(true) %}
+{%             endif %}
+{%             if ethernet_interface.dot1x.timeout.reauth_timeout_ignore is arista.avd.defined(true) %}
    dot1x timeout reauth-timeout-ignore always
-{%                 endif %}
-{%                 if ethernet_interface.dot1x.timeout.tx_period is arista.avd.defined %}
+{%             endif %}
+{%             if ethernet_interface.dot1x.timeout.tx_period is arista.avd.defined %}
    dot1x timeout tx-period {{ ethernet_interface.dot1x.timeout.tx_period }}
-{%                 endif %}
-{%                 if ethernet_interface.dot1x.timeout.reauth_period is arista.avd.defined %}
+{%             endif %}
+{%             if ethernet_interface.dot1x.timeout.reauth_period is arista.avd.defined %}
    dot1x timeout reauth-period {{ ethernet_interface.dot1x.timeout.reauth_period }}
-{%                 endif %}
-{%                 if ethernet_interface.dot1x.timeout.idle_host is arista.avd.defined %}
+{%             endif %}
+{%             if ethernet_interface.dot1x.timeout.idle_host is arista.avd.defined %}
    dot1x timeout idle-host {{ ethernet_interface.dot1x.timeout.idle_host }} seconds
-{%                 endif %}
 {%             endif %}
-{%             if ethernet_interface.dot1x.reauthorization_request_limit is arista.avd.defined %}
+{%         endif %}
+{%         if ethernet_interface.dot1x.reauthorization_request_limit is arista.avd.defined %}
    dot1x reauthorization request limit {{ ethernet_interface.dot1x.reauthorization_request_limit }}
-{%             endif %}
-{%             if ethernet_interface.dot1x.eapol is arista.avd.defined %}
-{%                 if ethernet_interface.dot1x.eapol.disabled is arista.avd.defined(true) %}
+{%         endif %}
+{%         if ethernet_interface.dot1x.eapol is arista.avd.defined %}
+{%             if ethernet_interface.dot1x.eapol.disabled is arista.avd.defined(true) %}
    dot1x eapol disabled
-{%                 elif ethernet_interface.dot1x.eapol.authentication_failure_fallback_mba.enabled is arista.avd.defined(true) %}
-{%                     set auth_failure_fallback_mba = "dot1x eapol authentication failure fallback mba" %}
-{%                     if ethernet_interface.dot1x.eapol.authentication_failure_fallback_mba.timeout is arista.avd.defined %}
-{%                         set auth_failure_fallback_mba = auth_failure_fallback_mba ~ " timeout " ~ ethernet_interface.dot1x.eapol.authentication_failure_fallback_mba.timeout %}
-{%                     endif %}
+{%             elif ethernet_interface.dot1x.eapol.authentication_failure_fallback_mba.enabled is arista.avd.defined(true) %}
+{%                 set auth_failure_fallback_mba = "dot1x eapol authentication failure fallback mba" %}
+{%                 if ethernet_interface.dot1x.eapol.authentication_failure_fallback_mba.timeout is arista.avd.defined %}
+{%                     set auth_failure_fallback_mba = auth_failure_fallback_mba ~ " timeout " ~ ethernet_interface.dot1x.eapol.authentication_failure_fallback_mba.timeout %}
+{%                 endif %}
    {{ auth_failure_fallback_mba }}
-{%                 endif %}
 {%             endif %}
 {%         endif %}
-{%         if ethernet_interface.snmp_trap_link_change is arista.avd.defined(false) %}
+{%     endif %}
+{%     if ethernet_interface.snmp_trap_link_change is arista.avd.defined(false) %}
    no snmp trap link-change
-{%         elif ethernet_interface.snmp_trap_link_change is arista.avd.defined(true) %}
+{%     elif ethernet_interface.snmp_trap_link_change is arista.avd.defined(true) %}
    snmp trap link-change
+{%     endif %}
+{%     if ethernet_interface.address_locking.ipv4 is arista.avd.defined(true) or ethernet_interface.address_locking.ipv6 is arista.avd.defined(true) %}
+{%         set address_locking_cli = "address locking" %}
+{%         if ethernet_interface.address_locking.ipv4 is arista.avd.defined(true) %}
+{%             set address_locking_cli = address_locking_cli + " ipv4" %}
 {%         endif %}
-{%         if ethernet_interface.address_locking.ipv4 is arista.avd.defined(true) or ethernet_interface.address_locking.ipv6 is arista.avd.defined(true) %}
-{%             set address_locking_cli = "address locking" %}
-{%             if ethernet_interface.address_locking.ipv4 is arista.avd.defined(true) %}
-{%                 set address_locking_cli = address_locking_cli + " ipv4" %}
-{%             endif %}
-{%             if ethernet_interface.address_locking.ipv6 is arista.avd.defined(true) %}
-{%                 set address_locking_cli = address_locking_cli + " ipv6" %}
-{%             endif %}
+{%         if ethernet_interface.address_locking.ipv6 is arista.avd.defined(true) %}
+{%             set address_locking_cli = address_locking_cli + " ipv6" %}
+{%         endif %}
    {{ address_locking_cli }}
-{%         endif %}
-{%         if ethernet_interface.vrf is arista.avd.defined %}
+{%     endif %}
+{%     if ethernet_interface.vrf is arista.avd.defined %}
    vrf {{ ethernet_interface.vrf }}
-{%         endif %}
-{%         if ethernet_interface.ip_proxy_arp is arista.avd.defined(true) %}
+{%     endif %}
+{%     if ethernet_interface.ip_proxy_arp is arista.avd.defined(true) %}
    ip proxy-arp
-{%         endif %}
-{%         if ethernet_interface.ip_address is arista.avd.defined %}
+{%     endif %}
+{%     if ethernet_interface.ip_address is arista.avd.defined %}
    ip address {{ ethernet_interface.ip_address }}
-{%             if ethernet_interface.ip_address_secondaries is arista.avd.defined %}
-{%                 for ip_address_secondary in ethernet_interface.ip_address_secondaries %}
+{%         if ethernet_interface.ip_address_secondaries is arista.avd.defined %}
+{%             for ip_address_secondary in ethernet_interface.ip_address_secondaries %}
    ip address {{ ip_address_secondary }} secondary
-{%                 endfor %}
+{%             endfor %}
+{%         endif %}
+{%         for ip_helper in ethernet_interface.ip_helpers | arista.avd.natural_sort('ip_helper') %}
+{%             set ip_helper_cli = "ip helper-address " ~ ip_helper.ip_helper %}
+{%             if ip_helper.vrf is arista.avd.defined %}
+{%                 set ip_helper_cli = ip_helper_cli ~ " vrf " ~ ip_helper.vrf %}
 {%             endif %}
-{%             for ip_helper in ethernet_interface.ip_helpers | arista.avd.natural_sort('ip_helper') %}
-{%                 set ip_helper_cli = "ip helper-address " ~ ip_helper.ip_helper %}
-{%                 if ip_helper.vrf is arista.avd.defined %}
-{%                     set ip_helper_cli = ip_helper_cli ~ " vrf " ~ ip_helper.vrf %}
-{%                 endif %}
-{%                 if ip_helper.source_interface is arista.avd.defined %}
-{%                     set ip_helper_cli = ip_helper_cli ~ " source-interface " ~ ip_helper.source_interface %}
-{%                 endif %}
+{%             if ip_helper.source_interface is arista.avd.defined %}
+{%                 set ip_helper_cli = ip_helper_cli ~ " source-interface " ~ ip_helper.source_interface %}
+{%             endif %}
    {{ ip_helper_cli }}
-{%             endfor %}
-{%         endif %}
-{%         if ethernet_interface.bfd.interval is arista.avd.defined and
-              ethernet_interface.bfd.min_rx is arista.avd.defined and
-              ethernet_interface.bfd.multiplier is arista.avd.defined %}
+{%         endfor %}
+{%     endif %}
+{%     if ethernet_interface.bfd.interval is arista.avd.defined and
+          ethernet_interface.bfd.min_rx is arista.avd.defined and
+          ethernet_interface.bfd.multiplier is arista.avd.defined %}
    bfd interval {{ ethernet_interface.bfd.interval }} min-rx {{ ethernet_interface.bfd.min_rx }} multiplier {{ ethernet_interface.bfd.multiplier }}
-{%         endif %}
-{%         if ethernet_interface.bfd.echo is arista.avd.defined(true) %}
+{%     endif %}
+{%     if ethernet_interface.bfd.echo is arista.avd.defined(true) %}
    bfd echo
-{%         elif ethernet_interface.bfd.echo is arista.avd.defined(false) %}
+{%     elif ethernet_interface.bfd.echo is arista.avd.defined(false) %}
    no bfd echo
-{%         endif %}
-{%         if ethernet_interface.ipv6_enable is arista.avd.defined(true) %}
+{%     endif %}
+{%     if ethernet_interface.ipv6_enable is arista.avd.defined(true) %}
    ipv6 enable
-{%         endif %}
-{%         if ethernet_interface.ipv6_address is arista.avd.defined %}
+{%     endif %}
+{%     if ethernet_interface.ipv6_address is arista.avd.defined %}
    ipv6 address {{ ethernet_interface.ipv6_address }}
-{%         endif %}
-{%         if ethernet_interface.ipv6_address_link_local is arista.avd.defined %}
+{%     endif %}
+{%     if ethernet_interface.ipv6_address_link_local is arista.avd.defined %}
    ipv6 address {{ ethernet_interface.ipv6_address_link_local }} link-local
-{%         endif %}
-{%         if ethernet_interface.ipv6_nd_ra_disabled is arista.avd.defined(true) %}
+{%     endif %}
+{%     if ethernet_interface.ipv6_nd_ra_disabled is arista.avd.defined(true) %}
    ipv6 nd ra disabled
-{%         endif %}
-{%         if ethernet_interface.ipv6_nd_managed_config_flag is arista.avd.defined(true) %}
+{%     endif %}
+{%     if ethernet_interface.ipv6_nd_managed_config_flag is arista.avd.defined(true) %}
    ipv6 nd managed-config-flag
-{%         endif %}
-{%         if ethernet_interface.ipv6_nd_prefixes is arista.avd.defined %}
-{%             for prefix in ethernet_interface.ipv6_nd_prefixes %}
-{%                 set ipv6_nd_prefix_cli = "ipv6 nd prefix " ~ prefix.ipv6_prefix %}
-{%                 if prefix.valid_lifetime is arista.avd.defined %}
-{%                     set ipv6_nd_prefix_cli = ipv6_nd_prefix_cli ~ " " ~ prefix.valid_lifetime %}
-{%                     if prefix.preferred_lifetime is arista.avd.defined %}
-{%                         set ipv6_nd_prefix_cli = ipv6_nd_prefix_cli ~ " " ~ prefix.preferred_lifetime %}
-{%                     endif %}
+{%     endif %}
+{%     if ethernet_interface.ipv6_nd_prefixes is arista.avd.defined %}
+{%         for prefix in ethernet_interface.ipv6_nd_prefixes %}
+{%             set ipv6_nd_prefix_cli = "ipv6 nd prefix " ~ prefix.ipv6_prefix %}
+{%             if prefix.valid_lifetime is arista.avd.defined %}
+{%                 set ipv6_nd_prefix_cli = ipv6_nd_prefix_cli ~ " " ~ prefix.valid_lifetime %}
+{%                 if prefix.preferred_lifetime is arista.avd.defined %}
+{%                     set ipv6_nd_prefix_cli = ipv6_nd_prefix_cli ~ " " ~ prefix.preferred_lifetime %}
 {%                 endif %}
-{%                 if prefix.no_autoconfig_flag is arista.avd.defined(true) %}
-{%                     set ipv6_nd_prefix_cli = ipv6_nd_prefix_cli ~ " no-autoconfig" %}
-{%                 endif %}
+{%             endif %}
+{%             if prefix.no_autoconfig_flag is arista.avd.defined(true) %}
+{%                 set ipv6_nd_prefix_cli = ipv6_nd_prefix_cli ~ " no-autoconfig" %}
+{%             endif %}
    {{ ipv6_nd_prefix_cli }}
-{%             endfor %}
-{%         endif %}
+{%         endfor %}
 {%     endif %}
 {%     for destination in ethernet_interface.ipv6_dhcp_relay_destinations | arista.avd.natural_sort('address') %}
 {%         set destination_cli = "ipv6 dhcp relay destination " ~ destination.address %}
@@ -419,272 +397,270 @@ interface {{ ethernet_interface.name }}
 {%     if ethernet_interface.lldp.ztp_vlan is arista.avd.defined %}
    lldp tlv transmit ztp vlan {{ ethernet_interface.lldp.ztp_vlan }}
 {%     endif %}
-{%     if print_ethernet is arista.avd.defined(true) %}
-{%         if ethernet_interface.mpls.ldp.igp_sync is arista.avd.defined(true) %}
+{%     if ethernet_interface.mpls.ldp.igp_sync is arista.avd.defined(true) %}
    mpls ldp igp sync
-{%         endif %}
-{%         if ethernet_interface.mpls.ldp.interface is arista.avd.defined(true) %}
+{%     endif %}
+{%     if ethernet_interface.mpls.ldp.interface is arista.avd.defined(true) %}
    mpls ldp interface
-{%         elif ethernet_interface.mpls.ldp.interface is arista.avd.defined(false) %}
+{%     elif ethernet_interface.mpls.ldp.interface is arista.avd.defined(false) %}
    no mpls ldp interface
-{%         endif %}
-{%         if ethernet_interface.access_group_in is arista.avd.defined %}
+{%     endif %}
+{%     if ethernet_interface.access_group_in is arista.avd.defined %}
    ip access-group {{ ethernet_interface.access_group_in }} in
-{%         endif %}
-{%         if ethernet_interface.access_group_out is arista.avd.defined %}
+{%     endif %}
+{%     if ethernet_interface.access_group_out is arista.avd.defined %}
    ip access-group {{ ethernet_interface.access_group_out }} out
-{%         endif %}
-{%         if ethernet_interface.ipv6_access_group_in is arista.avd.defined %}
+{%     endif %}
+{%     if ethernet_interface.ipv6_access_group_in is arista.avd.defined %}
    ipv6 access-group {{ ethernet_interface.ipv6_access_group_in }} in
-{%         endif %}
-{%         if ethernet_interface.ipv6_access_group_out is arista.avd.defined %}
+{%     endif %}
+{%     if ethernet_interface.ipv6_access_group_out is arista.avd.defined %}
    ipv6 access-group {{ ethernet_interface.ipv6_access_group_out }} out
-{%         endif %}
-{%         if ethernet_interface.mac_access_group_in is arista.avd.defined %}
+{%     endif %}
+{%     if ethernet_interface.mac_access_group_in is arista.avd.defined %}
    mac access-group {{ ethernet_interface.mac_access_group_in }} in
-{%         endif %}
-{%         if ethernet_interface.mac_access_group_out is arista.avd.defined %}
+{%     endif %}
+{%     if ethernet_interface.mac_access_group_out is arista.avd.defined %}
    mac access-group {{ ethernet_interface.mac_access_group_out }} out
-{%         endif %}
-{%         if ethernet_interface.multicast is arista.avd.defined %}
-{%             if ethernet_interface.multicast.ipv4.boundaries is arista.avd.defined %}
-{%                 for boundary in ethernet_interface.multicast.ipv4.boundaries %}
-{%                     set boundary_cli = "multicast ipv4 boundary " ~ boundary.boundary %}
-{%                     if boundary.out is arista.avd.defined(true) %}
-{%                         set boundary_cli = boundary_cli ~ " out" %}
-{%                     endif %}
+{%     endif %}
+{%     if ethernet_interface.multicast is arista.avd.defined %}
+{%         if ethernet_interface.multicast.ipv4.boundaries is arista.avd.defined %}
+{%             for boundary in ethernet_interface.multicast.ipv4.boundaries %}
+{%                 set boundary_cli = "multicast ipv4 boundary " ~ boundary.boundary %}
+{%                 if boundary.out is arista.avd.defined(true) %}
+{%                     set boundary_cli = boundary_cli ~ " out" %}
+{%                 endif %}
    {{ boundary_cli }}
-{%                 endfor %}
-{%             endif %}
-{%             if ethernet_interface.multicast.ipv6.boundaries is arista.avd.defined %}
-{%                 for boundary in ethernet_interface.multicast.ipv6.boundaries %}
+{%             endfor %}
+{%         endif %}
+{%         if ethernet_interface.multicast.ipv6.boundaries is arista.avd.defined %}
+{%             for boundary in ethernet_interface.multicast.ipv6.boundaries %}
    multicast ipv6 boundary {{ boundary.boundary }} out
-{%                 endfor %}
-{%             endif %}
-{%             if ethernet_interface.multicast.ipv4.static is arista.avd.defined(true) %}
+{%             endfor %}
+{%         endif %}
+{%         if ethernet_interface.multicast.ipv4.static is arista.avd.defined(true) %}
    multicast ipv4 static
-{%             endif %}
-{%             if ethernet_interface.multicast.ipv6.static is arista.avd.defined(true) %}
+{%         endif %}
+{%         if ethernet_interface.multicast.ipv6.static is arista.avd.defined(true) %}
    multicast ipv6 static
-{%             endif %}
 {%         endif %}
-{%         if ethernet_interface.mpls.ip is arista.avd.defined(true) %}
+{%     endif %}
+{%     if ethernet_interface.mpls.ip is arista.avd.defined(true) %}
    mpls ip
-{%         elif ethernet_interface.mpls.ip is arista.avd.defined(false) %}
+{%     elif ethernet_interface.mpls.ip is arista.avd.defined(false) %}
    no mpls ip
-{%         endif %}
-{%         if ethernet_interface.ip_nat is arista.avd.defined %}
-{%             set interface_ip_nat = ethernet_interface.ip_nat %}
-{%             include 'eos/interface-ip-nat.j2' %}
-{%         endif %}
-{%         if ethernet_interface.ospf_cost is arista.avd.defined %}
+{%     endif %}
+{%     if ethernet_interface.ip_nat is arista.avd.defined %}
+{%         set interface_ip_nat = ethernet_interface.ip_nat %}
+{%         include 'eos/interface-ip-nat.j2' %}
+{%     endif %}
+{%     if ethernet_interface.ospf_cost is arista.avd.defined %}
    ip ospf cost {{ ethernet_interface.ospf_cost }}
-{%         endif %}
-{%         if ethernet_interface.ospf_network_point_to_point is arista.avd.defined(true) %}
+{%     endif %}
+{%     if ethernet_interface.ospf_network_point_to_point is arista.avd.defined(true) %}
    ip ospf network point-to-point
-{%         endif %}
-{%         if ethernet_interface.ospf_authentication is arista.avd.defined('simple') %}
+{%     endif %}
+{%     if ethernet_interface.ospf_authentication is arista.avd.defined('simple') %}
    ip ospf authentication
-{%         elif ethernet_interface.ospf_authentication is arista.avd.defined('message-digest') %}
+{%     elif ethernet_interface.ospf_authentication is arista.avd.defined('message-digest') %}
    ip ospf authentication message-digest
-{%         endif %}
-{%         if ethernet_interface.ospf_authentication_key is arista.avd.defined %}
+{%     endif %}
+{%     if ethernet_interface.ospf_authentication_key is arista.avd.defined %}
    ip ospf authentication-key 7 {{ ethernet_interface.ospf_authentication_key }}
-{%         endif %}
-{%         if ethernet_interface.ospf_area is arista.avd.defined %}
+{%     endif %}
+{%     if ethernet_interface.ospf_area is arista.avd.defined %}
    ip ospf area {{ ethernet_interface.ospf_area }}
-{%         endif %}
-{%         for ospf_message_digest_key in ethernet_interface.ospf_message_digest_keys | arista.avd.natural_sort('id') %}
-{%             if ospf_message_digest_key.hash_algorithm is arista.avd.defined and ospf_message_digest_key.key is arista.avd.defined %}
+{%     endif %}
+{%     for ospf_message_digest_key in ethernet_interface.ospf_message_digest_keys | arista.avd.natural_sort('id') %}
+{%         if ospf_message_digest_key.hash_algorithm is arista.avd.defined and ospf_message_digest_key.key is arista.avd.defined %}
    ip ospf message-digest-key {{ ospf_message_digest_key.id }} {{ ospf_message_digest_key.hash_algorithm }} 7 {{ ospf_message_digest_key.key }}
-{%             endif %}
-{%         endfor %}
-{%         if ethernet_interface.pim.ipv4.sparse_mode is arista.avd.defined(true) %}
+{%         endif %}
+{%     endfor %}
+{%     if ethernet_interface.pim.ipv4.sparse_mode is arista.avd.defined(true) %}
    pim ipv4 sparse-mode
-{%         endif %}
-{%         if ethernet_interface.pim.ipv4.dr_priority is arista.avd.defined %}
+{%     endif %}
+{%     if ethernet_interface.pim.ipv4.dr_priority is arista.avd.defined %}
    pim ipv4 dr-priority {{ ethernet_interface.pim.ipv4.dr_priority }}
-{%         endif %}
-{%         if ethernet_interface.poe.priority is arista.avd.defined %}
+{%     endif %}
+{%     if ethernet_interface.poe.priority is arista.avd.defined %}
    poe priority {{ ethernet_interface.poe.priority }}
-{%         endif %}
-{%         if ethernet_interface.poe.reboot.action is arista.avd.defined %}
+{%     endif %}
+{%     if ethernet_interface.poe.reboot.action is arista.avd.defined %}
    poe reboot action {{ ethernet_interface.poe.reboot.action }}
+{%     endif %}
+{%     if ethernet_interface.poe.link_down.action is arista.avd.defined %}
+{%         set poe_link_down_action_cli = 'poe link down action ' ~ ethernet_interface.poe.link_down.action %}
+{%         if ethernet_interface.poe.link_down.power_off_delay is arista.avd.defined %}
+{%             set poe_link_down_action_cli = poe_link_down_action_cli ~ ' ' ~ ethernet_interface.poe.link_down.power_off_delay %}
 {%         endif %}
-{%         if ethernet_interface.poe.link_down.action is arista.avd.defined %}
-{%             set poe_link_down_action_cli = 'poe link down action ' ~ ethernet_interface.poe.link_down.action %}
-{%             if ethernet_interface.poe.link_down.power_off_delay is arista.avd.defined %}
-{%                 set poe_link_down_action_cli = poe_link_down_action_cli ~ ' ' ~ ethernet_interface.poe.link_down.power_off_delay %}
-{%             endif %}
    {{ poe_link_down_action_cli }}
-{%         endif %}
-{%         if ethernet_interface.poe.shutdown.action is arista.avd.defined %}
+{%     endif %}
+{%     if ethernet_interface.poe.shutdown.action is arista.avd.defined %}
    poe shutdown action {{ ethernet_interface.poe.shutdown.action }}
-{%         endif %}
-{%         if ethernet_interface.poe.disabled is arista.avd.defined(true) %}
+{%     endif %}
+{%     if ethernet_interface.poe.disabled is arista.avd.defined(true) %}
    poe disabled
+{%     endif %}
+{%     if ethernet_interface.poe.limit is arista.avd.defined %}
+{%         if ethernet_interface.poe.limit.class is arista.avd.defined %}
+{%             set poe_limit_cli = 'poe limit ' ~ POE_CLASS_MAP[ethernet_interface.poe.limit.class] ~ ' watts' %}
+{%         elif ethernet_interface.poe.limit.watts is arista.avd.defined %}
+{%             set poe_limit_cli = 'poe limit ' ~ "%.2f" | format(ethernet_interface.poe.limit.watts | float) ~ ' watts' %}
 {%         endif %}
-{%         if ethernet_interface.poe.limit is arista.avd.defined %}
-{%             if ethernet_interface.poe.limit.class is arista.avd.defined %}
-{%                 set poe_limit_cli = 'poe limit ' ~ POE_CLASS_MAP[ethernet_interface.poe.limit.class] ~ ' watts' %}
-{%             elif ethernet_interface.poe.limit.watts is arista.avd.defined %}
-{%                 set poe_limit_cli = 'poe limit ' ~ "%.2f" | format(ethernet_interface.poe.limit.watts | float) ~ ' watts' %}
-{%             endif %}
-{%             if poe_limit_cli is arista.avd.defined and ethernet_interface.poe.limit.fixed is arista.avd.defined(true) %}
-{%                 set poe_limit_cli = poe_limit_cli ~ ' fixed' %}
-{%             endif %}
+{%         if poe_limit_cli is arista.avd.defined and ethernet_interface.poe.limit.fixed is arista.avd.defined(true) %}
+{%             set poe_limit_cli = poe_limit_cli ~ ' fixed' %}
+{%         endif %}
    {{ poe_limit_cli }}
-{%         endif %}
-{%         if ethernet_interface.poe.negotiation_lldp is arista.avd.defined(false) %}
+{%     endif %}
+{%     if ethernet_interface.poe.negotiation_lldp is arista.avd.defined(false) %}
    poe negotiation lldp disabled
-{%         endif %}
-{%         if ethernet_interface.poe.legacy_detect is arista.avd.defined(true) %}
+{%     endif %}
+{%     if ethernet_interface.poe.legacy_detect is arista.avd.defined(true) %}
    poe legacy detect
-{%         endif %}
-{%         if ethernet_interface.qos.trust is arista.avd.defined %}
-{%             if ethernet_interface.qos.trust == 'disabled' %}
+{%     endif %}
+{%     if ethernet_interface.qos.trust is arista.avd.defined %}
+{%         if ethernet_interface.qos.trust == 'disabled' %}
    no qos trust
-{%             else %}
+{%         else %}
    qos trust {{ ethernet_interface.qos.trust }}
-{%             endif %}
 {%         endif %}
-{%         if ethernet_interface.qos.cos is arista.avd.defined %}
+{%     endif %}
+{%     if ethernet_interface.qos.cos is arista.avd.defined %}
    qos cos {{ ethernet_interface.qos.cos }}
-{%         endif %}
-{%         if ethernet_interface.qos.dscp is arista.avd.defined %}
+{%     endif %}
+{%     if ethernet_interface.qos.dscp is arista.avd.defined %}
    qos dscp {{ ethernet_interface.qos.dscp }}
-{%         endif %}
-{%         if ethernet_interface.shape.rate is arista.avd.defined %}
+{%     endif %}
+{%     if ethernet_interface.shape.rate is arista.avd.defined %}
    shape rate {{ ethernet_interface.shape.rate }}
-{%         endif %}
-{%         if ethernet_interface.priority_flow_control.enabled is arista.avd.defined(true) %}
+{%     endif %}
+{%     if ethernet_interface.priority_flow_control.enabled is arista.avd.defined(true) %}
    priority-flow-control on
-{%         elif ethernet_interface.priority_flow_control.enabled is arista.avd.defined(false) %}
+{%     elif ethernet_interface.priority_flow_control.enabled is arista.avd.defined(false) %}
    no priority-flow-control
-{%         endif %}
-{%         for priority_block in ethernet_interface.priority_flow_control.priorities | arista.avd.natural_sort %}
-{%             if priority_block.priority is arista.avd.defined %}
-{%                 if priority_block.no_drop is arista.avd.defined(true) %}
+{%     endif %}
+{%     for priority_block in ethernet_interface.priority_flow_control.priorities | arista.avd.natural_sort %}
+{%         if priority_block.priority is arista.avd.defined %}
+{%             if priority_block.no_drop is arista.avd.defined(true) %}
    priority-flow-control priority {{ priority_block.priority }} no-drop
-{%                 elif priority_block.no_drop is arista.avd.defined(false) %}
+{%             elif priority_block.no_drop is arista.avd.defined(false) %}
    priority-flow-control priority {{ priority_block.priority }} drop
-{%                 endif %}
 {%             endif %}
-{%         endfor %}
-{%         for section in ethernet_interface.storm_control | arista.avd.natural_sort %}
-{%             if ethernet_interface.storm_control[section].level is arista.avd.defined %}
-{%                 if ethernet_interface.storm_control[section].unit is arista.avd.defined('pps') %}
+{%         endif %}
+{%     endfor %}
+{%     for section in ethernet_interface.storm_control | arista.avd.natural_sort %}
+{%         if ethernet_interface.storm_control[section].level is arista.avd.defined %}
+{%             if ethernet_interface.storm_control[section].unit is arista.avd.defined('pps') %}
    storm-control {{ section | replace("_", "-") }} level pps {{ ethernet_interface.storm_control[section].level }}
-{%                 else %}
-   storm-control {{ section | replace("_", "-") }} level {{ ethernet_interface.storm_control[section].level }}
-{%                 endif %}
-{%             endif %}
-{%         endfor %}
-{%         if ethernet_interface.ptp.enable is arista.avd.defined(true) %}
-   ptp enable
-{%         endif %}
-{%         if ethernet_interface.ptp.sync_message.interval is arista.avd.defined %}
-   ptp sync-message interval {{ ethernet_interface.ptp.sync_message.interval }}
-{%         endif %}
-{%         if ethernet_interface.ptp.delay_mechanism is arista.avd.defined %}
-   ptp delay-mechanism {{ ethernet_interface.ptp.delay_mechanism }}
-{%         endif %}
-{%         if ethernet_interface.ptp.announce.interval is arista.avd.defined %}
-   ptp announce interval {{ ethernet_interface.ptp.announce.interval }}
-{%         endif %}
-{%         if ethernet_interface.ptp.transport is arista.avd.defined %}
-   ptp transport {{ ethernet_interface.ptp.transport }}
-{%         endif %}
-{%         if ethernet_interface.ptp.announce.timeout is arista.avd.defined %}
-   ptp announce timeout {{ ethernet_interface.ptp.announce.timeout }}
-{%         endif %}
-{%         if ethernet_interface.ptp.delay_req is arista.avd.defined %}
-   ptp delay-req interval {{ ethernet_interface.ptp.delay_req }}
-{%         endif %}
-{%         if ethernet_interface.ptp.role is arista.avd.defined %}
-   ptp role {{ ethernet_interface.ptp.role }}
-{%         endif %}
-{%         if ethernet_interface.ptp.vlan is arista.avd.defined %}
-   ptp vlan {{ ethernet_interface.ptp.vlan }}
-{%         endif %}
-{%         if ethernet_interface.service_policy.pbr.input is arista.avd.defined %}
-   service-policy type pbr input {{ ethernet_interface.service_policy.pbr.input }}
-{%         endif %}
-{%         if ethernet_interface.service_policy.qos.input is arista.avd.defined %}
-   service-policy type qos input {{ ethernet_interface.service_policy.qos.input }}
-{%         endif %}
-{%         if ethernet_interface.service_profile is arista.avd.defined %}
-   service-profile {{ ethernet_interface.service_profile }}
-{%         endif %}
-{%         if ethernet_interface.isis_enable is arista.avd.defined %}
-   isis enable {{ ethernet_interface.isis_enable }}
-{%         endif %}
-{%         if ethernet_interface.isis_circuit_type is arista.avd.defined %}
-   isis circuit-type {{ ethernet_interface.isis_circuit_type }}
-{%         endif %}
-{%         if ethernet_interface.isis_metric is arista.avd.defined %}
-   isis metric {{ ethernet_interface.isis_metric }}
-{%         endif %}
-{%         if ethernet_interface.isis_passive is arista.avd.defined(true) %}
-   isis passive
-{%         endif %}
-{%         if ethernet_interface.isis_hello_padding is arista.avd.defined(false) %}
-   no isis hello padding
-{%         elif ethernet_interface.isis_hello_padding is arista.avd.defined(true) %}
-   isis hello padding
-{%         endif %}
-{%         if ethernet_interface.isis_network_point_to_point is arista.avd.defined(true) %}
-   isis network point-to-point
-{%         endif %}
-{%         if ethernet_interface.isis_authentication_mode is arista.avd.defined and
-              ethernet_interface.isis_authentication_mode in ["text", "md5"] %}
-   isis authentication mode {{ ethernet_interface.isis_authentication_mode }}
-{%         endif %}
-{%         if ethernet_interface.isis_authentication_key is arista.avd.defined %}
-   isis authentication key 7 {{ ethernet_interface.isis_authentication_key }}
-{%         endif %}
-{%         if ethernet_interface.spanning_tree_portfast is arista.avd.defined('edge') %}
-   spanning-tree portfast
-{%         elif ethernet_interface.spanning_tree_portfast is arista.avd.defined('network') %}
-   spanning-tree portfast network
-{%         endif %}
-{%         if ethernet_interface.spanning_tree_bpduguard is arista.avd.defined and ethernet_interface.spanning_tree_bpduguard in [True, "True", "enabled"] %}
-   spanning-tree bpduguard enable
-{%         elif ethernet_interface.spanning_tree_bpduguard is arista.avd.defined("disabled") %}
-   spanning-tree bpduguard disable
-{%         endif %}
-{%         if ethernet_interface.spanning_tree_bpdufilter is arista.avd.defined and ethernet_interface.spanning_tree_bpdufilter in [True, "True", "enabled"] %}
-   spanning-tree bpdufilter enable
-{%         elif ethernet_interface.spanning_tree_bpdufilter is arista.avd.defined("disabled") %}
-   spanning-tree bpdufilter disable
-{%         endif %}
-{%         if ethernet_interface.spanning_tree_guard is arista.avd.defined %}
-{%             if ethernet_interface.spanning_tree_guard == 'disabled' %}
-   spanning-tree guard none
 {%             else %}
+   storm-control {{ section | replace("_", "-") }} level {{ ethernet_interface.storm_control[section].level }}
+{%             endif %}
+{%         endif %}
+{%     endfor %}
+{%     if ethernet_interface.ptp.enable is arista.avd.defined(true) %}
+   ptp enable
+{%     endif %}
+{%     if ethernet_interface.ptp.sync_message.interval is arista.avd.defined %}
+   ptp sync-message interval {{ ethernet_interface.ptp.sync_message.interval }}
+{%     endif %}
+{%     if ethernet_interface.ptp.delay_mechanism is arista.avd.defined %}
+   ptp delay-mechanism {{ ethernet_interface.ptp.delay_mechanism }}
+{%     endif %}
+{%     if ethernet_interface.ptp.announce.interval is arista.avd.defined %}
+   ptp announce interval {{ ethernet_interface.ptp.announce.interval }}
+{%     endif %}
+{%     if ethernet_interface.ptp.transport is arista.avd.defined %}
+   ptp transport {{ ethernet_interface.ptp.transport }}
+{%     endif %}
+{%     if ethernet_interface.ptp.announce.timeout is arista.avd.defined %}
+   ptp announce timeout {{ ethernet_interface.ptp.announce.timeout }}
+{%     endif %}
+{%     if ethernet_interface.ptp.delay_req is arista.avd.defined %}
+   ptp delay-req interval {{ ethernet_interface.ptp.delay_req }}
+{%     endif %}
+{%     if ethernet_interface.ptp.role is arista.avd.defined %}
+   ptp role {{ ethernet_interface.ptp.role }}
+{%     endif %}
+{%     if ethernet_interface.ptp.vlan is arista.avd.defined %}
+   ptp vlan {{ ethernet_interface.ptp.vlan }}
+{%     endif %}
+{%     if ethernet_interface.service_policy.pbr.input is arista.avd.defined %}
+   service-policy type pbr input {{ ethernet_interface.service_policy.pbr.input }}
+{%     endif %}
+{%     if ethernet_interface.service_policy.qos.input is arista.avd.defined %}
+   service-policy type qos input {{ ethernet_interface.service_policy.qos.input }}
+{%     endif %}
+{%     if ethernet_interface.service_profile is arista.avd.defined %}
+   service-profile {{ ethernet_interface.service_profile }}
+{%     endif %}
+{%     if ethernet_interface.isis_enable is arista.avd.defined %}
+   isis enable {{ ethernet_interface.isis_enable }}
+{%     endif %}
+{%     if ethernet_interface.isis_circuit_type is arista.avd.defined %}
+   isis circuit-type {{ ethernet_interface.isis_circuit_type }}
+{%     endif %}
+{%     if ethernet_interface.isis_metric is arista.avd.defined %}
+   isis metric {{ ethernet_interface.isis_metric }}
+{%     endif %}
+{%     if ethernet_interface.isis_passive is arista.avd.defined(true) %}
+   isis passive
+{%     endif %}
+{%     if ethernet_interface.isis_hello_padding is arista.avd.defined(false) %}
+   no isis hello padding
+{%     elif ethernet_interface.isis_hello_padding is arista.avd.defined(true) %}
+   isis hello padding
+{%     endif %}
+{%     if ethernet_interface.isis_network_point_to_point is arista.avd.defined(true) %}
+   isis network point-to-point
+{%     endif %}
+{%     if ethernet_interface.isis_authentication_mode is arista.avd.defined and
+          ethernet_interface.isis_authentication_mode in ["text", "md5"] %}
+   isis authentication mode {{ ethernet_interface.isis_authentication_mode }}
+{%     endif %}
+{%     if ethernet_interface.isis_authentication_key is arista.avd.defined %}
+   isis authentication key 7 {{ ethernet_interface.isis_authentication_key }}
+{%     endif %}
+{%     if ethernet_interface.spanning_tree_portfast is arista.avd.defined('edge') %}
+   spanning-tree portfast
+{%     elif ethernet_interface.spanning_tree_portfast is arista.avd.defined('network') %}
+   spanning-tree portfast network
+{%     endif %}
+{%     if ethernet_interface.spanning_tree_bpduguard is arista.avd.defined and ethernet_interface.spanning_tree_bpduguard in [True, "True", "enabled"] %}
+   spanning-tree bpduguard enable
+{%     elif ethernet_interface.spanning_tree_bpduguard is arista.avd.defined("disabled") %}
+   spanning-tree bpduguard disable
+{%     endif %}
+{%     if ethernet_interface.spanning_tree_bpdufilter is arista.avd.defined and ethernet_interface.spanning_tree_bpdufilter in [True, "True", "enabled"] %}
+   spanning-tree bpdufilter enable
+{%     elif ethernet_interface.spanning_tree_bpdufilter is arista.avd.defined("disabled") %}
+   spanning-tree bpdufilter disable
+{%     endif %}
+{%     if ethernet_interface.spanning_tree_guard is arista.avd.defined %}
+{%         if ethernet_interface.spanning_tree_guard == 'disabled' %}
+   spanning-tree guard none
+{%         else %}
    spanning-tree guard {{ ethernet_interface.spanning_tree_guard }}
-{%             endif %}
 {%         endif %}
-{%         if ethernet_interface.sflow is arista.avd.defined %}
-{%             if ethernet_interface.sflow.enable is arista.avd.defined(true) %}
+{%     endif %}
+{%     if ethernet_interface.sflow is arista.avd.defined %}
+{%         if ethernet_interface.sflow.enable is arista.avd.defined(true) %}
    sflow enable
-{%             elif ethernet_interface.sflow.enable is arista.avd.defined(false) %}
+{%         elif ethernet_interface.sflow.enable is arista.avd.defined(false) %}
    no sflow enable
-{%             endif %}
-{%             if ethernet_interface.sflow.egress.enable is arista.avd.defined(true) %}
+{%         endif %}
+{%         if ethernet_interface.sflow.egress.enable is arista.avd.defined(true) %}
    sflow egress enable
-{%             elif ethernet_interface.sflow.egress.enable is arista.avd.defined(false) %}
+{%         elif ethernet_interface.sflow.egress.enable is arista.avd.defined(false) %}
    no sflow egress enable
-{%             endif %}
-{%             if ethernet_interface.sflow.egress.unmodified_enable is arista.avd.defined(true) %}
+{%         endif %}
+{%         if ethernet_interface.sflow.egress.unmodified_enable is arista.avd.defined(true) %}
    sflow egress unmodified enable
-{%             elif ethernet_interface.sflow.egress.unmodified_enable is arista.avd.defined(false) %}
+{%         elif ethernet_interface.sflow.egress.unmodified_enable is arista.avd.defined(false) %}
    no sflow egress unmodified enable
-{%             endif %}
 {%         endif %}
-{%         if ethernet_interface.vmtracer is arista.avd.defined(true) %}
+{%     endif %}
+{%     if ethernet_interface.vmtracer is arista.avd.defined(true) %}
    vmtracer vmware-esx
-{%         endif %}
 {%     endif %}
 {%     if ethernet_interface.transceiver.media.override is arista.avd.defined %}
    transceiver media override {{ ethernet_interface.transceiver.media.override }}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -141,7 +141,7 @@ interface {{ ethernet_interface.name }}
    encapsulation vlan
       {{ encapsulation_cli }}
 {%         endif %}
-{%     elif ethernet_interface.type is arista.avd.defined('switched') %}
+{%     elif ethernet_interface.type | arista.avd.default('switched') == 'switched' %}
    switchport
 {%     endif %}
 {%     if ethernet_interface.trunk_private_vlan_secondary is arista.avd.defined(true) %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
@@ -51,7 +51,7 @@ interface {{ port_channel_interface.name }}
    encapsulation vlan
       {{ encapsulation_cli }}
 {%         endif %}
-{%     elif port_channel_interface.type is arista.avd.defined("switched") %}
+{%     elif port_channel_interface.type | arista.avd.default("switched") == 'switched' %}
    switchport
 {%     endif %}
 {%     if port_channel_interface.vlans is arista.avd.defined and port_channel_interface.mode is arista.avd.defined("access") %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
@@ -51,7 +51,7 @@ interface {{ port_channel_interface.name }}
    encapsulation vlan
       {{ encapsulation_cli }}
 {%         endif %}
-{%     else %}
+{%     elif port_channel_interface.type is arista.avd.defined("switched") %}
    switchport
 {%     endif %}
 {%     if port_channel_interface.vlans is arista.avd.defined and port_channel_interface.mode is arista.avd.defined("access") %}

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/connected_endpoints/ethernet_interfaces.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/connected_endpoints/ethernet_interfaces.py
@@ -96,7 +96,6 @@ class EthernetInterfacesMixin(UtilsMixin):
         short_esi = self._get_short_esi(adapter, channel_group_id)
 
         # Common ethernet_interface settings
-        # TODO: avoid generating redundant structured config for port-channel members
         ethernet_interface = {
             "name": adapter["switch_ports"][node_index],
             "peer": peer,
@@ -105,22 +104,7 @@ class EthernetInterfacesMixin(UtilsMixin):
             "port_profile": adapter.get("profile"),
             "description": self.shared_utils.interface_descriptions.connected_endpoints_ethernet_interfaces(peer, peer_interface, adapter.get("description")),
             "speed": adapter.get("speed"),
-            "mtu": adapter.get("mtu"),
-            "l2_mtu": adapter.get("l2_mtu"),
-            "type": "switched",
             "shutdown": not adapter.get("enabled", True),
-            "mode": adapter.get("mode"),
-            "vlans": adapter.get("vlans"),
-            "trunk_groups": self._get_adapter_trunk_groups(adapter, connected_endpoint),
-            "native_vlan_tag": adapter.get("native_vlan_tag"),
-            "native_vlan": adapter.get("native_vlan"),
-            "spanning_tree_portfast": adapter.get("spanning_tree_portfast"),
-            "spanning_tree_bpdufilter": adapter.get("spanning_tree_bpdufilter"),
-            "spanning_tree_bpduguard": adapter.get("spanning_tree_bpduguard"),
-            "storm_control": self._get_adapter_storm_control(adapter),
-            "service_profile": adapter.get("qos_profile"),
-            "dot1x": adapter.get("dot1x"),
-            "ptp": self._get_adapter_ptp(adapter),
             "eos_cli": adapter.get("raw_eos_cli"),
             "struct_cfg": adapter.get("structured_config"),
         }
@@ -143,6 +127,21 @@ class EthernetInterfacesMixin(UtilsMixin):
         else:
             ethernet_interface.update(
                 {
+                    "type": "switched",
+                    "mtu": adapter.get("mtu"),
+                    "l2_mtu": adapter.get("l2_mtu"),
+                    "mode": adapter.get("mode"),
+                    "vlans": adapter.get("vlans"),
+                    "trunk_groups": self._get_adapter_trunk_groups(adapter, connected_endpoint),
+                    "native_vlan_tag": adapter.get("native_vlan_tag"),
+                    "native_vlan": adapter.get("native_vlan"),
+                    "spanning_tree_portfast": adapter.get("spanning_tree_portfast"),
+                    "spanning_tree_bpdufilter": adapter.get("spanning_tree_bpdufilter"),
+                    "spanning_tree_bpduguard": adapter.get("spanning_tree_bpduguard"),
+                    "storm_control": self._get_adapter_storm_control(adapter),
+                    "service_profile": adapter.get("qos_profile"),
+                    "dot1x": adapter.get("dot1x"),
+                    "ptp": self._get_adapter_ptp(adapter),
                     "evpn_ethernet_segment": self._get_adapter_evpn_ethernet_segment_cfg(
                         adapter, short_esi, node_index, connected_endpoint, "auto", "single-active"
                     ),

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/connected_endpoints/ethernet_interfaces.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/connected_endpoints/ethernet_interfaces.py
@@ -111,10 +111,15 @@ class EthernetInterfacesMixin(UtilsMixin):
 
         # Port-channel member
         if (port_channel_mode := get(adapter, "port_channel.mode")) is not None:
-            ethernet_interface["channel_group"] = {
-                "id": channel_group_id,
-                "mode": port_channel_mode,
-            }
+            ethernet_interface.update(
+                {
+                    "type": "port-channel-member",
+                    "channel_group": {
+                        "id": channel_group_id,
+                        "mode": port_channel_mode,
+                    },
+                }
+            )
             if get(adapter, "port_channel.lacp_fallback.mode") == "static":
                 ethernet_interface["lacp_port_priority"] = 8192 if node_index == 0 else 32768
             if port_channel_mode != "on" and get(adapter, "port_channel.lacp_timer") is not None:

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/connected_endpoints/port_channel_interfaces.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/connected_endpoints/port_channel_interfaces.py
@@ -106,6 +106,7 @@ class PortChannelInterfacesMixin(UtilsMixin):
             "mtu": adapter.get("mtu"),
             "service_profile": adapter.get("qos_profile"),
             "link_tracking_groups": self._get_adapter_link_tracking_groups(adapter),
+            "ptp": self._get_adapter_ptp(adapter),
             "eos_cli": get(adapter, "port_channel.raw_eos_cli"),
             "struct_cfg": get(adapter, "port_channel.structured_config"),
         }

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/core_interfaces/utils.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/core_interfaces/utils.py
@@ -297,6 +297,7 @@ class UtilsMixin:
         default_description = f"P2P_LINK_TO_{peer}_{peer_interface}"
         return {
             "name": interface_name,
+            "type": "port-channel-member",
             "peer": peer,
             "peer_interface": peer_interface,
             "peer_type": p2p_link["data"]["peer_type"],

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/l3_edge/utils.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/l3_edge/utils.py
@@ -302,6 +302,7 @@ class UtilsMixin:
         default_description = f"P2P_LINK_TO_{peer}_{peer_interface}"
         return {
             "name": interface_name,
+            "type": "port-channel-member",
             "peer": peer,
             "peer_interface": peer_interface,
             "peer_type": p2p_link["data"]["peer_type"],

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/mlag/avdstructuredconfig.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/mlag/avdstructuredconfig.py
@@ -172,7 +172,6 @@ class AvdStructuredConfig(AvdFacts):
                 "peer_interface": mlag_interface,
                 "peer_type": "mlag_peer",
                 "description": self.shared_utils.interface_descriptions.mlag_ethernet_interfaces(mlag_interface),
-                "type": "switched",
                 "shutdown": False,
                 "channel_group": {
                     "id": self.shared_utils.mlag_port_channel_id,

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/mlag/avdstructuredconfig.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/mlag/avdstructuredconfig.py
@@ -172,6 +172,7 @@ class AvdStructuredConfig(AvdFacts):
                 "peer_interface": mlag_interface,
                 "peer_type": "mlag_peer",
                 "description": self.shared_utils.interface_descriptions.mlag_ethernet_interfaces(mlag_interface),
+                "type": "port-channel-member",
                 "shutdown": False,
                 "channel_group": {
                     "id": self.shared_utils.mlag_port_channel_id,

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/ethernet_interfaces.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/ethernet_interfaces.py
@@ -101,10 +101,15 @@ class EthernetInterfacesMixin(UtilsMixin):
             # L2 interface
             elif link["type"] == "underlay_l2":
                 if (channel_group_id := link.get("channel_group_id")) is not None:
-                    ethernet_interface["channel_group"] = {
-                        "id": int(channel_group_id),
-                        "mode": "active",
-                    }
+                    ethernet_interface.update(
+                        {
+                            "type": "port-channel-member",
+                            "channel_group": {
+                                "id": int(channel_group_id),
+                                "mode": "active",
+                            },
+                        }
+                    )
                 else:
                     vlans = get(link, "vlans", default=[])
                     ethernet_interface.update(

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/ethernet_interfaces.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/ethernet_interfaces.py
@@ -100,8 +100,6 @@ class EthernetInterfacesMixin(UtilsMixin):
 
             # L2 interface
             elif link["type"] == "underlay_l2":
-                ethernet_interface["type"] = "switched"
-
                 if (channel_group_id := link.get("channel_group_id")) is not None:
                     ethernet_interface["channel_group"] = {
                         "id": int(channel_group_id),
@@ -111,6 +109,7 @@ class EthernetInterfacesMixin(UtilsMixin):
                     vlans = get(link, "vlans", default=[])
                     ethernet_interface.update(
                         {
+                            "type": "switched",
                             "vlans": list_compress(vlans),
                             "native_vlan": link.get("native_vlan"),
                             "service_profile": self.shared_utils.p2p_uplinks_qos_profile,

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/documentation/connected-endpoints.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/documentation/connected-endpoints.j2
@@ -16,18 +16,21 @@
 {%         if peer_type in all_connected_endpoints_keys.values() | map(attribute='type') | list %}
 {#             Retrieving key from peer_type using magic Jinja - it relies on the fact that once using items, key and value #}
 {#             can be accessed using "0" and "1" in the tuple #}
+{%             if ethernet_interface.channel_group.id is arista.avd.defined %}
+{%                 set port_channel_interface = (node_hostvars.port_channel_interfaces | selectattr("name", "eq", "Port-Channel" ~ ethernet_interface.channel_group.id))[0] | arista.avd.default %}
+{%             endif %}
 {%             set connected_endpoint_key = all_connected_endpoints_keys.items() | selectattr("1.type", "equalto", peer_type) | map(attribute="0") | first %}
-{%             set connected_endpoint = namespace () %}
+{%             set connected_endpoint = namespace() %}
 {%             set connected_endpoint.fabric_switch = node %}
 {%             set connected_endpoint.fabric_port = ethernet_interface.name %}
 {%             set connected_endpoint.peer_type = peer_type %}
 {%             set connected_endpoint.peer = ethernet_interface.peer | arista.avd.default("-") %}
 {%             set connected_endpoint.peer_interface = ethernet_interface.peer_interface | arista.avd.default("-") %}
 {%             set connected_endpoint.description = ethernet_interface.description | arista.avd.default("-") %}
-{%             set connected_endpoint.shutdown = ethernet_interface.shutdown | arista.avd.default("-") %}
-{%             set connected_endpoint.type = ethernet_interface.type | arista.avd.default("-") %}
-{%             set connected_endpoint.mode = ethernet_interface.mode | arista.avd.default("-") %}
-{%             set connected_endpoint.vlans = ethernet_interface.vlans | arista.avd.default("-") %}
+{%             set connected_endpoint.shutdown = ethernet_interface.shutdown | arista.avd.default(port_channel_interface.shutdown, "-") %}
+{%             set connected_endpoint.type = ethernet_interface.type | arista.avd.default(port_channel_interface.type, "-") %}
+{%             set connected_endpoint.mode = ethernet_interface.mode | arista.avd.default(port_channel_interface.mode, "-") %}
+{%             set connected_endpoint.vlans = ethernet_interface.vlans | arista.avd.default(port_channel_interface.vlans, "-") %}
 {%             set connected_endpoint.profile = ethernet_interface.port_profile | arista.avd.default("-") %}
 {%             do all_connected_endpoints.setdefault(connected_endpoint_key, []).append(connected_endpoint) %}
 {%         endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/documentation/connected-endpoints.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/documentation/connected-endpoints.j2
@@ -29,7 +29,7 @@
 {%             set connected_endpoint.description = ethernet_interface.description | arista.avd.default("-") %}
 {%             set connected_endpoint.shutdown = ethernet_interface.shutdown | arista.avd.default(port_channel_interface.shutdown, "-") %}
 {%             if ethernet_interface.type is arista.avd.defined("port-channel-member") %}
-{%                 set connected_endpoint.type = port_channel_interface.type, "-") %}
+{%                 set connected_endpoint.type = port_channel_interface.type | arista.avd.default("-") %}
 {%             else %}
 {%                 set connected_endpoint.type = ethernet_interface.type | arista.avd.default(port_channel_interface.type, "-") %}
 {%             endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/documentation/connected-endpoints.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/documentation/connected-endpoints.j2
@@ -28,7 +28,11 @@
 {%             set connected_endpoint.peer_interface = ethernet_interface.peer_interface | arista.avd.default("-") %}
 {%             set connected_endpoint.description = ethernet_interface.description | arista.avd.default("-") %}
 {%             set connected_endpoint.shutdown = ethernet_interface.shutdown | arista.avd.default(port_channel_interface.shutdown, "-") %}
-{%             set connected_endpoint.type = ethernet_interface.type | arista.avd.default(port_channel_interface.type, "-") %}
+{%             if ethernet_interface.type is arista.avd.defined("port-channel-member") %}
+{%                 set connected_endpoint.type = port_channel_interface.type, "-") %}
+{%             else %}
+{%                 set connected_endpoint.type = ethernet_interface.type | arista.avd.default(port_channel_interface.type, "-") %}
+{%             endif %}
 {%             set connected_endpoint.mode = ethernet_interface.mode | arista.avd.default(port_channel_interface.mode, "-") %}
 {%             set connected_endpoint.vlans = ethernet_interface.vlans | arista.avd.default(port_channel_interface.vlans, "-") %}
 {%             set connected_endpoint.profile = ethernet_interface.port_profile | arista.avd.default("-") %}


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Remove default "switchport" and remove logic from eos_cli_config_gen

*These changes are potentially breaking for users of `eos_cli_config_gen`, they will be transparent for users of `eos_designs`.*

## Component(s) name

- `arista.avd.eos_designs`
- `arista.avd.eos_cli_config_gen`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

Fixes: aristanetworks/avd-internal#89

### eos_cli_config_gen
1. Remove undocumented default value of `type` under `ethernet_interfaces` and `port_channel_interfaces`. It was `'switched'`
2. Result of 1. is that interface configs will no longer render `switchport` unless `type: 'switched'` is specifically set.
3. Remove `print_ethernet` logic from `ethernet_interfaces` jinja template in `eos_cli_config_gen`, to no longer ignore interface settings on port-channel members.
4. Update device documentation templates to only print interfaces under `L2 Interfaces` if `type == 'switched'`
5. Update molecule data with `type` where needed.
6. Fix a couple of files with erronous molecule data - hidden by previous `print_ethernet` logic.
7. Update old documentation to show type for switched interfaces.
8. Update schema with note on `type` is required for the interface to show up in documentation (previously it defaulted to `switched` so interfaces without type showed up under "L2 Interfaces".

*re. 8. this will change when we refactor to classify interfaces based on actual config keys instead of `type`.*

### eos_designs

1. Update `eos_designs` to add `type` as required to all generated interface configs
2. Update `eos_designs` to only render valid config for port_channel members (was previously ignored because of the `print_ethernet` logic in `eos_cli_config_gen`
3. Adjust molecule configs to render the same configs as before. Structured configs change because of reordering and removal of invalid configs, but no cfg changes.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Updated molecule scenarios to render the same configs for eos_designs

Updated molecule scenarios to render mostly the same configs for eos_cli_config_gen. A few fixes have been done for wrongful switchport under subinterface and trunk information on port-channel member.


## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
