### PR TITLE
Fix(eos_cli_config_gen): Add variable protection for router_bgp.as in doc template (#2503)

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
@@ -7,12 +7,12 @@
 
 | BGP AS | Router ID |
 | ------ | --------- |
-| {{ router_bgp.as }}|  {{ router_bgp.router_id | arista.avd.default('-') }} |
+| {{ router_bgp.as | arista.avd.default('-') }}|  {{ router_bgp.router_id | arista.avd.default('-') }} |
 {%     if router_bgp.bgp_cluster_id is arista.avd.defined %}
 
 | BGP AS | Cluster ID |
 | ------ | --------- |
-| {{ router_bgp.as }}|  {{ router_bgp.bgp_cluster_id }} |
+| {{ router_bgp.as | arista.avd.default('-') }}|  {{ router_bgp.bgp_cluster_id }} |
 {%     endif %}
 {%     if router_bgp.bgp_defaults is arista.avd.defined or router_bgp.bgp is arista.avd.defined %}
 


### PR DESCRIPTION
Cherry-pick of #2503 for 3.8.2 release