### PR TITLE
Refactor(eos_designs): prefix_lists python_module as per eos_cli_config_gen

### DIFF
--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf1a.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf1a.yml
@@ -417,12 +417,12 @@ loopback_interfaces:
   ip_address: 10.255.11.3/32
   name: Loopback11
 prefix_lists:
-- sequence_numbers:
-  - action: permit 10.255.0.0/27 eq 32
-    sequence: 10
-  - action: permit 10.255.1.0/27 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 10.255.0.0/27 eq 32
+  - sequence: 20
+    action: permit 10.255.1.0/27 eq 32
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf1b.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf1b.yml
@@ -417,12 +417,12 @@ loopback_interfaces:
   ip_address: 10.255.11.4/32
   name: Loopback11
 prefix_lists:
-- sequence_numbers:
-  - action: permit 10.255.0.0/27 eq 32
-    sequence: 10
-  - action: permit 10.255.1.0/27 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 10.255.0.0/27 eq 32
+  - sequence: 20
+    action: permit 10.255.1.0/27 eq 32
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf2a.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf2a.yml
@@ -486,12 +486,12 @@ loopback_interfaces:
   ip_address: 10.255.11.5/32
   name: Loopback11
 prefix_lists:
-- sequence_numbers:
-  - action: permit 10.255.0.0/27 eq 32
-    sequence: 10
-  - action: permit 10.255.1.0/27 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 10.255.0.0/27 eq 32
+  - sequence: 20
+    action: permit 10.255.1.0/27 eq 32
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf2b.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf2b.yml
@@ -486,12 +486,12 @@ loopback_interfaces:
   ip_address: 10.255.11.6/32
   name: Loopback11
 prefix_lists:
-- sequence_numbers:
-  - action: permit 10.255.0.0/27 eq 32
-    sequence: 10
-  - action: permit 10.255.1.0/27 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 10.255.0.0/27 eq 32
+  - sequence: 20
+    action: permit 10.255.1.0/27 eq 32
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-spine1.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-spine1.yml
@@ -148,10 +148,10 @@ loopback_interfaces:
   ip_address: 10.255.0.1/32
   name: Loopback0
 prefix_lists:
-- sequence_numbers:
-  - action: permit 10.255.0.0/27 eq 32
-    sequence: 10
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 10.255.0.0/27 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-spine2.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-spine2.yml
@@ -148,10 +148,10 @@ loopback_interfaces:
   ip_address: 10.255.0.2/32
   name: Loopback0
 prefix_lists:
-- sequence_numbers:
-  - action: permit 10.255.0.0/27 eq 32
-    sequence: 10
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 10.255.0.0/27 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf1a.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf1a.yml
@@ -417,12 +417,12 @@ loopback_interfaces:
   ip_address: 10.255.11.13/32
   name: Loopback11
 prefix_lists:
-- sequence_numbers:
-  - action: permit 10.255.128.0/27 eq 32
-    sequence: 10
-  - action: permit 10.255.129.0/27 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 10.255.128.0/27 eq 32
+  - sequence: 20
+    action: permit 10.255.129.0/27 eq 32
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf1b.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf1b.yml
@@ -417,12 +417,12 @@ loopback_interfaces:
   ip_address: 10.255.11.14/32
   name: Loopback11
 prefix_lists:
-- sequence_numbers:
-  - action: permit 10.255.128.0/27 eq 32
-    sequence: 10
-  - action: permit 10.255.129.0/27 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 10.255.128.0/27 eq 32
+  - sequence: 20
+    action: permit 10.255.129.0/27 eq 32
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf2a.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf2a.yml
@@ -486,12 +486,12 @@ loopback_interfaces:
   ip_address: 10.255.11.15/32
   name: Loopback11
 prefix_lists:
-- sequence_numbers:
-  - action: permit 10.255.128.0/27 eq 32
-    sequence: 10
-  - action: permit 10.255.129.0/27 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 10.255.128.0/27 eq 32
+  - sequence: 20
+    action: permit 10.255.129.0/27 eq 32
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf2b.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf2b.yml
@@ -486,12 +486,12 @@ loopback_interfaces:
   ip_address: 10.255.11.16/32
   name: Loopback11
 prefix_lists:
-- sequence_numbers:
-  - action: permit 10.255.128.0/27 eq 32
-    sequence: 10
-  - action: permit 10.255.129.0/27 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 10.255.128.0/27 eq 32
+  - sequence: 20
+    action: permit 10.255.129.0/27 eq 32
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-spine1.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-spine1.yml
@@ -148,10 +148,10 @@ loopback_interfaces:
   ip_address: 10.255.128.11/32
   name: Loopback0
 prefix_lists:
-- sequence_numbers:
-  - action: permit 10.255.128.0/27 eq 32
-    sequence: 10
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 10.255.128.0/27 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-spine2.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-spine2.yml
@@ -148,10 +148,10 @@ loopback_interfaces:
   ip_address: 10.255.128.12/32
   name: Loopback0
 prefix_lists:
-- sequence_numbers:
-  - action: permit 10.255.128.0/27 eq 32
-    sequence: 10
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 10.255.128.0/27 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf1a.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf1a.yml
@@ -417,12 +417,12 @@ loopback_interfaces:
   ip_address: 10.255.11.3/32
   name: Loopback11
 prefix_lists:
-- sequence_numbers:
-  - action: permit 10.255.0.0/27 eq 32
-    sequence: 10
-  - action: permit 10.255.1.0/27 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 10.255.0.0/27 eq 32
+  - sequence: 20
+    action: permit 10.255.1.0/27 eq 32
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf1b.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf1b.yml
@@ -417,12 +417,12 @@ loopback_interfaces:
   ip_address: 10.255.11.4/32
   name: Loopback11
 prefix_lists:
-- sequence_numbers:
-  - action: permit 10.255.0.0/27 eq 32
-    sequence: 10
-  - action: permit 10.255.1.0/27 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 10.255.0.0/27 eq 32
+  - sequence: 20
+    action: permit 10.255.1.0/27 eq 32
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf2a.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf2a.yml
@@ -417,12 +417,12 @@ loopback_interfaces:
   ip_address: 10.255.11.5/32
   name: Loopback11
 prefix_lists:
-- sequence_numbers:
-  - action: permit 10.255.0.0/27 eq 32
-    sequence: 10
-  - action: permit 10.255.1.0/27 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 10.255.0.0/27 eq 32
+  - sequence: 20
+    action: permit 10.255.1.0/27 eq 32
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf2b.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf2b.yml
@@ -417,12 +417,12 @@ loopback_interfaces:
   ip_address: 10.255.11.6/32
   name: Loopback11
 prefix_lists:
-- sequence_numbers:
-  - action: permit 10.255.0.0/27 eq 32
-    sequence: 10
-  - action: permit 10.255.1.0/27 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 10.255.0.0/27 eq 32
+  - sequence: 20
+    action: permit 10.255.1.0/27 eq 32
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-spine1.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-spine1.yml
@@ -148,10 +148,10 @@ loopback_interfaces:
   ip_address: 10.255.0.1/32
   name: Loopback0
 prefix_lists:
-- sequence_numbers:
-  - action: permit 10.255.0.0/27 eq 32
-    sequence: 10
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 10.255.0.0/27 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-spine2.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-spine2.yml
@@ -148,10 +148,10 @@ loopback_interfaces:
   ip_address: 10.255.0.2/32
   name: Loopback0
 prefix_lists:
-- sequence_numbers:
-  - action: permit 10.255.0.0/27 eq 32
-    sequence: 10
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 10.255.0.0/27 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-BL1A.yml
@@ -415,12 +415,12 @@ loopback_interfaces:
   ip_address: 192.168.254.10/32
   name: Loopback1
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 router_bfd:
   multihop:
     interval: 1200

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-BL1B.yml
@@ -415,12 +415,12 @@ loopback_interfaces:
   ip_address: 192.168.254.10/32
   name: Loopback1
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 router_bfd:
   multihop:
     interval: 1200

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF1A.yml
@@ -238,12 +238,12 @@ loopback_interfaces:
   ip_address: 192.168.254.5/32
   name: Loopback1
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF2A.yml
@@ -690,12 +690,12 @@ loopback_interfaces:
   ip_address: 10.255.1.6/32
   name: Loopback100
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 router_bfd:
   multihop:
     interval: 1200

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF2B.yml
@@ -690,12 +690,12 @@ loopback_interfaces:
   ip_address: 10.255.1.7/32
   name: Loopback100
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 router_bfd:
   multihop:
     interval: 1200

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SPINE1.yml
@@ -213,10 +213,10 @@ loopback_interfaces:
   ip_address: 192.168.255.1/32
   name: Loopback0
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SPINE2.yml
@@ -213,10 +213,10 @@ loopback_interfaces:
   ip_address: 192.168.255.2/32
   name: Loopback0
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SPINE3.yml
@@ -213,10 +213,10 @@ loopback_interfaces:
   ip_address: 192.168.255.3/32
   name: Loopback0
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SPINE4.yml
@@ -213,10 +213,10 @@ loopback_interfaces:
   ip_address: 192.168.255.4/32
   name: Loopback0
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SVC3A.yml
@@ -856,12 +856,12 @@ loopback_interfaces:
   ip_address: 10.255.1.8/32
   name: Loopback100
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 router_bfd:
   multihop:
     interval: 1200

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SVC3B.yml
@@ -837,12 +837,12 @@ loopback_interfaces:
   ip_address: 10.255.1.9/32
   name: Loopback100
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 router_bfd:
   multihop:
     interval: 1200

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF1A.yml
@@ -184,10 +184,10 @@ prefix_lists:
     action: permit 172.16.110.0/24 eq 32
   - sequence: 20
     action: permit 172.18.110.0/24 eq 32
