### PR TITLE
Feat(eos_designs): deprecate port_channel.short_esi under connected endpoints

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER1.md
@@ -301,7 +301,6 @@ interface Ethernet8
 
 | Interface | Ethernet Segment Identifier | Multihoming Redundancy Mode | Route Target |
 | --------- | --------------------------- | --------------------------- | ------------ |
-| Port-Channel8 | 0000:0000:0303:0202:0101 | all-active | 03:03:02:02:01:01 |
 | Port-Channel8.111 | 0000:0000:0303:0202:0111 | all-active | 03:03:02:02:01:11 |
 | Port-Channel8.222 | 0000:0000:0303:0202:0222 | all-active | 03:03:02:02:02:22 |
 | Port-Channel8.333 | 0000:0000:0303:0202:0333 | all-active | 03:03:02:02:03:33 |
@@ -347,10 +346,6 @@ interface Port-Channel8
    description CPE_TENANT_A_SITE1_EVPN-A-A-PortChannel
    no shutdown
    no switchport
-   evpn ethernet-segment
-      identifier 0000:0000:0303:0202:0101
-      route-target import 03:03:02:02:01:01
-   lacp system-id 0303.0202.0101
 !
 interface Port-Channel8.111
    vlan id 111

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER2.md
@@ -295,7 +295,6 @@ interface Ethernet8
 
 | Interface | Ethernet Segment Identifier | Multihoming Redundancy Mode | Route Target |
 | --------- | --------------------------- | --------------------------- | ------------ |
-| Port-Channel8 | 0000:0000:0303:0202:0101 | all-active | 03:03:02:02:01:01 |
 | Port-Channel8.111 | 0000:0000:0303:0202:0111 | all-active | 03:03:02:02:01:11 |
 | Port-Channel8.222 | 0000:0000:0303:0202:0222 | all-active | 03:03:02:02:02:22 |
 | Port-Channel8.333 | 0000:0000:0303:0202:0333 | all-active | 03:03:02:02:03:33 |
@@ -341,10 +340,6 @@ interface Port-Channel8
    description CPE_TENANT_A_SITE1_EVPN-A-A-PortChannel
    no shutdown
    no switchport
-   evpn ethernet-segment
-      identifier 0000:0000:0303:0202:0101
-      route-target import 03:03:02:02:01:01
-   lacp system-id 0303.0202.0101
 !
 interface Port-Channel8.111
    vlan id 111

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE1-LER1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE1-LER1.cfg
@@ -64,10 +64,6 @@ interface Port-Channel8
    description CPE_TENANT_A_SITE1_EVPN-A-A-PortChannel
    no shutdown
    no switchport
-   evpn ethernet-segment
-      identifier 0000:0000:0303:0202:0101
-      route-target import 03:03:02:02:01:01
-   lacp system-id 0303.0202.0101
 !
 interface Port-Channel8.111
    vlan id 111

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE1-LER2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE1-LER2.cfg
@@ -66,10 +66,6 @@ interface Port-Channel8
    description CPE_TENANT_A_SITE1_EVPN-A-A-PortChannel
    no shutdown
    no switchport
-   evpn ethernet-segment
-      identifier 0000:0000:0303:0202:0101
-      route-target import 03:03:02:02:01:01
-   lacp system-id 0303.0202.0101
 !
 interface Port-Channel8.111
    vlan id 111

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LER1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LER1.yml
@@ -281,10 +281,6 @@ port_channel_interfaces:
 - description: CPE_TENANT_A_SITE1_EVPN-A-A-PortChannel
   type: routed
   shutdown: false
-  evpn_ethernet_segment:
-    identifier: 0000:0000:0303:0202:0101
-    route_target: 03:03:02:02:01:01
-  lacp_id: 0303.0202.0101
   name: Port-Channel8
 - type: l2dot1q
   vlan_id: 111

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LER2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LER2.yml
@@ -311,10 +311,6 @@ port_channel_interfaces:
 - description: CPE_TENANT_A_SITE1_EVPN-A-A-PortChannel
   type: routed
   shutdown: false
