### PR TITLE
Revert(eos_validate_state): Revert removal of error=ignore on lookups

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/tasks/main.yml
@@ -30,7 +30,7 @@
   include_vars:
     file: "{{ filename }}"
   delegate_to: localhost
-  when: structured_config is not defined and lookup('first_found', filename, skip=True)
+  when: structured_config is not defined and lookup('first_found', filename, skip=True, errors='ignore')
   vars:
     filename: "{{ structured_dir }}/{{ inventory_hostname }}.{{ avd_structured_config_file_format }}"
 

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/main.yml
@@ -8,7 +8,7 @@
     versions: "{{ lookup('pipe', 'ansible-galaxy collection list -p ' ~ collection_path ~ ' --format yaml ' ~ ansible_collection_name) | from_yaml }}"
     collection_path: "{{ (role_path | split('/'))[0:-4] | join('/') }}"
     version: "{{ versions[collection_path][ansible_collection_name].version | default('Unknown') }}"
-    git_tag: "{{ lookup('pipe', 'git -C ' ~ collection_path ~ ' describe --tags --always 2>/dev/null') }}"
+    git_tag: "{{ lookup('pipe', 'git -C ' ~ collection_path ~ ' describe --tags --always 2>/dev/null', errors='ignore') }}"
   run_once: true
   failed_when: false
 
@@ -27,7 +27,7 @@
 - name: Include device intended structure configuration variables
   include_vars: "{{ filename }}"
   delegate_to: localhost
-  when: structured_config is not defined and lookup('first_found', filename, skip=True)
+  when: structured_config is not defined and lookup('first_found', filename, skip=True, errors='ignore')
   vars:
     filename: "{{ structured_dir }}/{{ inventory_hostname }}.{{ avd_structured_config_file_format }}"
   tags:


### PR DESCRIPTION
## Change Summary

add "errors='ignore'" back to support older ansible-core versions.  This was removed as part of PR#2400 (https://github.com/aristanetworks/ansible-avd/pull/2400)

## Related Issue(s)

Fixes #2459 

## Component(s) name

`arista.avd.eos_validate_state`
`arista.avd.eos_cli_config_gen`

## Proposed changes
add errors='ignore'" statement to main.yml tasks for eos_cli_config_gen and eos_validate_state roles

## How to test
run validate state on a network using older ansible-core version (ex: 2.12.x)

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
