### PR TITLE
Feat(plugins): Support for importlib.metadata multi dist detection

### DIFF
--- a/ansible_collections/arista/avd/requirements.txt
+++ b/ansible_collections/arista/avd/requirements.txt
@@ -9,4 +9,3 @@ PyYAML>=5.4.1
 md-toc>=7.1.0
 deepmerge>=1.1.0
 cryptography>=38.0.4
-packaging>=21.3


### PR DESCRIPTION
## Change Summary

In some cases where there are leftovers dist-info folder for a Python library in site-packages, `importlib.metadata` can detect the wrong "installed" version and our module would fail, This PR implement multi dist detection and takes the following assumption:
* if any version detected matches the requirement then the requirement check for the library is accepted. e.g.,
```
TASK [arista.avd.eos_designs : Verify Requirements] *********************************************************************************************************************************
AVD version v4.0.0-dev6-4-g3e1914f5d
Use -v for details.
[WARNING]: Found deepmerge valid versions ['1.1.0'] among ['1.0.1', '1.1.0'] from metadata - assuming a valid version is running - more information available with -v
```
* if no version detected matches then the requirement check for the library is failed

## Component(s) name

`plugins`

## Proposed changes
cf description

## How to test
no test yet

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
