### PR TITLE
CI: Bump isort to 5.12.0 to address isort issue 2077 (#2475)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
   #   -   id: autopep8
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         name: Check for changes when running isort on all python files

--- a/ansible_collections/arista/avd/docs/contribution/style-guide.md
+++ b/ansible_collections/arista/avd/docs/contribution/style-guide.md
@@ -10,7 +10,7 @@ Furthermore the CI Pipeline (& pre-commit) for AVD enforces:
 
 - Maximum line length 160
 - [Black](https://black.readthedocs.io/en/stable/index.html) version 22.8.0
-- [isort](https://pycqa.github.io/isort/) version 5.10.1
+- [isort](https://pycqa.github.io/isort/) version 5.12.0
 - [Flake-8](https://flake8.pycqa.org/en/4.0.1/index.html) version 4.0.1
 - [pylint](https://pylint.pycqa.org/en/2.6/) version 2.6.0
 

--- a/ansible_collections/arista/avd/requirements-dev.txt
+++ b/ansible_collections/arista/avd/requirements-dev.txt
@@ -17,5 +17,5 @@ md_toc
 natsort
 jsonschema>=4.5.1
 deepmerge>=1.0.1
-isort==5.10.1
+isort==5.12.0
 black==22.8.0


### PR DESCRIPTION
Cherry-pick of https://github.com/aristanetworks/ansible-avd/pull/2475 for 3.8.x train