### PR TITLE
Fix(eos_cli_config_gen): Update radius-server and radius-servers to match EOS behavior

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/aaa.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/aaa.md
@@ -90,8 +90,8 @@ tacacs-server host 10.10.10.249 timeout 23 key 7 071B245F5A
 | VRF | RADIUS Servers | Timeout | Retransmit |
 | --- | -------------- | ------- | ---------- |
 | mgt | 10.10.10.157 | - | - |
-| default | 10.10.10.158 | - | - |
 | default | 10.10.10.249 | - | - |
+| default | 10.10.10.158 | - | - |
 
 ### RADIUS Server Device Configuration
 
@@ -99,7 +99,7 @@ tacacs-server host 10.10.10.249 timeout 23 key 7 071B245F5A
 !
 radius-server host 10.10.10.157 vrf mgt key 7 071B245F5A
 radius-server host 10.10.10.249 key 7 071B245F5A
-radius-server host 10.10.10.158 vrf default key 7 071B245F5A
+radius-server host 10.10.10.158 key 7 071B245F5A
 ```
 
 ## AAA Server Groups

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/radius-server.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/radius-server.md
@@ -47,11 +47,11 @@ interface Management1
 | VRF | RADIUS Servers | Timeout | Retransmit |
 | --- | -------------- | ------- | ---------- |
 | mgt | 10.10.11.157 | 1 | 1 |
-| default | 10.10.11.158 | 1 | 1 |
 | mgt | 10.10.11.159 | - | 1 |
 | mgt | 10.10.11.160 | 1 | - |
 | mgt | 10.10.11.248 | - | - |
 | default | 10.10.11.249 | 1 | 1 |
+| default | 10.10.11.158 | 1 | 1 |
 
 ### RADIUS Server Device Configuration
 
@@ -60,9 +60,9 @@ interface Management1
 radius-server attribute 32 include-in-access-req hostname
 radius-server dynamic-authorization port 1700 tls ssl-profile SSL_PROFILE
 radius-server host 10.10.11.157 vrf mgt timeout 1 retransmit 1 key 7 071B245F5A
-radius-server host 10.10.11.158 vrf default timeout 1 retransmit 1 key 7 071B245F5A
 radius-server host 10.10.11.159 vrf mgt retransmit 1 key 7 071B245F5A
 radius-server host 10.10.11.160 vrf mgt timeout 1 key 7 071B245F5A
 radius-server host 10.10.11.248 vrf mgt key 7 071B245F5A
 radius-server host 10.10.11.249 timeout 1 retransmit 1 key 7 071B245F5A
+radius-server host 10.10.11.158 timeout 1 retransmit 1 key 7 071B245F5A
 ```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/aaa.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/aaa.cfg
@@ -6,7 +6,7 @@ hostname aaa
 !
 radius-server host 10.10.10.157 vrf mgt key 7 071B245F5A
 radius-server host 10.10.10.249 key 7 071B245F5A
-radius-server host 10.10.10.158 vrf default key 7 071B245F5A
+radius-server host 10.10.10.158 key 7 071B245F5A
 !
 tacacs-server host 10.10.10.157 single-connection vrf mgt key 7 071B245F5A
 tacacs-server host 10.10.10.158 key 7 071B245F5A

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/radius-server.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/radius-server.cfg
@@ -7,11 +7,11 @@ hostname radius-server
 radius-server attribute 32 include-in-access-req hostname
 radius-server dynamic-authorization port 1700 tls ssl-profile SSL_PROFILE
 radius-server host 10.10.11.157 vrf mgt timeout 1 retransmit 1 key 7 071B245F5A
-radius-server host 10.10.11.158 vrf default timeout 1 retransmit 1 key 7 071B245F5A
 radius-server host 10.10.11.159 vrf mgt retransmit 1 key 7 071B245F5A
 radius-server host 10.10.11.160 vrf mgt timeout 1 key 7 071B245F5A
 radius-server host 10.10.11.248 vrf mgt key 7 071B245F5A
 radius-server host 10.10.11.249 timeout 1 retransmit 1 key 7 071B245F5A
+radius-server host 10.10.11.158 timeout 1 retransmit 1 key 7 071B245F5A
 !
 no enable password
 no aaa root

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/aaa.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/aaa.md
@@ -90,8 +90,8 @@ tacacs-server host 10.10.10.249 timeout 23 key 7 071B245F5A
 | VRF | RADIUS Servers | Timeout | Retransmit |
 | --- | -------------- | ------- | ---------- |
 | mgt | 10.10.10.157 | - | - |
