### PR TITLE
Doc(plugins): Fix plugin name in BGP example

### DIFF
--- a/ansible_collections/arista/avd/plugins/README.md
+++ b/ansible_collections/arista/avd/plugins/README.md
@@ -183,8 +183,8 @@ The `arista.avd.encrypt` and `arista.avd.decrypt` filters are used to encrypt or
 To use these filters:
 
 ```jinja
-{{ <var_with_clear_text_password> | encrypt(passwd_type=<type>, key=<encryption_key>) }}
-{{ <var_with_encrypted_password> | decrypt(passwd_type=<type>, key=<encryption_key>) }}
+{{ <var_with_clear_text_password> | arista.avd.encrypt(passwd_type=<type>, key=<encryption_key>) }}
+{{ <var_with_encrypted_password> | arista.avd.decrypt(passwd_type=<type>, key=<encryption_key>) }}
 ```
 
 Supported types:
@@ -203,7 +203,7 @@ An example usage for `arista.avd.encrypt` filter for BGP is to use it in conjunc
 bgp_peer_groups:
   ipv4_underlay_peers:
       name: IPv4-UNDERLAY-PEERS
-          password: "{{ bgp_vault_password | encrypt(passwd_type='bgp', key='IPv4-UNDERLAY-PEERS') }}"
+          password: "{{ bgp_vault_password | arista.avd.encrypt(passwd_type='bgp', key='IPv4-UNDERLAY-PEERS') }}"
 ```
 
 ## Plugin Tests


### PR DESCRIPTION
## Change Summary

Corrected the example to use the full plugin name

## Proposed changes

Before:

```
bgp_peer_groups:
  ipv4_underlay_peers:
      name: IPv4-UNDERLAY-PEERS
          password: "{{ bgp_vault_password | encrypt(passwd_type='bgp', key='IPv4-UNDERLAY-PEERS') }}"
```

After

```
bgp_peer_groups:
  ipv4_underlay_peers:
      name: IPv4-UNDERLAY-PEERS
          password: "{{ bgp_vault_password | arista.avd.encrypt(passwd_type='bgp', key='IPv4-UNDERLAY-PEERS') }}"
```

## How to test

N/A

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
