### PR TITLE
Feat(eos_designs): Only require 'virtual_router_mac_address' when using VARP or anycast IP on SVIs

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF1A.cfg
@@ -37,8 +37,6 @@ interface Vxlan1
    vxlan source-interface Loopback1
    vxlan udp-port 4789
 !
-ip virtual-router mac-address 00:dc:00:00:00:0a
-!
 ip routing
 no ip routing vrf MGMT
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF1B.cfg
@@ -37,8 +37,6 @@ interface Vxlan1
    vxlan source-interface Loopback1
    vxlan udp-port 4789
 !
-ip virtual-router mac-address 00:dc:00:00:00:0a
-!
 ip routing
 no ip routing vrf MGMT
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF2.cfg
@@ -37,8 +37,6 @@ interface Vxlan1
    vxlan source-interface Loopback1
    vxlan udp-port 4789
 !
-ip virtual-router mac-address 00:dc:00:00:00:0a
-!
 ip routing
 no ip routing vrf MGMT
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF3A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF3A.cfg
@@ -79,8 +79,6 @@ interface Vxlan1
    vxlan virtual-router encapsulation mac-address mlag-system-id
    vxlan udp-port 4789
 !
-ip virtual-router mac-address 00:dc:00:00:00:0a
-!
 ip routing
 no ip routing vrf MGMT
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF3B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF3B.cfg
@@ -79,8 +79,6 @@ interface Vxlan1
    vxlan virtual-router encapsulation mac-address mlag-system-id
    vxlan udp-port 4789
 !
-ip virtual-router mac-address 00:dc:00:00:00:0a
-!
 ip routing
 no ip routing vrf MGMT
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF4A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF4A.cfg
@@ -79,8 +79,6 @@ interface Vxlan1
    vxlan virtual-router encapsulation mac-address mlag-system-id
    vxlan udp-port 4789
 !
-ip virtual-router mac-address 00:dc:00:00:00:0a
-!
 ip routing
 no ip routing vrf MGMT
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF4B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF4B.cfg
@@ -79,8 +79,6 @@ interface Vxlan1
    vxlan virtual-router encapsulation mac-address mlag-system-id
    vxlan udp-port 4789
 !
-ip virtual-router mac-address 00:dc:00:00:00:0a
-!
 ip routing
 no ip routing vrf MGMT
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF5A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF5A.cfg
@@ -37,8 +37,6 @@ interface Vxlan1
    vxlan source-interface Loopback1
    vxlan udp-port 4789
 !
-ip virtual-router mac-address 00:dc:00:00:00:0a
-!
 ip routing
 no ip routing vrf MGMT
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF7A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF7A.cfg
@@ -79,8 +79,6 @@ interface Vxlan1
    vxlan virtual-router encapsulation mac-address mlag-system-id
    vxlan udp-port 4789
 !
-ip virtual-router mac-address 00:dc:00:00:00:0a
-!
 ip routing
 no ip routing vrf MGMT
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF7B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF7B.cfg
@@ -79,8 +79,6 @@ interface Vxlan1
    vxlan virtual-router encapsulation mac-address mlag-system-id
    vxlan udp-port 4789
 !
-ip virtual-router mac-address 00:dc:00:00:00:0a
-!
 ip routing
 no ip routing vrf MGMT
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF8A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF8A.cfg
@@ -37,8 +37,6 @@ interface Vxlan1
    vxlan source-interface Loopback1
    vxlan udp-port 4789
 !
-ip virtual-router mac-address 00:dc:00:00:00:0a
-!
 ip routing
 no ip routing vrf MGMT
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF8B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF8B.cfg
@@ -37,8 +37,6 @@ interface Vxlan1
    vxlan source-interface Loopback1
    vxlan udp-port 4789
 !
-ip virtual-router mac-address 00:dc:00:00:00:0a
-!
 ip routing
 no ip routing vrf MGMT
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_UNGROUPED_LEAF6.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_UNGROUPED_LEAF6.cfg
@@ -37,8 +37,6 @@ interface Vxlan1
    vxlan source-interface Loopback1
    vxlan udp-port 4789
 !
