### PR TITLE
Feat(eos_designs): Allow disabling filtering on redist connected in underlay bgp

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF1A.md
@@ -34,7 +34,6 @@
 - [Multicast](#multicast)
   - [IP IGMP Snooping](#ip-igmp-snooping)
 - [Filters](#filters)
-  - [Prefix-lists](#prefix-lists)
   - [Route-maps](#route-maps)
 - [VRF Instances](#vrf-instances)
   - [VRF Instances Summary](#vrf-instances-summary)
@@ -489,7 +488,7 @@ router bgp 65111.100
    neighbor 172.17.110.2 remote-as 65110.100
    neighbor 172.17.110.2 description DC1-POD1-SPINE2_Ethernet3
    redistribute attached-host
-   redistribute connected route-map RM-CONN-2-BGP
+   redistribute connected
    !
    address-family evpn
       neighbor EVPN-OVERLAY-PEERS activate
@@ -539,45 +538,9 @@ router bfd
 
 # Filters
 
-## Prefix-lists
-
-### Prefix-lists Summary
-
-#### PL-L2LEAF-INBAND-MGMT
-
-| Sequence | Action |
-| -------- | ------ |
-| 10 | permit 172.21.110.0/24 |
-
-#### PL-LOOPBACKS-EVPN-OVERLAY
-
-| Sequence | Action |
-| -------- | ------ |
-| 10 | permit 172.16.110.0/24 eq 32 |
-| 20 | permit 172.18.110.0/24 eq 32 |
-
-### Prefix-lists Device Configuration
-
-```eos
-!
-ip prefix-list PL-L2LEAF-INBAND-MGMT
-   seq 10 permit 172.21.110.0/24
-!
-ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
-   seq 10 permit 172.16.110.0/24 eq 32
-   seq 20 permit 172.18.110.0/24 eq 32
-```
-
 ## Route-maps
 
 ### Route-maps Summary
-
-#### RM-CONN-2-BGP
-
-| Sequence | Type | Match | Set | Sub-Route-Map | Continue |
-| -------- | ---- | ----- | --- | ------------- | -------- |
-| 10 | permit | ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY | - | - | - |
-| 20 | permit | ip address prefix-list PL-L2LEAF-INBAND-MGMT | - | - | - |
 
 #### RM-EVPN-FILTER-AS65200
 
@@ -610,12 +573,6 @@ ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
 ### Route-maps Device Configuration
 
 ```eos
-!
-route-map RM-CONN-2-BGP permit 10
-   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
-!
-route-map RM-CONN-2-BGP permit 20
-   match ip address prefix-list PL-L2LEAF-INBAND-MGMT
 !
 route-map RM-EVPN-FILTER-AS65200 deny 10
    match as 65200

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2B.md
@@ -39,7 +39,6 @@
 - [Multicast](#multicast)
   - [IP IGMP Snooping](#ip-igmp-snooping)
 - [Filters](#filters)
-  - [Prefix-lists](#prefix-lists)
   - [Route-maps](#route-maps)
 - [VRF Instances](#vrf-instances)
   - [VRF Instances Summary](#vrf-instances-summary)
@@ -948,7 +947,7 @@ router bgp 65112.100
    neighbor 172.20.110.2 peer group MLAG-IPv4-UNDERLAY-PEER
    neighbor 172.20.110.2 description DC1.POD1.LEAF2A
    redistribute attached-host
-   redistribute connected route-map RM-CONN-2-BGP
+   redistribute connected
    !
    vlan 110
       rd 172.16.110.5:99110
@@ -1095,45 +1094,9 @@ router bfd
 
 # Filters
 
-## Prefix-lists
-
-### Prefix-lists Summary
-
-#### PL-L2LEAF-INBAND-MGMT
-
-| Sequence | Action |
-| -------- | ------ |
-| 10 | permit 172.21.110.0/24 |
-
-#### PL-LOOPBACKS-EVPN-OVERLAY
-
-| Sequence | Action |
-| -------- | ------ |
-| 10 | permit 172.16.110.0/24 eq 32 |
-| 20 | permit 172.18.110.0/24 eq 32 |
-
-### Prefix-lists Device Configuration
-
-```eos
-!
-ip prefix-list PL-L2LEAF-INBAND-MGMT
-   seq 10 permit 172.21.110.0/24
-!
-ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
-   seq 10 permit 172.16.110.0/24 eq 32
-   seq 20 permit 172.18.110.0/24 eq 32
-```
-
 ## Route-maps
 
 ### Route-maps Summary
-
-#### RM-CONN-2-BGP
-
-| Sequence | Type | Match | Set | Sub-Route-Map | Continue |
-| -------- | ---- | ----- | --- | ------------- | -------- |
-| 10 | permit | ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY | - | - | - |
-| 20 | permit | ip address prefix-list PL-L2LEAF-INBAND-MGMT | - | - | - |
 
 #### RM-EVPN-FILTER-AS65101
 
@@ -1165,12 +1128,6 @@ ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
 ### Route-maps Device Configuration
 
 ```eos
-!
-route-map RM-CONN-2-BGP permit 10
-   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
-!
-route-map RM-CONN-2-BGP permit 20
-   match ip address prefix-list PL-L2LEAF-INBAND-MGMT
 !
 route-map RM-EVPN-FILTER-AS65101 deny 10
    match as 65101

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-SPINE1.md
@@ -25,7 +25,6 @@
 - [BFD](#bfd)
   - [Router BFD](#router-bfd)
 - [Filters](#filters)
-  - [Prefix-lists](#prefix-lists)
   - [Route-maps](#route-maps)
 - [VRF Instances](#vrf-instances)
   - [VRF Instances Summary](#vrf-instances-summary)
@@ -438,7 +437,7 @@ router bgp 65110.100
    neighbor 172.17.110.21 peer group IPv4-UNDERLAY-PEERS
    neighbor 172.17.110.21 remote-as 65112.100
    neighbor 172.17.110.21 description DC1-POD1-LEAF2B_Ethernet11
-   redistribute connected route-map RM-CONN-2-BGP
+   redistribute connected
    !
    address-family evpn
       neighbor EVPN-OVERLAY-PEERS activate
@@ -472,33 +471,9 @@ router bfd
 
 # Filters
 
-## Prefix-lists
-
-### Prefix-lists Summary
-
-#### PL-LOOPBACKS-EVPN-OVERLAY
-
-| Sequence | Action |
-| -------- | ------ |
-| 10 | permit 172.16.110.0/24 eq 32 |
-
-### Prefix-lists Device Configuration
-
-```eos
-!
-ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
-   seq 10 permit 172.16.110.0/24 eq 32
-```
-
 ## Route-maps
 
 ### Route-maps Summary
-
-#### RM-CONN-2-BGP
-
-| Sequence | Type | Match | Set | Sub-Route-Map | Continue |
-| -------- | ---- | ----- | --- | ------------- | -------- |
-| 10 | permit | ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY | - | - | - |
 
 #### RM-EVPN-FILTER-AS65200
 
@@ -531,9 +506,6 @@ ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
 ### Route-maps Device Configuration
 
 ```eos
-!
-route-map RM-CONN-2-BGP permit 10
-   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
 !
 route-map RM-EVPN-FILTER-AS65200 deny 10
    match as 65200

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-SPINE2.md
@@ -23,9 +23,6 @@
   - [IPv6 Routing](#ipv6-routing)
   - [Static Routes](#static-routes)
   - [Router BGP](#router-bgp)
-- [Filters](#filters)
-  - [Prefix-lists](#prefix-lists)
-  - [Route-maps](#route-maps)
 - [VRF Instances](#vrf-instances)
   - [VRF Instances Summary](#vrf-instances-summary)
   - [VRF Instances Device Configuration](#vrf-instances-device-configuration)
@@ -394,48 +391,10 @@ router bgp 65110.100
    neighbor 172.17.110.23 peer group IPv4-UNDERLAY-PEERS
    neighbor 172.17.110.23 remote-as 65112.100
    neighbor 172.17.110.23 description DC1-POD1-LEAF2B_Ethernet12
-   redistribute connected route-map RM-CONN-2-BGP
+   redistribute connected
    !
    address-family ipv4
       neighbor IPv4-UNDERLAY-PEERS activate
-```
-
-# Filters
-
-## Prefix-lists
-
-### Prefix-lists Summary
-
-#### PL-LOOPBACKS-EVPN-OVERLAY
-
-| Sequence | Action |
-| -------- | ------ |
-| 10 | permit 172.16.110.0/24 eq 32 |
-
-### Prefix-lists Device Configuration
-
-```eos
-!
-ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
-   seq 10 permit 172.16.110.0/24 eq 32
-```
-
-## Route-maps
-
-### Route-maps Summary
-
-#### RM-CONN-2-BGP
-
-| Sequence | Type | Match | Set | Sub-Route-Map | Continue |
-| -------- | ---- | ----- | --- | ------------- | -------- |
-| 10 | permit | ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY | - | - | - |
-
-### Route-maps Device Configuration
-
-```eos
-!
-route-map RM-CONN-2-BGP permit 10
-   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
 ```
 
 # VRF Instances

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1.POD1.LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1.POD1.LEAF2A.md
@@ -38,7 +38,6 @@
 - [Multicast](#multicast)
   - [IP IGMP Snooping](#ip-igmp-snooping)
 - [Filters](#filters)
-  - [Prefix-lists](#prefix-lists)
   - [Route-maps](#route-maps)
 - [VRF Instances](#vrf-instances)
   - [VRF Instances Summary](#vrf-instances-summary)
@@ -922,7 +921,7 @@ router bgp 65112.100
    neighbor 172.20.110.3 peer group MLAG-IPv4-UNDERLAY-PEER
    neighbor 172.20.110.3 description DC1-POD1-LEAF2B
    redistribute attached-host
-   redistribute connected route-map RM-CONN-2-BGP
+   redistribute connected
    !
    vlan 110
       rd 172.16.110.4:99110
@@ -1059,45 +1058,9 @@ router bfd
 
 # Filters
 
-## Prefix-lists
-
-### Prefix-lists Summary
-
-#### PL-L2LEAF-INBAND-MGMT
-
-| Sequence | Action |
-| -------- | ------ |
-| 10 | permit 172.21.110.0/24 |
-
-#### PL-LOOPBACKS-EVPN-OVERLAY
-
-| Sequence | Action |
-| -------- | ------ |
-| 10 | permit 172.16.110.0/24 eq 32 |
-| 20 | permit 172.18.110.0/24 eq 32 |
-
-### Prefix-lists Device Configuration
-
-```eos
-!
-ip prefix-list PL-L2LEAF-INBAND-MGMT
-   seq 10 permit 172.21.110.0/24
-!
-ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
-   seq 10 permit 172.16.110.0/24 eq 32
-   seq 20 permit 172.18.110.0/24 eq 32
-```
-
 ## Route-maps
 
 ### Route-maps Summary
-
-#### RM-CONN-2-BGP
-
-| Sequence | Type | Match | Set | Sub-Route-Map | Continue |
-| -------- | ---- | ----- | --- | ------------- | -------- |
-| 10 | permit | ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY | - | - | - |
-| 20 | permit | ip address prefix-list PL-L2LEAF-INBAND-MGMT | - | - | - |
 
 #### RM-EVPN-FILTER-AS65101
 
@@ -1129,12 +1092,6 @@ ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
 ### Route-maps Device Configuration
 
 ```eos
-!
-route-map RM-CONN-2-BGP permit 10
-   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
-!
-route-map RM-CONN-2-BGP permit 20
-   match ip address prefix-list PL-L2LEAF-INBAND-MGMT
 !
 route-map RM-EVPN-FILTER-AS65101 deny 10
    match as 65101

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF1A.cfg
@@ -89,20 +89,7 @@ ip virtual-router mac-address 00:1c:73:00:dc:01
 ip routing
 no ip routing vrf MGMT
 !
-ip prefix-list PL-L2LEAF-INBAND-MGMT
-   seq 10 permit 172.21.110.0/24
-!
-ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
-   seq 10 permit 172.16.110.0/24 eq 32
-   seq 20 permit 172.18.110.0/24 eq 32
-!
 ip route vrf MGMT 0.0.0.0/0 192.168.1.254
-!
-route-map RM-CONN-2-BGP permit 10
-   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
-!
-route-map RM-CONN-2-BGP permit 20
-   match ip address prefix-list PL-L2LEAF-INBAND-MGMT
 !
 route-map RM-EVPN-FILTER-AS65200 deny 10
    match as 65200
@@ -179,7 +166,7 @@ router bgp 65111.100
    neighbor 172.17.110.2 remote-as 65110.100
    neighbor 172.17.110.2 description DC1-POD1-SPINE2_Ethernet3
    redistribute attached-host
-   redistribute connected route-map RM-CONN-2-BGP
+   redistribute connected
    !
    address-family evpn
       neighbor EVPN-OVERLAY-PEERS activate

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2B.cfg
@@ -349,13 +349,6 @@ ip routing vrf vrf_with_loopbacks_dc1_pod1_only
 ip routing vrf vrf_with_loopbacks_from_overlapping_pool
 ip routing vrf vrf_with_loopbacks_from_pod_pools
 !
-ip prefix-list PL-L2LEAF-INBAND-MGMT
-   seq 10 permit 172.21.110.0/24
-!
-ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
-   seq 10 permit 172.16.110.0/24 eq 32
-   seq 20 permit 172.18.110.0/24 eq 32
-!
 mlag configuration
    domain-id RACK2_MLAG
    local-interface Vlan4094
@@ -365,12 +358,6 @@ mlag configuration
    reload-delay non-mlag 330
 !
 ip route vrf MGMT 0.0.0.0/0 192.168.1.254
-!
-route-map RM-CONN-2-BGP permit 10
-   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
-!
-route-map RM-CONN-2-BGP permit 20
-   match ip address prefix-list PL-L2LEAF-INBAND-MGMT
 !
 route-map RM-EVPN-FILTER-AS65101 deny 10
    match as 65101
@@ -461,7 +448,7 @@ router bgp 65112.100
    neighbor 172.20.110.2 peer group MLAG-IPv4-UNDERLAY-PEER
    neighbor 172.20.110.2 description DC1.POD1.LEAF2A
    redistribute attached-host
-   redistribute connected route-map RM-CONN-2-BGP
+   redistribute connected
    !
    vlan 110
       rd 172.16.110.5:99110

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-SPINE1.cfg
@@ -100,13 +100,7 @@ interface Loopback0
 ip routing
 no ip routing vrf MGMT
 !
-ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
-   seq 10 permit 172.16.110.0/24 eq 32
-!
 ip route vrf MGMT 0.0.0.0/0 192.168.1.254
-!
-route-map RM-CONN-2-BGP permit 10
-   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
 !
 route-map RM-EVPN-FILTER-AS65200 deny 10
    match as 65200
@@ -197,7 +191,7 @@ router bgp 65110.100
    neighbor 172.17.110.21 peer group IPv4-UNDERLAY-PEERS
    neighbor 172.17.110.21 remote-as 65112.100
    neighbor 172.17.110.21 description DC1-POD1-LEAF2B_Ethernet11
-   redistribute connected route-map RM-CONN-2-BGP
+   redistribute connected
    !
    address-family evpn
       neighbor EVPN-OVERLAY-PEERS activate

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-SPINE2.cfg
@@ -98,13 +98,7 @@ interface Management1
 ip routing
 no ip routing vrf MGMT
 !
-ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
-   seq 10 permit 172.16.110.0/24 eq 32
-!
 ip route vrf MGMT 0.0.0.0/0 192.168.1.254
-!
-route-map RM-CONN-2-BGP permit 10
-   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
 !
 router bgp 65110.100
    router-id 172.16.110.2
@@ -138,7 +132,7 @@ router bgp 65110.100
    neighbor 172.17.110.23 peer group IPv4-UNDERLAY-PEERS
    neighbor 172.17.110.23 remote-as 65112.100
    neighbor 172.17.110.23 description DC1-POD1-LEAF2B_Ethernet12
-   redistribute connected route-map RM-CONN-2-BGP
+   redistribute connected
    !
    address-family ipv4
       neighbor IPv4-UNDERLAY-PEERS activate

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1.POD1.LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1.POD1.LEAF2A.cfg
@@ -343,13 +343,6 @@ ip routing vrf vrf_with_loopbacks_dc1_pod1_only
 ip routing vrf vrf_with_loopbacks_from_overlapping_pool
 ip routing vrf vrf_with_loopbacks_from_pod_pools
 !
-ip prefix-list PL-L2LEAF-INBAND-MGMT
-   seq 10 permit 172.21.110.0/24
-!
-ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
-   seq 10 permit 172.16.110.0/24 eq 32
-   seq 20 permit 172.18.110.0/24 eq 32
-!
 mlag configuration
    domain-id RACK2_MLAG
    local-interface Vlan4094
@@ -361,12 +354,6 @@ mlag configuration
    reload-delay non-mlag 330
 !
 ip route vrf MGMT 0.0.0.0/0 192.168.1.254
-!
-route-map RM-CONN-2-BGP permit 10
-   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
-!
-route-map RM-CONN-2-BGP permit 20
-   match ip address prefix-list PL-L2LEAF-INBAND-MGMT
 !
 route-map RM-EVPN-FILTER-AS65101 deny 10
    match as 65101
@@ -455,7 +442,7 @@ router bgp 65112.100
    neighbor 172.20.110.3 peer group MLAG-IPv4-UNDERLAY-PEER
    neighbor 172.20.110.3 description DC1-POD1-LEAF2B
    redistribute attached-host
-   redistribute connected route-map RM-CONN-2-BGP
+   redistribute connected
    !
    vlan 110
       rd 172.16.110.4:99110

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF1A.yml
@@ -29,8 +29,7 @@ router_bgp:
     - activate: false
       name: EVPN-OVERLAY-PEERS
   redistribute_routes:
-  - route_map: RM-CONN-2-BGP
-    source_protocol: connected
+  - source_protocol: connected
   - source_protocol: attached-host
   neighbors:
   - peer_group: IPv4-UNDERLAY-PEERS
@@ -188,17 +187,12 @@ prefix_lists:
   sequence_numbers:
   - sequence: 10
     action: permit 172.21.110.0/24
+router_bfd:
+  multihop:
+    interval: 300
+    min_rx: 300
+    multiplier: 3
 route_maps:
-- name: RM-CONN-2-BGP
-  sequence_numbers:
-  - sequence: 10
-    type: permit
-    match:
-    - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
-  - type: permit
-    match:
-    - ip address prefix-list PL-L2LEAF-INBAND-MGMT
-    sequence: 20
 - name: RM-EVPN-FILTER-AS65200
   sequence_numbers:
   - sequence: 10
@@ -231,11 +225,6 @@ route_maps:
     - as 65211
   - sequence: 20
     type: permit
-router_bfd:
-  multihop:
-    interval: 300
-    min_rx: 300
-    multiplier: 3
 ip_igmp_snooping:
   globally_enabled: true
 ip_virtual_router_mac_address: 00:1c:73:00:dc:01

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF1A.yml
@@ -176,17 +176,6 @@ loopback_interfaces:
   description: VTEP_VXLAN_Tunnel_Source
   shutdown: false
   ip_address: 172.18.110.3/32
-prefix_lists:
-- name: PL-LOOPBACKS-EVPN-OVERLAY
-  sequence_numbers:
-  - sequence: 10
-    action: permit 172.16.110.0/24 eq 32
-  - sequence: 20
-    action: permit 172.18.110.0/24 eq 32
-- name: PL-L2LEAF-INBAND-MGMT
-  sequence_numbers:
-  - sequence: 10
-    action: permit 172.21.110.0/24
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2B.yml
@@ -768,17 +768,6 @@ loopback_interfaces:
   shutdown: false
   vrf: vrf_with_loopbacks_from_pod_pools
   ip_address: 10.101.101.5/32
-prefix_lists:
-- name: PL-LOOPBACKS-EVPN-OVERLAY
-  sequence_numbers:
-  - sequence: 10
-    action: permit 172.16.110.0/24 eq 32
-  - sequence: 20
-    action: permit 172.18.110.0/24 eq 32
-- name: PL-L2LEAF-INBAND-MGMT
-  sequence_numbers:
-  - sequence: 10
-    action: permit 172.21.110.0/24
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2B.yml
@@ -93,8 +93,7 @@ router_bgp:
     local_as: '65120'
     ip_address: 11.1.0.39
   redistribute_routes:
-  - route_map: RM-CONN-2-BGP
-    source_protocol: connected
+  - source_protocol: connected
   - source_protocol: attached-host
   address_family_evpn:
     neighbor_default:
@@ -721,16 +720,6 @@ route_maps:
     set:
     - origin incomplete
     description: Make routes learned over MLAG Peer-link less preferred on spines to ensure optimal routing
-- name: RM-CONN-2-BGP
-  sequence_numbers:
-  - sequence: 10
-    type: permit
-    match:
-    - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
-  - type: permit
-    match:
-    - ip address prefix-list PL-L2LEAF-INBAND-MGMT
-    sequence: 20
 - name: RM-EVPN-FILTER-AS65101
   sequence_numbers:
   - sequence: 10

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-SPINE1.yml
@@ -29,8 +29,7 @@ router_bgp:
     - activate: false
       name: EVPN-OVERLAY-PEERS
   redistribute_routes:
-  - route_map: RM-CONN-2-BGP
-    source_protocol: connected
+  - source_protocol: connected
   neighbors:
   - peer_group: IPv4-UNDERLAY-PEERS
     remote_as: '65100'
@@ -240,13 +239,12 @@ prefix_lists:
   sequence_numbers:
   - sequence: 10
     action: permit 172.16.110.0/24 eq 32
+router_bfd:
+  multihop:
+    interval: 300
+    min_rx: 300
+    multiplier: 3
 route_maps:
-- name: RM-CONN-2-BGP
-  sequence_numbers:
-  - sequence: 10
-    type: permit
-    match:
-    - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
 - name: RM-EVPN-FILTER-AS65200
   sequence_numbers:
   - sequence: 10
@@ -279,8 +277,3 @@ route_maps:
     - as 65211
   - sequence: 20
     type: permit
-router_bfd:
-  multihop:
-    interval: 300
-    min_rx: 300
-    multiplier: 3

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-SPINE1.yml
@@ -234,11 +234,6 @@ loopback_interfaces:
   description: EVPN_Overlay_Peering
   shutdown: false
   ip_address: 172.16.110.1/32
-prefix_lists:
-- name: PL-LOOPBACKS-EVPN-OVERLAY
-  sequence_numbers:
-  - sequence: 10
-    action: permit 172.16.110.0/24 eq 32
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-SPINE2.yml
@@ -178,15 +178,3 @@ loopback_interfaces:
   description: EVPN_Overlay_Peering
   shutdown: false
   ip_address: 172.16.110.2/32
-prefix_lists:
-- name: PL-LOOPBACKS-EVPN-OVERLAY
-  sequence_numbers:
-  - sequence: 10
-    action: permit 172.16.110.0/24 eq 32
-route_maps:
-- name: RM-CONN-2-BGP
-  sequence_numbers:
-  - sequence: 10
-    type: permit
-    match:
-    - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-SPINE2.yml
@@ -18,8 +18,7 @@ router_bgp:
     - activate: true
       name: IPv4-UNDERLAY-PEERS
   redistribute_routes:
-  - route_map: RM-CONN-2-BGP
-    source_protocol: connected
+  - source_protocol: connected
   neighbors:
   - peer_group: IPv4-UNDERLAY-PEERS
     remote_as: '65100'

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1.POD1.LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1.POD1.LEAF2A.yml
@@ -91,8 +91,7 @@ router_bgp:
     peer_group: IPv4-UNDERLAY-PEERS
     ip_address: 100.100.100.201
   redistribute_routes:
-  - route_map: RM-CONN-2-BGP
-    source_protocol: connected
+  - source_protocol: connected
   - source_protocol: attached-host
   address_family_evpn:
     neighbor_default:
@@ -683,16 +682,6 @@ route_maps:
     set:
     - origin incomplete
     description: Make routes learned over MLAG Peer-link less preferred on spines to ensure optimal routing
-- name: RM-CONN-2-BGP
-  sequence_numbers:
-  - sequence: 10
-    type: permit
-    match:
-    - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
-  - type: permit
-    match:
-    - ip address prefix-list PL-L2LEAF-INBAND-MGMT
-    sequence: 20
 - name: RM-EVPN-FILTER-AS65101
   sequence_numbers:
   - sequence: 10

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1.POD1.LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1.POD1.LEAF2A.yml
@@ -730,17 +730,6 @@ loopback_interfaces:
   shutdown: false
   vrf: vrf_with_loopbacks_from_pod_pools
   ip_address: 10.101.101.4/32
-prefix_lists:
-- name: PL-LOOPBACKS-EVPN-OVERLAY
-  sequence_numbers:
-  - sequence: 10
-    action: permit 172.16.110.0/24 eq 32
-  - sequence: 20
-    action: permit 172.18.110.0/24 eq 32
-- name: PL-L2LEAF-INBAND-MGMT
-  sequence_numbers:
-  - sequence: 10
-    action: permit 172.21.110.0/24
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/inventory/group_vars/DC1_POD1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/inventory/group_vars/DC1_POD1.yml
@@ -3,6 +3,9 @@ pod_name: DC1_POD1
 
 max_l3leaf_to_spine_links: 2
 
+# Test removing redistribute connected route-map and prefix-list (default true) in combination with inband_management
+underlay_filter_redistribute_connected: false
+
 spine:
   defaults:
     platform: vEOS-LAB

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY_FILTER_PEER_AS_L3LEAF1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY_FILTER_PEER_AS_L3LEAF1.cfg
@@ -40,13 +40,6 @@ ip virtual-router mac-address 00:11:22:33:44:55
 ip routing
 no ip routing vrf MGMT
 !
-ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
-   seq 10 permit 192.168.255.0/24 eq 32
-   seq 20 permit 192.168.254.0/24 eq 32
-!
-route-map RM-CONN-2-BGP permit 10
-   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
-!
 router bfd
    multihop interval 300 min-rx 300 multiplier 3
 !
@@ -65,7 +58,7 @@ router bgp 65001
    neighbor 192.168.0.0 peer group IPv4-UNDERLAY-PEERS
    neighbor 192.168.0.0 remote-as 65000
    neighbor 192.168.0.0 description UNDERLAY_FILTER_PEER_AS_SPINE1_Ethernet1
-   redistribute connected route-map RM-CONN-2-BGP
+   redistribute connected
    !
    address-family evpn
       neighbor EVPN-OVERLAY-PEERS activate

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY_FILTER_PEER_AS_L3LEAF1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY_FILTER_PEER_AS_L3LEAF1.yml
@@ -22,8 +22,7 @@ router_bgp:
     - activate: false
       name: EVPN-OVERLAY-PEERS
   redistribute_routes:
-  - route_map: RM-CONN-2-BGP
-    source_protocol: connected
+  - source_protocol: connected
   neighbors:
   - peer_group: IPv4-UNDERLAY-PEERS
     remote_as: '65000'

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY_FILTER_PEER_AS_L3LEAF1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY_FILTER_PEER_AS_L3LEAF1.yml
@@ -65,20 +65,6 @@ loopback_interfaces:
   description: VTEP_VXLAN_Tunnel_Source
   shutdown: false
   ip_address: 192.168.254.3/32
-prefix_lists:
-- name: PL-LOOPBACKS-EVPN-OVERLAY
-  sequence_numbers:
-  - sequence: 10
-    action: permit 192.168.255.0/24 eq 32
-  - sequence: 20
-    action: permit 192.168.254.0/24 eq 32
-route_maps:
-- name: RM-CONN-2-BGP
-  sequence_numbers:
-  - sequence: 10
-    type: permit
-    match:
-    - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/UNDERLAY_FILTER_PEER_AS_L3LEAF1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/UNDERLAY_FILTER_PEER_AS_L3LEAF1.yml
@@ -4,6 +4,9 @@ type: l3leaf
 # This device is a EVPN client by default, so we will not see any changes from "underlay_filter_peer_as"
 underlay_filter_peer_as: true
 
+# Test removing redistribute connected route-map and prefix-list (default true)
+underlay_filter_redistribute_connected: false
+
 l3leaf:
   nodes:
     UNDERLAY_FILTER_PEER_AS_L3LEAF1:

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-variables.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-variables.md
@@ -184,6 +184,11 @@ evpn_import_pruning: < true | false | default -> false >
 # from Route-server-1 to Router-server-2 just for Route-server-2 to throw them away because of AS Path loop detection.
 evpn_prevent_readvertise_to_server: < true | false | default -> false >
 
+# Filter redistribution of connected into underlay routing protocol.
+# Only applicable when overlay_routing_protocol != 'none' and underlay_routing_protocol == BGP.
+# Creates a route-map and prefix-list assigned to redistribute connected permitting only loopbacks and inband management subnets.
+underlay_filter_redistribute_connected: < true | false | default -> true >
+
 # Configure route-map on eBGP sessions towards underlay peers, where prefixes with the peer's ASN in the AS Path are filtered away.
 # This is very useful in very large scale networks not using EVPN overlays, where convergence will be quicker by not having to return
 # all updates received from Spine-1 to Spine-2 just for Spine-2 to throw them away because of AS Path loop detection.

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/inband_management/avdstructuredconfig.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/inband_management/avdstructuredconfig.py
@@ -182,11 +182,18 @@ class AvdStructuredConfig(AvdFacts):
         }
 
     @cached_property
+    def _underlay_filter_redistribute_connected(self) -> bool:
+        return get(self._hostvars, "underlay_filter_redistribute_connected", default=True) is True
+
+    @cached_property
     def prefix_lists(self) -> list | None:
         if self._inband_management_role != "parent":
             return None
 
         if not self._underlay_bgp:
+            return None
+
+        if not self._underlay_filter_redistribute_connected:
             return None
 
         sequence_numbers = [
@@ -209,6 +216,9 @@ class AvdStructuredConfig(AvdFacts):
             return None
 
         if not self._underlay_bgp:
+            return None
+
+        if not self._underlay_filter_redistribute_connected:
             return None
 
         return {

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/route_maps.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/route_maps.py
@@ -95,19 +95,6 @@ class RouteMapsMixin(UtilsMixin):
             ],
         }
 
-        bgp = {
-            "name": "RM-CONN-2-BGP",
-            "sequence_numbers": [
-                # Add subnets to redistribution in default VRF
-                # sequence 10 is set in underlay and sequence 20 in inband management, so avoid setting those here
-                {
-                    "sequence": 30,
-                    "type": "permit",
-                    "match": ["ip address prefix-list PL-SVI-VRF-DEFAULT"],
-                },
-            ],
-        }
-
         if subnets:
             vrf_default["sequence_numbers"].append(
                 {
@@ -141,6 +128,22 @@ class RouteMapsMixin(UtilsMixin):
                     "match": ["ip address prefix-list PL-STATIC-VRF-DEFAULT"],
                 }
             )
+
+        if not self._underlay_filter_redistribute_connected:
+            return [vrf_default, peers_out]
+
+        bgp = {
+            "name": "RM-CONN-2-BGP",
+            "sequence_numbers": [
+                # Add subnets to redistribution in default VRF
+                # sequence 10 is set in underlay and sequence 20 in inband management, so avoid setting those here
+                {
+                    "sequence": 30,
+                    "type": "permit",
+                    "match": ["ip address prefix-list PL-SVI-VRF-DEFAULT"],
+                },
+            ],
+        }
 
         return [vrf_default, peers_out, bgp]
 

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/utils.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/utils.py
@@ -329,3 +329,7 @@ class UtilsMixin(UtilsFilteredTenantsMixin):
     @cached_property
     def _virtual_router_mac_address(self) -> str | None:
         return get(self._hostvars, "switch.virtual_router_mac_address")
+
+    @cached_property
+    def _underlay_filter_redistribute_connected(self) -> bool:
+        return get(self._hostvars, "underlay_filter_redistribute_connected", default=True) is True

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/prefix_lists.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/prefix_lists.py
@@ -22,6 +22,9 @@ class PrefixListsMixin(UtilsMixin):
         if self._overlay_routing_protocol == "none":
             return None
 
+        if not self._underlay_filter_redistribute_connected:
+            return None
+
         # IPv4 - PL-LOOPBACKS-EVPN-OVERLAY
         sequence_numbers = [{"sequence": 10, "action": f"permit {self._loopback_ipv4_pool} eq 32"}]
 
@@ -47,6 +50,9 @@ class PrefixListsMixin(UtilsMixin):
             return None
 
         if self._overlay_routing_protocol == "none":
+            return None
+
+        if not self._underlay_filter_redistribute_connected:
             return None
 
         # IPv6 - PL-LOOPBACKS-EVPN-OVERLAY-V6

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/route_maps.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/route_maps.py
@@ -18,14 +18,14 @@ class RouteMapsMixin(UtilsMixin):
 
         Contains two parts.
         - Route map for connected routes redistribution in BGP
-        - Route map to filter peer AS in uderlay
+        - Route map to filter peer AS in underlay
         """
         if self._underlay_bgp is not True:
             return None
 
         route_maps = []
 
-        if self._overlay_routing_protocol != "none":
+        if self._overlay_routing_protocol != "none" and self._underlay_filter_redistribute_connected:
             # RM-CONN-2-BGP
             sequence_numbers = []
             sequence_numbers.append(

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/router_bgp.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/router_bgp.py
@@ -107,7 +107,7 @@ class RouterBgpMixin(UtilsMixin):
         """
         Return structured config for router_bgp.redistribute_routes
         """
-        if self._overlay_routing_protocol == "none":
+        if self._overlay_routing_protocol == "none" or not self._underlay_filter_redistribute_connected:
             return {"connected": {}}
 
         return {"connected": {"route_map": "RM-CONN-2-BGP"}}

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/utils.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/utils.py
@@ -126,6 +126,10 @@ class UtilsMixin:
         return get(self._hostvars, "underlay_filter_peer_as") is True
 
     @cached_property
+    def _underlay_filter_redistribute_connected(self) -> bool:
+        return get(self._hostvars, "underlay_filter_redistribute_connected", default=True) is True
+
+    @cached_property
     def _underlay_filter_peer_as_route_maps_asns(self) -> list:
         """
         Filtered ASNs


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Allow disabling filtering on redist connected in underlay bgp

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

```yaml
# Filter redistribution of connected into underlay routing protocol.
# Only applicable when overlay_routing_protocol != 'none' and underlay_routing_protocol == BGP.
# Creates a route-map and prefix-list assigned to redistribute connected permitting only loopbacks and inband management subnets.
underlay_filter_redistribute_connected: < true | false | default -> true >
```

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Added to molecule

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
