### PR TITLE
Fix(eos_snapshot): Only collect cli-text commands when "text" or "markdown" are selected

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_snapshot/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_snapshot/tasks/main.yml
@@ -37,6 +37,8 @@
   with_items: "{{ commands_list }}"
   failed_when: false
   register: cli_output
+  when: ("'text' in output_format") or
+        ("'markdown' in output_format")
 
 - name: run show commands on remote EOS devices with json output
   eos_command:

--- a/ansible_collections/arista/avd/roles/eos_snapshot/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_snapshot/tasks/main.yml
@@ -31,7 +31,7 @@
     mode: 0775
   when: ("text" in output_format or "markdown" in output_format)
 
-- name: run show commands on remote EOS devices
+- name: run show commands on remote EOS devices with text output
   eos_command:
     commands: "{{ item }}"
   with_items: "{{ commands_list }}"


### PR DESCRIPTION
## Change Summary

Add conditional when to eos_command task with cli-text output only to collect when text or markdown are selected.

## Component(s) name

`arista.avd.eos_snapshot`

## How to test

Run eos_snapshot with only yaml or json selected and task: "run show commands on remote EOS devices with text output" should not run.

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
