### PR TITLE
Refactor(eos_designs): router_ospf python_module as per eos_cli_config_gen

### DIFF
--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/SPINE1.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/SPINE1.yml
@@ -304,7 +304,8 @@ loopback_interfaces:
   name: Loopback0
 router_ospf:
   process_ids:
-  - passive_interface_default: true
+  - id: 100
+    passive_interface_default: true
     router_id: 172.16.1.1
     max_lsa: 12000
     no_passive_interfaces:
@@ -313,7 +314,6 @@ router_ospf:
     bfd_enable: false
     redistribute:
       connected: {}
-    id: 100
 ip_igmp_snooping:
   globally_enabled: true
 ip_virtual_router_mac_address: 00:1c:73:00:dc:01

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/SPINE2.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/SPINE2.yml
@@ -304,7 +304,8 @@ loopback_interfaces:
   name: Loopback0
 router_ospf:
   process_ids:
-  - passive_interface_default: true
+  - id: 100
+    passive_interface_default: true
     router_id: 172.16.1.2
     max_lsa: 12000
     no_passive_interfaces:
@@ -313,7 +314,6 @@ router_ospf:
     bfd_enable: false
     redistribute:
       connected: {}
-    id: 100
 ip_igmp_snooping:
   globally_enabled: true
 ip_virtual_router_mac_address: 00:1c:73:00:dc:01

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-SPINE1.yml
@@ -132,7 +132,8 @@ loopback_interfaces:
   name: Loopback0
 router_ospf:
   process_ids:
-  - passive_interface_default: true
+  - id: 100
+    passive_interface_default: true
     router_id: 192.168.255.1
     max_lsa: 12000
     no_passive_interfaces:
@@ -141,7 +142,6 @@ router_ospf:
     bfd_enable: false
     redistribute:
       connected: {}
-    id: 100
 ip_igmp_snooping:
   globally_enabled: true
 ip_virtual_router_mac_address: 00:1c:73:00:00:99

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-SPINE2.yml
@@ -135,7 +135,8 @@ loopback_interfaces:
   name: Loopback0
 router_ospf:
   process_ids:
-  - passive_interface_default: true
+  - id: 100
+    passive_interface_default: true
     router_id: 192.168.255.2
     max_lsa: 12000
     no_passive_interfaces:
@@ -145,7 +146,6 @@ router_ospf:
     redistribute:
       connected: {}
       static: {}
-    id: 100
 ip_igmp_snooping:
   globally_enabled: true
 ip_virtual_router_mac_address: 00:1c:73:00:00:99

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LER1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LER1.yml
@@ -463,7 +463,8 @@ vlan_interfaces:
   name: Vlan2020
 router_ospf:
   process_ids:
-  - vrf: TENANT_B_INTRA
+  - id: 19
+    vrf: TENANT_B_INTRA
     passive_interface_default: true
     router_id: 123.1.1.0
     no_passive_interfaces:
@@ -471,4 +472,3 @@ router_ospf:
     max_lsa: 10000
     redistribute:
       bgp: {}
-    id: 19

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE2-LER1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE2-LER1.yml
@@ -488,7 +488,8 @@ vlan_interfaces:
   name: Vlan2020
 router_ospf:
   process_ids:
-  - vrf: TENANT_B_WAN
+  - id: 99
+    vrf: TENANT_B_WAN
     passive_interface_default: true
     router_id: 192.168.48.4
     no_passive_interfaces:
@@ -496,4 +497,3 @@ router_ospf:
     max_lsa: 10000
     redistribute:
       bgp: {}
-    id: 99

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1A.yml
@@ -556,7 +556,8 @@ vlan_interfaces:
   name: Vlan350
 router_ospf:
   process_ids:
-  - vrf: Tenant_A_WAN_Zone
+  - id: 14
+    vrf: Tenant_A_WAN_Zone
     passive_interface_default: true
     router_id: 192.168.255.14
     no_passive_interfaces:
@@ -565,7 +566,6 @@ router_ospf:
     max_lsa: 15000
     redistribute:
       bgp: {}
