### PR TITLE
Feat(eos_cli_config_gen): CVX Client non-default VRF support

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-cvx.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-cvx.md
@@ -39,6 +39,12 @@ interface Management1
 | -------- | ----------- |
 | False | 10.90.224.188, 10.90.224.189, leaf1.atd.lab |
 
+### Management CVX Source Interface
+
+| Interface | VRF |
+| --------- | --- |
+| Loopback0 | MGMT |
+
 ### Management CVX configuration
 
 ```eos
@@ -48,5 +54,6 @@ management cvx
    server host 10.90.224.188
    server host 10.90.224.189
    server host leaf1.atd.lab
-   source-interface loopback0
+   source-interface Loopback0
+   vrf MGMT
 ```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/management-cvx.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/management-cvx.cfg
@@ -17,6 +17,7 @@ management cvx
    server host 10.90.224.188
    server host 10.90.224.189
    server host leaf1.atd.lab
-   source-interface loopback0
+   source-interface Loopback0
+   vrf MGMT
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/management-cvx.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/management-cvx.yml
@@ -5,4 +5,5 @@ management_cvx:
   - 10.90.224.188
   - 10.90.224.189
   - leaf1.atd.lab
-  source_interface: loopback0
+  source_interface: Loopback0
+  vrf: MGMT

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/data_model/Management.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/data_model/Management.md
@@ -236,6 +236,7 @@ Search list of DNS domains
     | [<samp>&nbsp;&nbsp;server_hosts</samp>](## "management_cvx.server_hosts") | List, items: String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "management_cvx.server_hosts.[].&lt;str&gt;") | String |  |  |  | IP or hostname |
     | [<samp>&nbsp;&nbsp;source_interface</samp>](## "management_cvx.source_interface") | String |  |  |  | Interface name |
+    | [<samp>&nbsp;&nbsp;vrf</samp>](## "management_cvx.vrf") | String |  |  |  | VRF Name |
 
 === "YAML"
 
@@ -245,6 +246,7 @@ Search list of DNS domains
       server_hosts:
         - <str>
       source_interface: <str>
+      vrf: <str>
     ```
 
 ## Management Defaults

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -5226,6 +5226,11 @@
           "type": "string",
           "description": "Interface name",
           "title": "Source Interface"
+        },
+        "vrf": {
+          "type": "string",
+          "description": "VRF Name",
+          "title": "VRF"
         }
       },
       "additionalProperties": false,

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -3920,6 +3920,9 @@ keys:
       source_interface:
         type: str
         description: Interface name
+      vrf:
+        type: str
+        description: VRF Name
   management_defaults:
     documentation_options:
       filename: data_model/Management

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_cvx.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_cvx.schema.yml
@@ -18,3 +18,6 @@ keys:
       source_interface:
         type: str
         description: Interface name
+      vrf:
+        type: str
+        description: VRF Name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-cvx.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-cvx.j2
@@ -8,8 +8,8 @@
 {%     set shut = management_cvx.shutdown | arista.avd.default('-') %}
 {%     set servers = management_cvx.server_hosts | arista.avd.default('-') | join(', ') %}
 | {{ shut }} | {{ servers }} |
-
 {%     if management_cvx.source_interface is arista.avd.defined %}
+
 ### Management CVX Source Interface
 
 | Interface | VRF |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-cvx.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-cvx.j2
@@ -9,6 +9,14 @@
 {%     set servers = management_cvx.server_hosts | arista.avd.default('-') | join(', ') %}
 | {{ shut }} | {{ servers }} |
 
+{%     if management_cvx.source_interface is arista.avd.defined %}
+### Management CVX Source Interface
+
+| Interface | VRF |
+| --------- | --- |
+| {{ management_cvx.source_interface }} | {{ management_cvx.vrf | arista.avd.default('-') }} |
+{%     endif %}
+
 ### Management CVX configuration
 
 ```eos

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-cvx.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-cvx.j2
@@ -13,4 +13,7 @@ management cvx
 {%     if management_cvx.source_interface is arista.avd.defined %}
    source-interface {{ management_cvx.source_interface }}
 {%     endif %}
+{%     if management_cvx.vrf is arista.avd.defined %}
+   vrf {{ management_cvx.vrf }}
+{%     endif %}
 {% endif %}


### PR DESCRIPTION
## Change Summary

Add support for non-default vrf under `management cvx`

```shell
management cvx
   no shutdown
   server host 10.90.224.188
   server host 10.90.224.189
   server host leaf1.atd.lab
   source-interface Loopback0
   vrf MGMT
```

## Related Issue(s)

Fixes #2367

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Add following to the management cvx template

```j2
{%     if management_cvx.vrf is arista.avd.defined %}
   vrf {{ management_cvx.vrf }}
{%     endif %}
```

Following change made to the documentation template

```j2
{%     if management_cvx.source_interface is arista.avd.defined %}
### Management CVX Source Interface

| Interface | VRF |
| --------- | --- |
| {{ management_cvx.source_interface }} | {{ management_cvx.vrf | arista.avd.default('-') }} |
{%     endif %}
```

## How to test
Ran precommit 

Ran `molecule test --scenario-name eos_cli_config_gen`

## Checklist

### User Checklist

- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
