### PR TITLE
Fix(eos_cli_config_gen): Fix the router_multicast vrfs indentation

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-multicast.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-multicast.md
@@ -122,14 +122,14 @@ router multicast
       routing
       multipath deterministic router-id
       software-forwarding sfe
-      !
-      vrf MCAST_VRF1
-         ipv4
-            routing
-      !
-      vrf MCAST_VRF2
-         ipv4
-            routing
+   !
+   vrf MCAST_VRF1
+      ipv4
+         routing
+   !
+   vrf MCAST_VRF2
+      ipv4
+         routing
 ```
 
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-multicast.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-multicast.cfg
@@ -21,13 +21,13 @@ router multicast
       routing
       multipath deterministic router-id
       software-forwarding sfe
-      !
-      vrf MCAST_VRF1
-         ipv4
-            routing
-      !
-      vrf MCAST_VRF2
-         ipv4
-            routing
+   !
+   vrf MCAST_VRF1
+      ipv4
+         routing
+   !
+   vrf MCAST_VRF2
+      ipv4
+         routing
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/router-multicast.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/router-multicast.md
@@ -109,14 +109,14 @@ router multicast
       routing
       multipath deterministic router-id
       software-forwarding sfe
-      !
-      vrf MCAST_VRF1
-         ipv4
-            routing
-      !
-      vrf MCAST_VRF2
-         ipv4
-            routing
+   !
+   vrf MCAST_VRF1
+      ipv4
+         routing
+   !
+   vrf MCAST_VRF2
+      ipv4
+         routing
 ```
 
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/router-multicast.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/router-multicast.cfg
@@ -17,13 +17,13 @@ router multicast
       routing
       multipath deterministic router-id
       software-forwarding sfe
-      !
-      vrf MCAST_VRF1
-         ipv4
-            routing
-      !
-      vrf MCAST_VRF2
-         ipv4
-            routing
+   !
+   vrf MCAST_VRF1
+      ipv4
+         routing
+   !
+   vrf MCAST_VRF2
+      ipv4
+         routing
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF1A.cfg
@@ -1110,34 +1110,34 @@ router multicast
    ipv4
       routing
       software-forwarding sfe
-      !
-      vrf TEN_C_L3_MULTICAST_ENABLED_130_131
-         ipv4
-            routing
-      !
-      vrf TEN_C_L3_MULTICAST_ENABLED_230_DISABLED_231
-         ipv4
-            routing
-      !
-      vrf TEN_D_L3_MULTICAST_ENABLED_140_DISABLED_141
-         ipv4
-            routing
-      !
-      vrf TEN_E_L3_MULTICAST_ENABLED_PEG_OVERRIDE
-         ipv4
-            routing
-      !
-      vrf TEN_E_L3_MULTICAST_EVPN_PEG_RP_NODES
-         ipv4
-            routing
-      !
-      vrf TEN_E_L3_MULTICAST_TRANSIT
-         ipv4
-            routing
-      !
-      vrf TEN_E_PEG_L3_MULTICAST_ENABLED
-         ipv4
-            routing
+   !
+   vrf TEN_C_L3_MULTICAST_ENABLED_130_131
+      ipv4
+         routing
+   !
+   vrf TEN_C_L3_MULTICAST_ENABLED_230_DISABLED_231
+      ipv4
+         routing
+   !
+   vrf TEN_D_L3_MULTICAST_ENABLED_140_DISABLED_141
+      ipv4
+         routing
+   !
+   vrf TEN_E_L3_MULTICAST_ENABLED_PEG_OVERRIDE
+      ipv4
+         routing
+   !
+   vrf TEN_E_L3_MULTICAST_EVPN_PEG_RP_NODES
+      ipv4
+         routing
+   !
+   vrf TEN_E_L3_MULTICAST_TRANSIT
+      ipv4
+         routing
+   !
+   vrf TEN_E_PEG_L3_MULTICAST_ENABLED
+      ipv4
+         routing
 !
 router pim sparse-mode
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF1B.cfg
@@ -1110,34 +1110,34 @@ router multicast
    ipv4
       routing
       software-forwarding sfe