-    id: 14
 vxlan_interface:
   Vxlan1:
     description: DC1-BL1A_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1B.yml
@@ -530,7 +530,8 @@ vlan_interfaces:
   name: Vlan350
 router_ospf:
   process_ids:
-  - vrf: Tenant_A_WAN_Zone
+  - id: 14
+    vrf: Tenant_A_WAN_Zone
     passive_interface_default: true
     router_id: 192.168.255.15
     no_passive_interfaces:
@@ -538,7 +539,6 @@ router_ospf:
     max_lsa: 15000
     redistribute:
       bgp: {}
-    id: 14
 vxlan_interface:
   Vxlan1:
     description: DC1-BL1B_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
@@ -1078,7 +1078,8 @@ ipv6_static_routes:
   vrf: Tenant_D_OP_Zone
 router_ospf:
   process_ids:
-  - vrf: Tenant_A_OSPF
+  - id: 16
+    vrf: Tenant_A_OSPF
     passive_interface_default: true
     router_id: 192.168.255.10
     no_passive_interfaces:
@@ -1086,7 +1087,6 @@ router_ospf:
     - Ethernet23
     redistribute:
       bgp: {}
-    id: 16
 vxlan_interface:
   Vxlan1:
     description: DC1-LEAF2A_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
@@ -1019,14 +1019,14 @@ ipv6_static_routes:
   vrf: Tenant_D_OP_Zone
 router_ospf:
   process_ids:
-  - vrf: Tenant_A_OSPF
+  - id: 16
+    vrf: Tenant_A_OSPF
     passive_interface_default: true
     router_id: 192.168.255.11
     no_passive_interfaces:
     - Ethernet24
     redistribute:
       bgp: {}
-    id: 16
 vxlan_interface:
   Vxlan1:
     description: DC1-LEAF2B_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG-OSPF-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG-OSPF-L3LEAF1A.yml
@@ -164,14 +164,14 @@ loopback_interfaces:
   name: Loopback1
 router_ospf:
   process_ids:
-  - passive_interface_default: true
+  - id: 100
+    passive_interface_default: true
     router_id: 192.168.255.36
     max_lsa: 12000
     no_passive_interfaces:
     - Ethernet1
     - Vlan4094
     bfd_enable: false
-    id: 100
 router_bfd:
   multihop:
     interval: 1200

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG-OSPF-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG-OSPF-L3LEAF1B.yml
@@ -164,14 +164,14 @@ loopback_interfaces:
   name: Loopback1
 router_ospf:
   process_ids:
-  - passive_interface_default: true
+  - id: 100
+    passive_interface_default: true
     router_id: 192.168.255.37
     max_lsa: 12000
     no_passive_interfaces:
     - Ethernet1
     - Vlan4094
     bfd_enable: false
-    id: 100
 router_bfd:
   multihop:
     interval: 1200

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/SVI_PROFILE_NODE_1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/SVI_PROFILE_NODE_1.yml
@@ -414,7 +414,8 @@ vlan_interfaces:
   name: Vlan512
 router_ospf:
   process_ids:
-  - vrf: svi_profile_tests_vrf
+  - id: 1
+    vrf: svi_profile_tests_vrf
     passive_interface_default: true
     router_id: 192.168.255.1
     no_passive_interfaces:
@@ -424,7 +425,6 @@ router_ospf:
     max_lsa: 15000
     redistribute:
       bgp: {}
-    id: 1
 vxlan_interface:
   Vxlan1:
     description: SVI_PROFILE_NODE_1_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/SVI_PROFILE_NODE_2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/SVI_PROFILE_NODE_2.yml
@@ -302,7 +302,8 @@ vlan_interfaces:
   name: Vlan512
 router_ospf:
   process_ids:
-  - vrf: svi_profile_tests_vrf
+  - id: 1
+    vrf: svi_profile_tests_vrf
     passive_interface_default: true
     router_id: 192.168.255.1
     no_passive_interfaces:
@@ -312,7 +313,6 @@ router_ospf:
     max_lsa: 15000
     redistribute:
       bgp: {}
