### PR TITLE
Fix(eos_designs): remove speed from port-channel interfaces (#2463)

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-L2LEAF1A.cfg
@@ -87,11 +87,13 @@ interface Port-Channel3
 interface Ethernet1
    description DC1-LEAF2A_Ethernet7
    no shutdown
+   speed forced 10000
    channel-group 1 mode active
 !
 interface Ethernet2
    description DC1-LEAF2B_Ethernet7
    no shutdown
+   speed forced 10000
    channel-group 1 mode active
 !
 interface Ethernet3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-L2LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-L2LEAF1B.cfg
@@ -87,11 +87,13 @@ interface Port-Channel3
 interface Ethernet1
    description DC1-LEAF2A_Ethernet8
    no shutdown
+   speed forced 10000
    channel-group 1 mode active
 !
 interface Ethernet2
    description DC1-LEAF2B_Ethernet8
    no shutdown
+   speed forced 10000
    channel-group 1 mode active
 !
 interface Ethernet3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2A.cfg
@@ -209,11 +209,13 @@ interface Port-Channel141
 interface Ethernet7
    description DC1-L2LEAF1A_Ethernet1
    no shutdown
+   speed forced 10000
    channel-group 7 mode active
 !
 interface Ethernet8
    description DC1-L2LEAF1B_Ethernet1
    no shutdown
+   speed forced 10000
    channel-group 7 mode active
 !
 interface Ethernet9

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2B.cfg
@@ -209,11 +209,13 @@ interface Port-Channel141
 interface Ethernet7
    description DC1-L2LEAF1A_Ethernet2
    no shutdown
+   speed forced 10000
    channel-group 7 mode active
 !
 interface Ethernet8
    description DC1-L2LEAF1B_Ethernet2
    no shutdown
+   speed forced 10000
    channel-group 7 mode active
 !
 interface Ethernet9

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -143,6 +143,7 @@ ethernet_interfaces:
     peer_interface: Ethernet7
     peer_type: l3leaf
     description: DC1-LEAF2A_Ethernet7
+    speed: forced 10000
     shutdown: false
     type: switched
     channel_group:
@@ -153,6 +154,7 @@ ethernet_interfaces:
     peer_interface: Ethernet7
     peer_type: l3leaf
     description: DC1-LEAF2B_Ethernet7
+    speed: forced 10000
     shutdown: false
     type: switched
     channel_group:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF1B.yml
@@ -143,6 +143,7 @@ ethernet_interfaces:
     peer_interface: Ethernet8
     peer_type: l3leaf
     description: DC1-LEAF2A_Ethernet8
+    speed: forced 10000
     shutdown: false
     type: switched
     channel_group:
@@ -153,6 +154,7 @@ ethernet_interfaces:
     peer_interface: Ethernet8
     peer_type: l3leaf
     description: DC1-LEAF2B_Ethernet8
+    speed: forced 10000
     shutdown: false
     type: switched
     channel_group:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
@@ -405,6 +405,7 @@ ethernet_interfaces:
     peer_interface: Ethernet1
     peer_type: l2leaf
     description: DC1-L2LEAF1A_Ethernet1
+    speed: forced 10000
     shutdown: false
     type: switched
     channel_group:
@@ -415,6 +416,7 @@ ethernet_interfaces:
     peer_interface: Ethernet1
     peer_type: l2leaf
     description: DC1-L2LEAF1B_Ethernet1
+    speed: forced 10000
     shutdown: false
     type: switched
     channel_group:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
@@ -405,6 +405,7 @@ ethernet_interfaces:
     peer_interface: Ethernet2
     peer_type: l2leaf
     description: DC1-L2LEAF1A_Ethernet2
+    speed: forced 10000
     shutdown: false
     type: switched
     channel_group:
@@ -415,6 +416,7 @@ ethernet_interfaces:
     peer_interface: Ethernet2
     peer_type: l2leaf
     description: DC1-L2LEAF1B_Ethernet2
+    speed: forced 10000
     shutdown: false
     type: switched
     channel_group:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_FABRIC.yml
@@ -286,6 +286,7 @@ l2leaf:
   node_groups:
     DC1_L2LEAF1:
       mlag_interfaces_speed: forced 40gfull
+      uplink_interface_speed: forced 10000
       uplink_switches: [ DC1-LEAF2A, DC1-LEAF2B ]
       short_esi: 0808:0707:0606
       filter:

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/port_channel_interfaces.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/port_channel_interfaces.py
@@ -36,7 +36,6 @@ class PortChannelInterfacesMixin(UtilsMixin):
                 "description": self._avd_interface_descriptions.underlay_port_channel_interfaces(
                     link["peer"], link["peer_channel_group_id"], link.get("channel_description")
                 ),
-                "speed": link.get("speed"),
                 "type": "switched",
                 "shutdown": False,
                 "mode": "trunk",


### PR DESCRIPTION
Cherry-pick of https://github.com/aristanetworks/ansible-avd/pull/2463 for 3.8.1 release