-- sequence_numbers:
-  - action: permit 172.21.110.0/24
-    sequence: 10
-  name: PL-L2LEAF-INBAND-MGMT
+- name: PL-L2LEAF-INBAND-MGMT
+  sequence_numbers:
+  - sequence: 10
+    action: permit 172.21.110.0/24
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF1A.yml
@@ -178,12 +178,12 @@ loopback_interfaces:
   ip_address: 172.18.110.3/32
   name: Loopback1
 prefix_lists:
-- sequence_numbers:
-  - action: permit 172.16.110.0/24 eq 32
-    sequence: 10
-  - action: permit 172.18.110.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 172.16.110.0/24 eq 32
+  - sequence: 20
+    action: permit 172.18.110.0/24 eq 32
 - sequence_numbers:
   - action: permit 172.21.110.0/24
     sequence: 10

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2B.yml
@@ -776,12 +776,12 @@ loopback_interfaces:
   ip_address: 10.101.101.5/32
   name: Loopback101
 prefix_lists:
-- sequence_numbers:
-  - action: permit 172.16.110.0/24 eq 32
-    sequence: 10
-  - action: permit 172.18.110.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 172.16.110.0/24 eq 32
+  - sequence: 20
+    action: permit 172.18.110.0/24 eq 32
 - sequence_numbers:
   - action: permit 172.21.110.0/24
     sequence: 10

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2B.yml
@@ -782,10 +782,10 @@ prefix_lists:
     action: permit 172.16.110.0/24 eq 32
   - sequence: 20
     action: permit 172.18.110.0/24 eq 32
-- sequence_numbers:
-  - action: permit 172.21.110.0/24
-    sequence: 10
-  name: PL-L2LEAF-INBAND-MGMT
+- name: PL-L2LEAF-INBAND-MGMT
+  sequence_numbers:
+  - sequence: 10
+    action: permit 172.21.110.0/24
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-SPINE1.yml
@@ -236,10 +236,10 @@ loopback_interfaces:
   ip_address: 172.16.110.1/32
   name: Loopback0
 prefix_lists:
-- sequence_numbers:
-  - action: permit 172.16.110.0/24 eq 32
-    sequence: 10
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 172.16.110.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-SPINE2.yml
@@ -180,10 +180,10 @@ loopback_interfaces:
   ip_address: 172.16.110.2/32
   name: Loopback0
 prefix_lists:
-- sequence_numbers:
-  - action: permit 172.16.110.0/24 eq 32
-    sequence: 10
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 172.16.110.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD2-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD2-LEAF1A.yml
@@ -305,12 +305,12 @@ loopback_interfaces:
   ip_address: 10.101.102.3/32
   name: Loopback101
 prefix_lists:
-- sequence_numbers:
-  - action: permit 172.16.120.0/24 eq 32
-    sequence: 10
-  - action: permit 172.18.120.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 172.16.120.0/24 eq 32
+  - sequence: 20
+    action: permit 172.18.120.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD2-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD2-SPINE1.yml
@@ -169,10 +169,10 @@ loopback_interfaces:
   ip_address: 172.16.120.1/32
   name: Loopback0
 prefix_lists:
-- sequence_numbers:
-  - action: permit 172.16.120.0/24 eq 32
-    sequence: 10
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 172.16.120.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD2-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD2-SPINE2.yml
@@ -158,10 +158,10 @@ loopback_interfaces:
   ip_address: 172.16.120.2/32
   name: Loopback0
 prefix_lists:
-- sequence_numbers:
-  - action: permit 172.16.120.0/24 eq 32
-    sequence: 10
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 172.16.120.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-RS1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-RS1.yml
@@ -150,10 +150,10 @@ loopback_interfaces:
   ip_address: 172.16.10.1/32
   name: Loopback0
 prefix_lists:
-- sequence_numbers:
-  - action: permit 172.16.10.0/24 eq 32
-    sequence: 10
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 172.16.10.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-RS2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-RS2.yml
@@ -150,10 +150,10 @@ loopback_interfaces:
   ip_address: 172.16.10.2/32
   name: Loopback0
 prefix_lists:
-- sequence_numbers:
-  - action: permit 172.16.10.0/24 eq 32
-    sequence: 10
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 172.16.10.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-SUPER-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-SUPER-SPINE1.yml
@@ -161,10 +161,10 @@ loopback_interfaces:
   ip_address: 172.16.100.1/32
   name: Loopback0
 prefix_lists:
-- sequence_numbers:
-  - action: permit 172.16.100.0/24 eq 32
-    sequence: 10
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 172.16.100.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-SUPER-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-SUPER-SPINE2.yml
@@ -164,10 +164,10 @@ loopback_interfaces:
   ip_address: 172.16.100.2/32
   name: Loopback0
 prefix_lists:
-- sequence_numbers:
-  - action: permit 172.16.100.0/24 eq 32
-    sequence: 10
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 172.16.100.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1.POD1.LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1.POD1.LEAF2A.yml
@@ -738,12 +738,12 @@ loopback_interfaces:
   ip_address: 10.101.101.4/32
   name: Loopback101
 prefix_lists:
-- sequence_numbers:
-  - action: permit 172.16.110.0/24 eq 32
-    sequence: 10
-  - action: permit 172.18.110.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 172.16.110.0/24 eq 32
+  - sequence: 20
+    action: permit 172.18.110.0/24 eq 32
 - sequence_numbers:
   - action: permit 172.21.110.0/24
     sequence: 10

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1.POD1.LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1.POD1.LEAF2A.yml
@@ -744,10 +744,10 @@ prefix_lists:
     action: permit 172.16.110.0/24 eq 32
   - sequence: 20
     action: permit 172.18.110.0/24 eq 32
-- sequence_numbers:
-  - action: permit 172.21.110.0/24
-    sequence: 10
-  name: PL-L2LEAF-INBAND-MGMT
+- name: PL-L2LEAF-INBAND-MGMT
+  sequence_numbers:
+  - sequence: 10
+    action: permit 172.21.110.0/24
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-LEAF1A.yml
@@ -276,12 +276,12 @@ loopback_interfaces:
   ip_address: 10.101.201.3/32
   name: Loopback101
 prefix_lists:
-- sequence_numbers:
-  - action: permit 172.16.210.0/24 eq 32
-    sequence: 10
-  - action: permit 172.18.210.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 172.16.210.0/24 eq 32
+  - sequence: 20
+    action: permit 172.18.210.0/24 eq 32
 - sequence_numbers:
   - action: permit 172.21.210.0/24
     sequence: 10

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-LEAF1A.yml
@@ -282,10 +282,10 @@ prefix_lists:
     action: permit 172.16.210.0/24 eq 32
   - sequence: 20
     action: permit 172.18.210.0/24 eq 32
-- sequence_numbers:
-  - action: permit 172.21.210.0/24
-    sequence: 10
-  name: PL-L2LEAF-INBAND-MGMT
+- name: PL-L2LEAF-INBAND-MGMT
+  sequence_numbers:
+  - sequence: 10
+    action: permit 172.21.210.0/24
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-LEAF2A.yml
@@ -147,10 +147,10 @@ prefix_lists:
     action: permit 172.16.210.0/24 eq 32
   - sequence: 20
     action: permit 172.18.210.0/24 eq 32
