### PR TITLE
Fix(eos_designs): Fix error with dotted hostname, l2leaf and mlag

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2A.cfg
@@ -244,12 +244,12 @@ interface Ethernet13
    channel-group 13 mode active
 !
 interface Ethernet14/1
-   description DC1-L2LEAF5A_Ethernet1
+   description DC1.L2LEAF5A_Ethernet1
    no shutdown
    channel-group 141 mode active
 !
 interface Ethernet15/1
-   description DC1-L2LEAF5B_Ethernet1
+   description DC1.L2LEAF5B_Ethernet1
    no shutdown
    channel-group 141 mode active
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2B.cfg
@@ -244,12 +244,12 @@ interface Ethernet13
    channel-group 13 mode active
 !
 interface Ethernet14/1
-   description DC1-L2LEAF5A_Ethernet2
+   description DC1.L2LEAF5A_Ethernet2
    no shutdown
    channel-group 141 mode active
 !
 interface Ethernet15/1
-   description DC1-L2LEAF5B_Ethernet2
+   description DC1.L2LEAF5B_Ethernet2
    no shutdown
    channel-group 141 mode active
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1.L2LEAF5A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1.L2LEAF5A.cfg
@@ -14,7 +14,7 @@ transceiver qsfp default-mode 4x10G
 !
 service routing protocols model multi-agent
 !
-hostname DC1-L2LEAF5B
+hostname DC1.L2LEAF5A
 ip name-server vrf MGMT 8.8.8.8
 ip name-server vrf MGMT 192.168.200.5
 !
@@ -22,7 +22,7 @@ ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 !
 snmp-server contact example@example.com
-snmp-server location EOS_DESIGNS_UNIT_TESTS rackE DC1-L2LEAF5B
+snmp-server location EOS_DESIGNS_UNIT_TESTS rackE DC1.L2LEAF5A
 !
 spanning-tree mode mstp
 no spanning-tree vlan-id 4091
@@ -77,7 +77,7 @@ interface Port-Channel1
    mlag 1
 !
 interface Port-Channel3
-   description MLAG_PEER_DC1-L2LEAF5A_Po3
+   description MLAG_PEER_DC1.L2LEAF5B_Po3
    no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
@@ -85,22 +85,22 @@ interface Port-Channel3
    switchport trunk group MLAG
 !
 interface Ethernet1
-   description DC1-LEAF2A_Ethernet15/1
+   description DC1-LEAF2A_Ethernet14/1
    no shutdown
    channel-group 1 mode active
 !
 interface Ethernet2
-   description DC1-LEAF2B_Ethernet15/1
+   description DC1-LEAF2B_Ethernet14/1
    no shutdown
    channel-group 1 mode active
 !
 interface Ethernet3
-   description MLAG_PEER_DC1-L2LEAF5A_Ethernet3
+   description MLAG_PEER_DC1.L2LEAF5B_Ethernet3
    no shutdown
    channel-group 3 mode active
 !
 interface Ethernet4
-   description MLAG_PEER_DC1-L2LEAF5A_Ethernet4
+   description MLAG_PEER_DC1.L2LEAF5B_Ethernet4
    no shutdown
    channel-group 3 mode active
 !
@@ -108,14 +108,14 @@ interface Management1
    description oob_management
    no shutdown
    vrf MGMT
-   ip address 192.168.200.121/24
+   ip address 192.168.200.120/24
 !
 interface Vlan4091
    description MLAG_PEER
    no shutdown
    mtu 1500
    no autostate
-   ip address 10.255.252.27/31
+   ip address 10.255.252.26/31
 !
 ip routing
 no ip routing vrf MGMT
@@ -123,7 +123,7 @@ no ip routing vrf MGMT
 mlag configuration
    domain-id DC1_L2LEAF5
    local-interface Vlan4091
-   peer-address 10.255.252.26
+   peer-address 10.255.252.27
    peer-link Port-Channel3
    reload-delay mlag 300
    reload-delay non-mlag 330

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1.L2LEAF5B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1.L2LEAF5B.cfg
@@ -14,7 +14,7 @@ transceiver qsfp default-mode 4x10G
 !
 service routing protocols model multi-agent
 !
-hostname DC1-L2LEAF5A
+hostname DC1.L2LEAF5B
 ip name-server vrf MGMT 8.8.8.8
 ip name-server vrf MGMT 192.168.200.5
 !
@@ -22,7 +22,7 @@ ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 !
 snmp-server contact example@example.com