-    id: 1
 vxlan_interface:
   Vxlan1:
     description: SVI_PROFILE_NODE_2_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/core-2-ospf-ldp.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/core-2-ospf-ldp.yml
@@ -31,7 +31,8 @@ loopback_interfaces:
   name: Loopback0
 router_ospf:
   process_ids:
-  - passive_interface_default: true
+  - id: 101
+    passive_interface_default: true
     router_id: 10.0.0.2
     max_lsa: 12000
     no_passive_interfaces:
@@ -44,7 +45,6 @@ router_ospf:
     - Ethernet10
     - Port-Channel12
     bfd_enable: true
-    id: 101
 mpls:
   ip: true
   ldp:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/l3_edge_ospf.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/l3_edge_ospf.yml
@@ -22,7 +22,8 @@ loopback_interfaces:
   name: Loopback0
 router_ospf:
   process_ids:
-  - passive_interface_default: true
+  - id: 100
+    passive_interface_default: true
     router_id: 1.2.3.1
     max_lsa: 12000
     no_passive_interfaces:
@@ -30,7 +31,6 @@ router_ospf:
     - ethernet3
     - ethernet4
     bfd_enable: false
-    id: 100
 ethernet_interfaces:
 - peer: peer1
   peer_interface: ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-BL1A.yml
@@ -528,7 +528,8 @@ vlan_interfaces:
     vrf: Tenant_C_WAN_Zone
 router_ospf:
   process_ids:
-  - vrf: Tenant_A_WAN_Zone
+  - id: 14
+    vrf: Tenant_A_WAN_Zone
     passive_interface_default: true
     router_id: 192.168.255.14
     no_passive_interfaces:
@@ -537,7 +538,6 @@ router_ospf:
     max_lsa: 15000
     redistribute:
       bgp: {}
-    id: 14
 vxlan_interface:
   Vxlan1:
     description: DC1-BL1A_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-BL1A.yml
@@ -528,16 +528,16 @@ vlan_interfaces:
     vrf: Tenant_C_WAN_Zone
 router_ospf:
   process_ids:
-    14:
-      vrf: Tenant_A_WAN_Zone
-      passive_interface_default: true
-      router_id: 192.168.255.14
-      no_passive_interfaces:
-      - Ethernet7
-      - Vlan150
-      max_lsa: 15000
-      redistribute:
-        bgp: {}
+  - vrf: Tenant_A_WAN_Zone
+    passive_interface_default: true
+    router_id: 192.168.255.14
+    no_passive_interfaces:
+    - Ethernet7
+    - Vlan150
+    max_lsa: 15000
+    redistribute:
+      bgp: {}
+    id: 14
 vxlan_interface:
   Vxlan1:
     description: DC1-BL1A_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-BL1B.yml
@@ -506,15 +506,15 @@ vlan_interfaces:
     vrf: Tenant_C_WAN_Zone
 router_ospf:
   process_ids:
-    14:
-      vrf: Tenant_A_WAN_Zone
-      passive_interface_default: true
-      router_id: 192.168.255.15
-      no_passive_interfaces:
-      - Vlan150
-      max_lsa: 15000
-      redistribute:
-        bgp: {}
+  - vrf: Tenant_A_WAN_Zone
+    passive_interface_default: true
+    router_id: 192.168.255.15
+    no_passive_interfaces:
+    - Vlan150
+    max_lsa: 15000
+    redistribute:
+      bgp: {}
+    id: 14
 vxlan_interface:
   Vxlan1:
     description: DC1-BL1B_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-BL1B.yml
@@ -506,7 +506,8 @@ vlan_interfaces:
     vrf: Tenant_C_WAN_Zone
 router_ospf:
   process_ids:
-  - vrf: Tenant_A_WAN_Zone
+  - id: 14
+    vrf: Tenant_A_WAN_Zone
     passive_interface_default: true
     router_id: 192.168.255.15
     no_passive_interfaces:
@@ -514,7 +515,6 @@ router_ospf:
     max_lsa: 15000
     redistribute:
       bgp: {}
