### PR TITLE
Fix(eos_cli_config_gen): Correct schema min values for terminal length/width

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -3802,7 +3802,7 @@ boot:
 ```yaml
 terminal:
   length: < 0-32767 >
-  width: < 0-32767 >
+  width: < 10-32767 >
 ```
 
 ### Traffic Policies

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
@@ -3283,7 +3283,7 @@ spanning_tree:
 ```yaml
 terminal:
   length: < 0-32767 >
-  width: < 0-32767 >
+  width: < 10-32767 >
 ```
 
 ### Traffic Policies

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -6132,8 +6132,8 @@ tcam_profile:
 | Variable | Type | Required | Default | Value Restrictions | Description |
 | -------- | ---- | -------- | ------- | ------------------ | ----------- |
 | [<samp>terminal</samp>](## "terminal") | Dictionary |  |  |  |  |
-| [<samp>&nbsp;&nbsp;length</samp>](## "terminal.length") | Integer |  |  | Min: 1<br>Max: 32767 |  |
-| [<samp>&nbsp;&nbsp;width</samp>](## "terminal.width") | Integer |  |  | Min: 1<br>Max: 32767 |  |
+| [<samp>&nbsp;&nbsp;length</samp>](## "terminal.length") | Integer |  |  | Min: 0<br>Max: 32767 |  |
+| [<samp>&nbsp;&nbsp;width</samp>](## "terminal.width") | Integer |  |  | Min: 10<br>Max: 32767 |  |
 
 ### YAML
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -13693,13 +13693,13 @@
       "properties": {
         "length": {
           "type": "integer",
-          "minimum": 1,
+          "minimum": 0,
           "maximum": 32767,
           "title": "Length"
         },
         "width": {
           "type": "integer",
-          "minimum": 1,
+          "minimum": 10,
           "maximum": 32767,
           "title": "Width"
         }

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -9264,11 +9264,11 @@ keys:
     keys:
       length:
         type: int
-        min: 1
+        min: 0
         max: 32767
       width:
         type: int
-        min: 1
+        min: 10
         max: 32767
   trackers:
     type: list

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/terminal.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/terminal.schema.yml
@@ -9,9 +9,9 @@ keys:
     keys:
       length:
         type: int
-        min: 1
+        min: 0
         max: 32767
       width:
         type: int
-        min: 1
+        min: 10
         max: 32767


### PR DESCRIPTION
## Change Summary

Fix for eos_cli_config_gen schema for terminal.length and width min values.

## Related Issue(s)

Fixes #2480 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Changed schema min value for terminal.length to 0
Changed schema min value for terminal.width to 10

```yaml
keys:
  terminal:
    type: dict
    display_name: Terminal Settings
    keys:
      length:
        type: int
        min: 0
        max: 32767
      width:
        type: int
        min: 10
        max: 32767
```

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
