### PR TITLE
Refactor(eos_designs): Use python for all default interface descriptions (#2490)

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_designs/defaults/main/default-templates.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/defaults/main/default-templates.yml
@@ -42,8 +42,6 @@ default_templates:
     interface_descriptions:
       python_module: "ansible_collections.arista.avd.roles.eos_designs.python_modules.interface_descriptions"
       python_class_name: "AvdInterfaceDescriptions"
-      connected_endpoints_ethernet_interfaces: "interface_descriptions/connected_endpoints/ethernet-interfaces.j2"
-      connected_endpoints_port_channel_interfaces: "interface_descriptions/connected_endpoints/port-channel-interfaces.j2"
 
   mpls:
     structured_config:
@@ -79,8 +77,6 @@ default_templates:
     interface_descriptions:
       python_module: "ansible_collections.arista.avd.roles.eos_designs.python_modules.interface_descriptions"
       python_class_name: "AvdInterfaceDescriptions"
-      connected_endpoints_ethernet_interfaces: "interface_descriptions/connected_endpoints/ethernet-interfaces.j2"
-      connected_endpoints_port_channel_interfaces: "interface_descriptions/connected_endpoints/port-channel-interfaces.j2"
 
   l2ls:
     structured_config:
@@ -120,5 +116,3 @@ default_templates:
     interface_descriptions:
       python_module: "ansible_collections.arista.avd.roles.eos_designs.python_modules.interface_descriptions"
       python_class_name: "AvdInterfaceDescriptions"
-      connected_endpoints_ethernet_interfaces: "interface_descriptions/connected_endpoints/ethernet-interfaces.j2"
-      connected_endpoints_port_channel_interfaces: "interface_descriptions/connected_endpoints/port-channel-interfaces.j2"


### PR DESCRIPTION
Cherry-pick of #2490 for 3.8.2 release