### PR TITLE
Fix!: Change uppercase CVP role vars to lower case

### DIFF
--- a/ansible_collections/arista/avd/docs/modules/inventory_to_container.rst.md
+++ b/ansible_collections/arista/avd/docs/modules/inventory_to_container.rst.md
@@ -109,22 +109,22 @@ The following options may be specified for this module:
     configlet_prefix: 'AVD'
     device_filter: ['DC1-LE']
     # destination: 'generated_vars/{{inventory_hostname}}.yml'
-  register: CVP_VARS
+  register: cvp_vars
 
 - name: 'Collecting facts from CVP {{inventory_hostname}}.'
   arista.cvp.cv_facts:
-  register: CVP_FACTS
+  register: cvp_facts
 
 - name: 'Create configlets on CVP {{inventory_hostname}}.'
   arista.cvp.cv_configlet:
-    cvp_facts: "{{CVP_FACTS.ansible_facts}}"
-    configlets: "{{CVP_VARS.CVP_CONFIGLETS}}"
+    cvp_facts: "{{ cvp_facts.ansible_facts }}"
+    configlets: "{{ cvp_vars.cvp_configlets }}"
     configlet_filter: ["AVD"]
 
 - name: "Building Container topology on {{inventory_hostname}}"
   arista.cvp.cv_container:
-    topology: '{{CVP_VARS.CVP_TOPOLOGY}}'
-    cvp_facts: '{{CVP_FACTS.ansible_facts}}'
+    topology: '{{ cvp_vars.cvp_topology }}'
+    cvp_facts: '{{ cvp_facts.ansible_facts }}'
     save_topology: true
 ```
 

--- a/ansible_collections/arista/avd/docs/release-notes/4.x.x.md
+++ b/ansible_collections/arista/avd/docs/release-notes/4.x.x.md
@@ -17,7 +17,6 @@
 Breaking changes may require modifications to the inventory or playbook. See the [Porting guide for AVD 4.x.x](../porting-guides/4.x.x.md)
 for details.
 
-<!-- list of breaking changes to come -->
 #### Change upper case CVP roles and module vars to lower case
 
 Potentially breaking in rare cases where custom logic relies on the registered vars or content of files.
@@ -25,12 +24,14 @@ The custom scripts must be updated to use the lowercase variable instead.
 
 Component(s) name
 Roles:
-* arista.avd.eos_config_deploy_cvp
-* arista.avd.cvp_configlet_upload
+
+- arista.avd.eos_config_deploy_cvp
+- arista.avd.cvp_configlet_upload
 
 Modules:
-arista.avd.inventory_to_container
-arista.avd.configlet_build_config
+
+- arista.avd.inventory_to_container
+- arista.avd.configlet_build_config
 
 The following vars are changed from uppercase to lowercase, to conform with Ansible linting requirements.
 

--- a/ansible_collections/arista/avd/docs/release-notes/4.x.x.md
+++ b/ansible_collections/arista/avd/docs/release-notes/4.x.x.md
@@ -25,8 +25,8 @@ The custom scripts must be updated to use the lowercase variable instead.
 
 Component(s) name
 Roles:
-arista.avd.eos_config_deploy_cvp
-arista.avd.cvp_configlet_upload
+* arista.avd.eos_config_deploy_cvp
+* arista.avd.cvp_configlet_upload
 
 Modules:
 arista.avd.inventory_to_container

--- a/ansible_collections/arista/avd/docs/release-notes/4.x.x.md
+++ b/ansible_collections/arista/avd/docs/release-notes/4.x.x.md
@@ -18,3 +18,30 @@ Breaking changes may require modifications to the inventory or playbook. See the
 for details.
 
 <!-- list of breaking changes to come -->
+#### Change upper case CVP roles and module vars to lower case
+
+Potentially breaking in rare cases where custom logic relies on the registered vars or content of files.
+The custom scripts must be updated to use the lowercase variable instead.
+
+Component(s) name
+Roles:
+arista.avd.eos_config_deploy_cvp
+arista.avd.cvp_configlet_upload
+
+Modules:
+arista.avd.inventory_to_container
+arista.avd.configlet_build_config
+
+The following vars are changed from uppercase to lowercase, to conform with Ansible linting requirements.
+
+```sh
+CVP_CONFIGLETS -> cvp_configlets
+CVP_CONFIGLETS_STATUS -> cvp_configlets_status
+CVP_CONTAINERS -> cvp_containers
+CVP_CONTAINER_RESULTS -> cvp_container_results
+CVP_DEVICES -> cvp_devices
+CVP_DEVICES_RESULTS -> cvp_devices_results
+CVP_FACTS -> cvp_facts
+CVP_TOPOLOGY -> cvp_topology
+CVP_VARS -> cvp_vars
+```

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/cvp/cv_server.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/cvp/cv_server.yml
@@ -1,5 +1,5 @@
 ---
-CVP_DEVICES:
+cvp_devices:
   DC1-BL1A:
     name: DC1-BL1A
     parentContainerName: DC1_BL1
@@ -72,7 +72,7 @@ CVP_DEVICES:
     configlets:
       - AVD_DC1-SPINE4
     imageBundle: []
-CVP_CONTAINERS:
+cvp_containers:
   DC1_BL1:
     parent_container: DC1_LEAFS
   DC1_FABRIC:

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/cvp/cv_server_configlets.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/cvp/cv_server_configlets.yml
@@ -1,4 +1,4 @@
-CVP_CONFIGLETS:
+cvp_configlets:
   AVD_DC1-BL1A: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr
     -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
     -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
@@ -1437,7 +1437,7 @@ CVP_CONFIGLETS:
     \     neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
     connected\n!\nmanagement api http-commands\n   protocol https\n   no shutdown\n
     \  !\n   vrf MGMT\n      no shutdown\n!\nend\n"
-CVP_TOPOLOGY:
+cvp_topology:
   DC1_BL1:
     devices:
     - DC1-BL1A

--- a/ansible_collections/arista/avd/plugins/README.md
+++ b/ansible_collections/arista/avd/plugins/README.md
@@ -397,7 +397,7 @@ Generated output ready to be used by [`arista.cvp`](https://github.com/aristanet
 
 ```yaml
 ---
