### PR TITLE
Feat(eos_cli_config_gen): Add support for as-path options for BGP neighbors

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
@@ -128,6 +128,8 @@ router bgp 65101
    neighbor interface Ethernet2 peer-group PG-FOO-v4 remote-as 65102
    neighbor interface Ethernet3 peer-group PG-FOO-v4 peer-filter PF-BAR-v4
    neighbor 192.0.3.1 remote-as 65432
+   neighbor 192.0.3.1 as-path remote-as replace out
+   neighbor 192.0.3.1 as-path prepend-own disabled
    neighbor 192.0.3.1 rib-in pre-policy retain
    neighbor 192.0.3.1 default-originate always
    neighbor 192.0.3.1 send-community

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-vrf-lite.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-vrf-lite.md
@@ -146,6 +146,8 @@ router bgp 65001
    graceful-restart
    neighbor OBS_WAN peer group
    neighbor OBS_WAN remote-as 65000
+   neighbor OBS_WAN as-path remote-as replace out
+   neighbor OBS_WAN as-path prepend-own disabled
    neighbor OBS_WAN description BGP Connection to OBS WAN CPE
    neighbor SEDI peer group
    neighbor SEDI remote-as 65003
@@ -173,6 +175,7 @@ router bgp 65001
       neighbor 10.1.1.0 peer group OBS_WAN
       neighbor 10.255.1.1 peer group WELCOME_ROUTERS
       neighbor 10.255.1.1 weight 65535
+      neighbor 10.255.1.1 as-path remote-as replace out
       neighbor 10.255.1.1 route-reflector-client
       neighbor 101.0.3.1 peer group SEDI
       neighbor 101.0.3.1 weight 100

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-base.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-base.cfg
@@ -34,6 +34,8 @@ router bgp 65101
    neighbor interface Ethernet2 peer-group PG-FOO-v4 remote-as 65102
    neighbor interface Ethernet3 peer-group PG-FOO-v4 peer-filter PF-BAR-v4
    neighbor 192.0.3.1 remote-as 65432
+   neighbor 192.0.3.1 as-path remote-as replace out
+   neighbor 192.0.3.1 as-path prepend-own disabled
    neighbor 192.0.3.1 rib-in pre-policy retain
    neighbor 192.0.3.1 default-originate always
    neighbor 192.0.3.1 send-community

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-vrf-lite.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-vrf-lite.cfg
@@ -41,6 +41,8 @@ router bgp 65001
    graceful-restart
    neighbor OBS_WAN peer group
    neighbor OBS_WAN remote-as 65000
+   neighbor OBS_WAN as-path remote-as replace out
+   neighbor OBS_WAN as-path prepend-own disabled
    neighbor OBS_WAN description BGP Connection to OBS WAN CPE
    neighbor SEDI peer group
    neighbor SEDI remote-as 65003
@@ -68,6 +70,7 @@ router bgp 65001
       neighbor 10.1.1.0 peer group OBS_WAN
       neighbor 10.255.1.1 peer group WELCOME_ROUTERS
       neighbor 10.255.1.1 weight 65535
+      neighbor 10.255.1.1 as-path remote-as replace out
       neighbor 10.255.1.1 route-reflector-client
       neighbor 101.0.3.1 peer group SEDI
       neighbor 101.0.3.1 weight 100

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-base.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-base.yml
@@ -105,6 +105,9 @@ router_bgp:
         always: true
       rib_in_pre_policy_retain:
         enabled: true
+      as_path:
+        remote_as_replace_out: true
+        prepend_own_disabled: true
     192.0.3.2:
       remote_as: 65433
       send_community: extended

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-vrf-lite.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-vrf-lite.yml
@@ -42,6 +42,9 @@ router_bgp:
       type: ipv4
       description: 'BGP Connection to OBS WAN CPE'
       remote_as: 65000
+      as_path:
+        remote_as_replace_out: true
+        prepend_own_disabled: true
     WELCOME_ROUTERS:
       type: ipv4
       description: 'BGP Connection to WELCOME ROUTER 02'
@@ -80,6 +83,8 @@ router_bgp:
           peer_group: WELCOME_ROUTERS
           route_reflector_client: true
           weight: 65535
