### PR TITLE
Feat(eos_cli_config_gen): Deprecation of 'vlan_interfaces.ipv6_address_virtual' (singular)

### DIFF
--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -38,8 +38,8 @@ jobs:
               - 'ansible_collections/arista/avd/roles/eos_cli_config_gen/*'
               - 'ansible_collections/arista/avd/roles/eos_cli_config_gen/**/*'
               - '.github/workflows/pull-request-management.yml'
-              - 'ansible_collections/arista/avd/molecule/eos_cli_config_gen/*'
-              - 'ansible_collections/arista/avd/molecule/eos_cli_config_gen/**/*'
+              - 'ansible_collections/arista/avd/molecule/eos_cli_config_gen*/*'
+              - 'ansible_collections/arista/avd/molecule/eos_cli_config_gen*/**/*'
             cloudvision:
               - 'ansible_collections/arista/avd/roles/eos_config_deploy_cvp/*'
               - 'ansible_collections/arista/avd/roles/eos_config_deploy_cvp/**/*'
@@ -149,6 +149,7 @@ jobs:
       matrix:
         avd_scenario:
           - 'eos_cli_config_gen'
+          - 'eos_cli_config_gen_deprecated_vars'
           - 'eos_cli_config_gen_v4.0'
         ansible_version:
           - 'ansible-core>=2.12.6,<2.15.0,!=2.13.0'

--- a/ansible_collections/arista/avd/molecule/MOLECULE_SCENARIOS.txt
+++ b/ansible_collections/arista/avd/molecule/MOLECULE_SCENARIOS.txt
@@ -1,5 +1,6 @@
 eos_cli_config_gen
 eos_cli_config_gen_v4.0
+eos_cli_config_gen_deprecated_vars
 eos_config_deploy_cvp
 eos_designs_unit_tests
 eos_designs_unit_tests_v4.0

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
@@ -114,14 +114,14 @@ interface Management1
 
 #### IPv6
 
-| Interface | VRF | IPv6 Address | IPv6 Virtual Address | Virtual Router Address | VRRP | ND RA Disabled | Managed Config Flag | IPv6 ACL In | IPv6 ACL Out |
+| Interface | VRF | IPv6 Address | IPv6 Virtual Addresses | Virtual Router Address | VRRP | ND RA Disabled | Managed Config Flag | IPv6 ACL In | IPv6 ACL Out |
 | --------- | --- | ------------ | -------------------- | ---------------------- | ---- | -------------- | ------------------- | ----------- | ------------ |
 | Vlan24 | default | 1b11:3a00:22b0:6::15/64 | - | 1b11:3a00:22b0:6::1 | - | - | True | - | - |
 | Vlan25 | default | 1b11:3a00:22b0:16::16/64 | - | 1b11:3a00:22b0:16::15, 1b11:3a00:22b0:16::14 | - | - | - | - | - |
 | Vlan43 | default | a0::1/64 | - | - | - | - | - | - | - |
 | Vlan44 | default | a0::4/64 | - | - | - | - | - | - | - |
 | Vlan75 | default | 1b11:3a00:22b0:1000::15/64 | - | 1b11:3a00:22b0:1000::1 | - | - | True | - | - |
-| Vlan81 | Tenant_C | - | fc00:10:10:81::1/64 | - | - | - | - | - | - |
+| Vlan81 | Tenant_C | - | fc00:10:11:81::1/64, fc00:10:12:81::1/64 | - | - | - | - | - | - |
 | Vlan89 | default | 1b11:3a00:22b0:5200::15/64 | - | 1b11:3a00:22b0:5200::3 | - | - | True | - | - |
 | Vlan333 | default | 2001:db8::2/64 | - | - | - | - | - | - | - |
 | Vlan501 | default | 1b11:3a00:22b0:0088::207/127 | - | - | - | True | - | - | - |
@@ -223,7 +223,6 @@ interface Vlan81
    description IPv6 Virtual Address
    vrf Tenant_C
    ipv6 enable