-snmp-server location EOS_DESIGNS_UNIT_TESTS rackE DC1-L2LEAF5A
+snmp-server location EOS_DESIGNS_UNIT_TESTS rackE DC1.L2LEAF5B
 !
 spanning-tree mode mstp
 no spanning-tree vlan-id 4091
@@ -77,7 +77,7 @@ interface Port-Channel1
    mlag 1
 !
 interface Port-Channel3
-   description MLAG_PEER_DC1-L2LEAF5B_Po3
+   description MLAG_PEER_DC1.L2LEAF5A_Po3
    no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
@@ -85,22 +85,22 @@ interface Port-Channel3
    switchport trunk group MLAG
 !
 interface Ethernet1
-   description DC1-LEAF2A_Ethernet14/1
+   description DC1-LEAF2A_Ethernet15/1
    no shutdown
    channel-group 1 mode active
 !
 interface Ethernet2
-   description DC1-LEAF2B_Ethernet14/1
+   description DC1-LEAF2B_Ethernet15/1
    no shutdown
    channel-group 1 mode active
 !
 interface Ethernet3
-   description MLAG_PEER_DC1-L2LEAF5B_Ethernet3
+   description MLAG_PEER_DC1.L2LEAF5A_Ethernet3
    no shutdown
    channel-group 3 mode active
 !
 interface Ethernet4
-   description MLAG_PEER_DC1-L2LEAF5B_Ethernet4
+   description MLAG_PEER_DC1.L2LEAF5A_Ethernet4
    no shutdown
    channel-group 3 mode active
 !
@@ -108,14 +108,14 @@ interface Management1
    description oob_management
    no shutdown
    vrf MGMT
-   ip address 192.168.200.120/24
+   ip address 192.168.200.121/24
 !
 interface Vlan4091
    description MLAG_PEER
    no shutdown
    mtu 1500
    no autostate
-   ip address 10.255.252.26/31
+   ip address 10.255.252.27/31
 !
 ip routing
 no ip routing vrf MGMT
@@ -123,7 +123,7 @@ no ip routing vrf MGMT
 mlag configuration
    domain-id DC1_L2LEAF5
    local-interface Vlan4091
-   peer-address 10.255.252.27
+   peer-address 10.255.252.26
    peer-link Port-Channel3
    reload-delay mlag 300
    reload-delay non-mlag 330

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
@@ -460,20 +460,20 @@ ethernet_interfaces:
     id: 13
     mode: active
   name: Ethernet13
-- peer: DC1-L2LEAF5A
+- peer: DC1.L2LEAF5A
   peer_interface: Ethernet1
   peer_type: l2leaf
-  description: DC1-L2LEAF5A_Ethernet1
+  description: DC1.L2LEAF5A_Ethernet1
   shutdown: false
   type: switched
   channel_group:
     id: 141
     mode: active
   name: Ethernet14/1
-- peer: DC1-L2LEAF5B
+- peer: DC1.L2LEAF5B
   peer_interface: Ethernet1
   peer_type: l2leaf
-  description: DC1-L2LEAF5B_Ethernet1
+  description: DC1.L2LEAF5B_Ethernet1
   shutdown: false
   type: switched
   channel_group:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
@@ -460,20 +460,20 @@ ethernet_interfaces:
     id: 13
     mode: active
   name: Ethernet13
-- peer: DC1-L2LEAF5A
+- peer: DC1.L2LEAF5A
   peer_interface: Ethernet2
   peer_type: l2leaf
-  description: DC1-L2LEAF5A_Ethernet2
+  description: DC1.L2LEAF5A_Ethernet2
   shutdown: false
   type: switched
   channel_group:
     id: 141
     mode: active
   name: Ethernet14/1
-- peer: DC1-L2LEAF5B
+- peer: DC1.L2LEAF5B
   peer_interface: Ethernet2
   peer_type: l2leaf
-  description: DC1-L2LEAF5B_Ethernet2
+  description: DC1.L2LEAF5B_Ethernet2
   shutdown: false
   type: switched
   channel_group:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1.L2LEAF5A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1.L2LEAF5A.yml
@@ -27,7 +27,7 @@ name_server:
   - 8.8.8.8
 snmp_server:
   contact: example@example.com
-  location: EOS_DESIGNS_UNIT_TESTS rackE DC1-L2LEAF5B
+  location: EOS_DESIGNS_UNIT_TESTS rackE DC1.L2LEAF5A
 spanning_tree:
   mode: mstp
   mst_instances:
@@ -50,7 +50,7 @@ management_interfaces:
 - description: oob_management
   shutdown: false
   vrf: MGMT
-  ip_address: 192.168.200.121/24
+  ip_address: 192.168.200.120/24
   gateway: 192.168.200.5
   type: oob
   name: Management1
@@ -95,12 +95,12 @@ vlans:
 vlan_interfaces:
 - description: MLAG_PEER
   shutdown: false
-  ip_address: 10.255.252.27/31
+  ip_address: 10.255.252.26/31
   no_autostate: true
   mtu: 1500
   name: Vlan4091
 port_channel_interfaces:
-- description: MLAG_PEER_DC1-L2LEAF5A_Po3
+- description: MLAG_PEER_DC1.L2LEAF5B_Po3
   type: switched
   shutdown: false
   vlans: 2-4094
@@ -116,20 +116,20 @@ port_channel_interfaces:
   mlag: 1
   name: Port-Channel1
 ethernet_interfaces:
-- peer: DC1-L2LEAF5A
+- peer: DC1.L2LEAF5B
   peer_interface: Ethernet3
   peer_type: mlag_peer
-  description: MLAG_PEER_DC1-L2LEAF5A_Ethernet3
+  description: MLAG_PEER_DC1.L2LEAF5B_Ethernet3
   type: switched
   shutdown: false
   channel_group:
     id: 3
     mode: active
   name: Ethernet3
-- peer: DC1-L2LEAF5A
+- peer: DC1.L2LEAF5B
   peer_interface: Ethernet4
   peer_type: mlag_peer
-  description: MLAG_PEER_DC1-L2LEAF5A_Ethernet4
+  description: MLAG_PEER_DC1.L2LEAF5B_Ethernet4
   type: switched
   shutdown: false
   channel_group:
@@ -137,9 +137,9 @@ ethernet_interfaces:
     mode: active
   name: Ethernet4
 - peer: DC1-LEAF2A
-  peer_interface: Ethernet15/1
+  peer_interface: Ethernet14/1
   peer_type: l3leaf
-  description: DC1-LEAF2A_Ethernet15/1
+  description: DC1-LEAF2A_Ethernet14/1
   shutdown: false
   type: switched
   channel_group:
@@ -147,9 +147,9 @@ ethernet_interfaces:
     mode: active
   name: Ethernet1
 - peer: DC1-LEAF2B
-  peer_interface: Ethernet15/1
+  peer_interface: Ethernet14/1
   peer_type: l3leaf
-  description: DC1-LEAF2B_Ethernet15/1
+  description: DC1-LEAF2B_Ethernet14/1
   shutdown: false
   type: switched
   channel_group:
@@ -159,7 +159,7 @@ ethernet_interfaces:
 mlag_configuration:
   domain_id: DC1_L2LEAF5
   local_interface: Vlan4091
-  peer_address: 10.255.252.26
+  peer_address: 10.255.252.27
   peer_link: Port-Channel3
   reload_delay_mlag: '300'
   reload_delay_non_mlag: '330'

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1.L2LEAF5B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1.L2LEAF5B.yml
@@ -27,7 +27,7 @@ name_server:
   - 8.8.8.8
 snmp_server:
   contact: example@example.com
-  location: EOS_DESIGNS_UNIT_TESTS rackE DC1-L2LEAF5A
+  location: EOS_DESIGNS_UNIT_TESTS rackE DC1.L2LEAF5B
 spanning_tree:
   mode: mstp
   mst_instances:
@@ -50,7 +50,7 @@ management_interfaces:
 - description: oob_management
   shutdown: false
   vrf: MGMT
-  ip_address: 192.168.200.120/24
+  ip_address: 192.168.200.121/24
   gateway: 192.168.200.5
   type: oob
   name: Management1
@@ -95,12 +95,12 @@ vlans:
 vlan_interfaces:
 - description: MLAG_PEER
   shutdown: false
-  ip_address: 10.255.252.26/31
+  ip_address: 10.255.252.27/31
   no_autostate: true
   mtu: 1500
   name: Vlan4091
 port_channel_interfaces:
-- description: MLAG_PEER_DC1-L2LEAF5B_Po3
+- description: MLAG_PEER_DC1.L2LEAF5A_Po3
   type: switched
   shutdown: false
   vlans: 2-4094
