### PR TITLE
Feat(eos_designs): Uplink native vlan for l2 switches

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink-native-vlan-child.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink-native-vlan-child.cfg
@@ -1,0 +1,45 @@
+!RANCID-CONTENT-TYPE: arista
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname uplink-native-vlan-child
+!
+no enable password
+no aaa root
+!
+vlan 100
+   name NETWORK_SERVICES_VLAN
+!
+vlan 200
+   name UPLINK_NATIVE_VLAN
+!
+vrf instance MGMT
+!
+interface Port-Channel2
+   description UPLINK-NATIVE-VLAN-PARENT_Po2
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 100
+   switchport trunk native vlan 200
+   switchport mode trunk
+!
+interface Ethernet2
+   description UPLINK-NATIVE-VLAN-PARENT_Ethernet2
+   no shutdown
+   channel-group 2 mode active
+!
+ip routing
+no ip routing vrf MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink-native-vlan-child.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink-native-vlan-child.cfg
@@ -15,7 +15,8 @@ vlan 100
    name NETWORK_SERVICES_VLAN
 !
 vlan 200
-   name UPLINK_NATIVE_VLAN
+   name NATIVE_VLAN
+   state suspend
 !
 vrf instance MGMT
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink-native-vlan-grandparent.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink-native-vlan-grandparent.cfg
@@ -1,0 +1,42 @@
+!RANCID-CONTENT-TYPE: arista
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname uplink-native-vlan-grandparent
+!
+no enable password
+no aaa root
+!
+vlan 100
+   name NETWORK_SERVICES_VLAN
+!
+vrf instance MGMT
+!
+interface Port-Channel1
+   description UPLINK-NATIVE-VLAN-PARENT_Po1
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 100
+   switchport trunk native vlan 100
+   switchport mode trunk
+!
+interface Ethernet1
+   description UPLINK-NATIVE-VLAN-PARENT_Ethernet1
+   no shutdown
+   channel-group 1 mode active
+!
+ip routing
+no ip routing vrf MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink-native-vlan-grandparent.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink-native-vlan-grandparent.cfg
@@ -13,6 +13,7 @@ no aaa root
 !
 vlan 100
    name NETWORK_SERVICES_VLAN
+   state suspend
 !
 vrf instance MGMT
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink-native-vlan-grandparent.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink-native-vlan-grandparent.cfg
@@ -13,7 +13,6 @@ no aaa root
 !
 vlan 100
    name NETWORK_SERVICES_VLAN
-   state suspend
 !
 vrf instance MGMT
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink-native-vlan-parent.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink-native-vlan-parent.cfg
@@ -13,9 +13,11 @@ no aaa root
 !
 vlan 100
    name NETWORK_SERVICES_VLAN
+   state suspend
 !
 vlan 200
-   name UPLINK_NATIVE_VLAN
+   name NATIVE_VLAN
+   state suspend
 !
 vrf instance MGMT
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink-native-vlan-parent.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink-native-vlan-parent.cfg
@@ -13,7 +13,6 @@ no aaa root
 !
 vlan 100
    name NETWORK_SERVICES_VLAN