-   ipv6 address virtual fc00:10:10:81::1/64
    ipv6 address virtual fc00:10:11:81::1/64
    ipv6 address virtual fc00:10:12:81::1/64
    ip address virtual 10.10.81.1/24

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
@@ -121,7 +121,7 @@ interface Management1
 | Vlan43 | default | a0::1/64 | - | - | - | - | - | - | - |
 | Vlan44 | default | a0::4/64 | - | - | - | - | - | - | - |
 | Vlan75 | default | 1b11:3a00:22b0:1000::15/64 | - | 1b11:3a00:22b0:1000::1 | - | - | True | - | - |
-| Vlan81 | Tenant_C | - | fc00:10:11:81::1/64, fc00:10:12:81::1/64 | - | - | - | - | - | - |
+| Vlan81 | Tenant_C | - | fc00:10:10:81::1/64, fc00:10:11:81::1/64, fc00:10:12:81::1/64 | - | - | - | - | - | - |
 | Vlan89 | default | 1b11:3a00:22b0:5200::15/64 | - | 1b11:3a00:22b0:5200::3 | - | - | True | - | - |
 | Vlan333 | default | 2001:db8::2/64 | - | - | - | - | - | - | - |
 | Vlan501 | default | 1b11:3a00:22b0:0088::207/127 | - | - | - | True | - | - | - |
@@ -223,6 +223,7 @@ interface Vlan81
    description IPv6 Virtual Address
    vrf Tenant_C
    ipv6 enable
+   ipv6 address virtual fc00:10:10:81::1/64
    ipv6 address virtual fc00:10:11:81::1/64
    ipv6 address virtual fc00:10:12:81::1/64
    ip address virtual 10.10.81.1/24

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
@@ -75,7 +75,6 @@ interface Vlan81
    description IPv6 Virtual Address
    vrf Tenant_C
    ipv6 enable
-   ipv6 address virtual fc00:10:10:81::1/64
    ipv6 address virtual fc00:10:11:81::1/64
    ipv6 address virtual fc00:10:12:81::1/64
    ip address virtual 10.10.81.1/24

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
@@ -75,6 +75,7 @@ interface Vlan81
    description IPv6 Virtual Address
    vrf Tenant_C
    ipv6 enable
+   ipv6 address virtual fc00:10:10:81::1/64
    ipv6 address virtual fc00:10:11:81::1/64
    ipv6 address virtual fc00:10:12:81::1/64
    ip address virtual 10.10.81.1/24

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
@@ -23,6 +23,7 @@ vlan_interfaces:
     ip_address_virtual: 10.10.81.1/24
     ipv6_enable: true
     ipv6_address_virtuals:
+      - fc00:10:10:81::1/64
       - fc00:10:11:81::1/64
       - fc00:10:12:81::1/64
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
@@ -22,7 +22,6 @@ vlan_interfaces:
     vrf: Tenant_C
     ip_address_virtual: 10.10.81.1/24
     ipv6_enable: true
-    ipv6_address_virtual: fc00:10:10:81::1/64
     ipv6_address_virtuals:
       - fc00:10:11:81::1/64
       - fc00:10:12:81::1/64

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/converge.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/converge.yml
@@ -1,0 +1,11 @@
+---
+- name: Converge
+  hosts: test-hosts
+  gather_facts: false
+  connection: local
+  tasks:
+
+    - name: Generate device intended config and documentation
+      delegate_to: 127.0.0.1
+      ansible.builtin.import_role:
+        name: arista.avd.eos_cli_config_gen

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/create.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/create.yml
@@ -1,0 +1,11 @@
+---
+- name: Configure local folders
+  hosts: test-hosts
+  gather_facts: false
+  connection: local
+  tasks:
+    - name: Create local output folders
+      delegate_to: 127.0.0.1
+      ansible.builtin.import_role:
+        name: arista.avd.build_output_folders
+      run_once: true

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/destroy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/destroy.yml
@@ -1,0 +1,17 @@
+---
+- name: Remove output folders
+  hosts: test-hosts
+  gather_facts: false
+  connection: local
+  tasks:
+    - name: Delete local folders
+      delegate_to: 127.0.0.1
+      run_once: true
+      ansible.builtin.file:
+        path: "{{ root_dir }}/{{ item }}"
+        state: absent
+      with_items:
+        - documentation
+        - intended/structured_configs
+        - config_backup
+        - reports

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/documentation/devices/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/documentation/devices/vlan-interfaces.md
@@ -27,7 +27,7 @@
 | Interface | VRF | IPv6 Address | IPv6 Virtual Addresses | Virtual Router Address | VRRP | ND RA Disabled | Managed Config Flag | IPv6 ACL In | IPv6 ACL Out |
 | --------- | --- | ------------ | -------------------- | ---------------------- | ---- | -------------- | ------------------- | ----------- | ------------ |
 | Vlan1 | default | - | fc00:10:10:1::1/64 | - | - | - | - | - | - |