-| default | 10.10.10.158 | - | - |
 | default | 10.10.10.249 | - | - |
+| default | 10.10.10.158 | - | - |
 
 ### RADIUS Server Device Configuration
 
@@ -99,7 +99,7 @@ tacacs-server host 10.10.10.249 timeout 23 key 7 071B245F5A
 !
 radius-server host 10.10.10.157 vrf mgt key 7 071B245F5A
 radius-server host 10.10.10.249 key 7 071B245F5A
-radius-server host 10.10.10.158 vrf default key 7 071B245F5A
+radius-server host 10.10.10.158 key 7 071B245F5A
 ```
 
 ## AAA Server Groups

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/aaa.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/aaa.cfg
@@ -6,7 +6,7 @@ hostname aaa
 !
 radius-server host 10.10.10.157 vrf mgt key 7 071B245F5A
 radius-server host 10.10.10.249 key 7 071B245F5A
-radius-server host 10.10.10.158 vrf default key 7 071B245F5A
+radius-server host 10.10.10.158 key 7 071B245F5A
 !
 tacacs-server host 10.10.10.157 single-connection vrf mgt key 7 071B245F5A
 tacacs-server host 10.10.10.158 key 7 071B245F5A

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/radius-server.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/radius-server.j2
@@ -29,14 +29,14 @@
 | VRF | RADIUS Servers | Timeout | Retransmit |
 | --- | -------------- | ------- | ---------- |
 {#     Old data model #}
-{%     for radius_server in radius_servers | arista.avd.natural_sort('host') %}
+{%     for radius_server in radius_servers | arista.avd.default([]) %}
 {%         set vrf = radius_server.vrf | arista.avd.default('default') %}
 {%         set timeout = radius_server.timeout | arista.avd.default('-') %}
 {%         set retransmit = radius_server.retransmit | arista.avd.default('-') %}
 | {{ vrf }} | {{ radius_server.host }} | {{ timeout }} | {{ retransmit }} |
 {%     endfor %}
 {#     New data model #}
-{%     for host in radius_server.hosts | arista.avd.natural_sort('host') %}
+{%     for host in radius_server.hosts | arista.avd.default([]) %}
 {%         set vrf = host.vrf | arista.avd.default('default') %}
 {%         set timeout = host.timeout | arista.avd.default('-') %}
 {%         set retransmit = host.retransmit | arista.avd.default('-') %}
@@ -46,7 +46,7 @@
 ### RADIUS Server Device Configuration
 
 ```eos
-{%     include 'eos/radius-server.j2' %}
 {%     include 'eos/radius-servers.j2' %}
+{%     include 'eos/radius-server.j2' %}
 ```
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/radius-server.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/radius-server.j2
@@ -21,9 +21,9 @@
 {%         endif %}
 {{ dynamic_authorization_cli }}
 {%     endif %}
-{%     for radius_host in radius_server.hosts | arista.avd.natural_sort('host') %}
+{%     for radius_host in radius_server.hosts | arista.avd.default([]) %}
 {%         set radius_cli = "radius-server host " ~ radius_host.host %}
-{%         if radius_host.vrf is arista.avd.defined %}
+{%         if radius_host.vrf is arista.avd.defined and radius_host.vrf != "default" %}
 {%             set radius_cli = radius_cli ~ " vrf " ~ radius_host.vrf %}
 {%         endif %}
 {%         if radius_host.timeout is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/radius-servers.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/radius-servers.j2
@@ -5,7 +5,7 @@
 {%         if radius_server.host is arista.avd.defined %}
 {%             set radius_cli = "radius-server host " ~ radius_server.host %}
 {%         endif %}
-{%         if radius_server.vrf is arista.avd.defined %}
+{%         if radius_server.vrf is arista.avd.defined and radius_server.vrf != "default" %}
 {%             set radius_cli = radius_cli ~ " vrf " ~ radius_server.vrf %}
 {%         endif %}
 {%         if radius_server.key is arista.avd.defined %}


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Update 'radius_server' and 'radius_servers' to match EOS behavior

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

- Remove sorting of servers
- Remove vrf from config if vrf is `default`
- Align documentation order to order of generated eos config

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Verified molecule outputs and tested on EOS 4.30.0F-eng release

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
