### PR TITLE
Fix(eos_cli_config_gen): Add variable protection for router_bgp.as in doc template

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
@@ -12,7 +12,7 @@
 
 | BGP AS | Cluster ID |
 | ------ | --------- |
-| {{ router_bgp.as }}|  {{ router_bgp.bgp_cluster_id }} |
+| {{ router_bgp.as | arista.avd.default('-') }}|  {{ router_bgp.bgp_cluster_id }} |
 {%     endif %}
 {%     if router_bgp.bgp_defaults is arista.avd.defined or router_bgp.bgp is arista.avd.defined %}
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
@@ -7,7 +7,7 @@
 
 | BGP AS | Router ID |
 | ------ | --------- |
-| {{ router_bgp.as }}|  {{ router_bgp.router_id | arista.avd.default('-') }} |
+| {{ router_bgp.as | arista.avd.default('-') }}|  {{ router_bgp.router_id | arista.avd.default('-') }} |
 {%     if router_bgp.bgp_cluster_id is arista.avd.defined %}
 
 | BGP AS | Cluster ID |


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Add variable protection for router_bgp.as in doc template

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

Add default `'-'` value on `router_bgp.as` in doc template.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Tested with customer repo producing error for this corner case.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
