### PR TITLE
Fix(eos_designs): Fix issue with hardware_counters python code

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/hardware-counter.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/hardware-counter.md
@@ -58,6 +58,7 @@ interface Management1
 | Feature | Flow Direction |
 | ------- | -------------- |
 | ip | in |
+| ip | out |
 | gre | out |
 
 ### Hardware Counters Configuration
@@ -65,6 +66,7 @@ interface Management1
 ```eos
 !
 hardware counter feature ip in
+hardware counter feature ip out
 hardware counter feature gre out
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/hardware-counter.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/hardware-counter.cfg
@@ -1,6 +1,7 @@
 !RANCID-CONTENT-TYPE: arista
 !
 hardware counter feature ip in
+hardware counter feature ip out
 hardware counter feature gre out
 !
 transceiver qsfp default-mode 4x10G

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/hardware-counter.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/hardware-counter.yml
@@ -2,4 +2,5 @@
 hardware_counters:
   features:
     - ip: in
+    - ip: out
     - gre: out

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/hardware_counters.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/hardware_counters.cfg
@@ -1,6 +1,7 @@
 !RANCID-CONTENT-TYPE: arista
 !
 hardware counter feature vlan-interface in
+hardware counter feature vlan-interface out
 hardware counter feature flow-spec in
 !
 vlan internal order ascending range 1006 1199

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/hardware_counters.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/hardware_counters.cfg
@@ -1,0 +1,29 @@
+!RANCID-CONTENT-TYPE: arista
+!
+hardware counter feature vlan-interface in
+hardware counter feature flow-spec in
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname hardware_counters
+!
+no enable password
+no aaa root
+!
+vrf instance MGMT
+!
+ip routing
+no ip routing vrf MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/hardware_counters.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/hardware_counters.yml
@@ -3,6 +3,7 @@ ip_routing: true
 hardware_counters:
   features:
   - vlan-interface: in
+  - vlan-interface: out
   - flow-spec: in
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/hardware_counters.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/hardware_counters.yml
@@ -1,0 +1,20 @@
+service_routing_protocols_model: multi-agent
+ip_routing: true
+hardware_counters:
+  features:
+  - vlan-interface: in
+  - flow-spec: in
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+vrfs:
+  MGMT:
+    ip_routing: false
+management_api_http:
+  enable_vrfs:
+    MGMT: {}
+  enable_https: true
+ip_igmp_snooping:
+  globally_enabled: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/hardware_counters.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/hardware_counters.yml
@@ -1,8 +1,6 @@
 hardware_counters:
   features:
     - vlan-interface: in
-    # in 3.8, this will trigger a warning in eos_cli_config_gen because of the
-    # conversion
     - vlan-interface: out
     - flow-spec: in
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/hardware_counters.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/hardware_counters.yml
@@ -1,0 +1,11 @@
+hardware_counters:
+  features:
+    - vlan-interface: in
+    - flow-spec: in
+
+type: l2leaf
+l2leaf:
+  defaults:
+  nodes:
+    hardware_counters:
+      id: 42

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/hardware_counters.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/hardware_counters.yml
@@ -1,6 +1,9 @@
 hardware_counters:
   features:
     - vlan-interface: in
+    # in 3.8, this will trigger a warning in eos_cli_config_gen because of the
+    # conversion
+    - vlan-interface: out
     - flow-spec: in
 
 type: l2leaf

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
@@ -10,6 +10,7 @@ all:
             filter.only_vlans_in_use:
             no_mgmt_interface:
             no_mgmt_gateway:
+            hardware_counters:
         CORE_UNIT_TESTS:
           hosts:
             core-1-isis-sr-ldp:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -1430,16 +1430,12 @@ hardware:
 | -------- | ---- | -------- | ------- | ------------------ | ----------- |
 | [<samp>hardware_counters</samp>](## "hardware_counters") | Dictionary |  |  |  |  |
 | [<samp>&nbsp;&nbsp;features</samp>](## "hardware_counters.features") | List, items: Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "hardware_counters.features.[].name") | String | Required, Unique |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;direction</samp>](## "hardware_counters.features.[].direction") | String | Required |  | Valid Values:<br>- in<br>- out |  |
 
 ### YAML
 
 ```yaml
 hardware_counters:
   features:
-    - name: <str>
-      direction: <str>
 ```
 
 ## Interface Defaults

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -2889,26 +2889,7 @@
         "features": {
           "type": "array",
           "items": {
-            "type": "object",
-            "properties": {
-              "name": {
-                "type": "string",
-                "title": "Name"
-              },
-              "direction": {
-                "type": "string",
-                "enum": [
-                  "in",
-                  "out"
-                ],
-                "title": "Direction"
-              }
-            },
-            "required": [
-              "name",
-              "direction"
-            ],
-            "additionalProperties": false
+            "type": "object"
           },
           "title": "Features"
         }

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -2089,22 +2089,8 @@ keys:
     keys:
       features:
         type: list
-        primary_key: name
-        secondary_key: direction
-        convert_types:
-        - list
         items:
           type: dict
-          keys:
-            name:
-              type: str
-              required: true
-            direction:
-              type: str
-              required: true
-              valid_values:
-              - in
-              - out
   interface_defaults:
     type: dict
     keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/hardware_counters.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/hardware_counters.schema.yml
@@ -8,17 +8,5 @@ keys:
     keys:
       features:
         type: list
-        primary_key: name
-        secondary_key: direction
-        convert_types:
-          - list
         items:
           type: dict
-          keys:
-            name:
-              type: str
-              required: true
-            direction:
-              type: str
-              required: true
-              valid_values: ["in", "out"]

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/hardware-counters.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/hardware-counters.j2
@@ -16,7 +16,11 @@
 | {{ feature.name }} | {{ feature.direction }} |
 {%                 else %}
 {%                     for feat in feature %}
+{%                         if 'name' in feat %}
 | {{ feat.name }} | {{ feat.direction }} |
+{%                         else %}
+| {{ feat }} | {{ feature[feat] }} |
+{%                         endif %}
 {%                     endfor %}
 {%                 endif %}
 {%             endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/hardware-counters.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/hardware-counters.j2
@@ -6,7 +6,11 @@
 hardware counter feature {{ feature.name }} {{ feature.direction }}
 {%         else %}
 {%             for feat in feature %}
+{%                 if 'name' in feat %}
 hardware counter feature {{ feat.name }} {{ feat.direction }}
+{%                 else %}
+hardware counter feature {{ feat }} {{ feature[feat] }}
+{%                 endif %}
 {%             endfor %}
 {%         endif %}
 {%     endfor %}

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/base/avdstructuredconfig.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/base/avdstructuredconfig.py
@@ -157,10 +157,7 @@ class AvdStructuredConfig(AvdFacts):
         """
         hardware_counters set based on hardware_counters.features variable
         """
-        if (hardware_counter_features := get(self._hostvars, "hardware_counters.features")) is None:
-            return None
-
-        return {"features": hardware_counter_features}
+        return get(self._hostvars, "hardware_counters")
 
     @cached_property
     def hardware(self):

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/base/avdstructuredconfig.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/base/avdstructuredconfig.py
@@ -160,8 +160,7 @@ class AvdStructuredConfig(AvdFacts):
         if (hardware_counter_features := get(self._hostvars, "hardware_counters.features")) is None:
             return None
 
-        features = [{feature: direction} for feature, direction in hardware_counter_features.items()]
-        return {"features": features}
+        return {"features": hardware_counter_features}
 
     @cached_property
     def hardware(self):


### PR DESCRIPTION
## Change Summary

When porting from AVD 3.7.0 jinja2 template to AVD3.8.0 python module, the logic was not correctly implemented and it was not caught up at implementation time because no test existed in molecule for `hardware_counters.features`

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

As we are only copying over the list of dictionaries, removing the double for loop and just injecting the incoming data.

## How to test

new molecule test for it in `eos_designs_unit_test
## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