-  evpn_ethernet_segment:
-    identifier: 0000:0000:0303:0202:0101
-    route_target: 03:03:02:02:01:01
-  lacp_id: 0303.0202.0101
   name: Port-Channel8
 - type: l2dot1q
   vlan_id: 111

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/inventory/group_vars/SITE1_CONNECTED_ENDPOINTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/inventory/group_vars/SITE1_CONNECTED_ENDPOINTS.yml
@@ -20,7 +20,6 @@ cpes:
       port_channel:
         description: EVPN-A-A-PortChannel
         mode: active
-        short_esi: 0303:0202:0101
         subinterfaces:
         - number: 111
           short_esi: 0303:0202:0111

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MH-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MH-LEAF1A.cfg
@@ -46,10 +46,6 @@ interface Port-Channel10
    no shutdown
    switchport
    switchport access vlan 310
-   evpn ethernet-segment
-      identifier 0000:0000:0001:1010:1010
-      route-target import 00:01:10:10:10:10
-   lacp system-id 0001.1010.1010
    link tracking group LT_GROUP1 downstream
 !
 interface Port-Channel11
@@ -94,10 +90,6 @@ interface Port-Channel12
    no shutdown
    switchport
    switchport access vlan 310
-   evpn ethernet-segment
-      identifier 0000:0000:fc87:ae24:2cb3
-      route-target import fc:87:ae:24:2c:b3
-   lacp system-id fc87.ae24.2cb3
    link tracking group LT_GROUP1 downstream
 !
 interface Port-Channel13
@@ -105,10 +97,6 @@ interface Port-Channel13
    no shutdown
    switchport
    switchport access vlan 310
-   evpn ethernet-segment
-      identifier 0000:0000:29cc:4043:0a29
-      route-target import 29:cc:40:43:0a:29
-   lacp system-id 29cc.4043.0a29
    link tracking group LT_GROUP1 downstream
 !
 interface Port-Channel14
@@ -116,10 +104,6 @@ interface Port-Channel14
    no shutdown
    switchport
    switchport access vlan 310
-   evpn ethernet-segment
-      identifier 0000:0000:010a:010a:010a
-      route-target import 01:0a:01:0a:01:0a
-   lacp system-id 010a.010a.010a
    link tracking group LT_GROUP1 downstream
 !
 interface Port-Channel15

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MH-LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MH-LEAF1B.cfg
@@ -46,10 +46,6 @@ interface Port-Channel10
    no shutdown
    switchport
    switchport access vlan 310
-   evpn ethernet-segment
-      identifier 0000:0000:0001:1010:1010
-      route-target import 00:01:10:10:10:10
-   lacp system-id 0001.1010.1010
    link tracking group LT_GROUP1 downstream
 !
 interface Port-Channel11
@@ -94,10 +90,6 @@ interface Port-Channel12
    no shutdown
    switchport
    switchport access vlan 310
-   evpn ethernet-segment
-      identifier 0000:0000:fc87:ae24:2cb3
-      route-target import fc:87:ae:24:2c:b3
-   lacp system-id fc87.ae24.2cb3
    link tracking group LT_GROUP1 downstream
 !
 interface Port-Channel13
@@ -105,10 +97,6 @@ interface Port-Channel13
    no shutdown
    switchport
    switchport access vlan 310
-   evpn ethernet-segment
-      identifier 0000:0000:29cc:4043:0a29
-      route-target import 29:cc:40:43:0a:29
-   lacp system-id 29cc.4043.0a29
    link tracking group LT_GROUP1 downstream
 !
 interface Port-Channel14
@@ -116,10 +104,6 @@ interface Port-Channel14
    no shutdown
    switchport
    switchport access vlan 310
-   evpn ethernet-segment
-      identifier 0000:0000:010a:010a:010a
-      route-target import 01:0a:01:0a:01:0a
-   lacp system-id 010a.010a.010a
    link tracking group LT_GROUP1 downstream
 !
 interface Port-Channel15

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF1A.yml
@@ -405,10 +405,6 @@ port_channel_interfaces:
     direction: downstream
   mode: access
   vlans: '310'
-  evpn_ethernet_segment:
-    identifier: 0000:0000:0001:1010:1010
-    route_target: 00:01:10:10:10:10
-  lacp_id: 0001.1010.1010
   name: Port-Channel10
 - description: server03_AUTO_ESI_Auto-ESI PortChannel
   type: switched