-CVP_DEVICES:
+cvp_devices:
   DC1-SPINE1:
     name: DC1-SPINE1
     parentContainerName: DC1_SPINES
@@ -405,7 +405,7 @@ CVP_DEVICES:
         - DC1-AVD_DC1-SPINE1
     imageBundle: []
 
-CVP_CONTAINERS:
+cvp_containers:
   DC1_LEAF1:
     parent_container: DC1_L3LEAFS
   DC1_FABRIC:
@@ -640,7 +640,7 @@ The module arguments are:
 
 ```yaml
   # Path to Jinja2 Template file | Required
-  template: <str>
+  ansible.builtin.template: <str>
 
   # Destination path. The rendered template will be written to this file | Optional
   dest: <str>

--- a/ansible_collections/arista/avd/plugins/action/inventory_to_container.py
+++ b/ansible_collections/arista/avd/plugins/action/inventory_to_container.py
@@ -26,12 +26,12 @@ class ActionModule(ActionBase):
         result = self._execute_module(module_name="inventory_to_container", module_args=module_args, task_vars=task_vars, tmp=tmp)
 
         if not result.get("failed") and module_args.get("inventory") is None and module_args.get("container_root") is not None:
-            result["CVP_TOPOLOGY"] = self.build_cvp_topology_from_inventory(task_vars, module_args)
+            result["cvp_topology"] = self.build_cvp_topology_from_inventory(task_vars, module_args)
 
         # Write vars to file if set by user
         if (destination := module_args.get("destination")) is not None:
             # file should only contain subset of result data, so we build a smaller dict
-            file_data_keys = ["CVP_CONFIGLETS", "CVP_TOPOLOGY"]
+            file_data_keys = ["cvp_configlets", "cvp_topology"]
             file_data = {key: result[key] for key in file_data_keys if key in result}
 
             with open(destination, "w", encoding="utf8") as file:

--- a/ansible_collections/arista/avd/plugins/modules/configlet_build_config.py
+++ b/ansible_collections/arista/avd/plugins/modules/configlet_build_config.py
@@ -126,7 +126,7 @@ def main():
 
     # If set, build configlet topology
     if module.params["configlet_dir"] is not None:
-        result["CVP_CONFIGLETS"] = get_configlet(
+        result["cvp_configlets"] = get_configlet(
             src_folder=module.params["configlet_dir"], prefix=module.params["configlet_prefix"], extension=module.params["configlet_extension"]
         )
 

--- a/ansible_collections/arista/avd/plugins/modules/inventory_to_container.py
+++ b/ansible_collections/arista/avd/plugins/modules/inventory_to_container.py
@@ -71,23 +71,23 @@ EXAMPLES = r"""
     configlet_dir: 'intended_configs'
     configlet_prefix: 'AVD'
     device_filter: ['DC1-LE']
-    # destination: 'generated_vars/{{inventory_hostname}}.yml'
-  register: CVP_VARS
+    # destination: 'generated_vars/{{ inventory_hostname }}.yml'
+  register: cvp_vars
 
 - name: 'Collecting facts from CVP {{inventory_hostname}}.'
   arista.cvp.cv_facts:
-  register: CVP_FACTS
+  register: cvp_facts
 
 - name: 'Create configlets on CVP {{inventory_hostname}}.'
   arista.cvp.cv_configlet:
-    cvp_facts: "{{CVP_FACTS.ansible_facts}}"
-    configlets: "{{CVP_VARS.CVP_CONFIGLETS}}"
+    cvp_facts: "{{ cvp_facts.ansible_facts }}"
+    configlets: "{{ cvp_vars.cvp_configlets }}"
     configlet_filter: ["AVD"]
 
 - name: "Building Container topology on {{inventory_hostname}}"
   arista.cvp.cv_container:
-    topology: '{{CVP_VARS.CVP_TOPOLOGY}}'
-    cvp_facts: '{{CVP_FACTS.ansible_facts}}'
+    topology: '{{ cvp_vars.cvp_topology }}'
+    cvp_facts: '{{ cvp_facts.ansible_facts }}'
     save_topology: true
 """
 
@@ -419,13 +419,13 @@ def main():
                 inventory_content = yaml.safe_load(stream)
             except yaml.YAMLError as exc:
                 raise AnsibleValidationError("Failed to parse inventory file") from exc
-        result["CVP_TOPOLOGY"] = get_containers(
+        result["cvp_topology"] = get_containers(
             inventory_content=inventory_content, parent_container=parent_container, device_filter=module.params["device_filter"]
         )
 
     # If set, build configlet topology
     if module.params["configlet_dir"] is not None:
-        result["CVP_CONFIGLETS"] = get_configlet(
+        result["cvp_configlets"] = get_configlet(
             src_folder=module.params["configlet_dir"], prefix=module.params["configlet_prefix"], device_filter=module.params["device_filter"]
         )
 

--- a/ansible_collections/arista/avd/roles/cvp_configlet_upload/tasks/cv_collection_v1.yml
+++ b/ansible_collections/arista/avd/roles/cvp_configlet_upload/tasks/cv_collection_v1.yml
@@ -1,19 +1,19 @@
 - name: "collecting facts from CVP {{ inventory_hostname }}."
   tags: [provision, apply]
   arista.cvp.cv_facts:
-  register: CVP_FACTS
+  register: cvp_facts
 
 - name: "create configlets on CVP {{ inventory_hostname }}."
   tags: [provision, apply]
   arista.cvp.cv_configlet:
-    cvp_facts: "{{ CVP_FACTS.ansible_facts }}"
-    configlets: "{{ CVP_VARS.CVP_CONFIGLETS }}"
+    cvp_facts: "{{ cvp_facts.ansible_facts }}"
+    configlets: "{{ cvp_vars.cvp_configlets }}"
     configlet_filter: ["{{ configlets_cvp_prefix }}"]
 
 - name: "Execute pending tasks on {{ inventory_hostname }}"
   tags: [apply]
   arista.cvp.cv_task:
-    tasks: "{{ CVP_DEVICES_RESULTS.data.tasks }}"
+    tasks: "{{ cvp_devices_results.data.tasks }}"  # noqa: args[module]
     wait: 720
   when:
     - execute_tasks|bool

--- a/ansible_collections/arista/avd/roles/cvp_configlet_upload/tasks/cv_collection_v3.yml
+++ b/ansible_collections/arista/avd/roles/cvp_configlet_upload/tasks/cv_collection_v3.yml
@@ -1,11 +1,11 @@
 - name: "create configlets on CVP {{ inventory_hostname }}."
   tags: [provision, apply]
   arista.cvp.cv_configlet_v3:
-    configlets: "{{ CVP_VARS.CVP_CONFIGLETS }}"
+    configlets: "{{ cvp_vars.cvp_configlets }}"
 
 - name: "Execute pending tasks on {{ inventory_hostname }}"
   tags: [apply]
   arista.cvp.cv_task_v3:
-    tasks: "{{ CVP_DEVICES_RESULTS.tasks }}"
+    tasks: "{{ cvp_devices_results.tasks }}"
   when:
     - execute_tasks|bool

--- a/ansible_collections/arista/avd/roles/cvp_configlet_upload/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/cvp_configlet_upload/tasks/main.yml
@@ -6,7 +6,7 @@
     configlet_dir: "{{ configlet_directory }}"
     configlet_prefix: "{{ configlets_cvp_prefix }}"
     configlet_extension: "{{ file_extension }}"
-  register: CVP_VARS
+  register: cvp_vars
 
 - name: "Execute upload with collection in version {{ cv_collection }}"
   include_tasks: "cv_collection_{{ cv_collection }}.yml"

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v1/absent.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v1/absent.yml
@@ -3,7 +3,7 @@
 - name: "Collecting facts from CVP {{ inventory_hostname }}."
   tags: [reset]
   arista.cvp.cv_facts:
-  register: CVP_FACTS
+  register: cvp_facts
 
 # Load tasks when device_filter is string
 - name: Load conditional cv_device execution if device_filter is string.
@@ -20,25 +20,25 @@
 - name: "Execute pending tasks on {{ inventory_hostname }}"
   tags: [reset]
   arista.cvp.cv_task:
-    tasks: "{{ CVP_DEVICES_RESULTS.data.tasks }}"
+    tasks: "{{ cvp_devices_results.data.tasks }}"  # noqa: args[module]
     wait: 720
 
 - name: "Refreshing facts from CVP {{ inventory_hostname }}."
   tags: [reset]
   arista.cvp.cv_facts:
-  register: CVP_FACTS
+  register: cvp_facts
 
 - name: "Deleting Containers topology on {{ inventory_hostname }}"
   tags: [reset]
   arista.cvp.cv_container:
-    topology: "{{ CVP_CONTAINERS }}"
-    cvp_facts: "{{ CVP_FACTS.ansible_facts }}"
+    topology: "{{ cvp_containers }}"
+    cvp_facts: "{{ cvp_facts.ansible_facts }}"
     mode: delete
 
 - name: "Delete configlets from CVP {{ inventory_hostname }}."
   tags: [reset]
   arista.cvp.cv_configlet:
-    cvp_facts: "{{ CVP_FACTS.ansible_facts }}"
-    configlets: "{{ CVP_VARS.CVP_CONFIGLETS }}"
+    cvp_facts: "{{ cvp_facts.ansible_facts }}"
+    configlets: "{{ cvp_vars.cvp_configlets }}"
     configlet_filter: ["{{ configlets_prefix }}"]
     state: absent

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v1/cv-device-filter-list.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v1/cv-device-filter-list.yml
@@ -2,8 +2,8 @@
 - name: "Configure devices on {{ inventory_hostname }}"
   tags: [provision, apply]
   arista.cvp.cv_device:
-    devices: "{{ CVP_DEVICES }}"
-    cvp_facts: "{{ CVP_FACTS.ansible_facts }}"
+    devices: "{{ cvp_devices }}"
+    cvp_facts: "{{ cvp_facts.ansible_facts }}"
     device_filter: "{{ device_filter }}"
     state: "{{ state }}"
-  register: CVP_DEVICES_RESULTS
+  register: cvp_devices_results

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v1/cv-device-filter-string.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v1/cv-device-filter-string.yml
@@ -2,8 +2,8 @@
 - name: "Configure devices on {{ inventory_hostname }}"
   tags: [provision, apply]
   arista.cvp.cv_device:
-    devices: "{{ CVP_DEVICES }}"
-    cvp_facts: "{{ CVP_FACTS.ansible_facts }}"
+    devices: "{{ cvp_devices }}"
+    cvp_facts: "{{ cvp_facts.ansible_facts }}"
     device_filter: ["{{ device_filter }}"]
     state: "{{ state }}"
-  register: CVP_DEVICES_RESULTS
+  register: cvp_devices_results

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v1/main-filter-list.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v1/main-filter-list.yml
@@ -9,4 +9,4 @@
     configlet_prefix: "{{ configlets_prefix }}"
     destination: "{{ structured_cvp_dir }}/{{ inventory_hostname }}_configlets.yml"
     device_filter: "{{ device_filter }}"
-  register: CVP_VARS
+  register: cvp_vars

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v1/main-filter-string.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v1/main-filter-string.yml
@@ -9,4 +9,4 @@
     configlet_prefix: "{{ configlets_prefix }}"
     destination: "{{ structured_cvp_dir }}/{{ inventory_hostname }}_configlets.yml"
     device_filter: ['{{ device_filter }}']
-  register: CVP_VARS
+  register: cvp_vars

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v1/present.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v1/present.yml
@@ -3,7 +3,7 @@
 - name: "Collecting facts from CVP {{ inventory_hostname }}."
   tags: [always]
   arista.cvp.cv_facts:
-  register: CVP_FACTS
+  register: cvp_facts
 
 - name: "Execute pending tasks on {{ inventory_hostname }}"
   tags: [apply]

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v1/present.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v1/present.yml
@@ -8,37 +8,37 @@
 - name: "Execute pending tasks on {{ inventory_hostname }}"
   tags: [apply]
   arista.cvp.cv_task:
-    tasks: "{{ CVP_FACTS.ansible_facts.tasks }}"
+    tasks: "{{ cvp_facts.ansible_facts.tasks }}"  # noqa: args[module]
   when: execute_tasks|bool
 
 - name: "Create configlets on CVP {{ inventory_hostname }}."
   tags: [provision]
   arista.cvp.cv_configlet:
-    cvp_facts: "{{ CVP_FACTS.ansible_facts }}"
-    configlets: "{{ CVP_VARS.CVP_CONFIGLETS }}"
+    cvp_facts: "{{ cvp_facts.ansible_facts }}"
+    configlets: "{{ cvp_vars.cvp_configlets }}"
     configlet_filter: ["{{ configlets_prefix }}"]
-  register: CVP_CONFIGLETS_STATUS
+  register: cvp_configlets_status
 
 - name: "Execute any configlet generated tasks to update configuration on {{ inventory_hostname }}"
   tags: [apply]
   arista.cvp.cv_task:
-    tasks: "{{ CVP_CONFIGLETS_STATUS.data.tasks }}"
+    tasks: "{{ cvp_configlets_status.data.tasks }}"  # noqa: args[module]
     wait: 90
   when:
-    - CVP_CONFIGLETS_STATUS.data.tasks | length > 0
+    - cvp_configlets_status.data.tasks | length > 0
     - execute_tasks|bool
 
 - name: "Building Containers topology on {{ inventory_hostname }}"
   tags: [provision]
   arista.cvp.cv_container:
-    topology: "{{ CVP_CONTAINERS }}"
-    cvp_facts: "{{ CVP_FACTS.ansible_facts }}"
-  register: CVP_CONTAINER_RESULTS
+    topology: "{{ cvp_containers }}"
+    cvp_facts: "{{ cvp_facts.ansible_facts }}"
+  register: cvp_container_results
 
 - name: "Execute pending tasks on {{ inventory_hostname }}"
   tags: [apply]
   arista.cvp.cv_task:
-    tasks: "{{ CVP_CONTAINER_RESULTS.data.tasks }}"
+    tasks: "{{ cvp_container_results.data.tasks }}"  # noqa: args[module]
     wait: 720
   when:
     - execute_tasks|bool
@@ -46,7 +46,7 @@
 - name: "Refreshing facts from CVP {{ inventory_hostname }}."
   tags: [always]
   arista.cvp.cv_facts:
-  register: CVP_FACTS
+  register: cvp_facts
 
 # Load tasks when device_filter is string
 - name: Load conditional cv_device execution if device_filter is string.
@@ -63,7 +63,7 @@
 - name: "Execute pending tasks on {{ inventory_hostname }}"
   tags: [apply]
   arista.cvp.cv_task:
-    tasks: "{{ CVP_DEVICES_RESULTS.data.tasks }}"
+    tasks: "{{ cvp_devices_results.data.tasks }}"  # noqa: args[module]
     wait: 720
   when:
     - execute_tasks|bool

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v3/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v3/main.yml
@@ -21,7 +21,7 @@
     configlet_prefix: "{{ configlets_prefix }}"
     destination: "{{ structured_cvp_dir }}/{{ inventory_hostname }}_configlets.yml"
     device_filter: "{{ device_filter }}"
-  register: CVP_VARS
+  register: cvp_vars
 
 - name: "Build DEVICES and CONTAINER definition for {{ inventory_hostname }}"
   tags: [generate, build, provision]

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v3/present.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v3/present.yml
@@ -6,44 +6,44 @@
 - name: "Create configlets on CVP {{ inventory_hostname }}."
   tags: [provision]
   arista.cvp.cv_configlet_v3:
-    configlets: "{{ CVP_VARS.CVP_CONFIGLETS }}"
-  register: CVP_CONFIGLETS_STATUS
+    configlets: "{{ cvp_vars.cvp_configlets }}"
+  register: cvp_configlets_status
 
 - name: "Execute any configlet generated tasks to update configuration on {{ inventory_hostname }}"
   tags: [apply]
   arista.cvp.cv_task_v3:
-    tasks: "{{ CVP_CONFIGLETS_STATUS.taskIds }}"
+    tasks: "{{ cvp_configlets_status.taskIds }}"
   when:
-    - CVP_CONFIGLETS_STATUS.taskIds | length > 0
+    - cvp_configlets_status.taskIds | length > 0
     - execute_tasks|bool
 
 - name: "Building Containers topology on {{ inventory_hostname }}"
   tags: [provision, containers]
   arista.cvp.cv_container_v3:
-    topology: "{{ CVP_CONTAINERS }}"
+    topology: "{{ cvp_containers }}"
     state: present
     apply_mode: loose
-  register: CVP_CONTAINER_RESULTS
+  register: cvp_container_results
 
 - name: "Execute pending tasks on {{ inventory_hostname }}"
   tags: [apply]
   arista.cvp.cv_task_v3:
-    tasks: "{{ CVP_CONTAINER_RESULTS.taskIds }}"
+    tasks: "{{ cvp_container_results.taskIds }}"
   when:
-    - CVP_CONTAINER_RESULTS.taskIds | length > 0
+    - cvp_container_results.taskIds | length > 0
     - execute_tasks|bool
 
 - name: "Configure devices on {{ inventory_hostname }}"
   tags: [provision, apply]
   arista.cvp.cv_device_v3:
-    devices: "{{ CVP_DEVICES }}"
+    devices: "{{ cvp_devices }}"  # noqa: args[module]
     state: present
-  register: CVP_DEVICES_RESULTS
+  register: cvp_devices_results
 
 - name: "Execute pending tasks on {{ inventory_hostname }}"
   tags: [apply]
   arista.cvp.cv_task_v3:
-    tasks: "{{ CVP_DEVICES_RESULTS.taskIds }}"
+    tasks: "{{ cvp_devices_results.taskIds }}"
   when:
-    - CVP_DEVICES_RESULTS.taskIds | length > 0
+    - cvp_devices_results.taskIds | length > 0
     - execute_tasks|bool

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/templates/cvp-devices-v3.j2
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/templates/cvp-devices-v3.j2
@@ -7,13 +7,13 @@
 {% endif %}
 {% set dev_cntr = namespace(value=0) %}
 ---
-CVP_DEVICES:
+cvp_devices:
 {% for device in groups[container_root] | arista.avd.natural_sort %}
 {%     if device | arista.avd.is_in_filter(local_var.device_filter) %}
 {%         if hostvars[device]['is_deployed'] is arista.avd.defined(true) or hostvars[device]['is_deployed'] is not arista.avd.defined %}
   - fqdn: {{ device }}
 {%             set dev_cntr.value = dev_cntr.value + 1 %}
-{%             for container_name, container in CVP_VARS.CVP_TOPOLOGY.items() | arista.avd.natural_sort %}
+{%             for container_name, container in cvp_vars.cvp_topology.items() | arista.avd.natural_sort %}
 {%                 if 'devices' in container %}
 {%                     for device_container in container['devices'] %}
 {%                         if device == device_container %}
@@ -35,8 +35,8 @@ CVP_DEVICES:
 {% if dev_cntr.value == 0 %}
   []
 {% endif %}
-CVP_CONTAINERS:
-{% for container_name, container in CVP_VARS.CVP_TOPOLOGY.items() | arista.avd.natural_sort %}
+cvp_containers:
+{% for container_name, container in cvp_vars.cvp_topology.items() | arista.avd.natural_sort %}
   {{ container_name }}:
     parentContainerName: {{ container['parent_container'] }}
 {%     if hostvars[groups[container_root][0]]['cv_configlets']['containers'][container_name] is defined and hostvars[groups[container_root][0]]['cv_configlets']['containers'][container_name] is iterable %}

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/templates/cvp-devices.j2
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/templates/cvp-devices.j2
@@ -6,13 +6,13 @@
 {%     set local_var.device_filter = device_filter %}
 {% endif %}
 ---
-CVP_DEVICES:
+cvp_devices:
 {% for device in groups[container_root] | arista.avd.natural_sort %}
 {%     if device | arista.avd.is_in_filter(local_var.device_filter) %}
 {%         if (hostvars[device]['is_deployed'] is defined and hostvars[device]['is_deployed'] == true) or (hostvars[device]['is_deployed'] is not defined) %}
   {{ device }}:
     name: {{ device }}
-{%             for container_name, container in CVP_VARS.CVP_TOPOLOGY.items() | arista.avd.natural_sort %}
+{%             for container_name, container in cvp_vars.cvp_topology.items() | arista.avd.natural_sort %}
 {%                 if 'devices' in container %}
 {%                     for device_container in container['devices'] %}
 {%                         if device == device_container %}
@@ -32,8 +32,8 @@ CVP_DEVICES:
 {%         endif %}
 {%     endif %}
 {% endfor %}
-CVP_CONTAINERS:
-{% for container_name, container in CVP_VARS.CVP_TOPOLOGY.items() | arista.avd.natural_sort %}
+cvp_containers:
+{% for container_name, container in cvp_vars.cvp_topology.items() | arista.avd.natural_sort %}
   {{ container_name }}:
     parent_container: {{ container['parent_container'] }}
 {%     if hostvars[groups[container_root][0]]['cv_configlets']['containers'][container_name] is defined and hostvars[groups[container_root][0]]['cv_configlets']['containers'][container_name] is iterable %}

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/vars/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/vars/main.yml
@@ -1,8 +1,8 @@
 ---
 # vars file for eos-config-deploy-cvp
-CVP_CONFIGLET:
+cvp_configlets:
   DC1_CONFIGLET: "alias a{{ 999 | random }} show version"
 
-CVP_TOPOLOGY:
+cvp_topology:
   # Testing specific environment
   staging:

--- a/ansible_collections/arista/avd/tests/integration/targets/configlet_build_config/tests/test_blank_prefix.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/configlet_build_config/tests/test_blank_prefix.yml
@@ -15,8 +15,8 @@
     that:
       - result is success
       - result.changed == false
-      - result.CVP_CONFIGLETS != {}
+      - result.cvp_configlets != {}
       - item is defined
       - "'_' in item[0]"
       - diff_output.stdout == ""
-  with_items: "{{ result.CVP_CONFIGLETS }}"
+  with_items: "{{ result.cvp_configlets }}"

--- a/ansible_collections/arista/avd/tests/integration/targets/configlet_build_config/tests/test_with_all_parameters.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/configlet_build_config/tests/test_with_all_parameters.yml
@@ -15,8 +15,8 @@
     that:
       - result is success
       - result.changed == false
-      - result.CVP_CONFIGLETS != {}
+      - result.cvp_configlets != {}
       - diff_output.stdout == ""
       - item is defined
       - "'Prefix' in item[0:6]"
-  with_items: "{{ result.CVP_CONFIGLETS }}"
+  with_items: "{{ result.cvp_configlets }}"

--- a/ansible_collections/arista/avd/tests/integration/targets/configlet_build_config/tests/test_without_extension.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/configlet_build_config/tests/test_without_extension.yml
@@ -14,8 +14,8 @@
     that:
       - result is success
       - result.changed == false
-      - result.CVP_CONFIGLETS != {}
+      - result.cvp_configlets != {}
       - item is defined
       - "'Prefix' in item[0:6]"
       - diff_output.stdout == ""
-  with_items: "{{ result.CVP_CONFIGLETS }}"
+  with_items: "{{ result.cvp_configlets }}"

--- a/ansible_collections/arista/avd/tests/integration/targets/inventory_to_container/tests/test_with_all_parameters.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/inventory_to_container/tests/test_with_all_parameters.yml
@@ -1,12 +1,12 @@
 - name: Test with all parameters
-  register: CVP_VARS
+  register: cvp_vars
   inventory_to_container:
-        inventory: '{{ inventory_path }}/inventory.yml'
-        container_root: 'DC1_FABRIC'
-        configlet_dir: '{{ configlet_path }}'
-        configlet_prefix: 'AVD'
-        device_filter: ['DC1-LE']
-        destination: "{{ actual_output }}"
+    inventory: '{{ inventory_path }}/inventory.yml'
+    container_root: 'DC1_FABRIC'
+    configlet_dir: '{{ configlet_path }}'
+    configlet_prefix: 'AVD'
+    device_filter: ['DC1-LE']
+    destination: "{{ actual_output }}"
 
 - local_action: shell diff "{{ expected_output }}/expected_with_all_param.yml" "{{ actual_output }}"
   failed_when: "diff_output.rc > 1"
@@ -14,18 +14,18 @@
 
 - name: Validate output
   assert:
-        that:
-              - CVP_VARS is success
-              - CVP_VARS.CVP_TOPOLOGY != {}
-              - CVP_VARS.CVP_CONFIGLETS != {}
-              - item is defined
-              - "'AVD_DC1-LE' in item[0:10]"
-              - diff_output.stdout == ""
-  with_items: "{{ CVP_VARS.CVP_CONFIGLETS }}"
+    that:
+      - cvp_vars is success
+      - cvp_vars.cvp_topology != {}
+      - cvp_vars.cvp_configlets != {}
+      - item is defined
+      - "'AVD_DC1-LE' in item[0:10]"
+      - diff_output.stdout == ""
+  with_items: "{{ cvp_vars.cvp_configlets }}"
 
-- name: Validate CVP_TOPOLOGY
+- name: Validate cvp_topology
   assert:
-        that:
-              - item is defined
-              - item == "Tenant"
-  with_items: "{{ CVP_VARS.CVP_TOPOLOGY.DC1_FABRIC.parent_container }}"
+    that:
+      - item is defined
+      - item == "Tenant"
+  with_items: "{{ cvp_vars.cvp_topology.DC1_FABRIC.parent_container }}"

--- a/ansible_collections/arista/avd/tests/integration/targets/inventory_to_container/tests/test_without_configlet_dir.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/inventory_to_container/tests/test_without_configlet_dir.yml
@@ -1,11 +1,11 @@
 - name: Test without configlet_dir
-  register: CVP_VARS
+  register: cvp_vars
   inventory_to_container:
-        inventory: '{{ inventory_path }}/inventory.yml'
-        container_root: 'DC1_FABRIC'
-        configlet_prefix: 'AVD'
-        device_filter: ['DC1-LE']
-        destination: "{{ actual_output }}"
+    inventory: '{{ inventory_path }}/inventory.yml'
+    container_root: 'DC1_FABRIC'
+    configlet_prefix: 'AVD'
+    device_filter: ['DC1-LE']
+    destination: "{{ actual_output }}"
 
 - local_action: shell diff "{{ expected_output }}/expected_without_configlet_dir.yml" "{{ actual_output }}"
   failed_when: "diff_output.rc > 1"
@@ -13,10 +13,10 @@
 
 - name: Validate output
   assert:
-        that:
-              - CVP_VARS is success
-              - CVP_VARS.CVP_TOPOLOGY != {}
-              - diff_output.stdout == ""
-              - item is defined
-              - item == "Tenant"
-  with_items: "{{ CVP_VARS.CVP_TOPOLOGY.DC1_FABRIC.parent_container }}"
+    that:
+      - cvp_vars is success
+      - cvp_vars.cvp_topology != {}
+      - diff_output.stdout == ""
+      - item is defined
+      - item == "Tenant"
+  with_items: "{{ cvp_vars.cvp_topology.DC1_FABRIC.parent_container }}"

--- a/ansible_collections/arista/avd/tests/integration/targets/inventory_to_container/tests/test_without_configlet_prefix.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/inventory_to_container/tests/test_without_configlet_prefix.yml
@@ -1,11 +1,11 @@
 - name: Test without configlet prefix
-  register: CVP_VARS
+  register: cvp_vars
   inventory_to_container:
-        inventory: '{{ inventory_path }}/inventory.yml'
-        container_root: 'DC1_FABRIC'
-        configlet_dir: '{{ configlet_path }}'
-        device_filter: ['DC1-LE']
-        destination: "{{ actual_output }}"
+    inventory: '{{ inventory_path }}/inventory.yml'
+    container_root: 'DC1_FABRIC'
+    configlet_dir: '{{ configlet_path }}'
+    device_filter: ['DC1-LE']
+    destination: "{{ actual_output }}"
 
 - local_action: shell diff "{{ expected_output }}/expected_with_all_param.yml" "{{ actual_output }}"
   failed_when: "diff_output.rc > 1"
@@ -13,18 +13,18 @@
 
 - name: Validate output
   assert:
-        that:
-              - CVP_VARS is success
-              - CVP_VARS.CVP_TOPOLOGY != {}
-              - CVP_VARS.CVP_CONFIGLETS != {}
-              - item is defined
-              - diff_output.stdout == ""
-              - "'AVD_DC1-LE' in item[0:10]"
-  with_items: "{{ CVP_VARS.CVP_CONFIGLETS }}"
+    that:
+      - cvp_vars is success
+      - cvp_vars.cvp_topology != {}
+      - cvp_vars.cvp_configlets != {}
+      - item is defined
+      - diff_output.stdout == ""
+      - "'AVD_DC1-LE' in item[0:10]"
+  with_items: "{{ cvp_vars.cvp_configlets }}"
 
-- name: Validate CVP_TOPOLOGY
+- name: Validate cvp_topology
   assert:
-        that:
-              - item is defined
-              - item == "Tenant"
-  with_items: "{{ CVP_VARS.CVP_TOPOLOGY.DC1_FABRIC.parent_container }}"
+    that:
+      - item is defined
+      - item == "Tenant"
+  with_items: "{{ cvp_vars.cvp_topology.DC1_FABRIC.parent_container }}"

--- a/ansible_collections/arista/avd/tests/integration/targets/inventory_to_container/tests/test_without_container_root.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/inventory_to_container/tests/test_without_container_root.yml
@@ -1,5 +1,5 @@
 - name: Test without container_root
-  register: CVP_VARS
+  register: cvp_vars
   ignore_errors: yes
   inventory_to_container:
         inventory: '{{ inventory_path }}/inventory.yml'
@@ -10,7 +10,7 @@
 
 - name: Validate output
   assert:
-        that:
-              - CVP_VARS is failed
-              - "'missing required arguments:' in CVP_VARS.msg"
-              - CVP_VARS.changed == false
+    that:
+      - cvp_vars is failed
+      - "'missing required arguments:' in cvp_vars.msg"
+      - cvp_vars.changed == false

--- a/ansible_collections/arista/avd/tests/integration/targets/inventory_to_container/tests/test_without_container_root.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/inventory_to_container/tests/test_without_container_root.yml
@@ -2,11 +2,11 @@
   register: cvp_vars
   ignore_errors: yes
   inventory_to_container:
-        inventory: '{{ inventory_path }}/inventory.yml'
-        configlet_dir: '{{ configlet_path }}'
-        configlet_prefix: 'AVD'
-        device_filter: ['DC1-LE']
-        destination: "{{ actual_output }}"
+    inventory: '{{ inventory_path }}/inventory.yml'
+    configlet_dir: '{{ configlet_path }}'
+    configlet_prefix: 'AVD'
+    device_filter: ['DC1-LE']
+    destination: "{{ actual_output }}"
 
 - name: Validate output
   assert:

--- a/ansible_collections/arista/avd/tests/integration/targets/inventory_to_container/tests/test_without_device_filter.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/inventory_to_container/tests/test_without_device_filter.yml
@@ -1,11 +1,11 @@
 - name: Test without device filter
-  register: CVP_VARS
+  register: cvp_vars
   inventory_to_container:
-        inventory: '{{ inventory_path }}/inventory.yml'
-        container_root: 'DC1_FABRIC'
-        configlet_dir: '{{ configlet_path }}'
-        configlet_prefix: 'AVD'
-        destination: "{{ actual_output }}"
+    inventory: '{{ inventory_path }}/inventory.yml'
+    container_root: 'DC1_FABRIC'
+    configlet_dir: '{{ configlet_path }}'
+    configlet_prefix: 'AVD'
+    destination: "{{ actual_output }}"
 
 - local_action: shell diff "{{ expected_output }}/expected_without_device_filter.yml" "{{ actual_output }}"
   failed_when: "diff_output.rc > 1"
@@ -13,18 +13,18 @@
 
 - name: Validate output
   assert:
-        that:
-              - CVP_VARS is success
-              - CVP_VARS.CVP_TOPOLOGY != {}
-              - CVP_VARS.CVP_CONFIGLETS != {}
-              - item is defined
-              - "'AVD' in item[0:3]"
-              - diff_output.stdout == ""
-  with_items: "{{ CVP_VARS.CVP_CONFIGLETS }}"
+    that:
+      - cvp_vars is success
+      - cvp_vars.cvp_topology != {}
+      - cvp_vars.cvp_configlets != {}
+      - item is defined
+      - "'AVD' in item[0:3]"
+      - diff_output.stdout == ""
+  with_items: "{{ cvp_vars.cvp_configlets }}"
 
-- name: Validate CVP_TOPOLOGY
+- name: Validate cvp_topology
   assert:
-        that:
-              - item is defined
-              - item == "Tenant"
-  with_items: "{{ CVP_VARS.CVP_TOPOLOGY.DC1_FABRIC.parent_container }}"
+    that:
+      - item is defined
+      - item == "Tenant"
+  with_items: "{{ cvp_vars.cvp_topology.DC1_FABRIC.parent_container }}"

--- a/ansible_collections/arista/avd/tests/integration/targets/inventory_to_container/tests/test_without_inventory.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/inventory_to_container/tests/test_without_inventory.yml
@@ -58,7 +58,7 @@
     is_deployed: false
 
 - name: Test without inventory file
-  register: CVP_VARS
+  register: cvp_vars
   inventory_to_container:
     container_root: 'DC1_FABRIC'
     configlet_dir: '{{ configlet_path }}'
@@ -73,17 +73,17 @@
 - name: Validate output
   assert:
     that:
-      - CVP_VARS is success
-      - CVP_VARS.CVP_TOPOLOGY != {}
-      - CVP_VARS.CVP_CONFIGLETS != {}
+      - cvp_vars is success
+      - cvp_vars.cvp_topology != {}
+      - cvp_vars.cvp_configlets != {}
       - item is defined
       - "'AVD_DC1-LE' in item[0:10]"
       - diff_output.stdout == ""
-  with_items: "{{ CVP_VARS.CVP_CONFIGLETS }}"
+  with_items: "{{ cvp_vars.cvp_configlets }}"
 
-- name: Validate CVP_TOPOLOGY
+- name: Validate cvp_topology
   assert:
     that:
       - item is defined
       - item == "Tenant"
-  with_items: "{{ CVP_VARS.CVP_TOPOLOGY.DC1_FABRIC.parent_container }}"
+  with_items: "{{ cvp_vars.cvp_topology.DC1_FABRIC.parent_container }}"

--- a/ansible_collections/arista/avd/tests/inventory/configlet_build_config/expected_output/expected_with_all_parameters.yml
+++ b/ansible_collections/arista/avd/tests/inventory/configlet_build_config/expected_output/expected_with_all_parameters.yml
@@ -1,4 +1,5 @@
-CVP_CONFIGLETS:
+changed: false
+cvp_configlets:
   Prefix_DC1-L2LEAF1A: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec\
     \ /usr/bin/TerminAttr -cvaddr=10.255.0.1:9910 -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata\
     \ -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n\
@@ -1000,4 +1001,3 @@ CVP_CONFIGLETS:
     \ ip routing vrf MGMT\n!\nip route vrf MGMT 0.0.0.0/0 10.255.0.1\n!\nmanagement\
     \ api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n  \
     \    no shutdown\n!\nend\n"
-changed: false

--- a/ansible_collections/arista/avd/tests/inventory/configlet_build_config/expected_output/expected_with_blank_prefix.yml
+++ b/ansible_collections/arista/avd/tests/inventory/configlet_build_config/expected_output/expected_with_blank_prefix.yml
@@ -1,4 +1,5 @@
-CVP_CONFIGLETS:
+changed: false
+cvp_configlets:
   _DC1-L2LEAF1A: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr\
     \ -cvaddr=10.255.0.1:9910 -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata\
     \ -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n\
@@ -1000,4 +1001,3 @@ CVP_CONFIGLETS:
     \ ip routing vrf MGMT\n!\nip route vrf MGMT 0.0.0.0/0 10.255.0.1\n!\nmanagement\
     \ api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n  \
     \    no shutdown\n!\nend\n"
-changed: false

--- a/ansible_collections/arista/avd/tests/inventory/configlet_build_config/expected_output/expected_without_extension.yml
+++ b/ansible_collections/arista/avd/tests/inventory/configlet_build_config/expected_output/expected_without_extension.yml
@@ -1,4 +1,5 @@
-CVP_CONFIGLETS:
+changed: false
+cvp_configlets:
   Prefix_default_extension: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n\
     \   exec /usr/bin/TerminAttr -cvaddr=10.255.0.1:9910 -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata\
     \ -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n\
@@ -26,4 +27,3 @@ CVP_CONFIGLETS:
     \ ip routing vrf MGMT\n!\nip route vrf MGMT 0.0.0.0/0 10.255.0.1\n!\nmanagement\
     \ api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n  \
     \    no shutdown\n!\nend\n"
-changed: false

--- a/ansible_collections/arista/avd/tests/inventory/inventory_to_container/expected_output/expected_with_all_param.yml
+++ b/ansible_collections/arista/avd/tests/inventory/inventory_to_container/expected_output/expected_with_all_param.yml
@@ -1,4 +1,4 @@
-CVP_CONFIGLETS:
+cvp_configlets:
   AVD_DC1-LEAF1A: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr
     -cvaddr=10.255.0.1:9910 -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
     -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
@@ -791,7 +791,7 @@ CVP_CONFIGLETS:
     \     neighbor 10.255.251.4 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
     connected\n!\nmanagement api http-commands\n   protocol https\n   no shutdown\n
     \  !\n   vrf MGMT\n      no shutdown\n!\nend\n"
-CVP_TOPOLOGY:
+cvp_topology:
   DC1_FABRIC:
     parent_container: Tenant
   DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/tests/inventory/inventory_to_container/expected_output/expected_without_configlet_dir.yml
+++ b/ansible_collections/arista/avd/tests/inventory/inventory_to_container/expected_output/expected_without_configlet_dir.yml
@@ -1,4 +1,4 @@
-CVP_TOPOLOGY:
+cvp_topology:
   DC1_FABRIC:
     parent_container: Tenant
   DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/tests/inventory/inventory_to_container/expected_output/expected_without_device_filter.yml
+++ b/ansible_collections/arista/avd/tests/inventory/inventory_to_container/expected_output/expected_without_device_filter.yml
@@ -1,4 +1,4 @@
-CVP_CONFIGLETS:
+cvp_configlets:
   AVD_DC1-L2LEAF1A: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr
     -cvaddr=10.255.0.1:9910 -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
     -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
@@ -977,7 +977,7 @@ CVP_CONFIGLETS:
     address 10.255.0.17/24\n!\nip routing\nno ip routing vrf MGMT\n!\nip route vrf
     MGMT 0.0.0.0/0 10.255.0.1\n!\nmanagement api http-commands\n   protocol https\n
     \  no shutdown\n   !\n   vrf MGMT\n      no shutdown\n!\nend\n"
-CVP_TOPOLOGY:
+cvp_topology:
   DC1_FABRIC:
     parent_container: Tenant
   DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/tests/inventory/inventory_to_container/expected_output/expected_without_inventory.yml
+++ b/ansible_collections/arista/avd/tests/inventory/inventory_to_container/expected_output/expected_without_inventory.yml
@@ -1,4 +1,4 @@
-CVP_CONFIGLETS:
+cvp_configlets:
   AVD_DC1-LEAF1A: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr
     -cvaddr=10.255.0.1:9910 -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
     -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
@@ -791,7 +791,7 @@ CVP_CONFIGLETS:
     \     neighbor 10.255.251.4 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
     connected\n!\nmanagement api http-commands\n   protocol https\n   no shutdown\n
     \  !\n   vrf MGMT\n      no shutdown\n!\nend\n"
-CVP_TOPOLOGY:
+cvp_topology:
   DC1_FABRIC:
     devices: []
     parent_container: Tenant


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Change uppercase CVP role vars to lower case

Potentially breaking in rare cases where custom logic relies on the registered vars or content of files.

## Component(s) name

Roles:
`arista.avd.eos_config_deploy_cvp`
`arista.avd.cvp_configlet_upload`

Modules:
`arista.avd.inventory_to_container`
`arista.avd.configlet_build_config`


## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

Change registered vars in above roles/modules from uppercase to lowercase, to conform with Ansible linting requirements.
```
CVP_CONFIGLETS -> cvp_configlets
CVP_CONFIGLETS_STATUS -> cvp_configlets_status
CVP_CONTAINERS -> cvp_containers
CVP_CONTAINER_RESULTS -> cvp_container_results
CVP_DEVICES -> cvp_devices
CVP_DEVICES_RESULTS -> cvp_devices_results
CVP_FACTS -> cvp_facts
CVP_TOPOLOGY -> cvp_topology
CVP_VARS -> cvp_vars
```

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

All existing integration tests and molecule have been updated.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
