### PR TITLE
Fix(eos_snapshot): Conditional in tasks are not honored and support for limit

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_snapshot/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_snapshot/tasks/main.yml
@@ -29,7 +29,8 @@
     path: "{{ snapshots_backup_dir }}/{{ inventory_hostname }}"
     state: directory
     mode: 0775
-  when: ("text" in output_format or "markdown" in output_format)
+  when: ('text' in output_format) or
+        ('markdown' in output_format)
 
 - name: run show commands on remote EOS devices with text output
   eos_command:
@@ -37,8 +38,8 @@
   with_items: "{{ commands_list }}"
   failed_when: false
   register: cli_output
-  when: ("'text' in output_format") or
-        ("'markdown' in output_format")
+  when: ('text' in output_format) or
+        ('markdown' in output_format)
 
 - name: run show commands on remote EOS devices with json output
   eos_command:
@@ -48,8 +49,8 @@
   with_items: "{{ commands_list }}"
   failed_when: false
   register: cli_output_json
-  when: ("'json' in output_format") or
-        ("'yaml' in output_format")
+  when: ('json' in output_format) or
+        ('yaml' in output_format)
 
 - name: save collected commands in text files
   delegate_to: localhost
@@ -58,7 +59,7 @@
     dest: "{{ snapshots_backup_dir }}/{{ inventory_hostname }}/{{ item.item | replace('/', '_') }}.txt"
     mode: 0664
   loop: "{{ cli_output.results }}"
-  when: "'text' in output_format"
+  when: ('text' in output_format)
 
 - name: Generate json report for fabric
   delegate_to: localhost
@@ -67,7 +68,7 @@
     dest: "{{ snapshots_backup_dir }}/report.json"
     mode: 0664
   run_once: true
-  when: "'json' in output_format"
+  when: ('json' in output_format)
 
 - name: Generate yaml report for fabric
   delegate_to: localhost
@@ -76,8 +77,8 @@
     dest: "{{ snapshots_backup_dir }}/report.yaml"
     mode: 0664
   run_once: true
-  when: "'yaml' in output_format"
+  when: ('yaml' in output_format)
 
 - name: Generate markdown report for fabric
   include_tasks: "markdown.yml"
-  when: "'markdown' in output_format"
+  when: ('markdown' in output_format)

--- a/ansible_collections/arista/avd/roles/eos_snapshot/templates/fabric_json_output.j2
+++ b/ansible_collections/arista/avd/roles/eos_snapshot/templates/fabric_json_output.j2
@@ -1,7 +1,7 @@
 {# j2lint: disable=jinja-statements-delimiter #}
 {
     "devices": {
-{% for node in groups[fabric_name] | arista.avd.natural_sort %}
+{% for node in ansible_play_hosts | arista.avd.natural_sort %}
         "{{ node }}": {
 {%     for command in commands_list %}
             "{{ command | replace(" ","_") }}":

--- a/ansible_collections/arista/avd/roles/eos_snapshot/templates/fabric_yaml_output.j2
+++ b/ansible_collections/arista/avd/roles/eos_snapshot/templates/fabric_yaml_output.j2
@@ -1,5 +1,5 @@
 devices:
-{% for node in groups[fabric_name] | arista.avd.natural_sort %}
+{% for node in ansible_play_hosts | arista.avd.natural_sort %}
   {{ node }}:
 {%     for command in commands_list %}
     "{{ command }}":


### PR DESCRIPTION
## Change Summary

Update conditionals `when` on tasks as they were not being honored.
Update YAML and JSON output templates to support limit.

## Component(s) name

`arista.avd.snapshot`

## How to test

Tested with ATD environment with all output formats (one by one and all) and with and without`--limit` optionl.

## Checklist


### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
