### PR TITLE
Fix: Formatting to pass latest galaxy-importer and ansible-lint rules

### DIFF
--- a/.github/workflows/pull-request-conflict.yml
+++ b/.github/workflows/pull-request-conflict.yml
@@ -8,7 +8,7 @@ jobs:
     name: 'Check PR status: conflicts and resolution'
     runs-on: ubuntu-20.04
     steps:
-      - name: check if PRs are dirty
+      - name: Check if PRs are dirty
         uses: eps1lon/actions-label-merge-conflict@releases/2.x
         with:
           dirtyLabel: "state: conflict"

--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -386,10 +386,11 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.10"
-      - name: 'Install Python requirements'
+      - name: 'Install Python & Ansible requirements'
         run: |
           pip install -r ansible_collections/arista/avd/requirements.txt
           pip install -r ansible_collections/arista/avd/requirements-dev.txt
+          ansible-galaxy collection install -r ansible_collections/arista/avd/collections.yml
       - name: 'Run ansible-test integration test cases'
         run: |
           cd ansible_collections/arista/avd/

--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -95,19 +95,19 @@ jobs:
     if: needs.file-changes.outputs.docs == 'true'
     steps:
       - uses: actions/checkout@v3
-      - name: 'start docker-compose stack'
+      - name: 'Start docker-compose stack'
         run: |
           cp development/docker-compose.yml .
           sed -i 's/cd\sansible-avd\/\s\&\&//g' docker-compose.yml
           docker-compose -f docker-compose.yml up -d webdoc_avd
           docker-compose -f docker-compose.yml ps
-      - name: 'test connectivity to mkdoc server'
+      - name: 'Test connectivity to mkdoc server'
         run: |
           until docker exec webdoc_avd curl -s -I http://localhost:8000/ ; do sleep 2; done
-      - name: check links for 404
+      - name: Check links for 404
         run: |
           docker run --network container:webdoc_avd raviqqe/muffet:2.6.1 http://127.0.0.1:8000/ -e ".*fonts.googleapis.com.*" -e ".*fonts.gstatic.com.*" -e ".*tools.ietf.org.*" -e ".*edit.*" -e ".*docs.github.com.*" -e "twitter.com" -f --max-redirections=3 --timeout=30 --rate-limit=1
-      - name: 'stop docker-compose stack'
+      - name: 'Stop docker-compose stack'
         run: |
           docker-compose -f docker-compose.yml down
 
@@ -124,7 +124,7 @@ jobs:
       matrix:
         python_version: [ "3.8", "3.9", "3.10" ]
     steps:
-      - name: 'set environment variables'
+      - name: 'Set environment variables'
         run: |
           echo "PY_COLORS=1" >> $GITHUB_ENV
           echo "ANSIBLE_FORCE_COLOR=1" >> $GITHUB_ENV
@@ -159,7 +159,7 @@ jobs:
     needs: [ pre_commit ]
     if: needs.file-changes.outputs.config_gen == 'true'
     steps:
-      - name: 'set environment variables'
+      - name: 'Set environment variables'
         run: |
           echo "PY_COLORS=1" >> $GITHUB_ENV
           echo "ANSIBLE_FORCE_COLOR=1" >> $GITHUB_ENV
@@ -194,7 +194,7 @@ jobs:
     needs: [ pre_commit ]
     if: needs.file-changes.outputs.dhcp == 'true'
     steps:
-      - name: 'set environment variables'
+      - name: 'Set environment variables'
         run: |
           echo "PY_COLORS=1" >> $GITHUB_ENV
           echo "ANSIBLE_FORCE_COLOR=1" >> $GITHUB_ENV
@@ -248,7 +248,7 @@ jobs:
     needs: [ pre_commit ]
     if: needs.file-changes.outputs.eos_design == 'true' || needs.file-changes.outputs.config_gen == 'true'
     steps:
-      - name: 'set environment variables'
+      - name: 'Set environment variables'
         run: |
           echo "PY_COLORS=1" >> $GITHUB_ENV
           echo "ANSIBLE_FORCE_COLOR=1" >> $GITHUB_ENV
@@ -282,7 +282,7 @@ jobs:
     needs: [ pre_commit ]
     if: needs.file-changes.outputs.cloudvision == 'true'
     steps:
-      - name: 'set environment variables'
+      - name: 'Set environment variables'
         run: |
           echo "PY_COLORS=1" >> $GITHUB_ENV
           echo "ANSIBLE_FORCE_COLOR=1" >> $GITHUB_ENV
@@ -307,71 +307,93 @@ jobs:
   # ----------------------------------- #
   ansible_test_sanity:
     name: Run ansible-test sanity validation
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [ pre_commit ]
     #needs: [ molecule_eos_designs, molecule_cloudvision ]
     #if: needs.cloudvision.status != 'failed' && needs.molecule_eos_designs.status != 'failed' && needs.file-changes.outputs.plugins == 'true'
     steps:
-      - name: 'set environment variables'
+      - name: 'Set environment variables'
         run: |
           echo "PY_COLORS=1" >> $GITHUB_ENV
       - uses: actions/checkout@v3
       - name: Set up Python 3
         uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "3.10"
       - name: 'Install Python requirements'
         run: |
           pip install -r ansible_collections/arista/avd/requirements.txt --upgrade
           pip install -r ansible_collections/arista/avd/requirements-dev.txt --upgrade
-      - name: 'run ansible-test sanity'
+      - name: 'Run ansible-test sanity'
         run: |
           cd ansible_collections/arista/avd/
           ansible-test sanity --color yes -v --requirements --docker
 
   ansible_test_units:
     name: Run ansible-test units test cases
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [ pre_commit ]
     steps:
-      - name: 'set environment variables'
+      - name: 'Set environment variables'
         run: |
           echo "PY_COLORS=1" >> $GITHUB_ENV
       - uses: actions/checkout@v3
       - name: Set up Python 3
         uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "3.10"
       - name: 'Install Python requirements'
         run: |
           pip install -r ansible_collections/arista/avd/requirements.txt
           pip install -r ansible_collections/arista/avd/requirements-dev.txt
-      - name: 'run ansible-test units test cases'
+      - name: 'Run ansible-test units test cases'
         run: |
           cd ansible_collections/arista/avd/
           ansible-test units --requirements --docker -vv
 
   ansible_test_integration:
     name: Run ansible-test integration test cases
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [ pre_commit ]
     steps:
-      - name: 'set environment variables'
+      - name: 'Set environment variables'
         run: |
           echo "PY_COLORS=1" >> $GITHUB_ENV
       - uses: actions/checkout@v3
       - name: Set up Python 3
         uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "3.10"
       - name: 'Install Python requirements'
         run: |
           pip install -r ansible_collections/arista/avd/requirements.txt
           pip install -r ansible_collections/arista/avd/requirements-dev.txt
-      - name: 'run ansible-test integration test cases'
+      - name: 'Run ansible-test integration test cases'
         run: |
           cd ansible_collections/arista/avd/
           ansible-test integration --requirements --docker -vv
+
+  ansible_lint:
+    name: Run ansible-lint test case
+    runs-on: ubuntu-22.04
+    needs: [ pre_commit ]
+    steps:
+      - name: 'Set environment variables'
+        run: |
+          echo "PY_COLORS=1" >> $GITHUB_ENV
+      - uses: actions/checkout@v3
+      - name: Set up Python 3
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: 'Install Python requirements'
+        run: |
+          pip install -r ansible_collections/arista/avd/requirements.txt
+          pip install -r ansible_collections/arista/avd/requirements-dev.txt
+      - name: 'Run ansible-test integration test cases'
+        run: |
+          cd ansible_collections/arista/avd/
+          ansible-lint --force-color --strict -v
   # ----------------------------------- #
   # Galaxy Importer
   # ----------------------------------- #
@@ -383,18 +405,18 @@ jobs:
       PY_COLORS: 1 # allows molecule colors to be passed to GitHub Actions
       ANSIBLE_FORCE_COLOR: 1 # allows ansible colors to be passed to GitHub Actions
     steps:
-      - name: 'set environment variables'
+      - name: 'Set environment variables'
         run: |
           echo "PY_COLORS=1" >> $GITHUB_ENV
           echo "ANSIBLE_FORCE_COLOR=1" >> $GITHUB_ENV
       - uses: actions/checkout@v3
-      - name: install requirements
+      - name: Install requirements
         run: |
-          pip install -r ansible_collections/arista/avd/requirements.txt
-          pip install -r ansible_collections/arista/avd/requirements-dev.txt
-      - name: 'build ansible package'
+          pip install -r ansible_collections/arista/avd/requirements.txt --upgrade
+          pip install -r ansible_collections/arista/avd/requirements-dev.txt --upgrade
+      - name: 'Build ansible package'
         run: make collection-build
-      - name: 'run galaxy-importer checks'
+      - name: 'Run galaxy-importer checks'
         run: python -m galaxy_importer.main *.tar.gz
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -307,7 +307,7 @@ jobs:
   # ----------------------------------- #
   ansible_test_sanity:
     name: Run ansible-test sanity validation
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     needs: [ pre_commit ]
     #needs: [ molecule_eos_designs, molecule_cloudvision ]
     #if: needs.cloudvision.status != 'failed' && needs.molecule_eos_designs.status != 'failed' && needs.file-changes.outputs.plugins == 'true'
@@ -331,7 +331,7 @@ jobs:
 
   ansible_test_units:
     name: Run ansible-test units test cases
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     needs: [ pre_commit ]
     steps:
       - name: 'Set environment variables'
@@ -353,7 +353,7 @@ jobs:
 
   ansible_test_integration:
     name: Run ansible-test integration test cases
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     needs: [ pre_commit ]
     steps:
       - name: 'Set environment variables'
@@ -375,7 +375,7 @@ jobs:
 
   ansible_lint:
     name: Run ansible-lint test case
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     needs: [ pre_commit ]
     steps:
       - name: 'Set environment variables'

--- a/ansible_collections/arista/avd/.ansible-lint
+++ b/ansible_collections/arista/avd/.ansible-lint
@@ -1,0 +1,3 @@
+---
+skip_list:
+  - name[template]

--- a/ansible_collections/arista/avd/.ansible-lint
+++ b/ansible_collections/arista/avd/.ansible-lint
@@ -1,3 +1,4 @@
 ---
 skip_list:
   - name[template]
+  - run_once[task]

--- a/ansible_collections/arista/avd/.ansible-lint
+++ b/ansible_collections/arista/avd/.ansible-lint
@@ -1,4 +1,6 @@
 ---
 skip_list:
-  - name[template]
-  - run_once[task]
+  - name[template] # Remove warnings on task names where Jinja template is not at the end
+  - run_once[task] # Remove warnings on using run_once with other strategies
+  - experimental # False positive when having a var names "roles" inside hostvars file. Roles is not listed as reserved
+  - meta-no-info # Ansible-lint does not honor meta-schema with standalone: false

--- a/ansible_collections/arista/avd/docs/getting-started.md
+++ b/ansible_collections/arista/avd/docs/getting-started.md
@@ -66,16 +66,16 @@ Please refer to [`eos_designs` documentation](../roles/eos_designs/README.md)
 
   tasks:
 
-    - name: generate intended variables
-      import_role:
+    - name: Generate intended variables
+      ansible.builtin.import_role:
          name: arista.avd.eos_designs
 
-    - name: generate device intended config and documentation
-      import_role:
+    - name: Generate device intended config and documentation
+      ansible.builtin.import_role:
          name: arista.avd.eos_cli_config_gen
 
-    - name: deploy configuration via CVP
-      import_role:
+    - name: Deploy configuration via CVP
+      ansible.builtin.import_role:
          name: arista.avd.eos_config_deploy_cvp
 ```
 
@@ -88,16 +88,16 @@ Please refer to [`eos_designs` documentation](../roles/eos_designs/README.md)
 
   tasks:
 
-    - name: generate intended variables
-      import_role:
+    - name: Generate intended variables
+      ansible.builtin.import_role:
          name: arista.avd.eos_designs
 
-    - name: generate device intended config and documentation
-      import_role:
+    - name: Generate device intended config and documentation
+      ansible.builtin.import_role:
          name: arista.avd.eos_cli_config_gen
 
-    - name: deploy configuration to device
-      import_role:
+    - name: Deploy configuration to device
+      ansible.builtin.import_role:
          name: arista.avd.eos_config_deploy_eapi
 ```
 

--- a/ansible_collections/arista/avd/docs/getting-started/intro-to-ansible-and-avd.md
+++ b/ansible_collections/arista/avd/docs/getting-started/intro-to-ansible-and-avd.md
@@ -314,11 +314,11 @@ A simple example of a play defined in a playbook is shown below:
   hosts: FABRIC
   gather_facts: false
   tasks:
-    - name: generate intended variables
-      import_role:
+    - name: Generate intended variables
+      ansible.builtin.import_role:
         name: arista.avd.eos_designs
-    - name: generate device intended config and documentation
-      import_role:
+    - name: Generate device intended config and documentation
+      ansible.builtin.import_role:
         name: arista.avd.eos_cli_config_gen
 ```
 
@@ -390,14 +390,14 @@ If you want to push to switches in the entire fabric using eAPI and your playboo
   hosts: FABRIC
   gather_facts: false
   tasks:
-    - name: generate intended variables
-      import_role:
+    - name: Generate intended variables
+      ansible.builtin.import_role:
         name: arista.avd.eos_designs
-    - name: generate device intended config and documentation
-      import_role:
+    - name: Generate device intended config and documentation
+      ansible.builtin.import_role:
         name: arista.avd.eos_cli_config_gen
-    - name: deploy configuration to device
-      import_role:
+    - name: Deploy configuration to device
+      ansible.builtin.import_role:
          name: arista.avd.eos_config_deploy_eapi
 ```
 
@@ -423,14 +423,14 @@ If you want to push to switches in the entire fabric using CloudVision and your 
   hosts: FABRIC
   gather_facts: false
   tasks:
-    - name: generate intended variables
-      import_role:
+    - name: Generate intended variables
+      ansible.builtin.import_role:
         name: arista.avd.eos_designs
-    - name: generate device intended config and documentation
-      import_role:
+    - name: Generate device intended config and documentation
+      ansible.builtin.import_role:
         name: arista.avd.eos_cli_config_gen
-    - name: deploy configuration to device
-      import_role:
+    - name: Deploy configuration to device
+      ansible.builtin.import_role:
          name: arista.avd.eos_config_deploy_eapi
 
 - name: Push to CVP
@@ -439,8 +439,8 @@ If you want to push to switches in the entire fabric using CloudVision and your 
   connection: local
 
   tasks:
-    - name: run CVP provisioning
-      import_role:
+    - name: Run CVP provisioning
+      ansible.builtin.import_role:
         name: arista.avd.eos_config_deploy_cvp
       vars:
         container_root: 'DC1'