-   state suspend
 !
 vlan 200
    name NATIVE_VLAN

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink-native-vlan-parent.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink-native-vlan-parent.cfg
@@ -1,0 +1,58 @@
+!RANCID-CONTENT-TYPE: arista
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname uplink-native-vlan-parent
+!
+no enable password
+no aaa root
+!
+vlan 100
+   name NETWORK_SERVICES_VLAN
+!
+vlan 200
+   name UPLINK_NATIVE_VLAN
+!
+vrf instance MGMT
+!
+interface Port-Channel1
+   description UPLINK-NATIVE-VLAN-GRANDPARENT_Po1
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 100
+   switchport trunk native vlan 100
+   switchport mode trunk
+!
+interface Port-Channel2
+   description UPLINK-NATIVE-VLAN-CHILD_Po2
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 100
+   switchport trunk native vlan 200
+   switchport mode trunk
+!
+interface Ethernet1
+   description UPLINK-NATIVE-VLAN-GRANDPARENT_Ethernet1
+   no shutdown
+   channel-group 1 mode active
+!
+interface Ethernet2
+   description UPLINK-NATIVE-VLAN-CHILD_Ethernet2
+   no shutdown
+   channel-group 2 mode active
+!
+ip routing
+no ip routing vrf MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink-native-vlan-child.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink-native-vlan-child.yml
@@ -13,7 +13,8 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- name: UPLINK_NATIVE_VLAN
+- name: NATIVE_VLAN
+  state: suspend
   id: 200
 - tenant: test
   name: NETWORK_SERVICES_VLAN

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink-native-vlan-child.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink-native-vlan-child.yml
@@ -1,0 +1,41 @@
+service_routing_protocols_model: multi-agent
+ip_routing: true
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+vrfs:
+- ip_routing: false
+  name: MGMT
+management_api_http:
+  enable_vrfs:
+  - name: MGMT
+  enable_https: true
+vlans:
+- name: UPLINK_NATIVE_VLAN
+  id: 200
+- tenant: test
+  name: NETWORK_SERVICES_VLAN
+  id: 100
+ethernet_interfaces:
+- peer: uplink-native-vlan-parent
+  peer_interface: Ethernet2
+  peer_type: l2leaf
+  description: UPLINK-NATIVE-VLAN-PARENT_Ethernet2
+  shutdown: false
+  type: switched
+  channel_group:
+    id: 2
+    mode: active
+  name: Ethernet2
+port_channel_interfaces:
+- description: UPLINK-NATIVE-VLAN-PARENT_Po2
+  type: switched
+  shutdown: false
+  mode: trunk
+  native_vlan: 200
+  vlans: '100'
+  name: Port-Channel2
+ip_igmp_snooping:
+  globally_enabled: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink-native-vlan-grandparent.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink-native-vlan-grandparent.yml
@@ -1,0 +1,39 @@
+service_routing_protocols_model: multi-agent
+ip_routing: true
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+vrfs:
+- ip_routing: false
+  name: MGMT
+management_api_http:
+  enable_vrfs:
+  - name: MGMT
+  enable_https: true
+vlans:
+- name: NETWORK_SERVICES_VLAN
+  id: 100
+  tenant: test
+ethernet_interfaces:
+- peer: uplink-native-vlan-parent
+  peer_interface: Ethernet1
+  peer_type: l2leaf
+  description: UPLINK-NATIVE-VLAN-PARENT_Ethernet1
+  shutdown: false
+  type: switched
+  channel_group:
+    id: 1
+    mode: active
+  name: Ethernet1
+port_channel_interfaces:
+- description: UPLINK-NATIVE-VLAN-PARENT_Po1
+  type: switched
+  shutdown: false
+  mode: trunk
+  native_vlan: 100
+  vlans: '100'
+  name: Port-Channel1
+ip_igmp_snooping:
+  globally_enabled: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink-native-vlan-grandparent.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink-native-vlan-grandparent.yml
@@ -12,11 +12,6 @@ management_api_http:
   enable_vrfs:
   - name: MGMT
   enable_https: true
-vlans:
-- name: NETWORK_SERVICES_VLAN
-  state: suspend
-  id: 100
-  tenant: test
 ethernet_interfaces:
 - peer: uplink-native-vlan-parent
   peer_interface: Ethernet1
@@ -36,5 +31,9 @@ port_channel_interfaces:
   native_vlan: 100
   vlans: '100'
   name: Port-Channel1
+vlans:
+- tenant: test
+  name: NETWORK_SERVICES_VLAN
+  id: 100
 ip_igmp_snooping:
   globally_enabled: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink-native-vlan-grandparent.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink-native-vlan-grandparent.yml
@@ -14,6 +14,7 @@ management_api_http:
   enable_https: true
 vlans:
 - name: NETWORK_SERVICES_VLAN
+  state: suspend
   id: 100
   tenant: test
 ethernet_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink-native-vlan-parent.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink-native-vlan-parent.yml