-- sequence_numbers:
-  - action: permit 172.21.210.0/24
-    sequence: 10
-  name: PL-L2LEAF-INBAND-MGMT
+- name: PL-L2LEAF-INBAND-MGMT
+  sequence_numbers:
+  - sequence: 10
+    action: permit 172.21.210.0/24
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-LEAF2A.yml
@@ -141,12 +141,12 @@ loopback_interfaces:
   ip_address: 172.18.210.4/32
   name: Loopback1
 prefix_lists:
-- sequence_numbers:
-  - action: permit 172.16.210.0/24 eq 32
-    sequence: 10
-  - action: permit 172.18.210.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 172.16.210.0/24 eq 32
+  - sequence: 20
+    action: permit 172.18.210.0/24 eq 32
 - sequence_numbers:
   - action: permit 172.21.210.0/24
     sequence: 10

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-SPINE1.yml
@@ -177,10 +177,10 @@ loopback_interfaces:
   ip_address: 172.16.210.1/32
   name: Loopback0
 prefix_lists:
-- sequence_numbers:
-  - action: permit 172.16.210.0/24 eq 32
-    sequence: 10
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 172.16.210.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-SPINE2.yml
@@ -144,10 +144,10 @@ loopback_interfaces:
   ip_address: 172.16.210.2/32
   name: Loopback0
 prefix_lists:
-- sequence_numbers:
-  - action: permit 172.16.210.0/24 eq 32
-    sequence: 10
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 172.16.210.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-RS1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-RS1.yml
@@ -127,10 +127,10 @@ loopback_interfaces:
   ip_address: 172.16.20.1/32
   name: Loopback0
 prefix_lists:
-- sequence_numbers:
-  - action: permit 172.16.20.0/24 eq 32
-    sequence: 10
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 172.16.20.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-RS2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-RS2.yml
@@ -91,10 +91,10 @@ loopback_interfaces:
   ip_address: 172.16.20.2/32
   name: Loopback0
 prefix_lists:
-- sequence_numbers:
-  - action: permit 172.16.20.0/24 eq 32
-    sequence: 10
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 172.16.20.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-SUPER-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-SUPER-SPINE1.yml
@@ -205,10 +205,10 @@ loopback_interfaces:
   ip_address: 172.16.200.1/32
   name: Loopback0
 prefix_lists:
-- sequence_numbers:
-  - action: permit 172.16.200.0/24 eq 32
-    sequence: 10
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 172.16.200.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-SUPER-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-SUPER-SPINE2.yml
@@ -108,10 +108,10 @@ loopback_interfaces:
   ip_address: 172.16.200.2/32
   name: Loopback0
 prefix_lists:
-- sequence_numbers:
-  - action: permit 172.16.200.0/24 eq 32
-    sequence: 10
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 172.16.200.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF1A.yml
@@ -71,12 +71,12 @@ loopback_interfaces:
   ip_address: 192.168.254.3/32
   name: Loopback1
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF1B.yml
@@ -71,12 +71,12 @@ loopback_interfaces:
   ip_address: 192.168.254.4/32
   name: Loopback1
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF2.yml
@@ -71,12 +71,12 @@ loopback_interfaces:
   ip_address: 192.168.254.5/32
   name: Loopback1
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF3A.yml
@@ -161,12 +161,12 @@ loopback_interfaces:
   ip_address: 192.168.254.7/32
   name: Loopback1
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF3B.yml
@@ -161,12 +161,12 @@ loopback_interfaces:
   ip_address: 192.168.254.7/32
   name: Loopback1
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF4A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF4A.yml
@@ -161,12 +161,12 @@ loopback_interfaces:
   ip_address: 192.168.254.9/32
   name: Loopback1
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF4B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF4B.yml
@@ -161,12 +161,12 @@ loopback_interfaces:
   ip_address: 192.168.254.9/32
   name: Loopback1
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF5A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF5A.yml
@@ -71,12 +71,12 @@ loopback_interfaces:
   ip_address: 192.168.254.11/32
   name: Loopback1
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF7A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF7A.yml
@@ -161,12 +161,12 @@ loopback_interfaces:
   ip_address: 192.168.254.13/32
   name: Loopback1
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF7B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF7B.yml
@@ -161,12 +161,12 @@ loopback_interfaces:
   ip_address: 192.168.254.13/32
   name: Loopback1
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF8A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF8A.yml
@@ -71,12 +71,12 @@ loopback_interfaces:
   ip_address: 192.168.254.15/32
   name: Loopback1
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF8B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF8B.yml
@@ -71,12 +71,12 @@ loopback_interfaces:
   ip_address: 192.168.254.16/32
   name: Loopback1
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_UNGROUPED_LEAF6.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_UNGROUPED_LEAF6.yml
@@ -71,12 +71,12 @@ loopback_interfaces:
   ip_address: 192.168.254.12/32
   name: Loopback1
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_NODE_TYPE_LEAF01.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_NODE_TYPE_LEAF01.yml
@@ -107,12 +107,12 @@ loopback_interfaces:
   ip_address: 192.168.254.3/32
   name: Loopback1
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_NODE_TYPE_SPINE01.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_NODE_TYPE_SPINE01.yml
@@ -101,10 +101,10 @@ loopback_interfaces:
   ip_address: 192.168.255.1/32
   name: Loopback0
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_NODE_TYPE_SPINE02.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_NODE_TYPE_SPINE02.yml
@@ -101,10 +101,10 @@ loopback_interfaces:
   ip_address: 192.168.255.2/32
   name: Loopback0
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_NODE_TYPE_UNGROUPED_LEAF02.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_NODE_TYPE_UNGROUPED_LEAF02.yml
@@ -107,12 +107,12 @@ loopback_interfaces:
   ip_address: 192.168.254.4/32
   name: Loopback1
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-TEMPLATES-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-TEMPLATES-L3LEAF1A.yml
@@ -226,12 +226,12 @@ loopback_interfaces:
   ip_address: 192.168.254.21/32
   name: Loopback1
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-TEMPLATES-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-TEMPLATES-L3LEAF1B.yml
@@ -226,12 +226,12 @@ loopback_interfaces:
   ip_address: 192.168.254.21/32
   name: Loopback1
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-TEMPLATES-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-TEMPLATES-SPINE1.yml
@@ -99,10 +99,10 @@ loopback_interfaces:
   ip_address: 192.168.255.1/32
   name: Loopback0
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1A.yml
@@ -479,14 +479,14 @@ loopback_interfaces:
   - 192.168.255.255/32
   name: Loopback1
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  - action: permit 192.168.255.255/32
-    sequence: 30
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
+  - sequence: 30
+    action: permit 192.168.255.255/32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1B.yml
@@ -455,12 +455,12 @@ loopback_interfaces:
   ip_address: 192.168.254.15/32
   name: Loopback1
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL2A.yml
@@ -359,12 +359,12 @@ loopback_interfaces:
   ip_address: 192.168.254.16/32
   name: Loopback1
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL2B.yml
@@ -352,12 +352,12 @@ loopback_interfaces:
   ip_address: 192.168.254.17/32
   name: Loopback1
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-CL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-CL1A.yml
@@ -418,12 +418,12 @@ loopback_interfaces:
   ip_address: 192.168.254.18/32
   name: Loopback1
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 router_bfd:
   multihop:
     interval: 1200

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-CL1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-CL1B.yml
@@ -418,12 +418,12 @@ loopback_interfaces:
   ip_address: 192.168.254.18/32
   name: Loopback1
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 router_bfd:
   multihop:
     interval: 1200

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF1A.yml
@@ -290,12 +290,12 @@ loopback_interfaces:
   ip_address: 192.168.254.9/32
   name: Loopback1
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
@@ -771,12 +771,12 @@ loopback_interfaces:
   ip_address: 10.255.1.10/32
   name: Loopback100
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
@@ -717,12 +717,12 @@ loopback_interfaces:
   ip_address: 10.255.1.11/32
   name: Loopback100
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SPINE1.yml
@@ -436,10 +436,10 @@ loopback_interfaces:
   ip_address: 192.168.255.1/32
   name: Loopback0
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SPINE2.yml
@@ -366,10 +366,10 @@ loopback_interfaces:
   ip_address: 192.168.255.2/32
   name: Loopback0
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SPINE3.yml
@@ -360,10 +360,10 @@ loopback_interfaces:
   ip_address: 192.168.255.3/32
   name: Loopback0
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SPINE4.yml
@@ -360,10 +360,10 @@ loopback_interfaces:
   ip_address: 192.168.255.4/32
   name: Loopback0
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3A.yml
@@ -1459,12 +1459,12 @@ loopback_interfaces:
   ip_address: 10.255.1.12/32
   name: Loopback100
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 router_bfd:
   multihop:
     interval: 1200

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3B.yml
@@ -1424,12 +1424,12 @@ loopback_interfaces:
   ip_address: 10.255.1.13/32
   name: Loopback100
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 router_bfd:
   multihop:
     interval: 1200

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1_UNDEPLOYED_LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1_UNDEPLOYED_LEAF1A.yml
@@ -892,12 +892,12 @@ loopback_interfaces:
   ip_address: 10.255.1.21/32
   name: Loopback100
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 router_bfd:
   multihop:
     interval: 1200

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1_UNDEPLOYED_LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1_UNDEPLOYED_LEAF1B.yml
@@ -892,12 +892,12 @@ loopback_interfaces:
   ip_address: 10.255.1.22/32
   name: Loopback100
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 router_bfd:
   multihop:
     interval: 1200

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF1A.yml
@@ -1348,12 +1348,12 @@ loopback_interfaces:
   ip_address: 10.255.51.3/32
   name: Loopback51
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF1B.yml
@@ -1348,12 +1348,12 @@ loopback_interfaces:
   ip_address: 10.255.51.4/32
   name: Loopback51
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF2A.yml
@@ -707,12 +707,12 @@ loopback_interfaces:
   ip_address: 10.255.51.5/32
   name: Loopback51
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF3A.yml
@@ -739,12 +739,12 @@ loopback_interfaces:
   ip_address: 10.255.51.6/32
   name: Loopback51
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF3B.yml
@@ -739,12 +739,12 @@ loopback_interfaces:
   ip_address: 10.255.51.7/32
   name: Loopback51
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-SPINE1.yml
@@ -168,10 +168,10 @@ loopback_interfaces:
   ip_address: 192.168.255.1/32
   name: Loopback0
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/IGMP-QUERIER-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/IGMP-QUERIER-L3LEAF1A.yml
@@ -274,12 +274,12 @@ loopback_interfaces:
   ip_address: 192.168.254.1/32
   name: Loopback1
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF1A.yml
@@ -347,12 +347,12 @@ loopback_interfaces:
   ip_address: 10.255.1.33/32
   name: Loopback100
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF1B.yml
@@ -347,12 +347,12 @@ loopback_interfaces:
   ip_address: 10.255.1.34/32
   name: Loopback100
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF2A.yml
@@ -222,14 +222,14 @@ prefix_lists:
   - action: permit 192.168.254.0/24 eq 32
     sequence: 20
   name: PL-LOOPBACKS-EVPN-OVERLAY