-ip virtual-router mac-address 00:dc:00:00:00:0a
-!
 ip routing
 no ip routing vrf MGMT
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_NODE_TYPE_LEAF01.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_NODE_TYPE_LEAF01.cfg
@@ -51,8 +51,6 @@ interface Vxlan1
    vxlan source-interface Loopback1
    vxlan udp-port 4789
 !
-ip virtual-router mac-address 00:dc:00:00:00:0a
-!
 ip routing
 no ip routing vrf MGMT
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_NODE_TYPE_UNGROUPED_LEAF02.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_NODE_TYPE_UNGROUPED_LEAF02.cfg
@@ -51,8 +51,6 @@ interface Vxlan1
    vxlan source-interface Loopback1
    vxlan udp-port 4789
 !
-ip virtual-router mac-address 00:dc:00:00:00:0a
-!
 ip routing
 no ip routing vrf MGMT
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MLAG-OSPF-L3LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MLAG-OSPF-L3LEAF1A.cfg
@@ -98,8 +98,6 @@ interface Vxlan1
    vxlan virtual-router encapsulation mac-address mlag-system-id
    vxlan udp-port 4789
 !
-ip virtual-router mac-address 00:1c:73:00:dc:01
-!
 ip routing
 no ip routing vrf MGMT
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MLAG-OSPF-L3LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MLAG-OSPF-L3LEAF1B.cfg
@@ -98,8 +98,6 @@ interface Vxlan1
    vxlan virtual-router encapsulation mac-address mlag-system-id
    vxlan udp-port 4789
 !
-ip virtual-router mac-address 00:1c:73:00:dc:01
-!
 ip routing
 no ip routing vrf MGMT
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF1.cfg
@@ -75,8 +75,6 @@ interface Vxlan1
    vxlan vlan 3902 vni 13902
    vxlan vlan 3902 flood vtep 192.168.253.2
 !
-ip virtual-router mac-address 00:1c:73:00:dc:01
-!
 ip routing
 no ip routing vrf MGMT
 ip routing vrf TEST

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF2.cfg
@@ -75,8 +75,6 @@ interface Vxlan1
    vxlan vlan 3903 vni 13903
    vxlan vlan 3903 flood vtep 192.168.253.3
 !
-ip virtual-router mac-address 00:1c:73:00:dc:01
-!
 ip routing
 no ip routing vrf MGMT
 ip routing vrf TEST

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3A.cfg
@@ -113,8 +113,6 @@ interface Vxlan1
    vxlan vlan 3903 vni 13903
    vxlan vlan 3903 flood vtep 192.168.253.2 192.168.253.3
 !
-ip virtual-router mac-address 00:1c:73:00:dc:01
-!
 ip routing
 no ip routing vrf MGMT
 ip routing vrf TEST

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3B.cfg
@@ -113,8 +113,6 @@ interface Vxlan1
    vxlan vlan 3903 vni 13903
    vxlan vlan 3903 flood vtep 192.168.253.2 192.168.253.3
 !
-ip virtual-router mac-address 00:1c:73:00:dc:01
-!
 ip routing
 no ip routing vrf MGMT
 ip routing vrf TEST

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L3LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L3LEAF1A.cfg
@@ -106,8 +106,6 @@ interface Vxlan1
    vxlan virtual-router encapsulation mac-address mlag-system-id
    vxlan udp-port 4789
 !
-ip virtual-router mac-address 00:dc:00:00:00:0a
-!
 ip routing
 no ip routing vrf MGMT
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L3LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L3LEAF1B.cfg
@@ -93,8 +93,6 @@ interface Vxlan1
    vxlan virtual-router encapsulation mac-address mlag-system-id
    vxlan udp-port 4789
 !
-ip virtual-router mac-address 00:dc:00:00:00:0a
-!
 ip routing
 no ip routing vrf MGMT
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L3LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L3LEAF2A.cfg
@@ -83,8 +83,6 @@ interface Vxlan1
    vxlan virtual-router encapsulation mac-address mlag-system-id
    vxlan udp-port 4789
 !
-ip virtual-router mac-address 00:dc:00:00:00:0a
-!
 ip routing
 no ip routing vrf MGMT
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L3LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L3LEAF2B.cfg
@@ -83,8 +83,6 @@ interface Vxlan1
    vxlan virtual-router encapsulation mac-address mlag-system-id
    vxlan udp-port 4789
 !
