### PR TITLE
Feat(eos_designs): User defined description on management interface

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_description.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_description.cfg
@@ -1,0 +1,34 @@
+!RANCID-CONTENT-TYPE: arista
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname mgmt_interface_description
+!
+no enable password
+no aaa root
+!
+vrf instance MGMT
+!
+interface Management1
+   description Custom Management Interface Description
+   no shutdown
+   vrf MGMT
+   ip address 1.1.1.2
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip route vrf MGMT 0.0.0.0/0 1.1.1.1
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_description.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_description.yml
@@ -1,0 +1,28 @@
+static_routes:
+- vrf: MGMT
+  destination_address_prefix: 0.0.0.0/0
+  gateway: 1.1.1.1
+service_routing_protocols_model: multi-agent
+ip_routing: true
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+vrfs:
+- ip_routing: false
+  name: MGMT
+management_interfaces:
+- description: Custom Management Interface Description
+  shutdown: false
+  vrf: MGMT
+  ip_address: 1.1.1.2
+  gateway: 1.1.1.1
+  type: oob
+  name: Management1
+management_api_http:
+  enable_vrfs:
+  - name: MGMT
+  enable_https: true
+ip_igmp_snooping:
+  globally_enabled: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/mgmt_interface_description.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/mgmt_interface_description.yml
@@ -1,0 +1,11 @@
+# Minimum config to only test the specific feature.
+type: l2leaf
+mgmt_interface_vrf: MGMT
+mgmt_interface_description: "Custom Management Interface Description"
+mgmt_gateway: 1.1.1.1
+l2leaf:
+  defaults:
+  nodes:
+    mgmt_interface_description:
+      mgmt_ip: 1.1.1.2
+      id: 102

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
@@ -11,6 +11,7 @@ all:
             no_mgmt_interface:
             no_mgmt_gateway:
             hardware_counters:
+            mgmt_interface_description:
         CORE_UNIT_TESTS:
           hosts:
             core-1-isis-sr-ldp:

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/management-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/management-settings.md
@@ -60,6 +60,7 @@ terminattr_disable_aaa: "< boolean | default -> false >"
 mgmt_vrf_routing: < boolean | default -> false >
 mgmt_interface: < mgmt_interface | default -> Management1 >
 mgmt_interface_vrf: < vrf_name | default -> MGMT >
+mgmt_interface_description: < description | default -> "oob_management" >
 mgmt_gateway: < IPv4 address >
 # OOB mgmt interface destination networks - override default route
 mgmt_destination_networks:

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/base/avdstructuredconfig.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/base/avdstructuredconfig.py
@@ -486,7 +486,7 @@ class AvdStructuredConfig(AvdFacts):
         if mgmt_interface is not None and self._mgmt_ip is not None and self._mgmt_interface_vrf is not None:
             return {
                 mgmt_interface: {
-                    "description": "oob_management",
+                    "description": get(self._hostvars, "mgmt_interface_description", default="oob_management"),
                     "shutdown": False,
                     "vrf": self._mgmt_interface_vrf,
                     "ip_address": self._mgmt_ip,


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
User defined descriptions on management interface

Fixes #2392 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

```yaml
mgmt_interface_description: < description | default -> "oob_management" >
```

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Added to molecule

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