@@ -418,10 +414,6 @@ port_channel_interfaces:
     direction: downstream
   mode: access
   vlans: '310'
-  evpn_ethernet_segment:
-    identifier: 0000:0000:fc87:ae24:2cb3
-    route_target: fc:87:ae:24:2c:b3
-  lacp_id: fc87.ae24.2cb3
   name: Port-Channel12
 - description: server04_AUTO_ESI_Profile_Auto-ESI PortChannel from profile
   type: switched
@@ -431,10 +423,6 @@ port_channel_interfaces:
     direction: downstream
   mode: access
   vlans: '310'
-  evpn_ethernet_segment:
-    identifier: 0000:0000:29cc:4043:0a29
-    route_target: 29:cc:40:43:0a:29
-  lacp_id: 29cc.4043.0a29
   name: Port-Channel13
 - description: server05_AUTO_ESI_Profile_Override_Auto-ESI PortChannel overridden on server
   type: switched
@@ -444,10 +432,6 @@ port_channel_interfaces:
     direction: downstream
   mode: access
   vlans: '310'
-  evpn_ethernet_segment:
-    identifier: 0000:0000:010a:010a:010a
-    route_target: 01:0a:01:0a:01:0a
-  lacp_id: 010a.010a.010a
   name: Port-Channel14
 - description: server06_Single_Active_Port_Channel_Single-Active ESI
   type: switched

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF1B.yml
@@ -405,10 +405,6 @@ port_channel_interfaces:
     direction: downstream
   mode: access
   vlans: '310'
-  evpn_ethernet_segment:
-    identifier: 0000:0000:0001:1010:1010
-    route_target: 00:01:10:10:10:10
-  lacp_id: 0001.1010.1010
   name: Port-Channel10
 - description: server03_AUTO_ESI_Auto-ESI PortChannel
   type: switched
@@ -418,10 +414,6 @@ port_channel_interfaces:
     direction: downstream
   mode: access
   vlans: '310'
-  evpn_ethernet_segment:
-    identifier: 0000:0000:fc87:ae24:2cb3
-    route_target: fc:87:ae:24:2c:b3
-  lacp_id: fc87.ae24.2cb3
   name: Port-Channel12
 - description: server04_AUTO_ESI_Profile_Auto-ESI PortChannel from profile
   type: switched
@@ -431,10 +423,6 @@ port_channel_interfaces:
     direction: downstream
   mode: access
   vlans: '310'
-  evpn_ethernet_segment:
-    identifier: 0000:0000:29cc:4043:0a29
-    route_target: 29:cc:40:43:0a:29
-  lacp_id: 29cc.4043.0a29
   name: Port-Channel13
 - description: server05_AUTO_ESI_Profile_Override_Auto-ESI PortChannel overridden on server
   type: switched
@@ -444,10 +432,6 @@ port_channel_interfaces:
     direction: downstream
   mode: access
   vlans: '310'
-  evpn_ethernet_segment:
-    identifier: 0000:0000:010a:010a:010a
-    route_target: 01:0a:01:0a:01:0a
-  lacp_id: 010a.010a.010a
   name: Port-Channel14
 - description: server06_Single_Active_Port_Channel_Single-Active ESI
   type: switched

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/MH-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/MH-LEAF1A.yml
@@ -255,10 +255,6 @@ port_channel_interfaces:
       direction: downstream
     mode: access
     vlans: '310'
-    evpn_ethernet_segment:
-      identifier: 0000:0000:0001:1010:1010
-      route_target: 00:01:10:10:10:10
-    lacp_id: 0001.1010.1010
   Port-Channel12:
     description: server03_AUTO_ESI_Auto-ESI PortChannel
     type: switched
@@ -268,10 +264,6 @@ port_channel_interfaces:
       direction: downstream
     mode: access
     vlans: '310'
-    evpn_ethernet_segment:
-      identifier: 0000:0000:fc87:ae24:2cb3
-      route_target: fc:87:ae:24:2c:b3
-    lacp_id: fc87.ae24.2cb3
   Port-Channel11:
     description: ROUTER02_WITH_SUBIF_Testing L2 subinterfaces
     type: routed

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/MH-LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/MH-LEAF1B.yml
@@ -255,10 +255,6 @@ port_channel_interfaces:
       direction: downstream
     mode: access
     vlans: '310'