-ip virtual-router mac-address 00:dc:00:00:00:0a
-!
 ip routing
 no ip routing vrf MGMT
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1A.cfg
@@ -109,8 +109,6 @@ interface Vxlan1
    vxlan virtual-router encapsulation mac-address mlag-system-id
    vxlan udp-port 4789
 !
-ip virtual-router mac-address 00:dc:00:00:00:0a
-!
 ip routing
 no ip routing vrf MGMT
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1B.cfg
@@ -109,8 +109,6 @@ interface Vxlan1
    vxlan virtual-router encapsulation mac-address mlag-system-id
    vxlan udp-port 4789
 !
-ip virtual-router mac-address 00:dc:00:00:00:0a
-!
 ip routing
 no ip routing vrf MGMT
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/bgp-peer-groups-structured-config-1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/bgp-peer-groups-structured-config-1.cfg
@@ -56,8 +56,6 @@ interface Vxlan1
    vxlan virtual-router encapsulation mac-address mlag-system-id
    vxlan udp-port 4789
 !
-ip virtual-router mac-address 00:dc:00:00:00:0a
-!
 ip routing
 no ip routing vrf MGMT
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/bgp-peer-groups-structured-config-2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/bgp-peer-groups-structured-config-2.cfg
@@ -56,8 +56,6 @@ interface Vxlan1
    vxlan virtual-router encapsulation mac-address mlag-system-id
    vxlan udp-port 4789
 !
-ip virtual-router mac-address 00:dc:00:00:00:0a
-!
 ip routing
 no ip routing vrf MGMT
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/bgp-peer-groups-structured-config-3.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/bgp-peer-groups-structured-config-3.cfg
@@ -21,8 +21,6 @@ interface Loopback0
    isis passive
    node-segment ipv4 index 206
 !
-ip virtual-router mac-address 00:dc:00:00:00:0a
-!
 ip routing
 no ip routing vrf MGMT
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-leaf1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-leaf1.cfg
@@ -131,8 +131,6 @@ interface Vxlan1
    vxlan vlan 11 vni 10011
    vxlan vrf VRF1 vni 1
 !
-ip virtual-router mac-address 00:1c:73:00:00:99
-!
 ip routing
 no ip routing vrf MGMT
 ip routing vrf VRF1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-leaf2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-leaf2.cfg
@@ -112,8 +112,6 @@ interface Vxlan1
    vxlan vlan 11 vni 10011
    vxlan vrf VRF1 vni 1
 !
-ip virtual-router mac-address 00:1c:73:00:00:99
-!
 ip routing
 no ip routing vrf MGMT
 ip routing vrf VRF1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF1A.yml
@@ -91,7 +91,6 @@ router_bfd:
     multiplier: 3
 ip_igmp_snooping:
   globally_enabled: true
-ip_virtual_router_mac_address: 00:dc:00:00:00:0a
 vxlan_interface:
   Vxlan1:
     description: AUTO_BGP_ASN_LEAF1A_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF1B.yml
@@ -91,7 +91,6 @@ router_bfd:
     multiplier: 3
 ip_igmp_snooping:
   globally_enabled: true
-ip_virtual_router_mac_address: 00:dc:00:00:00:0a
 vxlan_interface:
   Vxlan1:
     description: AUTO_BGP_ASN_LEAF1B_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF2.yml
@@ -91,7 +91,6 @@ router_bfd:
     multiplier: 3
 ip_igmp_snooping:
   globally_enabled: true
-ip_virtual_router_mac_address: 00:dc:00:00:00:0a
 vxlan_interface:
   Vxlan1:
     description: AUTO_BGP_ASN_LEAF2_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF3A.yml
@@ -174,7 +174,6 @@ router_bfd:
     multiplier: 3
 ip_igmp_snooping:
   globally_enabled: true
-ip_virtual_router_mac_address: 00:dc:00:00:00:0a
 vxlan_interface:
   Vxlan1:
     description: AUTO_BGP_ASN_LEAF3A_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF3B.yml
@@ -174,7 +174,6 @@ router_bfd:
     multiplier: 3
 ip_igmp_snooping:
   globally_enabled: true