+          as_path:
+            remote_as_replace_out: true
         101.0.3.1:
           peer_group: SEDI
           weight: 100

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/data_model/Routing.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/data_model/Routing.md
@@ -209,6 +209,9 @@ MAC address (hh:hh:hh:hh:hh:hh)
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;local_as</samp>](## "router_bgp.peer_groups.[].local_as") | String |  |  |  | BGP AS <1-4294967295> or AS number in asdot notation <1-65535>.<0-65535> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;description</samp>](## "router_bgp.peer_groups.[].description") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;shutdown</samp>](## "router_bgp.peer_groups.[].shutdown") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;as_path</samp>](## "router_bgp.peer_groups.[].as_path") | Dictionary |  |  |  | BGP AS-PATH options |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;remote_as_replace_out</samp>](## "router_bgp.peer_groups.[].as_path.remote_as_replace_out") | Boolean |  |  |  | Replace AS number with local AS number |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;prepend_own_disabled</samp>](## "router_bgp.peer_groups.[].as_path.prepend_own_disabled") | Boolean |  |  |  | Disable prepending own AS number to AS path |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;remove_private_as</samp>](## "router_bgp.peer_groups.[].remove_private_as") | Dictionary |  |  |  | Remove private AS numbers in outbound AS path |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "router_bgp.peer_groups.[].remove_private_as.enabled") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;all</samp>](## "router_bgp.peer_groups.[].remove_private_as.all") | Boolean |  |  |  |  |
@@ -251,6 +254,9 @@ MAC address (hh:hh:hh:hh:hh:hh)
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;peer_group</samp>](## "router_bgp.neighbors.[].peer_group") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;remote_as</samp>](## "router_bgp.neighbors.[].remote_as") | String |  |  |  | BGP AS <1-4294967295> or AS number in asdot notation <1-65535>.<0-65535> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;local_as</samp>](## "router_bgp.neighbors.[].local_as") | String |  |  |  | BGP AS <1-4294967295> or AS number in asdot notation <1-65535>.<0-65535> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;as_path</samp>](## "router_bgp.neighbors.[].as_path") | Dictionary |  |  |  | BGP AS-PATH options |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;remote_as_replace_out</samp>](## "router_bgp.neighbors.[].as_path.remote_as_replace_out") | Boolean |  |  |  | Replace AS number with local AS number |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;prepend_own_disabled</samp>](## "router_bgp.neighbors.[].as_path.prepend_own_disabled") | Boolean |  |  |  | Disable prepending own AS number to AS path |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;description</samp>](## "router_bgp.neighbors.[].description") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_reflector_client</samp>](## "router_bgp.neighbors.[].route_reflector_client") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;shutdown</samp>](## "router_bgp.neighbors.[].shutdown") | Boolean |  |  |  |  |
@@ -534,6 +540,9 @@ MAC address (hh:hh:hh:hh:hh:hh)
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;replace_as</samp>](## "router_bgp.vrfs.[].neighbors.[].remove_private_as_ingress.replace_as") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;weight</samp>](## "router_bgp.vrfs.[].neighbors.[].weight") | Integer |  |  | Min: 0<br>Max: 65535 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;local_as</samp>](## "router_bgp.vrfs.[].neighbors.[].local_as") | String |  |  |  | BGP AS <1-4294967295> or AS number in asdot notation <1-65535>.<0-65535> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;as_path</samp>](## "router_bgp.vrfs.[].neighbors.[].as_path") | Dictionary |  |  |  | BGP AS-PATH options |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;remote_as_replace_out</samp>](## "router_bgp.vrfs.[].neighbors.[].as_path.remote_as_replace_out") | Boolean |  |  |  | Replace AS number with local AS number |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;prepend_own_disabled</samp>](## "router_bgp.vrfs.[].neighbors.[].as_path.prepend_own_disabled") | Boolean |  |  |  | Disable prepending own AS number to AS path |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;description</samp>](## "router_bgp.vrfs.[].neighbors.[].description") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_reflector_client</samp>](## "router_bgp.vrfs.[].neighbors.[].route_reflector_client") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ebgp_multihop</samp>](## "router_bgp.vrfs.[].neighbors.[].ebgp_multihop") | Integer |  |  | Min: 1<br>Max: 255 | Time-to-live in range of hops |
@@ -642,6 +651,9 @@ MAC address (hh:hh:hh:hh:hh:hh)
           local_as: <str>
           description: <str>
           shutdown: <bool>
+          as_path:
+            remote_as_replace_out: <bool>
+            prepend_own_disabled: <bool>
           remove_private_as:
             enabled: <bool>
             all: <bool>
@@ -684,6 +696,9 @@ MAC address (hh:hh:hh:hh:hh:hh)
           peer_group: <str>
           remote_as: <str>
           local_as: <str>
+          as_path:
+            remote_as_replace_out: <bool>
+            prepend_own_disabled: <bool>
           description: <str>
           route_reflector_client: <bool>
           shutdown: <bool>
@@ -967,6 +982,9 @@ MAC address (hh:hh:hh:hh:hh:hh)
                 replace_as: <bool>
               weight: <int>
               local_as: <str>
+              as_path:
+                remote_as_replace_out: <bool>
+                prepend_own_disabled: <bool>
               description: <str>
               route_reflector_client: <bool>
               ebgp_multihop: <int>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -8693,6 +8693,24 @@
                 "type": "boolean",
                 "title": "Shutdown"
               },
