### PR TITLE
Fix(eos_designs): Ensure proper formatting of raised errors

### DIFF
--- a/ansible_collections/arista/avd/plugins/action/yaml_templates_to_facts.py
+++ b/ansible_collections/arista/avd/plugins/action/yaml_templates_to_facts.py
@@ -164,7 +164,7 @@ class ActionModule(ActionBase):
                 try:
                     template_result_data = cls_instance.render()
                 except Exception as error:
-                    raise AnsibleActionFail(error) from error
+                    raise AnsibleActionFail(message=str(error)) from error
 
             else:
                 raise AnsibleActionFail("Invalid template data")


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Ensure proper formatting of raised errors

## Related Issue(s)

Fixes #2572

## Component(s) name

`arista.avd.yaml_templates_to_facts`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

We already caught errors and reraised as AnsibleActionFail, but we did not fill out the "message" correctly, so it ended up as a traceback in the output.
This change sets the raised error message as message on AnsibleActionFail, so Ansible and various callback plugins get the expected data format.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Tested on various molecule scenarios by filling out invalid data.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