-    evpn_ethernet_segment:
-      identifier: 0000:0000:0001:1010:1010
-      route_target: 00:01:10:10:10:10
-    lacp_id: 0001.1010.1010
   Port-Channel12:
     description: server03_AUTO_ESI_Auto-ESI PortChannel
     type: switched
@@ -268,10 +264,6 @@ port_channel_interfaces:
       direction: downstream
     mode: access
     vlans: '310'
-    evpn_ethernet_segment:
-      identifier: 0000:0000:fc87:ae24:2cb3
-      route_target: fc:87:ae:24:2c:b3
-    lacp_id: fc87.ae24.2cb3
   Port-Channel11:
     description: ROUTER02_WITH_SUBIF_Testing L2 subinterfaces
     type: routed

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/inventory/group_vars/MH_SERVERS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/inventory/group_vars/MH_SERVERS.yml
@@ -25,7 +25,6 @@ servers:
         port_channel:
           description: PortChanne1
           mode: active
-          # short_esi: 0001:1010:1010
 
   - name: server02
     rack: RackA
@@ -47,7 +46,6 @@ servers:
         port_channel:
           description: Auto-ESI PortChannel
           mode: active
-          # short_esi: auto
 
 routers:
   - name: ROUTER01

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/inventory/group_vars/MH_SERVERS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/inventory/group_vars/MH_SERVERS.yml
@@ -25,7 +25,7 @@ servers:
         port_channel:
           description: PortChanne1
           mode: active
-          short_esi: 0001:1010:1010
+          # short_esi: 0001:1010:1010
 
   - name: server02
     rack: RackA
@@ -47,7 +47,7 @@ servers:
         port_channel:
           description: Auto-ESI PortChannel
           mode: active
-          short_esi: auto
+          # short_esi: auto
 
 routers:
   - name: ROUTER01

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -624,21 +624,13 @@ interface Ethernet44
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
 | Port-Channel5 | CUSTOM_MLAG_PEER_DC1-SVC3B_Po5 | switched | trunk | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
 | Port-Channel7 | CUSTOM_DC1_L2LEAF2_Po1 | switched | trunk | 110-111,120-124,130-131,140-141,150,160-162,210-211,250,310-311,350 | - | - | - | - | 7 | - |
-| Port-Channel10 | CUSTOM_server03_ESI_PortChanne1 | switched | trunk | 110-111,210-211 | - | - | - | - | - | 0000:1234:0303:0202:0101 |
+| Port-Channel10 | CUSTOM_server03_ESI_PortChanne1 | switched | trunk | 110-111,210-211 | - | - | - | - | 10 | - |
 | Port-Channel14 | CUSTOM_server07_inherit_all_from_profile_port_channel_ALL_WITH_SECURITY_PORT_CHANNEL | switched | trunk | 1-4094 | - | - | - | - | 14 | - |
 | Port-Channel15 | CUSTOM_server08_no_profile_port_channel_server08_no_profile_port_channel | switched | trunk | 1-4094 | - | - | - | - | 15 | - |
 | Port-Channel17 | CUSTOM_server10_no_profile_port_channel_lacp_fallback_server10_no_profile_port_channel_lacp_fallback | switched | trunk | 1-4094 | - | - | 90 | static | 17 | - |
 | Port-Channel18 | CUSTOM_server11_inherit_profile_port_channel_lacp_fallback_ALL_WITH_SECURITY_PORT_CHANNEL | switched | trunk | 1-4094 | - | - | 10 | static | 18 | - |
 | Port-Channel19 | CUSTOM_server12_inherit_nested_profile_port_channel_lacp_fallback_NESTED_ALL_WITH_SECURITY_PORT_CHANNEL | switched | trunk | 1-4094 | - | - | 10 | static | 19 | - |
 | Port-Channel22 | CUSTOM_server15_port_channel_disabled_interfaces_ | switched | access | 110 | - | - | - | - | 22 | - |