@@ -1,0 +1,58 @@
+service_routing_protocols_model: multi-agent
+ip_routing: true
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+vrfs:
+- ip_routing: false
+  name: MGMT
+management_api_http:
+  enable_vrfs:
+  - name: MGMT
+  enable_https: true
+vlans:
+- name: UPLINK_NATIVE_VLAN
+  id: 200
+- name: NETWORK_SERVICES_VLAN
+  id: 100
+  tenant: test
+ethernet_interfaces:
+- peer: uplink-native-vlan-grandparent
+  peer_interface: Ethernet1
+  peer_type: l2leaf
+  description: UPLINK-NATIVE-VLAN-GRANDPARENT_Ethernet1
+  shutdown: false
+  type: switched
+  channel_group:
+    id: 1
+    mode: active
+  name: Ethernet1
+- peer: uplink-native-vlan-child
+  peer_interface: Ethernet2
+  peer_type: l2leaf
+  description: UPLINK-NATIVE-VLAN-CHILD_Ethernet2
+  shutdown: false
+  type: switched
+  channel_group:
+    id: 2
+    mode: active
+  name: Ethernet2
+port_channel_interfaces:
+- description: UPLINK-NATIVE-VLAN-GRANDPARENT_Po1
+  type: switched
+  shutdown: false
+  mode: trunk
+  native_vlan: 100
+  vlans: '100'
+  name: Port-Channel1
+- description: UPLINK-NATIVE-VLAN-CHILD_Po2
+  type: switched
+  shutdown: false
+  mode: trunk
+  native_vlan: 200
+  vlans: '100'
+  name: Port-Channel2
+ip_igmp_snooping:
+  globally_enabled: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink-native-vlan-parent.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink-native-vlan-parent.yml
@@ -13,9 +13,11 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- name: UPLINK_NATIVE_VLAN
+- name: NATIVE_VLAN
+  state: suspend
   id: 200
 - name: NETWORK_SERVICES_VLAN
+  state: suspend
   id: 100
   tenant: test
 ethernet_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink-native-vlan-parent.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink-native-vlan-parent.yml
@@ -16,10 +16,9 @@ vlans:
 - name: NATIVE_VLAN
   state: suspend
   id: 200
-- name: NETWORK_SERVICES_VLAN
-  state: suspend
+- tenant: test
+  name: NETWORK_SERVICES_VLAN
   id: 100
-  tenant: test
 ethernet_interfaces:
 - peer: uplink-native-vlan-grandparent
   peer_interface: Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/UPLINK_NATIVE_VLAN_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/UPLINK_NATIVE_VLAN_TESTS.yml
@@ -1,0 +1,28 @@
+type: l2leaf
+
+l2leaf:
+  nodes:
+    - name: uplink-native-vlan-grandparent
+      id: 1
+    - name: uplink-native-vlan-parent
+      id: 2
+      # vlan 100 is also in network services vlans, so we test that both ends have vlan 100 configured
+      # with name NETWORK_SERVICES_VLAN and configured as native-vlan as well as permitted vlan on uplink port-channel.
+      uplink_native_vlan: 100
+      uplink_switches: [ uplink-native-vlan-grandparent ]
+      uplink_interfaces: [ Ethernet1 ]
+      uplink_switch_interfaces: [ Ethernet1 ]
+    - name: uplink-native-vlan-child
+      id: 3
+      # vlan 200 is not in network services vlans, so we test that both ends have vlan 200 configured
+      # with name UPLINK_NATIVE_VLAN and configured as native-vlan on uplink port-channel. Vlan 200 should _not_ be permitted on the trunk.
+      uplink_native_vlan: 200
+      uplink_switches: [ uplink-native-vlan-parent ]
+      uplink_interfaces: [ Ethernet2 ]
+      uplink_switch_interfaces: [ Ethernet2 ]
+
+tenants:
+  - name: test
+    l2vlans:
+      - id: 100
+        name: NETWORK_SERVICES_VLAN

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
@@ -177,6 +177,11 @@ all:
             l3_edge_bgp:
             l3_edge_ospf:
             l3_edge_isis:
+        UPLINK_NATIVE_VLAN_TESTS:
+          hosts:
+            uplink-native-vlan-grandparent:
+            uplink-native-vlan-parent:
+            uplink-native-vlan-child:
         AVD_LAB:
           children:
             DC1_FABRIC:

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_facts.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_facts.py
@@ -940,6 +940,9 @@ class EosDesignsFacts(AvdFacts):
         Return the compressed list of vlans to be defined on this switch
 
         Ex. "1-100, 201-202"