-    id: 14
 vxlan_interface:
   Vxlan1:
     description: DC1-BL1B_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/core-2-ospf-ldp.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/core-2-ospf-ldp.yml
@@ -31,20 +31,20 @@ loopback_interfaces:
         interface: true
 router_ospf:
   process_ids:
-    101:
-      passive_interface_default: true
-      router_id: 10.0.0.2
-      max_lsa: 12000
-      no_passive_interfaces:
-      - Ethernet1
-      - Ethernet2
-      - Ethernet3
-      - Ethernet4
-      - Ethernet5
-      - Ethernet6
-      - Ethernet10
-      - Port-Channel12
-      bfd_enable: true
+  - id: 101
+    passive_interface_default: true
+    router_id: 10.0.0.2
+    max_lsa: 12000
+    no_passive_interfaces:
+    - Ethernet1
+    - Ethernet2
+    - Ethernet3
+    - Ethernet4
+    - Ethernet5
+    - Ethernet6
+    - Ethernet10
+    - Port-Channel12
+    bfd_enable: true
 mpls:
   ip: true
   ldp:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
@@ -220,7 +220,8 @@ loopback_interfaces:
   name: Loopback1
 router_ospf:
   process_ids:
-  - passive_interface_default: true
+  - id: 101
+    passive_interface_default: true
     router_id: 192.168.255.10
     max_lsa: 12000
     no_passive_interfaces:
@@ -230,7 +231,6 @@ router_ospf:
     - Ethernet4
     - Vlan4093
     bfd_enable: true
-    id: 101
 router_bfd:
   multihop:
     interval: 1200

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
@@ -220,7 +220,8 @@ loopback_interfaces:
   name: Loopback1
 router_ospf:
   process_ids:
-  - passive_interface_default: true
+  - id: 101
+    passive_interface_default: true
     router_id: 192.168.255.11
     max_lsa: 12000
     no_passive_interfaces:
@@ -230,7 +231,6 @@ router_ospf:
     - Ethernet4
     - Vlan4093
     bfd_enable: true
-    id: 101
 router_bfd:
   multihop:
     interval: 1200

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
@@ -157,7 +157,8 @@ loopback_interfaces:
   name: Loopback1
 router_ospf:
   process_ids:
-  - passive_interface_default: true
+  - id: 101
+    passive_interface_default: true
     router_id: 192.168.255.5
     max_lsa: 12000
     no_passive_interfaces:
@@ -166,7 +167,6 @@ router_ospf:
     - Ethernet3
     - Ethernet4
     bfd_enable: true
-    id: 101
 router_bfd:
   multihop:
     interval: 1200

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -302,7 +302,8 @@ loopback_interfaces:
   name: Loopback1
 router_ospf:
   process_ids:
-  - passive_interface_default: true
+  - id: 101
+    passive_interface_default: true
     router_id: 192.168.255.6
     max_lsa: 12000
     no_passive_interfaces:
@@ -312,7 +313,6 @@ router_ospf:
     - Ethernet4
     - Vlan4093
     bfd_enable: true
-    id: 101
 router_bfd:
   multihop:
     interval: 1200

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -302,7 +302,8 @@ loopback_interfaces:
   name: Loopback1
 router_ospf:
   process_ids:
-  - passive_interface_default: true
+  - id: 101
+    passive_interface_default: true
     router_id: 192.168.255.7
     max_lsa: 12000
     no_passive_interfaces:
@@ -312,7 +313,6 @@ router_ospf:
     - Ethernet4
     - Vlan4093
     bfd_enable: true
-    id: 101
 router_bfd:
   multihop:
     interval: 1200

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SPINE1.yml
@@ -191,7 +191,8 @@ loopback_interfaces:
   name: Loopback0
 router_ospf:
   process_ids:
-  - passive_interface_default: true
+  - id: 101
+    passive_interface_default: true
     router_id: 192.168.255.1
     max_lsa: 12000
     no_passive_interfaces:
@@ -203,7 +204,6 @@ router_ospf:
     - Ethernet6
     - Ethernet7
     bfd_enable: true