-ip_virtual_router_mac_address: 00:dc:00:00:00:0a
 vxlan_interface:
   Vxlan1:
     description: AUTO_BGP_ASN_LEAF3B_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF4A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF4A.yml
@@ -174,7 +174,6 @@ router_bfd:
     multiplier: 3
 ip_igmp_snooping:
   globally_enabled: true
-ip_virtual_router_mac_address: 00:dc:00:00:00:0a
 vxlan_interface:
   Vxlan1:
     description: AUTO_BGP_ASN_LEAF4A_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF4B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF4B.yml
@@ -174,7 +174,6 @@ router_bfd:
     multiplier: 3
 ip_igmp_snooping:
   globally_enabled: true
-ip_virtual_router_mac_address: 00:dc:00:00:00:0a
 vxlan_interface:
   Vxlan1:
     description: AUTO_BGP_ASN_LEAF4B_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF5A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF5A.yml
@@ -91,7 +91,6 @@ router_bfd:
     multiplier: 3
 ip_igmp_snooping:
   globally_enabled: true
-ip_virtual_router_mac_address: 00:dc:00:00:00:0a
 vxlan_interface:
   Vxlan1:
     description: AUTO_BGP_ASN_LEAF5A_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF7A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF7A.yml
@@ -174,7 +174,6 @@ router_bfd:
     multiplier: 3
 ip_igmp_snooping:
   globally_enabled: true
-ip_virtual_router_mac_address: 00:dc:00:00:00:0a
 vxlan_interface:
   Vxlan1:
     description: AUTO_BGP_ASN_LEAF7A_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF7B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF7B.yml
@@ -174,7 +174,6 @@ router_bfd:
     multiplier: 3
 ip_igmp_snooping:
   globally_enabled: true
-ip_virtual_router_mac_address: 00:dc:00:00:00:0a
 vxlan_interface:
   Vxlan1:
     description: AUTO_BGP_ASN_LEAF7B_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF8A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF8A.yml
@@ -91,7 +91,6 @@ router_bfd:
     multiplier: 3
 ip_igmp_snooping:
   globally_enabled: true
-ip_virtual_router_mac_address: 00:dc:00:00:00:0a
 vxlan_interface:
   Vxlan1:
     description: AUTO_BGP_ASN_LEAF8A_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF8B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF8B.yml
@@ -91,7 +91,6 @@ router_bfd:
     multiplier: 3
 ip_igmp_snooping:
   globally_enabled: true
-ip_virtual_router_mac_address: 00:dc:00:00:00:0a
 vxlan_interface:
   Vxlan1:
     description: AUTO_BGP_ASN_LEAF8B_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_UNGROUPED_LEAF6.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_UNGROUPED_LEAF6.yml
@@ -91,7 +91,6 @@ router_bfd:
     multiplier: 3
 ip_igmp_snooping:
   globally_enabled: true
-ip_virtual_router_mac_address: 00:dc:00:00:00:0a
 vxlan_interface:
   Vxlan1:
     description: AUTO_BGP_UNGROUPED_LEAF6_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_NODE_TYPE_LEAF01.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_NODE_TYPE_LEAF01.yml
@@ -127,7 +127,6 @@ router_bfd:
     multiplier: 3
 ip_igmp_snooping:
   globally_enabled: true
-ip_virtual_router_mac_address: 00:dc:00:00:00:0a
 vxlan_interface:
   Vxlan1:
     description: AUTO_NODE_TYPE_LEAF01_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_NODE_TYPE_UNGROUPED_LEAF02.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_NODE_TYPE_UNGROUPED_LEAF02.yml
@@ -127,7 +127,6 @@ router_bfd:
     multiplier: 3
 ip_igmp_snooping:
   globally_enabled: true
-ip_virtual_router_mac_address: 00:dc:00:00:00:0a
 vxlan_interface:
   Vxlan1:
     description: AUTO_NODE_TYPE_UNGROUPED_LEAF02_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG-OSPF-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG-OSPF-L3LEAF1A.yml
@@ -179,7 +179,6 @@ router_bfd:
     multiplier: 3
 ip_igmp_snooping:
   globally_enabled: true