-      !
-      vrf TEN_C_L3_MULTICAST_ENABLED_130_131
-         ipv4
-            routing
-      !
-      vrf TEN_C_L3_MULTICAST_ENABLED_230_DISABLED_231
-         ipv4
-            routing
-      !
-      vrf TEN_D_L3_MULTICAST_ENABLED_140_DISABLED_141
-         ipv4
-            routing
-      !
-      vrf TEN_E_L3_MULTICAST_ENABLED_PEG_OVERRIDE
-         ipv4
-            routing
-      !
-      vrf TEN_E_L3_MULTICAST_EVPN_PEG_RP_NODES
-         ipv4
-            routing
-      !
-      vrf TEN_E_L3_MULTICAST_TRANSIT
-         ipv4
-            routing
-      !
-      vrf TEN_E_PEG_L3_MULTICAST_ENABLED
-         ipv4
-            routing
+   !
+   vrf TEN_C_L3_MULTICAST_ENABLED_130_131
+      ipv4
+         routing
+   !
+   vrf TEN_C_L3_MULTICAST_ENABLED_230_DISABLED_231
+      ipv4
+         routing
+   !
+   vrf TEN_D_L3_MULTICAST_ENABLED_140_DISABLED_141
+      ipv4
+         routing
+   !
+   vrf TEN_E_L3_MULTICAST_ENABLED_PEG_OVERRIDE
+      ipv4
+         routing
+   !
+   vrf TEN_E_L3_MULTICAST_EVPN_PEG_RP_NODES
+      ipv4
+         routing
+   !
+   vrf TEN_E_L3_MULTICAST_TRANSIT
+      ipv4
+         routing
+   !
+   vrf TEN_E_PEG_L3_MULTICAST_ENABLED
+      ipv4
+         routing
 !
 router pim sparse-mode
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF2A.cfg
@@ -856,34 +856,34 @@ router multicast
    ipv4
       routing
       software-forwarding sfe
-      !
-      vrf TEN_C_L3_MULTICAST_ENABLED_130_131
-         ipv4
-            routing
-      !
-      vrf TEN_C_L3_MULTICAST_ENABLED_230_DISABLED_231
-         ipv4
-            routing
-      !
-      vrf TEN_D_L3_MULTICAST_ENABLED_140_DISABLED_141
-         ipv4
-            routing
-      !
-      vrf TEN_E_L3_MULTICAST_ENABLED_PEG_OVERRIDE
-         ipv4
-            routing
-      !
-      vrf TEN_E_L3_MULTICAST_EVPN_PEG_RP_NODES
-         ipv4
-            routing
-      !
-      vrf TEN_E_L3_MULTICAST_TRANSIT
-         ipv4
-            routing
-      !
-      vrf TEN_E_PEG_L3_MULTICAST_ENABLED
-         ipv4
-            routing
+   !
+   vrf TEN_C_L3_MULTICAST_ENABLED_130_131
+      ipv4
+         routing
+   !
+   vrf TEN_C_L3_MULTICAST_ENABLED_230_DISABLED_231
+      ipv4
+         routing
+   !
+   vrf TEN_D_L3_MULTICAST_ENABLED_140_DISABLED_141
+      ipv4
+         routing
+   !
+   vrf TEN_E_L3_MULTICAST_ENABLED_PEG_OVERRIDE
+      ipv4
+         routing
+   !
+   vrf TEN_E_L3_MULTICAST_EVPN_PEG_RP_NODES
+      ipv4
+         routing
+   !
+   vrf TEN_E_L3_MULTICAST_TRANSIT
+      ipv4
+         routing
+   !
+   vrf TEN_E_PEG_L3_MULTICAST_ENABLED
+      ipv4
+         routing
 !
 router pim sparse-mode
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF3A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF3A.cfg
@@ -882,34 +882,34 @@ router multicast
    ipv4
       routing
       software-forwarding sfe