-- sequence_numbers:
-  - action: permit 10.2.10.0/24
-    sequence: 10
-  name: PL-SVI-VRF-DEFAULT
-- sequence_numbers:
-  - action: permit 10.0.0.0/8
-    sequence: 10
-  name: PL-STATIC-VRF-DEFAULT
+- name: PL-SVI-VRF-DEFAULT
+  sequence_numbers:
+  - sequence: 10
+    action: permit 10.2.10.0/24
+- name: PL-STATIC-VRF-DEFAULT
+  sequence_numbers:
+  - sequence: 10
+    action: permit 10.0.0.0/8
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF2A.yml
@@ -216,20 +216,20 @@ loopback_interfaces:
   ip_address: 10.255.1.35/32
   name: Loopback100
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
-- sequence_numbers:
-  - action: permit 10.2.10.0/24
-    sequence: 10
-  name: PL-SVI-VRF-DEFAULT
-- sequence_numbers:
-  - action: permit 10.0.0.0/8
-    sequence: 10
-  name: PL-STATIC-VRF-DEFAULT
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
+- name: PL-SVI-VRF-DEFAULT
+  sequence_numbers:
+  - sequence: 10
+    action: permit 10.2.10.0/24
+- name: PL-STATIC-VRF-DEFAULT
+  sequence_numbers:
+  - sequence: 10
+    action: permit 10.0.0.0/8
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF2A.yml
@@ -222,14 +222,14 @@ prefix_lists:
   - action: permit 192.168.254.0/24 eq 32
     sequence: 20
   name: PL-LOOPBACKS-EVPN-OVERLAY
-- name: PL-SVI-VRF-DEFAULT
-  sequence_numbers:
-  - sequence: 10
-    action: permit 10.2.10.0/24
-- name: PL-STATIC-VRF-DEFAULT
-  sequence_numbers:
-  - sequence: 10
-    action: permit 10.0.0.0/8
+- sequence_numbers:
+  - action: permit 10.2.10.0/24
+    sequence: 10
+  name: PL-SVI-VRF-DEFAULT
+- sequence_numbers:
+  - action: permit 10.0.0.0/8
+    sequence: 10
+  name: PL-STATIC-VRF-DEFAULT
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF1.yml
@@ -42,12 +42,12 @@ loopback_interfaces:
   ip_address: 192.168.253.1/32
   name: Loopback1
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.253.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.254.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.253.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF2.yml
@@ -42,12 +42,12 @@ loopback_interfaces:
   ip_address: 192.168.253.2/32
   name: Loopback1
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.253.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.254.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.253.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3A.yml
@@ -175,12 +175,12 @@ loopback_interfaces:
   ip_address: 192.168.253.3/32
   name: Loopback1
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.253.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.254.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.253.0/24 eq 32
 ip_igmp_snooping:
   globally_enabled: true
 ip_virtual_router_mac_address: 00:1c:73:00:dc:01

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3B.yml
@@ -175,12 +175,12 @@ loopback_interfaces:
   ip_address: 192.168.253.3/32
   name: Loopback1
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.253.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.254.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.253.0/24 eq 32
 ip_igmp_snooping:
   globally_enabled: true
 ip_virtual_router_mac_address: 00:1c:73:00:dc:01

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF1.yml
@@ -100,12 +100,12 @@ loopback_interfaces:
   ip_address: 192.168.254.1/32
   name: Loopback1
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF2.yml
@@ -100,12 +100,12 @@ loopback_interfaces:
   ip_address: 192.168.254.2/32
   name: Loopback1
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF3.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF3.yml
@@ -100,12 +100,12 @@ loopback_interfaces:
   ip_address: 192.168.254.3/32
   name: Loopback1
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF4.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF4.yml
@@ -100,12 +100,12 @@ loopback_interfaces:
   ip_address: 192.168.254.4/32
   name: Loopback1
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF5.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF5.yml
@@ -100,12 +100,12 @@ loopback_interfaces:
   ip_address: 192.168.254.5/32
   name: Loopback1
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF6.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF6.yml
@@ -100,12 +100,12 @@ loopback_interfaces:
   ip_address: 192.168.254.6/32
   name: Loopback1
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF7.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF7.yml
@@ -100,12 +100,12 @@ loopback_interfaces:
   ip_address: 192.168.254.7/32
   name: Loopback1
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/SVI_PROFILE_NODE_1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/SVI_PROFILE_NODE_1.yml
@@ -208,12 +208,12 @@ loopback_interfaces:
   ip_address: 192.168.254.1/32
   name: Loopback1
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/SVI_PROFILE_NODE_2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/SVI_PROFILE_NODE_2.yml
@@ -96,12 +96,12 @@ loopback_interfaces:
   ip_address: 192.168.254.1/32
   name: Loopback1
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF1A.yml
@@ -215,12 +215,12 @@ loopback_interfaces:
   ip_address: 192.168.254.3/32
   name: Loopback1
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF1B.yml
@@ -198,12 +198,12 @@ loopback_interfaces:
   ip_address: 192.168.254.3/32
   name: Loopback1
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF2A.yml
@@ -188,12 +188,12 @@ loopback_interfaces:
   ip_address: 192.168.254.5/32
   name: Loopback1
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF2B.yml
@@ -188,12 +188,12 @@ loopback_interfaces:
   ip_address: 192.168.254.5/32
   name: Loopback1
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-SPINE1.yml
@@ -148,10 +148,10 @@ loopback_interfaces:
   ip_address: 192.168.255.1/32
   name: Loopback0
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-SPINE2.yml
@@ -133,10 +133,10 @@ loopback_interfaces:
   ip_address: 192.168.255.2/32
   name: Loopback0
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY_FILTER_PEER_AS_L3LEAF1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY_FILTER_PEER_AS_L3LEAF1.yml
@@ -67,12 +67,12 @@ loopback_interfaces:
   ip_address: 192.168.254.3/32
   name: Loopback1
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY_FILTER_PEER_AS_SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY_FILTER_PEER_AS_SPINE1.yml
@@ -53,10 +53,10 @@ loopback_interfaces:
   ip_address: 192.168.255.1/32
   name: Loopback0
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1A.yml
@@ -215,12 +215,12 @@ loopback_interfaces:
   ip_address: 192.168.254.3/32
   name: Loopback1
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1B.yml
@@ -215,12 +215,12 @@ loopback_interfaces:
   ip_address: 192.168.254.3/32
   name: Loopback1
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-SPINE1.yml
@@ -105,10 +105,10 @@ loopback_interfaces:
   ip_address: 192.168.255.1/32
   name: Loopback0
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-structured-config-1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-structured-config-1.yml
@@ -149,12 +149,12 @@ loopback_interfaces:
   ip_address: 192.168.254.111/32
   name: Loopback1
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 ip_extcommunity_lists:
 - name: ECL-EVPN-SOO
   entries:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-structured-config-2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-structured-config-2.yml