-ip_virtual_router_mac_address: 00:1c:73:00:dc:01
 vxlan_interface:
   Vxlan1:
     description: MLAG-OSPF-L3LEAF1A_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG-OSPF-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG-OSPF-L3LEAF1B.yml
@@ -179,7 +179,6 @@ router_bfd:
     multiplier: 3
 ip_igmp_snooping:
   globally_enabled: true
-ip_virtual_router_mac_address: 00:1c:73:00:dc:01
 vxlan_interface:
   Vxlan1:
     description: MLAG-OSPF-L3LEAF1B_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF1.yml
@@ -76,7 +76,6 @@ vlans:
   id: 2902
 ip_igmp_snooping:
   globally_enabled: true
-ip_virtual_router_mac_address: 00:1c:73:00:dc:01
 vlan_interfaces:
 - tenant: TEST
   tags:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF2.yml
@@ -76,7 +76,6 @@ vlans:
   id: 2903
 ip_igmp_snooping:
   globally_enabled: true
-ip_virtual_router_mac_address: 00:1c:73:00:dc:01
 vlan_interfaces:
 - tenant: TEST
   tags:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3A.yml
@@ -183,7 +183,6 @@ prefix_lists:
     action: permit 192.168.253.0/24 eq 32
 ip_igmp_snooping:
   globally_enabled: true
-ip_virtual_router_mac_address: 00:1c:73:00:dc:01
 vxlan_interface:
   Vxlan1:
     description: OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3A_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3B.yml
@@ -183,7 +183,6 @@ prefix_lists:
     action: permit 192.168.253.0/24 eq 32
 ip_igmp_snooping:
   globally_enabled: true
-ip_virtual_router_mac_address: 00:1c:73:00:dc:01
 vxlan_interface:
   Vxlan1:
     description: OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3B_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF1A.yml
@@ -228,7 +228,6 @@ router_bfd:
     multiplier: 3
 ip_igmp_snooping:
   globally_enabled: true
-ip_virtual_router_mac_address: 00:dc:00:00:00:0a
 vxlan_interface:
   Vxlan1:
     description: UNDERLAY-MULTICAST-L3LEAF1A_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF1B.yml
@@ -211,7 +211,6 @@ router_bfd:
     multiplier: 3
 ip_igmp_snooping:
   globally_enabled: true
-ip_virtual_router_mac_address: 00:dc:00:00:00:0a
 vxlan_interface:
   Vxlan1:
     description: UNDERLAY-MULTICAST-L3LEAF1B_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF2A.yml
@@ -201,7 +201,6 @@ router_bfd:
     multiplier: 3
 ip_igmp_snooping:
   globally_enabled: true
-ip_virtual_router_mac_address: 00:dc:00:00:00:0a
 vxlan_interface:
   Vxlan1:
     description: UNDERLAY-MULTICAST-L3LEAF2A_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF2B.yml
@@ -201,7 +201,6 @@ router_bfd:
     multiplier: 3
 ip_igmp_snooping:
   globally_enabled: true
-ip_virtual_router_mac_address: 00:dc:00:00:00:0a
 vxlan_interface:
   Vxlan1:
     description: UNDERLAY-MULTICAST-L3LEAF2B_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1A.yml
@@ -228,7 +228,6 @@ router_bfd:
     multiplier: 3
 ip_igmp_snooping:
   globally_enabled: true
-ip_virtual_router_mac_address: 00:dc:00:00:00:0a
 vxlan_interface:
   Vxlan1:
     description: UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1A_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1B.yml
@@ -228,7 +228,6 @@ router_bfd:
     multiplier: 3
 ip_igmp_snooping:
   globally_enabled: true
-ip_virtual_router_mac_address: 00:dc:00:00:00:0a
 vxlan_interface:
   Vxlan1:
     description: UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1B_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-structured-config-1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-structured-config-1.yml
@@ -167,7 +167,6 @@ router_bfd:
     multiplier: 3
 ip_igmp_snooping:
   globally_enabled: true
-ip_virtual_router_mac_address: 00:dc:00:00:00:0a
 vxlan_interface:
   Vxlan1:
     description: bgp-peer-groups-structured-config-1_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-structured-config-2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-structured-config-2.yml