-      !
-      vrf TEN_C_L3_MULTICAST_ENABLED_130_131
-         ipv4
-            routing
-      !
-      vrf TEN_C_L3_MULTICAST_ENABLED_230_DISABLED_231
-         ipv4
-            routing
-      !
-      vrf TEN_D_L3_MULTICAST_ENABLED_140_DISABLED_141
-         ipv4
-            routing
-      !
-      vrf TEN_E_L3_MULTICAST_ENABLED_PEG_OVERRIDE
-         ipv4
-            routing
-      !
-      vrf TEN_E_L3_MULTICAST_EVPN_PEG_RP_NODES
-         ipv4
-            routing
-      !
-      vrf TEN_E_L3_MULTICAST_TRANSIT
-         ipv4
-            routing
-      !
-      vrf TEN_E_PEG_L3_MULTICAST_ENABLED
-         ipv4
-            routing
+   !
+   vrf TEN_C_L3_MULTICAST_ENABLED_130_131
+      ipv4
+         routing
+   !
+   vrf TEN_C_L3_MULTICAST_ENABLED_230_DISABLED_231
+      ipv4
+         routing
+   !
+   vrf TEN_D_L3_MULTICAST_ENABLED_140_DISABLED_141
+      ipv4
+         routing
+   !
+   vrf TEN_E_L3_MULTICAST_ENABLED_PEG_OVERRIDE
+      ipv4
+         routing
+   !
+   vrf TEN_E_L3_MULTICAST_EVPN_PEG_RP_NODES
+      ipv4
+         routing
+   !
+   vrf TEN_E_L3_MULTICAST_TRANSIT
+      ipv4
+         routing
+   !
+   vrf TEN_E_PEG_L3_MULTICAST_ENABLED
+      ipv4
+         routing
 !
 router pim sparse-mode
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF3B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF3B.cfg
@@ -882,34 +882,34 @@ router multicast
    ipv4
       routing
       software-forwarding sfe
-      !
-      vrf TEN_C_L3_MULTICAST_ENABLED_130_131
-         ipv4
-            routing
-      !
-      vrf TEN_C_L3_MULTICAST_ENABLED_230_DISABLED_231
-         ipv4
-            routing
-      !
-      vrf TEN_D_L3_MULTICAST_ENABLED_140_DISABLED_141
-         ipv4
-            routing
-      !
-      vrf TEN_E_L3_MULTICAST_ENABLED_PEG_OVERRIDE
-         ipv4
-            routing
-      !
-      vrf TEN_E_L3_MULTICAST_EVPN_PEG_RP_NODES
-         ipv4
-            routing
-      !
-      vrf TEN_E_L3_MULTICAST_TRANSIT
-         ipv4
-            routing
-      !
-      vrf TEN_E_PEG_L3_MULTICAST_ENABLED
-         ipv4
-            routing
+   !
+   vrf TEN_C_L3_MULTICAST_ENABLED_130_131
+      ipv4
+         routing
+   !
+   vrf TEN_C_L3_MULTICAST_ENABLED_230_DISABLED_231
+      ipv4
+         routing
+   !
+   vrf TEN_D_L3_MULTICAST_ENABLED_140_DISABLED_141
+      ipv4
+         routing
+   !
+   vrf TEN_E_L3_MULTICAST_ENABLED_PEG_OVERRIDE
+      ipv4
+         routing
+   !
+   vrf TEN_E_L3_MULTICAST_EVPN_PEG_RP_NODES
+      ipv4
+         routing
+   !
+   vrf TEN_E_L3_MULTICAST_TRANSIT
+      ipv4
+         routing
+   !
+   vrf TEN_E_PEG_L3_MULTICAST_ENABLED
+      ipv4
+         routing
 !
 router pim sparse-mode
    !

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-multicast.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-multicast.j2
@@ -27,13 +27,13 @@ router multicast
 {%         endif %}
 {%     endif %}
 {%     for vrf in router_multicast.vrfs | arista.avd.natural_sort('name') %}
-      !
-      vrf {{ vrf.name }}
+   !
+   vrf {{ vrf.name }}
 {%         if vrf.ipv4 is arista.avd.defined %}
-         ipv4
+      ipv4
 {%         endif %}
 {%         if vrf.ipv4.routing is arista.avd.defined(true) %}
-            routing
+         routing
 {%         endif %}
 {%     endfor %}
 {% endif %}


### PR DESCRIPTION
## Change Summary

Fix the router_multicast.vrfs configuration indentation

## Related Issue(s)

Fixes #2474 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

## How to test

All molecule tests should pass or run locally

`make refresh-facts`


## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