@@ -166,12 +166,12 @@ loopback_interfaces:
   ip_address: 192.168.254.111/32
   name: Loopback1
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 ip_extcommunity_lists:
 - name: ECL-EVPN-SOO
   entries:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cvp-instance-ips-cvaas.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cvp-instance-ips-cvaas.yml
@@ -65,10 +65,10 @@ loopback_interfaces:
   ip_address: 1.2.3.1/32
   name: Loopback0
 prefix_lists:
-- sequence_numbers:
-  - action: permit 1.2.3.4/24 eq 32
-    sequence: 10
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 1.2.3.4/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/device.with.dots.in.hostname.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/device.with.dots.in.hostname.yml
@@ -55,10 +55,10 @@ loopback_interfaces:
   ip_address: 1.2.3.1/32
   name: Loopback0
 prefix_lists:
-- sequence_numbers:
-  - action: permit 1.2.3.4/24 eq 32
-    sequence: 10
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 1.2.3.4/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_false.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_false.yml
@@ -419,12 +419,12 @@ loopback_interfaces:
   ip_address: 10.255.1.109/32
   name: Loopback100
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_true.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_true.yml
@@ -217,12 +217,12 @@ loopback_interfaces:
   ip_address: 192.168.254.109/32
   name: Loopback1
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/l3_edge_bgp.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/l3_edge_bgp.yml
@@ -58,10 +58,10 @@ loopback_interfaces:
   ip_address: 1.2.3.1/32
   name: Loopback0
 prefix_lists:
-- sequence_numbers:
-  - action: permit 1.2.3.4/24 eq 32
-    sequence: 10
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 1.2.3.4/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-leaf1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-leaf1.yml
@@ -221,12 +221,12 @@ loopback_interfaces:
   ip_address: 10.254.11.1/32
   name: Loopback1
 prefix_lists:
-- sequence_numbers:
-  - action: permit 10.254.1.0/27 eq 32
-    sequence: 10
-  - action: permit 10.254.11.0/27 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 10.254.1.0/27 eq 32
+  - sequence: 20
+    action: permit 10.254.11.0/27 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-leaf2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-leaf2.yml
@@ -197,12 +197,12 @@ loopback_interfaces:
   ip_address: 10.254.11.2/32
   name: Loopback1
 prefix_lists:
-- sequence_numbers:
-  - action: permit 10.254.1.0/27 eq 32
-    sequence: 10
-  - action: permit 10.254.11.0/27 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 10.254.1.0/27 eq 32
+  - sequence: 20
+    action: permit 10.254.11.0/27 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-spine1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-spine1.yml
@@ -247,10 +247,10 @@ loopback_interfaces:
   ip_address: 10.255.0.1/32
   name: Loopback0
 prefix_lists:
-- sequence_numbers:
-  - action: permit 10.255.0.0/27 eq 32
-    sequence: 10
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 10.255.0.0/27 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-spine2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-spine2.yml
@@ -94,10 +94,10 @@ loopback_interfaces:
   ip_address: 10.255.0.2/32
   name: Loopback0
 prefix_lists:
-- sequence_numbers:
-  - action: permit 10.255.0.0/27 eq 32
-    sequence: 10
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 10.255.0.0/27 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf1a.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf1a.yml
@@ -528,12 +528,12 @@ loopback_interfaces:
   ip_address: 192.168.249.9/32
   name: Loopback1
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.250.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.249.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.250.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.249.0/24 eq 32
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf1b.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf1b.yml
@@ -505,12 +505,12 @@ loopback_interfaces:
   ip_address: 192.168.249.9/32
   name: Loopback1
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.250.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.249.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.250.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.249.0/24 eq 32
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf2a.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf2a.yml
@@ -241,12 +241,12 @@ loopback_interfaces:
   ip_address: 192.168.249.11/32
   name: Loopback1
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.250.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.249.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.250.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.249.0/24 eq 32
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf2b.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf2b.yml
@@ -237,12 +237,12 @@ loopback_interfaces:
   ip_address: 192.168.249.11/32
   name: Loopback1
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.250.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.249.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.250.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.249.0/24 eq 32
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-BL1A.yml
@@ -453,12 +453,12 @@ loopback_interfaces:
     shutdown: false
     ip_address: 192.168.254.14/32
 prefix_lists:
-  PL-LOOPBACKS-EVPN-OVERLAY:
-    sequence_numbers:
-      10:
-        action: permit 192.168.255.0/24 eq 32
-      20:
-        action: permit 192.168.254.0/24 eq 32
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 route_maps:
   RM-CONN-2-BGP:
     sequence_numbers:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-BL1B.yml
@@ -431,12 +431,12 @@ loopback_interfaces:
     shutdown: false
     ip_address: 192.168.254.15/32
 prefix_lists:
-  PL-LOOPBACKS-EVPN-OVERLAY:
-    sequence_numbers:
-      10:
-        action: permit 192.168.255.0/24 eq 32
-      20:
-        action: permit 192.168.254.0/24 eq 32
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 route_maps:
   RM-CONN-2-BGP:
     sequence_numbers:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-BL2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-BL2A.yml
@@ -278,12 +278,12 @@ loopback_interfaces:
     shutdown: false
     ip_address: 192.168.254.16/32
 prefix_lists:
-  PL-LOOPBACKS-EVPN-OVERLAY:
-    sequence_numbers:
-      10:
-        action: permit 192.168.255.0/24 eq 32
-      20:
-        action: permit 192.168.254.0/24 eq 32
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 route_maps:
   RM-CONN-2-BGP:
     sequence_numbers:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-BL2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-BL2B.yml
@@ -272,12 +272,12 @@ loopback_interfaces:
     shutdown: false
     ip_address: 192.168.254.17/32
 prefix_lists:
-  PL-LOOPBACKS-EVPN-OVERLAY:
-    sequence_numbers:
-      10:
-        action: permit 192.168.255.0/24 eq 32
-      20:
-        action: permit 192.168.254.0/24 eq 32
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 route_maps:
   RM-CONN-2-BGP:
     sequence_numbers:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-CL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-CL1A.yml
@@ -420,12 +420,12 @@ loopback_interfaces:
     shutdown: false
     ip_address: 192.168.254.18/32
 prefix_lists:
-  PL-LOOPBACKS-EVPN-OVERLAY:
-    sequence_numbers:
-      10:
-        action: permit 192.168.255.0/24 eq 32
-      20:
-        action: permit 192.168.254.0/24 eq 32
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 router_bfd:
   multihop:
     interval: 1200

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-CL1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-CL1B.yml
@@ -436,12 +436,12 @@ loopback_interfaces:
     shutdown: false
     ip_address: 192.168.254.18/32
 prefix_lists:
-  PL-LOOPBACKS-EVPN-OVERLAY:
-    sequence_numbers:
-      10:
-        action: permit 192.168.255.0/24 eq 32
-      20:
-        action: permit 192.168.254.0/24 eq 32
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 router_bfd:
   multihop:
     interval: 1200

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-LEAF1A.yml
@@ -275,12 +275,12 @@ loopback_interfaces:
     shutdown: false
     ip_address: 192.168.254.9/32
 prefix_lists:
-  PL-LOOPBACKS-EVPN-OVERLAY:
-    sequence_numbers:
-      10:
-        action: permit 192.168.255.0/24 eq 32
-      20:
-        action: permit 192.168.254.0/24 eq 32
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 route_maps:
   RM-CONN-2-BGP:
     sequence_numbers:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-LEAF2A.yml
@@ -558,12 +558,12 @@ loopback_interfaces:
     vrf: Tenant_A_OP_Zone
     ip_address: 10.255.1.10/32
 prefix_lists:
-  PL-LOOPBACKS-EVPN-OVERLAY:
-    sequence_numbers:
-      10:
-        action: permit 192.168.255.0/24 eq 32
-      20:
-        action: permit 192.168.254.0/24 eq 32
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 route_maps:
   RM-CONN-2-BGP:
     sequence_numbers:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-LEAF2B.yml
@@ -558,12 +558,12 @@ loopback_interfaces:
     vrf: Tenant_A_OP_Zone
     ip_address: 10.255.1.11/32
 prefix_lists:
-  PL-LOOPBACKS-EVPN-OVERLAY:
-    sequence_numbers:
-      10:
-        action: permit 192.168.255.0/24 eq 32
-      20:
-        action: permit 192.168.254.0/24 eq 32
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 route_maps:
   RM-CONN-2-BGP:
     sequence_numbers:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SPINE1.yml
@@ -349,10 +349,10 @@ loopback_interfaces:
     shutdown: false
     ip_address: 192.168.255.1/32
 prefix_lists:
-  PL-LOOPBACKS-EVPN-OVERLAY:
-    sequence_numbers:
-      10:
-        action: permit 192.168.255.0/24 eq 32
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
 route_maps:
   RM-CONN-2-BGP:
     sequence_numbers:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SPINE2.yml
@@ -304,10 +304,10 @@ loopback_interfaces:
     shutdown: false
     ip_address: 192.168.255.2/32
 prefix_lists:
-  PL-LOOPBACKS-EVPN-OVERLAY:
-    sequence_numbers:
-      10:
-        action: permit 192.168.255.0/24 eq 32
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
 route_maps:
   RM-CONN-2-BGP:
     sequence_numbers:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SPINE3.yml
@@ -298,10 +298,10 @@ loopback_interfaces:
     shutdown: false
     ip_address: 192.168.255.3/32
 prefix_lists:
-  PL-LOOPBACKS-EVPN-OVERLAY:
-    sequence_numbers:
-      10:
-        action: permit 192.168.255.0/24 eq 32
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
 route_maps:
   RM-CONN-2-BGP:
     sequence_numbers:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SPINE4.yml
@@ -298,10 +298,10 @@ loopback_interfaces:
     shutdown: false
     ip_address: 192.168.255.4/32
 prefix_lists:
-  PL-LOOPBACKS-EVPN-OVERLAY:
-    sequence_numbers:
-      10:
-        action: permit 192.168.255.0/24 eq 32
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
 route_maps:
   RM-CONN-2-BGP:
     sequence_numbers:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SVC3A.yml
@@ -1443,12 +1443,12 @@ loopback_interfaces:
     vrf: Tenant_A_OP_Zone
     ip_address: 10.255.1.12/32
 prefix_lists:
-  PL-LOOPBACKS-EVPN-OVERLAY:
-    sequence_numbers:
-      10:
-        action: permit 192.168.255.0/24 eq 32
-      20:
-        action: permit 192.168.254.0/24 eq 32
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 router_bfd:
   multihop:
     interval: 1200

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SVC3B.yml
@@ -1408,12 +1408,12 @@ loopback_interfaces:
     vrf: Tenant_A_OP_Zone
     ip_address: 10.255.1.13/32
 prefix_lists:
-  PL-LOOPBACKS-EVPN-OVERLAY:
-    sequence_numbers:
-      10:
-        action: permit 192.168.255.0/24 eq 32
-      20:
-        action: permit 192.168.254.0/24 eq 32
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 router_bfd:
   multihop:
     interval: 1200

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/MH-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/MH-LEAF1A.yml
@@ -196,12 +196,12 @@ loopback_interfaces:
     vrf: Tenant_X_OP_Zone
     ip_address: 10.255.1.33/32
 prefix_lists:
-  PL-LOOPBACKS-EVPN-OVERLAY:
-    sequence_numbers:
-      10:
-        action: permit 192.168.255.0/24 eq 32
-      20:
-        action: permit 192.168.254.0/24 eq 32
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 route_maps:
   RM-CONN-2-BGP:
     sequence_numbers:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/MH-LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/MH-LEAF1B.yml
@@ -196,12 +196,12 @@ loopback_interfaces:
     vrf: Tenant_X_OP_Zone
     ip_address: 10.255.1.34/32
 prefix_lists:
-  PL-LOOPBACKS-EVPN-OVERLAY:
-    sequence_numbers:
-      10:
-        action: permit 192.168.255.0/24 eq 32
-      20:
-        action: permit 192.168.254.0/24 eq 32
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 route_maps:
   RM-CONN-2-BGP:
     sequence_numbers:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/MH-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/MH-LEAF2A.yml
@@ -210,10 +210,16 @@ loopback_interfaces:
     vrf: Tenant_X_OP_Zone
     ip_address: 10.255.1.35/32
 prefix_lists:
-- sequence_numbers:
-  - action: permit 10.2.10.0/24
-    sequence: 10
-  name: PL-SVI-VRF-DEFAULT
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
+- name: PL-SVI-VRF-DEFAULT
+  sequence_numbers:
+  - sequence: 10
+    action: permit 10.2.10.0/24
 route_maps:
   RM-CONN-2-BGP:
     sequence_numbers:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/MH-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/MH-LEAF2A.yml
@@ -210,10 +210,10 @@ loopback_interfaces:
     vrf: Tenant_X_OP_Zone
     ip_address: 10.255.1.35/32
 prefix_lists:
-- name: PL-SVI-VRF-DEFAULT
-  sequence_numbers:
-  - sequence: 10
-    action: permit 10.2.10.0/24
+- sequence_numbers:
+  - action: permit 10.2.10.0/24
+    sequence: 10
+  name: PL-SVI-VRF-DEFAULT
 route_maps:
   RM-CONN-2-BGP:
     sequence_numbers:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/MH-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/MH-LEAF2A.yml
@@ -210,16 +210,10 @@ loopback_interfaces:
     vrf: Tenant_X_OP_Zone
     ip_address: 10.255.1.35/32
 prefix_lists:
-  PL-LOOPBACKS-EVPN-OVERLAY:
-    sequence_numbers:
-      10:
-        action: permit 192.168.255.0/24 eq 32
-      20:
-        action: permit 192.168.254.0/24 eq 32
-  PL-SVI-VRF-DEFAULT:
-    sequence_numbers:
-      10:
-        action: permit 10.2.10.0/24
+- name: PL-SVI-VRF-DEFAULT
+  sequence_numbers:
+  - sequence: 10
+    action: permit 10.2.10.0/24
 route_maps:
   RM-CONN-2-BGP:
     sequence_numbers:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/cvp-instance-ips-cvaas.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/cvp-instance-ips-cvaas.yml
@@ -65,10 +65,10 @@ loopback_interfaces:
     shutdown: false
     ip_address: 1.2.3.1/32
 prefix_lists:
-  PL-LOOPBACKS-EVPN-OVERLAY:
-    sequence_numbers:
-      10:
-        action: permit 1.2.3.4/24 eq 32
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 1.2.3.4/24 eq 32
 route_maps:
   RM-CONN-2-BGP:
     sequence_numbers:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/evpn_services_l2_only_false.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/evpn_services_l2_only_false.yml
@@ -342,12 +342,12 @@ loopback_interfaces:
     vrf: Tenant_A_OP_Zone
     ip_address: 10.255.1.109/32
 prefix_lists:
-  PL-LOOPBACKS-EVPN-OVERLAY:
-    sequence_numbers:
-      10:
-        action: permit 192.168.255.0/24 eq 32
-      20:
-        action: permit 192.168.254.0/24 eq 32
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 route_maps:
   RM-CONN-2-BGP:
     sequence_numbers:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/evpn_services_l2_only_true.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/evpn_services_l2_only_true.yml
@@ -194,12 +194,12 @@ loopback_interfaces:
     shutdown: false
     ip_address: 192.168.254.109/32
 prefix_lists:
-  PL-LOOPBACKS-EVPN-OVERLAY:
-    sequence_numbers:
-      10:
-        action: permit 192.168.255.0/24 eq 32
-      20:
-        action: permit 192.168.254.0/24 eq 32
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 route_maps:
   RM-CONN-2-BGP:
     sequence_numbers:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
