### PR TITLE
Feat(eos_cli_config_gen): Support ND parameters inside router_l2_vpn the same as ARP

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-l2-vpn.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-l2-vpn.md
@@ -43,6 +43,10 @@ interface Management1
 
 - VXLAN ARP Proxying is disabled for IPv4 addresses defined in the prefix-list pl-router-l2-vpn.
 
+- ND learning bridged is enabled.
+
+- VXLAN ND Proxying is disabled for IPv6 addresses defined in the prefix-list pl-router-l2-vpn.
+
 - Selective ARP is enabled.
 
 - Neighbor discovery router solicitation VTEP flooding is disabled.
@@ -56,6 +60,8 @@ interface Management1
 router l2-vpn
    arp learning bridged
    arp proxy prefix-list pl-router-l2-vpn
+   nd learning bridged
+   nd proxy prefix-list pl-router-l2-vpn
    arp selective-install
    nd rs flooding disabled
    virtual-router neighbor advertisement flooding disabled

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-l2-vpn.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-l2-vpn.md
@@ -43,11 +43,11 @@ interface Management1
 
 - VXLAN ARP Proxying is disabled for IPv4 addresses defined in the prefix-list pl-router-l2-vpn.
 
+- Selective ARP is enabled.
+
 - ND learning bridged is enabled.
 
 - VXLAN ND Proxying is disabled for IPv6 addresses defined in the prefix-list pl-router-l2-vpn.
-
-- Selective ARP is enabled.
 
 - Neighbor discovery router solicitation VTEP flooding is disabled.
 
@@ -60,9 +60,9 @@ interface Management1
 router l2-vpn
    arp learning bridged
    arp proxy prefix-list pl-router-l2-vpn
+   arp selective-install
    nd learning bridged
    nd proxy prefix-list pl-router-l2-vpn
-   arp selective-install
    nd rs flooding disabled
    virtual-router neighbor advertisement flooding disabled
 ```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-l2-vpn.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-l2-vpn.cfg
@@ -7,6 +7,8 @@ hostname router-l2-vpn
 router l2-vpn
    arp learning bridged
    arp proxy prefix-list pl-router-l2-vpn
+   nd learning bridged
+   nd proxy prefix-list pl-router-l2-vpn
    arp selective-install
    nd rs flooding disabled
    virtual-router neighbor advertisement flooding disabled

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-l2-vpn.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-l2-vpn.cfg
@@ -7,9 +7,9 @@ hostname router-l2-vpn
 router l2-vpn
    arp learning bridged
    arp proxy prefix-list pl-router-l2-vpn
+   arp selective-install
    nd learning bridged
    nd proxy prefix-list pl-router-l2-vpn
-   arp selective-install
    nd rs flooding disabled
    virtual-router neighbor advertisement flooding disabled
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-l2-vpn.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-l2-vpn.yml
@@ -3,10 +3,10 @@
 router_l2_vpn:
   nd_rs_flooding_disabled: true
   virtual_router_nd_ra_flooding_disabled: true
-  arp_selective_install: true
   arp_proxy:
     prefix_list: "pl-router-l2-vpn"
   arp_learning_bridged: true
+  arp_selective_install: true
   nd_proxy:
     prefix_list: "pl-router-l2-vpn"
   nd_learning_bridged: true

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-l2-vpn.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-l2-vpn.yml
@@ -7,3 +7,6 @@ router_l2_vpn:
   arp_proxy:
     prefix_list: "pl-router-l2-vpn"
   arp_learning_bridged: true
+  nd_proxy:
+    prefix_list: "pl-router-l2-vpn"
+  nd_learning_bridged: true

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/data_model/Routing.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/data_model/Routing.md
@@ -1203,6 +1203,9 @@ MAC address (hh:hh:hh:hh:hh:hh)
     | [<samp>&nbsp;&nbsp;arp_learning_bridged</samp>](## "router_l2_vpn.arp_learning_bridged") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;arp_proxy</samp>](## "router_l2_vpn.arp_proxy") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;prefix_list</samp>](## "router_l2_vpn.arp_proxy.prefix_list") | String |  |  |  | Prefix-list Name |
+    | [<samp>&nbsp;&nbsp;nd_learning_bridged</samp>](## "router_l2_vpn.nd_learning_bridged") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;nd_proxy</samp>](## "router_l2_vpn.nd_proxy") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;prefix_list</samp>](## "router_l2_vpn.nd_proxy.prefix_list") | String |  |  |  | Prefix-list Name |
     | [<samp>&nbsp;&nbsp;arp_selective_install</samp>](## "router_l2_vpn.arp_selective_install") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;nd_rs_flooding_disabled</samp>](## "router_l2_vpn.nd_rs_flooding_disabled") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;virtual_router_nd_ra_flooding_disabled</samp>](## "router_l2_vpn.virtual_router_nd_ra_flooding_disabled") | Boolean |  |  |  |  |
@@ -1213,6 +1216,9 @@ MAC address (hh:hh:hh:hh:hh:hh)
     router_l2_vpn:
       arp_learning_bridged: <bool>
       arp_proxy:
+        prefix_list: <str>
+      nd_learning_bridged: <bool>
+      nd_proxy:
         prefix_list: <str>
       arp_selective_install: <bool>
       nd_rs_flooding_disabled: <bool>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/data_model/Routing.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/data_model/Routing.md
@@ -1203,10 +1203,10 @@ MAC address (hh:hh:hh:hh:hh:hh)
     | [<samp>&nbsp;&nbsp;arp_learning_bridged</samp>](## "router_l2_vpn.arp_learning_bridged") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;arp_proxy</samp>](## "router_l2_vpn.arp_proxy") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;prefix_list</samp>](## "router_l2_vpn.arp_proxy.prefix_list") | String |  |  |  | Prefix-list name. ARP Proxying is disabled for IPv4 addresses defined in the prefix-list. |
+    | [<samp>&nbsp;&nbsp;arp_selective_install</samp>](## "router_l2_vpn.arp_selective_install") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;nd_learning_bridged</samp>](## "router_l2_vpn.nd_learning_bridged") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;nd_proxy</samp>](## "router_l2_vpn.nd_proxy") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;prefix_list</samp>](## "router_l2_vpn.nd_proxy.prefix_list") | String |  |  |  | Prefix-list name. ND Proxying is disabled for IPv6 addresses defined in the prefix-list. |
-    | [<samp>&nbsp;&nbsp;arp_selective_install</samp>](## "router_l2_vpn.arp_selective_install") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;nd_rs_flooding_disabled</samp>](## "router_l2_vpn.nd_rs_flooding_disabled") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;virtual_router_nd_ra_flooding_disabled</samp>](## "router_l2_vpn.virtual_router_nd_ra_flooding_disabled") | Boolean |  |  |  |  |
 
@@ -1217,10 +1217,10 @@ MAC address (hh:hh:hh:hh:hh:hh)
       arp_learning_bridged: <bool>
       arp_proxy:
         prefix_list: <str>
+      arp_selective_install: <bool>
       nd_learning_bridged: <bool>
       nd_proxy:
         prefix_list: <str>
-      arp_selective_install: <bool>
       nd_rs_flooding_disabled: <bool>
       virtual_router_nd_ra_flooding_disabled: <bool>
     ```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/data_model/Routing.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/data_model/Routing.md