+              "as_path": {
+                "type": "object",
+                "description": "BGP AS-PATH options",
+                "properties": {
+                  "remote_as_replace_out": {
+                    "type": "boolean",
+                    "description": "Replace AS number with local AS number",
+                    "title": "Remote As Replace Out"
+                  },
+                  "prepend_own_disabled": {
+                    "type": "boolean",
+                    "description": "Disable prepending own AS number to AS path",
+                    "title": "Prepend Own Disabled"
+                  }
+                },
+                "additionalProperties": false,
+                "title": "As Path"
+              },
               "remove_private_as": {
                 "type": "object",
                 "description": "Remove private AS numbers in outbound AS path",
@@ -8911,6 +8929,24 @@
                 "type": "string",
                 "description": "BGP AS <1-4294967295> or AS number in asdot notation <1-65535>.<0-65535>",
                 "title": "Local As"
+              },
+              "as_path": {
+                "type": "object",
+                "description": "BGP AS-PATH options",
+                "properties": {
+                  "remote_as_replace_out": {
+                    "type": "boolean",
+                    "description": "Replace AS number with local AS number",
+                    "title": "Remote As Replace Out"
+                  },
+                  "prepend_own_disabled": {
+                    "type": "boolean",
+                    "description": "Disable prepending own AS number to AS path",
+                    "title": "Prepend Own Disabled"
+                  }
+                },
+                "additionalProperties": false,
+                "title": "As Path"
               },
               "description": {
                 "type": "string",
@@ -10583,6 +10619,24 @@
                       "type": "string",
                       "description": "BGP AS <1-4294967295> or AS number in asdot notation <1-65535>.<0-65535>",
                       "title": "Local As"
+                    },
+                    "as_path": {
+                      "type": "object",
+                      "description": "BGP AS-PATH options",
+                      "properties": {
+                        "remote_as_replace_out": {
+                          "type": "boolean",
+                          "description": "Replace AS number with local AS number",
+                          "title": "Remote As Replace Out"
+                        },
+                        "prepend_own_disabled": {
+                          "type": "boolean",
+                          "description": "Disable prepending own AS number to AS path",
+                          "title": "Prepend Own Disabled"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "title": "As Path"
                     },
                     "description": {
                       "type": "string",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -6359,6 +6359,16 @@ keys:
               type: str
             shutdown:
               type: bool
+            as_path:
+              type: dict
+              description: BGP AS-PATH options
+              keys:
+                remote_as_replace_out:
+                  type: bool
+                  description: Replace AS number with local AS number
+                prepend_own_disabled:
+                  type: bool
+                  description: Disable prepending own AS number to AS path
             remove_private_as:
               type: dict
               description: Remove private AS numbers in outbound AS path
@@ -6517,6 +6527,16 @@ keys:
               description: BGP AS <1-4294967295> or AS number in asdot notation <1-65535>.<0-65535>
               convert_types:
               - int
+            as_path:
+              type: dict
+              description: BGP AS-PATH options
+              keys:
+                remote_as_replace_out:
+                  type: bool
+                  description: Replace AS number with local AS number
+                prepend_own_disabled:
+                  type: bool
+                  description: Disable prepending own AS number to AS path
             description:
               type: str
             route_reflector_client:
@@ -7524,6 +7544,16 @@ keys:
                       <1-65535>.<0-65535>
                     convert_types:
                     - int
+                  as_path:
+                    type: dict
+                    description: BGP AS-PATH options
+                    keys:
+                      remote_as_replace_out:
+                        type: bool
+                        description: Replace AS number with local AS number
+                      prepend_own_disabled:
+                        type: bool
+                        description: Disable prepending own AS number to AS path
                   description:
                     type: str
                   route_reflector_client:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_bgp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_bgp.schema.yml
@@ -169,6 +169,16 @@ keys:
               type: str
             shutdown:
               type: bool
+            as_path:
+              type: dict
+              description: BGP AS-PATH options
+              keys:
+                remote_as_replace_out:
+                  type: bool
+                  description: Replace AS number with local AS number
+                prepend_own_disabled:
+                  type: bool
+                  description: Disable prepending own AS number to AS path
             remove_private_as:
               type: dict
               description: Remove private AS numbers in outbound AS path
@@ -311,6 +321,16 @@ keys:
               description: BGP AS <1-4294967295> or AS number in asdot notation <1-65535>.<0-65535>
               convert_types:
                 - int
+            as_path:
+              type: dict
+              description: BGP AS-PATH options
+              keys:
+                remote_as_replace_out:
+                  type: bool
+                  description: Replace AS number with local AS number
+                prepend_own_disabled:
+                  type: bool
+                  description: Disable prepending own AS number to AS path
             description:
               type: str
             route_reflector_client:
@@ -1300,6 +1320,16 @@ keys:
                     description: BGP AS <1-4294967295> or AS number in asdot notation <1-65535>.<0-65535>
                     convert_types:
                       - int
+                  as_path:
+                    type: dict
+                    description: BGP AS-PATH options
+                    keys:
+                      remote_as_replace_out:
+                        type: bool
+                        description: Replace AS number with local AS number
+                      prepend_own_disabled:
+                        type: bool
+                        description: Disable prepending own AS number to AS path
                   description:
                     type: str
                   route_reflector_client:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -84,6 +84,12 @@ router bgp {{ router_bgp.as }}
 {%         if peer_group.local_as is arista.avd.defined %}
    neighbor {{ peer_group.name }} local-as {{ peer_group.local_as }} no-prepend replace-as
 {%         endif %}
+{%         if peer_group.as_path.remote_as_replace_out is arista.avd.defined(true) %}
+   neighbor {{ peer_group.name }} as-path remote-as replace out
+{%         endif %}
+{%         if peer_group.as_path.prepend_own_disabled is arista.avd.defined(true) %}
+   neighbor {{ peer_group.name }} as-path prepend-own disabled
+{%         endif %}
 {%         if peer_group.next_hop_self is arista.avd.defined(true) %}
    neighbor {{ peer_group.name }} next-hop-self
 {%         endif %}
@@ -231,6 +237,12 @@ router bgp {{ router_bgp.as }}
    {{ remove_private_as_ingress_cli }}
 {%         elif neighbor.remove_private_as_ingress.enabled is arista.avd.defined(false) %}
    no neighbor {{ neighbor.ip_address }} remove-private-as ingress
+{%         endif %}
+{%         if neighbor.as_path.remote_as_replace_out is arista.avd.defined(true) %}
+   neighbor {{ neighbor.ip_address }} as-path remote-as replace out
+{%         endif %}
+{%         if neighbor.as_path.prepend_own_disabled is arista.avd.defined(true) %}
+   neighbor {{ neighbor.ip_address }} as-path prepend-own disabled
 {%         endif %}
 {%         if neighbor.local_as is arista.avd.defined %}
    neighbor {{ neighbor.ip_address }} local-as {{ neighbor.local_as }} no-prepend replace-as
@@ -887,6 +899,12 @@ router bgp {{ router_bgp.as }}
 {%             endif %}
 {%             if neighbor.weight is arista.avd.defined %}
       neighbor {{ neighbor.ip_address }} weight {{ neighbor.weight }}
+{%             endif %}
+{%             if neighbor.as_path.remote_as_replace_out is arista.avd.defined(true) %}
+      neighbor {{ neighbor.ip_address }} as-path remote-as replace out
+{%             endif %}
+{%             if neighbor.as_path.prepend_own_disabled is arista.avd.defined(true) %}
+      neighbor {{ neighbor.ip_address }} as-path prepend-own disabled
 {%             endif %}
 {%             if neighbor.local_as is arista.avd.defined %}
       neighbor {{ neighbor.ip_address }} local-as {{ neighbor.local_as }} no-prepend replace-as


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Add support for the following CLI at peer group and bgp neighbor level (global or VRF):

```
neighbor x.x.x.x as-path remote-as replace out
neighbor x.x.x.x as-path prepend-own disabled
```

## Related Issue(s)

Fixes #2549

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->
Modified BGP template and schemas to accomodate the new options

Note: Skipped documentation changes since I don't think these are key options to display in the docs

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
See molecule test results

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