@@ -116,20 +116,20 @@ port_channel_interfaces:
   mlag: 1
   name: Port-Channel1
 ethernet_interfaces:
-- peer: DC1-L2LEAF5B
+- peer: DC1.L2LEAF5A
   peer_interface: Ethernet3
   peer_type: mlag_peer
-  description: MLAG_PEER_DC1-L2LEAF5B_Ethernet3
+  description: MLAG_PEER_DC1.L2LEAF5A_Ethernet3
   type: switched
   shutdown: false
   channel_group:
     id: 3
     mode: active
   name: Ethernet3
-- peer: DC1-L2LEAF5B
+- peer: DC1.L2LEAF5A
   peer_interface: Ethernet4
   peer_type: mlag_peer
-  description: MLAG_PEER_DC1-L2LEAF5B_Ethernet4
+  description: MLAG_PEER_DC1.L2LEAF5A_Ethernet4
   type: switched
   shutdown: false
   channel_group:
@@ -137,9 +137,9 @@ ethernet_interfaces:
     mode: active
   name: Ethernet4
 - peer: DC1-LEAF2A
-  peer_interface: Ethernet14/1
+  peer_interface: Ethernet15/1
   peer_type: l3leaf
-  description: DC1-LEAF2A_Ethernet14/1
+  description: DC1-LEAF2A_Ethernet15/1
   shutdown: false
   type: switched
   channel_group:
@@ -147,9 +147,9 @@ ethernet_interfaces:
     mode: active
   name: Ethernet1
 - peer: DC1-LEAF2B
-  peer_interface: Ethernet14/1
+  peer_interface: Ethernet15/1
   peer_type: l3leaf
-  description: DC1-LEAF2B_Ethernet14/1
+  description: DC1-LEAF2B_Ethernet15/1
   shutdown: false
   type: switched
   channel_group:
@@ -159,7 +159,7 @@ ethernet_interfaces:
 mlag_configuration:
   domain_id: DC1_L2LEAF5
   local_interface: Vlan4091
-  peer_address: 10.255.252.27
+  peer_address: 10.255.252.26
   peer_link: Port-Channel3
   reload_delay_mlag: '300'
   reload_delay_non_mlag: '330'

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_FABRIC.yml
@@ -347,10 +347,11 @@ l2leaf:
         tenants: [ Tenant_A ]
         tags: [ opzone, web, app ]
       nodes:
-        DC1-L2LEAF5A:
+        # Testing with l2 leaf in MLAG with dotted hostnames
+        DC1.L2LEAF5A:
           id: 14
           mgmt_ip: 192.168.200.120/24
-        DC1-L2LEAF5B:
+        DC1.L2LEAF5B:
           id: 15
           mgmt_ip: 192.168.200.121/24
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
@@ -262,9 +262,9 @@ all:
                           ansible_host: 192.168.200.119
                     DC1_L2LEAF5:
                       hosts:
-                        DC1-L2LEAF5A:
+                        DC1.L2LEAF5A:
                           ansible_host: 192.168.200.120
-                        DC1-L2LEAF5B:
+                        DC1.L2LEAF5B:
                           ansible_host: 192.168.200.121
                     TESTS:
                       hosts:

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_facts.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_facts.py
@@ -1588,7 +1588,13 @@ class EosDesignsFacts(AvdFacts):
                     uplink["peer_channel_description"] = self.group
 
                 if self.mlag_role == "secondary":
-                    mlag_peer_switch_facts: EosDesignsFacts = get(self._hostvars, f"avd_switch_facts.{self.mlag_peer}.switch", required=True)
+                    mlag_peer_switch_facts: EosDesignsFacts = get(
+                        self._hostvars,
+                        f"avd_switch_facts..{self.mlag_peer}..switch",
+                        required=True,
+                        separator="..",
+                        org_key=f"avd_switch_facts.{self.mlag_peer}.switch",
+                    )
 
                     uplink["channel_group_id"] = "".join(re.findall(r"\d", mlag_peer_switch_facts.uplink_interfaces[0]))
                     uplink["peer_channel_group_id"] = "".join(re.findall(r"\d", mlag_peer_switch_facts.uplink_switch_interfaces[0]))


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Fix error with dotted hostname, l2leaf and mlag

## Related Issue(s)

When having dots in the hostname for l2leafs with mlag, we see errors during eos_designs_facts phase:

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

Fix fetching of mlag peer facts for l2leafs to handle dots in hostnames. Similar to how we do it elsewhere.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Tested with customer repo.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