--- a/ansible_collections/arista/avd/docs/how-to/first-project.md
+++ b/ansible_collections/arista/avd/docs/how-to/first-project.md
@@ -471,9 +471,9 @@ AVD comes with a role to [generate your folder structure](https://github.com/ari
 
 ```yaml
 tasks:
-    - name: build local folders
+    - name: Build local folders
       tags: [build]
-      import_role:
+      ansible.builtin.import_role:
         name: arista.avd.build_output_folders
       vars:
         fabric_dir_name: '{{ fabric_name }}'
@@ -485,9 +485,9 @@ AVD provides the [**`eos_designs`**](https://github.com/aristanetworks/ansible-a
 
 ```yaml
   tasks:
-    - name: generate intended variables
+    - name: Generate intended variables
       tags: [build]
-      import_role:
+      ansible.builtin.import_role:
         name: arista.avd.eos_designs
 ```
 
@@ -497,9 +497,9 @@ After device data have been generated, AVD can build EOS configuration as well a
 
 ```yaml
   tasks:
-    - name: generate device intended config and documentation
+    - name: Generate device intended config and documentation
       tags: [build]
-      import_role:
+      ansible.builtin.import_role:
         name: arista.avd.eos_cli_config_gen
 ```
 
@@ -513,9 +513,9 @@ Once your configuration files have been generated, you can use [`arista.avd.eos_
 
 ```yaml
   tasks:
-    - name: deploy configuration to device
+    - name: Deploy configuration to device
       tags: [deploy, never]
-      import_role:
+      ansible.builtin.import_role:
          name: arista.avd.eos_config_deploy_eapi
 ```
 
@@ -528,16 +528,16 @@ The complete playbook is below. Feel free to update it to create your workflow.
 - name: Build Switch configuration
   hosts: all
   tasks:
-    - name: generate intended variables
+    - name: Generate intended variables
       tags: [build]
-      import_role:
+      ansible.builtin.import_role:
         name: arista.avd.eos_designs
-    - name: generate device intended config and documentation
+    - name: Generate device intended config and documentation
       tags: [build]
-      import_role:
+      ansible.builtin.import_role:
         name: arista.avd.eos_cli_config_gen
-    - name: deploy configuration to device
+    - name: Deploy configuration to device
       tags: [deploy, never]
-      import_role:
+      ansible.builtin.import_role:
          name: arista.avd.eos_config_deploy_eapi
 ```

--- a/ansible_collections/arista/avd/docs/how-to/tower-integration.md
+++ b/ansible_collections/arista/avd/docs/how-to/tower-integration.md
@@ -242,8 +242,8 @@ inventory_file: '/tmp/inventory.yml'
         mode: '0755'
       delegate_to: 127.0.0.1
 
-    - name: run CVP provisioning
-      import_role:
+    - name: Run CVP provisioning
+      ansible.builtin.import_role:
         name: arista.avd.eos_config_deploy_cvp
       vars:
         container_root: 'DC1_FABRIC'

--- a/ansible_collections/arista/avd/docs/how-to/ztp.md
+++ b/ansible_collections/arista/avd/docs/how-to/ztp.md
@@ -79,6 +79,6 @@ Playbook is fairly simple:
   gather_facts: true
   tasks:
     - name: 'Execute DHCP configuration role'
-      import_role:
+      ansible.builtin.import_role:
         name: arista.cvp.dhcp_configuration
 ```

--- a/ansible_collections/arista/avd/docs/modules/configlet_build_config.rst.md
+++ b/ansible_collections/arista/avd/docs/modules/configlet_build_config.rst.md
@@ -78,7 +78,7 @@ The following options may be specified for this module:
 
 ```yaml
 # tasks file for cvp_configlet_upload
-- name: generate intended variables
+- name: Generate intended variables
     tags: [build, provision]
     configlet_build_config:
     configlet_dir: '{{ configlet_dir }}'

--- a/ansible_collections/arista/avd/docs/modules/inventory_to_container.rst.md
+++ b/ansible_collections/arista/avd/docs/modules/inventory_to_container.rst.md
@@ -101,8 +101,8 @@ The following options may be specified for this module:
 ## Examples
 
 ```yaml
-- name: generate intended variables
-  inventory_to_container:
+- name: Generate intended variables
+  arista.avd.inventory_to_container:
     inventory: 'inventory.yml'
     container_root: 'DC1_FABRIC'
     configlet_dir: 'intended_configs'

--- a/ansible_collections/arista/avd/docs/modules/inventory_to_container.rst.md
+++ b/ansible_collections/arista/avd/docs/modules/inventory_to_container.rst.md
@@ -109,27 +109,23 @@ The following options may be specified for this module:
     configlet_prefix: 'AVD'
     device_filter: ['DC1-LE']
     # destination: 'generated_vars/{{inventory_hostname}}.yml'
-  register: cvp_vars
+  register: CVP_VARS
 
-- name: 'Collecting facts from CVP {{inventory_hostname}}.'
+- name: 'Collecting facts from CVP {{ inventory_hostname }}.'
   arista.cvp.cv_facts:
-  register: cvp_facts
+  register: CVP_FACTS
 
-- name: 'Create configlets on CVP {{inventory_hostname}}.'
+- name: 'Create configlets on CVP {{ inventory_hostname }}.'
   arista.cvp.cv_configlet:
     cvp_facts: "{{ cvp_facts.ansible_facts }}"
     configlets: "{{ cvp_vars.cvp_configlets }}"
     configlet_filter: ["AVD"]
 
-- name: "Building Container topology on {{inventory_hostname}}"
+- name: "Building Container topology on {{ inventory_hostname }}"
   arista.cvp.cv_container:
     topology: '{{ cvp_vars.cvp_topology }}'
     cvp_facts: '{{ cvp_facts.ansible_facts }}'
     save_topology: true
-```
-
-### Author
-
 - Ansible Arista Team (@aristanetworks)
 
 ### Status

--- a/ansible_collections/arista/avd/examples/campus-fabric/build.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/build.yml
@@ -7,9 +7,9 @@
   tasks:
 
     - name: Generate AVD Structured Configurations and Fabric Documentation
-      import_role:
+      ansible.builtin.import_role:
         name: arista.avd.eos_designs
 
     - name: Generate Device Configurations and Documentation
-      import_role:
+      ansible.builtin.import_role:
         name: arista.avd.eos_cli_config_gen

--- a/ansible_collections/arista/avd/examples/campus-fabric/deploy.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/deploy.yml
@@ -7,13 +7,13 @@
   tasks:
 
     - name: Generate AVD Structured Configurations and Fabric Documentation
-      import_role:
+      ansible.builtin.import_role:
         name: arista.avd.eos_designs
 
     - name: Generate Device Configurations and Documentation
-      import_role:
+      ansible.builtin.import_role:
         name: arista.avd.eos_cli_config_gen
 
     - name: Deploy Configurations to Devices
-      import_role:
+      ansible.builtin.import_role:
         name: arista.avd.eos_config_deploy_eapi

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/build.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/build.yml
@@ -7,9 +7,9 @@
   tasks:
 
     - name: Generate AVD Structured Configurations and Fabric Documentation
-      import_role:
+      ansible.builtin.import_role:
         name: arista.avd.eos_designs
 
     - name: Generate Device Configurations and Documentation
-      import_role:
+      ansible.builtin.import_role:
         name: arista.avd.eos_cli_config_gen

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/deploy.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/deploy.yml
@@ -7,13 +7,13 @@
   tasks:
 
     - name: Generate AVD Structured Configurations and Fabric Documentation
-      import_role:
+      ansible.builtin.import_role:
         name: arista.avd.eos_designs
 
     - name: Generate Device Configurations and Documentation
-      import_role:
+      ansible.builtin.import_role:
         name: arista.avd.eos_cli_config_gen
 
     - name: Deploy Configurations to Devices
-      import_role:
+      ansible.builtin.import_role:
         name: arista.avd.eos_config_deploy_eapi

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/build.yml
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/build.yml
@@ -7,9 +7,9 @@
   tasks:
 
     - name: Generate AVD Structured Configurations and Fabric Documentation
-      import_role:
+      ansible.builtin.import_role:
         name: arista.avd.eos_designs
 
     - name: Generate Device Configurations and Documentation
-      import_role:
+      ansible.builtin.import_role:
         name: arista.avd.eos_cli_config_gen

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/deploy.yml
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/deploy.yml
@@ -7,13 +7,13 @@
   tasks:
 
     - name: Generate AVD Structured Configurations and Fabric Documentation
-      import_role:
+      ansible.builtin.import_role:
         name: arista.avd.eos_designs
 
     - name: Generate Device Configurations and Documentation
-      import_role:
+      ansible.builtin.import_role:
         name: arista.avd.eos_cli_config_gen
 
     - name: Deploy Configurations to Devices
-      import_role:
+      ansible.builtin.import_role:
         name: arista.avd.eos_config_deploy_eapi

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/README.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/README.md
@@ -621,14 +621,14 @@ Example of using this playbook without devices (local tasks):
   hosts: FABRIC
   gather_facts: false
   tasks:
-    - name: generate intended variables
-      import_role:
+    - name: Generate intended variables
+      ansible.builtin.import_role:
         name: arista.avd.eos_designs
-    - name: generate device intended config and documentation
-      import_role:
+    - name: Generate device intended config and documentation
+      ansible.builtin.import_role:
         name: arista.avd.eos_cli_config_gen
-    # - name: deploy configuration to device
-    #   import_role:
+    # - name: Deploy configuration to device
+    #   ansible.builtin.import_role:
     #      name: arista.avd.eos_config_deploy_eapi
 ```
 

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/playbook.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/playbook.yml
@@ -5,11 +5,11 @@
   gather_facts: false
   tasks:
     - name: Generate AVD Structured Configurations and Fabric Documentation # (2)!
-      import_role:
+      ansible.builtin.import_role:
         name: arista.avd.eos_designs
     - name: Generate Device Configurations and Documentation # (3)!
-      import_role:
+      ansible.builtin.import_role:
         name: arista.avd.eos_cli_config_gen
     - name: Deploy Configurations to Devices # (4)!
-      import_role:
+      ansible.builtin.import_role:
         name: arista.avd.eos_config_deploy_eapi

--- a/ansible_collections/arista/avd/molecule/build_schemas_and_docs/converge.yml
+++ b/ansible_collections/arista/avd/molecule/build_schemas_and_docs/converge.yml
@@ -1,9 +1,10 @@
 ---
-- name: This molecule scenario has been replaced by pre-commit. Use "pre-commit run schemas" instead
+- name: This molecule scenario has been replaced by pre-commit. Use "pre-commit run schemas --all" instead
   hosts: localhost
   tasks:
-    - ansible.builtin.fail:
+    - name: This molecule scenario has been replaced by pre-commit. Use "pre-commit run schemas --all" instead
+      ansible.builtin.fail:
         msg:
           This molecule scenario has been replaced by pre-commit.
-          Use 'pre-commit run schemas' instead.
+          Use 'pre-commit run schemas --all' instead.
           Good practice is to automatically run pre-commit. Enable with 'pre-commit install'.

--- a/ansible_collections/arista/avd/molecule/dhcp_configuration/converge.yml
+++ b/ansible_collections/arista/avd/molecule/dhcp_configuration/converge.yml
@@ -3,10 +3,10 @@
   hosts: TOOLS
   gather_facts: true
   tasks:
-    - name: create local output folders
-      import_role:
+    - name: Create local output folders
+      ansible.builtin.import_role:
         name: arista.avd.build_output_folders
       run_once: true
-    - name: generate intended variables
-      import_role:
+    - name: Generate intended variables
+      ansible.builtin.import_role:
         name: arista.avd.dhcp_provisioner

--- a/ansible_collections/arista/avd/molecule/dhcp_configuration/inventory/group_vars/AVD_LAB.yml
+++ b/ansible_collections/arista/avd/molecule/dhcp_configuration/inventory/group_vars/AVD_LAB.yml
@@ -1,5 +1,5 @@
 # Nashua EVE-NG LAB shared attributes
-root_dir: '{{playbook_dir}}'
+root_dir: '{{ playbook_dir }}'
 
 # local users
 local_users:

--- a/ansible_collections/arista/avd/molecule/dhcp_configuration/inventory/group_vars/TOOLS.yml
+++ b/ansible_collections/arista/avd/molecule/dhcp_configuration/inventory/group_vars/TOOLS.yml
@@ -1,5 +1,5 @@
 ---
-root_dir: '{{playbook_dir}}'
+root_dir: '{{ playbook_dir }}'
 # ZTP & DHCP configuration section
 fabric_group: DC1_FABRIC
 ztp_network_summary: 172.17.0.0/16

--- a/ansible_collections/arista/avd/molecule/dhcp_configuration/inventory/host_vars/all.yml
+++ b/ansible_collections/arista/avd/molecule/dhcp_configuration/inventory/host_vars/all.yml
@@ -1,2 +1,2 @@
 ---
-root_dir: '{{playbook_dir}}'
+root_dir: '{{ playbook_dir }}'

--- a/ansible_collections/arista/avd/molecule/dhcp_provisioning/converge.yml
+++ b/ansible_collections/arista/avd/molecule/dhcp_provisioning/converge.yml
@@ -4,6 +4,6 @@
   gather_facts: false
   connection: local
   tasks:
-    - name: generate intended configuration
-      import_role:
+    - name: Generate intended configuration
+      ansible.builtin.import_role:
         name: arista.avd.dhcp_provisioner

--- a/ansible_collections/arista/avd/molecule/dhcp_provisioning/create.yml
+++ b/ansible_collections/arista/avd/molecule/dhcp_provisioning/create.yml
@@ -4,10 +4,10 @@
   gather_facts: false
   connection: local
   vars:
-    root_dir: '{{playbook_dir}}'
+    root_dir: '{{ playbook_dir }}'
   tasks:
-    - name: create local output folders
+    - name: Create local output folders
       delegate_to: 127.0.0.1
-      import_role:
+      ansible.builtin.import_role:
         name: arista.avd.build_output_folders
       run_once: true

--- a/ansible_collections/arista/avd/molecule/dhcp_provisioning/destroy.yml
+++ b/ansible_collections/arista/avd/molecule/dhcp_provisioning/destroy.yml
@@ -4,7 +4,7 @@
   gather_facts: false
   connection: local
   tasks:
-    - name: Delete local folDers
+    - name: Delete local folders
       delegate_to: 127.0.0.1
       run_once: true
       ansible.builtin.file:

--- a/ansible_collections/arista/avd/molecule/dhcp_provisioning/destroy.yml
+++ b/ansible_collections/arista/avd/molecule/dhcp_provisioning/destroy.yml
@@ -7,7 +7,7 @@
     - name: delete local folders
       delegate_to: 127.0.0.1
       run_once: true
-      file:
+      ansible.builtin.file:
         path: "{{root_dir}}/{{ item }}"
         state: absent
       with_items:

--- a/ansible_collections/arista/avd/molecule/dhcp_provisioning/destroy.yml
+++ b/ansible_collections/arista/avd/molecule/dhcp_provisioning/destroy.yml
@@ -4,11 +4,11 @@
   gather_facts: false
   connection: local
   tasks:
-    - name: delete local folders
+    - name: Delete local folDers
       delegate_to: 127.0.0.1
       run_once: true
       ansible.builtin.file:
-        path: "{{root_dir}}/{{ item }}"
+        path: "{{ root_dir }}/{{ item }}"
         state: absent
       with_items:
         - documentation

--- a/ansible_collections/arista/avd/molecule/dhcp_provisioning/inventory/group_vars/AVD_LAB.yml
+++ b/ansible_collections/arista/avd/molecule/dhcp_provisioning/inventory/group_vars/AVD_LAB.yml
@@ -1,5 +1,5 @@
 # Nashua EVE-NG LAB shared attributes
-root_dir: '{{playbook_dir}}'
+root_dir: '{{ playbook_dir }}'
 
 # local users
 local_users:

--- a/ansible_collections/arista/avd/molecule/dhcp_provisioning/inventory/group_vars/TOOLS.yml
+++ b/ansible_collections/arista/avd/molecule/dhcp_provisioning/inventory/group_vars/TOOLS.yml
@@ -1,5 +1,5 @@
 ---
-root_dir: '{{playbook_dir}}'
+root_dir: '{{ playbook_dir }}'
 # ZTP & DHCP configuration section
 ztp_network_summary: 172.17.0.0/16
 ztp_pool_start: 172.17.255.200

--- a/ansible_collections/arista/avd/molecule/dhcp_provisioning/inventory/host_vars/all.yml
+++ b/ansible_collections/arista/avd/molecule/dhcp_provisioning/inventory/host_vars/all.yml
@@ -1,2 +1,2 @@
 ---
-root_dir: '{{playbook_dir}}'
+root_dir: '{{ playbook_dir }}'

--- a/ansible_collections/arista/avd/molecule/dhcp_provisioning/verify.yml
+++ b/ansible_collections/arista/avd/molecule/dhcp_provisioning/verify.yml
@@ -5,7 +5,7 @@
   connection: local
   tasks:
 
-    - name: generate device intended config and documentation
+    - name: Generate device intended config and documentation
       delegate_to: 127.0.0.1
-      import_role:
+      ansible.builtin.import_role:
         name: arista.avd.eos_cli_config_gen

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/converge.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/converge.yml
@@ -5,7 +5,7 @@
   connection: local
   tasks:
 
-    - name: generate device intended config and documentation
+    - name: Generate device intended config and documentation
       delegate_to: 127.0.0.1
-      import_role:
+      ansible.builtin.import_role:
         name: arista.avd.eos_cli_config_gen

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/create.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/create.yml
@@ -4,8 +4,8 @@
   gather_facts: false
   connection: local
   tasks:
-    - name: create local output folders
+    - name: Create local output folders
       delegate_to: 127.0.0.1
-      import_role:
+      ansible.builtin.import_role:
         name: arista.avd.build_output_folders
       run_once: true

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/destroy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/destroy.yml
@@ -7,7 +7,7 @@
     - name: delete local folders
       delegate_to: 127.0.0.1
       run_once: true
-      file:
+      ansible.builtin.file:
         path: "{{root_dir}}/{{ item }}"
         state: absent
       with_items:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/destroy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/destroy.yml
@@ -4,11 +4,11 @@
   gather_facts: false
   connection: local
   tasks:
-    - name: delete local folders
+    - name: Delete local folders
       delegate_to: 127.0.0.1
       run_once: true
       ansible.builtin.file:
-        path: "{{root_dir}}/{{ item }}"
+        path: "{{ root_dir }}/{{ item }}"
         state: absent
       with_items:
         - documentation

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/group_vars/all.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/group_vars/all.yml
@@ -1,5 +1,5 @@
 ---
-root_dir: '{{playbook_dir}}'
+root_dir: '{{ playbook_dir }}'
 is_for_test: true
 ### Management Interfaces ###
 management_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/roles.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/roles.yml
@@ -1,5 +1,6 @@
+---
 ### Roles ###
-roles:
+roles:  # noqa: schema[vars]
   - name: network-limited
     sequence_numbers:
       - sequence: 10

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/tcam-profile.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/tcam-profile.yml
@@ -1,4 +1,4 @@
 tcam_profile:
   system: traffic_policy
   profiles:
-    traffic_policy: "{{lookup('file', '{{ root_dir }}/inventory/TCAM_TRAFFIC_POLICY.conf')}}"
+    traffic_policy: "{{ lookup('file', '{{ root_dir }}/inventory/TCAM_TRAFFIC_POLICY.conf') }}"

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/verify.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/verify.yml
@@ -6,14 +6,16 @@
   gather_facts: false
   connection: local
   tasks:
-    - name: detect git change in tracked files
+    - name: Detect git change in tracked files
       delegate_to: 127.0.0.1
-      shell:
-        cmd: git status --short | grep -e "^ M" | wc -l | awk -F ' ' '{print $1}'
+      ansible.builtin.shell:
+        cmd: git status --short | grep -e "^ M" | wc -l | awk -F ' ' '{print $1}'  # noqa: command-instead-of-module
+      changed_when: |
+        "0" in git_status.stdout
       register: git_status
 
-    - name: fail if change detected
+    - name: Fail if change detected  # noqa: no-handler
       delegate_to: 127.0.0.1
-      debug:
+      ansible.builtin.debug:
         msg: 'Change detected in output. Please check ! Found {{ git_status.stdout }} changes'
-      # when: '"0" in git_status.stdout'
+      when: git_status.changed

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/converge.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/converge.yml
@@ -5,7 +5,7 @@
   connection: local
   tasks:
 
-    - name: generate device intended config and documentation
+    - name: Generate device intended config and documentation
       delegate_to: 127.0.0.1
-      import_role:
+      ansible.builtin.import_role:
         name: arista.avd.eos_cli_config_gen

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/create.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/create.yml
@@ -4,8 +4,8 @@
   gather_facts: false
   connection: local
   tasks:
-    - name: create local output folders
+    - name: Create local output folders
       delegate_to: 127.0.0.1
-      import_role:
+      ansible.builtin.import_role:
         name: arista.avd.build_output_folders
       run_once: true

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/destroy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/destroy.yml
@@ -7,7 +7,7 @@
     - name: delete local folders
       delegate_to: 127.0.0.1
       run_once: true
-      file:
+      ansible.builtin.file:
         path: "{{root_dir}}/{{ item }}"
         state: absent
       with_items:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/destroy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/destroy.yml
@@ -4,11 +4,11 @@
   gather_facts: false
   connection: local
   tasks:
-    - name: delete local folders
+    - name: Delete local folders
       delegate_to: 127.0.0.1
       run_once: true
       ansible.builtin.file:
-        path: "{{root_dir}}/{{ item }}"
+        path: "{{ root_dir }}/{{ item }}"
         state: absent
       with_items:
         - documentation

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/group_vars/all.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/group_vars/all.yml
@@ -1,5 +1,5 @@
 ---
-root_dir: '{{playbook_dir}}'
+root_dir: '{{ playbook_dir }}'
 is_for_test: true
 ### Management Interfaces ###
 management_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/roles.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/roles.yml
@@ -1,5 +1,6 @@
+---
 ### Roles ###
-roles:
+roles:  # noqa: schema[vars]
   - name: network-limited
     sequence_numbers:
       - sequence: 10

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/tcam-profile.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/tcam-profile.yml
@@ -2,4 +2,4 @@ tcam_profile:
   system: traffic_policy
   profiles:
     - name: traffic_policy
-      config: "{{lookup('file', '{{ root_dir }}/inventory/TCAM_TRAFFIC_POLICY.conf')}}"
+      config: "{{ lookup('file', '{{ root_dir }}/inventory/TCAM_TRAFFIC_POLICY.conf') }}"

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/verify.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/verify.yml
@@ -6,14 +6,16 @@
   gather_facts: false
   connection: local
   tasks:
-    - name: detect git change in tracked files
+    - name: Detect git change in tracked files
       delegate_to: 127.0.0.1
-      shell:
-        cmd: git status --short | grep -e "^ M" | wc -l | awk -F ' ' '{print $1}'
+      ansible.builtin.shell:
+        cmd: git status --short | grep -e "^ M" | wc -l | awk -F ' ' '{print $1}'  # noqa: command-instead-of-module
+      changed_when: |
+        "0" in git_status.stdout
       register: git_status
 
-    - name: fail if change detected
+    - name: Fail if change detected  # noqa: no-handler
       delegate_to: 127.0.0.1
-      debug:
+      ansible.builtin.debug:
         msg: 'Change detected in output. Please check ! Found {{ git_status.stdout }} changes'
-      # when: '"0" in git_status.stdout'
+      when: git_status.changed

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/converge.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/converge.yml
@@ -4,13 +4,13 @@
   gather_facts: false
   connection: local
   vars:
-    root_dir: '{{playbook_dir}}'
+    root_dir: '{{ playbook_dir }}'
   tasks:
-    - name: generate intended variables
-      import_role:
+    - name: Generate intended variables
+      ansible.builtin.import_role:
         name: arista.avd.eos_designs
-    - name: generate device intended config and documentation
-      import_role:
+    - name: Generate device intended config and documentation
+      ansible.builtin.import_role:
         name: arista.avd.eos_cli_config_gen
 
 - name: "Converge -- Build Cloudvision Configuration"
@@ -18,11 +18,11 @@
   gather_facts: false
   connection: local
   vars:
-    root_dir: '{{playbook_dir}}'
+    root_dir: '{{ playbook_dir }}'
   tasks:
-    - name: run CVP provisioning
+    - name: Run CVP provisioning
       # tags: generate
-      import_role:
+      ansible.builtin.import_role:
         name: arista.avd.eos_config_deploy_cvp
       vars:
         container_root: 'DC1_FABRIC'

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/create.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/create.yml
@@ -4,10 +4,10 @@
   gather_facts: false
   connection: local
   vars:
-    root_dir: '{{playbook_dir}}'
+    root_dir: '{{ playbook_dir }}'
   tasks:
-    - name: create local output folders
+    - name: Create local output folders
       delegate_to: 127.0.0.1
-      import_role:
+      ansible.builtin.import_role:
         name: arista.avd.build_output_folders
       run_once: true

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/destroy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/destroy.yml
@@ -7,7 +7,7 @@
     - name: delete local folders
       delegate_to: 127.0.0.1
       run_once: true
-      file:
+      ansible.builtin.file:
         path: "{{root_dir}}/{{ item }}"
         state: absent
       with_items:

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/destroy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/destroy.yml
@@ -4,11 +4,11 @@
   gather_facts: false
   connection: local
   tasks:
-    - name: delete local folders
+    - name: Delete local folders
       delegate_to: 127.0.0.1
       run_once: true
       ansible.builtin.file:
-        path: "{{root_dir}}/{{ item }}"
+        path: "{{ root_dir }}/{{ item }}"
         state: absent
       with_items:
         - documentation

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/cvp/cv_server.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/cvp/cv_server.yml
@@ -1,5 +1,5 @@
 ---
-cvp_devices:
+CVP_DEVICES:
   DC1-BL1A:
     name: DC1-BL1A
     parentContainerName: DC1_BL1
@@ -72,7 +72,7 @@ cvp_devices:
     configlets:
       - AVD_DC1-SPINE4
     imageBundle: []
-cvp_containers:
+CVP_CONTAINERS:
   DC1_BL1:
     parent_container: DC1_LEAFS
   DC1_FABRIC:

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/cvp/cv_server_configlets.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/cvp/cv_server_configlets.yml
@@ -1,4 +1,3 @@
-changed: false
 CVP_CONFIGLETS:
   AVD_DC1-BL1A: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr
     -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/cvp/cv_server_configlets.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/cvp/cv_server_configlets.yml
@@ -1,5 +1,5 @@
 changed: false
-cvp_configlets:
+CVP_CONFIGLETS:
   AVD_DC1-BL1A: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr
     -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
     -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
@@ -1438,7 +1438,7 @@ cvp_configlets:
     \     neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
     connected\n!\nmanagement api http-commands\n   protocol https\n   no shutdown\n
     \  !\n   vrf MGMT\n      no shutdown\n!\nend\n"
-cvp_topology:
+CVP_TOPOLOGY:
   DC1_BL1:
     devices:
     - DC1-BL1A

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/cvp/cv_server_configlets.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/cvp/cv_server_configlets.yml
@@ -1,3 +1,4 @@
+changed: false
 cvp_configlets:
   AVD_DC1-BL1A: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr
     -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/inventory/group_vars/AVD_LAB.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/inventory/group_vars/AVD_LAB.yml
@@ -1,5 +1,5 @@
 # Nashua EVE-NG LAB shared attributes
-root_dir: '{{playbook_dir}}'
+root_dir: '{{ playbook_dir }}'
 
 # local users
 local_users:

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/inventory/host_vars/all.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/inventory/host_vars/all.yml
@@ -1,2 +1,2 @@
 ---
-root_dir: '{{playbook_dir}}'
+root_dir: '{{ playbook_dir }}'

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/verify.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/verify.yml
@@ -5,7 +5,7 @@
   connection: local
   tasks:
 
-    - name: generate device intended config and documentation
+    - name: Generate device intended config and documentation
       delegate_to: 127.0.0.1
-      import_role:
+      ansible.builtin.import_role:
         name: arista.avd.eos_cli_config_gen

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/converge.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/converge.yml
@@ -4,7 +4,7 @@
   gather_facts: false
   connection: local
   tasks:
-    - name: generate intended variables
+    - name: Generate intended variables
       delegate_to: 127.0.0.1
-      import_role:
+      ansible.builtin.import_role:
         name: arista.avd.eos_designs

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/create.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/create.yml
@@ -4,10 +4,10 @@
   gather_facts: false
   connection: local
   vars:
-    root_dir: '{{playbook_dir}}'
+    root_dir: '{{ playbook_dir }}'
   tasks:
-    - name: create local output folders
+    - name: Create local output folders
       delegate_to: 127.0.0.1
-      import_role:
+      ansible.builtin.import_role:
         name: arista.avd.build_output_folders
       run_once: true

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/destroy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/destroy.yml
@@ -7,7 +7,7 @@
     - name: delete local folders
       delegate_to: 127.0.0.1
       run_once: true
-      file:
+      ansible.builtin.file:
         path: "{{root_dir}}/{{ item }}"
         state: absent
       with_items:

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/destroy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/destroy.yml
@@ -4,11 +4,11 @@
   gather_facts: false
   connection: local
   tasks:
-    - name: delete local folders
+    - name: Delete local folders
       delegate_to: 127.0.0.1
       run_once: true
       ansible.builtin.file:
-        path: "{{root_dir}}/{{ item }}"
+        path: "{{ root_dir }}/{{ item }}"
         state: absent
       with_items:
         - documentation

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/inventory/group_vars/all.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/inventory/group_vars/all.yml
@@ -1,4 +1,4 @@
 ---
-root_dir: '{{playbook_dir}}'
+root_dir: '{{ playbook_dir }}'
 
 avd_data_validation_mode: "error"

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/inventory/host_vars/all.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/inventory/host_vars/all.yml
@@ -1,2 +1,2 @@
 ---
-root_dir: '{{playbook_dir}}'
+root_dir: '{{ playbook_dir }}'

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/verify.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/verify.yml
@@ -4,7 +4,7 @@
   gather_facts: false
   connection: local
   tasks:
-    - name: generate device intended config and documentation
+    - name: Generate device intended config and documentation
       delegate_to: 127.0.0.1
-      import_role:
+      ansible.builtin.import_role:
         name: arista.avd.eos_cli_config_gen

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/converge.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/converge.yml
@@ -5,7 +5,7 @@
   connection: local
   tasks:
 
-    - name: generate intended variables
+    - name: Generate intended variables
       delegate_to: 127.0.0.1
-      import_role:
+      ansible.builtin.import_role:
         name: arista.avd.eos_designs

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/create.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/create.yml
@@ -4,10 +4,10 @@
   gather_facts: false
   connection: local
   vars:
-    root_dir: '{{playbook_dir}}'
+    root_dir: '{{ playbook_dir }}'
   tasks:
-    - name: create local output folders
+    - name: Create local output folders
       delegate_to: 127.0.0.1
-      import_role:
+      ansible.builtin.import_role:
         name: arista.avd.build_output_folders
       run_once: true

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/destroy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/destroy.yml
@@ -7,7 +7,7 @@
     - name: delete local folders
       delegate_to: 127.0.0.1
       run_once: true
-      file:
+      ansible.builtin.file:
         path: "{{root_dir}}/{{ item }}"
         state: absent
       with_items:

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/destroy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/destroy.yml
@@ -4,11 +4,11 @@
   gather_facts: false
   connection: local
   tasks:
-    - name: delete local folders
+    - name: Delete local folders
       delegate_to: 127.0.0.1
       run_once: true
       ansible.builtin.file:
-        path: "{{root_dir}}/{{ item }}"
+        path: "{{ root_dir }}/{{ item }}"
         state: absent
       with_items:
         - documentation

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/inventory/group_vars/MPLS_CORE.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/inventory/group_vars/MPLS_CORE.yml
@@ -1,6 +1,6 @@
 ---
 # Shared attributes
-root_dir: '{{playbook_dir}}'
+root_dir: '{{ playbook_dir }}'
 
 design:
   type: "mpls"

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/inventory/host_vars/all.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/inventory/host_vars/all.yml
@@ -1,2 +1,2 @@
 ---
-root_dir: '{{playbook_dir}}'
+root_dir: '{{ playbook_dir }}'

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/verify.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/verify.yml
@@ -5,7 +5,7 @@
   connection: local
   tasks:
 
-    - name: generate device intended config and documentation
+    - name: Generate device intended config and documentation
       delegate_to: 127.0.0.1
-      import_role:
+      ansible.builtin.import_role:
         name: arista.avd.eos_cli_config_gen

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/converge.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/converge.yml
@@ -5,7 +5,7 @@
   connection: local
   tasks:
 
-    - name: generate intended variables
+    - name: Generate intended variables
       delegate_to: 127.0.0.1
-      import_role:
+      ansible.builtin.import_role:
         name: arista.avd.eos_designs

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/create.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/create.yml
@@ -4,10 +4,10 @@
   gather_facts: false
   connection: local
   vars:
-    root_dir: '{{playbook_dir}}'
+    root_dir: '{{ playbook_dir }}'
   tasks:
-    - name: create local output folders
+    - name: Create local output folders
       delegate_to: 127.0.0.1
-      import_role:
+      ansible.builtin.import_role:
         name: arista.avd.build_output_folders
       run_once: true

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/destroy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/destroy.yml
@@ -7,7 +7,7 @@
     - name: delete local folders
       delegate_to: 127.0.0.1
       run_once: true
-      file:
+      ansible.builtin.file:
         path: "{{root_dir}}/{{ item }}"
         state: absent
       with_items:

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/destroy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/destroy.yml
@@ -4,11 +4,11 @@
   gather_facts: false
   connection: local
   tasks:
-    - name: delete local folders
+    - name: Delete local folders
       delegate_to: 127.0.0.1
       run_once: true
       ansible.builtin.file:
-        path: "{{root_dir}}/{{ item }}"
+        path: "{{ root_dir }}/{{ item }}"
         state: absent
       with_items:
         - documentation

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/inventory/group_vars/all.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/inventory/group_vars/all.yml
@@ -1,4 +1,4 @@
 ---
-root_dir: '{{playbook_dir}}'
+root_dir: '{{ playbook_dir }}'
 
 avd_data_validation_mode: "error"

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/inventory/host_vars/all.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/inventory/host_vars/all.yml
@@ -1,2 +1,2 @@
 ---
-root_dir: '{{playbook_dir}}'
+root_dir: '{{ playbook_dir }}'

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/verify.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/verify.yml
@@ -5,7 +5,7 @@
   connection: local
   tasks:
 
-    - name: generate device intended config and documentation
+    - name: Generate device intended config and documentation
       delegate_to: 127.0.0.1
-      import_role:
+      ansible.builtin.import_role:
         name: arista.avd.eos_cli_config_gen

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/converge.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/converge.yml
@@ -5,7 +5,7 @@
   connection: local
   tasks:
 
-    - name: generate intended variables
+    - name: Generate intended variables
       delegate_to: 127.0.0.1
-      import_role:
+      ansible.builtin.import_role:
         name: arista.avd.eos_designs

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/create.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/create.yml
@@ -4,10 +4,10 @@
   gather_facts: false
   connection: local
   vars:
-    root_dir: '{{playbook_dir}}'
+    root_dir: '{{ playbook_dir }}'
   tasks:
-    - name: create local output folders
+    - name: Create local output folders
       delegate_to: 127.0.0.1
-      import_role:
+      ansible.builtin.import_role:
         name: arista.avd.build_output_folders
       run_once: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/destroy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/destroy.yml
@@ -7,7 +7,7 @@
     - name: delete local folders
       delegate_to: 127.0.0.1
       run_once: true
-      file:
+      ansible.builtin.file:
         path: "{{root_dir}}/{{ item }}"
         state: absent
       with_items:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/destroy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/destroy.yml
@@ -4,11 +4,11 @@
   gather_facts: false
   connection: local
   tasks:
-    - name: delete local folders
+    - name: Delete local folders
       delegate_to: 127.0.0.1
       run_once: true
       ansible.builtin.file:
-        path: "{{root_dir}}/{{ item }}"
+        path: "{{ root_dir }}/{{ item }}"
         state: absent
       with_items:
         - documentation

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_A.yml
@@ -1,4 +1,4 @@
-Tenant_A:
+tenant_a:
   mac_vrf_vni_base: 10000
   mac_vrf_id_base: 20000
   vrfs:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_B.yml
@@ -1,4 +1,4 @@
-Tenant_B:
+tenant_b:
   mac_vrf_vni_base: 20000
   vrfs:
     Tenant_B_OP_Zone:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_C.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_C.yml
@@ -1,4 +1,4 @@
-Tenant_C:
+tenant_c:
   mac_vrf_vni_base: 30000
   evpn_l2_multi_domain: false
   bgp_peer_groups:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_D.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_D.yml
@@ -1,4 +1,4 @@
-Tenant_D:
+tenant_d:
   mac_vrf_vni_base: 40000
   vrfs:
     Tenant_D_OP_Zone:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/main.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/main.yml
@@ -66,7 +66,7 @@ svi_profiles:
 
 tenants:
   # Tenant_A Specific Information - VRFs / VLANs
-  Tenant_A: "{{ Tenant_A }}"
-  Tenant_B: "{{ Tenant_B }}"
-  Tenant_C: "{{ Tenant_C }}"
-  Tenant_D: "{{ Tenant_D }}"
+  Tenant_A: "{{ tenant_a }}"
+  Tenant_B: "{{ tenant_b }}"
+  Tenant_C: "{{ tenant_c }}"
+  Tenant_D: "{{ tenant_d }}"

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/verify.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/verify.yml
@@ -5,7 +5,7 @@
   connection: local
   tasks:
 
-    - name: generate device intended config and documentation
+    - name: Generate device intended config and documentation
       delegate_to: 127.0.0.1
-      import_role:
+      ansible.builtin.import_role:
         name: arista.avd.eos_cli_config_gen

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/converge.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/converge.yml
@@ -5,7 +5,7 @@
   connection: local
   tasks:
 
-    - name: generate intended variables
+    - name: Generate intended variables
       delegate_to: 127.0.0.1
-      import_role:
+      ansible.builtin.import_role:
         name: arista.avd.eos_designs

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/create.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/create.yml
@@ -4,10 +4,10 @@
   gather_facts: false
   connection: local
   vars:
-    root_dir: '{{playbook_dir}}'
+    root_dir: '{{ playbook_dir }}'
   tasks:
-    - name: create local output folders
+    - name: Create local output folders
       delegate_to: 127.0.0.1
-      import_role:
+      ansible.builtin.import_role:
         name: arista.avd.build_output_folders
       run_once: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/destroy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/destroy.yml
@@ -7,7 +7,7 @@
     - name: delete local folders
       delegate_to: 127.0.0.1
       run_once: true
-      file:
+      ansible.builtin.file:
         path: "{{root_dir}}/{{ item }}"
         state: absent
       with_items:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/destroy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/destroy.yml
@@ -4,11 +4,11 @@
   gather_facts: false
   connection: local
   tasks:
-    - name: delete local folders
+    - name: Delete local folders
       delegate_to: 127.0.0.1
       run_once: true
       ansible.builtin.file:
-        path: "{{root_dir}}/{{ item }}"
+        path: "{{ root_dir }}/{{ item }}"
         state: absent
       with_items:
         - documentation

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/verify.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/verify.yml
@@ -5,7 +5,7 @@
   connection: local
   tasks:
 
-    - name: generate device intended config and documentation
+    - name: Generate device intended config and documentation
       delegate_to: 127.0.0.1
-      import_role:
+      ansible.builtin.import_role:
         name: arista.avd.eos_cli_config_gen

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/converge.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/converge.yml
@@ -5,7 +5,7 @@
   connection: local
   tasks:
 
-    - name: generate intended variables
+    - name: Generate intended variables
       delegate_to: 127.0.0.1
-      import_role:
+      ansible.builtin.import_role:
         name: arista.avd.eos_designs

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/create.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/create.yml
@@ -4,10 +4,10 @@
   gather_facts: false
   connection: local
   vars:
-    root_dir: '{{playbook_dir}}'
+    root_dir: '{{ playbook_dir }}'
   tasks:
-    - name: create local output folders
+    - name: Create local output folders
       delegate_to: 127.0.0.1
-      import_role:
+      ansible.builtin.import_role:
         name: arista.avd.build_output_folders
       run_once: true

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/destroy.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/destroy.yml
@@ -7,7 +7,7 @@
     - name: delete local folders
       delegate_to: 127.0.0.1
       run_once: true
-      file:
+      ansible.builtin.file:
         path: "{{root_dir}}/{{ item }}"
         state: absent
       with_items:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/destroy.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/destroy.yml
@@ -4,11 +4,11 @@
   gather_facts: false
   connection: local
   tasks:
-    - name: delete local folders
+    - name: Delete local folders
       delegate_to: 127.0.0.1
       run_once: true
       ansible.builtin.file:
-        path: "{{root_dir}}/{{ item }}"
+        path: "{{ root_dir }}/{{ item }}"
         state: absent
       with_items:
         - documentation

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/AVD_LAB.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/AVD_LAB.yml
@@ -1,5 +1,5 @@
 # Nashua EVE-NG LAB shared attributes
-root_dir: '{{playbook_dir}}'
+root_dir: '{{ playbook_dir }}'
 
 # local users
 local_users:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/host_vars/all.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/host_vars/all.yml
@@ -1,2 +1,2 @@
 ---
-root_dir: '{{playbook_dir}}'
+root_dir: '{{ playbook_dir }}'

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/verify.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/verify.yml
@@ -5,7 +5,7 @@
   connection: local
   tasks:
 
-    - name: generate device intended config and documentation
+    - name: Generate device intended config and documentation
       delegate_to: 127.0.0.1
-      import_role:
+      ansible.builtin.import_role:
         name: arista.avd.eos_cli_config_gen

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/converge.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/converge.yml
@@ -5,7 +5,7 @@
   connection: local
   tasks:
 
-    - name: generate intended variables
+    - name: Generate intended variables
       delegate_to: 127.0.0.1
-      import_role:
+      ansible.builtin.import_role:
         name: arista.avd.eos_designs

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/create.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/create.yml
@@ -4,10 +4,10 @@
   gather_facts: false
   connection: local
   vars:
-    root_dir: '{{playbook_dir}}'
+    root_dir: '{{ playbook_dir }}'
   tasks:
-    - name: create local output folders
+    - name: Create local output folders
       delegate_to: 127.0.0.1
-      import_role:
+      ansible.builtin.import_role:
         name: arista.avd.build_output_folders
       run_once: true

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/destroy.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/destroy.yml
@@ -7,7 +7,7 @@
     - name: delete local folders
       delegate_to: 127.0.0.1
       run_once: true
-      file:
+      ansible.builtin.file:
         path: "{{root_dir}}/{{ item }}"
         state: absent
       with_items:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/destroy.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/destroy.yml
@@ -4,11 +4,11 @@
   gather_facts: false
   connection: local
   tasks:
-    - name: delete local folders
+    - name: Delete local folders
       delegate_to: 127.0.0.1
       run_once: true
       ansible.builtin.file:
-        path: "{{root_dir}}/{{ item }}"
+        path: "{{ root_dir }}/{{ item }}"
         state: absent
       with_items:
         - documentation

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/inventory/group_vars/AVD_LAB.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/inventory/group_vars/AVD_LAB.yml
@@ -1,5 +1,5 @@
 # Nashua EVE-NG LAB shared attributes
-root_dir: '{{playbook_dir}}'
+root_dir: '{{ playbook_dir }}'
 
 # local users
 local_users:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/inventory/host_vars/all.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/inventory/host_vars/all.yml
@@ -1,2 +1,2 @@
 ---
-root_dir: '{{playbook_dir}}'
+root_dir: '{{ playbook_dir }}'

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/verify.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/verify.yml
@@ -5,7 +5,7 @@
   connection: local
   tasks:
 
-    - name: generate device intended config and documentation
+    - name: Generate device intended config and documentation
       delegate_to: 127.0.0.1
-      import_role:
+      ansible.builtin.import_role:
         name: arista.avd.eos_cli_config_gen

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/converge.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/converge.yml
@@ -5,7 +5,7 @@
   connection: local
   tasks:
 
-    - name: generate intended variables
+    - name: Generate intended variables
       delegate_to: 127.0.0.1
-      import_role:
+      ansible.builtin.import_role:
         name: arista.avd.eos_designs

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/create.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/create.yml
@@ -4,10 +4,10 @@
   gather_facts: false
   connection: local
   vars:
-    root_dir: '{{playbook_dir}}'
+    root_dir: '{{ playbook_dir }}'
   tasks:
-    - name: create local output folders
+    - name: Create local output folders
       delegate_to: 127.0.0.1
-      import_role:
+      ansible.builtin.import_role:
         name: arista.avd.build_output_folders
       run_once: true

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/destroy.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/destroy.yml
@@ -7,7 +7,7 @@
     - name: delete local folders
       delegate_to: 127.0.0.1
       run_once: true
-      file:
+      ansible.builtin.file:
         path: "{{root_dir}}/{{ item }}"
         state: absent
       with_items:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/destroy.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/destroy.yml
@@ -4,11 +4,11 @@
   gather_facts: false
   connection: local
   tasks:
-    - name: delete local folders
+    - name: Delete local folders
       delegate_to: 127.0.0.1
       run_once: true
       ansible.builtin.file:
-        path: "{{root_dir}}/{{ item }}"
+        path: "{{ root_dir }}/{{ item }}"
         state: absent
       with_items:
         - documentation

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/inventory/group_vars/AVD_LAB.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/inventory/group_vars/AVD_LAB.yml
@@ -1,5 +1,5 @@
 # Nashua EVE-NG LAB shared attributes
-root_dir: '{{playbook_dir}}'
+root_dir: '{{ playbook_dir }}'
 
 # local users
 local_users:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/inventory/host_vars/all.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/inventory/host_vars/all.yml
@@ -1,2 +1,2 @@
 ---
-root_dir: '{{playbook_dir}}'
+root_dir: '{{ playbook_dir }}'

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/verify.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/verify.yml
@@ -5,7 +5,7 @@
   connection: local
   tasks:
 
-    - name: generate device intended config and documentation
+    - name: Generate device intended config and documentation
       delegate_to: 127.0.0.1
-      import_role:
+      ansible.builtin.import_role:
         name: arista.avd.eos_cli_config_gen

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/converge.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/converge.yml
@@ -5,7 +5,7 @@
   connection: local
   tasks:
 
-    - name: generate intended variables
+    - name: Generate intended variables
       delegate_to: 127.0.0.1
-      import_role:
+      ansible.builtin.import_role:
         name: arista.avd.eos_designs

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/create.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/create.yml
@@ -4,10 +4,10 @@
   gather_facts: false
   connection: local
   vars:
-    root_dir: '{{playbook_dir}}'
+    root_dir: '{{ playbook_dir }}'
   tasks:
-    - name: create local output folders
+    - name: Create local output folders
       delegate_to: 127.0.0.1
-      import_role:
+      ansible.builtin.import_role:
         name: arista.avd.build_output_folders
       run_once: true

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/destroy.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/destroy.yml
@@ -7,7 +7,7 @@
     - name: delete local folders
       delegate_to: 127.0.0.1
       run_once: true
-      file:
+      ansible.builtin.file:
         path: "{{root_dir}}/{{ item }}"
         state: absent
       with_items:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/destroy.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/destroy.yml
@@ -4,11 +4,11 @@
   gather_facts: false
   connection: local
   tasks:
-    - name: delete local folders
+    - name: Delete local folders
       delegate_to: 127.0.0.1
       run_once: true
       ansible.builtin.file:
-        path: "{{root_dir}}/{{ item }}"
+        path: "{{ root_dir }}/{{ item }}"
         state: absent
       with_items:
         - documentation

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/inventory/group_vars/AVD_LAB.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/inventory/group_vars/AVD_LAB.yml
@@ -1,5 +1,5 @@
 # Nashua EVE-NG LAB shared attributes
-root_dir: '{{playbook_dir}}'
+root_dir: '{{ playbook_dir }}'
 
 # local users
 local_users:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/inventory/host_vars/all.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/inventory/host_vars/all.yml
@@ -1,2 +1,2 @@
 ---
-root_dir: '{{playbook_dir}}'
+root_dir: '{{ playbook_dir }}'

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/verify.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/verify.yml
@@ -5,7 +5,7 @@
   connection: local
   tasks:
 
-    - name: generate device intended config and documentation
+    - name: Generate device intended config and documentation
       delegate_to: 127.0.0.1
-      import_role:
+      ansible.builtin.import_role:
         name: arista.avd.eos_cli_config_gen

--- a/ansible_collections/arista/avd/molecule/example-campus-fabric/destroy.yml
+++ b/ansible_collections/arista/avd/molecule/example-campus-fabric/destroy.yml
@@ -7,7 +7,7 @@
     - name: delete local folders
       delegate_to: 127.0.0.1
       run_once: true
-      file:
+      ansible.builtin.file:
         path: "{{root_dir}}/{{ item }}"
         state: absent
       with_items:

--- a/ansible_collections/arista/avd/molecule/example-campus-fabric/destroy.yml
+++ b/ansible_collections/arista/avd/molecule/example-campus-fabric/destroy.yml
@@ -4,11 +4,11 @@
   gather_facts: false
   connection: local
   tasks:
-    - name: delete local folders
+    - name: Delete local folders
       delegate_to: 127.0.0.1
       run_once: true
       ansible.builtin.file:
-        path: "{{root_dir}}/{{ item }}"
+        path: "{{ root_dir }}/{{ item }}"
         state: absent
       with_items:
         - documentation

--- a/ansible_collections/arista/avd/molecule/example-dual-dc-l3ls/destroy.yml
+++ b/ansible_collections/arista/avd/molecule/example-dual-dc-l3ls/destroy.yml
@@ -4,11 +4,11 @@
   gather_facts: false
   connection: local
   tasks:
-    - name: delete local folders
+    - name: Delete local folders
       delegate_to: 127.0.0.1
       run_once: true
-      file:
-        path: "{{root_dir}}/{{ item }}"
+      ansible.builtin.file:
+        path: "{{ root_dir }}/{{ item }}"
         state: absent
       with_items:
         - documentation

--- a/ansible_collections/arista/avd/molecule/example-l2ls-fabric/destroy.yml
+++ b/ansible_collections/arista/avd/molecule/example-l2ls-fabric/destroy.yml
@@ -7,7 +7,7 @@
     - name: delete local folders
       delegate_to: 127.0.0.1
       run_once: true
-      file:
+      ansible.builtin.file:
         path: "{{root_dir}}/{{ item }}"
         state: absent
       with_items:

--- a/ansible_collections/arista/avd/molecule/example-l2ls-fabric/destroy.yml
+++ b/ansible_collections/arista/avd/molecule/example-l2ls-fabric/destroy.yml
@@ -4,11 +4,11 @@
   gather_facts: false
   connection: local
   tasks:
-    - name: delete local folders
+    - name: Delete local folders
       delegate_to: 127.0.0.1
       run_once: true
       ansible.builtin.file:
-        path: "{{root_dir}}/{{ item }}"
+        path: "{{ root_dir }}/{{ item }}"
         state: absent
       with_items:
         - documentation

--- a/ansible_collections/arista/avd/molecule/example-single-dc-l3ls/destroy.yml
+++ b/ansible_collections/arista/avd/molecule/example-single-dc-l3ls/destroy.yml
@@ -7,7 +7,7 @@
     - name: delete local folders
       delegate_to: 127.0.0.1
       run_once: true
-      file:
+      ansible.builtin.file:
         path: "{{root_dir}}/{{ item }}"
         state: absent
       with_items:

--- a/ansible_collections/arista/avd/molecule/example-single-dc-l3ls/destroy.yml
+++ b/ansible_collections/arista/avd/molecule/example-single-dc-l3ls/destroy.yml
@@ -4,11 +4,11 @@
   gather_facts: false
   connection: local
   tasks:
-    - name: delete local folders
+    - name: Delete local folders
       delegate_to: 127.0.0.1
       run_once: true
       ansible.builtin.file:
-        path: "{{root_dir}}/{{ item }}"
+        path: "{{ root_dir }}/{{ item }}"
         state: absent
       with_items:
         - documentation

--- a/ansible_collections/arista/avd/playbooks/_build_documentation.yml
+++ b/ansible_collections/arista/avd/playbooks/_build_documentation.yml
@@ -4,11 +4,11 @@
   gather_facts: false
   tasks:
     - name: Create Schema Documentation for eos_cli_config_gen
-      import_role:
+      ansible.builtin.import_role:
         name: arista.avd.eos_cli_config_gen
         tasks_from: build-documentation
 
     - name: Create Schema Documentation for eos_designs
-      import_role:
+      ansible.builtin.import_role:
         name: arista.avd.eos_designs
         tasks_from: build-documentation

--- a/ansible_collections/arista/avd/playbooks/_build_schemas.yml
+++ b/ansible_collections/arista/avd/playbooks/_build_schemas.yml
@@ -4,11 +4,11 @@
   gather_facts: false
   tasks:
     - name: Gather AVD Schema Fragments for eos_cli_config_gen
-      import_role:
+      ansible.builtin.import_role:
         name: arista.avd.eos_cli_config_gen
         tasks_from: build-schemas
 
     - name: Gather AVD Schema Fragments for eos_designs
-      import_role:
+      ansible.builtin.import_role:
         name: arista.avd.eos_designs
         tasks_from: build-schemas

--- a/ansible_collections/arista/avd/playbooks/install_examples.yml
+++ b/ansible_collections/arista/avd/playbooks/install_examples.yml
@@ -4,10 +4,11 @@
   gather_facts: false
   tasks:
     - name: "Copy all examples to {{ pwd }}"
-      copy:
+      ansible.builtin.copy:
         src: "{{ examples_dir }}/"
         dest: "{{ pwd }}"
         force: false
+        mode: 0664
       vars:
         pwd: "{{ lookup('env', 'PWD') }}"
         examples_dir: "{{ playbook_dir ~ '/../examples' }}"

--- a/ansible_collections/arista/avd/plugins/README.md
+++ b/ansible_collections/arista/avd/plugins/README.md
@@ -364,7 +364,7 @@ tasks:
       container_root: "{{ container_root }}"
       configlet_dir: "intended/configs"
       configlet_prefix: "{{ configlets_prefix }}"
-      destination: "{{ playbook_dir }}/intended/structured_configs/{{inventory_hostname}}.yml"
+      destination: "{{ playbook_dir }}/intended/structured_configs/{{ inventory_hostname }}.yml"
 ```
 
 Inventory example applied to this example:
@@ -397,7 +397,7 @@ Generated output ready to be used by [`arista.cvp`](https://github.com/aristanet
 
 ```yaml
 ---
-cvp_devices:
+CVP_DEVICES:
   DC1-SPINE1:
     name: DC1-SPINE1
     parentContainerName: DC1_SPINES
@@ -405,7 +405,7 @@ cvp_devices:
         - DC1-AVD_DC1-SPINE1
     imageBundle: []
 
-cvp_containers:
+CVP_CONTAINERS:
   DC1_LEAF1:
     parent_container: DC1_L3LEAFS
   DC1_FABRIC:
@@ -640,7 +640,7 @@ The module arguments are:
 
 ```yaml
   # Path to Jinja2 Template file | Required
-  ansible.builtin.template: <str>
+  template: <str>
 
   # Destination path. The rendered template will be written to this file | Optional
   dest: <str>

--- a/ansible_collections/arista/avd/plugins/README.md
+++ b/ansible_collections/arista/avd/plugins/README.md
@@ -359,12 +359,12 @@ To use this module:
 tasks:
   - name: generate intended variables
     tags: [always]
-    inventory_to_container:
+    arista.avd.inventory_to_container:
       inventory: "{{ inventory_file }}"
       container_root: "{{ container_root }}"
       configlet_dir: "intended/configs"
       configlet_prefix: "{{ configlets_prefix }}"
-      destination: "{{playbook_dir}}/intended/structured_configs/{{inventory_hostname}}.yml"
+      destination: "{{ playbook_dir }}/intended/structured_configs/{{inventory_hostname}}.yml"
 ```
 
 Inventory example applied to this example:
@@ -428,7 +428,7 @@ The `arista.avd.configlet_build_config` module provides the following capabiliti
 **options:**
 
 ```yaml
-- configlet_build_config:
+- arista.avd.configlet_build_config:
     configlet_dir:  "< Directory where configlets are located | Required >"
     configlet_prefix: "< Prefix to append on configlet | Required >"
     destination: "< File where to save information | Optional >"
@@ -441,7 +441,7 @@ The `arista.avd.configlet_build_config` module provides the following capabiliti
 # tasks file for configlet_build_config
 - name: generate intended variables
   tags: [build, provision]
-  configlet_build_config:
+  arista.avd.configlet_build_config:
     configlet_dir: "/path/to/configlets/folder/"
     configlet_prefix: "AVD_"
     configlet_extension: "cfg"
@@ -462,7 +462,7 @@ The module is used in `eos_designs` to generate the `structured_configuration` b
 The module arguments are:
 
 ```yaml
-- yaml_templates_to_facts:
+- arista.avd.yaml_templates_to_facts:
     root_key: < optional root_key name >
     templates:
         # Path to template file
@@ -495,7 +495,7 @@ The module arguments are:
 ```yaml
 - name: Set AVD facts
   tags: [build, provision]
-  yaml_templates_to_facts:
+  arista.avd.yaml_templates_to_facts:
     templates: "{{ templates.facts }}"
   delegate_to: localhost
   check_mode: no
@@ -503,7 +503,7 @@ The module arguments are:
 
 - name: Generate device configuration in structured format
   tags: [build, provision]
-  yaml_templates_to_facts:
+  arista.avd.yaml_templates_to_facts:
     templates: "{{ templates.structured_config }}"
     dest: "{{ structured_dir }}/{{ inventory_hostname }}.{{ avd_structured_config_file_format }}"
     template_output: True

--- a/ansible_collections/arista/avd/plugins/action/inventory_to_container.py
+++ b/ansible_collections/arista/avd/plugins/action/inventory_to_container.py
@@ -26,12 +26,12 @@ class ActionModule(ActionBase):
         result = self._execute_module(module_name="inventory_to_container", module_args=module_args, task_vars=task_vars, tmp=tmp)
 
         if not result.get("failed") and module_args.get("inventory") is None and module_args.get("container_root") is not None:
-            result["cvp_topology"] = self.build_cvp_topology_from_inventory(task_vars, module_args)
+            result["CVP_TOPOLOGY"] = self.build_cvp_topology_from_inventory(task_vars, module_args)
 
         # Write vars to file if set by user
         if (destination := module_args.get("destination")) is not None:
             # file should only contain subset of result data, so we build a smaller dict
-            file_data_keys = ["cvp_configlets", "cvp_topology"]
+            file_data_keys = ["CVP_CONFIGLETS", "CVP_TOPOLOGY"]
             file_data = {key: result[key] for key in file_data_keys if key in result}
 
             with open(destination, "w", encoding="utf8") as file:

--- a/ansible_collections/arista/avd/plugins/modules/configlet_build_config.py
+++ b/ansible_collections/arista/avd/plugins/modules/configlet_build_config.py
@@ -126,7 +126,7 @@ def main():
 
     # If set, build configlet topology
     if module.params["configlet_dir"] is not None:
-        result["cvp_configlets"] = get_configlet(
+        result["CVP_CONFIGLETS"] = get_configlet(
             src_folder=module.params["configlet_dir"], prefix=module.params["configlet_prefix"], extension=module.params["configlet_extension"]
         )
 

--- a/ansible_collections/arista/avd/plugins/modules/inventory_to_container.py
+++ b/ansible_collections/arista/avd/plugins/modules/inventory_to_container.py
@@ -74,17 +74,17 @@ EXAMPLES = r"""
     # destination: 'generated_vars/{{ inventory_hostname }}.yml'
   register: cvp_vars
 
-- name: 'Collecting facts from CVP {{inventory_hostname}}.'
+- name: 'Collecting facts from CVP {{ inventory_hostname }}.'
   arista.cvp.cv_facts:
-  register: cvp_facts
+  register: CVP_FACTS
 
-- name: 'Create configlets on CVP {{inventory_hostname}}.'
+- name: 'Create configlets on CVP {{ inventory_hostname }}.'
   arista.cvp.cv_configlet:
     cvp_facts: "{{ cvp_facts.ansible_facts }}"
     configlets: "{{ cvp_vars.cvp_configlets }}"
     configlet_filter: ["AVD"]
 
-- name: "Building Container topology on {{inventory_hostname}}"
+- name: "Building Container topology on {{ inventory_hostname }}"
   arista.cvp.cv_container:
     topology: '{{ cvp_vars.cvp_topology }}'
     cvp_facts: '{{ cvp_facts.ansible_facts }}'
@@ -419,13 +419,13 @@ def main():
                 inventory_content = yaml.safe_load(stream)
             except yaml.YAMLError as exc:
                 raise AnsibleValidationError("Failed to parse inventory file") from exc
-        result["cvp_topology"] = get_containers(
+        result["CVP_TOPOLOGY"] = get_containers(
             inventory_content=inventory_content, parent_container=parent_container, device_filter=module.params["device_filter"]
         )
 
     # If set, build configlet topology
     if module.params["configlet_dir"] is not None:
-        result["cvp_configlets"] = get_configlet(
+        result["CVP_CONFIGLETS"] = get_configlet(
             src_folder=module.params["configlet_dir"], prefix=module.params["configlet_prefix"], device_filter=module.params["device_filter"]
         )
 

--- a/ansible_collections/arista/avd/plugins/modules/validate_and_template.py
+++ b/ansible_collections/arista/avd/plugins/modules/validate_and_template.py
@@ -26,7 +26,7 @@ description:
   - the input data is not valid.
   - For Markdown files the plugin can also run md_toc on the output before writing to the file.
 options:
-  template:
+  ansible.builtin.template:
     description: Path to Jinja2 Template file
     required: true
     type: str

--- a/ansible_collections/arista/avd/plugins/modules/yaml_templates_to_facts.py
+++ b/ansible_collections/arista/avd/plugins/modules/yaml_templates_to_facts.py
@@ -129,7 +129,7 @@ options:
 EXAMPLES = r"""
 # tasks file for configlet_build_config
 - name: Generate device configuration in structured format
-  yaml_templates_to_facts:
+  arista.avd.yaml_templates_to_facts:
     root_key: structured_config
     templates:
       - python_module: "ansible_collections.arista.avd.roles.eos_designs.python_modules.base"

--- a/ansible_collections/arista/avd/requirements-dev.txt
+++ b/ansible_collections/arista/avd/requirements-dev.txt
@@ -1,5 +1,5 @@
 ansible-core>=2.12.6,<2.15.0,!=2.13.0
-ansible-lint
+ansible-lint<6.12  # BUG with FQCN in 6.12.x
 galaxy-importer>=0.3.1
 pycodestyle
 flake8

--- a/ansible_collections/arista/avd/roles/build_output_folders/README.md
+++ b/ansible_collections/arista/avd/roles/build_output_folders/README.md
@@ -64,9 +64,9 @@ Below is an example to use in your playbook to build output folders using defaul
   connection: local
   gather_facts: no
   tasks:
-    - name: 'build local folders for output'
+    - name: 'Build local folders for output'
       tags: [build]
-      import_role:
+      ansible.builtin.import_role:
         name: arista.avd.build_output_folders
 ```
 

--- a/ansible_collections/arista/avd/roles/build_output_folders/meta/main.yml
+++ b/ansible_collections/arista/avd/roles/build_output_folders/meta/main.yml
@@ -6,3 +6,4 @@ galaxy_info:
   min_ansible_version: 2.12.6
   galaxy_tags: ['arista', 'network', 'networking', 'eos', 'avd', 'cloudvision', 'cvp']
 dependencies: []
+platforms: []

--- a/ansible_collections/arista/avd/roles/build_output_folders/meta/main.yml
+++ b/ansible_collections/arista/avd/roles/build_output_folders/meta/main.yml
@@ -5,5 +5,5 @@ galaxy_info:
   license: Apache-2.0
   min_ansible_version: 2.12.6
   galaxy_tags: ['arista', 'network', 'networking', 'eos', 'avd', 'cloudvision', 'cvp']
+  platforms: []
 dependencies: []
-platforms: []

--- a/ansible_collections/arista/avd/roles/build_output_folders/meta/main.yml
+++ b/ansible_collections/arista/avd/roles/build_output_folders/meta/main.yml
@@ -1,9 +1,3 @@
 galaxy_info:
-  author: Arista Ansible Team <ansible@arista.com>
   description: Generates Output folders for arista.avd collection.
-  company: Arista Networks
-  license: Apache-2.0
-  min_ansible_version: 2.12.6
-  galaxy_tags: ['arista', 'network', 'networking', 'eos', 'avd', 'cloudvision', 'cvp']
-  platforms: []
-dependencies: []
+  standalone: false

--- a/ansible_collections/arista/avd/roles/build_output_folders/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/build_output_folders/tasks/main.yml
@@ -2,7 +2,7 @@
 # tasks file for build_directories
 
 - name: "Cleanup existing folders in {{ output_dir }}"
-  file:
+  ansible.builtin.file:
     path: "{{ output_dir }}"
     state: absent
     mode: 0775
@@ -10,7 +10,7 @@
   run_once: True
 
 - name: "Create folder {{ output_dir }}"
-  file:
+  ansible.builtin.file:
     path: "{{ output_dir }}"
     state: directory
     mode: 0775
@@ -18,7 +18,7 @@
   run_once: True
 
 - name: "Create folder {{ structured_dir_name }} for structured YAML files"
-  file:
+  ansible.builtin.file:
     path: "{{ structured_dir }}"
     state: directory
     mode: 0775
@@ -26,7 +26,7 @@
   run_once: True
 
 - name: "Create folder {{ eos_config_dir_name }} for EOS Configuration files"
-  file:
+  ansible.builtin.file:
     path: "{{ eos_config_dir }}"
     state: directory
     mode: 0775
@@ -34,7 +34,7 @@
   run_once: True
 
 - name: "Create folder {{ structured_cvp_dir_name }} for CVP structured YAML files"
-  file:
+  ansible.builtin.file:
     path: "{{ structured_cvp_dir }}"
     state: directory
     mode: 0775
@@ -42,7 +42,7 @@
   run_once: True
 
 - name: "Create documentation folder: {{ documentation_dir_name }}"
-  file:
+  ansible.builtin.file:
     path: "{{ documentation_dir }}"
     state: directory
     mode: 0775
@@ -50,7 +50,7 @@
   run_once: True
 
 - name: "Create folder {{ fabric_dir_name }} for Fabric documentation"
-  file:
+  ansible.builtin.file:
     path: "{{ fabric_dir }}"
     state: directory
     mode: 0775
@@ -58,7 +58,7 @@
   run_once: True
 
 - name: "Create folder {{ devices_dir_name }} for EOS documentation"
-  file:
+  ansible.builtin.file:
     path: "{{ devices_dir }}"
     state: directory
     mode: 0775
@@ -66,7 +66,7 @@
   run_once: True
 
 - name: "Create folder {{ post_running_config_backup_dir }} for EOS post backup dir"
-  file:
+  ansible.builtin.file:
     path: "{{ post_running_config_backup_dir }}"
     state: directory
     mode: 0775
@@ -74,7 +74,7 @@
   run_once: True
 
 - name: "Create folder {{ pre_running_config_backup_dir }} for EOS pre backup dir"
-  file:
+  ansible.builtin.file:
     path: "{{ pre_running_config_backup_dir }}"
     state: directory
     mode: 0775
@@ -82,7 +82,7 @@
   run_once: True
 
 - name: "Create folder {{ eos_validate_state_name }} for EOS state report dir"
-  file:
+  ansible.builtin.file:
     path: "{{ eos_validate_state_dir }}"
     state: directory
     mode: 0775
@@ -90,7 +90,7 @@
   run_once: True
 
 - name: Create output directory for each EOS device
-  file:
+  ansible.builtin.file:
     path: "{{ snapshots_backup_dir }}"
     state: directory
     mode: 0775

--- a/ansible_collections/arista/avd/roles/cvp_configlet_upload/README.md
+++ b/ansible_collections/arista/avd/roles/cvp_configlet_upload/README.md
@@ -62,8 +62,8 @@ For complete list of authentication options available with CloudVision Ansible c
 
 ```yaml
 tasks:
-  - name: upload cvp configlets
-    import_role:
+  - name: Upload cvp configlets
+    ansible.builtin.import_role:
         name: arista.avd.cvp_configlet_upload
     vars:
       configlet_directory: 'configlets/'

--- a/ansible_collections/arista/avd/roles/cvp_configlet_upload/meta/main.yml
+++ b/ansible_collections/arista/avd/roles/cvp_configlet_upload/meta/main.yml
@@ -6,4 +6,4 @@ galaxy_info:
   license: Apache-2.0
   min_ansible_version: 2.12.6
   galaxy_tags: ['arista', 'network', 'networking', 'eos', 'avd', 'cloudvision', 'cvp']
-platforms: []
+  platforms: []

--- a/ansible_collections/arista/avd/roles/cvp_configlet_upload/meta/main.yml
+++ b/ansible_collections/arista/avd/roles/cvp_configlet_upload/meta/main.yml
@@ -6,3 +6,4 @@ galaxy_info:
   license: Apache-2.0
   min_ansible_version: 2.12.6
   galaxy_tags: ['arista', 'network', 'networking', 'eos', 'avd', 'cloudvision', 'cvp']
+platforms: []

--- a/ansible_collections/arista/avd/roles/cvp_configlet_upload/meta/main.yml
+++ b/ansible_collections/arista/avd/roles/cvp_configlet_upload/meta/main.yml
@@ -6,4 +6,3 @@ galaxy_info:
   license: Apache-2.0
   min_ansible_version: 2.12.6
   galaxy_tags: ['arista', 'network', 'networking', 'eos', 'avd', 'cloudvision', 'cvp']
-dependencies: ['']

--- a/ansible_collections/arista/avd/roles/cvp_configlet_upload/meta/main.yml
+++ b/ansible_collections/arista/avd/roles/cvp_configlet_upload/meta/main.yml
@@ -1,9 +1,3 @@
 galaxy_info:
-  author: Arista Ansible Team <ansible@arista.com>
   description: Publish AVD configuration to CloudVision
-  issue_tracker_url: https://github.com/aristanetworks/ansible-avd/issues
-  company: Arista Networks
-  license: Apache-2.0
-  min_ansible_version: 2.12.6
-  galaxy_tags: ['arista', 'network', 'networking', 'eos', 'avd', 'cloudvision', 'cvp']
-  platforms: []
+  standalone: false

--- a/ansible_collections/arista/avd/roles/cvp_configlet_upload/tasks/cv_collection_v1.yml
+++ b/ansible_collections/arista/avd/roles/cvp_configlet_upload/tasks/cv_collection_v1.yml
@@ -1,9 +1,9 @@
-- name: "collecting facts from CVP {{ inventory_hostname }}."
+- name: "Collecting facts from CVP {{ inventory_hostname }}"
   tags: [provision, apply]
   arista.cvp.cv_facts:
   register: cvp_facts
 
-- name: "create configlets on CVP {{ inventory_hostname }}."
+- name: "Create configlets on CVP {{ inventory_hostname }}"
   tags: [provision, apply]
   arista.cvp.cv_configlet:
     cvp_facts: "{{ cvp_facts.ansible_facts }}"

--- a/ansible_collections/arista/avd/roles/cvp_configlet_upload/tasks/cv_collection_v1.yml
+++ b/ansible_collections/arista/avd/roles/cvp_configlet_upload/tasks/cv_collection_v1.yml
@@ -1,19 +1,19 @@
 - name: "Collecting facts from CVP {{ inventory_hostname }}"
   tags: [provision, apply]
   arista.cvp.cv_facts:
-  register: cvp_facts
+  register: CVP_FACTS
 
 - name: "Create configlets on CVP {{ inventory_hostname }}"
   tags: [provision, apply]
   arista.cvp.cv_configlet:
-    cvp_facts: "{{ cvp_facts.ansible_facts }}"
-    configlets: "{{ cvp_vars.cvp_configlets }}"
+    cvp_facts: "{{ CVP_FACTS.ansible_facts }}"
+    configlets: "{{ CVP_VARS.CVP_CONFIGLETS }}"
     configlet_filter: ["{{ configlets_cvp_prefix }}"]
 
 - name: "Execute pending tasks on {{ inventory_hostname }}"
   tags: [apply]
   arista.cvp.cv_task:
-    tasks: "{{ cvp_devices_results.data.tasks }}"  # noqa: args[module]
+    tasks: "{{ CVP_DEVICES_RESULTS.data.tasks }}"  # noqa: args[module]
     wait: 720
   when:
     - execute_tasks|bool

--- a/ansible_collections/arista/avd/roles/cvp_configlet_upload/tasks/cv_collection_v3.yml
+++ b/ansible_collections/arista/avd/roles/cvp_configlet_upload/tasks/cv_collection_v3.yml
@@ -1,4 +1,4 @@
-- name: "create configlets on CVP {{ inventory_hostname }}."
+- name: "Create configlets on CVP {{ inventory_hostname }}"
   tags: [provision, apply]
   arista.cvp.cv_configlet_v3:
     configlets: "{{ cvp_vars.cvp_configlets }}"

--- a/ansible_collections/arista/avd/roles/cvp_configlet_upload/tasks/cv_collection_v3.yml
+++ b/ansible_collections/arista/avd/roles/cvp_configlet_upload/tasks/cv_collection_v3.yml
@@ -1,11 +1,11 @@
 - name: "Create configlets on CVP {{ inventory_hostname }}"
   tags: [provision, apply]
   arista.cvp.cv_configlet_v3:
-    configlets: "{{ cvp_vars.cvp_configlets }}"
+    configlets: "{{ CVP_VARS.CVP_CONFIGLETS }}"
 
 - name: "Execute pending tasks on {{ inventory_hostname }}"
   tags: [apply]
   arista.cvp.cv_task_v3:
-    tasks: "{{ cvp_devices_results.tasks }}"
+    tasks: "{{ CVP_DEVICES_RESULTS.tasks }}"
   when:
-    - execute_tasks|bool
+    - execute_tasks | bool

--- a/ansible_collections/arista/avd/roles/cvp_configlet_upload/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/cvp_configlet_upload/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 # tasks file for cvp_configlet_upload
-- name: generate intended variables
+- name: Generate intended variables
   tags: [build, provision, apply]
   arista.avd.configlet_build_config:
     configlet_dir: "{{ configlet_directory }}"
@@ -9,4 +9,4 @@
   register: cvp_vars
 
 - name: "Execute upload with collection in version {{ cv_collection }}"
-  include_tasks: "cv_collection_{{ cv_collection }}.yml"
+  ansible.builtin.include_tasks: "cv_collection_{{ cv_collection }}.yml"

--- a/ansible_collections/arista/avd/roles/cvp_configlet_upload/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/cvp_configlet_upload/tasks/main.yml
@@ -6,7 +6,7 @@
     configlet_dir: "{{ configlet_directory }}"
     configlet_prefix: "{{ configlets_cvp_prefix }}"
     configlet_extension: "{{ file_extension }}"
-  register: cvp_vars
+  register: CVP_VARS
 
 - name: "Execute upload with collection in version {{ cv_collection }}"
   ansible.builtin.include_tasks: "cv_collection_{{ cv_collection }}.yml"

--- a/ansible_collections/arista/avd/roles/cvp_configlet_upload/tests/inventory
+++ b/ansible_collections/arista/avd/roles/cvp_configlet_upload/tests/inventory
@@ -1,1 +1,0 @@
-localhost

--- a/ansible_collections/arista/avd/roles/cvp_configlet_upload/tests/test.yml
+++ b/ansible_collections/arista/avd/roles/cvp_configlet_upload/tests/test.yml
@@ -1,5 +1,0 @@
----
-- hosts: localhost
-  remote_user: root
-  roles:
-    - cvp_configlet_upload

--- a/ansible_collections/arista/avd/roles/dhcp_provisioner/README.md
+++ b/ansible_collections/arista/avd/roles/dhcp_provisioner/README.md
@@ -56,8 +56,8 @@ all:
   gather_facts: false
   tasks:
     - name: Create dhcp configuration file
-      import_role:
-          name: arista.avd.dhcp_provisioner
+      ansible.builtin.import_role:
+        name: arista.avd.dhcp_provisioner
       vars:
         ztp_network_summary: 10.73.1.0/24
         ztp_pool_start: 10.73.1.200

--- a/ansible_collections/arista/avd/roles/dhcp_provisioner/meta/main.yml
+++ b/ansible_collections/arista/avd/roles/dhcp_provisioner/meta/main.yml
@@ -1,11 +1,6 @@
 galaxy_info:
-  author: Arista Ansible Team <ansible@arista.com>
   description: Build and deploy DHCP configuration file to support Zero Touch Provisioning with Arista EOS devices
-  issue_tracker_url: https://github.com/aristanetworks/ansible-avd/issues
-  company: Arista Networks
-  license: Apache-2.0
-  min_ansible_version: 2.12.6
-  galaxy_tags: ['arista', 'network', 'networking', 'eos', 'avd', 'cloudvision', 'cvp']
+  standalone: false
   platforms:
     - name: EL
       versions: ["7", "8"]

--- a/ansible_collections/arista/avd/roles/dhcp_provisioner/meta/main.yml
+++ b/ansible_collections/arista/avd/roles/dhcp_provisioner/meta/main.yml
@@ -10,4 +10,4 @@ galaxy_info:
     - name: EL
       versions: ["7", "8"]
     - name: Ubuntu
-      versions: [ "focal" ]
+      versions: ["focal"]

--- a/ansible_collections/arista/avd/roles/dhcp_provisioner/meta/main.yml
+++ b/ansible_collections/arista/avd/roles/dhcp_provisioner/meta/main.yml
@@ -11,5 +11,3 @@ galaxy_info:
       versions: ["7", "8"]
     - name: Ubuntu
       versions: [ "focal" ]
-dependencies:
-  - role: arista.cvp

--- a/ansible_collections/arista/avd/roles/dhcp_provisioner/meta/main.yml
+++ b/ansible_collections/arista/avd/roles/dhcp_provisioner/meta/main.yml
@@ -8,8 +8,8 @@ galaxy_info:
   galaxy_tags: ['arista', 'network', 'networking', 'eos', 'avd', 'cloudvision', 'cvp']
   platforms:
     - name: EL
-      versions: [7, 8]
+      versions: ["7", "8"]
     - name: Ubuntu
-      versions: [ 20.04 ]
-  dependencies:
-    "arista.cvp": "*"
+      versions: [ "focal" ]
+dependencies:
+  - role: arista.cvp

--- a/ansible_collections/arista/avd/roles/dhcp_provisioner/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/dhcp_provisioner/tasks/main.yml
@@ -2,7 +2,7 @@
 # tasks file for dhcp_provisioner
 
 - name: Create required output directories if not present
-  file:
+  ansible.builtin.file:
     path: "{{ item }}"
     state: directory
     mode: 0775
@@ -14,17 +14,17 @@
   run_once: true
 
 - name: Build DHCP intended variables
-  template:
+  ansible.builtin.template:
     src: ztp_configuration.j2
     dest: "{{ structured_cvp_dir }}/ztp_configuration.yml"
     mode: 0664
   delegate_to: localhost
   run_once: true
 
-- name: include DHCP variables to build dhcpd.conf file
-  include_vars: "{{ structured_cvp_dir }}/ztp_configuration.yml"
+- name: Include DHCP variables to build dhcpd.conf file
+  ansible.builtin.include_vars: "{{ structured_cvp_dir }}/ztp_configuration.yml"
   run_once: true
 
-- name: start creation/update process.
+- name: Start creation/update process.
   tags: [provision]
-  include_tasks: "./{{ ztp_mode }}.yml"
+  ansible.builtin.include_tasks: "./{{ ztp_mode }}.yml"

--- a/ansible_collections/arista/avd/roles/dhcp_provisioner/tasks/offline.yml
+++ b/ansible_collections/arista/avd/roles/dhcp_provisioner/tasks/offline.yml
@@ -2,7 +2,7 @@
 # Tasks to build offline dhcpd.conf file
 
 - name: Execute DHCP configuration role
-  import_role:
+  ansible.builtin.import_role:
     name: arista.cvp.dhcp_configuration
   vars:
     mode: offline

--- a/ansible_collections/arista/avd/roles/dhcp_provisioner/tasks/online.yml
+++ b/ansible_collections/arista/avd/roles/dhcp_provisioner/tasks/online.yml
@@ -2,7 +2,7 @@
 # Tasks to build online dhcpd.conf to specified server
 
 - name: Execute DHCP configuration role
-  import_role:
+  ansible.builtin.import_role:
     name: arista.cvp.dhcp_configuration
   vars:
     mode: online

--- a/ansible_collections/arista/avd/roles/dhcp_provisioner/tests/inventory
+++ b/ansible_collections/arista/avd/roles/dhcp_provisioner/tests/inventory
@@ -1,1 +1,0 @@
-localhost

--- a/ansible_collections/arista/avd/roles/dhcp_provisioner/tests/test.yml
+++ b/ansible_collections/arista/avd/roles/dhcp_provisioner/tests/test.yml
@@ -1,5 +1,0 @@
----
-- hosts: localhost
-  remote_user: root
-  roles:
-    - dhcp_provisioner

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/meta/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/meta/main.yml
@@ -1,10 +1,3 @@
 galaxy_info:
-  author: Arista Ansible Team <ansible@arista.com>
   description: Generates eos cli syntax and device documentation.
-  issue_tracker_url: https://github.com/aristanetworks/ansible-avd/issues
-  company: Arista Networks
-  license: Apache-2.0
-  min_ansible_version: 2.12.6
-  galaxy_tags: ['arista', 'network', 'networking', 'eos', 'avd', 'cloudvision', 'cvp']
-  platforms: []
-dependencies: []
+  standalone: false

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/meta/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/meta/main.yml
@@ -7,3 +7,4 @@ galaxy_info:
   min_ansible_version: 2.12.6
   galaxy_tags: ['arista', 'network', 'networking', 'eos', 'avd', 'cloudvision', 'cvp']
 dependencies: []
+platforms: []

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/meta/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/meta/main.yml
@@ -6,5 +6,5 @@ galaxy_info:
   license: Apache-2.0
   min_ansible_version: 2.12.6
   galaxy_tags: ['arista', 'network', 'networking', 'eos', 'avd', 'cloudvision', 'cvp']
+  platforms: []
 dependencies: []
-platforms: []

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/tasks/build-documentation.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/tasks/build-documentation.yml
@@ -1,6 +1,8 @@
 ---
 - name: Recreate required output directories
   tags: [eos_cli_config_gen]
+  delegate_to: localhost
+  run_once: true
   block:
     - name: "Cleanup {{ role_documentation_dir }}"
       ansible.builtin.file:
@@ -21,8 +23,6 @@
         path: "{{ role_documentation_dir }}/data_model"
         state: directory
         mode: 0775
-  delegate_to: localhost
-  run_once: true
 
 - name: Import and Convert eos_cli_config_gen schema
   tags: [eos_cli_config_gen]
@@ -34,7 +34,7 @@
 
 - name: Output eos_cli_config_gen Documentation
   tags: [eos_cli_config_gen]
-  template:
+  ansible.builtin.template:
     src: avd_schema_documentation.j2
     dest: "{{ role_documentation_dir ~ '/' ~ documentation_file.filename ~ '.md'  }}"
     mode: 0664

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/tasks/build-schemas.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/tasks/build-schemas.yml
@@ -1,6 +1,8 @@
 ---
 - name: Create required output directories
   tags: [eos_cli_config_gen]
+  delegate_to: localhost
+  run_once: true
   block:
     - name: "Create {{ role_schema_dir }}"
       ansible.builtin.file:
@@ -12,8 +14,6 @@
         path: "{{ role_schema_fragments_dir }}"
         state: directory
         mode: 0775
-  delegate_to: localhost
-  run_once: true
 
 - name: Gather AVD Schema Fragments for eos_cli_config_gen
   tags: [eos_cli_config_gen]

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: "Collection {{ ansible_collection_name }} version {{ version }}{{ ('(git ' ~ git_tag ~ ')') if git_tag }} loaded from {{ collection_path }}"
   tags: [always, avd_version]
-  set_fact:
+  ansible.builtin.set_fact:
     avd_collection_version: version
   vars:
     versions: "{{ lookup('pipe', 'ansible-galaxy collection list -p ' ~ collection_path ~ ' --format yaml ' ~ ansible_collection_name) | from_yaml }}"
@@ -13,7 +13,7 @@
 
 - name: Create required output directories if not present
   tags: [build, provision]
-  file:
+  ansible.builtin.file:
     path: "{{ item }}"
     state: directory
     mode: 0775
@@ -27,8 +27,8 @@
 
 - name: Include device intended structure configuration variables
   tags: [build, provision]
-  include_vars:
-    file: "{{ filename }}"
+  ansible.builtin.include_vars:
+    ansible.builtin.file: "{{ filename }}"
   delegate_to: localhost
   when: structured_config is not defined and lookup('first_found', filename, skip=True, errors='ignore')
   vars:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/tasks/main.yml
@@ -28,7 +28,7 @@
 - name: Include device intended structure configuration variables
   tags: [build, provision]
   ansible.builtin.include_vars:
-    ansible.builtin.file: "{{ filename }}"
+    file: "{{ filename }}"
   delegate_to: localhost
   when: structured_config is not defined and lookup('first_found', filename, skip=True, errors='ignore')
   vars:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/tests/inventory
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/tests/inventory
@@ -1,1 +1,0 @@
-localhost

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/tests/test.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/tests/test.yml
@@ -1,5 +1,0 @@
----
-- hosts: localhost
-  remote_user: root
-  roles:
-    - eos_cli_config_gen

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/README.md
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/README.md
@@ -82,8 +82,8 @@ Below is an example of how to use role with a single string as `device_filter`:
 
 ```yaml
 tasks:
-  - name: run CVP provisioning
-    import_role:
+  - name: Run CVP provisioning
+    ansible.builtin.import_role:
         name: eos_config_deploy_cvp
     vars:
       container_root: 'DC1_FABRIC'
@@ -97,8 +97,8 @@ The following code block is an example of how to use this role with a list of st
 
 ```yaml
 tasks:
-  - name: run CVP provisioning
-    import_role:
+  - name: Run CVP provisioning
+    ansible.builtin.import_role:
         name: eos_config_deploy_cvp
     vars:
       container_root: 'DC1_FABRIC'

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/meta/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/meta/main.yml
@@ -1,10 +1,3 @@
 galaxy_info:
-  author: Arista Ansible Team <ansible@arista.com>
   description: Publish AVD configuration to CloudVision
-  issue_tracker_url: https://github.com/aristanetworks/ansible-avd/issues
-  company: Arista Networks
-  license: Apache-2.0
-  min_ansible_version: 2.12.6
-  galaxy_tags: ['arista', 'network', 'networking', 'eos', 'avd', 'cloudvision', 'cvp']
-  platforms: []
-dependencies: []
+  standalone: false

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/meta/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/meta/main.yml
@@ -7,3 +7,4 @@ galaxy_info:
   min_ansible_version: 2.12.6
   galaxy_tags: ['arista', 'network', 'networking', 'eos', 'avd', 'cloudvision', 'cvp']
 dependencies: []
+platforms: []

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/meta/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/meta/main.yml
@@ -6,5 +6,5 @@ galaxy_info:
   license: Apache-2.0
   min_ansible_version: 2.12.6
   galaxy_tags: ['arista', 'network', 'networking', 'eos', 'avd', 'cloudvision', 'cvp']
+  platforms: []
 dependencies: []
-platforms: []

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Create required output directories if not present
   tags: [always]
-  file:
+  ansible.builtin.file:
     path: "{{ item }}"
     state: directory
     mode: 0775
@@ -12,4 +12,4 @@
 
 - name: Start creation/update process.
   tags: [always]
-  include_tasks: "{{ cv_collection }}/main.yml"
+  ansible.builtin.include_tasks: "{{ cv_collection }}/main.yml"

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v1/absent.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v1/absent.yml
@@ -8,13 +8,13 @@
 # Load tasks when device_filter is string
 - name: Load conditional cv_device execution if device_filter is string.
   tags: [reset]
-  include_tasks: "./cv-device-filter-string.yml"
+  ansible.builtin.include_tasks: "./cv-device-filter-string.yml"
   when: "device_filter is string"
 
 # Load tasks when device_filter is list
 - name: Load conditional cv_device execution if device_filter is list.
   tags: [reset]
-  include_tasks: "./cv-device-filter-list.yml"
+  ansible.builtin.include_tasks: "./cv-device-filter-list.yml"
   when: "device_filter is not string"
 
 - name: "Execute pending tasks on {{ inventory_hostname }}"

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v1/absent.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v1/absent.yml
@@ -3,7 +3,7 @@
 - name: "Collecting facts from CVP {{ inventory_hostname }}."
   tags: [reset]
   arista.cvp.cv_facts:
-  register: cvp_facts
+  register: CVP_FACTS
 
 # Load tasks when device_filter is string
 - name: Load conditional cv_device execution if device_filter is string.
@@ -20,25 +20,25 @@
 - name: "Execute pending tasks on {{ inventory_hostname }}"
   tags: [reset]
   arista.cvp.cv_task:
-    tasks: "{{ cvp_devices_results.data.tasks }}"  # noqa: args[module]
+    tasks: "{{ CVP_DEVICES_RESULTS.data.tasks }}"  # noqa: args[module]
     wait: 720
 
 - name: "Refreshing facts from CVP {{ inventory_hostname }}."
   tags: [reset]
   arista.cvp.cv_facts:
-  register: cvp_facts
+  register: CVP_FACTS
 
 - name: "Deleting Containers topology on {{ inventory_hostname }}"
   tags: [reset]
   arista.cvp.cv_container:
-    topology: "{{ cvp_containers }}"
-    cvp_facts: "{{ cvp_facts.ansible_facts }}"
+    topology: "{{ CVP_CONTAINERS }}"
+    cvp_facts: "{{ CVP_FACTS.ansible_facts }}"
     mode: delete
 
 - name: "Delete configlets from CVP {{ inventory_hostname }}."
   tags: [reset]
   arista.cvp.cv_configlet:
-    cvp_facts: "{{ cvp_facts.ansible_facts }}"
-    configlets: "{{ cvp_vars.cvp_configlets }}"
+    cvp_facts: "{{ CVP_FACTS.ansible_facts }}"
+    configlets: "{{ CVP_VARS.CVP_CONFIGLETS }}"
     configlet_filter: ["{{ configlets_prefix }}"]
     state: absent

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v1/cv-device-filter-list.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v1/cv-device-filter-list.yml
@@ -2,8 +2,8 @@
 - name: "Configure devices on {{ inventory_hostname }}"
   tags: [provision, apply]
   arista.cvp.cv_device:
-    devices: "{{ cvp_devices }}"
-    cvp_facts: "{{ cvp_facts.ansible_facts }}"
+    devices: "{{ CVP_DEVICES }}"
+    cvp_facts: "{{ CVP_FACTS.ansible_facts }}"
     device_filter: "{{ device_filter }}"
     state: "{{ state }}"
-  register: cvp_devices_results
+  register: CVP_DEVICES_RESULTS

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v1/cv-device-filter-string.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v1/cv-device-filter-string.yml
@@ -2,8 +2,8 @@
 - name: "Configure devices on {{ inventory_hostname }}"
   tags: [provision, apply]
   arista.cvp.cv_device:
-    devices: "{{ cvp_devices }}"
-    cvp_facts: "{{ cvp_facts.ansible_facts }}"
+    devices: "{{ CVP_DEVICES }}"
+    cvp_facts: "{{ CVP_FACTS.ansible_facts }}"
     device_filter: ["{{ device_filter }}"]
     state: "{{ state }}"
-  register: cvp_devices_results
+  register: CVP_DEVICES_RESULTS

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v1/main-filter-list.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v1/main-filter-list.yml
@@ -1,5 +1,5 @@
 ---
-- name: generate intended variables
+- name: Generate intended variables
   tags: [always]
   arista.avd.inventory_to_container:
     # Inventory is read from memory unless 'avd_inventory_to_container_file' is set

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v1/main-filter-list.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v1/main-filter-list.yml
@@ -9,4 +9,4 @@
     configlet_prefix: "{{ configlets_prefix }}"
     destination: "{{ structured_cvp_dir }}/{{ inventory_hostname }}_configlets.yml"
     device_filter: "{{ device_filter }}"
-  register: cvp_vars
+  register: CVP_VARS

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v1/main-filter-string.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v1/main-filter-string.yml
@@ -1,5 +1,5 @@
 ---
-- name: generate intended variables
+- name: Generate intended variables
   tags: [always]
   arista.avd.inventory_to_container:
     # Inventory is read from memory unless 'avd_inventory_to_container_file' is set

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v1/main-filter-string.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v1/main-filter-string.yml
@@ -9,4 +9,4 @@
     configlet_prefix: "{{ configlets_prefix }}"
     destination: "{{ structured_cvp_dir }}/{{ inventory_hostname }}_configlets.yml"
     device_filter: ['{{ device_filter }}']
-  register: cvp_vars
+  register: CVP_VARS

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v1/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v1/main.yml
@@ -3,7 +3,7 @@
 
 - name: "Collection {{ ansible_collection_name }} version {{ version }}{{ ('(git ' ~ git_tag ~ ')') if git_tag }} loaded from {{ collection_path }}"
   tags: [always, avd_version]
-  set_fact:
+  ansible.builtin.set_fact:
     avd_collection_version: version
   vars:
     versions: "{{ lookup('pipe', 'ansible-galaxy collection list -p ' ~ collection_path ~ ' --format yaml ' ~ ansible_collection_name) | from_yaml }}"
@@ -16,18 +16,18 @@
 # Load tasks when device_filter is string
 - name: Generate CVP information using device_filter as string.
   tags: [always]
-  include_tasks: "{{ cv_collection }}/main-filter-string.yml"
+  ansible.builtin.include_tasks: "{{ cv_collection }}/main-filter-string.yml"
   when: "device_filter is string"
 
 # Load tasks when device_filter is list
 - name: Generate CVP information using device_filter as list.
   tags: [always]
-  include_tasks: "{{ cv_collection }}/main-filter-list.yml"
+  ansible.builtin.include_tasks: "{{ cv_collection }}/main-filter-list.yml"
   when: "device_filter is not string"
 
 - name: "Build DEVICES and CONTAINER definition for {{ inventory_hostname }}"
   tags: [generate, build, provision]
-  template:
+  ansible.builtin.template:
     src: "cvp-devices.j2"
     dest: "{{ structured_cvp_dir }}/{{ inventory_hostname }}.yml"
     mode: 0664
@@ -36,7 +36,7 @@
 
 - name: "Load CVP device information for {{ inventory_hostname }}"
   tags: [build, provision, online]
-  include_vars: "{{ structured_cvp_dir }}/{{ inventory_hostname }}.yml"
+  ansible.builtin.include_vars: "{{ structured_cvp_dir }}/{{ inventory_hostname }}.yml"
   # delegate_to: localhost
 
 #################################################
@@ -45,6 +45,6 @@
 # If state=absent launch deletion process
 - name: Start creation/update process.
   tags: [provision, online]
-  include_tasks: "{{ cv_collection }}/{{ state }}.yml"
+  ansible.builtin.include_tasks: "{{ cv_collection }}/{{ state }}.yml"
 
 #################################################

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v1/present.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v1/present.yml
@@ -51,13 +51,13 @@
 # Load tasks when device_filter is string
 - name: Load conditional cv_device execution if device_filter is string.
   tags: [provision, apply]
-  include_tasks: "./cv-device-filter-string.yml"
+  ansible.builtin.include_tasks: "./cv-device-filter-string.yml"
   when: "device_filter is string"
 
 # Load tasks when device_filter is list
 - name: Load conditional cv_device execution if device_filter is list.
   tags: [provision, apply]
-  include_tasks: "./cv-device-filter-list.yml"
+  ansible.builtin.include_tasks: "./cv-device-filter-list.yml"
   when: "device_filter is not string"
 
 - name: "Execute pending tasks on {{ inventory_hostname }}"

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v1/present.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v1/present.yml
@@ -15,7 +15,7 @@
   tags: [provision]
   arista.cvp.cv_configlet:
     cvp_facts: "{{ CVP_FACTS.ansible_facts }}"
-    configlets: "{{ cvp_vars.CVP_CONFIGLETS }}"
+    configlets: "{{ CVP_VARS.CVP_CONFIGLETS }}"
     configlet_filter: ["{{ configlets_prefix }}"]
   register: CVP_CONFIGLETS_STATUS
 

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v1/present.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v1/present.yml
@@ -3,7 +3,7 @@
 - name: "Collecting facts from CVP {{ inventory_hostname }}."
   tags: [always]
   arista.cvp.cv_facts:
-  register: cvp_facts
+  register: CVP_FACTS
 
 - name: "Execute pending tasks on {{ inventory_hostname }}"
   tags: [apply]

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v1/present.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v1/present.yml
@@ -8,37 +8,37 @@
 - name: "Execute pending tasks on {{ inventory_hostname }}"
   tags: [apply]
   arista.cvp.cv_task:
-    tasks: "{{ cvp_facts.ansible_facts.tasks }}"  # noqa: args[module]
+    tasks: "{{ CVP_FACTS.ansible_facts.tasks }}"  # noqa: args[module]
   when: execute_tasks|bool
 
 - name: "Create configlets on CVP {{ inventory_hostname }}."
   tags: [provision]
   arista.cvp.cv_configlet:
-    cvp_facts: "{{ cvp_facts.ansible_facts }}"
-    configlets: "{{ cvp_vars.cvp_configlets }}"
+    cvp_facts: "{{ CVP_FACTS.ansible_facts }}"
+    configlets: "{{ cvp_vars.CVP_CONFIGLETS }}"
     configlet_filter: ["{{ configlets_prefix }}"]
-  register: cvp_configlets_status
+  register: CVP_CONFIGLETS_STATUS
 
 - name: "Execute any configlet generated tasks to update configuration on {{ inventory_hostname }}"
   tags: [apply]
   arista.cvp.cv_task:
-    tasks: "{{ cvp_configlets_status.data.tasks }}"  # noqa: args[module]
+    tasks: "{{ CVP_CONFIGLETS_STATUS.data.tasks }}"  # noqa: args[module]
     wait: 90
   when:
-    - cvp_configlets_status.data.tasks | length > 0
+    - CVP_CONFIGLETS_STATUS.data.tasks | length > 0
     - execute_tasks|bool
 
 - name: "Building Containers topology on {{ inventory_hostname }}"
   tags: [provision]
   arista.cvp.cv_container:
-    topology: "{{ cvp_containers }}"
-    cvp_facts: "{{ cvp_facts.ansible_facts }}"
-  register: cvp_container_results
+    topology: "{{ CVP_CONTAINERS }}"
+    cvp_facts: "{{ CVP_FACTS.ansible_facts }}"
+  register: CVP_CONTAINER_RESULTS
 
 - name: "Execute pending tasks on {{ inventory_hostname }}"
   tags: [apply]
   arista.cvp.cv_task:
-    tasks: "{{ cvp_container_results.data.tasks }}"  # noqa: args[module]
+    tasks: "{{ CVP_CONTAINER_RESULTS.data.tasks }}"  # noqa: args[module]
     wait: 720
   when:
     - execute_tasks|bool
@@ -46,7 +46,7 @@
 - name: "Refreshing facts from CVP {{ inventory_hostname }}."
   tags: [always]
   arista.cvp.cv_facts:
-  register: cvp_facts
+  register: CVP_FACTS
 
 # Load tasks when device_filter is string
 - name: Load conditional cv_device execution if device_filter is string.
@@ -63,7 +63,7 @@
 - name: "Execute pending tasks on {{ inventory_hostname }}"
   tags: [apply]
   arista.cvp.cv_task:
-    tasks: "{{ cvp_devices_results.data.tasks }}"  # noqa: args[module]
+    tasks: "{{ CVP_DEVICES_RESULTS.data.tasks }}"  # noqa: args[module]
     wait: 720
   when:
     - execute_tasks|bool

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v3/absent.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v3/absent.yml
@@ -1,6 +1,6 @@
 ---
 - name: "Unsupported option"
   delegate_to: localhost
-  debug:
+  ansible.builtin.debug:
     msg:
       - "!!! Absent state not yet supported by Cloudvision collection."

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v3/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v3/main.yml
@@ -21,7 +21,7 @@
     configlet_prefix: "{{ configlets_prefix }}"
     destination: "{{ structured_cvp_dir }}/{{ inventory_hostname }}_configlets.yml"
     device_filter: "{{ device_filter }}"
-  register: cvp_vars
+  register: CVP_VARS
 
 - name: "Build DEVICES and CONTAINER definition for {{ inventory_hostname }}"
   tags: [generate, build, provision]

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v3/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v3/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: "Collection {{ ansible_collection_name }} version {{ version }}{{ ('(git ' ~ git_tag ~ ')') if git_tag }} loaded from {{ collection_path }}"
   tags: [always, avd_version]
-  set_fact:
+  ansible.builtin.set_fact:
     avd_collection_version: version
   vars:
     versions: "{{ lookup('pipe', 'ansible-galaxy collection list -p ' ~ collection_path ~ ' --format yaml ' ~ ansible_collection_name) | from_yaml }}"
@@ -25,7 +25,7 @@
 
 - name: "Build DEVICES and CONTAINER definition for {{ inventory_hostname }}"
   tags: [generate, build, provision]
-  template:
+  ansible.builtin.template:
     src: "cvp-devices-v3.j2"
     dest: "{{ structured_cvp_dir }}/{{ inventory_hostname }}.yml"
     mode: 0664
@@ -38,6 +38,6 @@
 # If state=absent launch deletion process
 - name: Start creation/update process.
   tags: [provision, online]
-  include_tasks: "{{ cv_collection }}/{{ state }}.yml"
+  ansible.builtin.include_tasks: "{{ cv_collection }}/{{ state }}.yml"
 
 #################################################

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v3/present.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v3/present.yml
@@ -6,44 +6,44 @@
 - name: "Create configlets on CVP {{ inventory_hostname }}."
   tags: [provision]
   arista.cvp.cv_configlet_v3:
-    configlets: "{{ cvp_vars.cvp_configlets }}"
-  register: cvp_configlets_status
+    configlets: "{{ CVP_VARS.CVP_CONFIGLETS }}"
+  register: CVP_CONFIGLETS_STATUS
 
 - name: "Execute any configlet generated tasks to update configuration on {{ inventory_hostname }}"
   tags: [apply]
   arista.cvp.cv_task_v3:
-    tasks: "{{ cvp_configlets_status.taskIds }}"
+    tasks: "{{ CVP_CONFIGLETS_STATUS.taskIds }}"
   when:
-    - cvp_configlets_status.taskIds | length > 0
+    - CVP_CONFIGLETS_STATUS.taskIds | length > 0
     - execute_tasks|bool
 
 - name: "Building Containers topology on {{ inventory_hostname }}"
   tags: [provision, containers]
   arista.cvp.cv_container_v3:
-    topology: "{{ cvp_containers }}"
+    topology: "{{ CVP_CONTAINERS }}"
     state: present
     apply_mode: loose
-  register: cvp_container_results
+  register: CVP_CONTAINER_RESULTS
 
 - name: "Execute pending tasks on {{ inventory_hostname }}"
   tags: [apply]
   arista.cvp.cv_task_v3:
-    tasks: "{{ cvp_container_results.taskIds }}"
+    tasks: "{{ CVP_CONTAINER_RESULTS.taskIds }}"
   when:
-    - cvp_container_results.taskIds | length > 0
+    - CVP_CONTAINER_RESULTS.taskIds | length > 0
     - execute_tasks|bool
 
 - name: "Configure devices on {{ inventory_hostname }}"
   tags: [provision, apply]
   arista.cvp.cv_device_v3:
-    devices: "{{ cvp_devices }}"  # noqa: args[module]
+    devices: "{{ CVP_DEVICES }}"  # noqa: args[module]
     state: present
-  register: cvp_devices_results
+  register: CVP_DEVICES_RESULTS
 
 - name: "Execute pending tasks on {{ inventory_hostname }}"
   tags: [apply]
   arista.cvp.cv_task_v3:
-    tasks: "{{ cvp_devices_results.taskIds }}"
+    tasks: "{{ CVP_DEVICES_RESULTS.taskIds }}"
   when:
-    - cvp_devices_results.taskIds | length > 0
+    - CVP_DEVICES_RESULTS.taskIds | length > 0
     - execute_tasks|bool

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v3/present.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v3/present.yml
@@ -1,7 +1,7 @@
 ---
 - name: "Load CVP device information for {{ inventory_hostname }}"
   tags: [build, provision, online]
-  include_vars: "{{ structured_cvp_dir }}/{{ inventory_hostname }}.yml"
+  ansible.builtin.include_vars: "{{ structured_cvp_dir }}/{{ inventory_hostname }}.yml"
 
 - name: "Create configlets on CVP {{ inventory_hostname }}."
   tags: [provision]

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/templates/cvp-devices-v3.j2
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/templates/cvp-devices-v3.j2
@@ -7,13 +7,13 @@
 {% endif %}
 {% set dev_cntr = namespace(value=0) %}
 ---
-cvp_devices:
+CVP_DEVICES:
 {% for device in groups[container_root] | arista.avd.natural_sort %}
 {%     if device | arista.avd.is_in_filter(local_var.device_filter) %}
 {%         if hostvars[device]['is_deployed'] is arista.avd.defined(true) or hostvars[device]['is_deployed'] is not arista.avd.defined %}
   - fqdn: {{ device }}
 {%             set dev_cntr.value = dev_cntr.value + 1 %}
-{%             for container_name, container in cvp_vars.cvp_topology.items() | arista.avd.natural_sort %}
+{%             for container_name, container in CVP_VARS.CVP_TOPOLOGY.items() | arista.avd.natural_sort %}
 {%                 if 'devices' in container %}
 {%                     for device_container in container['devices'] %}
 {%                         if device == device_container %}
@@ -35,8 +35,8 @@ cvp_devices:
 {% if dev_cntr.value == 0 %}
   []
 {% endif %}
-cvp_containers:
-{% for container_name, container in cvp_vars.cvp_topology.items() | arista.avd.natural_sort %}
+CVP_CONTAINERS:
+{% for container_name, container in CVP_VARS.CVP_TOPOLOGY.items() | arista.avd.natural_sort %}
   {{ container_name }}:
     parentContainerName: {{ container['parent_container'] }}
 {%     if hostvars[groups[container_root][0]]['cv_configlets']['containers'][container_name] is defined and hostvars[groups[container_root][0]]['cv_configlets']['containers'][container_name] is iterable %}

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/templates/cvp-devices.j2
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/templates/cvp-devices.j2
@@ -6,13 +6,13 @@
 {%     set local_var.device_filter = device_filter %}
 {% endif %}
 ---
-cvp_devices:
+CVP_DEVICES:
 {% for device in groups[container_root] | arista.avd.natural_sort %}
 {%     if device | arista.avd.is_in_filter(local_var.device_filter) %}
 {%         if (hostvars[device]['is_deployed'] is defined and hostvars[device]['is_deployed'] == true) or (hostvars[device]['is_deployed'] is not defined) %}
   {{ device }}:
     name: {{ device }}
-{%             for container_name, container in cvp_vars.cvp_topology.items() | arista.avd.natural_sort %}
+{%             for container_name, container in CVP_VARS.CVP_TOPOLOGY.items() | arista.avd.natural_sort %}
 {%                 if 'devices' in container %}
 {%                     for device_container in container['devices'] %}
 {%                         if device == device_container %}
@@ -32,8 +32,8 @@ cvp_devices:
 {%         endif %}
 {%     endif %}
 {% endfor %}
-cvp_containers:
-{% for container_name, container in cvp_vars.cvp_topology.items() | arista.avd.natural_sort %}
+CVP_CONTAINERS:
+{% for container_name, container in CVP_VARS.CVP_TOPOLOGY.items() | arista.avd.natural_sort %}
   {{ container_name }}:
     parent_container: {{ container['parent_container'] }}
 {%     if hostvars[groups[container_root][0]]['cv_configlets']['containers'][container_name] is defined and hostvars[groups[container_root][0]]['cv_configlets']['containers'][container_name] is iterable %}

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tests/inventory
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tests/inventory
@@ -1,1 +1,0 @@
-localhost

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tests/test.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tests/test.yml
@@ -1,5 +1,0 @@
----
-- hosts: localhost
-  remote_user: root
-  roles:
-    - eos-config-deploy-cvp

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/vars/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/vars/main.yml
@@ -1,8 +1,8 @@
 ---
 # vars file for eos-config-deploy-cvp
-cvp_configlets:
+CVP_CONFIGLET:
   DC1_CONFIGLET: "alias a{{ 999 | random }} show version"
 
-cvp_topology:
+CVP_TOPOLOGY:
   # Testing specific environment
   staging:

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_eapi/handlers/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_eapi/handlers/main.yml
@@ -1,8 +1,8 @@
 ---
   # handlers file for eos_config_deploy_eapi
 
-- name: backup running config
-  eos_config:
+- name: Backup running config
+  arista.eos.eos_config:
     backup: yes
     backup_options:
       filename: "{{ post_running_config_backup_filename }}"

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_eapi/meta/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_eapi/meta/main.yml
@@ -1,10 +1,3 @@
 galaxy_info:
-  author: Arista Ansible Team <ansible@arista.com>
   description: Deploys eos intended configuration via eapi.
-  issue_tracker_url: https://github.com/aristanetworks/ansible-avd/issues
-  company: Arista Networks
-  license: Apache-2.0
-  min_ansible_version: 2.12.6
-  galaxy_tags: ['arista', 'network', 'networking', 'eos', 'avd', 'cloudvision', 'cvp']
-  platforms: []
-dependencies: []
+  standalone: false

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_eapi/meta/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_eapi/meta/main.yml
@@ -7,3 +7,4 @@ galaxy_info:
   min_ansible_version: 2.12.6
   galaxy_tags: ['arista', 'network', 'networking', 'eos', 'avd', 'cloudvision', 'cvp']
 dependencies: []
+platforms: []

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_eapi/meta/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_eapi/meta/main.yml
@@ -6,5 +6,5 @@ galaxy_info:
   license: Apache-2.0
   min_ansible_version: 2.12.6
   galaxy_tags: ['arista', 'network', 'networking', 'eos', 'avd', 'cloudvision', 'cvp']
+  platforms: []
 dependencies: []
-platforms: []

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_eapi/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_eapi/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: "Collection {{ ansible_collection_name }} version {{ version }}{{ ('(git ' ~ git_tag ~ ')') if git_tag }} loaded from {{ collection_path }}"
   tags: [always, avd_version]
-  set_fact:
+  ansible.builtin.set_fact:
     avd_collection_version: version
   vars:
     versions: "{{ lookup('pipe', 'ansible-galaxy collection list -p ' ~ collection_path ~ ' --format yaml ' ~ ansible_collection_name) | from_yaml }}"
@@ -12,7 +12,7 @@
   failed_when: false
 
 - name: Create required output directories if not present
-  file:
+  ansible.builtin.file:
     path: "{{ item }}"
     state: directory
     mode: 0775
@@ -22,8 +22,8 @@
   delegate_to: localhost
   run_once: true
 
-- name: replace configuration with intended configuration
-  eos_config:
+- name: Replace configuration with intended configuration
+  arista.eos.eos_config:
     src: "{{ eos_config_dir }}/{{ inventory_hostname }}.cfg"
     replace: config
     save_when: modified

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_eapi/tests/inventory
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_eapi/tests/inventory
@@ -1,1 +1,0 @@
-localhost

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_eapi/tests/test.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_eapi/tests/test.yml
@@ -1,5 +1,0 @@
----
-- hosts: localhost
-  remote_user: root
-  roles:
-    - eos_config_deploy_eapi

--- a/ansible_collections/arista/avd/roles/eos_designs/meta/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/meta/main.yml
@@ -1,10 +1,3 @@
 galaxy_info:
-  author: Arista Ansible Team <ansible@arista.com>
   description: Opinionated Data model to aid with the deployment of Arista Validated Designs.
-  issue_tracker_url: https://github.com/aristanetworks/ansible-avd/issues
-  company: Arista Networks
-  license: Apache-2.0
-  min_ansible_version: 2.12.6
-  galaxy_tags: ['arista', 'network', 'networking', 'eos', 'avd', 'cloudvision', 'cvp']
-  platforms: []
-dependencies: []
+  standalone: false

--- a/ansible_collections/arista/avd/roles/eos_designs/meta/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/meta/main.yml
@@ -7,3 +7,4 @@ galaxy_info:
   min_ansible_version: 2.12.6
   galaxy_tags: ['arista', 'network', 'networking', 'eos', 'avd', 'cloudvision', 'cvp']
 dependencies: []
+platforms: []

--- a/ansible_collections/arista/avd/roles/eos_designs/meta/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/meta/main.yml
@@ -6,5 +6,5 @@ galaxy_info:
   license: Apache-2.0
   min_ansible_version: 2.12.6
   galaxy_tags: ['arista', 'network', 'networking', 'eos', 'avd', 'cloudvision', 'cvp']
+  platforms: []
 dependencies: []
-platforms: []

--- a/ansible_collections/arista/avd/roles/eos_designs/tasks/build-documentation.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/tasks/build-documentation.yml
@@ -1,6 +1,8 @@
 ---
 - name: Recreate required output directories
   tags: [eos_designs]
+  delegate_to: localhost
+  run_once: true
   block:
     - name: "Cleanup {{ role_documentation_dir }}"
       ansible.builtin.file:
@@ -11,8 +13,6 @@
         path: "{{ role_documentation_dir }}"
         state: directory
         mode: 0775
-  delegate_to: localhost
-  run_once: true
 
 - name: Import and Convert eos_designs schema
   tags: [eos_designs]
@@ -21,7 +21,7 @@
 
 - name: Output eos_designs Documentation
   tags: [eos_designs]
-  template:
+  ansible.builtin.template:
     src: avd_schema_documentation.j2
     dest: "{{ role_documentation_dir ~ '/' ~ documentation_file.filename ~ '.md'  }}"
     mode: 0664

--- a/ansible_collections/arista/avd/roles/eos_designs/tasks/build-schemas.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/tasks/build-schemas.yml
@@ -1,6 +1,8 @@
 ---
 - name: Create required output directories
   tags: [eos_designs]
+  delegate_to: localhost
+  run_once: true
   block:
     - name: "Create {{ role_schema_dir }}"
       ansible.builtin.file:
@@ -12,8 +14,6 @@
         path: "{{ role_schema_fragments_dir }}"
         state: directory
         mode: 0775
-  delegate_to: localhost
-  run_once: true
 
 - name: Gather AVD Schema Fragments for eos_designs
   tags: [eos_designs]

--- a/ansible_collections/arista/avd/roles/eos_designs/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/tasks/main.yml
@@ -72,7 +72,7 @@
   delegate_to: localhost
   check_mode: false
   ansible.builtin.copy:
-    content: "{{ lookup('template','documentation/fabric-documentation.j2') | arista.avd.add_md_toc(skip_lines=3) }}"
+    content: "{{ lookup('template', 'documentation/fabric-documentation.j2') | arista.avd.add_md_toc(skip_lines=3) }}"
     dest: "{{ fabric_dir }}/{{ fabric_name }}-documentation.md"
     mode: 0664
 

--- a/ansible_collections/arista/avd/roles/eos_designs/tests/inventory
+++ b/ansible_collections/arista/avd/roles/eos_designs/tests/inventory
@@ -1,1 +1,0 @@
-localhost

--- a/ansible_collections/arista/avd/roles/eos_designs/tests/test.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/tests/test.yml
@@ -1,5 +1,0 @@
----
-- hosts: localhost
-  remote_user: root
-  roles:
-    - eos_designs

--- a/ansible_collections/arista/avd/roles/eos_snapshot/README.md
+++ b/ansible_collections/arista/avd/roles/eos_snapshot/README.md
@@ -78,7 +78,7 @@ Requirements are located here: [avd-requirements](../../README.md#Requirements)
     - arista.avd
   tasks:
     - name: Collect commands
-      import_role:
+      ansible.builtin.import_role:
         name: eos_snapshot
 ```
 

--- a/ansible_collections/arista/avd/roles/eos_snapshot/meta/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_snapshot/meta/main.yml
@@ -1,10 +1,3 @@
 galaxy_info:
-  author: Arista Ansible Team <ansible@arista.com>
   description: Collect show commands on EOS devices and generate reports
-  issue_tracker_url: https://github.com/aristanetworks/ansible-avd/issues
-  company: Arista Networks
-  license: Apache-2.0
-  min_ansible_version: 2.12.6
-  galaxy_tags: ['arista', 'network', 'networking', 'eos', 'avd', 'cloudvision', 'cvp']
-  platforms: []
-dependencies: []
+  standalone: false

--- a/ansible_collections/arista/avd/roles/eos_snapshot/meta/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_snapshot/meta/main.yml
@@ -7,3 +7,4 @@ galaxy_info:
   min_ansible_version: 2.12.6
   galaxy_tags: ['arista', 'network', 'networking', 'eos', 'avd', 'cloudvision', 'cvp']
 dependencies: []
+platforms: []

--- a/ansible_collections/arista/avd/roles/eos_snapshot/meta/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_snapshot/meta/main.yml
@@ -6,5 +6,5 @@ galaxy_info:
   license: Apache-2.0
   min_ansible_version: 2.12.6
   galaxy_tags: ['arista', 'network', 'networking', 'eos', 'avd', 'cloudvision', 'cvp']
+  platforms: []
 dependencies: []
-platforms: []

--- a/ansible_collections/arista/avd/roles/eos_snapshot/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_snapshot/tasks/main.yml
@@ -3,7 +3,7 @@
 - name: "Collection {{ ansible_collection_name }} version {{ version }}{{ ('(git ' ~ git_tag ~ ')') if git_tag }} loaded from {{ collection_path }}"
   delegate_to: localhost
   tags: [always, avd_version]
-  set_fact:
+  ansible.builtin.set_fact:
     avd_collection_version: version
   vars:
     versions: "{{ lookup('pipe', 'ansible-galaxy collection list -p ' ~ collection_path ~ ' --format yaml ' ~ ansible_collection_name) | from_yaml }}"
@@ -15,7 +15,7 @@
 
 - name: Create required output directories if not present
   delegate_to: localhost
-  file:
+  ansible.builtin.file:
     path: "{{ item }}"
     state: directory
     mode: 0775
@@ -25,15 +25,15 @@
 
 - name: Create output directory for each EOS device
   delegate_to: localhost
-  file:
+  ansible.builtin.file:
     path: "{{ snapshots_backup_dir }}/{{ inventory_hostname }}"
     state: directory
     mode: 0775
   when: ('text' in output_format) or
         ('markdown' in output_format)
 
-- name: run show commands on remote EOS devices with text output
-  eos_command:
+- name: Run show commands on remote EOS devices with text output
+  arista.eos.eos_command:
     commands: "{{ item }}"
   with_items: "{{ commands_list }}"
   failed_when: false
@@ -41,8 +41,8 @@
   when: ('text' in output_format) or
         ('markdown' in output_format)
 
-- name: run show commands on remote EOS devices with json output
-  eos_command:
+- name: Run show commands on remote EOS devices with json output
+  arista.eos.eos_command:
     commands:
       - command: "{{ item }}"
         output: json
@@ -52,9 +52,9 @@
   when: ('json' in output_format) or
         ('yaml' in output_format)
 
-- name: save collected commands in text files
+- name: Save collected commands in text files
   delegate_to: localhost
-  template:
+  ansible.builtin.template:
     src: device_text_command.j2
     dest: "{{ snapshots_backup_dir }}/{{ inventory_hostname }}/{{ item.item | replace('/', '_') }}.txt"
     mode: 0664
@@ -63,7 +63,7 @@
 
 - name: Generate json report for fabric
   delegate_to: localhost
-  template:
+  ansible.builtin.template:
     src: fabric_json_output.j2
     dest: "{{ snapshots_backup_dir }}/report.json"
     mode: 0664
@@ -72,7 +72,7 @@
 
 - name: Generate yaml report for fabric
   delegate_to: localhost
-  template:
+  ansible.builtin.template:
     src: fabric_yaml_output.j2
     dest: "{{ snapshots_backup_dir }}/report.yaml"
     mode: 0664
@@ -80,5 +80,5 @@
   when: ('yaml' in output_format)
 
 - name: Generate markdown report for fabric
-  include_tasks: "markdown.yml"
+  ansible.builtin.include_tasks: "markdown.yml"
   when: ('markdown' in output_format)

--- a/ansible_collections/arista/avd/roles/eos_snapshot/tasks/markdown.yml
+++ b/ansible_collections/arista/avd/roles/eos_snapshot/tasks/markdown.yml
@@ -1,34 +1,34 @@
 - name: Create md_fragments directory for each EOS device
   delegate_to: localhost
-  file:
+  ansible.builtin.file:
     path: "{{ snapshots_backup_dir }}/{{ inventory_hostname }}/md_fragments"
     state: directory
     mode: 0775
 
-- name: save collected commands in md files
+- name: Save collected commands in md files
   delegate_to: localhost
-  template:
+  ansible.builtin.template:
     src: md_report.j2
     dest: "{{ snapshots_backup_dir }}/{{ inventory_hostname }}/md_fragments/{{ item.item | replace('/', '_') }}.md"
     mode: 0664
   loop: "{{ cli_output.results }}"
 
-- name: generate table of content report
+- name: Generate table of content report
   delegate_to: localhost
-  template:
+  ansible.builtin.template:
     src: md_table_of_content.j2
     dest: "{{ snapshots_backup_dir }}/{{ inventory_hostname }}/md_fragments/0_table_of_content.md"
     mode: 0664
 
 - name: Assembling md_fragments
   delegate_to: localhost
-  assemble:
+  ansible.builtin.assemble:
     src: "{{ snapshots_backup_dir }}/{{ inventory_hostname }}/md_fragments"
     dest: "{{ snapshots_backup_dir }}/{{ inventory_hostname }}/report.md"
     mode: 0664
 
 - name: Delete md_fragments directory for each EOS device
   delegate_to: localhost
-  file:
+  ansible.builtin.file:
     path: "{{ snapshots_backup_dir }}/{{ inventory_hostname }}/md_fragments"
     state: absent

--- a/ansible_collections/arista/avd/roles/eos_snapshot/tests/inventory
+++ b/ansible_collections/arista/avd/roles/eos_snapshot/tests/inventory
@@ -1,1 +1,0 @@
-localhost

--- a/ansible_collections/arista/avd/roles/eos_snapshot/tests/test.yml
+++ b/ansible_collections/arista/avd/roles/eos_snapshot/tests/test.yml
@@ -1,5 +1,0 @@
----
-- hosts: localhost
-  remote_user: root
-  roles:
-    - eos_commands_collect

--- a/ansible_collections/arista/avd/roles/eos_validate_state/README.md
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/README.md
@@ -130,7 +130,7 @@ Requirements are located here: [avd-requirements](../../README.md#Requirements)
   tasks:
 
     - name: validate states on EOS devices
-      import_role:
+      ansible.builtin.import_role:
          name: arista.avd.eos_validate_state
 ```
 

--- a/ansible_collections/arista/avd/roles/eos_validate_state/meta/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/meta/main.yml
@@ -7,3 +7,4 @@ galaxy_info:
   min_ansible_version: 2.12.6
   galaxy_tags: ['arista', 'network', 'networking', 'eos', 'avd', 'cloudvision', 'cvp']
 dependencies: []
+platforms: []

--- a/ansible_collections/arista/avd/roles/eos_validate_state/meta/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/meta/main.yml
@@ -1,10 +1,3 @@
 galaxy_info:
-  author: Arista Ansible Team <ansible@arista.com>
   description: Validate states on EOS devices via eapi.
-  issue_tracker_url: https://github.com/aristanetworks/ansible-avd/issues
-  company: Arista Networks
-  license: Apache-2.0
-  min_ansible_version: 2.12.6
-  galaxy_tags: ['arista', 'network', 'networking', 'eos', 'avd', 'cloudvision', 'cvp']
-  platforms: []
-dependencies: []
+  standalone: false

--- a/ansible_collections/arista/avd/roles/eos_validate_state/meta/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/meta/main.yml
@@ -6,5 +6,5 @@ galaxy_info:
   license: Apache-2.0
   min_ansible_version: 2.12.6
   galaxy_tags: ['arista', 'network', 'networking', 'eos', 'avd', 'cloudvision', 'cvp']
+  platforms: []
 dependencies: []
-platforms: []

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/bgp_check.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/bgp_check.yml
@@ -3,7 +3,7 @@
 # BGP Validation tests
 
 - name: Gather ip route summary and ArBGP state
-  eos_command:
+  arista.eos.eos_command:
     commands: "show ip route summary"
   register: ip_route_summary
   tags:
@@ -11,11 +11,11 @@
 
 - name: Validate ArBGP is configured and operating
   delegate_to: localhost
-  assert:
+  ansible.builtin.assert:
     that:
       - ip_route_summary.stdout_lines[0][0] | regex_search('multi-agent')
       - ip_route_summary.stdout_lines[0][1] | regex_search('multi-agent')
-    fail_msg: "{{ ip_route_summary.stdout_lines[0][0] | replace('\"','') }}, {{ ip_route_summary.stdout_lines[0][1] | replace('\"','') }}"
+    fail_msg: "{{ ip_route_summary.stdout_lines[0][0] | replace('\"', '') }}, {{ ip_route_summary.stdout_lines[0][1] | replace('\"', '') }}"
     quiet: yes
   when: (service_routing_protocols_model is defined and service_routing_protocols_model == 'multi-agent')
   ignore_errors: "{{ eos_validate_state_validation_mode_loose }}"
@@ -24,7 +24,7 @@
     - bgp_check
 
 - name: Gather bgp summary (ip and evpn)
-  eos_command:
+  arista.eos.eos_command:
     commands:
       - command: "show ip bgp summary | json"
       - command: "show bgp evpn summary | json"
@@ -36,10 +36,10 @@
 
 - name: Validate ip bgp neighbors peer state
   delegate_to: localhost
-  assert:
+  ansible.builtin.assert:
     that:
       - bgp_summary.stdout[0].vrfs.default.peers[bgp_neighbor.ip_address].peerState | arista.avd.default('Not configured') == 'Established'
-    fail_msg: "Session state {{ bgp_summary.stdout[0].vrfs.default.peers[bgp_neighbor.ip_address].peerState | arista.avd.default('Not configured') | replace('\"','') }}"
+    fail_msg: "Session state {{ bgp_summary.stdout[0].vrfs.default.peers[bgp_neighbor.ip_address].peerState | arista.avd.default('Not configured') | replace('\"', '') }}"
     quiet: yes
   loop: "{{ router_bgp.neighbors | arista.avd.default({}) | arista.avd.convert_dicts('ip_address') }}"
   loop_control:
@@ -53,10 +53,10 @@
 
 - name: Validate bgp evpn neighbors peer state
   delegate_to: localhost
-  assert:
+  ansible.builtin.assert:
     that:
       - bgp_summary.stdout[1].vrfs.default.peers[bgp_neighbor.ip_address].peerState | arista.avd.default('Not configured') == 'Established'
-    fail_msg: "Session state: {{ bgp_summary.stdout[1].vrfs.default.peers[bgp_neighbor.ip_address].peerState | arista.avd.default('Not configured') | replace('\"','') }}"
+    fail_msg: "Session state: {{ bgp_summary.stdout[1].vrfs.default.peers[bgp_neighbor.ip_address].peerState | arista.avd.default('Not configured') | replace('\"', '') }}"
     quiet: yes
   loop: "{{ router_bgp.neighbors | arista.avd.default({}) | arista.avd.convert_dicts('ip_address') }}"
   loop_control:

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/hardware.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/hardware.yml
@@ -3,7 +3,7 @@
 # Hardware Validation Tests
 
 - name: Gather power supplies status
-  eos_command:
+  arista.eos.eos_command:
     commands: "show system environment power | json"
   register: system_environment_power
   tags:
@@ -11,10 +11,10 @@
 
 - name: Validate power supplies status
   delegate_to: localhost
-  assert:
+  ansible.builtin.assert:
     that:
       - "powerSupply.value.state in {{ accepted_pwr_supply_states }}"
-    fail_msg: "Power supply state is {{ powerSupply.value.state | replace('\"','') }}"
+    fail_msg: "Power supply state is {{ powerSupply.value.state | replace('\"', '') }}"
     quiet: true
   loop: "{{ system_environment_power.stdout_lines.0.powerSupplies | dict2items }}"
   loop_control:
@@ -25,7 +25,7 @@
     - hardware
 
 - name: Gather system environment fan status
-  eos_command:
+  arista.eos.eos_command:
     commands: "show system environment cooling | json"
   register: system_environment_cooling
   tags:
@@ -33,10 +33,10 @@
 
 - name: Validate fan status (power supplies)
   delegate_to: localhost
-  assert:
+  ansible.builtin.assert:
     that:
       - "powerSupplySlot.status in {{ accepted_fan_states }}"
-    fail_msg: "Power supply fan status is {{ powerSupplySlot.status | replace('\"','') }}"
+    fail_msg: "Power supply fan status is {{ powerSupplySlot.status | replace('\"', '') }}"
     quiet: true
   loop: "{{ system_environment_cooling.stdout_lines.0.powerSupplySlots }}"
   loop_control:
@@ -48,10 +48,10 @@
 
 - name: Validate fan status (fan tray)
   delegate_to: localhost
-  assert:
+  ansible.builtin.assert:
     that:
       - "fanTraySlot.status in {{ accepted_fan_states }}"
-    fail_msg: "Fan status is {{ fanTraySlot.status | replace('\"','') }}"
+    fail_msg: "Fan status is {{ fanTraySlot.status | replace('\"', '') }}"
     quiet: true
   loop: "{{ system_environment_cooling.stdout_lines.0.fanTraySlots }}"
   loop_control:
@@ -62,7 +62,7 @@
     - hardware
 
 - name: Gather system environment temperature
-  eos_command:
+  arista.eos.eos_command:
     commands: "show system environment temperature | json"
   ignore_errors: "{{ eos_validate_state_validation_mode_loose }}"
   register: environment_temperature
@@ -71,10 +71,10 @@
 
 - name: Validate system temperature
   delegate_to: localhost
-  assert:
+  ansible.builtin.assert:
     that:
       - environment_temperature.stdout[0].systemStatus == 'temperatureOk'
-    fail_msg: "System temperature is {{ environment_temperature.stdout[0].systemStatus | replace('\"','') }}"
+    fail_msg: "System temperature is {{ environment_temperature.stdout[0].systemStatus | replace('\"', '') }}"
     quiet: true
   ignore_errors: "{{ eos_validate_state_validation_mode_loose }}"
   register: environment_temperature_results
@@ -82,7 +82,7 @@
     - hardware
 
 - name: Gather transceivers inventory
-  eos_command:
+  arista.eos.eos_command:
     commands: "show inventory | json"
   register: inventory
   tags:
@@ -90,10 +90,10 @@
 
 - name: Validate transceivers manufacturers
   delegate_to: localhost
-  assert:
+  ansible.builtin.assert:
     that:
       - "xcvrSlot.value.mfgName in {{ accepted_xcvr_manufacturers }}"
-    fail_msg: "Transceivers manufacturers is {{ xcvrSlot.value.mfgName | replace('\"','') }}"
+    fail_msg: "Transceivers manufacturers is {{ xcvrSlot.value.mfgName | replace('\"', '') }}"
     quiet: true
   loop: "{{ inventory.stdout_lines.0.xcvrSlots | dict2items }}"
   loop_control:

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/interface_state.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/interface_state.yml
@@ -3,7 +3,7 @@
 # Interface State Tests
 
 - name: Gather interfaces state
-  eos_command:
+  arista.eos.eos_command:
     commands: "show interfaces description | json"
   ignore_errors: "{{ eos_validate_state_validation_mode_loose }}"
   register: interfaces_state
@@ -12,7 +12,7 @@
 
 - name: Validate Ethernet interfaces state
   delegate_to: localhost
-  assert:
+  ansible.builtin.assert:
     that:
       ( interfaces_state.stdout[0].interfaceDescriptions[ethernet_interface.name].interfaceStatus | arista.avd.default('Not present') == 'up' and
       interfaces_state.stdout[0].interfaceDescriptions[ethernet_interface.name].lineProtocolStatus | arista.avd.default('Not present') == 'up' and
@@ -22,9 +22,9 @@
       interfaces_state.stdout[0].interfaceDescriptions[ethernet_interface.name].lineProtocolStatus | arista.avd.default('Not present') != 'up' and
       ethernet_interface.shutdown
       )
-    fail_msg: "Interface shutdown: {{ ethernet_interface.shutdown | replace('\"','') }} -
-      interface status: {{ interfaces_state.stdout[0].interfaceDescriptions[ethernet_interface.name].interfaceStatus | arista.avd.default('Not present') | replace('\"','') }} -
-      line protocol status: {{ interfaces_state.stdout[0].interfaceDescriptions[ethernet_interface.name].lineProtocolStatus | arista.avd.default('Not present') | replace('\"','') }}"
+    fail_msg: "Interface shutdown: {{ ethernet_interface.shutdown | replace('\"', '') }} -
+      interface status: {{ interfaces_state.stdout[0].interfaceDescriptions[ethernet_interface.name].interfaceStatus | arista.avd.default('Not present') | replace('\"', '') }} -
+      line protocol status: {{ interfaces_state.stdout[0].interfaceDescriptions[ethernet_interface.name].lineProtocolStatus | arista.avd.default('Not present') | replace('\"', '') }}"
     quiet: true
   loop: "{{ ethernet_interfaces | arista.avd.default({}) | arista.avd.convert_dicts('name') }}"
   loop_control:
@@ -36,7 +36,7 @@
 
 - name: Validate Port-Channel interfaces state
   delegate_to: localhost
-  assert:
+  ansible.builtin.assert:
     that:
       ( interfaces_state.stdout[0].interfaceDescriptions[port_channel_interface.name].interfaceStatus | arista.avd.default('Not configured') == 'up' and
       interfaces_state.stdout[0].interfaceDescriptions[port_channel_interface.name].lineProtocolStatus | arista.avd.default('Not configured') == 'up' and
@@ -46,9 +46,9 @@
       interfaces_state.stdout[0].interfaceDescriptions[port_channel_interface.name].lineProtocolStatus | arista.avd.default('Not configured') != 'up' and
       port_channel_interface.shutdown
       )
-    fail_msg: "Interface shutdown: {{ port_channel_interface.shutdown | replace('\"','') }} -
-      interface status: {{ interfaces_state.stdout[0].interfaceDescriptions[port_channel_interface.name].interfaceStatus | arista.avd.default('Not configured') | replace('\"','') }} -
-      line protocol status: {{ interfaces_state.stdout[0].interfaceDescriptions[port_channel_interface.name].lineProtocolStatus | arista.avd.default('Not configured') | replace('\"','') }}"
+    fail_msg: "Interface shutdown: {{ port_channel_interface.shutdown | replace('\"', '') }} -
+      interface status: {{ interfaces_state.stdout[0].interfaceDescriptions[port_channel_interface.name].interfaceStatus | arista.avd.default('Not configured') | replace('\"', '') }} -
+      line protocol status: {{ interfaces_state.stdout[0].interfaceDescriptions[port_channel_interface.name].lineProtocolStatus | arista.avd.default('Not configured') | replace('\"', '') }}"
     quiet: true
   loop: "{{ port_channel_interfaces | arista.avd.default({}) | arista.avd.convert_dicts('name') }}"
   loop_control:
@@ -60,7 +60,7 @@
 
 - name: Validate Vlan interfaces state
   delegate_to: localhost
-  assert:
+  ansible.builtin.assert:
     that:
       ( interfaces_state.stdout[0].interfaceDescriptions[vlan_interface.name].interfaceStatus | arista.avd.default('Not configured') == 'up' and
       interfaces_state.stdout[0].interfaceDescriptions[vlan_interface.name].lineProtocolStatus | arista.avd.default('Not configured') == 'up' and
@@ -70,11 +70,11 @@
       interfaces_state.stdout[0].interfaceDescriptions[vlan_interface.name].lineProtocolStatus | arista.avd.default('Not configured') != 'up' and
       vlan_interface.shutdown
       )
-    fail_msg: "Interface shutdown: {{ vlan_interface.shutdown | replace('\"','') }} -
-      interface status: {{ interfaces_state.stdout[0].interfaceDescriptions[vlan_interface.name].interfaceStatus | arista.avd.default('Not configured') | replace('\"','') }} -
-      line protocol status: {{ interfaces_state.stdout[0].interfaceDescriptions[vlan_interface.name].lineProtocolStatus | arista.avd.default('Not configured') | replace('\"','') }}"
+    fail_msg: "Interface shutdown: {{ vlan_interface.shutdown | replace('\"', '') }} -
+      interface status: {{ interfaces_state.stdout[0].interfaceDescriptions[vlan_interface.name].interfaceStatus | arista.avd.default('Not configured') | replace('\"', '') }} -
+      line protocol status: {{ interfaces_state.stdout[0].interfaceDescriptions[vlan_interface.name].lineProtocolStatus | arista.avd.default('Not configured') | replace('\"', '') }}"
     quiet: true
-  loop: "{{ vlan_interfaces| arista.avd.default({}) | arista.avd.convert_dicts('name') }}"
+  loop: "{{ vlan_interfaces | arista.avd.default({}) | arista.avd.convert_dicts('name') }}"
   loop_control:
     loop_var: vlan_interface
   ignore_errors: "{{ eos_validate_state_validation_mode_loose }}"
@@ -84,12 +84,12 @@
 
 - name: Validate Vxlan interfaces state
   delegate_to: localhost
-  assert:
+  ansible.builtin.assert:
     that:
       - interfaces_state.stdout[0].interfaceDescriptions.Vxlan1.interfaceStatus | arista.avd.default('Not configured') == 'up'
       - interfaces_state.stdout[0].interfaceDescriptions.Vxlan1.lineProtocolStatus | arista.avd.default('Not configured') == 'up'
-    fail_msg: "Interface status: {{ interfaces_state.stdout[0].interfaceDescriptions.Vxlan1.interfaceStatus | arista.avd.default('Not configured') | replace('\"','') }} -
-      line protocol status: {{ interfaces_state.stdout[0].interfaceDescriptions.Vxlan1.lineProtocolStatus | arista.avd.default('Not configured') | replace('\"','') }}"
+    fail_msg: "Interface status: {{ interfaces_state.stdout[0].interfaceDescriptions.Vxlan1.interfaceStatus | arista.avd.default('Not configured') | replace('\"', '') }} -
+      line protocol status: {{ interfaces_state.stdout[0].interfaceDescriptions.Vxlan1.lineProtocolStatus | arista.avd.default('Not configured') | replace('\"', '') }}"
     quiet: true
   ignore_errors: "{{ eos_validate_state_validation_mode_loose }}"
   when: (vxlan_interface.Vxlan1 is arista.avd.defined)
@@ -99,12 +99,12 @@
 
 - name: Validate Loopback interfaces state
   delegate_to: localhost
-  assert:
+  ansible.builtin.assert:
     that:
       - interfaces_state.stdout[0].interfaceDescriptions[loopback_interface.name].interfaceStatus | arista.avd.default('Not configured') == 'up'
       - interfaces_state.stdout[0].interfaceDescriptions[loopback_interface.name].lineProtocolStatus | arista.avd.default('Not configured') == 'up'
-    fail_msg: "Interface status: {{ interfaces_state.stdout[0].interfaceDescriptions[loopback_interface.name].interfaceStatus | arista.avd.default('Not configured') | replace('\"','') }} -
-      line protocol status: {{ interfaces_state.stdout[0].interfaceDescriptions[loopback_interface.name].lineProtocolStatus | arista.avd.default('Not configured') | replace('\"','') }}"
+    fail_msg: "Interface status: {{ interfaces_state.stdout[0].interfaceDescriptions[loopback_interface.name].interfaceStatus | arista.avd.default('Not configured') | replace('\"', '') }} -
+      line protocol status: {{ interfaces_state.stdout[0].interfaceDescriptions[loopback_interface.name].lineProtocolStatus | arista.avd.default('Not configured') | replace('\"', '') }}"
     quiet: true
   loop: "{{ loopback_interfaces | arista.avd.default({}) | arista.avd.convert_dicts('name') }}"
   loop_control:

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/ip_reachability.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/ip_reachability.yml
@@ -3,8 +3,8 @@
 # IP Reachability tests
 
 - name: Gather ip reachability state (directly connected interfaces)
-  eos_command:
-    commands: "ping {{ peer_ip | ansible.utils.ipaddr('address') }} source {{ ethernet_interface.ip_address | ansible.utils.ipaddr('address') }} repeat 1"
+  arista.eos.eos_command:
+    commands: "ping {{ peer_ip | ansible.utils.ipaddr('address') }} source {{ ethernet_interface.ip_address | ansible.utils.ipaddr('address') }} repeat 1"  # noqa: jinja[invalid]
   loop: "{{ ethernet_interfaces | arista.avd.default({}) | arista.avd.convert_dicts('name') }}"
   loop_control:
     loop_var: ethernet_interface
@@ -25,7 +25,7 @@
 
 - name: Validate ip reachability (directly connected interfaces)
   delegate_to: localhost
-  assert:
+  ansible.builtin.assert:
     that:
       - ip_reachability_test.stdout[0] | regex_search('1 received')
     fail_msg: "100% packet loss"

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/lldp_topology_fqdn.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/lldp_topology_fqdn.yml
@@ -3,7 +3,7 @@
 # LLDP Topology Tests
 
 - name: Gather lldp topology
-  eos_command:
+  arista.eos.eos_command:
     commands: "show lldp neighbors detail | json"
   ignore_errors: "{{ eos_validate_state_validation_mode_loose }}"
   register: lldp_topology_state
@@ -12,12 +12,12 @@
 
 - name: Validate lldp topology when there is a domain name
   delegate_to: localhost
-  assert:
+  ansible.builtin.assert:
     that:
       - lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.name].lldpNeighborInfo[0] is defined
       - lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.name].lldpNeighborInfo[0].systemName == ethernet_interface.peer ~ '.' ~ hostvars[ethernet_interface.peer].dns_domain
       - lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.name].lldpNeighborInfo[0].neighborInterfaceInfo.interfaceId == "\"" ~ ethernet_interface.peer_interface ~ "\""
-    fail_msg: "{{ lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.name].lldpNeighborInfo[0].systemName | default('Interface Down') | replace('\"','') }} - {{ lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.name].lldpNeighborInfo[0].neighborInterfaceInfo.interfaceId | default('N/A') | replace('\"','') }}"
+    fail_msg: "{{ lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.name].lldpNeighborInfo[0].systemName | default('Interface Down') | replace('\"', '') }} - {{ lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.name].lldpNeighborInfo[0].neighborInterfaceInfo.interfaceId | default('N/A') | replace('\"', '') }}"
     quiet: true
   loop: "{{ ethernet_interfaces | arista.avd.default({}) | arista.avd.convert_dicts('name') }}"
   loop_control:

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/lldp_topology_no_fqdn.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/lldp_topology_no_fqdn.yml
@@ -3,7 +3,7 @@
 # LLDP Topology Tests
 
 - name: Gather lldp topology
-  eos_command:
+  arista.eos.eos_command:
     commands: "show lldp neighbors detail | json"
   ignore_errors: "{{ eos_validate_state_validation_mode_loose }}"
   register: lldp_topology_state
@@ -12,12 +12,12 @@
 
 - name: Validate lldp topology when there is no domain name
   delegate_to: localhost
-  assert:
+  ansible.builtin.assert:
     that:
       - lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.name].lldpNeighborInfo[0] is defined
       - lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.name].lldpNeighborInfo[0].systemName == ethernet_interface.peer
       - lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.name].lldpNeighborInfo[0].neighborInterfaceInfo.interfaceId == "\"" ~ ethernet_interface.peer_interface ~ "\""
-    fail_msg: "{{ lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.name].lldpNeighborInfo[0].systemName | default('Interface Down') | replace('\"','') }} - {{ lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.name].lldpNeighborInfo[0].neighborInterfaceInfo.interfaceId | default('N/A') | replace('\"','') }}"
+    fail_msg: "{{ lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.name].lldpNeighborInfo[0].systemName | default('Interface Down') | replace('\"', '') }} - {{ lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.name].lldpNeighborInfo[0].neighborInterfaceInfo.interfaceId | default('N/A') | replace('\"', '') }}"
     quiet: true
   loop: "{{ ethernet_interfaces | arista.avd.default({}) | arista.avd.convert_dicts('name') }}"
   loop_control:

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/loopback_reachability.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/loopback_reachability.yml
@@ -1,8 +1,8 @@
 ---
 
 - name: Gather ip reachability state between devices (loopback0 <-> loopback0)
-  eos_command:
-    commands: "ping {{ loopback0_address | ansible.utils.ipaddr('address') }} source {{ source_ip_address | ansible.utils.ipaddr('address') }} repeat 1"
+  arista.eos.eos_command:
+    commands: "ping {{ loopback0_address | ansible.utils.ipaddr('address') }} source {{ source_ip_address | ansible.utils.ipaddr('address') }} repeat 1"  # noqa: jinja[invalid]
   loop: "{{ loopback0_reachability.loopback0_range }}"
   loop_control:
     loop_var: loopback0_address
@@ -20,7 +20,7 @@
 
 - name: Validate ip reachability between devices (loopback0 <-> loopback0)
   delegate_to: localhost
-  assert:
+  ansible.builtin.assert:
     that:
       - loopback0_reachability_test.stdout[0] | regex_search("1 received")
     fail_msg: "100% packet loss"
@@ -34,7 +34,8 @@
   tags:
     - loopback0_reachability
 
-- include_tasks: ping_inband.yml
+- name: Ping inband management interfaces
+  ansible.builtin.include_tasks: ping_inband.yml
   loop: "{{ management_interfaces | arista.avd.default({}) | arista.avd.convert_dicts('name') }}"
   loop_control:
     loop_var: management_interface
@@ -46,7 +47,7 @@
 
 - name: Validate ip reachability from Inband Management to loopback0 in fabric
   delegate_to: localhost
-  assert:
+  ansible.builtin.assert:
     that:
       - inb_mgmt_loopback0_reachability_test.stdout[0] | regex_search('1 received')
     fail_msg: "100% packet loss"

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/main.yml
@@ -45,7 +45,7 @@
 
 - name: Include vars from validate_state_vars.yml
   ansible.builtin.include_vars:
-    ansible.builtin.file: "{{ eos_validate_state_dir }}/validate_state_vars.yml"
+    file: "{{ eos_validate_state_dir }}/validate_state_vars.yml"
   delegate_to: localhost
   run_once: true
   tags:

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: "Collection {{ ansible_collection_name }} version {{ version }}{{ ('(git ' ~ git_tag ~ ')') if git_tag }} loaded from {{ collection_path }}"
   delegate_to: localhost
   tags: [always, avd_version]
-  set_fact:
+  ansible.builtin.set_fact:
     avd_collection_version: version
   vars:
     versions: "{{ lookup('pipe', 'ansible-galaxy collection list -p ' ~ collection_path ~ ' --format yaml ' ~ ansible_collection_name) | from_yaml }}"
@@ -13,7 +13,7 @@
   failed_when: false
 
 - name: Create required output directories if not present
-  file:
+  ansible.builtin.file:
     path: "{{ item }}"
     state: directory
     mode: 0775
@@ -25,7 +25,7 @@
     - always
 
 - name: Include device intended structure configuration variables
-  include_vars: "{{ filename }}"
+  ansible.builtin.include_vars: "{{ filename }}"
   delegate_to: localhost
   when: structured_config is not defined and lookup('first_found', filename, skip=True, errors='ignore')
   vars:
@@ -34,7 +34,7 @@
     - always
 
 - name: Generate variables for testing
-  template:
+  ansible.builtin.template:
     src: generate_vars_for_testing.j2
     dest: "{{ eos_validate_state_dir }}/validate_state_vars.yml"
     mode: 0664
@@ -44,15 +44,15 @@
     - always
 
 - name: Include vars from validate_state_vars.yml
-  include_vars:
-    file: "{{ eos_validate_state_dir }}/validate_state_vars.yml"
+  ansible.builtin.include_vars:
+    ansible.builtin.file: "{{ eos_validate_state_dir }}/validate_state_vars.yml"
   delegate_to: localhost
   run_once: true
   tags:
     - always
 
 - name: Gather EOS platform and version details
-  eos_command:
+  arista.eos.eos_command:
     commands: "show version | json"
   register: eos_version
   tags:
@@ -61,7 +61,7 @@
 
 - name: Display device platform and release information
   delegate_to: localhost
-  debug:
+  ansible.builtin.debug:
     msg: "The device {{ inventory_hostname }} is a {{ eos_version.stdout_lines.0.modelName }} model running EOS version {{ eos_version.stdout_lines.0.version }}"
   tags:
     - platform_information
@@ -72,7 +72,7 @@
   #####################################
 
 - name: Load Hardware validation tasks
-  include_tasks: "hardware.yml"
+  ansible.builtin.include_tasks: "hardware.yml"
   when:
     - eos_version.stdout_lines.0.modelName != 'vEOS'
     - eos_version.stdout_lines.0.modelName != 'vEOS-lab'
@@ -81,65 +81,65 @@
     - hardware
 
 - name: Load ntp tasks
-  include_tasks: "ntp.yml"
+  ansible.builtin.include_tasks: "ntp.yml"
   tags:
     - ntp
 
 - name: Load interface state tasks
-  include_tasks: "interface_state.yml"
+  ansible.builtin.include_tasks: "interface_state.yml"
   tags:
     - interfaces_state
 
 - name: Load LLDP Topology tasks when dns domain is defined
-  include_tasks: "lldp_topology_fqdn.yml"
+  ansible.builtin.include_tasks: "lldp_topology_fqdn.yml"
   tags:
     - lldp_topology
   when: dns_domain is defined
 
 - name: Load LLDP Topology tasks when dns domain is not defined
-  include_tasks: "lldp_topology_no_fqdn.yml"
+  ansible.builtin.include_tasks: "lldp_topology_no_fqdn.yml"
   tags:
     - lldp_topology
   when: dns_domain is not defined
 
 - name: Load mlag tasks
-  include_tasks: "mlag.yml"
+  ansible.builtin.include_tasks: "mlag.yml"
   when: |
     (mlag_configuration is defined and mlag_configuration is not none)
   tags:
     - mlag
 
 - name: Load IP Reachability tasks
-  include_tasks: "ip_reachability.yml"
+  ansible.builtin.include_tasks: "ip_reachability.yml"
   tags:
     - ip_reachability
 
 - name: Load BGP tasks
-  include_tasks: "bgp_check.yml"
+  ansible.builtin.include_tasks: "bgp_check.yml"
   when: |
     (router_bgp is defined and router_bgp is not none)
   tags:
     - bgp_check
 
 - name: Validate reload cause
-  include_tasks: "reload_cause.yml"
+  ansible.builtin.include_tasks: "reload_cause.yml"
   tags:
     - reload_cause
     - optional
     - never
 
 - name: Validate routing table
-  include_tasks: "routing_table.yml"
+  ansible.builtin.include_tasks: "routing_table.yml"
   tags:
     - routing_table
 
 - name: Validate loopback reachability
-  include_tasks: "loopback_reachability.yml"
+  ansible.builtin.include_tasks: "loopback_reachability.yml"
   tags:
     - loopback_reachability
 
 - name: Remove generated vars for testing
-  file:
+  ansible.builtin.file:
     path: "{{ eos_validate_state_dir }}/validate_state_vars.yml"
     state: absent
   delegate_to: localhost
@@ -152,7 +152,7 @@
   ####################################
 
 - name: Create reports
-  include_tasks: "reports.yml"
+  ansible.builtin.include_tasks: "reports.yml"
   tags:
     - always
     - reports

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/mlag.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/mlag.yml
@@ -3,7 +3,7 @@
 # MLAG State Tests
 
 - name: Gather mlag status
-  eos_command:
+  arista.eos.eos_command:
     commands: "show mlag detail | json"
   register: mlag_state
   tags:
@@ -11,11 +11,11 @@
 
 - name: Validate mlag status
   delegate_to: localhost
-  assert:
+  ansible.builtin.assert:
     that:
       - mlag_state.stdout[0].state | arista.avd.default('Not configured') == 'active'
       - mlag_state.stdout[0].negStatus | arista.avd.default('Not configured') == 'connected'
-    fail_msg: "State: {{ mlag_state.stdout[0].state | arista.avd.default('Not configured') | replace('\"','')  }} - Negotiation_status: {{ mlag_state.stdout[0].negStatus | arista.avd.default('Not configured') | replace('\"','')  }}"
+    fail_msg: "State: {{ mlag_state.stdout[0].state | arista.avd.default('Not configured') | replace('\"', '') }} - Negotiation_status: {{ mlag_state.stdout[0].negStatus | arista.avd.default('Not configured') | replace('\"', '') }}"
     quiet: true
   ignore_errors: "{{ eos_validate_state_validation_mode_loose }}"
   register: mlag_state_results

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/ntp.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/ntp.yml
@@ -3,7 +3,7 @@
 # NTP Status Tests
 
 - name: Gather ntp status
-  eos_command:
+  arista.eos.eos_command:
     commands: "show ntp status"
   register: ntp_status
   tags:
@@ -11,7 +11,7 @@
 
 - name: Validate ntp status
   delegate_to: localhost
-  assert:
+  ansible.builtin.assert:
     that:
       - ntp_status.stdout[0] | regex_search('synchronised to NTP server')
     fail_msg: "Not synchronised to NTP server"

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/ping_inband.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/ping_inband.yml
@@ -1,8 +1,8 @@
 ---
 
 - name: Gather fabric reachability from Management Interface {{ management_interface.name }}
-  eos_command:
-    commands: "ping {{ loopback0_address | ansible.utils.ipaddr('address') }} repeat 1 interface {{ management_interface.name }}"
+  arista.eos.eos_command:
+    commands: "ping {{ loopback0_address | ansible.utils.ipaddr('address') }} repeat 1 interface {{ management_interface.name }}"  # noqa: jinja[invalid]
   loop: "{{ loopback0_reachability.loopback0_range }}"
   loop_control:
     loop_var: loopback0_address

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/reload_cause.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/reload_cause.yml
@@ -2,8 +2,8 @@
 
 # Reload Cause - Optional
 
-- name: gather reload cause information
-  eos_command:
+- name: Gather reload cause information
+  arista.eos.eos_command:
     commands: "show reload cause"
   register: reload_cause
   tags:
@@ -11,11 +11,11 @@
     - optional
     - never
 
-- name: validate reload cause
+- name: Validate reload cause
   delegate_to: localhost
-  assert:
+  ansible.builtin.assert:
     that: reload_cause.stdout_lines[0][2] == 'Reload requested by the user.'
-    fail_msg: "{{ reload_cause.stdout_lines[0][2] | replace('\"','') }}"
+    fail_msg: "{{ reload_cause.stdout_lines[0][2] | replace('\"', '') }}"
     quiet: true
   ignore_errors: "{{ eos_validate_state_validation_mode_loose }}"
   register: reload_cause_results

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/reports.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/reports.yml
@@ -13,7 +13,7 @@
     - report
 
 - name: Create Validation report - CSV
-  template:
+  ansible.builtin.template:
     src: validate_state_report-csv.j2
     dest: "{{ eos_validate_state_csv_report_path }}"
     mode: 0664
@@ -25,7 +25,7 @@
     - report
 
 - name: Create Validation report - Markdown
-  template:
+  ansible.builtin.template:
     src: validate_state_report-md.j2
     dest: "{{ eos_validate_state_md_report_path }}"
     mode: 0664

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/reports.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/reports.yml
@@ -3,7 +3,7 @@
 # Validation reports
 
 - name: Generate Results (Set eos_validate_state_report)
-  yaml_templates_to_facts:
+  arista.avd.yaml_templates_to_facts:
     templates:
       - template: generate_state_report_results.j2
   delegate_to: localhost

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/routing_table.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/routing_table.yml
@@ -1,7 +1,7 @@
 ---
 
-- name: run show ip route VTEP IP
-  eos_command:
+- name: Run show ip route VTEP IP
+  arista.eos.eos_command:
     commands: "show ip route {{ vtep_ip }}"
   loop: "{{ vtep_reachability.vtep_ip_reachability }}"
   loop_control:
@@ -16,10 +16,10 @@
 
 - name: Validate VTEP IP is in routing table
   delegate_to: localhost
-  assert:
+  ansible.builtin.assert:
     that:
       - vtep_reachability_test['stdout'][0] | regex_search(vtep_reachability_test.vtep_ip)
-    fail_msg: "VTEP {{ vtep_reachability_test.vtep_ip | replace('\"','') }} is not in the routing table"
+    fail_msg: "VTEP {{ vtep_reachability_test.vtep_ip | replace('\"', '') }} is not in the routing table"
     quiet: true
   loop: "{{ routing_table_vtep_state.results }}"
   loop_control:
@@ -30,8 +30,8 @@
   tags:
     - routing_table
 
-- name: run show ip route lo0
-  eos_command:
+- name: Run show ip route lo0
+  arista.eos.eos_command:
     commands: "show ip route {{ loopback0_address }}"
   loop: "{{ loopback0_reachability.loopback0_range }}"
   loop_control:
@@ -47,10 +47,10 @@
 
 - name: Validate lo0 is in routing table
   delegate_to: localhost
-  assert:
+  ansible.builtin.assert:
     that:
       - routing_table_loopback0_test['stdout'][0] | regex_search(routing_table_loopback0_test.loopback0_address)
-    fail_msg: "Lo0 {{ routing_table_loopback0_test.loopback0_address | replace('\"','') }} is not in the routing table"
+    fail_msg: "Lo0 {{ routing_table_loopback0_test.loopback0_address | replace('\"', '') }} is not in the routing table"
     quiet: true
   loop: "{{ routing_table_loopback0_state.results }}"
   loop_control:

--- a/ansible_collections/arista/avd/roles/eos_validate_state/templates/generate_state_report_results.j2
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/templates/generate_state_report_results.j2
@@ -73,7 +73,7 @@ eos_validate_state_report:
   result: "PASS"
 {%         else %}
   result: "FAIL"
-  failure_reason: "{{ copy_hostvars[node].environment_temperature_results.msg | replace('\"','') }}"
+  failure_reason: "{{ copy_hostvars[node].environment_temperature_results.msg | replace('\"', '') }}"
 {%         endif %}
 {%     endif %}
 {% endfor %}
@@ -195,7 +195,7 @@ eos_validate_state_report:
   result: "PASS"
 {%         else %}
   result: "FAIL"
-  failure_reason: "{{ copy_hostvars[node].vxlan_interface_state_results.msg | replace('\"','') }}"
+  failure_reason: "{{ copy_hostvars[node].vxlan_interface_state_results.msg | replace('\"', '') }}"
 {%         endif %}
 {%     endif %}
 {% endfor %}
@@ -252,7 +252,7 @@ eos_validate_state_report:
   result: "PASS"
 {%         else %}
   result: "FAIL"
-  failure_reason: "{{ copy_hostvars[node].mlag_state_results.msg | replace('\"','') }}"
+  failure_reason: "{{ copy_hostvars[node].mlag_state_results.msg | replace('\"', '') }}"
 {%         endif %}
 {%     endif %}
 {% endfor %}
@@ -290,7 +290,7 @@ eos_validate_state_report:
   result: "PASS"
 {%         else %}
   result: "FAIL"
-  failure_reason: "{{ copy_hostvars[node].arbgp_state_results.msg | replace('\"','') }}"
+  failure_reason: "{{ copy_hostvars[node].arbgp_state_results.msg | replace('\"', '') }}"
 {%         endif %}
 {%     endif %}
 {% endfor %}
@@ -349,7 +349,7 @@ eos_validate_state_report:
   result: "PASS"
 {%         else %}
   result: "FAIL"
-  failure_reason: "Reload Cause: {{ copy_hostvars[node].reload_cause_results.msg | replace('\"','') }}"
+  failure_reason: "Reload Cause: {{ copy_hostvars[node].reload_cause_results.msg | replace('\"', '') }}"
 {%         endif %}
 {%     endif %}
 {% endfor %}

--- a/ansible_collections/arista/avd/tests/integration/targets/configlet_build_config/tasks/main.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/configlet_build_config/tasks/main.yml
@@ -1,2 +1,3 @@
 ---
-- include: test.yml
+- name: Include test.yml
+  ansible.builtin.include_tasks: test.yml

--- a/ansible_collections/arista/avd/tests/integration/targets/configlet_build_config/tasks/test.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/configlet_build_config/tasks/test.yml
@@ -1,15 +1,16 @@
-- name: collect all test cases
-  find:
+- name: Collect all test cases
+  ansible.builtin.find:
     paths: '{{ role_path }}/tests/'
     patterns: '{{ testcase }}.yml'
   register: test_cases
   delegate_to: localhost
 
-- name: set test_items
-  set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
+- name: Set test_items
+  ansible.builtin.set_fact:
+    test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases
-  include: '{{ test_case_to_run }}'
+- name: Run test cases
+  ansible.builtin.include_tasks: '{{ test_case_to_run }}'
   with_items: '{{ test_items }}'
   loop_control:
     loop_var: test_case_to_run

--- a/ansible_collections/arista/avd/tests/integration/targets/configlet_build_config/tests/test_blank_prefix.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/configlet_build_config/tests/test_blank_prefix.yml
@@ -17,8 +17,8 @@
     that:
       - result is success
       - result.changed == false
-      - result.cvp_configlets != {}
+      - result.CVP_CONFIGLETS != {}
       - item is defined
       - "'_' in item[0]"
       - diff_output.stdout == ""
-  with_items: "{{ result.cvp_configlets }}"
+  with_items: "{{ result.CVP_CONFIGLETS }}"

--- a/ansible_collections/arista/avd/tests/integration/targets/configlet_build_config/tests/test_blank_prefix.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/configlet_build_config/tests/test_blank_prefix.yml
@@ -6,9 +6,11 @@
     destination: "{{ actual_output }}"
   register: result
 
-- local_action: shell diff "{{ expected_output }}/expected_with_blank_prefix.yml" "{{ actual_output }}"
+- name: Compare actual output with expected output
+  ansible.builtin.shell: diff "{{ expected_output }}/expected_with_blank_prefix.yml" "{{ actual_output }}"
   failed_when: "diff_output.rc > 1"
   register: diff_output
+  delegate_to: localhost
 
 - name: Validate output
   ansible.builtin.assert:

--- a/ansible_collections/arista/avd/tests/integration/targets/configlet_build_config/tests/test_blank_prefix.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/configlet_build_config/tests/test_blank_prefix.yml
@@ -11,7 +11,7 @@
   register: diff_output
 
 - name: Validate output
-  assert:
+  ansible.builtin.assert:
     that:
       - result is success
       - result.changed == false

--- a/ansible_collections/arista/avd/tests/integration/targets/configlet_build_config/tests/test_with_all_parameters.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/configlet_build_config/tests/test_with_all_parameters.yml
@@ -6,9 +6,11 @@
     destination: "{{ actual_output }}"
   register: result
 
-- local_action: shell diff "{{ expected_output }}/expected_with_all_parameters.yml" "{{ actual_output }}"
+- name: Compare actual output with expected output
+  ansible.builtin.shell: diff "{{ expected_output }}/expected_with_all_parameters.yml" "{{ actual_output }}"
   failed_when: "diff_output.rc > 1"
   register: diff_output
+  delegate_to: localhost
 
 - name: Validate output
   ansible.builtin.assert:

--- a/ansible_collections/arista/avd/tests/integration/targets/configlet_build_config/tests/test_with_all_parameters.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/configlet_build_config/tests/test_with_all_parameters.yml
@@ -11,7 +11,7 @@
   register: diff_output
 
 - name: Validate output
-  assert:
+  ansible.builtin.assert:
     that:
       - result is success
       - result.changed == false

--- a/ansible_collections/arista/avd/tests/integration/targets/configlet_build_config/tests/test_with_all_parameters.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/configlet_build_config/tests/test_with_all_parameters.yml
@@ -17,8 +17,8 @@
     that:
       - result is success
       - result.changed == false
-      - result.cvp_configlets != {}
+      - result.CVP_CONFIGLETS != {}
       - diff_output.stdout == ""
       - item is defined
       - "'Prefix' in item[0:6]"
-  with_items: "{{ result.cvp_configlets }}"
+  with_items: "{{ result.CVP_CONFIGLETS }}"

--- a/ansible_collections/arista/avd/tests/integration/targets/configlet_build_config/tests/test_without_configlet_dir.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/configlet_build_config/tests/test_without_configlet_dir.yml
@@ -7,7 +7,7 @@
   register: result
 
 - name: Validate output
-  assert:
+  ansible.builtin.assert:
     that:
       - result is failed
       - result.changed == false

--- a/ansible_collections/arista/avd/tests/integration/targets/configlet_build_config/tests/test_without_extension.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/configlet_build_config/tests/test_without_extension.yml
@@ -10,7 +10,7 @@
   register: diff_output
 
 - name: Validate output
-  assert:
+  ansible.builtin.assert:
     that:
       - result is success
       - result.changed == false

--- a/ansible_collections/arista/avd/tests/integration/targets/configlet_build_config/tests/test_without_extension.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/configlet_build_config/tests/test_without_extension.yml
@@ -16,8 +16,8 @@
     that:
       - result is success
       - result.changed == false
-      - result.cvp_configlets != {}
+      - result.CVP_CONFIGLETS != {}
       - item is defined
       - "'Prefix' in item[0:6]"
       - diff_output.stdout == ""
-  with_items: "{{ result.cvp_configlets }}"
+  with_items: "{{ result.CVP_CONFIGLETS }}"

--- a/ansible_collections/arista/avd/tests/integration/targets/configlet_build_config/tests/test_without_extension.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/configlet_build_config/tests/test_without_extension.yml
@@ -5,9 +5,11 @@
     destination: "{{ actual_output }}"
   register: result
 
-- local_action: shell diff "{{ expected_output }}/expected_without_extension.yml" "{{ actual_output }}"
+- name: Compare actual output with expected output
+  ansible.builtin.shell: diff "{{ expected_output }}/expected_without_extension.yml" "{{ actual_output }}"
   failed_when: "diff_output.rc > 1"
   register: diff_output
+  delegate_to: localhost
 
 - name: Validate output
   ansible.builtin.assert:

--- a/ansible_collections/arista/avd/tests/integration/targets/configlet_build_config/tests/test_without_prefix.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/configlet_build_config/tests/test_without_prefix.yml
@@ -7,7 +7,7 @@
   register: result
 
 - name: Validate output
-  assert:
+  ansible.builtin.assert:
     that:
       - result is failed
       - result.changed == false

--- a/ansible_collections/arista/avd/tests/integration/targets/configlet_build_config/tests/test_without_prefix_configlet_dir.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/configlet_build_config/tests/test_without_prefix_configlet_dir.yml
@@ -6,7 +6,7 @@
   register: result
 
 - name: Validate output
-  assert:
+  ansible.builtin.assert:
     that:
       - result is failed
       - result.changed == false

--- a/ansible_collections/arista/avd/tests/integration/targets/filter_password/tasks/main.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/filter_password/tasks/main.yml
@@ -4,6 +4,6 @@
     that:
       - "{{ clear_password | arista.avd.encrypt(passwd_type='bgp', key=neighbor_ip) == neighbor_encrypted_password }}"
       - "{{ clear_password | arista.avd.encrypt(passwd_type='bgp', key=peer_group) == peer_group_encrypted_password }}"
-      - "{{ non_string_clear_password | arista.avd.encrypt(passwd_type='bgp', key=peer_group) == expected_non_string_pg_encrypted_password}}"
+      - "{{ non_string_clear_password | arista.avd.encrypt(passwd_type='bgp', key=peer_group) == expected_non_string_pg_encrypted_password }}"
       - "{{ neighbor_encrypted_password | arista.avd.decrypt(passwd_type='bgp', key=neighbor_ip) == clear_password }}"
-      - "{{ peer_group_encrypted_password | arista.avd.decrypt(passwd_type='bgp', key=peer_group) == clear_password}}"
+      - "{{ peer_group_encrypted_password | arista.avd.decrypt(passwd_type='bgp', key=peer_group) == clear_password }}"

--- a/ansible_collections/arista/avd/tests/integration/targets/filter_password/tasks/main.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/filter_password/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Test Encrypt & Decrypt for BGP passwords
-  assert:
+  ansible.builtin.assert:
     that:
       - "{{ clear_password | arista.avd.encrypt(passwd_type='bgp', key=neighbor_ip) == neighbor_encrypted_password }}"
       - "{{ clear_password | arista.avd.encrypt(passwd_type='bgp', key=peer_group) == peer_group_encrypted_password }}"

--- a/ansible_collections/arista/avd/tests/integration/targets/inventory_to_container/tasks/main.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/inventory_to_container/tasks/main.yml
@@ -1,2 +1,3 @@
 ---
-- include: test.yml
+- name: Include test.yml
+  ansible.builtin.include_tasks: test.yml

--- a/ansible_collections/arista/avd/tests/integration/targets/inventory_to_container/tasks/test.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/inventory_to_container/tasks/test.yml
@@ -1,15 +1,16 @@
-- name: collect all test cases
-  find:
+- name: Collect all test cases
+  ansible.builtin.find:
     paths: '{{ role_path }}/tests/'
     patterns: '{{ testcase }}.yml'
   register: test_cases
   delegate_to: localhost
 
-- name: set test_items
-  set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
+- name: Set test_items
+  ansible.builtin.set_fact:
+    test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases
-  include: '{{ test_case_to_run }}'
+- name: Run test cases
+  ansible.builtin.include_tasks: '{{ test_case_to_run }}'
   with_items: '{{ test_items }}'
   loop_control:
     loop_var: test_case_to_run

--- a/ansible_collections/arista/avd/tests/integration/targets/inventory_to_container/tests/test_with_all_parameters.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/inventory_to_container/tests/test_with_all_parameters.yml
@@ -9,9 +9,10 @@
     destination: "{{ actual_output }}"
 
 - name: Compare actual output with expected output
-  ansible.builtin.local_action: shell diff "{{ expected_output }}/expected_with_all_param.yml" "{{ actual_output }}"
+  ansible.builtin.shell: diff "{{ expected_output }}/expected_with_all_param.yml" "{{ actual_output }}"
   failed_when: "diff_output.rc > 1"
   register: diff_output
+  delegate_to: localhost
 
 - name: Validate output
   ansible.builtin.assert:

--- a/ansible_collections/arista/avd/tests/integration/targets/inventory_to_container/tests/test_with_all_parameters.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/inventory_to_container/tests/test_with_all_parameters.yml
@@ -1,6 +1,6 @@
 - name: Test with all parameters
   register: cvp_vars
-  inventory_to_container:
+  arista.avd.inventory_to_container:
     inventory: '{{ inventory_path }}/inventory.yml'
     container_root: 'DC1_FABRIC'
     configlet_dir: '{{ configlet_path }}'
@@ -8,12 +8,13 @@
     device_filter: ['DC1-LE']
     destination: "{{ actual_output }}"
 
-- local_action: shell diff "{{ expected_output }}/expected_with_all_param.yml" "{{ actual_output }}"
+- name: Compare actual output with expected output
+  ansible.builtin.local_action: shell diff "{{ expected_output }}/expected_with_all_param.yml" "{{ actual_output }}"
   failed_when: "diff_output.rc > 1"
   register: diff_output
 
 - name: Validate output
-  assert:
+  ansible.builtin.assert:
     that:
       - cvp_vars is success
       - cvp_vars.cvp_topology != {}
@@ -24,7 +25,7 @@
   with_items: "{{ cvp_vars.cvp_configlets }}"
 
 - name: Validate cvp_topology
-  assert:
+  ansible.builtin.assert:
     that:
       - item is defined
       - item == "Tenant"

--- a/ansible_collections/arista/avd/tests/integration/targets/inventory_to_container/tests/test_with_all_parameters.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/inventory_to_container/tests/test_with_all_parameters.yml
@@ -1,5 +1,5 @@
 - name: Test with all parameters
-  register: cvp_vars
+  register: CVP_VARS
   arista.avd.inventory_to_container:
     inventory: '{{ inventory_path }}/inventory.yml'
     container_root: 'DC1_FABRIC'
@@ -17,17 +17,17 @@
 - name: Validate output
   ansible.builtin.assert:
     that:
-      - cvp_vars is success
-      - cvp_vars.cvp_topology != {}
-      - cvp_vars.cvp_configlets != {}
+      - CVP_VARS is success
+      - CVP_VARS.CVP_TOPOLOGY != {}
+      - CVP_VARS.CVP_CONFIGLETS != {}
       - item is defined
       - "'AVD_DC1-LE' in item[0:10]"
       - diff_output.stdout == ""
-  with_items: "{{ cvp_vars.cvp_configlets }}"
+  with_items: "{{ CVP_VARS.CVP_CONFIGLETS }}"
 
-- name: Validate cvp_topology
+- name: Validate CVP_TOPOLOGY
   ansible.builtin.assert:
     that:
       - item is defined
       - item == "Tenant"
-  with_items: "{{ cvp_vars.cvp_topology.DC1_FABRIC.parent_container }}"
+  with_items: "{{ CVP_VARS.CVP_TOPOLOGY.DC1_FABRIC.parent_container }}"

--- a/ansible_collections/arista/avd/tests/integration/targets/inventory_to_container/tests/test_without_configlet_dir.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/inventory_to_container/tests/test_without_configlet_dir.yml
@@ -1,18 +1,19 @@
 - name: Test without configlet_dir
   register: cvp_vars
-  inventory_to_container:
-    inventory: '{{ inventory_path }}/inventory.yml'
-    container_root: 'DC1_FABRIC'
-    configlet_prefix: 'AVD'
-    device_filter: ['DC1-LE']
-    destination: "{{ actual_output }}"
+  arista.avd.inventory_to_container:
+        inventory: '{{ inventory_path }}/inventory.yml'
+        container_root: 'DC1_FABRIC'
+        configlet_prefix: 'AVD'
+        device_filter: ['DC1-LE']
+        destination: "{{ actual_output }}"
 
-- local_action: shell diff "{{ expected_output }}/expected_without_configlet_dir.yml" "{{ actual_output }}"
+- name: Compare actual output with expected output
+  ansible.builtin.local_action: shell diff "{{ expected_output }}/expected_without_configlet_dir.yml" "{{ actual_output }}"
   failed_when: "diff_output.rc > 1"
   register: diff_output
 
 - name: Validate output
-  assert:
+  ansible.builtin.assert:
     that:
       - cvp_vars is success
       - cvp_vars.cvp_topology != {}

--- a/ansible_collections/arista/avd/tests/integration/targets/inventory_to_container/tests/test_without_configlet_dir.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/inventory_to_container/tests/test_without_configlet_dir.yml
@@ -8,9 +8,10 @@
     destination: "{{ actual_output }}"
 
 - name: Compare actual output with expected output
-  ansible.builtin.local_action: shell diff "{{ expected_output }}/expected_without_configlet_dir.yml" "{{ actual_output }}"
+  ansible.builtin.shell: diff "{{ expected_output }}/expected_without_configlet_dir.yml" "{{ actual_output }}"
   failed_when: "diff_output.rc > 1"
   register: diff_output
+  delegate_to: localhost
 
 - name: Validate output
   ansible.builtin.assert:

--- a/ansible_collections/arista/avd/tests/integration/targets/inventory_to_container/tests/test_without_configlet_dir.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/inventory_to_container/tests/test_without_configlet_dir.yml
@@ -1,11 +1,11 @@
 - name: Test without configlet_dir
   register: cvp_vars
   arista.avd.inventory_to_container:
-        inventory: '{{ inventory_path }}/inventory.yml'
-        container_root: 'DC1_FABRIC'
-        configlet_prefix: 'AVD'
-        device_filter: ['DC1-LE']
-        destination: "{{ actual_output }}"
+    inventory: '{{ inventory_path }}/inventory.yml'
+    container_root: 'DC1_FABRIC'
+    configlet_prefix: 'AVD'
+    device_filter: ['DC1-LE']
+    destination: "{{ actual_output }}"
 
 - name: Compare actual output with expected output
   ansible.builtin.local_action: shell diff "{{ expected_output }}/expected_without_configlet_dir.yml" "{{ actual_output }}"

--- a/ansible_collections/arista/avd/tests/integration/targets/inventory_to_container/tests/test_without_configlet_dir.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/inventory_to_container/tests/test_without_configlet_dir.yml
@@ -1,5 +1,5 @@
 - name: Test without configlet_dir
-  register: cvp_vars
+  register: CVP_VARS
   arista.avd.inventory_to_container:
     inventory: '{{ inventory_path }}/inventory.yml'
     container_root: 'DC1_FABRIC'
@@ -16,9 +16,9 @@
 - name: Validate output
   ansible.builtin.assert:
     that:
-      - cvp_vars is success
-      - cvp_vars.cvp_topology != {}
+      - CVP_VARS is success
+      - CVP_VARS.CVP_TOPOLOGY != {}
       - diff_output.stdout == ""
       - item is defined
       - item == "Tenant"
-  with_items: "{{ cvp_vars.cvp_topology.DC1_FABRIC.parent_container }}"
+  with_items: "{{ CVP_VARS.CVP_TOPOLOGY.DC1_FABRIC.parent_container }}"

--- a/ansible_collections/arista/avd/tests/integration/targets/inventory_to_container/tests/test_without_configlet_prefix.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/inventory_to_container/tests/test_without_configlet_prefix.yml
@@ -1,5 +1,5 @@
 - name: Test without configlet prefix
-  register: cvp_vars
+  register: CVP_VARS
   arista.avd.inventory_to_container:
     inventory: '{{ inventory_path }}/inventory.yml'
     container_root: 'DC1_FABRIC'
@@ -16,17 +16,17 @@
 - name: Validate output
   ansible.builtin.assert:
     that:
-      - cvp_vars is success
-      - cvp_vars.cvp_topology != {}
-      - cvp_vars.cvp_configlets != {}
+      - CVP_VARS is success
+      - CVP_VARS.CVP_TOPOLOGY != {}
+      - CVP_VARS.CVP_CONFIGLETS != {}
       - item is defined
       - diff_output.stdout == ""
       - "'AVD_DC1-LE' in item[0:10]"
-  with_items: "{{ cvp_vars.cvp_configlets }}"
+  with_items: "{{ CVP_VARS.CVP_CONFIGLETS }}"
 
-- name: Validate cvp_topology
+- name: Validate CVP_TOPOLOGY
   ansible.builtin.assert:
     that:
       - item is defined
       - item == "Tenant"
-  with_items: "{{ cvp_vars.cvp_topology.DC1_FABRIC.parent_container }}"
+  with_items: "{{ CVP_VARS.CVP_TOPOLOGY.DC1_FABRIC.parent_container }}"

--- a/ansible_collections/arista/avd/tests/integration/targets/inventory_to_container/tests/test_without_configlet_prefix.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/inventory_to_container/tests/test_without_configlet_prefix.yml
@@ -1,18 +1,19 @@
 - name: Test without configlet prefix
   register: cvp_vars
-  inventory_to_container:
+  arista.avd.inventory_to_container:
     inventory: '{{ inventory_path }}/inventory.yml'
     container_root: 'DC1_FABRIC'
     configlet_dir: '{{ configlet_path }}'
     device_filter: ['DC1-LE']
     destination: "{{ actual_output }}"
 
-- local_action: shell diff "{{ expected_output }}/expected_with_all_param.yml" "{{ actual_output }}"
+- name: Compare actual output with expected output
+  ansible.builtin.local_action: shell diff "{{ expected_output }}/expected_with_all_param.yml" "{{ actual_output }}"
   failed_when: "diff_output.rc > 1"
   register: diff_output
 
 - name: Validate output
-  assert:
+  ansible.builtin.assert:
     that:
       - cvp_vars is success
       - cvp_vars.cvp_topology != {}
@@ -23,7 +24,7 @@
   with_items: "{{ cvp_vars.cvp_configlets }}"
 
 - name: Validate cvp_topology
-  assert:
+  ansible.builtin.assert:
     that:
       - item is defined
       - item == "Tenant"

--- a/ansible_collections/arista/avd/tests/integration/targets/inventory_to_container/tests/test_without_configlet_prefix.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/inventory_to_container/tests/test_without_configlet_prefix.yml
@@ -8,9 +8,10 @@
     destination: "{{ actual_output }}"
 
 - name: Compare actual output with expected output
-  ansible.builtin.local_action: shell diff "{{ expected_output }}/expected_with_all_param.yml" "{{ actual_output }}"
+  ansible.builtin.shell: diff "{{ expected_output }}/expected_with_all_param.yml" "{{ actual_output }}"
   failed_when: "diff_output.rc > 1"
   register: diff_output
+  delegate_to: localhost
 
 - name: Validate output
   ansible.builtin.assert:

--- a/ansible_collections/arista/avd/tests/integration/targets/inventory_to_container/tests/test_without_container_root.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/inventory_to_container/tests/test_without_container_root.yml
@@ -1,7 +1,7 @@
 - name: Test without container_root
   register: cvp_vars
   ignore_errors: yes
-  inventory_to_container:
+  arista.avd.inventory_to_container:
     inventory: '{{ inventory_path }}/inventory.yml'
     configlet_dir: '{{ configlet_path }}'
     configlet_prefix: 'AVD'

--- a/ansible_collections/arista/avd/tests/integration/targets/inventory_to_container/tests/test_without_container_root.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/inventory_to_container/tests/test_without_container_root.yml
@@ -1,5 +1,5 @@
 - name: Test without container_root
-  register: cvp_vars
+  register: CVP_VARS
   ignore_errors: yes
   arista.avd.inventory_to_container:
     inventory: '{{ inventory_path }}/inventory.yml'
@@ -11,6 +11,6 @@
 - name: Validate output
   ansible.builtin.assert:
     that:
-      - cvp_vars is failed
-      - "'missing required arguments:' in cvp_vars.msg"
-      - cvp_vars.changed == false
+      - CVP_VARS is failed
+      - "'missing required arguments:' in CVP_VARS.msg"
+      - CVP_VARS.changed == false

--- a/ansible_collections/arista/avd/tests/integration/targets/inventory_to_container/tests/test_without_container_root.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/inventory_to_container/tests/test_without_container_root.yml
@@ -9,7 +9,7 @@
     destination: "{{ actual_output }}"
 
 - name: Validate output
-  assert:
+  ansible.builtin.assert:
     that:
       - cvp_vars is failed
       - "'missing required arguments:' in cvp_vars.msg"

--- a/ansible_collections/arista/avd/tests/integration/targets/inventory_to_container/tests/test_without_device_filter.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/inventory_to_container/tests/test_without_device_filter.yml
@@ -8,9 +8,10 @@
     destination: "{{ actual_output }}"
 
 - name: Compare actual output with expected output
-  ansible.builtin.local_action: shell diff "{{ expected_output }}/expected_without_device_filter.yml" "{{ actual_output }}"
+  ansible.builtin.shell: diff "{{ expected_output }}/expected_without_device_filter.yml" "{{ actual_output }}"
   failed_when: "diff_output.rc > 1"
   register: diff_output
+  delegate_to: localhost
 
 - name: Validate output
   ansible.builtin.assert:

--- a/ansible_collections/arista/avd/tests/integration/targets/inventory_to_container/tests/test_without_device_filter.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/inventory_to_container/tests/test_without_device_filter.yml
@@ -1,18 +1,19 @@
 - name: Test without device filter
   register: cvp_vars
-  inventory_to_container:
+  arista.avd.inventory_to_container:
     inventory: '{{ inventory_path }}/inventory.yml'
     container_root: 'DC1_FABRIC'
     configlet_dir: '{{ configlet_path }}'
     configlet_prefix: 'AVD'
     destination: "{{ actual_output }}"
 
-- local_action: shell diff "{{ expected_output }}/expected_without_device_filter.yml" "{{ actual_output }}"
+- name: Compare actual output with expected output
+  ansible.builtin.local_action: shell diff "{{ expected_output }}/expected_without_device_filter.yml" "{{ actual_output }}"
   failed_when: "diff_output.rc > 1"
   register: diff_output
 
 - name: Validate output
-  assert:
+  ansible.builtin.assert:
     that:
       - cvp_vars is success
       - cvp_vars.cvp_topology != {}
@@ -23,7 +24,7 @@
   with_items: "{{ cvp_vars.cvp_configlets }}"
 
 - name: Validate cvp_topology
-  assert:
+  ansible.builtin.assert:
     that:
       - item is defined
       - item == "Tenant"

--- a/ansible_collections/arista/avd/tests/integration/targets/inventory_to_container/tests/test_without_device_filter.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/inventory_to_container/tests/test_without_device_filter.yml
@@ -1,5 +1,5 @@
 - name: Test without device filter
-  register: cvp_vars
+  register: CVP_VARS
   arista.avd.inventory_to_container:
     inventory: '{{ inventory_path }}/inventory.yml'
     container_root: 'DC1_FABRIC'
@@ -16,17 +16,17 @@
 - name: Validate output
   ansible.builtin.assert:
     that:
-      - cvp_vars is success
-      - cvp_vars.cvp_topology != {}
-      - cvp_vars.cvp_configlets != {}
+      - CVP_VARS is success
+      - CVP_VARS.CVP_TOPOLOGY != {}
+      - CVP_VARS.CVP_CONFIGLETS != {}
       - item is defined
       - "'AVD' in item[0:3]"
       - diff_output.stdout == ""
-  with_items: "{{ cvp_vars.cvp_configlets }}"
+  with_items: "{{ CVP_VARS.CVP_CONFIGLETS }}"
 
-- name: Validate cvp_topology
+- name: Validate CVP_TOPOLOGY
   ansible.builtin.assert:
     that:
       - item is defined
       - item == "Tenant"
-  with_items: "{{ cvp_vars.cvp_topology.DC1_FABRIC.parent_container }}"
+  with_items: "{{ CVP_VARS.CVP_TOPOLOGY.DC1_FABRIC.parent_container }}"

--- a/ansible_collections/arista/avd/tests/integration/targets/inventory_to_container/tests/test_without_inventory.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/inventory_to_container/tests/test_without_inventory.yml
@@ -59,19 +59,21 @@
 
 - name: Test without inventory file
   register: cvp_vars
-  inventory_to_container:
+  ignore_errors: yes
+  arista.avd.inventory_to_container:
     container_root: 'DC1_FABRIC'
     configlet_dir: '{{ configlet_path }}'
     configlet_prefix: 'AVD'
     device_filter: ['DC1-LE']
     destination: "{{ actual_output }}"
 
-- local_action: shell diff "{{ expected_output }}/expected_without_inventory.yml" "{{ actual_output }}"
+- name: Compare actual output with expected output
+  ansible.builtin.local_action: shell diff "{{ expected_output }}/expected_without_inventory.yml" "{{ actual_output }}"
   failed_when: "diff_output.rc > 1"
   register: diff_output
 
 - name: Validate output
-  assert:
+  ansible.builtin.assert:
     that:
       - cvp_vars is success
       - cvp_vars.cvp_topology != {}
@@ -82,7 +84,7 @@
   with_items: "{{ cvp_vars.cvp_configlets }}"
 
 - name: Validate cvp_topology
-  assert:
+  ansible.builtin.assert:
     that:
       - item is defined
       - item == "Tenant"

--- a/ansible_collections/arista/avd/tests/integration/targets/inventory_to_container/tests/test_without_inventory.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/inventory_to_container/tests/test_without_inventory.yml
@@ -58,7 +58,7 @@
     is_deployed: false
 
 - name: Test without inventory file
-  register: cvp_vars
+  register: CVP_VARS
   ignore_errors: yes
   arista.avd.inventory_to_container:
     container_root: 'DC1_FABRIC'
@@ -76,17 +76,17 @@
 - name: Validate output
   ansible.builtin.assert:
     that:
-      - cvp_vars is success
-      - cvp_vars.cvp_topology != {}
-      - cvp_vars.cvp_configlets != {}
+      - CVP_VARS is success
+      - CVP_VARS.CVP_TOPOLOGY != {}
+      - CVP_VARS.CVP_CONFIGLETS != {}
       - item is defined
       - "'AVD_DC1-LE' in item[0:10]"
       - diff_output.stdout == ""
-  with_items: "{{ cvp_vars.cvp_configlets }}"
+  with_items: "{{ CVP_VARS.CVP_CONFIGLETS }}"
 
-- name: Validate cvp_topology
+- name: Validate CVP_TOPOLOGY
   ansible.builtin.assert:
     that:
       - item is defined
       - item == "Tenant"
-  with_items: "{{ cvp_vars.cvp_topology.DC1_FABRIC.parent_container }}"
+  with_items: "{{ CVP_VARS.CVP_TOPOLOGY.DC1_FABRIC.parent_container }}"

--- a/ansible_collections/arista/avd/tests/integration/targets/inventory_to_container/tests/test_without_inventory.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/inventory_to_container/tests/test_without_inventory.yml
@@ -68,9 +68,10 @@
     destination: "{{ actual_output }}"
 
 - name: Compare actual output with expected output
-  ansible.builtin.local_action: shell diff "{{ expected_output }}/expected_without_inventory.yml" "{{ actual_output }}"
+  ansible.builtin.shell: diff "{{ expected_output }}/expected_without_inventory.yml" "{{ actual_output }}"
   failed_when: "diff_output.rc > 1"
   register: diff_output
+  delegate_to: localhost
 
 - name: Validate output
   ansible.builtin.assert:

--- a/ansible_collections/arista/avd/tests/integration/targets/yaml_templates_to_facts/tasks/main.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/yaml_templates_to_facts/tasks/main.yml
@@ -1,2 +1,3 @@
 ---
-- include: test.yml
+- name: Include test.yml
+  ansible.builtin.include_tasks: test.yml

--- a/ansible_collections/arista/avd/tests/integration/targets/yaml_templates_to_facts/tasks/test.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/yaml_templates_to_facts/tasks/test.yml
@@ -1,15 +1,16 @@
-- name: collect all test cases
-  find:
+- name: Collect all test cases
+  ansible.builtin.find:
     paths: '{{ role_path }}/tests/'
     patterns: '{{ testcase }}.yml'
   register: test_cases
   delegate_to: localhost
 
-- name: set test_items
-  set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
+- name: Set test_items
+  ansible.builtin.set_fact:
+    test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases
-  include: '{{ test_case_to_run }}'
+- name: Run test cases
+  ansible.builtin.include_tasks: '{{ test_case_to_run }}'
   with_items: '{{ test_items }}'
   loop_control:
     loop_var: test_case_to_run

--- a/ansible_collections/arista/avd/tests/integration/targets/yaml_templates_to_facts/tests/test_with_debug.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/yaml_templates_to_facts/tests/test_with_debug.yml
@@ -4,7 +4,7 @@
     timezone: "test"
     hours: 36
   register: result
-  yaml_templates_to_facts:
+  arista.avd.yaml_templates_to_facts:
     debug: true
     templates:
       - template: "templates/template.j2"

--- a/ansible_collections/arista/avd/tests/integration/targets/yaml_templates_to_facts/tests/test_with_debug_dest.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/yaml_templates_to_facts/tests/test_with_debug_dest.yml
@@ -4,13 +4,13 @@
     timezone: "test"
     hours: 36
   register: result
-  yaml_templates_to_facts:
+  arista.avd.yaml_templates_to_facts:
     dest: "{{ actual_output_dir }}/yaml_templates_to_facts_test_with_dest.yml"
     debug: true
     templates:
       - template: "templates/template.j2"
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is success
       - result.ansible_facts is defined

--- a/ansible_collections/arista/avd/tests/integration/targets/yaml_templates_to_facts/tests/test_with_debug_template_output.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/yaml_templates_to_facts/tests/test_with_debug_template_output.yml
@@ -1,7 +1,7 @@
 - name: Test with debug and template_output
   ignore_errors: no
   register: result
-  yaml_templates_to_facts:
+  arista.avd.yaml_templates_to_facts:
     template_output: true
     debug: true
     templates:

--- a/ansible_collections/arista/avd/tests/integration/targets/yaml_templates_to_facts/tests/test_with_dest_changed.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/yaml_templates_to_facts/tests/test_with_dest_changed.yml
@@ -14,11 +14,14 @@
     templates:
       - template: "templates/template.j2"
 
-- local_action: shell diff "{{ expected_output_dir }}/yaml_templates_to_facts_test_with_dest.yml" "{{ actual_output_dir }}/yaml_templates_to_facts_test_with_dest.yml"
+- name: Compare actual output with expected output
+  ansible.builtin.shell: diff "{{ expected_output_dir }}/yaml_templates_to_facts_test_with_dest.yml" "{{ actual_output_dir }}/yaml_templates_to_facts_test_with_dest.yml"
   failed_when: "diff_output.rc > 1"
   register: diff_output
+  delegate_to: localhost
 
-- assert:
+- name: Validate result
+  ansible.builtin.assert:
     that:
       - result is success
       - result.changed == true

--- a/ansible_collections/arista/avd/tests/integration/targets/yaml_templates_to_facts/tests/test_with_dest_changed.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/yaml_templates_to_facts/tests/test_with_dest_changed.yml
@@ -9,7 +9,7 @@
     timezone: "test"
     hours: 36
   register: result
-  yaml_templates_to_facts:
+  arista.avd.yaml_templates_to_facts:
     dest: "{{ actual_output_dir }}/yaml_templates_to_facts_test_with_dest.yml"
     templates:
       - template: "templates/template.j2"

--- a/ansible_collections/arista/avd/tests/integration/targets/yaml_templates_to_facts/tests/test_with_dest_changed.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/yaml_templates_to_facts/tests/test_with_dest_changed.yml
@@ -1,5 +1,5 @@
 - name: Test with dest (no change) - Remove test file to force change in template action
-  file:
+  ansible.builtin.file:
     path: "{{ actual_output_dir }}/yaml_templates_to_facts_test_with_dest.yml"
     state: absent
 

--- a/ansible_collections/arista/avd/tests/integration/targets/yaml_templates_to_facts/tests/test_with_dest_json.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/yaml_templates_to_facts/tests/test_with_dest_json.yml
@@ -4,7 +4,7 @@
     timezone: "test"
     hours: 36
   register: result
-  yaml_templates_to_facts:
+  arista.avd.yaml_templates_to_facts:
     dest: "{{ actual_output_dir }}/yaml_templates_to_facts_test_with_dest.json"
     templates:
       - template: "templates/template.j2"

--- a/ansible_collections/arista/avd/tests/integration/targets/yaml_templates_to_facts/tests/test_with_dest_json.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/yaml_templates_to_facts/tests/test_with_dest_json.yml
@@ -9,11 +9,14 @@
     templates:
       - template: "templates/template.j2"
 
-- local_action: shell diff "{{ expected_output_dir }}/yaml_templates_to_facts_test_with_dest.json" "{{ actual_output_dir }}/yaml_templates_to_facts_test_with_dest.json"
+- name: Compare actual output with expected output
+  ansible.builtin.shell: diff "{{ expected_output_dir }}/yaml_templates_to_facts_test_with_dest.json" "{{ actual_output_dir }}/yaml_templates_to_facts_test_with_dest.json"
   failed_when: "diff_output.rc > 1"
   register: diff_output
+  delegate_to: localhost
 
-- assert:
+- name: Validate result
+  ansible.builtin.assert:
     that:
       - result is success
       - result.ansible_facts is defined

--- a/ansible_collections/arista/avd/tests/integration/targets/yaml_templates_to_facts/tests/test_with_dest_no_change.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/yaml_templates_to_facts/tests/test_with_dest_no_change.yml
@@ -20,11 +20,14 @@
     templates:
       - template: "templates/template.j2"
 
-- local_action: shell diff "{{ expected_output_dir }}/yaml_templates_to_facts_test_with_dest.yml" "{{ actual_output_dir }}/yaml_templates_to_facts_test_with_dest.yml"
+- name: Compare actual output with expected output
+  ansible.builtin.shell: diff "{{ expected_output_dir }}/yaml_templates_to_facts_test_with_dest.yml" "{{ actual_output_dir }}/yaml_templates_to_facts_test_with_dest.yml"
   failed_when: "diff_output.rc > 1"
   register: diff_output
+  delegate_to: localhost
 
-- assert:
+- name: Validate result
+  ansible.builtin.assert:
     that:
       - result is success
       - result.changed == false

--- a/ansible_collections/arista/avd/tests/integration/targets/yaml_templates_to_facts/tests/test_with_dest_no_change.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/yaml_templates_to_facts/tests/test_with_dest_no_change.yml
@@ -4,7 +4,7 @@
     timezone: "test"
     hours: 36
   register: result
-  yaml_templates_to_facts:
+  arista.avd.yaml_templates_to_facts:
     dest: "{{ actual_output_dir }}/yaml_templates_to_facts_test_with_dest.yml"
     templates:
       - template: "templates/template.j2"
@@ -15,7 +15,7 @@
     timezone: "test"
     hours: 36
   register: result
-  yaml_templates_to_facts:
+  arista.avd.yaml_templates_to_facts:
     dest: "{{ actual_output_dir }}/yaml_templates_to_facts_test_with_dest.yml"
     templates:
       - template: "templates/template.j2"

--- a/ansible_collections/arista/avd/tests/integration/targets/yaml_templates_to_facts/tests/test_with_list_merge_append.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/yaml_templates_to_facts/tests/test_with_list_merge_append.yml
@@ -4,7 +4,7 @@
   vars:
     timezone: "test"
     hours: 84
-  yaml_templates_to_facts:
+  arista.avd.yaml_templates_to_facts:
     templates:
       - template: "templates/template.j2"
       - template: "templates/template1.j2"

--- a/ansible_collections/arista/avd/tests/integration/targets/yaml_templates_to_facts/tests/test_with_list_merge_append_rp.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/yaml_templates_to_facts/tests/test_with_list_merge_append_rp.yml
@@ -4,7 +4,7 @@
   vars:
     timezone: "test"
     hours: 84
-  yaml_templates_to_facts:
+  arista.avd.yaml_templates_to_facts:
     templates:
       - template: "templates/template.j2"
       - template: "templates/template1.j2"

--- a/ansible_collections/arista/avd/tests/integration/targets/yaml_templates_to_facts/tests/test_with_list_merge_invalid.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/yaml_templates_to_facts/tests/test_with_list_merge_invalid.yml
@@ -4,7 +4,7 @@
   vars:
     timezone: "test"
     hours: 84
-  yaml_templates_to_facts:
+  arista.avd.yaml_templates_to_facts:
     templates:
       - template: "templates/template.j2"
       - template: "templates/template1.j2"

--- a/ansible_collections/arista/avd/tests/integration/targets/yaml_templates_to_facts/tests/test_with_list_merge_invalid.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/yaml_templates_to_facts/tests/test_with_list_merge_invalid.yml
@@ -12,7 +12,10 @@
           strip_empty_keys: false
           list_merge: "append12"
 
-- assert:
+- vars:
+    error_msg: >-
+      Unexpected failure during module execution: merge: 'list_merge' argument can only be equal to one of ['replace', 'keep', 'append', 'prepend', 'append_rp', 'prepend_rp']
+  assert:
     that:
       - result.failed == True
-      - result.msg == {{ lookup('file', './error_invalid_merge_option.txt') }}
+      - result.msg == error_msg

--- a/ansible_collections/arista/avd/tests/integration/targets/yaml_templates_to_facts/tests/test_with_list_merge_keep.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/yaml_templates_to_facts/tests/test_with_list_merge_keep.yml
@@ -5,7 +5,7 @@
   vars:
     timezone: "test"
     hours: 84
-  yaml_templates_to_facts:
+  arista.avd.yaml_templates_to_facts:
     templates:
       - template: "templates/template.j2"
       - template: "templates/template1.j2"

--- a/ansible_collections/arista/avd/tests/integration/targets/yaml_templates_to_facts/tests/test_with_list_merge_prepend.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/yaml_templates_to_facts/tests/test_with_list_merge_prepend.yml
@@ -4,7 +4,7 @@
   vars:
     timezone: "test"
     hours: 84
-  yaml_templates_to_facts:
+  arista.avd.yaml_templates_to_facts:
     templates:
       - template: "templates/template.j2"
       - template: "templates/template1.j2"

--- a/ansible_collections/arista/avd/tests/integration/targets/yaml_templates_to_facts/tests/test_with_list_merge_prepend_rp.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/yaml_templates_to_facts/tests/test_with_list_merge_prepend_rp.yml
@@ -4,7 +4,7 @@
   vars:
     timezone: "test"
     hours: 84
-  yaml_templates_to_facts:
+  arista.avd.yaml_templates_to_facts:
     templates:
       - template: "templates/template.j2"
       - template: "templates/template1.j2"

--- a/ansible_collections/arista/avd/tests/integration/targets/yaml_templates_to_facts/tests/test_with_list_merge_replace.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/yaml_templates_to_facts/tests/test_with_list_merge_replace.yml
@@ -4,7 +4,7 @@
   vars:
     timezone: "test"
     hours: 84
-  yaml_templates_to_facts:
+  arista.avd.yaml_templates_to_facts:
     templates:
       - template: "templates/template.j2"
       - template: "templates/template1.j2"

--- a/ansible_collections/arista/avd/tests/integration/targets/yaml_templates_to_facts/tests/test_with_root_key.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/yaml_templates_to_facts/tests/test_with_root_key.yml
@@ -4,7 +4,7 @@
     timezone: "test"
     hours:
   register: result
-  yaml_templates_to_facts:
+  arista.avd.yaml_templates_to_facts:
     root_key: structured_config
     templates:
       - template: "templates/template.j2"

--- a/ansible_collections/arista/avd/tests/integration/targets/yaml_templates_to_facts/tests/test_with_strip_empty_false.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/yaml_templates_to_facts/tests/test_with_strip_empty_false.yml
@@ -4,7 +4,7 @@
   vars:
     timezone: "test"
     hours:
-  yaml_templates_to_facts:
+  arista.avd.yaml_templates_to_facts:
     templates:
       - template: "templates/template.j2"
         options:

--- a/ansible_collections/arista/avd/tests/integration/targets/yaml_templates_to_facts/tests/test_with_strip_empty_invalid.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/yaml_templates_to_facts/tests/test_with_strip_empty_invalid.yml
@@ -4,7 +4,7 @@
   vars:
     timezone: "test"
     hours:
-  yaml_templates_to_facts:
+  arista.avd.yaml_templates_to_facts:
     templates:
       - template: "templates/template.j2"
         options:

--- a/ansible_collections/arista/avd/tests/integration/targets/yaml_templates_to_facts/tests/test_with_template_output.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/yaml_templates_to_facts/tests/test_with_template_output.yml
@@ -1,7 +1,7 @@
 - name: Test with template_output
   ignore_errors: no
   register: result
-  yaml_templates_to_facts:
+  arista.avd.yaml_templates_to_facts:
     template_output: true
     templates:
       - template: "templates/inline_jinja.j2"

--- a/ansible_collections/arista/avd/tests/integration/targets/yaml_templates_to_facts/tests/test_with_template_output_false.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/yaml_templates_to_facts/tests/test_with_template_output_false.yml
@@ -1,7 +1,7 @@
 - name: Test with template_output false
   ignore_errors: no
   register: result
-  yaml_templates_to_facts:
+  arista.avd.yaml_templates_to_facts:
     template_output: false
     templates:
       - template: "templates/inline_jinja.j2"

--- a/ansible_collections/arista/avd/tests/integration/targets/yaml_templates_to_facts/tests/test_without_root_key.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/yaml_templates_to_facts/tests/test_without_root_key.yml
@@ -4,7 +4,7 @@
     timezone: "test"
     hours: 36
   register: result
-  yaml_templates_to_facts:
+  arista.avd.yaml_templates_to_facts:
     templates:
       - template: "templates/template.j2"
 

--- a/ansible_collections/arista/avd/tests/integration/targets/yaml_templates_to_facts/tests/test_without_templates_parameter.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/yaml_templates_to_facts/tests/test_without_templates_parameter.yml
@@ -1,7 +1,7 @@
 - name: Test without 'templates' parameter
   ignore_errors: yes
   register: result
-  yaml_templates_to_facts:
+  arista.avd.yaml_templates_to_facts:
 
 - assert:
     that:

--- a/ansible_collections/arista/avd/tests/inventory/configlet_build_config/expected_output/expected_with_all_parameters.yml
+++ b/ansible_collections/arista/avd/tests/inventory/configlet_build_config/expected_output/expected_with_all_parameters.yml
@@ -1,5 +1,4 @@
-changed: false
-cvp_configlets:
+CVP_CONFIGLETS:
   Prefix_DC1-L2LEAF1A: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec\
     \ /usr/bin/TerminAttr -cvaddr=10.255.0.1:9910 -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata\
     \ -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n\
@@ -1001,3 +1000,4 @@ cvp_configlets:
     \ ip routing vrf MGMT\n!\nip route vrf MGMT 0.0.0.0/0 10.255.0.1\n!\nmanagement\
     \ api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n  \
     \    no shutdown\n!\nend\n"
+changed: false

--- a/ansible_collections/arista/avd/tests/inventory/configlet_build_config/expected_output/expected_with_all_parameters.yml
+++ b/ansible_collections/arista/avd/tests/inventory/configlet_build_config/expected_output/expected_with_all_parameters.yml
@@ -1,3 +1,4 @@
+changed: false
 cvp_configlets:
   Prefix_DC1-L2LEAF1A: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec\
     \ /usr/bin/TerminAttr -cvaddr=10.255.0.1:9910 -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata\

--- a/ansible_collections/arista/avd/tests/inventory/configlet_build_config/expected_output/expected_with_all_parameters.yml
+++ b/ansible_collections/arista/avd/tests/inventory/configlet_build_config/expected_output/expected_with_all_parameters.yml
@@ -1,4 +1,3 @@
-changed: false
 cvp_configlets:
   Prefix_DC1-L2LEAF1A: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec\
     \ /usr/bin/TerminAttr -cvaddr=10.255.0.1:9910 -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata\

--- a/ansible_collections/arista/avd/tests/inventory/configlet_build_config/expected_output/expected_with_blank_prefix.yml
+++ b/ansible_collections/arista/avd/tests/inventory/configlet_build_config/expected_output/expected_with_blank_prefix.yml
@@ -1,4 +1,3 @@
-changed: false
 cvp_configlets:
   _DC1-L2LEAF1A: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr\
     \ -cvaddr=10.255.0.1:9910 -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata\

--- a/ansible_collections/arista/avd/tests/inventory/configlet_build_config/expected_output/expected_with_blank_prefix.yml
+++ b/ansible_collections/arista/avd/tests/inventory/configlet_build_config/expected_output/expected_with_blank_prefix.yml
@@ -1,3 +1,4 @@
+changed: false
 cvp_configlets:
   _DC1-L2LEAF1A: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr\
     \ -cvaddr=10.255.0.1:9910 -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata\

--- a/ansible_collections/arista/avd/tests/inventory/configlet_build_config/expected_output/expected_with_blank_prefix.yml
+++ b/ansible_collections/arista/avd/tests/inventory/configlet_build_config/expected_output/expected_with_blank_prefix.yml
@@ -1,5 +1,4 @@
-changed: false
-cvp_configlets:
+CVP_CONFIGLETS:
   _DC1-L2LEAF1A: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr\
     \ -cvaddr=10.255.0.1:9910 -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata\
     \ -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n\
@@ -1001,3 +1000,4 @@ cvp_configlets:
     \ ip routing vrf MGMT\n!\nip route vrf MGMT 0.0.0.0/0 10.255.0.1\n!\nmanagement\
     \ api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n  \
     \    no shutdown\n!\nend\n"
+changed: false

--- a/ansible_collections/arista/avd/tests/inventory/configlet_build_config/expected_output/expected_without_extension.yml
+++ b/ansible_collections/arista/avd/tests/inventory/configlet_build_config/expected_output/expected_without_extension.yml
@@ -1,4 +1,3 @@
-changed: false
 cvp_configlets:
   Prefix_default_extension: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n\
     \   exec /usr/bin/TerminAttr -cvaddr=10.255.0.1:9910 -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata\

--- a/ansible_collections/arista/avd/tests/inventory/configlet_build_config/expected_output/expected_without_extension.yml
+++ b/ansible_collections/arista/avd/tests/inventory/configlet_build_config/expected_output/expected_without_extension.yml
@@ -1,3 +1,4 @@
+changed: false
 cvp_configlets:
   Prefix_default_extension: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n\
     \   exec /usr/bin/TerminAttr -cvaddr=10.255.0.1:9910 -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata\

--- a/ansible_collections/arista/avd/tests/inventory/configlet_build_config/expected_output/expected_without_extension.yml
+++ b/ansible_collections/arista/avd/tests/inventory/configlet_build_config/expected_output/expected_without_extension.yml
@@ -1,5 +1,4 @@
-changed: false
-cvp_configlets:
+CVP_CONFIGLETS:
   Prefix_default_extension: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n\
     \   exec /usr/bin/TerminAttr -cvaddr=10.255.0.1:9910 -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata\
     \ -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n\
@@ -27,3 +26,4 @@ cvp_configlets:
     \ ip routing vrf MGMT\n!\nip route vrf MGMT 0.0.0.0/0 10.255.0.1\n!\nmanagement\
     \ api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n  \
     \    no shutdown\n!\nend\n"
+changed: false

--- a/ansible_collections/arista/avd/tests/inventory/inventory_to_container/expected_output/expected_with_all_param.yml
+++ b/ansible_collections/arista/avd/tests/inventory/inventory_to_container/expected_output/expected_with_all_param.yml
@@ -1,3 +1,4 @@
+changed: false
 cvp_configlets:
   AVD_DC1-LEAF1A: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr
     -cvaddr=10.255.0.1:9910 -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata

--- a/ansible_collections/arista/avd/tests/inventory/inventory_to_container/expected_output/expected_with_all_param.yml
+++ b/ansible_collections/arista/avd/tests/inventory/inventory_to_container/expected_output/expected_with_all_param.yml
@@ -1,4 +1,4 @@
-cvp_configlets:
+CVP_CONFIGLETS:
   AVD_DC1-LEAF1A: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr
     -cvaddr=10.255.0.1:9910 -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
     -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
@@ -791,7 +791,7 @@ cvp_configlets:
     \     neighbor 10.255.251.4 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
     connected\n!\nmanagement api http-commands\n   protocol https\n   no shutdown\n
     \  !\n   vrf MGMT\n      no shutdown\n!\nend\n"
-cvp_topology:
+CVP_TOPOLOGY:
   DC1_FABRIC:
     parent_container: Tenant
   DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/tests/inventory/inventory_to_container/expected_output/expected_with_all_param.yml
+++ b/ansible_collections/arista/avd/tests/inventory/inventory_to_container/expected_output/expected_with_all_param.yml
@@ -1,4 +1,3 @@
-changed: false
 cvp_configlets:
   AVD_DC1-LEAF1A: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr
     -cvaddr=10.255.0.1:9910 -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata

--- a/ansible_collections/arista/avd/tests/inventory/inventory_to_container/expected_output/expected_without_configlet_dir.yml
+++ b/ansible_collections/arista/avd/tests/inventory/inventory_to_container/expected_output/expected_without_configlet_dir.yml
@@ -1,4 +1,4 @@
-cvp_topology:
+CVP_TOPOLOGY:
   DC1_FABRIC:
     parent_container: Tenant
   DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/tests/inventory/inventory_to_container/expected_output/expected_without_configlet_dir.yml
+++ b/ansible_collections/arista/avd/tests/inventory/inventory_to_container/expected_output/expected_without_configlet_dir.yml
@@ -1,3 +1,4 @@
+changed: false
 cvp_topology:
   DC1_FABRIC:
     parent_container: Tenant

--- a/ansible_collections/arista/avd/tests/inventory/inventory_to_container/expected_output/expected_without_configlet_dir.yml
+++ b/ansible_collections/arista/avd/tests/inventory/inventory_to_container/expected_output/expected_without_configlet_dir.yml
@@ -1,4 +1,3 @@
-changed: false
 cvp_topology:
   DC1_FABRIC:
     parent_container: Tenant

--- a/ansible_collections/arista/avd/tests/inventory/inventory_to_container/expected_output/expected_without_device_filter.yml
+++ b/ansible_collections/arista/avd/tests/inventory/inventory_to_container/expected_output/expected_without_device_filter.yml
@@ -1,4 +1,3 @@
-changed: false
 cvp_configlets:
   AVD_DC1-L2LEAF1A: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr
     -cvaddr=10.255.0.1:9910 -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata

--- a/ansible_collections/arista/avd/tests/inventory/inventory_to_container/expected_output/expected_without_device_filter.yml
+++ b/ansible_collections/arista/avd/tests/inventory/inventory_to_container/expected_output/expected_without_device_filter.yml
@@ -1,3 +1,4 @@
+changed: false
 cvp_configlets:
   AVD_DC1-L2LEAF1A: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr
     -cvaddr=10.255.0.1:9910 -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata

--- a/ansible_collections/arista/avd/tests/inventory/inventory_to_container/expected_output/expected_without_device_filter.yml
+++ b/ansible_collections/arista/avd/tests/inventory/inventory_to_container/expected_output/expected_without_device_filter.yml
@@ -1,4 +1,4 @@
-cvp_configlets:
+CVP_CONFIGLETS:
   AVD_DC1-L2LEAF1A: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr
     -cvaddr=10.255.0.1:9910 -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
     -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
@@ -977,7 +977,7 @@ cvp_configlets:
     address 10.255.0.17/24\n!\nip routing\nno ip routing vrf MGMT\n!\nip route vrf
     MGMT 0.0.0.0/0 10.255.0.1\n!\nmanagement api http-commands\n   protocol https\n
     \  no shutdown\n   !\n   vrf MGMT\n      no shutdown\n!\nend\n"
-cvp_topology:
+CVP_TOPOLOGY:
   DC1_FABRIC:
     parent_container: Tenant
   DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/tests/inventory/inventory_to_container/expected_output/expected_without_inventory.yml
+++ b/ansible_collections/arista/avd/tests/inventory/inventory_to_container/expected_output/expected_without_inventory.yml
@@ -1,4 +1,4 @@
-cvp_configlets:
+CVP_CONFIGLETS:
   AVD_DC1-LEAF1A: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr
     -cvaddr=10.255.0.1:9910 -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
     -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
@@ -791,7 +791,7 @@ cvp_configlets:
     \     neighbor 10.255.251.4 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
     connected\n!\nmanagement api http-commands\n   protocol https\n   no shutdown\n
     \  !\n   vrf MGMT\n      no shutdown\n!\nend\n"
-cvp_topology:
+CVP_TOPOLOGY:
   DC1_FABRIC:
     devices: []
     parent_container: Tenant


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->

## Related Issue(s)

Fixes #2444

## Component(s) name

~ every task file or playbook

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

- Fix all warnings from issue 2444. Most are just casing/spacing or FQCN for Ansible modules.
- Add ignore rules on false positives (dict inputs and ipaddr)
- Add general ignore of name[template] since we don't want to follow that.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Install latest ansible-core and latest galaxy-importer
Then run make job which builds the collection and run galaxy-importer on it.
```
pip3 install ansible-core --upgrade
pip3 install galaxy-importer --upgrade
cd ansible-avd
make galaxy-importer
```

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