+
+        This excludes the optional "uplink_native_vlan" if that vlan is not used for anything else.
+        This is to ensure that native vlan is not necessarily permitted on the uplink trunk.
         """
         return list_compress(self._vlans)
 
@@ -1046,6 +1049,12 @@ class EosDesignsFacts(AvdFacts):
     def uplink_ipv4_pool(self):
         if self.underlay_router is True:
             return get(self._switch_data_combined, "uplink_ipv4_pool")
+        return None
+
+    @cached_property
+    def uplink_native_vlan(self):
+        if self.uplink_type == "port-channel":
+            return get(self._switch_data_combined, "uplink_native_vlan")
         return None
 
     @cached_property
@@ -1615,6 +1624,9 @@ class EosDesignsFacts(AvdFacts):
                     uplink["vlans"] = list_compress(uplink_vlans)
                 else:
                     uplink["vlans"] = "none"
+
+                if uplink_native_vlan := get(self._switch_data_combined, "uplink_native_vlan"):
+                    uplink["native_vlan"] = uplink_native_vlan
 
                 if self.short_esi is not None:
                     uplink["peer_short_esi"] = self.short_esi

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_facts.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_facts.py
@@ -1052,12 +1052,6 @@ class EosDesignsFacts(AvdFacts):
         return None
 
     @cached_property
-    def uplink_native_vlan(self):
-        if self.uplink_type == "port-channel":
-            return get(self._switch_data_combined, "uplink_native_vlan")
-        return None
-
-    @cached_property
     def router_id(self):
         """
         Render ipv4 address for router_id using dynamically loaded python module.

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-topology.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-topology.md
@@ -238,7 +238,8 @@ defaults <- node_group <- node_group.node <- node
 
     # Uplink native vlan | Optional
     # Only applicable to switches with layer-2 port-channel uplinks
-    # The vlan will be created in both ends of the link even if it is not defined under network services
+    # A suspended (disabled) vlan will be created in both ends of the link unless the vlan
+    # is defined under network services.
     # By default the uplink will not have a native_vlan configured, so EOS defaults to vlan 1.
     uplink_native_vlan: < vlan_id >
 

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-topology.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-topology.md
@@ -236,6 +236,12 @@ defaults <- node_group <- node_group.node <- node
     # e.g. uplink_switches: [ 'DC1-SPINE1', 'DC1-SPINE1', 'DC1-SPINE2', 'DC1-SPINE2' ]
     uplink_switches: [ < uplink_switch_inventory_hostname 01 >, < uplink_switch_inventory_hostname 02 > ]
 
+    # Uplink native vlan | Optional
+    # Only applicable to switches with layer-2 port-channel uplinks
+    # The vlan will be created in both ends of the link even if it is not defined under network services
+    # By default the uplink will not have a native_vlan configured, so EOS defaults to vlan 1.
+    uplink_native_vlan: < vlan_id >
+
     # Maximum number of uplink switches. | Optional
     # Changing this value may change IP Addressing on uplinks.
     # Can be used to reserve IP space for future expansions.

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/ethernet_interfaces.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/ethernet_interfaces.py
@@ -108,6 +108,7 @@ class EthernetInterfacesMixin(UtilsMixin):
                     ethernet_interface.update(
                         {
                             "vlans": list_compress(vlans),
+                            "native_vlan": link.get("native_vlan"),
                             "service_profile": get(self._hostvars, "p2p_uplinks_qos_profile"),
                             "link_tracking_groups": link.get("link_tracking_groups"),
                         }

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/port_channel_interfaces.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/port_channel_interfaces.py
@@ -41,6 +41,7 @@ class PortChannelInterfacesMixin(UtilsMixin):
                 "mode": "trunk",
                 "service_profile": get(self._hostvars, "p2p_uplinks_qos_profile"),
                 "link_tracking_groups": link.get("link_tracking_groups"),
+                "native_vlan": link.get("native_vlan"),
             }
 
             if (trunk_groups := link.get("trunk_groups")) is not None:

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/utils.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/utils.py
@@ -188,6 +188,7 @@ class UtilsMixin:
                         "peer_channel_group_id": get(uplink, "channel_group_id"),
                         "channel_description": get(uplink, "peer_channel_description"),
                         "vlans": get(uplink, "vlans"),