-    id: 101
 router_bfd:
   multihop:
     interval: 1200

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SPINE2.yml
@@ -191,7 +191,8 @@ loopback_interfaces:
   name: Loopback0
 router_ospf:
   process_ids:
-  - passive_interface_default: true
+  - id: 101
+    passive_interface_default: true
     router_id: 192.168.255.2
     max_lsa: 12000
     no_passive_interfaces:
@@ -203,7 +204,6 @@ router_ospf:
     - Ethernet6
     - Ethernet7
     bfd_enable: true
-    id: 101
 router_bfd:
   multihop:
     interval: 1200

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SPINE3.yml
@@ -191,7 +191,8 @@ loopback_interfaces:
   name: Loopback0
 router_ospf:
   process_ids:
-  - passive_interface_default: true
+  - id: 101
+    passive_interface_default: true
     router_id: 192.168.255.3
     max_lsa: 12000
     no_passive_interfaces:
@@ -203,7 +204,6 @@ router_ospf:
     - Ethernet6
     - Ethernet7
     bfd_enable: true
-    id: 101
 router_bfd:
   multihop:
     interval: 1200

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SPINE4.yml
@@ -191,7 +191,8 @@ loopback_interfaces:
   name: Loopback0
 router_ospf:
   process_ids:
-  - passive_interface_default: true
+  - id: 101
+    passive_interface_default: true
     router_id: 192.168.255.4
     max_lsa: 12000
     no_passive_interfaces:
@@ -203,7 +204,6 @@ router_ospf:
     - Ethernet6
     - Ethernet7
     bfd_enable: true
-    id: 101
 router_bfd:
   multihop:
     interval: 1200

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -302,7 +302,8 @@ loopback_interfaces:
   name: Loopback1
 router_ospf:
   process_ids:
-  - passive_interface_default: true
+  - id: 101
+    passive_interface_default: true
     router_id: 192.168.255.8
     max_lsa: 12000
     no_passive_interfaces:
@@ -312,7 +313,6 @@ router_ospf:
     - Ethernet4
     - Vlan4094
     bfd_enable: true
-    id: 101
 router_bfd:
   multihop:
     interval: 1200

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -302,7 +302,8 @@ loopback_interfaces:
   name: Loopback1
 router_ospf:
   process_ids:
-  - passive_interface_default: true
+  - id: 101
+    passive_interface_default: true
     router_id: 192.168.255.9
     max_lsa: 12000
     no_passive_interfaces:
@@ -312,7 +313,6 @@ router_ospf:
     - Ethernet4
     - Vlan4094
     bfd_enable: true
