### PR TITLE
Feat(eos_cli_config_gen): Global IP Locking Configuration Options

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/address-locking.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/address-locking.md
@@ -63,7 +63,6 @@ interface Management1
 | 2.2.2.2 | dead.beef.cafe |
 | 3.3.3.3 | de:af:be:ef:ca:fe |
 
-
 ## Address Locking Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/address-locking.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/address-locking.md
@@ -54,6 +54,7 @@ interface Management1
 | Server IP |
 | --------- |
 | 1.1.1.1 |
+| 4.4.4.4 |
 
 ## Leases
 
@@ -71,6 +72,7 @@ address locking
    disabled
    local-interface Loopback0
    dhcp server ipv4 1.1.1.1
+   dhcp server ipv4 4.4.4.4
    lease 2.2.2.2 mac dead.beef.cafe
    lease 3.3.3.3 mac de:af:be:ef:ca:fe
    locked-address expiration mac disabled

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/address-locking.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/address-locking.md
@@ -1,5 +1,6 @@
 # address-locking
-# Table of Contents
+
+## Table of Contents
 
 - [Management](#management)
   - [Management Interfaces](#management-interfaces)
@@ -9,25 +10,25 @@
   - [Leases](#leases)
   - [Address Locking Configuration](#address-locking-configuration)
 
-# Management
+## Management
 
-## Management Interfaces
+### Management Interfaces
 
-### Management Interfaces Summary
+#### Management Interfaces Summary
 
-#### IPv4
+##### IPv4
 
 | Management Interface | description | Type | VRF | IP Address | Gateway |
 | -------------------- | ----------- | ---- | --- | ---------- | ------- |
 | Management1 | oob_management | oob | MGMT | 10.73.255.122/24 | 10.73.255.2 |
 
-#### IPv6
+##### IPv6
 
 | Management Interface | description | Type | VRF | IPv6 Address | IPv6 Gateway |
 | -------------------- | ----------- | ---- | --- | ------------ | ------------ |
 | Management1 | oob_management | oob | MGMT | - | - |
 
-### Management Interfaces Device Configuration
+#### Management Interfaces Device Configuration
 
 ```eos
 !
@@ -37,11 +38,11 @@ interface Management1
    ip address 10.73.255.122/24
 ```
 
-# Address Locking
+## Address Locking
 
-## Address Locking Summary
+### Address Locking Summary
 
-| Settings | Value |
+| Setting | Value |
 | -------- | ----- |
 | Disable IP locking on configured ports | True |
 | Local Interface | Loopback0 |
@@ -49,21 +50,21 @@ interface Management1
 | Disable enforcement for locked ipv4 addresses | True |
 | Disable enforcement for locked ipv6 addresses | True |
 
-## DHCP Servers
+### DHCP Servers
 
 | Server IP |
 | --------- |
 | 1.1.1.1 |
 | 4.4.4.4 |
 
-## Leases
+### Leases
 
 | Lease IP Address | Lease MAC Address |
 | ---------------- | ----------------- |
 | 2.2.2.2 | dead.beef.cafe |
 | 3.3.3.3 | de:af:be:ef:ca:fe |
 
-## Address Locking Configuration
+### Address Locking Configuration
 
 ```eos
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/address-locking.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/address-locking.md
@@ -1,0 +1,79 @@
+# address-locking
+# Table of Contents
+
+- [Management](#management)
+  - [Management Interfaces](#management-interfaces)
+- [Address Locking](#address-locking)
+  - [Address Locking Summary](#address-locking-summary)
+  - [DHCP Servers](#dhcp-servers)
+  - [Leases](#leases)
+  - [Address Locking Configuration](#address-locking-configuration)
+
+# Management
+
+## Management Interfaces
+
+### Management Interfaces Summary
+
+#### IPv4
+
+| Management Interface | description | Type | VRF | IP Address | Gateway |
+| -------------------- | ----------- | ---- | --- | ---------- | ------- |
+| Management1 | oob_management | oob | MGMT | 10.73.255.122/24 | 10.73.255.2 |
+
+#### IPv6
+
+| Management Interface | description | Type | VRF | IPv6 Address | IPv6 Gateway |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ |
+| Management1 | oob_management | oob | MGMT | - | - |
+
+### Management Interfaces Device Configuration
+
+```eos
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+```
+
+# Address Locking
+
+## Address Locking Summary
+
+| Settings | Value |
+| -------- | ----- |
+| Disable IP locking on configured ports | True |
+| Local Interface | Loopback0 |
+| Disable deauthorizing locked addresses upon MAC aging out | True |
+| Disable enforcement for locked ipv4 addresses | True |
+| Disable enforcement for locked ipv6 addresses | True |
+
+## DHCP Servers
+
+| Server IP |
+| --------- |
+| 1.1.1.1 |
+
+## Leases
+
+| Lease IP Address | Lease MAC Address |
+| ---------------- | ----------------- |
+| 2.2.2.2 | dead.beef.cafe |
+| 3.3.3.3 | de:af:be:ef:ca:fe |
+
+
+## Address Locking Configuration
+
+```eos
+!
+address locking
+   disabled
+   local-interface Loopback0
+   dhcp server ipv4 1.1.1.1
+   lease 2.2.2.2 mac dead.beef.cafe
+   lease 3.3.3.3 mac de:af:be:ef:ca:fe
+   locked-address expiration mac disabled
+   locked-address ipv4 enforcement disabled
+   locked-address ipv6 enforcement disabled
+```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/address-locking.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/address-locking.cfg
@@ -11,6 +11,7 @@ address locking
    disabled
    local-interface Loopback0
    dhcp server ipv4 1.1.1.1
+   dhcp server ipv4 4.4.4.4
    lease 2.2.2.2 mac dead.beef.cafe
    lease 3.3.3.3 mac de:af:be:ef:ca:fe
    locked-address expiration mac disabled

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/address-locking.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/address-locking.cfg
@@ -1,0 +1,25 @@
+!RANCID-CONTENT-TYPE: arista
+!
+transceiver qsfp default-mode 4x10G
+!
+hostname address-locking
+!
+no enable password
+no aaa root
+!
+address locking
+   disabled
+   local-interface Loopback0
+   dhcp server ipv4 1.1.1.1
+   lease 2.2.2.2 mac dead.beef.cafe
+   lease 3.3.3.3 mac de:af:be:ef:ca:fe
+   locked-address expiration mac disabled
+   locked-address ipv4 enforcement disabled
+   locked-address ipv6 enforcement disabled
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/address-locking.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/address-locking.yml
@@ -1,0 +1,15 @@
+### Address Locking ###
+address_locking:
+  dhcp_servers_ipv4:
+    - 1.1.1.1
+  disabled: true
+  leases:
+    - ip: 2.2.2.2
+      mac: dead.beef.cafe
+    - ip: 3.3.3.3
+      mac: de:af:be:ef:ca:fe
+  local_interface: Loopback0
+  locked_address:
+    expiration_mac_disabled: true
+    ipv4_enforcement_disabled: true
+    ipv6_enforcement_disabled: true

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/address-locking.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/address-locking.yml
@@ -2,6 +2,7 @@
 address_locking:
   dhcp_servers_ipv4:
     - 1.1.1.1
+    - 4.4.4.4
   disabled: true
   leases:
     - ip: 2.2.2.2

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts.ini
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts.ini
@@ -2,6 +2,7 @@
 ; ls -l | gawk -F ' ' '{print $9}'| gawk -F '.' '{print $1}'
 aaa
 acl
+address-locking
 aliases
 arp
 as-path

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/data_model/Address Locking.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/data_model/Address Locking.md
@@ -1,0 +1,42 @@
+---
+search:
+  boost: 2
+---
+
+# Address Locking
+
+## Address Locking
+
+=== "Table"
+
+    | Variable | Type | Required | Default | Value Restrictions | Description |
+    | -------- | ---- | -------- | ------- | ------------------ | ----------- |
+    | [<samp>address_locking</samp>](## "address_locking") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;dhcp_servers_ipv4</samp>](## "address_locking.dhcp_servers_ipv4") | List, items: String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "address_locking.dhcp_servers_ipv4.[].&lt;str&gt;") | String |  |  |  | DHCP server IPv4 address |
+    | [<samp>&nbsp;&nbsp;disabled</samp>](## "address_locking.disabled") | Boolean |  |  |  | Disable IP locking on configured ports |
+    | [<samp>&nbsp;&nbsp;leases</samp>](## "address_locking.leases") | List, items: Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- ip</samp>](## "address_locking.leases.[].ip") | String | Required |  |  | IP address |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mac</samp>](## "address_locking.leases.[].mac") | String | Required |  |  | MAC address (hhhh.hhhh.hhhh or hh:hh:hh:hh:hh:hh) |
+    | [<samp>&nbsp;&nbsp;local_interface</samp>](## "address_locking.local_interface") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;locked_address</samp>](## "address_locking.locked_address") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;expiration_mac_disabled</samp>](## "address_locking.locked_address.expiration_mac_disabled") | Boolean |  |  |  | Configure deauthorizing locked addresses upon MAC aging out |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv4_enforcement_disabled</samp>](## "address_locking.locked_address.ipv4_enforcement_disabled") | Boolean |  |  |  | Configure enforcement for locked IPv4 addresses |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_enforcement_disabled</samp>](## "address_locking.locked_address.ipv6_enforcement_disabled") | Boolean |  |  |  | Configure enforcement for locked IPv6 addresses |
+
+=== "YAML"
+
+    ```yaml
+    address_locking:
+      dhcp_servers_ipv4:
+        - <str>
+      disabled: <bool>
+      leases:
+        - ip: <str>
+          mac: <str>
+      local_interface: <str>
+      locked_address:
+        expiration_mac_disabled: <bool>
+        ipv4_enforcement_disabled: <bool>
+        ipv6_enforcement_disabled: <bool>
+    ```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -484,6 +484,76 @@
         "additionalProperties": false
       }
     },
+    "address_locking": {
+      "type": "object",
+      "properties": {
+        "dhcp_servers_ipv4": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "description": "DHCP server IPv4 address"
+          },
+          "title": "DHCP Servers IPv4"
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "Disable IP locking on configured ports",
+          "title": "Disabled"
+        },
+        "leases": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "ip": {
+                "type": "string",
+                "description": "IP address",
+                "title": "IP"
+              },
+              "mac": {
+                "type": "string",
+                "description": "MAC address (hhhh.hhhh.hhhh or hh:hh:hh:hh:hh:hh)",
+                "title": "MAC"
+              }
+            },
+            "required": [
+              "ip",
+              "mac"
+            ],
+            "additionalProperties": false
+          },
+          "title": "Leases"
+        },
+        "local_interface": {
+          "type": "string",
+          "title": "Local Interface"
+        },
+        "locked_address": {
+          "type": "object",
+          "properties": {
+            "expiration_mac_disabled": {
+              "type": "boolean",
+              "description": "Configure deauthorizing locked addresses upon MAC aging out",
+              "title": "Expiration MAC Disabled"
+            },
+            "ipv4_enforcement_disabled": {
+              "type": "boolean",
+              "description": "Configure enforcement for locked IPv4 addresses",
+              "title": "IPv4 Enforcement Disabled"
+            },
+            "ipv6_enforcement_disabled": {
+              "type": "boolean",
+              "description": "Configure enforcement for locked IPv6 addresses",
+              "title": "IPv6 Enforcement Disabled"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Locked Address"
+        }
+      },
+      "additionalProperties": false,
+      "title": "Address Locking"
+    },
     "aliases": {
       "type": "string",
       "description": "Multi-line string with one or more alias commands.\n\nExample:\n\n```yaml\naliases: |\n  alias wr copy running-config startup-config\n  alias siib show ip interface brief\n```",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -375,6 +375,46 @@ keys:
                 description: 'Action as string
 
                   Example: "deny ip any any"'
+  address_locking:
+    documentation_options:
+      filename: data_model/Address Locking
+    type: dict
+    keys:
+      dhcp_servers_ipv4:
+        type: list
+        items:
+          type: str
+          description: DHCP server IPv4 address
+      disabled:
+        type: bool
+        description: Disable IP locking on configured ports
+      leases:
+        type: list
+        items:
+          type: dict
+          keys:
+            ip:
+              type: str
+              required: true
+              description: IP address
+            mac:
+              type: str
+              required: true
+              description: MAC address (hhhh.hhhh.hhhh or hh:hh:hh:hh:hh:hh)
+      local_interface:
+        type: str
+      locked_address:
+        type: dict
+        keys:
+          expiration_mac_disabled:
+            type: bool
+            description: Configure deauthorizing locked addresses upon MAC aging out
+          ipv4_enforcement_disabled:
+            type: bool
+            description: Configure enforcement for locked IPv4 addresses
+          ipv6_enforcement_disabled:
+            type: bool
+            description: Configure enforcement for locked IPv6 addresses
   aliases:
     documentation_options:
       filename: data_model/Aliases

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/address_locking.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/address_locking.schema.yml
@@ -24,9 +24,11 @@ keys:
             ip:
               type: str
               required: true
+              description: IP address
             mac:
               type: str
               required: true
+              description: MAC address (hhhh.hhhh.hhhh or hh:hh:hh:hh:hh:hh)
       local_interface:
         type: str
       locked_address:
@@ -34,7 +36,10 @@ keys:
         keys:
           expiration_mac_disabled:
             type: bool
+            description: Configure deauthorizing locked addresses upon MAC aging out
           ipv4_enforcement_disabled:
             type: bool
+            description: Configure enforcement for locked IPv4 addresses
           ipv6_enforcement_disabled:
             type: bool
+            description: Configure enforcement for locked IPv6 addresses

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/address_locking.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/address_locking.yml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  address_locking:
+    documentation_options:
+      filename: data_model/Address Locking
+    type: dict
+    keys:
+      dhcp_servers_ipv4:
+        type: list
+        items:
+          type: str
+          description: DHCP server IPv4 address
+      disabled:
+        type: bool
+        description: Disable IP locking on configured ports
+      leases:
+        type: list
+        items:
+          type: dict
+          keys:
+            ip:
+              type: str
+              required: true
+            mac:
+              type: str
+              required: true
+      local_interface:
+        type: str
+      locked_address:
+        type: dict
+        keys:
+          expiration_mac_disabled:
+            type: bool
+          ipv4_enforcement_disabled:
+            type: bool
+          ipv6_enforcement_disabled:
+            type: bool

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/address-locking.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/address-locking.j2
@@ -1,28 +1,30 @@
 {# address locking #}
 {% if address_locking is arista.avd.defined %}
 
-# Address Locking
+## Address Locking
 
-## Address Locking Summary
+### Address Locking Summary
 
-| Settings | Value |
+| Setting | Value |
 | -------- | ----- |
-| Disable IP locking on configured ports | {{ address_locking.disabled | arista.avd.default(false) }} |
+{%     if address_locking.disabled is arista.avd.defined %}
+| Disable IP locking on configured ports | {{ address_locking.disabled }} |
+{%     endif %}
 {%     if address_locking.local_interface is arista.avd.defined %}
-| Local Interface | {{ address_locking.local_interface | arista.avd.default("-") }} |
+| Local Interface | {{ address_locking.local_interface }} |
 {%     endif %}
-{%     if address_locking.locked_address.expiration_mac_disabled is arista.avd.defined(true) %}
-| Disable deauthorizing locked addresses upon MAC aging out | True |
+{%     if address_locking.locked_address.expiration_mac_disabled is arista.avd.defined %}
+| Disable deauthorizing locked addresses upon MAC aging out | {{ address_locking.locked_address.expiration_mac_disabled }} |
 {%     endif %}
-{%     if address_locking.locked_address.ipv4_enforcement_disabled is arista.avd.defined(true) %}
-| Disable enforcement for locked ipv4 addresses | True |
+{%     if address_locking.locked_address.ipv4_enforcement_disabled is arista.avd.defined %}
+| Disable enforcement for locked ipv4 addresses | {{ address_locking.locked_address.ipv4_enforcement_disabled }} |
 {%     endif %}
-{%     if address_locking.locked_address.ipv6_enforcement_disabled is arista.avd.defined(true) %}
-| Disable enforcement for locked ipv6 addresses | True |
+{%     if address_locking.locked_address.ipv6_enforcement_disabled is arista.avd.defined %}
+| Disable enforcement for locked ipv6 addresses | {{ locked_address.ipv6_enforcement_disabled }} |
 {%     endif %}
 {%     if address_locking.dhcp_servers_ipv4 is arista.avd.defined %}
 
-## DHCP Servers
+### DHCP Servers
 
 | Server IP |
 | --------- |
@@ -32,7 +34,7 @@
 {%     endif %}
 {%     if address_locking.leases is arista.avd.defined %}
 
-## Leases
+### Leases
 
 | Lease IP Address | Lease MAC Address |
 | ---------------- | ----------------- |
@@ -41,7 +43,7 @@
 {%         endfor %}
 {%     endif %}
 
-## Address Locking Configuration
+### Address Locking Configuration
 
 ```eos
 {%     include 'eos/address-locking.j2' %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/address-locking.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/address-locking.j2
@@ -20,7 +20,7 @@
 | Disable enforcement for locked ipv4 addresses | {{ address_locking.locked_address.ipv4_enforcement_disabled }} |
 {%     endif %}
 {%     if address_locking.locked_address.ipv6_enforcement_disabled is arista.avd.defined %}
-| Disable enforcement for locked ipv6 addresses | {{ locked_address.ipv6_enforcement_disabled }} |
+| Disable enforcement for locked ipv6 addresses | {{ address_locking.locked_address.ipv6_enforcement_disabled }} |
 {%     endif %}
 {%     if address_locking.dhcp_servers_ipv4 is arista.avd.defined %}
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/address-locking.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/address-locking.j2
@@ -20,8 +20,8 @@
 {%     if address_locking.locked_address.ipv6_enforcement_disabled is arista.avd.defined(true) %}
 | Disable enforcement for locked ipv6 addresses | True |
 {%     endif %}
-
 {%     if address_locking.dhcp_servers_ipv4 is arista.avd.defined %}
+
 ## DHCP Servers
 
 | Server IP |
@@ -29,9 +29,9 @@
 {%         for ip in address_locking.dhcp_servers_ipv4 | arista.avd.natural_sort %}
 | {{ ip }} |
 {%         endfor %}
-
 {%     endif %}
 {%     if address_locking.leases is arista.avd.defined %}
+
 ## Leases
 
 | Lease IP Address | Lease MAC Address |
@@ -39,7 +39,6 @@
 {%         for lease in address_locking.leases | arista.avd.natural_sort('ip') %}
 | {{ lease.ip }} | {{ lease.mac }} |
 {%         endfor %}
-
 {%     endif %}
 
 ## Address Locking Configuration

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/address-locking.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/address-locking.j2
@@ -1,0 +1,50 @@
+{# address locking #}
+{% if address_locking is arista.avd.defined %}
+
+# Address Locking
+
+## Address Locking Summary
+
+| Settings | Value |
+| -------- | ----- |
+| Disable IP locking on configured ports | {{ address_locking.disabled | arista.avd.default(false) }} |
+{%     if address_locking.local_interface is arista.avd.defined %}
+| Local Interface | {{ address_locking.local_interface | arista.avd.default("-") }} |
+{%     endif %}
+{%     if address_locking.locked_address.expiration_mac_disabled is arista.avd.defined(true) %}
+| Disable deauthorizing locked addresses upon MAC aging out | True |
+{%     endif %}
+{%     if address_locking.locked_address.ipv4_enforcement_disabled is arista.avd.defined(true) %}
+| Disable enforcement for locked ipv4 addresses | True |
+{%     endif %}
+{%     if address_locking.locked_address.ipv6_enforcement_disabled is arista.avd.defined(true) %}
+| Disable enforcement for locked ipv6 addresses | True |
+{%     endif %}
+
+{%     if address_locking.dhcp_servers_ipv4 is arista.avd.defined %}
+## DHCP Servers
+
+| Server IP |
+| --------- |
+{%         for ip in address_locking.dhcp_servers_ipv4 | arista.avd.natural_sort %}
+| {{ ip }} |
+{%         endfor %}
+
+{%     endif %}
+{%     if address_locking.leases is arista.avd.defined %}
+## Leases
+
+| Lease IP Address | Lease MAC Address |
+| ---------------- | ----------------- |
+{%         for lease in address_locking.leases | arista.avd.natural_sort('ip') %}
+| {{ lease.ip }} | {{ lease.mac }} |
+{%         endfor %}
+
+{%     endif %}
+
+## Address Locking Configuration
+
+```eos
+{%     include 'eos/address-locking.j2' %}
+```
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-device-documentation.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-device-documentation.j2
@@ -10,6 +10,8 @@
 {% include 'documentation/cvx.j2' %}
 {# Authentication #}
 {% include 'documentation/authentication.j2' %}
+{# Address Locking #}
+{% include 'documentation/address-locking.j2' %}
 {# Management Security #}
 {% include 'documentation/management-security.j2' %}
 {# Prompt #}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-intended-config.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-intended-config.j2
@@ -108,6 +108,8 @@
 {% include 'eos/local-users.j2' %}
 {# roles #}
 {% include 'eos/roles.j2' %}
+{# address locking #}
+{% include 'eos/address-locking.j2' %}
 {# Tap Aggregation #}
 {% include 'eos/tap-aggregation.j2' %}
 {# clock #}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/address-locking.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/address-locking.j2
@@ -1,5 +1,6 @@
 {# eos - address locking #}
 {% if address_locking is arista.avd.defined %}
+!
 address locking
 {%     if address_locking.disabled is arista.avd.defined(true) %}
    disabled

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/address-locking.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/address-locking.j2
@@ -1,0 +1,25 @@
+{# eos - address locking #}
+{% if address_locking is arista.avd.defined %}
+address locking
+{%     if address_locking.disabled is arista.avd.defined(true) %}
+   disabled
+{%     endif %}
+{%     if address_locking.local_interface is arista.avd.defined %}
+   local-interface {{ address_locking.local_interface }}
+{%     endif %}
+{%     for ip in address_locking.dhcp_servers_ipv4 | arista.avd.natural_sort %}
+   dhcp server ipv4 {{ ip }}
+{%     endfor %}
+{%     for lease in address_locking.leases | arista.avd.natural_sort('ip') %}
+   lease {{ lease.ip }} mac {{ lease.mac }}
+{%     endfor %}
+{%     if address_locking.locked_address.expiration_mac_disabled is arista.avd.defined(true) %}
+   locked-address expiration mac disabled
+{%     endif %}
+{%     if address_locking.locked_address.ipv4_enforcement_disabled is arista.avd.defined(true) %}
+   locked-address ipv4 enforcement disabled
+{%     endif %}
+{%     if address_locking.locked_address.ipv6_enforcement_disabled is arista.avd.defined(true) %}
+   locked-address ipv6 enforcement disabled
+{%     endif %}
+{% endif %}


### PR DESCRIPTION
## Change Summary

Adds data model for global IP locking configuration options.

## Related Issue(s)

Fixes #2313 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
```yaml
address_locking:
  dhcp_servers_ipv4:
    - x.x.x.x
  disabled: bool
  leases:
    - ip: y.y.y.y
      mac: hhhh.hhhh.hhhh
    - ip: z.z.z.z
      mac: hh:hh:hh:hh:hh:hh
  local_interface:  str
  locked_address:
    expiration_mac_disabled: bool
    ipv4_enforcement_disabled: bool
    ipv6_enforcement_disabled: bool
```

## How to test
Tested with molecule and on physical EOS device

### Repository Checklist

- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