@@ -184,7 +184,6 @@ router_bfd:
     multiplier: 3
 ip_igmp_snooping:
   globally_enabled: true
-ip_virtual_router_mac_address: 00:dc:00:00:00:0a
 vxlan_interface:
   Vxlan1:
     description: bgp-peer-groups-structured-config-2_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-structured-config-3.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-structured-config-3.yml
@@ -96,4 +96,3 @@ router_bfd:
     multiplier: 3
 ip_igmp_snooping:
   globally_enabled: true
-ip_virtual_router_mac_address: 00:dc:00:00:00:0a

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-leaf1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-leaf1.yml
@@ -245,7 +245,6 @@ vlans:
   id: 11
 ip_igmp_snooping:
   globally_enabled: true
-ip_virtual_router_mac_address: 00:1c:73:00:00:99
 vlan_interfaces:
 - tenant: PTP
   description: VLAN11

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-leaf2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-leaf2.yml
@@ -221,7 +221,6 @@ vlans:
   id: 11
 ip_igmp_snooping:
   globally_enabled: true
-ip_virtual_router_mac_address: 00:1c:73:00:00:99
 vlan_interfaces:
 - tenant: PTP
   description: VLAN11

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/AUTO_BGP_ASN.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/AUTO_BGP_ASN.yml
@@ -12,7 +12,6 @@ l3leaf:
     uplink_ipv4_pool: 172.31.255.0/24
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']
     mlag_interfaces: [ Ethernet3, Ethernet4 ]
-    virtual_router_mac_address: 00:dc:00:00:00:0a
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
     mlag_peer_ipv4_pool: 10.255.252.0/24
     spanning_tree_mode: mstp

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/AUTO_NODE_TYPE.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/AUTO_NODE_TYPE.yml
@@ -34,7 +34,6 @@ l3leaf:
     uplink_ipv4_pool: 172.31.255.0/24
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']
     mlag_interfaces: [ Ethernet3, Ethernet4 ]
-    virtual_router_mac_address: 00:dc:00:00:00:0a
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
     mlag_peer_ipv4_pool: 10.255.252.0/24
     spanning_tree_mode: mstp

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/BGP_PEER_GROUPS_STRUCTURED_CONFIG.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/BGP_PEER_GROUPS_STRUCTURED_CONFIG.yml
@@ -69,7 +69,6 @@ l3leaf:
     loopback_ipv4_pool: 192.168.255.0/24
     loopback_ipv4_offset: 8
     vtep_loopback_ipv4_pool: 192.168.254.0/24
-    virtual_router_mac_address: 00:dc:00:00:00:0a
     mlag_peer_l3_vlan: 4094
     mlag_peer_ipv4_pool: 192.168.253.0/24
     mlag_interfaces: [ Ethernet3 ]
@@ -96,7 +95,6 @@ pe:
     loopback_ipv4_pool: 192.168.255.0/24
     loopback_ipv4_offset: 8
     vtep_loopback_ipv4_pool: 192.168.254.0/24
-    virtual_router_mac_address: 00:dc:00:00:00:0a
     is_type: level-1-2
     node_sid_base: 100
     isis_system_id_prefix: '0000.0002'

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/MLAG_OSPF_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/MLAG_OSPF_TESTS.yml
@@ -13,7 +13,6 @@ l3leaf:
     loopback_ipv4_pool: 192.168.255.0/24
     loopback_ipv4_offset: 32
     vtep_loopback_ipv4_pool: 192.168.254.0/24
-    virtual_router_mac_address: 00:1c:73:00:DC:01
     platform: vEOS-LAB
     uplink_switches: ["DC1-SPINE1"]
     uplink_interfaces: ["Ethernet1"]

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/OVERLAY_ROUTING_PROTOCOL_HER_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/OVERLAY_ROUTING_PROTOCOL_HER_TESTS.yml
@@ -13,7 +13,6 @@ l3leaf:
   defaults:
     loopback_ipv4_pool: 192.168.254.0/24
     vtep_loopback_ipv4_pool: 192.168.253.0/24
