### PR TITLE
Refactor(eos_designs): Change default native vlan name

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink-native-vlan-child.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink-native-vlan-child.cfg
@@ -15,7 +15,7 @@ vlan 100
    name NETWORK_SERVICES_VLAN
 !
 vlan 200
-   name NATIVE_VLAN
+   name NATIVE
    state suspend
 !
 vrf instance MGMT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink-native-vlan-parent.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink-native-vlan-parent.cfg
@@ -15,7 +15,7 @@ vlan 100
    name NETWORK_SERVICES_VLAN
 !
 vlan 200
-   name NATIVE_VLAN
+   name NATIVE
    state suspend
 !
 vrf instance MGMT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink-native-vlan-child.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink-native-vlan-child.yml
@@ -13,7 +13,7 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- name: NATIVE_VLAN
+- name: NATIVE
   state: suspend
   id: 200
 - tenant: test

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink-native-vlan-parent.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink-native-vlan-parent.yml
@@ -13,7 +13,7 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- name: NATIVE_VLAN
+- name: NATIVE
   state: suspend
   id: 200
 - tenant: test

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/UPLINK_NATIVE_VLAN_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/UPLINK_NATIVE_VLAN_TESTS.yml
@@ -15,7 +15,7 @@ l2leaf:
     - name: uplink-native-vlan-child
       id: 3
       # vlan 200 is not in network services vlans, so we test that both ends have vlan 200 configured
-      # with name UPLINK_NATIVE_VLAN and configured as native-vlan on uplink port-channel. Vlan 200 should _not_ be permitted on the trunk.
+      # with name NATIVE and configured as native-vlan on uplink port-channel. Vlan 200 should _not_ be permitted on the trunk.
       uplink_native_vlan: 200
       uplink_switches: [ uplink-native-vlan-parent ]
       uplink_interfaces: [ Ethernet2 ]

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/vlans.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/vlans.py
@@ -44,7 +44,7 @@ class VlansMixin(UtilsMixin):
         for peer_uplink_native_vlan in uplink_native_vlans:
             vlans.setdefault(int(peer_uplink_native_vlan), {}).update(
                 {
-                    "name": "NATIVE_VLAN",
+                    "name": "NATIVE",
                     "state": "suspend",
                 }
             )


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Change default native vlan name

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

`uplink_native_vlan` was added in #2522. This PR changes the vlan name of the default created native vlan.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Molecule

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