-    id: 101
 router_bfd:
   multihop:
     interval: 1200

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/core_interfaces/router_ospf.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/core_interfaces/router_ospf.py
@@ -25,11 +25,12 @@ class RouterOspfMixin(UtilsMixin):
         ]
         if no_passive_interfaces:
             return {
-                "process_ids": {
-                    self._underlay_ospf_process_id: {
+                "process_ids": [
+                    {
+                        "id": self._underlay_ospf_process_id,
                         "no_passive_interfaces": no_passive_interfaces,
                     }
-                }
+                ],
             }
 
         return None

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/l3_edge/router_ospf.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/l3_edge/router_ospf.py
@@ -23,11 +23,12 @@ class RouterOspfMixin(UtilsMixin):
         no_passive_interfaces = [p2p_link["data"]["interface"] for p2p_link in self._filtered_p2p_links if p2p_link.get("include_in_underlay_protocol") is True]
         if no_passive_interfaces:
             return {
-                "process_ids": {
-                    self._underlay_ospf_process_id: {
+                "process_ids": [
+                    {
+                        "id": self._underlay_ospf_process_id,
                         "no_passive_interfaces": no_passive_interfaces,
                     }
-                }
+                ]
             }
 
         return None

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/router_ospf.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/router_ospf.py
@@ -54,6 +54,7 @@ class RouterOspfMixin(UtilsMixin):
                     raise AristaAvdMissingVariableError(f"'ospf.process_id' or 'vrf_id' under vrf '{vrf['name']}")
 
                 process = {
+                    "id": process_id,
                     "vrf": vrf["name"],
                     "passive_interface_default": True,
                     "router_id": default(get(vrf, "ospf.router_id"), self._router_id),
@@ -69,8 +70,6 @@ class RouterOspfMixin(UtilsMixin):
                     if (route_map := get(vrf, "ospf.redistribute_bgp.route_map")) is not None:
                         process["redistribute"]["bgp"]["route_map"] = route_map
 
-                process["id"] = process_id
-
                 # Strip None values from process before adding to list
                 process = {key: value for key, value in process.items() if value is not None}
 
@@ -79,7 +78,7 @@ class RouterOspfMixin(UtilsMixin):
         # If we have static_routes in default VRF and not EPVN, and underlay is OSPF
         # Then add redistribute static to the underlay OSPF process.
         if self._vrf_default_ipv4_static_routes["redistribute_in_underlay"] and self._underlay_routing_protocol in ["ospf", "ospf-ldp"]:
-            ospf_processes.append(dict({"redistribute": {"static": {}}}, id=int(self._underlay_ospf_process_id)))
+            ospf_processes.append({"id": int(self._underlay_ospf_process_id), "redistribute": {"static": {}}})
         if ospf_processes:
             return {"process_ids": ospf_processes}
 

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/router_ospf.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/router_ospf.py
@@ -26,7 +26,7 @@ class RouterOspfMixin(UtilsMixin):
         if not self._network_services_l3:
             return None
 
-        ospf_processes = {}
+        ospf_processes = []
         for tenant in self._filtered_tenants:
             for vrf in tenant["vrfs"]:
                 if get(vrf, "ospf.enabled") is not True:
@@ -69,16 +69,17 @@ class RouterOspfMixin(UtilsMixin):
                     if (route_map := get(vrf, "ospf.redistribute_bgp.route_map")) is not None:
                         process["redistribute"]["bgp"]["route_map"] = route_map
 
+                process["id"] = process_id
+
                 # Strip None values from process before adding to list
                 process = {key: value for key, value in process.items() if value is not None}
 
-                ospf_processes[process_id] = process
+                ospf_processes.append(process)
 
         # If we have static_routes in default VRF and not EPVN, and underlay is OSPF
         # Then add redistribute static to the underlay OSPF process.
         if self._vrf_default_ipv4_static_routes["redistribute_in_underlay"] and self._underlay_routing_protocol in ["ospf", "ospf-ldp"]:
-            ospf_processes[self._underlay_ospf_process_id] = {"redistribute": {"static": {}}}
-
+            ospf_processes.append(dict({"redistribute": {"static": {}}}, id=int(self._underlay_ospf_process_id)))
         if ospf_processes:
             return {"process_ids": ospf_processes}
 

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/router_ospf.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/router_ospf.py
@@ -21,7 +21,7 @@ class RouterOspfMixin(UtilsMixin):
         if self._underlay_ospf is not True:
             return None
 
-        ospf_processes = {}
+        ospf_processes = []
 
         process_id = self._underlay_ospf_process_id
 
@@ -32,6 +32,7 @@ class RouterOspfMixin(UtilsMixin):
             no_passive_interfaces.append(f"Vlan{mlag_l3_vlan}")
 
         process = {
+            "id": process_id,
             "passive_interface_default": True,
             "router_id": self._router_id,
             "max_lsa": get(self._hostvars, "underlay_ospf_max_lsa"),
@@ -47,7 +48,7 @@ class RouterOspfMixin(UtilsMixin):
         # Strip None values from process before adding to list
         process = {key: value for key, value in process.items() if value is not None}
 
-        ospf_processes[process_id] = process
+        ospf_processes.append(process)
 
         if ospf_processes:
             return {"process_ids": ospf_processes}


### PR DESCRIPTION
## Change Summary

Refactor router_ospf python_module in core_interfaces, l3_edge, network_services and underlay modules as per eos_cli_config_gen

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
