### PR TITLE
Fix(eos_designs): Renders lacp fallback when port-channel mode is passive

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3A.cfg
@@ -390,7 +390,7 @@ interface Ethernet16
 interface Ethernet17
    description server10_no_profile_port_channel_lacp_fallback_Eth1
    no shutdown
-   channel-group 17 mode active
+   channel-group 17 mode passive
    lacp port-priority 8192
 !
 interface Ethernet18

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3B.cfg
@@ -377,7 +377,7 @@ interface Ethernet16
 interface Ethernet17
    description server10_no_profile_port_channel_lacp_fallback_Eth2
    no shutdown
-   channel-group 17 mode active
+   channel-group 17 mode passive
    lacp port-priority 32768
 !
 interface Ethernet18

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3A.yml
@@ -1221,7 +1221,7 @@ ethernet_interfaces:
         unit: percent
     channel_group:
       id: 17
-      mode: active
+      mode: passive
     lacp_port_priority: 8192
   Ethernet18:
     peer: server11_inherit_profile_port_channel_lacp_fallback

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3B.yml
@@ -1202,7 +1202,7 @@ ethernet_interfaces:
         unit: percent
     channel_group:
       id: 17
-      mode: active
+      mode: passive
     lacp_port_priority: 32768
   Ethernet18:
     peer: server11_inherit_profile_port_channel_lacp_fallback

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_SERVERS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_SERVERS.yml
@@ -332,7 +332,7 @@ servers:
             unit: percent
         port_channel:
           description: server10_no_profile_port_channel_lacp_fallback
-          mode: active
+          mode: passive
           lacp_fallback:
             mode: static
 

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/connected_endpoints/port_channel_interfaces.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/connected_endpoints/port_channel_interfaces.py
@@ -128,7 +128,7 @@ class PortChannelInterfacesMixin(UtilsMixin):
             port_channel_interface["mlag"] = channel_group_id
 
         # LACP Fallback
-        if port_channel_mode == "active" and (lacp_fallback_mode := get(adapter, "port_channel.lacp_fallback.mode")) == "static":
+        if port_channel_mode in ["active", "passive"] and (lacp_fallback_mode := get(adapter, "port_channel.lacp_fallback.mode")) == "static":
             port_channel_interface.update(
                 {
                     "lacp_fallback_mode": lacp_fallback_mode,


### PR DESCRIPTION
## Change Summary

With the change to AVD 3.8.0, lacp fallback commands are only rendered if the mode of the port_channel is `active`. This PR supports lacp fallback when the mode is in the list `["passive", "active"]`

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

Check if mode is in `["passive", "active"]` to render lacp_fallback

## How to test

tweaked a molecule test that was using `active` to use `passive` (another test is using `active` still)

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