@@ -1202,10 +1202,10 @@ MAC address (hh:hh:hh:hh:hh:hh)
     | [<samp>router_l2_vpn</samp>](## "router_l2_vpn") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;arp_learning_bridged</samp>](## "router_l2_vpn.arp_learning_bridged") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;arp_proxy</samp>](## "router_l2_vpn.arp_proxy") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;prefix_list</samp>](## "router_l2_vpn.arp_proxy.prefix_list") | String |  |  |  | Prefix-list Name |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;prefix_list</samp>](## "router_l2_vpn.arp_proxy.prefix_list") | String |  |  |  | Prefix-list name. ARP Proxying is disabled for IPv4 addresses defined in the prefix-list. |
     | [<samp>&nbsp;&nbsp;nd_learning_bridged</samp>](## "router_l2_vpn.nd_learning_bridged") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;nd_proxy</samp>](## "router_l2_vpn.nd_proxy") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;prefix_list</samp>](## "router_l2_vpn.nd_proxy.prefix_list") | String |  |  |  | Prefix-list Name |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;prefix_list</samp>](## "router_l2_vpn.nd_proxy.prefix_list") | String |  |  |  | Prefix-list name. ND Proxying is disabled for IPv6 addresses defined in the prefix-list. |
     | [<samp>&nbsp;&nbsp;arp_selective_install</samp>](## "router_l2_vpn.arp_selective_install") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;nd_rs_flooding_disabled</samp>](## "router_l2_vpn.nd_rs_flooding_disabled") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;virtual_router_nd_ra_flooding_disabled</samp>](## "router_l2_vpn.virtual_router_nd_ra_flooding_disabled") | Boolean |  |  |  |  |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -11316,6 +11316,10 @@
           "additionalProperties": false,
           "title": "ARP Proxy"
         },
+        "arp_selective_install": {
+          "type": "boolean",
+          "title": "ARP Selective Install"
+        },
         "nd_learning_bridged": {
           "type": "boolean",
           "title": "ND Learning Bridged"
@@ -11331,10 +11335,6 @@
           },
           "additionalProperties": false,
           "title": "ND Proxy"
-        },
-        "arp_selective_install": {
-          "type": "boolean",
-          "title": "ARP Selective Install"
         },
         "nd_rs_flooding_disabled": {
           "type": "boolean",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -11309,7 +11309,7 @@
           "properties": {
             "prefix_list": {
               "type": "string",
-              "description": "Prefix-list Name",
+              "description": "Prefix-list name. ARP Proxying is disabled for IPv4 addresses defined in the prefix-list.",
               "title": "Prefix List"
             }
           },
@@ -11325,7 +11325,7 @@
           "properties": {
             "prefix_list": {
               "type": "string",
-              "description": "Prefix-list Name",
+              "description": "Prefix-list name. ND Proxying is disabled for IPv6 addresses defined in the prefix-list.",
               "title": "Prefix List"
             }
           },

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -11316,6 +11316,22 @@
           "additionalProperties": false,
           "title": "ARP Proxy"
         },
+        "nd_learning_bridged": {
+          "type": "boolean",
+          "title": "ND Learning Bridged"
+        },
+        "nd_proxy": {
+          "type": "object",
+          "properties": {
+            "prefix_list": {
+              "type": "string",
+              "description": "Prefix-list Name",
+              "title": "Prefix List"
+            }
+          },
+          "additionalProperties": false,
+          "title": "ND Proxy"
+        },
         "arp_selective_install": {
           "type": "boolean",
           "title": "ARP Selective Install"

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -7954,7 +7954,8 @@ keys:
         keys:
           prefix_list:
             type: str
-            description: Prefix-list Name
+            description: Prefix-list name. ARP Proxying is disabled for IPv4 addresses
+              defined in the prefix-list.
       nd_learning_bridged:
         type: bool
       nd_proxy:
@@ -7962,7 +7963,8 @@ keys:
         keys:
           prefix_list:
             type: str
-            description: Prefix-list Name
+            description: Prefix-list name. ND Proxying is disabled for IPv6 addresses
+              defined in the prefix-list.
       arp_selective_install:
         type: bool
       nd_rs_flooding_disabled:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -7956,6 +7956,8 @@ keys:
             type: str
             description: Prefix-list name. ARP Proxying is disabled for IPv4 addresses
               defined in the prefix-list.
+      arp_selective_install:
+        type: bool
       nd_learning_bridged:
         type: bool
       nd_proxy:
@@ -7965,8 +7967,6 @@ keys:
             type: str
             description: Prefix-list name. ND Proxying is disabled for IPv6 addresses
               defined in the prefix-list.
-      arp_selective_install:
-        type: bool
       nd_rs_flooding_disabled:
         type: bool
       virtual_router_nd_ra_flooding_disabled:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -7955,6 +7955,14 @@ keys:
           prefix_list:
             type: str
             description: Prefix-list Name
+      nd_learning_bridged:
+        type: bool
+      nd_proxy:
+        type: dict
+        keys:
+          prefix_list:
+            type: str
+            description: Prefix-list Name
       arp_selective_install:
         type: bool
       nd_rs_flooding_disabled:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_l2_vpn.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_l2_vpn.schema.yml
@@ -16,6 +16,8 @@ keys:
           prefix_list:
             type: str
             description: Prefix-list name. ARP Proxying is disabled for IPv4 addresses defined in the prefix-list.
+      arp_selective_install:
+        type: bool
       nd_learning_bridged:
         type: bool
       nd_proxy:
@@ -24,8 +26,6 @@ keys:
           prefix_list:
             type: str
             description: Prefix-list name. ND Proxying is disabled for IPv6 addresses defined in the prefix-list.
-      arp_selective_install:
-        type: bool
       nd_rs_flooding_disabled:
         type: bool
       virtual_router_nd_ra_flooding_disabled:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_l2_vpn.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_l2_vpn.schema.yml
@@ -16,6 +16,14 @@ keys:
           prefix_list:
             type: str
             description: Prefix-list Name
+      nd_learning_bridged:
+        type: bool
+      nd_proxy:
+        type: dict
+        keys:
+          prefix_list:
+            type: str
+            description: Prefix-list Name
       arp_selective_install:
         type: bool
       nd_rs_flooding_disabled:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_l2_vpn.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_l2_vpn.schema.yml
@@ -15,7 +15,7 @@ keys:
         keys:
           prefix_list:
             type: str
-            description: Prefix-list Name
+            description: Prefix-list name. ARP Proxying is disabled for IPv4 addresses defined in the prefix-list.
       nd_learning_bridged:
         type: bool
       nd_proxy:
@@ -23,7 +23,7 @@ keys:
         keys:
           prefix_list:
             type: str
-            description: Prefix-list Name
+            description: Prefix-list name. ND Proxying is disabled for IPv6 addresses defined in the prefix-list.
       arp_selective_install:
         type: bool
       nd_rs_flooding_disabled:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-l2-vpn.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-l2-vpn.j2
@@ -12,6 +12,14 @@
 
 - VXLAN ARP Proxying is disabled for IPv4 addresses defined in the prefix-list {{ router_l2_vpn.arp_proxy.prefix_list }}.
 {%     endif %}
+{%     if router_l2_vpn.nd_learning_bridged is arista.avd.defined(true) %}
+
+- ND learning bridged is enabled.
+{%     endif %}
+{%     if router_l2_vpn.nd_proxy.prefix_list is arista.avd.defined %}
+
+- VXLAN ND Proxying is disabled for IPv6 addresses defined in the prefix-list {{ router_l2_vpn.nd_proxy.prefix_list }}.
+{%     endif %}
 {%     if router_l2_vpn.arp_selective_install is arista.avd.defined(true) %}
 
 - Selective ARP is enabled.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-l2-vpn.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-l2-vpn.j2
@@ -12,6 +12,10 @@
 
 - VXLAN ARP Proxying is disabled for IPv4 addresses defined in the prefix-list {{ router_l2_vpn.arp_proxy.prefix_list }}.
 {%     endif %}
+{%     if router_l2_vpn.arp_selective_install is arista.avd.defined(true) %}
+
+- Selective ARP is enabled.
+{%     endif %}
 {%     if router_l2_vpn.nd_learning_bridged is arista.avd.defined(true) %}
 
 - ND learning bridged is enabled.
@@ -19,10 +23,6 @@
 {%     if router_l2_vpn.nd_proxy.prefix_list is arista.avd.defined %}
 
 - VXLAN ND Proxying is disabled for IPv6 addresses defined in the prefix-list {{ router_l2_vpn.nd_proxy.prefix_list }}.
-{%     endif %}
-{%     if router_l2_vpn.arp_selective_install is arista.avd.defined(true) %}
-
-- Selective ARP is enabled.
 {%     endif %}
 {%     if router_l2_vpn.nd_rs_flooding_disabled is arista.avd.defined(true) %}
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-l2-vpn.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-l2-vpn.j2
@@ -8,14 +8,14 @@ router l2-vpn
 {%     if router_l2_vpn.arp_proxy.prefix_list is arista.avd.defined %}
    arp proxy prefix-list {{ router_l2_vpn.arp_proxy.prefix_list }}
 {%     endif %}
+{%     if router_l2_vpn.arp_selective_install is arista.avd.defined(true) %}
+   arp selective-install
+{%     endif %}
 {%     if router_l2_vpn.nd_learning_bridged is arista.avd.defined(true) %}
    nd learning bridged
 {%     endif %}
 {%     if router_l2_vpn.nd_proxy.prefix_list is arista.avd.defined %}
    nd proxy prefix-list {{ router_l2_vpn.nd_proxy.prefix_list }}
-{%     endif %}
-{%     if router_l2_vpn.arp_selective_install is arista.avd.defined(true) %}
-   arp selective-install
 {%     endif %}
 {%     if router_l2_vpn.nd_rs_flooding_disabled is arista.avd.defined(true) %}
    nd rs flooding disabled

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-l2-vpn.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-l2-vpn.j2
@@ -8,6 +8,12 @@ router l2-vpn
 {%     if router_l2_vpn.arp_proxy.prefix_list is arista.avd.defined %}
    arp proxy prefix-list {{ router_l2_vpn.arp_proxy.prefix_list }}
 {%     endif %}
+{%     if router_l2_vpn.nd_learning_bridged is arista.avd.defined(true) %}
+   nd learning bridged
+{%     endif %}
+{%     if router_l2_vpn.nd_proxy.prefix_list is arista.avd.defined %}
+   nd proxy prefix-list {{ router_l2_vpn.nd_proxy.prefix_list }}
+{%     endif %}
 {%     if router_l2_vpn.arp_selective_install is arista.avd.defined(true) %}
    arp selective-install
 {%     endif %}


### PR DESCRIPTION
## Change Summary

Support the parameters for ND the same way ARP is already supported.

## Related Issue(s)

Fixes #2537

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
See PR.

## How to test
Added those config options and validated that they work the same way ARP does already.

## Checklist

### User Checklist

None.

### Repository Checklist

- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)