### PR TITLE
Feat(eos_designs): Check for invalid characters in VRFs, VLANs, SVIs

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_A.yml
@@ -243,6 +243,15 @@ tenant_a:
             enabled: true
             point_to_point: true
             area: 0
+    Tenant_A_(DB)_Zone: # Invalid charcater in VRF name.
+      description: "Tenant_A_OP_Zone"
+      vrf_vni: 17
+      svis:
+        152:
+          name: Tenant_A_(DB)_Zone_1 # Invalid character in SVI name.
+          tags: ['opzone']
+          enabled: True
+          ip_address_virtual: 10.1.50.1/24
   l2vlans:
     # L2 vlan as string
     '160':
@@ -261,3 +270,6 @@ tenant_a:
       name: overlapping_name
     165:
       name: overlapping_name
+    166:
+      name: invalid_(name)
+      # Should render an error for invalid characters that EOS does not accept.

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
@@ -7,6 +7,7 @@
 - The filtering model allows for granular deployment of network service to the fabric leveraging the tenant name and tags applied to the service definition.
   - This allows for the re-use of SVI/VLAN IDs across the fabric.
   - An error will be returned at runtime in case of duplicate SVI/VLAN IDs, VRF names or VNIs targeted towards the same device.
+  - An error will be returned at runtime in case of invalid character usage in SVI, VLAN, or VRF names.
 
 ## Variables and Options
 

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/utils.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/utils.py
@@ -333,3 +333,8 @@ class UtilsMixin(UtilsFilteredTenantsMixin):
     @cached_property
     def _underlay_filter_redistribute_connected(self) -> bool:
         return get(self._hostvars, "underlay_filter_redistribute_connected", default=True) is True
+
+    @cached_property
+    def _invalid_characters(self) -> list:
+        invalid_characters = ["(", ")"]
+        return invalid_characters

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/vrfs.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/vrfs.py
@@ -24,6 +24,9 @@ class VrfsMixin(UtilsMixin):
 
         This function also detects duplicate vrfs and raise an error in case of duplicates between
         all Tenants deployed on this device.
+
+        This function also detects invalid character usage in VRF names and will raise an error in
+        case of an invalid character being present.
         """
 
         if not self._network_services_l3:
@@ -39,6 +42,10 @@ class VrfsMixin(UtilsMixin):
 
                 if vrf_name in vrf_names:
                     self._raise_duplicate_vrf_error(vrf_name, tenant["name"], get_item(vrfs, "name", vrf_name))
+
+                for character in self._invalid_characters:
+                    if character in vrf_name:
+                        self._raise_invalid_characters_vrf_error(vrf_name, tenant["name"])
 
                 vrf_names.append(vrf_name)
 
@@ -82,5 +89,10 @@ class VrfsMixin(UtilsMixin):
         msg = f"Duplicate VRF '{vrf_name}' found in Tenant '{tenant_name}'."
         if (duplicate_vlan_tenant := duplicate_vrf_config["tenant"]) != tenant_name:
             msg = f"{msg} Other VRF is in Tenant '{duplicate_vlan_tenant}'."
+
+        raise AristaAvdError(msg)
+
+    def _raise_invalid_characters_vrf_error(self, vrf_name: str, tenant_name: str) -> NoReturn:
+        msg = f"Invalid character in VRF '{vrf_name}' found in Tenant '{tenant_name}'."
 
         raise AristaAvdError(msg)


### PR DESCRIPTION
## Change Summary

Add a list of invalid characters to the UtilsMixin that can be expanded to other modules as necessary. Add logic to check for invalid characters in VRF, VLAN, and SVI modules. 

## Related Issue(s)

Fixes #2603

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

## How to test
Validated against test data set of tenants, modifying the VRF, VLAN and SVI each individually to validate that each error is raised for the appropriate case. 

e.g., ansible-playbook lab_fabric_config.yml -i lab_inventory.yml -t build 

Additionally, ran the molecule test cases for eos_designs_unit_tests by updating Tenant_A.yml to reflect the invalid values. 

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
