### PR TITLE
CI: Allow ' and " in PR names

### DIFF
--- a/.github/actions/rn-pr-labeler-action/action.yml
+++ b/.github/actions/rn-pr-labeler-action/action.yml
@@ -18,7 +18,9 @@ runs:
       shell: bash
       if: ${{ env.OLD_LABEL }}
     - name: Set Label
-      run: echo "LABEL=$(echo '${{ github.event.pull_request.title }}' | cut -d ':' -f 1 | tr -d ' ')" >> $GITHUB_ENV
+      # Using toJSON to support ' and " in commit messages
+      # https://stackoverflow.com/questions/73363167/github-actions-how-to-escape-characters-in-commit-message
+      run: echo "LABEL=$(echo ${{ toJSON(github.event.pull_request.title) }} | cut -d ':' -f 1 | tr -d ' ')" >> $GITHUB_ENV
       shell: bash
       # an alternative to verifying if the target label already exist is to
       # create the label with --force in the next step, it will keep on changing


### PR DESCRIPTION
## Change Summary

PRs like #2441 would fail in the PR labeler action because of `'` or `"` characters. This PR fixes it

## Proposed changes

Use `toJSON` to convert the title to JSON that will automatically escape properly the single and double quotes. cf https://stackoverflow.com/questions/73363167/github-actions-how-to-escape-characters-in-commit-message comment.

## How to test

tested in my own test repo for pipelines cf - https://github.com/gmuloc/test-pr-workflow/actions/runs/3985750409 

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
