### PR TITLE
Feat(eos_designs): Support for custom masks in core_interfaces ip pools

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-LER1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-LER1.md
@@ -185,7 +185,7 @@ vlan 2020
 | Ethernet6 | TENANT_B_SITE_5_WAN_TEST | routed | - | 123.10.10.2/31 | TENANT_B_WAN | - | False | - | - |
 | Ethernet6.10 | TENANT_B_SITE_5 | l3dot1q | - | 192.168.48.2/31 | TENANT_B_WAN | - | False | - | - |
 | Ethernet6.100 | TENANT_B_SITE_3_OSPF | l3dot1q | - | 192.168.48.4/31 | TENANT_B_WAN | - | False | - | - |
-| Ethernet11 | P2P_LINK_TO_SITE2-LSR2_Port-Channel12 | *routed | 11 | *100.64.48.17/31 | **default | *9178 | *False | **- | **- |
+| Ethernet11 | P2P_LINK_TO_SITE2-LSR2_Port-Channel12 | *routed | 11 | *100.64.49.2/30 | **default | *9178 | *False | **- | **- |
 *Inherited from Port-Channel Interface
 
 #### IPv6
@@ -305,7 +305,7 @@ interface Ethernet11
 
 | Interface | Description | Type | MLAG ID | IP Address | VRF | MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | ---- | ------- | ---------- | --- | --- | -------- | ------ | ------- |
-| Port-Channel11 | P2P_LINK_TO_SITE2-LSR2_Port-Channel12 | routed | - | 100.64.48.17/31 | default | 9178 | False | - | - |
+| Port-Channel11 | P2P_LINK_TO_SITE2-LSR2_Port-Channel12 | routed | - | 100.64.49.2/30 | default | 9178 | False | - | - |
 
 #### ISIS
 
@@ -351,7 +351,7 @@ interface Port-Channel11
    no shutdown
    mtu 9178
    no switchport
-   ip address 100.64.48.17/31
+   ip address 100.64.49.2/30
    ipv6 enable
    mpls ip
    mpls ldp interface

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-LSR2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-LSR2.md
@@ -129,8 +129,8 @@ vlan internal order ascending range 1006 1199
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
 | Ethernet3 | P2P_LINK_TO_SITE1-LSR2_Ethernet3 | routed | - | 100.64.48.11/31 | default | 9178 | False | - | - |
-| Ethernet12 | P2P_LINK_TO_SITE2-LER1_Port-Channel11 | *routed | 12 | *100.64.48.16/31 | **default | *9178 | *False | **- | **- |
-| Ethernet13 | P2P_LINK_TO_SITE2-LER1_Port-Channel11 | *routed | 12 | *100.64.48.16/31 | **default | *9178 | *False | **- | **- |
+| Ethernet12 | P2P_LINK_TO_SITE2-LER1_Port-Channel11 | *routed | 12 | *100.64.49.1/30 | **default | *9178 | *False | **- | **- |
+| Ethernet13 | P2P_LINK_TO_SITE2-LER1_Port-Channel11 | *routed | 12 | *100.64.49.1/30 | **default | *9178 | *False | **- | **- |
 *Inherited from Port-Channel Interface
 
 #### IPv6
@@ -202,7 +202,7 @@ interface Ethernet13
 
 | Interface | Description | Type | MLAG ID | IP Address | VRF | MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | ---- | ------- | ---------- | --- | --- | -------- | ------ | ------- |
-| Port-Channel12 | P2P_LINK_TO_SITE2-LER1_Port-Channel11 | routed | - | 100.64.48.16/31 | default | 9178 | False | - | - |
+| Port-Channel12 | P2P_LINK_TO_SITE2-LER1_Port-Channel11 | routed | - | 100.64.49.1/30 | default | 9178 | False | - | - |
 
 #### ISIS
 
@@ -219,7 +219,7 @@ interface Port-Channel12
    no shutdown
    mtu 9178
    no switchport
-   ip address 100.64.48.16/31
+   ip address 100.64.49.1/30
    ipv6 enable
    mpls ip
    mpls ldp interface

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE2-LER1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE2-LER1.cfg
@@ -63,7 +63,7 @@ interface Port-Channel11
    no shutdown
    mtu 9178
    no switchport
-   ip address 100.64.48.17/31
+   ip address 100.64.49.2/30
    ipv6 enable
    mpls ip
    mpls ldp interface

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE2-LSR2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE2-LSR2.cfg
@@ -20,7 +20,7 @@ interface Port-Channel12
    no shutdown
    mtu 9178
    no switchport
-   ip address 100.64.48.16/31
+   ip address 100.64.49.1/30
    ipv6 enable
    mpls ip
    mpls ldp interface

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE2-LER1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE2-LER1.yml
@@ -337,7 +337,7 @@ port_channel_interfaces:
   eos_cli: 'link-debounce time 1600
 
     '
-  ip_address: 100.64.48.17/31
+  ip_address: 100.64.49.2/30
   ipv6_enable: true
   isis_enable: CORE
   isis_metric: 60

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE2-LSR2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE2-LSR2.yml
@@ -130,7 +130,7 @@ port_channel_interfaces:
   eos_cli: 'link-debounce time 1600
 
     '