@@ -432,12 +432,12 @@ loopback_interfaces:
   ip_address: 192.168.254.14/32
   name: Loopback1
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
@@ -431,12 +431,12 @@ loopback_interfaces:
   ip_address: 192.168.254.15/32
   name: Loopback1
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
@@ -266,10 +266,10 @@ loopback_interfaces:
   ip_address: 192.168.255.9/32
   name: Loopback0
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -527,12 +527,12 @@ loopback_interfaces:
   ip_address: 10.255.1.10/32
   name: Loopback100
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -527,12 +527,12 @@ loopback_interfaces:
   ip_address: 10.255.1.11/32
   name: Loopback100
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE1.yml
@@ -226,10 +226,10 @@ loopback_interfaces:
   ip_address: 192.168.255.1/32
   name: Loopback0
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE2.yml
@@ -226,10 +226,10 @@ loopback_interfaces:
   ip_address: 192.168.255.2/32
   name: Loopback0
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE3.yml
@@ -226,10 +226,10 @@ loopback_interfaces:
   ip_address: 192.168.255.3/32
   name: Loopback0
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE4.yml
@@ -226,10 +226,10 @@ loopback_interfaces:
   ip_address: 192.168.255.4/32
   name: Loopback0
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -1351,12 +1351,12 @@ loopback_interfaces:
   ip_address: 10.255.1.12/32
   name: Loopback100
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 router_bfd:
   multihop:
     interval: 1200

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -1351,12 +1351,12 @@ loopback_interfaces:
   ip_address: 10.255.1.13/32
   name: Loopback100
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 router_bfd:
   multihop:
     interval: 1200

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
@@ -329,12 +329,12 @@ loopback_interfaces:
   ip_address: 192.168.254.10/32
   name: Loopback1
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
@@ -329,12 +329,12 @@ loopback_interfaces:
   ip_address: 192.168.254.11/32
   name: Loopback1
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
@@ -269,12 +269,12 @@ loopback_interfaces:
   ip_address: 192.168.254.5/32
   name: Loopback1
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -782,12 +782,12 @@ loopback_interfaces:
   ip_address: 10.255.1.6/32
   name: Loopback100
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 router_bfd:
   multihop:
     interval: 1200

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -782,12 +782,12 @@ loopback_interfaces:
   ip_address: 10.255.1.7/32
   name: Loopback100
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 router_bfd:
   multihop:
     interval: 1200

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF3A.yml
@@ -668,17 +668,17 @@ loopback_interfaces:
   ip_address: 10.255.1.12/32
   name: Loopback100
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 ipv6_prefix_lists:
-- sequence_numbers:
-  - action: permit 2001:1::/64 eq 128
-    sequence: 10
-  name: PL-LOOPBACKS-EVPN-OVERLAY-V6
+- name: PL-LOOPBACKS-EVPN-OVERLAY-V6
+  sequence_numbers:
+  - sequence: 10
+    action: permit 2001:1::/64 eq 128
 router_bfd:
   multihop:
     interval: 1200

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF3B.yml
@@ -668,17 +668,17 @@ loopback_interfaces:
   ip_address: 10.255.1.13/32
   name: Loopback100
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 ipv6_prefix_lists:
-- sequence_numbers:
-  - action: permit 2001:1::/64 eq 128
-    sequence: 10
-  name: PL-LOOPBACKS-EVPN-OVERLAY-V6
+- name: PL-LOOPBACKS-EVPN-OVERLAY-V6
+  sequence_numbers:
+  - sequence: 10
+    action: permit 2001:1::/64 eq 128
 router_bfd:
   multihop:
     interval: 1200

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF4A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF4A.yml
@@ -668,17 +668,17 @@ loopback_interfaces:
   ip_address: 10.255.1.14/32
   name: Loopback100
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 ipv6_prefix_lists:
-- sequence_numbers:
-  - action: permit 2001:1::/64 eq 128
-    sequence: 10
-  name: PL-LOOPBACKS-EVPN-OVERLAY-V6
+- name: PL-LOOPBACKS-EVPN-OVERLAY-V6
+  sequence_numbers:
+  - sequence: 10
+    action: permit 2001:1::/64 eq 128
 router_bfd:
   multihop:
     interval: 1200

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF4B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF4B.yml
@@ -668,17 +668,17 @@ loopback_interfaces:
   ip_address: 10.255.1.15/32
   name: Loopback100
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 ipv6_prefix_lists:
-- sequence_numbers:
-  - action: permit 2001:1::/64 eq 128
-    sequence: 10
-  name: PL-LOOPBACKS-EVPN-OVERLAY-V6
+- name: PL-LOOPBACKS-EVPN-OVERLAY-V6
+  sequence_numbers:
+  - sequence: 10
+    action: permit 2001:1::/64 eq 128
 router_bfd:
   multihop:
     interval: 1200

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE1.yml
@@ -218,10 +218,10 @@ loopback_interfaces:
   ip_address: 192.168.255.1/32
   name: Loopback0
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE2.yml
@@ -218,10 +218,10 @@ loopback_interfaces:
   ip_address: 192.168.255.2/32
   name: Loopback0
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE3.yml
@@ -218,10 +218,10 @@ loopback_interfaces:
   ip_address: 192.168.255.3/32
   name: Loopback0
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE4.yml
@@ -218,10 +218,10 @@ loopback_interfaces:
   ip_address: 192.168.255.4/32
   name: Loopback0
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE5.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE5.yml
@@ -138,15 +138,15 @@ loopback_interfaces:
   ipv6_address: 2001:1::5/128
   name: Loopback0
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
 ipv6_prefix_lists:
-- sequence_numbers:
-  - action: permit 2001:1::/64 eq 128
-    sequence: 10
-  name: PL-LOOPBACKS-EVPN-OVERLAY-V6
+- name: PL-LOOPBACKS-EVPN-OVERLAY-V6
+  sequence_numbers:
+  - sequence: 10
+    action: permit 2001:1::/64 eq 128
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE6.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE6.yml
@@ -138,15 +138,15 @@ loopback_interfaces:
   ipv6_address: 2001:1::6/128
   name: Loopback0
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
 ipv6_prefix_lists:
-- sequence_numbers:
-  - action: permit 2001:1::/64 eq 128
-    sequence: 10
-  name: PL-LOOPBACKS-EVPN-OVERLAY-V6
+- name: PL-LOOPBACKS-EVPN-OVERLAY-V6
+  sequence_numbers:
+  - sequence: 10
+    action: permit 2001:1::/64 eq 128
 route_maps:
 - sequence_numbers:
   - type: permit

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -1118,12 +1118,12 @@ loopback_interfaces:
   ip_address: 10.255.1.8/32
   name: Loopback100
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 router_bfd:
   multihop:
     interval: 1200

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -1099,12 +1099,12 @@ loopback_interfaces:
   ip_address: 10.255.1.9/32
   name: Loopback100
 prefix_lists:
-- sequence_numbers:
-  - action: permit 192.168.255.0/24 eq 32
-    sequence: 10
-  - action: permit 192.168.254.0/24 eq 32
-    sequence: 20
-  name: PL-LOOPBACKS-EVPN-OVERLAY
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
 router_bfd:
   multihop:
     interval: 1200

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/inband_management/avdstructuredconfig.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/inband_management/avdstructuredconfig.py
@@ -181,24 +181,26 @@ class AvdStructuredConfig(AvdFacts):
         }
 
     @cached_property
-    def prefix_lists(self) -> dict | None:
+    def prefix_lists(self) -> list | None:
         if self._inband_management_role != "parent":
             return None
 
         if not self._underlay_bgp:
             return None
 