-
-#### EVPN Multihoming
-
-##### EVPN Multihoming Summary
-
-| Interface | Ethernet Segment Identifier | Multihoming Redundancy Mode | Route Target |
-| --------- | --------------------------- | --------------------------- | ------------ |
-| Port-Channel10 | 0000:1234:0303:0202:0101 | all-active | 03:03:02:02:01:01 |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -667,10 +659,7 @@ interface Port-Channel10
    switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
-   evpn ethernet-segment
-      identifier 0000:1234:0303:0202:0101
-      route-target import 03:03:02:02:01:01
-   lacp system-id 0303.0202.0101
+   mlag 10
 !
 interface Port-Channel14
    description CUSTOM_server07_inherit_all_from_profile_port_channel_ALL_WITH_SECURITY_PORT_CHANNEL

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -624,21 +624,13 @@ interface Ethernet44
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
 | Port-Channel5 | CUSTOM_MLAG_PEER_DC1-SVC3A_Po5 | switched | trunk | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
 | Port-Channel7 | CUSTOM_DC1_L2LEAF2_Po1 | switched | trunk | 110-111,120-124,130-131,140-141,150,160-162,210-211,250,310-311,350 | - | - | - | - | 7 | - |
-| Port-Channel10 | CUSTOM_server03_ESI_PortChanne1 | switched | trunk | 110-111,210-211 | - | - | - | - | - | 0000:1234:0303:0202:0101 |
+| Port-Channel10 | CUSTOM_server03_ESI_PortChanne1 | switched | trunk | 110-111,210-211 | - | - | - | - | 10 | - |
 | Port-Channel14 | CUSTOM_server07_inherit_all_from_profile_port_channel_ALL_WITH_SECURITY_PORT_CHANNEL | switched | trunk | 1-4094 | - | - | - | - | 14 | - |
 | Port-Channel15 | CUSTOM_server08_no_profile_port_channel_server08_no_profile_port_channel | switched | trunk | 1-4094 | - | - | - | - | 15 | - |
 | Port-Channel17 | CUSTOM_server10_no_profile_port_channel_lacp_fallback_server10_no_profile_port_channel_lacp_fallback | switched | trunk | 1-4094 | - | - | 90 | static | 17 | - |
 | Port-Channel18 | CUSTOM_server11_inherit_profile_port_channel_lacp_fallback_ALL_WITH_SECURITY_PORT_CHANNEL | switched | trunk | 1-4094 | - | - | 10 | static | 18 | - |
 | Port-Channel19 | CUSTOM_server12_inherit_nested_profile_port_channel_lacp_fallback_NESTED_ALL_WITH_SECURITY_PORT_CHANNEL | switched | trunk | 1-4094 | - | - | 10 | static | 19 | - |
 | Port-Channel22 | CUSTOM_server15_port_channel_disabled_interfaces_ | switched | access | 110 | - | - | - | - | 22 | - |
-
-#### EVPN Multihoming
-
-##### EVPN Multihoming Summary
-
-| Interface | Ethernet Segment Identifier | Multihoming Redundancy Mode | Route Target |
-| --------- | --------------------------- | --------------------------- | ------------ |
-| Port-Channel10 | 0000:1234:0303:0202:0101 | all-active | 03:03:02:02:01:01 |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -667,10 +659,7 @@ interface Port-Channel10
    switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
-   evpn ethernet-segment
-      identifier 0000:1234:0303:0202:0101
-      route-target import 03:03:02:02:01:01
-   lacp system-id 0303.0202.0101
+   mlag 10
 !
 interface Port-Channel14
    description CUSTOM_server07_inherit_all_from_profile_port_channel_ALL_WITH_SECURITY_PORT_CHANNEL

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
@@ -184,10 +184,7 @@ interface Port-Channel10
    switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
-   evpn ethernet-segment
-      identifier 0000:1234:0303:0202:0101
-      route-target import 03:03:02:02:01:01
-   lacp system-id 0303.0202.0101
+   mlag 10
 !
 interface Port-Channel14
    description CUSTOM_server07_inherit_all_from_profile_port_channel_ALL_WITH_SECURITY_PORT_CHANNEL

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
@@ -184,10 +184,7 @@ interface Port-Channel10
    switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