-| Vlan2 | default | - | fc00:10:10:2::1/64 | - | - | - | - | - | - |
+| Vlan2 | default | - | fc00:10:10:2::1/64, fc00:10:11:2::1/64, fc00:10:12:2::1/64 | - | - | - | - | - | - |
 
 ### VLAN Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/documentation/devices/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/documentation/devices/vlan-interfaces.md
@@ -1,0 +1,47 @@
+# vlan-interfaces
+# Table of Contents
+
+- [Interfaces](#interfaces)
+  - [VLAN Interfaces](#vlan-interfaces)
+
+# Interfaces
+
+## VLAN Interfaces
+
+### VLAN Interfaces Summary
+
+| Interface | Description | VRF |  MTU | Shutdown |
+| --------- | ----------- | --- | ---- | -------- |
+| Vlan1 | test ipv6_address_virtual | default | - | - |
+| Vlan2 | test ipv6_address_virtual and ipv6_address_virtuals | default | - | - |
+
+#### IPv4
+
+| Interface | VRF | IP Address | IP Address Virtual | IP Router Virtual Address | VRRP | ACL In | ACL Out |
+| --------- | --- | ---------- | ------------------ | ------------------------- | ---- | ------ | ------- |
+| Vlan1 |  default  |  -  |  -  |  -  |  -  |  -  |  -  |
+| Vlan2 |  default  |  -  |  -  |  -  |  -  |  -  |  -  |
+
+#### IPv6
+
+| Interface | VRF | IPv6 Address | IPv6 Virtual Addresses | Virtual Router Address | VRRP | ND RA Disabled | Managed Config Flag | IPv6 ACL In | IPv6 ACL Out |
+| --------- | --- | ------------ | -------------------- | ---------------------- | ---- | -------------- | ------------------- | ----------- | ------------ |
+| Vlan1 | default | - | fc00:10:10:1::1/64 | - | - | - | - | - | - |
+| Vlan2 | default | - | fc00:10:10:2::1/64 | - | - | - | - | - | - |
+
+### VLAN Interfaces Device Configuration
+
+```eos
+!
+interface Vlan1
+   description test ipv6_address_virtual
+   ipv6 enable
+   ipv6 address virtual fc00:10:10:1::1/64
+!
+interface Vlan2
+   description test ipv6_address_virtual and ipv6_address_virtuals
+   ipv6 enable
+   ipv6 address virtual fc00:10:10:2::1/64
+   ipv6 address virtual fc00:10:11:2::1/64
+   ipv6 address virtual fc00:10:12:2::1/64
+```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/intended/configs/vlan-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/intended/configs/vlan-interfaces.cfg
@@ -1,0 +1,22 @@
+!RANCID-CONTENT-TYPE: arista
+!
+transceiver qsfp default-mode 4x10G
+!
+hostname vlan-interfaces
+!
+no enable password
+no aaa root
+!
+interface Vlan1
+   description test ipv6_address_virtual
+   ipv6 enable
+   ipv6 address virtual fc00:10:10:1::1/64
+!
+interface Vlan2
+   description test ipv6_address_virtual and ipv6_address_virtuals
+   ipv6 enable
+   ipv6 address virtual fc00:10:10:2::1/64
+   ipv6 address virtual fc00:10:11:2::1/64
+   ipv6 address virtual fc00:10:12:2::1/64
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/inventory/group_vars/all.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/inventory/group_vars/all.yml
@@ -1,0 +1,5 @@
+---
+root_dir: '{{ playbook_dir }}'
+is_for_test: true
+
+avd_data_validation_mode: "error"

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/inventory/host_vars/vlan-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/inventory/host_vars/vlan-interfaces.yml
@@ -1,0 +1,19 @@
+### VLAN Interfaces ###
+vlan_interfaces:
+
+  # Testing ipv6_address_virtual alone
+  # ipv6_address_virtual deprecated in 4.0.0. To be removed in 5.0.0
+  Vlan1:
+    description: test ipv6_address_virtual
+    ipv6_enable: true
+    ipv6_address_virtual: fc00:10:10:1::1/64
+
+  # Testing ipv6_address_virtual in combination with the new ipv6_address_virtuals to see that all three are configured
+  # ipv6_address_virtual deprecated in 4.0.0. To be removed in 5.0.0
+  Vlan2:
+    description: test ipv6_address_virtual and ipv6_address_virtuals
+    ipv6_enable: true
+    ipv6_address_virtual: fc00:10:10:2::1/64
+    ipv6_address_virtuals:
+      - fc00:10:11:2::1/64
+      - fc00:10:12:2::1/64

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/inventory/hosts.ini
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/inventory/hosts.ini
@@ -1,0 +1,2 @@
+[test-hosts]
+vlan-interfaces

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/molecule.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/molecule.yml
@@ -1,0 +1,34 @@
+---
+scenario:
+  converge_sequence:
+    - syntax
+    - create
+    - converge
+  test_sequence:
+    - syntax
+    - create
+    - converge
+    - idempotence
+  cleanup_sequence:
+    - destroy
+dependency:
+  name: galaxy
+driver:
+  name: delegated
+platforms:
+  - name: dummy
+    managed: false
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      jinja2_extensions: 'jinja2.ext.loopcontrols,jinja2.ext.do,jinja2.ext.i18n'
+      gathering: explicit
+
+  inventory:
+    links:
+      hosts: 'inventory/hosts.ini'
+      host_vars: 'inventory/host_vars/'
+      group_vars: 'inventory/group_vars/'
+verifier:
+  name: ansible

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/verify.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/verify.yml
@@ -1,0 +1,21 @@
+---
+# This is an example playbook to execute Ansible tests.
+
+- name: Verify
+  hosts: test-hosts
+  gather_facts: false
+  connection: local
+  tasks:
+    - name: Detect git change in tracked files
+      delegate_to: 127.0.0.1
+      ansible.builtin.shell:
+        cmd: git status --short | grep -e "^ M" | wc -l | awk -F ' ' '{print $1}'  # noqa: command-instead-of-module
+      changed_when: |
+        "0" in git_status.stdout
+      register: git_status
+
+    - name: Fail if change detected  # noqa: no-handler
+      delegate_to: 127.0.0.1
+      ansible.builtin.debug:
+        msg: 'Change detected in output. Please check ! Found {{ git_status.stdout }} changes'
+      when: git_status.changed

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/vlan-interfaces.md
@@ -102,7 +102,7 @@ interface Management1
 
 #### IPv6
 
-| Interface | VRF | IPv6 Address | IPv6 Virtual Address | Virtual Router Address | VRRP | ND RA Disabled | Managed Config Flag | IPv6 ACL In | IPv6 ACL Out |
+| Interface | VRF | IPv6 Address | IPv6 Virtual Addresses | Virtual Router Address | VRRP | ND RA Disabled | Managed Config Flag | IPv6 ACL In | IPv6 ACL Out |
 | --------- | --- | ------------ | -------------------- | ---------------------- | ---- | -------------- | ------------------- | ----------- | ------------ |
 | Vlan24 | default | 1b11:3a00:22b0:6::15/64 | - | 1b11:3a00:22b0:6::1 | - | - | True | - | - |
 | Vlan75 | default | 1b11:3a00:22b0:1000::15/64 | - | 1b11:3a00:22b0:1000::1 | - | - | True | - | - |

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF1A.yml
@@ -402,7 +402,8 @@ vlan_interfaces:
   - v6wan
   description: Tenant_D_v6_WAN_Zone_1
   shutdown: false
-  ipv6_address_virtual: 2001:db8:355::1/64
+  ipv6_address_virtuals:
+  - 2001:db8:355::1/64
   vrf: Tenant_D_WAN_Zone
 - name: Vlan451
   tenant: Tenant_D
@@ -411,7 +412,8 @@ vlan_interfaces:
   description: Tenant_D_v6_WAN_Zone_2
   shutdown: false
   mtu: 1560
-  ipv6_address_virtual: 2001:db8:451::1/64
+  ipv6_address_virtuals:
+  - 2001:db8:451::1/64
   vrf: Tenant_D_WAN_Zone
 - name: Vlan452
   tenant: Tenant_D
@@ -421,7 +423,8 @@ vlan_interfaces:
   shutdown: false
   mtu: 1560
   ip_address_virtual: 10.4.12.254/24
-  ipv6_address_virtual: 2001:db8:412::1/64
+  ipv6_address_virtuals:
+  - 2001:db8:412::1/64
   vrf: Tenant_D_WAN_Zone
 vxlan_interface:
   Vxlan1:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
@@ -999,8 +999,8 @@ vlan_interfaces:
   description: Tenant_D_v6_OP_Zone_1
   shutdown: false
   ip_address_virtual: 10.3.10.1/24
-  ipv6_address_virtual: 2001:db8:310::1/64
   ipv6_address_virtuals:
+  - 2001:db8:310::1/64
   - 2001:db8:311::1/64
   - 2001:db8:312::1/64
   vrf: Tenant_D_OP_Zone
@@ -1025,7 +1025,8 @@ vlan_interfaces:
   shutdown: false
   mtu: 1560
   ip_address_virtual: 10.4.12.254/24
-  ipv6_address_virtual: 2001:db8:412::1/64
+  ipv6_address_virtuals:
+  - 2001:db8:412::1/64
   vrf: Tenant_D_OP_Zone
 - name: Vlan413
   tenant: Tenant_D
@@ -1051,7 +1052,8 @@ vlan_interfaces:
   - v6wan
   description: Tenant_D_v6_WAN_Zone_1
   shutdown: false
-  ipv6_address_virtual: 2001:db8:355::1/64
+  ipv6_address_virtuals:
+  - 2001:db8:355::1/64
   vrf: Tenant_D_WAN_Zone
 - name: Vlan451
   tenant: Tenant_D
@@ -1060,7 +1062,8 @@ vlan_interfaces:
   description: Tenant_D_v6_WAN_Zone_2
   shutdown: false
   mtu: 1560
-  ipv6_address_virtual: 2001:db8:451::1/64
+  ipv6_address_virtuals:
+  - 2001:db8:451::1/64
   vrf: Tenant_D_WAN_Zone
 - name: Vlan452
   tenant: Tenant_D
@@ -1070,7 +1073,8 @@ vlan_interfaces:
   shutdown: false
   mtu: 1560
   ip_address_virtual: 10.4.12.254/24
-  ipv6_address_virtual: 2001:db8:412::1/64
+  ipv6_address_virtuals:
+  - 2001:db8:412::1/64
   vrf: Tenant_D_WAN_Zone
 ipv6_static_routes:
 - destination_address_prefix: ::/0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
@@ -943,8 +943,8 @@ vlan_interfaces:
   description: Tenant_D_v6_OP_Zone_1
   shutdown: false
   ip_address_virtual: 10.3.10.1/24
-  ipv6_address_virtual: 2001:db8:310::1/64
   ipv6_address_virtuals:
+  - 2001:db8:310::1/64
   - 2001:db8:311::1/64
   - 2001:db8:312::1/64
   vrf: Tenant_D_OP_Zone
@@ -969,7 +969,8 @@ vlan_interfaces:
   shutdown: false
   mtu: 1560
   ip_address_virtual: 10.4.12.254/24
-  ipv6_address_virtual: 2001:db8:412::1/64
+  ipv6_address_virtuals:
+  - 2001:db8:412::1/64
   vrf: Tenant_D_OP_Zone
 - name: Vlan413
   tenant: Tenant_D
@@ -995,7 +996,8 @@ vlan_interfaces:
   - v6wan
   description: Tenant_D_v6_WAN_Zone_1
   shutdown: false
-  ipv6_address_virtual: 2001:db8:355::1/64
+  ipv6_address_virtuals:
+  - 2001:db8:355::1/64
   vrf: Tenant_D_WAN_Zone
 - name: Vlan451
   tenant: Tenant_D
@@ -1004,7 +1006,8 @@ vlan_interfaces:
   description: Tenant_D_v6_WAN_Zone_2
   shutdown: false
   mtu: 1560
-  ipv6_address_virtual: 2001:db8:451::1/64
+  ipv6_address_virtuals:
+  - 2001:db8:451::1/64
   vrf: Tenant_D_WAN_Zone
 - name: Vlan452
   tenant: Tenant_D
@@ -1014,7 +1017,8 @@ vlan_interfaces:
   shutdown: false
   mtu: 1560
   ip_address_virtual: 10.4.12.254/24
-  ipv6_address_virtual: 2001:db8:412::1/64
+  ipv6_address_virtuals:
+  - 2001:db8:412::1/64
   vrf: Tenant_D_WAN_Zone
 ipv6_static_routes:
 - destination_address_prefix: ::/0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_false.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_false.yml
@@ -710,8 +710,8 @@ vlan_interfaces:
   description: Tenant_D_v6_OP_Zone_1
   shutdown: false
   ip_address_virtual: 10.3.10.1/24
-  ipv6_address_virtual: 2001:db8:310::1/64
   ipv6_address_virtuals:
+  - 2001:db8:310::1/64
   - 2001:db8:311::1/64
   - 2001:db8:312::1/64
   vrf: Tenant_D_OP_Zone
@@ -736,7 +736,8 @@ vlan_interfaces:
   shutdown: false
   mtu: 1560
   ip_address_virtual: 10.4.12.254/24
-  ipv6_address_virtual: 2001:db8:412::1/64
+  ipv6_address_virtuals:
+  - 2001:db8:412::1/64
   vrf: Tenant_D_OP_Zone
 - name: Vlan413
   tenant: Tenant_D
@@ -762,7 +763,8 @@ vlan_interfaces:
   - v6wan
   description: Tenant_D_v6_WAN_Zone_1
   shutdown: false
-  ipv6_address_virtual: 2001:db8:355::1/64
+  ipv6_address_virtuals:
+  - 2001:db8:355::1/64
   vrf: Tenant_D_WAN_Zone
 - name: Vlan451
   tenant: Tenant_D
@@ -771,7 +773,8 @@ vlan_interfaces:
   description: Tenant_D_v6_WAN_Zone_2
   shutdown: false
   mtu: 1560
-  ipv6_address_virtual: 2001:db8:451::1/64
+  ipv6_address_virtuals:
+  - 2001:db8:451::1/64
   vrf: Tenant_D_WAN_Zone
 - name: Vlan452
   tenant: Tenant_D
@@ -781,7 +784,8 @@ vlan_interfaces:
   shutdown: false
   mtu: 1560
   ip_address_virtual: 10.4.12.254/24
-  ipv6_address_virtual: 2001:db8:412::1/64
+  ipv6_address_virtuals:
+  - 2001:db8:412::1/64
   vrf: Tenant_D_WAN_Zone
 vxlan_interface:
   Vxlan1:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vlan-interfaces.j2
@@ -53,8 +53,7 @@
 {# IPv6 #}
 {%     set vlan_interfaces_ipv6 = [] %}
 {%     for vlan_interface in vlan_interfaces | arista.avd.default([]) %}
-{%         if vlan_interface.ipv6_address is arista.avd.defined or vlan_interface.ipv6_address_virtual is arista.avd.defined %}
-{# add also a test against ipv6_address_virtual when supported #}
+{%         if vlan_interface.ipv6_address is arista.avd.defined or vlan_interface.ipv6_address_virtual is arista.avd.defined or vlan_interface.ipv6_address_virtuals is arista.avd.defined %}
 {%             do vlan_interfaces_ipv6.append(vlan_interface) %}
 {%         endif %}
 {%     endfor %}
@@ -62,12 +61,16 @@
 
 #### IPv6
 
-| Interface | VRF | IPv6 Address | IPv6 Virtual Address | Virtual Router Address | VRRP | ND RA Disabled | Managed Config Flag | IPv6 ACL In | IPv6 ACL Out |
+| Interface | VRF | IPv6 Address | IPv6 Virtual Addresses | Virtual Router Address | VRRP | ND RA Disabled | Managed Config Flag | IPv6 ACL In | IPv6 ACL Out |
 | --------- | --- | ------------ | -------------------- | ---------------------- | ---- | -------------- | ------------------- | ----------- | ------------ |
 {%         for vlan_interface in vlan_interfaces_ipv6 | arista.avd.natural_sort('name') %}
 {%             set row_vrf = vlan_interface.vrf | arista.avd.default('default') %}
 {%             set row_ip_addr = vlan_interface.ipv6_address | arista.avd.default('-') %}
-{%             set row_ip_vaddr = vlan_interface.ipv6_address_virtual | arista.avd.default('-') %}
+{%             if vlan_interface.ipv6_address_virtual is arista.avd.defined %}
+{%                 set row_ip_vaddr = ([vlan_interface.ipv6_address_virtual] + vlan_interface.ipv6_address_virtuals | arista.avd.default([])) | join(", ") %}
+{%             else %}
+{%                 set row_ip_vaddr = vlan_interface.ipv6_address_virtuals | arista.avd.default('-') | join(", ") %}
+{%             endif %}
 {%             if vlan_interface.ipv6_virtual_router_addresses is arista.avd.defined %}
 {%                 set row_varp = vlan_interface.ipv6_virtual_router_addresses | join(", ") %}
 {%             else %}

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
@@ -442,7 +442,6 @@ mac_address_table:
             tags: [ < tag_1 >, < tag_2 > ]
             enabled: < true | false >
             ip_address_virtual: < IPv4_address/Mask >
-            ipv6_address_virtual: < IPv6_address/Mask >
 
         # List of L3 interfaces | Optional.
         # This will create IP routed interface inside VRF. Length of interfaces, nodes and ip_addresses and descriptions (if used) must match.

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/vlan_interfaces.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/vlan_interfaces.py
@@ -111,7 +111,7 @@ class VlanInterfacesMixin(UtilsMixin):
             if (ipv6_address_virtuals := svi.get("ipv6_address_virtuals")) is not None:
                 vlan_interface_config.setdefault("ipv6_address_virtuals", []).extend(ipv6_address_virtuals)
 
-            _check_virtual_router_mac_address(vlan_interface_config, ["ipv6_address_virtual", "ipv6_address_virtuals"])
+            _check_virtual_router_mac_address(vlan_interface_config, ["ipv6_address_virtuals"])
 
         if vrf["name"] != "default":
             vlan_interface_config["vrf"] = vrf["name"]

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/vlan_interfaces.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/vlan_interfaces.py
@@ -105,6 +105,7 @@ class VlanInterfacesMixin(UtilsMixin):
         # Only set Anycast v6 GW if VARPv6 is not set
         if vlan_interface_config.get("ip_virtual_router_addresses") is None:
             if (ipv6_address_virtual := svi.get("ipv6_address_virtual")) is not None:
+                # The singular ipv6_address_virtual is deprecated from eos_cli_config_gen. So set as list item into the new key.
                 vlan_interface_config["ipv6_address_virtuals"] = [ipv6_address_virtual]
 
             if (ipv6_address_virtuals := svi.get("ipv6_address_virtuals")) is not None:


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Deprecation of 'vlan_interfaces.ipv6_address_virtual' (singular)

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- [x] Mark the variable as deprecated in schema.
  - Point to replacement variable and porting guide if applicable.
- [x] Add section in porting guide if complex migration is needed.
- [x] Update regular molecule scenarios to use the replacement variable.
  - Ensure no configuration changes.
- [x] Add the deprecated variable to molecule `*_deprecated_vars`
- [x] Update other roles to not _output_ the deprecated variable
  - Ensure no configuration changes

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