+                        "native_vlan": get(uplink, "native_vlan"),
                         "trunk_groups": get(uplink, "peer_trunk_groups"),
                         "bfd": get(uplink, "bfd"),
                         "ptp": get(uplink, "ptp"),

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/vlans.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/vlans.py
@@ -4,6 +4,7 @@ from functools import cached_property
 
 from ansible_collections.arista.avd.plugins.filter.natural_sort import natural_sort
 from ansible_collections.arista.avd.plugins.filter.range_expand import range_expand
+from ansible_collections.arista.avd.plugins.plugin_utils.utils import get
 
 from .utils import UtilsMixin
 
@@ -22,6 +23,8 @@ class VlansMixin(UtilsMixin):
         This function goes through all the underlay trunk groups and returns an
         inverted dict where the key is the vlan ID and the value is the list of
         the unique trunk groups that should be configured under this vlan.
+
+        The function also creates uplink_native_vlan for this switch or downstream switches.
         """
 
         vlans = {}
@@ -32,6 +35,12 @@ class VlansMixin(UtilsMixin):
 
         for vlan, vlan_dict in vlans.items():
             vlan_dict["trunk_groups"] = natural_sort(set(vlan_dict["trunk_groups"]))
+
+        # Add configuration for uplink or peer's uplink_native_vlan if it is not defined as part of network services
+        switch_vlans = range_expand(get(self._hostvars, "switch.vlans"))
+        uplink_native_vlans = set(link["native_vlan"] for link in self._underlay_links if "native_vlan" in link and link["native_vlan"] not in switch_vlans)
+        for peer_uplink_native_vlan in uplink_native_vlans:
+            vlans.setdefault(int(peer_uplink_native_vlan), {}).update({"name": "UPLINK_NATIVE_VLAN"})
 
         if vlans:
             return vlans

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/vlans.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/vlans.py
@@ -40,7 +40,12 @@ class VlansMixin(UtilsMixin):
         switch_vlans = range_expand(get(self._hostvars, "switch.vlans"))
         uplink_native_vlans = set(link["native_vlan"] for link in self._underlay_links if "native_vlan" in link and link["native_vlan"] not in switch_vlans)
         for peer_uplink_native_vlan in uplink_native_vlans:
-            vlans.setdefault(int(peer_uplink_native_vlan), {}).update({"name": "UPLINK_NATIVE_VLAN"})
+            vlans.setdefault(int(peer_uplink_native_vlan), {}).update(
+                {
+                    "name": "NATIVE_VLAN",
+                    "state": "suspend",
+                }
+            )
 
         if vlans:
             return vlans

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/vlans.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/vlans.py
@@ -38,7 +38,9 @@ class VlansMixin(UtilsMixin):
 
         # Add configuration for uplink or peer's uplink_native_vlan if it is not defined as part of network services
         switch_vlans = range_expand(get(self._hostvars, "switch.vlans"))
-        uplink_native_vlans = set(link["native_vlan"] for link in self._underlay_links if "native_vlan" in link and link["native_vlan"] not in switch_vlans)
+        uplink_native_vlans = set(
+            link["native_vlan"] for link in self._underlay_links if "native_vlan" in link and str(link["native_vlan"]) not in switch_vlans
+        )
         for peer_uplink_native_vlan in uplink_native_vlans:
             vlans.setdefault(int(peer_uplink_native_vlan), {}).update(
                 {


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Uplink native vlan for l2 switches

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

```yaml
< node_type_key >:

  defaults:
    # Uplink native vlan | Optional
    # Only applicable to switches with layer-2 port-channel uplinks
    # The vlan will be created in both ends of the link even if it is not defined under network services
    # By default the uplink will not have a native_vlan configured, so EOS defaults to vlan 1.
    uplink_native_vlan: < vlan_id >

```

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Added molecule coverage for various combinations

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
