### PR TITLE
Fix(eos_designs): vtep_vvtep_ip doesn't generate any config

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1A.cfg
@@ -159,6 +159,7 @@ interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
    no shutdown
    ip address 192.168.254.14/32
+   ip address 192.168.255.255/32 secondary
 !
 interface Management1
    description oob_management
@@ -226,6 +227,7 @@ ip routing vrf Tenant_L3_VRF_Zone
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.168.255.0/24 eq 32
    seq 20 permit 192.168.254.0/24 eq 32
+   seq 30 permit 192.168.255.255/32
 !
 mac address-table notification host-flap logging
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1A.yml
@@ -464,6 +464,8 @@ loopback_interfaces:
     description: VTEP_VXLAN_Tunnel_Source
     shutdown: false
     ip_address: 192.168.254.14/32
+    ip_address_secondaries:
+    - 192.168.255.255/32
 prefix_lists:
   PL-LOOPBACKS-EVPN-OVERLAY:
     sequence_numbers:
@@ -471,6 +473,8 @@ prefix_lists:
         action: permit 192.168.255.0/24 eq 32
       20:
         action: permit 192.168.254.0/24 eq 32
+      30:
+        action: permit 192.168.255.255/32
 route_maps:
   RM-CONN-2-BGP:
     sequence_numbers:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/DC1-BL1A.yml
@@ -18,6 +18,8 @@ cvp_ingestauth_key: ""
 # Testing overlay loopback description override
 overlay_loopback_description: "MY_OVERLAY_LOOPBACK"
 
+vtep_vvtep_ip: 192.168.255.255/32
+
 # Testing event_handlers
 event_handlers:
   evpn-blacklist-recovery:

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_facts.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_facts.py
@@ -582,13 +582,6 @@ class EosDesignsFacts(AvdFacts):
         return {}
 
     @cached_property
-    def vtep_vvtep_ip(self):
-        """
-        switch.vtep_vvtep_ip set based on Global var vtep_vvtep_ip
-        """
-        return get(self._hostvars, "vtep_vvtep_ip")
-
-    @cached_property
     def mgmt_interface(self):
         """
         mgmt_interface is inherited from

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_facts.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_facts.py
@@ -582,6 +582,13 @@ class EosDesignsFacts(AvdFacts):
         return {}
 
     @cached_property
+    def vtep_vvtep_ip(self):
+        """
+        switch.vtep_vvtep_ip set based on Global var vtep_vvtep_ip
+        """
+        return get(self._hostvars, "vtep_vvtep_ip", default=None)
+
+    @cached_property
     def mgmt_interface(self):
         """
         mgmt_interface is inherited from

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_facts.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_facts.py
@@ -586,7 +586,7 @@ class EosDesignsFacts(AvdFacts):
         """
         switch.vtep_vvtep_ip set based on Global var vtep_vvtep_ip
         """
-        return get(self._hostvars, "vtep_vvtep_ip", default=None)
+        return get(self._hostvars, "vtep_vvtep_ip")
 
     @cached_property
     def mgmt_interface(self):

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/prefix_lists.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/prefix_lists.py
@@ -34,7 +34,7 @@ class PrefixListsMixin(UtilsMixin):
             sequence_numbers[20] = {"action": f"permit {self._vtep_loopback_ipv4_pool} eq 32"}
 
         if self._vtep_vvtep_ip is not None and self._network_services_l3 is True:
-            sequence_numbers[30] = {"action": f"permit {self.vtep_vvtep_ip}"}
+            sequence_numbers[30] = {"action": f"permit {self._vtep_vvtep_ip}"}
 
         prefix_lists["PL-LOOPBACKS-EVPN-OVERLAY"] = {"sequence_numbers": sequence_numbers}
 

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/utils.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/utils.py
@@ -278,4 +278,4 @@ class UtilsMixin:
 
     @cached_property
     def _vtep_vvtep_ip(self) -> str:
-        return get(self._hostvars, "switch.vtep_vvtep_ip")
+        return get(self._hostvars, "vtep_vvtep_ip")


### PR DESCRIPTION
## Change Summary

Fix issue with vtep_vvtep_ip not generating config.

## Related Issue(s)

Fixes #2441 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
Implement switch.vtep_vvtep_ip property in eos_desings_facts.py module and fix typo in underlay/prefix_lists.py module.

## How to test
Add vtep_vvtep_ip to any inventory running AVD 3.8 and you will see the secondary IP on lo1 is not generated for l3 vteps. 

## Checklist

### Repository Checklist

- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
