### PR TITLE
Doc: Updating the landing page, move the collection below AVD umbrella

### DIFF
--- a/ansible_collections/arista/avd/README.md
+++ b/ansible_collections/arista/avd/README.md
@@ -2,7 +2,7 @@
 
 <center><img src="media/avd-logo.png" alt="Arista AVD Overview" width="800"/></center>
 
-Arista Validated Designs (AVD) is an extensible data model that defines Arista’s Unified Cloud Network architecture as "code".
+Arista Validated Designs (AVD) is an extensible data model that defines Arista's Unified Cloud Network architecture as "code".
 
 ## Features
 

--- a/ansible_collections/arista/avd/README.md
+++ b/ansible_collections/arista/avd/README.md
@@ -21,7 +21,7 @@ Arista Validated Designs (AVD) is an extensible data model that defines Arista's
 Full documentation for the collection:
 
 - [stable version](https://www.avd.sh/en/stable/)
-- [collection development version](https://www.avd.sh/en/devel/)
+- [development version](https://www.avd.sh/en/devel/)
 
 ### Roles overview
 
@@ -64,6 +64,10 @@ This repository provides custom plugins for Arista's AVD collection:
 ## Ask a question
 
 Support for the `arista.avd` collection is provided by the community directly in this repository. If you have any questions, please leverage the GitHub [discussions board](https://github.com/aristanetworks/ansible-avd/discussions).
+
+### Official Arista support
+
+AVD version 4.x releases with full support from Arista TAC. If your organization has the appropriate support agreement, please don't hesitate to contact TAC with any questions or issues.
 
 ## Contributing
 

--- a/ansible_collections/arista/avd/README.md
+++ b/ansible_collections/arista/avd/README.md
@@ -2,7 +2,7 @@
 
 <center><img src="media/avd-logo.png" alt="Arista AVD Overview" width="800"/></center>
 
-Arista Validated Designs (AVD) is an extensible data model that defines Arista’s Unified Cloud Network architecture as “code.”
+Arista Validated Designs (AVD) is an extensible data model that defines Arista’s Unified Cloud Network architecture as "code".
 
 ## Features
 

--- a/ansible_collections/arista/avd/README.md
+++ b/ansible_collections/arista/avd/README.md
@@ -48,7 +48,7 @@ Ansible galaxy hosts all stable versions of the `arista.avd` collection. Install
 - [Getting started](./docs/getting-started/intro-to-ansible-and-avd.md)
 - [Arista NetDevOps GitHub repository](https://github.com/aristanetworks/netdevops-examples)
 
-## Custom plugins & modules
+### Custom plugins & modules
 
 This repository provides custom plugins for Arista's AVD collection:
 

--- a/ansible_collections/arista/avd/README.md
+++ b/ansible_collections/arista/avd/README.md
@@ -1,13 +1,8 @@
-# Ansible Collection for Arista Validated Designs
+# Arista Validated Designs
 
 <center><img src="media/avd-logo.png" alt="Arista AVD Overview" width="800"/></center>
 
-[Arista Networks](https://www.arista.com/) supports Ansible for managing devices running Arista's **Extensible Operating System (EOS)** natively through it's **EOS API (eAPI)** or [**CloudVision Portal (CVP)**](https://www.arista.com/en/products/eos/eos-cloudvision). This collection includes a set of Ansible roles and modules to help kick-start your automation with Arista. The various roles and templates provided are designed to be customized and extended to your needs.
-
-Full documentation for the collection:
-
-- [stable version](https://www.avd.sh/en/stable/)
-- [collection development version](https://www.avd.sh/en/devel/)
+Arista Validated Designs (AVD) is an extensible data model that defines Arista’s Unified Cloud Network architecture as “code.”
 
 ## Features
 
@@ -19,7 +14,16 @@ Full documentation for the collection:
 
 - [L3LS VXLAN-EVPN, L2LS, and MPLS (beta)](https://avd.sh/en/stable/roles/eos_designs/index.html)
 
-## Roles overview
+## AVD Ansible Collection
+
+[Arista Networks](https://www.arista.com/) supports Ansible for managing devices running Arista's **Extensible Operating System (EOS)** natively through it's **EOS API (eAPI)** or [**CloudVision Portal (CVP)**](https://www.arista.com/en/products/eos/eos-cloudvision). The collection includes a set of Ansible roles and modules to help kick-start your automation with Arista. The various roles and templates provided are designed to be customized and extended to your needs.
+
+Full documentation for the collection:
+
+- [stable version](https://www.avd.sh/en/stable/)
+- [collection development version](https://www.avd.sh/en/devel/)
+
+### Roles overview
 
 This repository provides content for Arista's **arista.avd** collection. The following roles are included.
 
@@ -35,20 +39,20 @@ This repository provides content for Arista's **arista.avd** collection. The fol
 ![Arista AVD Overview](docs/_media/avd_roles_dark.svg#only-dark)
 ![Arista AVD Overview](docs/_media/avd_roles_light.svg#only-light)
 
+### Collection installation
+
+Ansible galaxy hosts all stable versions of the `arista.avd` collection. Installation from ansible-galaxy is the most convenient approach for consuming `arista.avd` content. Please follow the collection installation [guide](https://avd.sh/en/stable/docs/installation/collection-installation.html).
+
+### Examples
+
+- [Getting started](./docs/getting-started/intro-to-ansible-and-avd.md)
+- [Arista NetDevOps GitHub repository](https://github.com/aristanetworks/netdevops-examples)
+
 ## Custom plugins & modules
 
 This repository provides custom plugins for Arista's AVD collection:
 
 - [Arista AVD Plugins](plugins/README.md)
-
-## Collection installation
-
-Ansible galaxy hosts all stable versions of this collection. Installation from ansible-galaxy is the most convenient approach for consuming `arista.avd` content. Please follow the collection installation [guide](https://avd.sh/en/stable/docs/installation/collection-installation.html).
-
-## Examples
-
-- [Getting started examples](./docs/getting-started/intro-to-ansible-and-avd.md)
-- [Arista NetDevOps Examples](https://github.com/aristanetworks/netdevops-examples)
 
 ## Additional resources
 
@@ -59,7 +63,7 @@ Ansible galaxy hosts all stable versions of this collection. Installation from a
 
 ## Ask a question
 
-Support for this `arista.avd` collection is provided by the community directly in this repository. If you have any questions, please leverage the GitHub [discussions board](https://github.com/aristanetworks/ansible-avd/discussions).
+Support for the `arista.avd` collection is provided by the community directly in this repository. If you have any questions, please leverage the GitHub [discussions board](https://github.com/aristanetworks/ansible-avd/discussions).
 
 ## Contributing
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 # Project information
-site_name: Arista AVD collection
+site_name: Arista AVD
 site_author: Arista Ansible Team
 site_description: Arista Validated Design collection's documentation
 copyright: Copyright &copy; 2019 - 2023 Arista Networks

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 # Project information
 site_name: Arista AVD
 site_author: Arista Ansible Team
-site_description: Arista Validated Design collection's documentation
+site_description: Arista Validated Designs documentation
 copyright: Copyright &copy; 2019 - 2023 Arista Networks
 
 # Repository information


### PR DESCRIPTION
## Change Summary

Updating landing page to move the Ansible collection below the AVD umbrella.

## Proposed changes

- Update layout to clarify The Ansible collection vs AVD as a framework

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