-        sequence_numbers = {
-            ((index + 1) * 10): {
+        sequence_numbers = [
+            {
+                "sequence": ((index + 1) * 10),
                 "action": f"permit {subnet}",
             }
             for index, subnet in enumerate(self._inband_management_data["subnets"])
-        }
-        return {
-            "PL-L2LEAF-INBAND-MGMT": {
+        ]
+        return [
+            {
+                "name": "PL-L2LEAF-INBAND-MGMT",
                 "sequence_numbers": sequence_numbers,
             }
-        }
+        ]
 
     @cached_property
     def route_maps(self) -> dict | None:

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/prefix_lists.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/prefix_lists.py
@@ -28,16 +28,16 @@ class PrefixListsMixin(UtilsMixin):
 
         prefix_lists = []
         if subnets:
-            prefix_lists_data = {"name": "PL-SVI-VRF-DEFAULT", "sequence_numbers": []}
+            prefix_lists_data = {"sequence_numbers": [], "name": "PL-SVI-VRF-DEFAULT"}
             for index, subnet in enumerate(subnets):
                 sequence = 10 * (index + 1)
-                prefix_lists_data["sequence_numbers"].append({"sequence": sequence, "action": f"permit {subnet}"})
+                prefix_lists_data["sequence_numbers"].append({"action": f"permit {subnet}", "sequence": sequence})
             prefix_lists.append(prefix_lists_data)
 
         if static_routes:
-            prefix_lists_data = {"name": "PL-STATIC-VRF-DEFAULT", "sequence_numbers": []}
+            prefix_lists_data = {"sequence_numbers": [], "name": "PL-STATIC-VRF-DEFAULT"}
             for index, static_route in enumerate(static_routes):
                 sequence = 10 * (index + 1)
-                prefix_lists_data["sequence_numbers"].append({"sequence": sequence, "action": f"permit {static_route}"})
+                prefix_lists_data["sequence_numbers"].append({"action": f"permit {static_route}", "sequence": sequence})
             prefix_lists.append(prefix_lists_data)
         return prefix_lists

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/prefix_lists.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/prefix_lists.py
@@ -28,16 +28,16 @@ class PrefixListsMixin(UtilsMixin):
 
         prefix_lists = []
         if subnets:
-            prefix_lists_sequence_numbers = {"name": "PL-SVI-VRF-DEFAULT", "sequence_numbers": []}
+            prefix_lists_data = {"name": "PL-SVI-VRF-DEFAULT", "sequence_numbers": []}
             for index, subnet in enumerate(subnets):
                 sequence = 10 * (index + 1)
-                prefix_lists_sequence_numbers["sequence_numbers"].append({"sequence": sequence, "action": f"permit {subnet}"})
-            prefix_lists.append(prefix_lists_sequence_numbers)
+                prefix_lists_data["sequence_numbers"].append({"sequence": sequence, "action": f"permit {subnet}"})
+            prefix_lists.append(prefix_lists_data)
 
         if static_routes:
-            prefix_lists_sequence_numbers = {"name": "PL-STATIC-VRF-DEFAULT", "sequence_numbers": []}
+            prefix_lists_data = {"name": "PL-STATIC-VRF-DEFAULT", "sequence_numbers": []}
             for index, static_route in enumerate(static_routes):
                 sequence = 10 * (index + 1)
-                prefix_lists_sequence_numbers["sequence_numbers"].append({"sequence": sequence, "action": f"permit {static_route}"})
-            prefix_lists.append(prefix_lists_sequence_numbers)
+                prefix_lists_data["sequence_numbers"].append({"sequence": sequence, "action": f"permit {static_route}"})
+            prefix_lists.append(prefix_lists_data)
         return prefix_lists

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/prefix_lists.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/prefix_lists.py
@@ -12,7 +12,7 @@ class PrefixListsMixin(UtilsMixin):
     """
 
     @cached_property
-    def prefix_lists(self) -> dict | None:
+    def prefix_lists(self) -> list | None:
         """
         Return structured config for prefix_lists
 
@@ -28,16 +28,16 @@ class PrefixListsMixin(UtilsMixin):
 
         prefix_lists = []
         if subnets:
-            prefix_lists_data = {"sequence_numbers": [], "name": "PL-SVI-VRF-DEFAULT"}
+            prefix_list = {"name": "PL-SVI-VRF-DEFAULT", "sequence_numbers": []}
             for index, subnet in enumerate(subnets):
                 sequence = 10 * (index + 1)
-                prefix_lists_data["sequence_numbers"].append({"action": f"permit {subnet}", "sequence": sequence})
-            prefix_lists.append(prefix_lists_data)
+                prefix_list["sequence_numbers"].append({"sequence": sequence, "action": f"permit {subnet}"})
+            prefix_lists.append(prefix_list)
 
         if static_routes:
-            prefix_lists_data = {"sequence_numbers": [], "name": "PL-STATIC-VRF-DEFAULT"}
+            prefix_list = {"name": "PL-STATIC-VRF-DEFAULT", "sequence_numbers": []}
             for index, static_route in enumerate(static_routes):
                 sequence = 10 * (index + 1)
-                prefix_lists_data["sequence_numbers"].append({"action": f"permit {static_route}", "sequence": sequence})
-            prefix_lists.append(prefix_lists_data)
+                prefix_list["sequence_numbers"].append({"sequence": sequence, "action": f"permit {static_route}"})
+            prefix_lists.append(prefix_list)
         return prefix_lists

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/prefix_lists.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/prefix_lists.py
@@ -26,17 +26,18 @@ class PrefixListsMixin(UtilsMixin):
         if not subnets and not static_routes:
             return None
 
-        prefix_lists = {}
+        prefix_lists = []
         if subnets:
-            prefix_lists["PL-SVI-VRF-DEFAULT"] = {"sequence_numbers": {}}
+            prefix_lists_sequence_numbers = {"name": "PL-SVI-VRF-DEFAULT", "sequence_numbers": []}
             for index, subnet in enumerate(subnets):
                 sequence = 10 * (index + 1)
-                prefix_lists["PL-SVI-VRF-DEFAULT"]["sequence_numbers"][sequence] = {"action": f"permit {subnet}"}
+                prefix_lists_sequence_numbers["sequence_numbers"].append({"sequence": sequence, "action": f"permit {subnet}"})
+            prefix_lists.append(prefix_lists_sequence_numbers)
 
         if static_routes:
-            prefix_lists["PL-STATIC-VRF-DEFAULT"] = {"sequence_numbers": {}}
+            prefix_lists_sequence_numbers = {"name": "PL-STATIC-VRF-DEFAULT", "sequence_numbers": []}
             for index, static_route in enumerate(static_routes):
                 sequence = 10 * (index + 1)
-                prefix_lists["PL-STATIC-VRF-DEFAULT"]["sequence_numbers"][sequence] = {"action": f"permit {static_route}"}
-
+                prefix_lists_sequence_numbers["sequence_numbers"].append({"sequence": sequence, "action": f"permit {static_route}"})
+            prefix_lists.append(prefix_lists_sequence_numbers)
         return prefix_lists

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/prefix_lists.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/prefix_lists.py
@@ -12,7 +12,7 @@ class PrefixListsMixin(UtilsMixin):
     """
 
     @cached_property
-    def prefix_lists(self) -> dict | None:
+    def prefix_lists(self) -> list | None:
         """
         Return structured config for prefix_lists
         """
@@ -22,21 +22,16 @@ class PrefixListsMixin(UtilsMixin):
         if self._overlay_routing_protocol == "none":
             return None
 
-        prefix_lists = {}
-
         # IPv4 - PL-LOOPBACKS-EVPN-OVERLAY
-        sequence_numbers = {}
-        sequence_numbers[10] = {
-            "action": f"permit {self._loopback_ipv4_pool} eq 32",
-        }
+        sequence_numbers = [{"sequence": 10, "action": f"permit {self._loopback_ipv4_pool} eq 32"}]
 
         if self._vtep_ip is not None and self._vtep_loopback.lower() != "loopback0":
-            sequence_numbers[20] = {"action": f"permit {self._vtep_loopback_ipv4_pool} eq 32"}
+            sequence_numbers.append({"sequence": 20, "action": f"permit {self._vtep_loopback_ipv4_pool} eq 32"})
 
         if self._vtep_vvtep_ip is not None and self._network_services_l3 is True:
-            sequence_numbers[30] = {"action": f"permit {self._vtep_vvtep_ip}"}
+            sequence_numbers.append({"sequence": 30, "action": f"permit {self._vtep_vvtep_ip}"})
 
-        prefix_lists["PL-LOOPBACKS-EVPN-OVERLAY"] = {"sequence_numbers": sequence_numbers}
+        prefix_lists = [{"name": "PL-LOOPBACKS-EVPN-OVERLAY", "sequence_numbers": sequence_numbers}]
 
         return prefix_lists
 
@@ -55,12 +50,14 @@ class PrefixListsMixin(UtilsMixin):
             return None
 
         # IPv6 - PL-LOOPBACKS-EVPN-OVERLAY-V6
-        return {
-            "PL-LOOPBACKS-EVPN-OVERLAY-V6": {
-                "sequence_numbers": {
-                    10: {
-                        "action": f"permit {self._loopback_ipv6_pool} eq 128",
+        return [
+            {
+                "name": "PL-LOOPBACKS-EVPN-OVERLAY-V6", 
+                "sequence_numbers": [
+                    {
+                        "sequence": 10,
+                        "action": f"permit {self._loopback_ipv6_pool} eq 128"
                     }
-                }
+                ]
             }
-        }
+        ]

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/prefix_lists.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/prefix_lists.py
@@ -50,14 +50,4 @@ class PrefixListsMixin(UtilsMixin):
             return None
 
         # IPv6 - PL-LOOPBACKS-EVPN-OVERLAY-V6
-        return [
-            {
-                "name": "PL-LOOPBACKS-EVPN-OVERLAY-V6", 
-                "sequence_numbers": [
-                    {
-                        "sequence": 10,
-                        "action": f"permit {self._loopback_ipv6_pool} eq 128"
-                    }
-                ]
-            }
-        ]
+        return [{"name": "PL-LOOPBACKS-EVPN-OVERLAY-V6", "sequence_numbers": [{"sequence": 10, "action": f"permit {self._loopback_ipv6_pool} eq 128"}]}]


### PR DESCRIPTION
## Change Summary

Refactor prefix_lists python_module in inband_management, network_services and underlay modules as per eos_cli_config_gen

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
