### PR TITLE
Bump: Cap ansible-lint to <6.14

### DIFF
--- a/ansible_collections/arista/avd/requirements-dev.txt
+++ b/ansible_collections/arista/avd/requirements-dev.txt
@@ -1,5 +1,5 @@
 ansible-core>=2.12.6,<2.15.0,!=2.13.0
-ansible-lint>=6.13.0
+ansible-lint>=6.13.0,<6.14
 galaxy-importer>=0.3.1
 pycodestyle
 flake8


### PR DESCRIPTION
## Change Summary

Until we can merge #2594 which requires to clean up the pipeline because Python 3.8 is not supported anymore for ansible-lint >=6.14 plus the test container is not there anymore.

## Component(s) name

`ci`

## Proposed changes

Cap on ansible-lint to `>=6.13,<6.14` in order to let our pipeline pass in the meantime

## How to test

Pipeline is 🟢 

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