-   evpn ethernet-segment
-      identifier 0000:1234:0303:0202:0101
-      route-target import 03:03:02:02:01:01
-   lacp system-id 0303.0202.0101
+   mlag 10
 !
 interface Port-Channel14
    description CUSTOM_server07_inherit_all_from_profile_port_channel_ALL_WITH_SECURITY_PORT_CHANNEL

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -807,10 +807,7 @@ port_channel_interfaces:
   shutdown: false
   mode: trunk
   vlans: 110-111,210-211
-  evpn_ethernet_segment:
-    identifier: 0000:1234:0303:0202:0101
-    route_target: 03:03:02:02:01:01
-  lacp_id: 0303.0202.0101
+  mlag: 10
   name: Port-Channel10
 - description: CUSTOM_server07_inherit_all_from_profile_port_channel_ALL_WITH_SECURITY_PORT_CHANNEL
   type: switched

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -807,10 +807,7 @@ port_channel_interfaces:
   shutdown: false
   mode: trunk
   vlans: 110-111,210-211
-  evpn_ethernet_segment:
-    identifier: 0000:1234:0303:0202:0101
-    route_target: 03:03:02:02:01:01
-  lacp_id: 0303.0202.0101
+  mlag: 10
   name: Port-Channel10
 - description: CUSTOM_server07_inherit_all_from_profile_port_channel_ALL_WITH_SECURITY_PORT_CHANNEL
   type: switched

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/connected_endpoints/utils.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/connected_endpoints/utils.py
@@ -159,10 +159,9 @@ class UtilsMixin:
             # Only configure ESI for multi-homing.
             return None
 
-        # # short_esi is only set when called from sub-interface port-channels.
+        # short_esi is only set when called from sub-interface port-channels.
         if short_esi is None:
-            #     # Setting short_esi under port_channel will be deprecated in AVD4.0
-            #     port_channel_short_esi = get(adapter, "port_channel.short_esi")
+            # Setting short_esi under port_channel will be deprecated in AVD4.0
             if (short_esi := get(adapter, "ethernet_segment.short_esi")) is None:
                 return None
 

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/connected_endpoints/utils.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/connected_endpoints/utils.py
@@ -159,12 +159,6 @@ class UtilsMixin:
             # Only configure ESI for multi-homing.
             return None
 
-        # short_esi is only set when called from sub-interface port-channels.
-        # if short_esi is None:
-        #     # Setting short_esi under port_channel will be deprecated in AVD4.0
-        #     port_channel_short_esi = get(adapter, "port_channel.short_esi")
-        #     if (short_esi := get(adapter, "ethernet_segment.short_esi", default=port_channel_short_esi)) is None:
-        #         return None
 
         endpoint_ports: list = default(
             adapter.get("endpoint_ports"),

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/connected_endpoints/utils.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/connected_endpoints/utils.py
@@ -159,6 +159,12 @@ class UtilsMixin:
             # Only configure ESI for multi-homing.
             return None
 
+        # # short_esi is only set when called from sub-interface port-channels.
+        if short_esi is None:
+            #     # Setting short_esi under port_channel will be deprecated in AVD4.0
+            #     port_channel_short_esi = get(adapter, "port_channel.short_esi")
+            if (short_esi := get(adapter, "ethernet_segment.short_esi")) is None:
+                return None
 
         endpoint_ports: list = default(
             adapter.get("endpoint_ports"),

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/connected_endpoints/utils.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/connected_endpoints/utils.py
@@ -160,11 +160,11 @@ class UtilsMixin:
             return None
 
         # short_esi is only set when called from sub-interface port-channels.
-        if short_esi is None:
-            # Setting short_esi under port_channel will be deprecated in AVD4.0
-            port_channel_short_esi = get(adapter, "port_channel.short_esi")
-            if (short_esi := get(adapter, "ethernet_segment.short_esi", default=port_channel_short_esi)) is None:
-                return None
+        # if short_esi is None:
+        #     # Setting short_esi under port_channel will be deprecated in AVD4.0
+        #     port_channel_short_esi = get(adapter, "port_channel.short_esi")
+        #     if (short_esi := get(adapter, "ethernet_segment.short_esi", default=port_channel_short_esi)) is None:
+        #         return None
 
         endpoint_ports: list = default(
             adapter.get("endpoint_ports"),


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.avd.<role-name>`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been rebased from devel before I start
- [ ] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