-    virtual_router_mac_address: 00:1c:73:00:DC:01
   nodes:
     OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF1:
       bgp_as: 65001

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/PTP_TESTS_LEAFS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/PTP_TESTS_LEAFS.yml
@@ -12,7 +12,6 @@ l3leaf:
     mlag_interfaces: ['Ethernet11', 'Ethernet12']
     mlag_peer_ipv4_pool: 10.254.1.64/27
     mlag_peer_l3_ipv4_pool: 10.254.1.96/27
-    virtual_router_mac_address: 00:1c:73:00:00:99
     spanning_tree_priority: 4096
     spanning_tree_mode: mstp
     ptp:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/UNDERLAY_MULTICAST_L3LEAFS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/UNDERLAY_MULTICAST_L3LEAFS.yml
@@ -15,7 +15,6 @@ l3leaf:
     uplink_switches: ['UNDERLAY-MULTICAST-SPINE1', 'UNDERLAY-MULTICAST-SPINE2']
     uplink_ipv4_pool: 172.31.255.0/24
     mlag_interfaces: [ Ethernet3, Ethernet4 ]
-    virtual_router_mac_address: 00:dc:00:00:00:0a
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
     mlag_peer_ipv4_pool: 10.255.252.0/24
   node_groups:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/UPLINK_MLAG_STRUCTURED_CONFIG_L3LEAFS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/UPLINK_MLAG_STRUCTURED_CONFIG_L3LEAFS.yml
@@ -20,7 +20,6 @@ l3leaf:
         ipv4:
           sparse_mode: true
     mlag_interfaces: [ Ethernet3, Ethernet4 ]
-    virtual_router_mac_address: 00:dc:00:00:00:0a
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
     mlag_peer_ipv4_pool: 10.255.252.0/24
     spanning_tree_mode: mstp

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-topology.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-topology.md
@@ -572,7 +572,7 @@ default_interfaces:
     # Spanning tree priority.
     spanning_tree_root_super: < true | false  >
 
-    # Virtual router mac address for anycast gateway | Required.
+    # Virtual router mac address for anycast gateway | Required when using VARP or Anycast IP on SVIs.
     virtual_router_mac_address: < mac address >
 ```
 

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/ip_virtual_router_mac_address.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/ip_virtual_router_mac_address.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from functools import cached_property
 
-from ansible_collections.arista.avd.plugins.plugin_utils.utils import get
-
 from .utils import UtilsMixin
 
 
@@ -18,8 +16,7 @@ class IpVirtualRouterMacAddressMixin(UtilsMixin):
         """
         Return structured config for ip_virtual_router_mac_address
         """
-        if self._network_services_l2 and self._network_services_l3:
-            mac = get(self._hostvars, "switch.virtual_router_mac_address", required=True, org_key="virtual_router_mac_address")
+        if self._network_services_l2 and self._network_services_l3 and (mac := self._virtual_router_mac_address) is not None:
             return str(mac).lower()
 
         return None

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/utils.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/utils.py
@@ -325,3 +325,7 @@ class UtilsMixin(UtilsFilteredTenantsMixin):
     @cached_property
     def _evpn_multicast(self) -> bool:
         return get(self._hostvars, "switch.evpn_multicast") is True
+
+    @cached_property
+    def _virtual_router_mac_address(self) -> str | None:
+        return get(self._hostvars, "switch.virtual_router_mac_address")

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/vlan_interfaces.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/vlan_interfaces.py
@@ -48,8 +48,6 @@ class VlanInterfacesMixin(UtilsMixin):
     def _get_vlan_interface_config_for_svi(self, svi, vrf, tenant) -> dict:
         def _check_virtual_router_mac_address(vlan_interface_config: dict, variables: list):
             """
-            Helper function
-
             Check if any variable in the list of variables is not None in vlan_interface_config
             and if it is the case, raise an Exception if virtual_router_mac_address is None
             """


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Only require 'virtual_router_mac_address' when using VARP or anycast IP on SVIs

## Related Issue(s)

Fixes #2473 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->
- Remove static requirement for `virtual_router_mac_address`
- Update docs
- Add check for mac during rendering of SVIs and emit errors accordingly
- Update molecule group_vars under `eos_designs_unit_tests` to only set the virtual mac where needed.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

- Removed the mac from the unit test groups vars where not strictly required. Still works.
- Tested with removing the mac from some of the remaining unit test group vars and saw the errors being raised.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