-  ip_address: 100.64.48.16/31
+  ip_address: 100.64.49.1/30
   ipv6_enable: true
   isis_enable: CUSTOM_NAME
   isis_metric: 60

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/inventory/group_vars/MPLS_CORE.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/inventory/group_vars/MPLS_CORE.yml
@@ -163,6 +163,9 @@ core_interfaces:
   p2p_links_ip_pools:
     - name: underlay_pool
       ipv4_pool: 100.64.48.0/24
+    - name: underlay_pool_custom_mask
+      ipv4_pool: 100.64.49.0/24
+      prefix_size: 30
   p2p_links_profiles:
     - name: default_bb_profile
       speed: "forced 40gfull"
@@ -228,7 +231,7 @@ core_interfaces:
       profile: default_bb_profile
 
     - nodes: [ SITE2-LSR2, SITE2-LER1 ]
-      id: 9
+      id: 1
       port_channel:
         mode: active
         nodes_child_interfaces:
@@ -237,3 +240,4 @@ core_interfaces:
       profile: default_bb_profile
       raw_eos_cli: |
         link-debounce time 1600
+      ip_pool: underlay_pool_custom_mask

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/core-interfaces-BETA.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/core-interfaces-BETA.md
@@ -16,6 +16,7 @@ core_interfaces:
   p2p_links_ip_pools:
     - name: < p2p_pool_name_1 >
       ipv4_pool: < IPv4_address/Mask >
+      prefix_size: < subnet mask size | default -> 31 >
   p2p_links_profiles:
     - name: < p2p_profile_name >
       < any variable supported under p2p_links can be inherited from a profile >

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/core_interfaces/utils.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/core_interfaces/utils.py
@@ -161,12 +161,14 @@ class UtilsMixin:
             return p2p_link
         else:
             # Resolving subnet from pool
-            ip_pool = get_item(self._p2p_links_ip_pools, "name", p2p_link["ip_pool"], default={}).get("ipv4_pool")
+            ip_pool = get_item(self._p2p_links_ip_pools, "name", p2p_link["ip_pool"], default={})
+            ip_pool_subnet = ip_pool.get("ipv4_pool")
             if not ip_pool:
                 # Not possible to resolve from pool. Returning original
                 return p2p_link
+            prefix_size = int(ip_pool.get("prefix_size", 31))
             id = int(p2p_link["id"])
-            subnet = list(islice(ip_network(ip_pool).subnets(new_prefix=31), id - 1, id))[0]
+            subnet = list(islice(ip_network(ip_pool_subnet).subnets(new_prefix=prefix_size), id - 1, id))[0]
 
         # hosts() return an iterator of all hosts in subnet.
         # islice() return a generator with only the first two iterations of hosts.

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/core_interfaces/utils.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/core_interfaces/utils.py
@@ -163,12 +163,11 @@ class UtilsMixin:
             # Resolving subnet from pool
             ip_pool = get_item(self._p2p_links_ip_pools, "name", p2p_link["ip_pool"], default={})
             ip_pool_subnet = ip_pool.get("ipv4_pool")
-            if not ip_pool:
-                # Not possible to resolve from pool. Returning original
+            if not ip_pool_subnet:
                 return p2p_link
             prefix_size = int(ip_pool.get("prefix_size", 31))
-            id = int(p2p_link["id"])
-            subnet = list(islice(ip_network(ip_pool_subnet).subnets(new_prefix=prefix_size), id - 1, id))[0]
+            link_id = int(p2p_link["id"])
+            subnet = list(islice(ip_network(ip_pool_subnet).subnets(new_prefix=prefix_size), link_id - 1, link_id))[0]
 
         # hosts() return an iterator of all hosts in subnet.
         # islice() return a generator with only the first two iterations of hosts.

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/l3_edge/utils.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/l3_edge/utils.py
@@ -171,8 +171,8 @@ class UtilsMixin:
             if not ip_pool_subnet:
                 return p2p_link
             prefix_size = int(ip_pool.get("prefix_size", 31))
-            id = int(p2p_link["id"])
-            subnet = list(islice(ip_network(ip_pool_subnet).subnets(new_prefix=prefix_size), id - 1, id))[0]
+            link_id = int(p2p_link["id"])
+            subnet = list(islice(ip_network(ip_pool_subnet).subnets(new_prefix=prefix_size), link_id - 1, link_id))[0]
 
         # hosts() return an iterator of all hosts in subnet.
         # islice() return a generator with only the first two iterations of hosts.


### PR DESCRIPTION
## Change Summary

Add support for custom subnet masks in eos_desings core_interfaces ip pools

## Related Issue(s)
none

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
```yaml
core_interfaces:
  p2p_links_ip_pools:
    - name: < p2p_pool_name_1 >
      prefix_size: < subnet mask size | default -> 31 >
```

## How to test
See molecule test MPLS-CORE.yml

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
