### PR TITLE
Feat(eos_cli_config_gen): add cvsourceintf flag to TerminAttr

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/terminattr-extra-flags.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/terminattr-extra-flags.md
@@ -49,6 +49,6 @@ interface Management1
 ```eos
 !
 daemon TerminAttr
-   exec /usr/bin/TerminAttr -cvaddr=10.10.10.8:9910,10.10.10.9:9910,10.10.10.10:9910 -cvauth=key,magickey -cvvrf=mgt -cvgnmi -disableaaa -cvproxy=http://arista:arista@10.10.10.1:3128 -grpcaddr=mgmt/0.0.0.0:6042 -grpcreadonly -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs=/var/log/messages,/var/log/agents/ -cvconfig
+   exec /usr/bin/TerminAttr -cvaddr=10.10.10.8:9910,10.10.10.9:9910,10.10.10.10:9910 -cvauth=key,magickey -cvvrf=mgt -cvgnmi -disableaaa -cvproxy=http://arista:arista@10.10.10.1:3128 -grpcaddr=mgmt/0.0.0.0:6042 -grpcreadonly -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs=/var/log/messages,/var/log/agents/ -cvconfig -cvsourceintf=Vlan100
    no shutdown
 ```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/terminattr-multi-cluster.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/terminattr-multi-cluster.md
@@ -50,6 +50,6 @@ interface Management1
 ```eos
 !
 daemon TerminAttr
-   exec /usr/bin/TerminAttr -cvopt DC1.addr=10.20.20.1:9910 -cvopt DC1.auth=key,arista -cvopt DC1.vrf=mgt -cvopt DC2.addr=10.30.30.1:9910 -cvopt DC2.auth=token,/tmp/tokenDC2 -cvopt DC2.vrf=mgt -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   exec /usr/bin/TerminAttr -cvopt DC1.addr=10.20.20.1:9910 -cvopt DC1.auth=key,arista -cvopt DC1.vrf=mgt -cvopt DC1.sourceintf=Loopback10 -cvopt DC2.addr=10.30.30.1:9910 -cvopt DC2.auth=token,/tmp/tokenDC2 -cvopt DC2.vrf=mgt -cvopt DC2.sourceintf=Vlan500 -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
 ```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/terminattr-extra-flags.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/terminattr-extra-flags.cfg
@@ -1,7 +1,7 @@
 !RANCID-CONTENT-TYPE: arista
 !
 daemon TerminAttr
-   exec /usr/bin/TerminAttr -cvaddr=10.10.10.8:9910,10.10.10.9:9910,10.10.10.10:9910 -cvauth=key,magickey -cvvrf=mgt -cvgnmi -disableaaa -cvproxy=http://arista:arista@10.10.10.1:3128 -grpcaddr=mgmt/0.0.0.0:6042 -grpcreadonly -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs=/var/log/messages,/var/log/agents/ -cvconfig
+   exec /usr/bin/TerminAttr -cvaddr=10.10.10.8:9910,10.10.10.9:9910,10.10.10.10:9910 -cvauth=key,magickey -cvvrf=mgt -cvgnmi -disableaaa -cvproxy=http://arista:arista@10.10.10.1:3128 -grpcaddr=mgmt/0.0.0.0:6042 -grpcreadonly -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs=/var/log/messages,/var/log/agents/ -cvconfig -cvsourceintf=Vlan100
    no shutdown
 !
 transceiver qsfp default-mode 4x10G

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/terminattr-multi-cluster.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/terminattr-multi-cluster.cfg
@@ -1,7 +1,7 @@
 !RANCID-CONTENT-TYPE: arista
 !
 daemon TerminAttr
-   exec /usr/bin/TerminAttr -cvopt DC1.addr=10.20.20.1:9910 -cvopt DC1.auth=key,arista -cvopt DC1.vrf=mgt -cvopt DC2.addr=10.30.30.1:9910 -cvopt DC2.auth=token,/tmp/tokenDC2 -cvopt DC2.vrf=mgt -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   exec /usr/bin/TerminAttr -cvopt DC1.addr=10.20.20.1:9910 -cvopt DC1.auth=key,arista -cvopt DC1.vrf=mgt -cvopt DC1.sourceintf=Loopback10 -cvopt DC2.addr=10.30.30.1:9910 -cvopt DC2.auth=token,/tmp/tokenDC2 -cvopt DC2.vrf=mgt -cvopt DC2.sourceintf=Vlan500 -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
 !
 transceiver qsfp default-mode 4x10G

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/terminattr-extra-flags.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/terminattr-extra-flags.yml
@@ -18,3 +18,4 @@ daemon_terminattr:
   cvcompression: gzip
   grpcreadonly: true
   cvconfig: true
+  cvsourceintf: Vlan100

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/terminattr-multi-cluster.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/terminattr-multi-cluster.yml
@@ -8,6 +8,7 @@ daemon_terminattr:
         method: "key"
         key: "arista"
       cvvrf: mgt
+      cvsourceintf: Loopback10
     DC2:
       cvaddrs:
         - 10.30.30.1:9910
@@ -15,5 +16,6 @@ daemon_terminattr:
         method: "token"
         token_file: "/tmp/tokenDC2"
       cvvrf: mgt
+      cvsourceintf: Vlan500
   smashexcludes: "ale,flexCounter,hardware,kni,pulse,strata"
   ingestexclude: "/Sysdb/cell/1/agent,/Sysdb/cell/2/agent"

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/data_model/Monitoring.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/data_model/Monitoring.md
@@ -32,6 +32,7 @@ Streaming to multiple clusters both on-prem and cloud service is supported.
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;cvobscurekeyfile</samp>](## "daemon_terminattr.clusters.[].cvobscurekeyfile") | Boolean |  |  |  | Encrypt the private key used for authentication to CloudVision<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;cvproxy</samp>](## "daemon_terminattr.clusters.[].cvproxy") | String |  |  |  | Proxy server through which CloudVision is reachable. Useful when the CloudVision server is hosted in the cloud.<br>The expected form is http://[user:password@]ip:port, e.g.: `http://arista:arista@10.83.12.78:3128`. Available as of TerminAttr v1.13.0<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;cvsourceip</samp>](## "daemon_terminattr.clusters.[].cvsourceip") | String |  |  |  | Set source IP address in case of in-band managament<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;cvsourceintf</samp>](## "daemon_terminattr.clusters.[].cvsourceintf") | String |  |  |  | Set source interface in case of in-band managament. Available as of TerminAttr v1.23.0<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;cvvrf</samp>](## "daemon_terminattr.clusters.[].cvvrf") | String |  |  |  | The VRF to use to connect to CloudVision<br> |
     | [<samp>&nbsp;&nbsp;cvauth</samp>](## "daemon_terminattr.cvauth") | Dictionary |  |  |  | Authentication scheme used to connect to CloudVision<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;method</samp>](## "daemon_terminattr.cvauth.method") | String |  |  | Valid Values:<br>- token<br>- token-secure<br>- key |  |
@@ -40,6 +41,7 @@ Streaming to multiple clusters both on-prem and cloud service is supported.
     | [<samp>&nbsp;&nbsp;cvobscurekeyfile</samp>](## "daemon_terminattr.cvobscurekeyfile") | Boolean |  |  |  | Encrypt the private key used for authentication to CloudVision<br> |
     | [<samp>&nbsp;&nbsp;cvproxy</samp>](## "daemon_terminattr.cvproxy") | String |  |  |  | Proxy server through which CloudVision is reachable. Useful when the CloudVision server is hosted in the cloud.<br>The expected form is http://[user:password@]ip:port, e.g.: `http://arista:arista@10.83.12.78:3128`. Available as of TerminAttr v1.13.0<br> |
     | [<samp>&nbsp;&nbsp;cvsourceip</samp>](## "daemon_terminattr.cvsourceip") | String |  |  |  | Set source IP address in case of in-band managament<br> |
+    | [<samp>&nbsp;&nbsp;cvsourceintf</samp>](## "daemon_terminattr.cvsourceintf") | String |  |  |  | Set source interface in case of in-band managament<br> |
     | [<samp>&nbsp;&nbsp;cvvrf</samp>](## "daemon_terminattr.cvvrf") | String |  |  |  | The VRF to use to connect to CloudVision<br> |
     | [<samp>&nbsp;&nbsp;cvgnmi</samp>](## "daemon_terminattr.cvgnmi") | Boolean |  |  |  | Stream states from EOS GNMI servers (Openconfig) to CloudVision. Available as of TerminAttr v1.13.1<br> |
     | [<samp>&nbsp;&nbsp;disable_aaa</samp>](## "daemon_terminattr.disable_aaa") | Boolean |  |  |  | Disable AAA authorization and accounting.<br>When setting this flag, all commands pushed from CloudVision are applied directly to the CLI without authorization<br> |
@@ -79,6 +81,7 @@ Streaming to multiple clusters both on-prem and cloud service is supported.
           cvobscurekeyfile: <bool>
           cvproxy: <str>
           cvsourceip: <str>
+          cvsourceintf: <str>
           cvvrf: <str>
       cvauth:
         method: <str>
@@ -87,6 +90,7 @@ Streaming to multiple clusters both on-prem and cloud service is supported.
       cvobscurekeyfile: <bool>
       cvproxy: <str>
       cvsourceip: <str>
+      cvsourceintf: <str>
       cvvrf: <str>
       cvgnmi: <bool>
       disable_aaa: <bool>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -925,6 +925,11 @@
                 "description": "Set source IP address in case of in-band managament\n",
                 "title": "Cvsourceip"
               },
+              "cvsourceintf": {
+                "type": "string",
+                "description": "Set source interface in case of in-band managament. Available as of TerminAttr v1.23.0\n",
+                "title": "Cvsourceintf"
+              },
               "cvvrf": {
                 "type": "string",
                 "description": "The VRF to use to connect to CloudVision\n",
@@ -978,6 +983,11 @@
           "type": "string",
           "description": "Set source IP address in case of in-band managament\n",
           "title": "Cvsourceip"
+        },
+        "cvsourceintf": {
+          "type": "string",
+          "description": "Set source interface in case of in-band managament\n",
+          "title": "Cvsourceintf"
         },
         "cvvrf": {
           "type": "string",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -379,9 +379,9 @@ keys:
     documentation_options:
       filename: data_model/Aliases
     type: str
-    description: "Multi-line string with one or more alias commands.\n\nExample:\n\
-      \n```yaml\naliases: |\n  alias wr copy running-config startup-config\n  alias\
-      \ siib show ip interface brief\n```"
+    description: "Multi-line string with one or more alias commands.\n\nExample:\n\n```yaml\naliases:
+      |\n  alias wr copy running-config startup-config\n  alias siib show ip interface
+      brief\n```"
   arp:
     documentation_options:
       filename: data_model/Routing
@@ -599,14 +599,14 @@ keys:
       filename: inputs/Role Inputs
     type: list
     display_name: Extensibility with Custom Templates
-    description: "- Custom templates can be added below the playbook directory.\n\
-      - If a location above the directory is desired, a symbolic link can be used.\n\
-      - Example under the `playbooks` directory create symbolic link with the following\
-      \ command:\n\n  ```bash\n  ln -s ../../shared_repo/custom_avd_templates/ ./custom_avd_templates\n\
-      \  ```\n\n- The output will be rendered at the end of the configuration.\n-\
-      \ The order of custom templates in the list can be important if they overlap.\n\
-      - It is recommended to use a `!` delimiter at the top of each custom template.\n\
-      \nAdd `custom_templates` to group/host variables:\n"
+    description: "- Custom templates can be added below the playbook directory.\n-
+      If a location above the directory is desired, a symbolic link can be used.\n-
+      Example under the `playbooks` directory create symbolic link with the following
+      command:\n\n  ```bash\n  ln -s ../../shared_repo/custom_avd_templates/ ./custom_avd_templates\n
+      \ ```\n\n- The output will be rendered at the end of the configuration.\n- The
+      order of custom templates in the list can be important if they overlap.\n- It
+      is recommended to use a `!` delimiter at the top of each custom template.\n\nAdd
+      `custom_templates` to group/host variables:\n"
     items:
       type: str
       description: Template relative path below playbook directory
@@ -651,13 +651,12 @@ keys:
     documentation_options:
       filename: data_model/Monitoring
     type: dict
-    description: "You can either provide a list of IPs/FQDNs to target on-premise\
-      \ Cloudvision cluster or use DNS name for your Cloudvision as a Service instance.\n\
-      Streaming to multiple clusters both on-prem and cloud service is supported.\n\
-      \n!!! note\n    For TerminAttr version recommendation and EOS compatibility\
-      \ matrix, please refer to the latest TerminAttr Release Notes\n    which always\
-      \ contain the latest recommended versions and minimum required versions per\
-      \ EOS release.\n"
+    description: "You can either provide a list of IPs/FQDNs to target on-premise
+      Cloudvision cluster or use DNS name for your Cloudvision as a Service instance.\nStreaming
+      to multiple clusters both on-prem and cloud service is supported.\n\n!!! note\n
+      \   For TerminAttr version recommendation and EOS compatibility matrix, please
+      refer to the latest TerminAttr Release Notes\n    which always contain the latest
+      recommended versions and minimum required versions per EOS release.\n"
     keys:
       cvaddrs:
         type: list
@@ -4113,8 +4112,8 @@ keys:
               type: str
             tls_versions:
               type: str
-              description: "List of allowed TLS versions as string\nExamples:\n  -\
-                \ \"1.0\"\n  - \"1.0 1.1\"\n"
+              description: "List of allowed TLS versions as string\nExamples:\n  -
+                \"1.0\"\n  - \"1.0 1.1\"\n"
               convert_types:
               - float
             cipher_list:
@@ -4526,12 +4525,12 @@ keys:
               type: str
         rate_limit_per_ingress_chip:
           type: str
-          description: "Ratelimit and unit as string.\nExamples:\n  \"100000 bps\"\
-            \n  \"100 kbps\"\n  \"10 mbps\"\n"
+          description: "Ratelimit and unit as string.\nExamples:\n  \"100000 bps\"\n
+            \ \"100 kbps\"\n  \"10 mbps\"\n"
         rate_limit_per_egress_chip:
           type: str
-          description: "Ratelimit and unit as string.\nExamples:\n  \"100000 bps\"\
-            \n  \"100 kbps\"\n  \"10 mbps\"\n"
+          description: "Ratelimit and unit as string.\nExamples:\n  \"100000 bps\"\n
+            \ \"100 kbps\"\n  \"10 mbps\"\n"
         sample:
           type: int
           convert_types:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -379,9 +379,9 @@ keys:
     documentation_options:
       filename: data_model/Aliases
     type: str
-    description: "Multi-line string with one or more alias commands.\n\nExample:\n\n```yaml\naliases:
-      |\n  alias wr copy running-config startup-config\n  alias siib show ip interface
-      brief\n```"
+    description: "Multi-line string with one or more alias commands.\n\nExample:\n\
+      \n```yaml\naliases: |\n  alias wr copy running-config startup-config\n  alias\
+      \ siib show ip interface brief\n```"
   arp:
     documentation_options:
       filename: data_model/Routing
@@ -599,14 +599,14 @@ keys:
       filename: inputs/Role Inputs
     type: list
     display_name: Extensibility with Custom Templates
-    description: "- Custom templates can be added below the playbook directory.\n-
-      If a location above the directory is desired, a symbolic link can be used.\n-
-      Example under the `playbooks` directory create symbolic link with the following
-      command:\n\n  ```bash\n  ln -s ../../shared_repo/custom_avd_templates/ ./custom_avd_templates\n
-      \ ```\n\n- The output will be rendered at the end of the configuration.\n- The
-      order of custom templates in the list can be important if they overlap.\n- It
-      is recommended to use a `!` delimiter at the top of each custom template.\n\nAdd
-      `custom_templates` to group/host variables:\n"
+    description: "- Custom templates can be added below the playbook directory.\n\
+      - If a location above the directory is desired, a symbolic link can be used.\n\
+      - Example under the `playbooks` directory create symbolic link with the following\
+      \ command:\n\n  ```bash\n  ln -s ../../shared_repo/custom_avd_templates/ ./custom_avd_templates\n\
+      \  ```\n\n- The output will be rendered at the end of the configuration.\n-\
+      \ The order of custom templates in the list can be important if they overlap.\n\
+      - It is recommended to use a `!` delimiter at the top of each custom template.\n\
+      \nAdd `custom_templates` to group/host variables:\n"
     items:
       type: str
       description: Template relative path below playbook directory
@@ -651,12 +651,13 @@ keys:
     documentation_options:
       filename: data_model/Monitoring
     type: dict
-    description: "You can either provide a list of IPs/FQDNs to target on-premise
-      Cloudvision cluster or use DNS name for your Cloudvision as a Service instance.\nStreaming
-      to multiple clusters both on-prem and cloud service is supported.\n\n!!! note\n
-      \   For TerminAttr version recommendation and EOS compatibility matrix, please
-      refer to the latest TerminAttr Release Notes\n    which always contain the latest
-      recommended versions and minimum required versions per EOS release.\n"
+    description: "You can either provide a list of IPs/FQDNs to target on-premise\
+      \ Cloudvision cluster or use DNS name for your Cloudvision as a Service instance.\n\
+      Streaming to multiple clusters both on-prem and cloud service is supported.\n\
+      \n!!! note\n    For TerminAttr version recommendation and EOS compatibility\
+      \ matrix, please refer to the latest TerminAttr Release Notes\n    which always\
+      \ contain the latest recommended versions and minimum required versions per\
+      \ EOS release.\n"
     keys:
       cvaddrs:
         type: list
@@ -737,6 +738,12 @@ keys:
               description: 'Set source IP address in case of in-band managament
 
                 '
+            cvsourceintf:
+              type: str
+              description: 'Set source interface in case of in-band managament. Available
+                as of TerminAttr v1.23.0
+
+                '
             cvvrf:
               type: str
               description: 'The VRF to use to connect to CloudVision
@@ -780,6 +787,11 @@ keys:
       cvsourceip:
         type: str
         description: 'Set source IP address in case of in-band managament
+
+          '
+      cvsourceintf:
+        type: str
+        description: 'Set source interface in case of in-band managament
 
           '
       cvvrf:
@@ -4101,8 +4113,8 @@ keys:
               type: str
             tls_versions:
               type: str
-              description: "List of allowed TLS versions as string\nExamples:\n  -
-                \"1.0\"\n  - \"1.0 1.1\"\n"
+              description: "List of allowed TLS versions as string\nExamples:\n  -\
+                \ \"1.0\"\n  - \"1.0 1.1\"\n"
               convert_types:
               - float
             cipher_list:
@@ -4514,12 +4526,12 @@ keys:
               type: str
         rate_limit_per_ingress_chip:
           type: str
-          description: "Ratelimit and unit as string.\nExamples:\n  \"100000 bps\"\n
-            \ \"100 kbps\"\n  \"10 mbps\"\n"
+          description: "Ratelimit and unit as string.\nExamples:\n  \"100000 bps\"\
+            \n  \"100 kbps\"\n  \"10 mbps\"\n"
         rate_limit_per_egress_chip:
           type: str
-          description: "Ratelimit and unit as string.\nExamples:\n  \"100000 bps\"\n
-            \ \"100 kbps\"\n  \"10 mbps\"\n"
+          description: "Ratelimit and unit as string.\nExamples:\n  \"100000 bps\"\
+            \n  \"100 kbps\"\n  \"10 mbps\"\n"
         sample:
           type: int
           convert_types:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/daemon_terminattr.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/daemon_terminattr.schema.yml
@@ -75,6 +75,10 @@ keys:
               type: str
               description: |
                 Set source IP address in case of in-band managament
+            cvsourceintf:
+              type: str
+              description: |
+                Set source interface in case of in-band managament. Available as of TerminAttr v1.23.0
             cvvrf:
               type: str
               description: |
@@ -107,6 +111,10 @@ keys:
         type: str
         description: |
           Set source IP address in case of in-band managament
+      cvsourceintf:
+        type: str
+        description: |
+          Set source interface in case of in-band managament
       cvvrf:
         type: str
         description: |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/daemon-terminattr.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/daemon-terminattr.j2
@@ -25,6 +25,9 @@ daemon TerminAttr
 {%         if cluster.cvobscurekeyfile is arista.avd.defined %}
 {%             set cvp_config.cli = cvp_config.cli ~ " -cvopt " ~ cluster.name ~ ".obscurekeyfile=" ~ cluster.cvobscurekeyfile %}
 {%         endif %}
+{%         if cluster.cvsourceintf is arista.avd.defined %}
+{%             set cvp_config.cli = cvp_config.cli ~ " -cvopt " ~ cluster.name ~ ".sourceintf=" ~ cluster.cvsourceintf %}
+{%         endif %}
 {%     endfor %}
 {%     if daemon_terminattr.cvaddrs is arista.avd.defined %}
 {%         set cvp_config.cli = cvp_config.cli ~ " -cvaddr=" ~ daemon_terminattr.cvaddrs | join(',') %}
@@ -92,6 +95,9 @@ daemon TerminAttr
 {%     endif %}
 {%     if daemon_terminattr.cvconfig is arista.avd.defined(true) %}
 {%         set cvp_config.cli = cvp_config.cli ~ " -cvconfig" %}
+{%     endif %}
+{%     if daemon_terminattr.cvsourceintf is arista.avd.defined %}
+{%         set cvp_config.cli = cvp_config.cli ~ " -cvsourceintf=" ~ daemon_terminattr.cvsourceintf %}
 {%     endif %}
    {{ cvp_config.cli }}
    no shutdown

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
@@ -5,31 +5,31 @@ keys:
     type: list
     documentation_options:
       filename: Fabric Topology
-    description: "- Set default uplink, downlink, and MLAG interfaces, which will\
-      \ be used if these interfaces are not defined on a device (either directly or\
-      \ through inheritance).\n- These are defined based on the combination of node_type\
-      \ (e.g., l3leaf or spine) and a regex for matching the platform.\n- A list of\
-      \ interfaces or interface ranges can be specified.\n- Each list item supports\
-      \ range syntax that can be expanded into a list of interfaces. Interface range\
-      \ examples:\n  - Ethernet49-52/1: Expands to [ Ethernet49/1, Ethernet50/1, Ethernet51/1,\
-      \ Ethernet52/1 ]\n  - Ethernet1/31-34/1: Expands to [ Ethernet1/31/1, Ethernet1/32/1,\
-      \ Ethernet1/33/1, Ethernet1/34/1 ]\n  - Ethernet49-50,53-54: Expands to [ Ethernet49,\
-      \ Ethernet50, Ethernet53, Ethernet54 ]\n  - Ethernet1-2/1-4: Expands to [ Ethernet1/1,\
-      \ Ethernet1/2, Ethernet1/3, Ethernet1/4, Ethernet2/1, Ethernet2/2, Ethernet2/3,\
-      \ Ethernet2/4 ]\n- `uplink_interfaces` and `mlag_interfaces` under `default_interfaces`\
-      \ are directly inherited by `uplink_interfaces` and `mlag_interfaces`.\n- `downlink_interfaces`\
-      \ are referenced by the child switch (e.g., the leaf in a leaf/spine network).\
-      \ The child switch leverages an upstream switch's `default_downlink_interfaces`\
-      \ using the child switch ID.  This is then used to build `uplink_switch_interfaces`\
-      \ for that child.\n  - In the case of `max_parallel_uplinks` > 1 the `default_downlink_interfaces`\
-      \ are mapped with consecutive downlinks per child ID.\n  - Example for `max_parallel_uplinks:\
-      \ 2`, downlink interfaces will be mapped as `[ <downlink1 to leaf-id1>, <downlink2\
-      \ to leaf-id1>, <downlink1 to leaf-id2>, <downlink2 to leaf-id2> ...]`\n- Please\
-      \ note that no default interfaces are defined in AVD itself. You will need to\
-      \ create your own based on the example below.\n\nExample:\n\n```yaml\ndefault_interfaces:\n\
-      \  - types: [ spine, l3leaf ]\n    platforms: [ \"7050[SC]X3\", vEOS.*, default\
-      \ ]\n    uplink_interfaces: [ Ethernet49-54/1 ]\n    mlag_interfaces: [ Ethernet55-56/1\
-      \ ]\n    downlink_interfaces: [ Ethernet1-32/1 ]\n```\n"
+    description: "- Set default uplink, downlink, and MLAG interfaces, which will
+      be used if these interfaces are not defined on a device (either directly or
+      through inheritance).\n- These are defined based on the combination of node_type
+      (e.g., l3leaf or spine) and a regex for matching the platform.\n- A list of
+      interfaces or interface ranges can be specified.\n- Each list item supports
+      range syntax that can be expanded into a list of interfaces. Interface range
+      examples:\n  - Ethernet49-52/1: Expands to [ Ethernet49/1, Ethernet50/1, Ethernet51/1,
+      Ethernet52/1 ]\n  - Ethernet1/31-34/1: Expands to [ Ethernet1/31/1, Ethernet1/32/1,
+      Ethernet1/33/1, Ethernet1/34/1 ]\n  - Ethernet49-50,53-54: Expands to [ Ethernet49,
+      Ethernet50, Ethernet53, Ethernet54 ]\n  - Ethernet1-2/1-4: Expands to [ Ethernet1/1,
+      Ethernet1/2, Ethernet1/3, Ethernet1/4, Ethernet2/1, Ethernet2/2, Ethernet2/3,
+      Ethernet2/4 ]\n- `uplink_interfaces` and `mlag_interfaces` under `default_interfaces`
+      are directly inherited by `uplink_interfaces` and `mlag_interfaces`.\n- `downlink_interfaces`
+      are referenced by the child switch (e.g., the leaf in a leaf/spine network).
+      The child switch leverages an upstream switch's `default_downlink_interfaces`
+      using the child switch ID.  This is then used to build `uplink_switch_interfaces`
+      for that child.\n  - In the case of `max_parallel_uplinks` > 1 the `default_downlink_interfaces`
+      are mapped with consecutive downlinks per child ID.\n  - Example for `max_parallel_uplinks:
+      2`, downlink interfaces will be mapped as `[ <downlink1 to leaf-id1>, <downlink2
+      to leaf-id1>, <downlink1 to leaf-id2>, <downlink2 to leaf-id2> ...]`\n- Please
+      note that no default interfaces are defined in AVD itself. You will need to
+      create your own based on the example below.\n\nExample:\n\n```yaml\ndefault_interfaces:\n
+      \ - types: [ spine, l3leaf ]\n    platforms: [ \"7050[SC]X3\", vEOS.*, default
+      ]\n    uplink_interfaces: [ Ethernet49-54/1 ]\n    mlag_interfaces: [ Ethernet55-56/1
+      ]\n    downlink_interfaces: [ Ethernet1-32/1 ]\n```\n"
     items:
       type: dict
       keys:

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
@@ -5,31 +5,31 @@ keys:
     type: list
     documentation_options:
       filename: Fabric Topology
-    description: "- Set default uplink, downlink, and MLAG interfaces, which will
-      be used if these interfaces are not defined on a device (either directly or
-      through inheritance).\n- These are defined based on the combination of node_type
-      (e.g., l3leaf or spine) and a regex for matching the platform.\n- A list of
-      interfaces or interface ranges can be specified.\n- Each list item supports
-      range syntax that can be expanded into a list of interfaces. Interface range
-      examples:\n  - Ethernet49-52/1: Expands to [ Ethernet49/1, Ethernet50/1, Ethernet51/1,
-      Ethernet52/1 ]\n  - Ethernet1/31-34/1: Expands to [ Ethernet1/31/1, Ethernet1/32/1,
-      Ethernet1/33/1, Ethernet1/34/1 ]\n  - Ethernet49-50,53-54: Expands to [ Ethernet49,
-      Ethernet50, Ethernet53, Ethernet54 ]\n  - Ethernet1-2/1-4: Expands to [ Ethernet1/1,
-      Ethernet1/2, Ethernet1/3, Ethernet1/4, Ethernet2/1, Ethernet2/2, Ethernet2/3,
-      Ethernet2/4 ]\n- `uplink_interfaces` and `mlag_interfaces` under `default_interfaces`
-      are directly inherited by `uplink_interfaces` and `mlag_interfaces`.\n- `downlink_interfaces`
-      are referenced by the child switch (e.g., the leaf in a leaf/spine network).
-      The child switch leverages an upstream switch's `default_downlink_interfaces`
-      using the child switch ID.  This is then used to build `uplink_switch_interfaces`
-      for that child.\n  - In the case of `max_parallel_uplinks` > 1 the `default_downlink_interfaces`
-      are mapped with consecutive downlinks per child ID.\n  - Example for `max_parallel_uplinks:
-      2`, downlink interfaces will be mapped as `[ <downlink1 to leaf-id1>, <downlink2
-      to leaf-id1>, <downlink1 to leaf-id2>, <downlink2 to leaf-id2> ...]`\n- Please
-      note that no default interfaces are defined in AVD itself. You will need to
-      create your own based on the example below.\n\nExample:\n\n```yaml\ndefault_interfaces:\n
-      \ - types: [ spine, l3leaf ]\n    platforms: [ \"7050[SC]X3\", vEOS.*, default
-      ]\n    uplink_interfaces: [ Ethernet49-54/1 ]\n    mlag_interfaces: [ Ethernet55-56/1
-      ]\n    downlink_interfaces: [ Ethernet1-32/1 ]\n```\n"
+    description: "- Set default uplink, downlink, and MLAG interfaces, which will\
+      \ be used if these interfaces are not defined on a device (either directly or\
+      \ through inheritance).\n- These are defined based on the combination of node_type\
+      \ (e.g., l3leaf or spine) and a regex for matching the platform.\n- A list of\
+      \ interfaces or interface ranges can be specified.\n- Each list item supports\
+      \ range syntax that can be expanded into a list of interfaces. Interface range\
+      \ examples:\n  - Ethernet49-52/1: Expands to [ Ethernet49/1, Ethernet50/1, Ethernet51/1,\
+      \ Ethernet52/1 ]\n  - Ethernet1/31-34/1: Expands to [ Ethernet1/31/1, Ethernet1/32/1,\
+      \ Ethernet1/33/1, Ethernet1/34/1 ]\n  - Ethernet49-50,53-54: Expands to [ Ethernet49,\
+      \ Ethernet50, Ethernet53, Ethernet54 ]\n  - Ethernet1-2/1-4: Expands to [ Ethernet1/1,\
+      \ Ethernet1/2, Ethernet1/3, Ethernet1/4, Ethernet2/1, Ethernet2/2, Ethernet2/3,\
+      \ Ethernet2/4 ]\n- `uplink_interfaces` and `mlag_interfaces` under `default_interfaces`\
+      \ are directly inherited by `uplink_interfaces` and `mlag_interfaces`.\n- `downlink_interfaces`\
+      \ are referenced by the child switch (e.g., the leaf in a leaf/spine network).\
+      \ The child switch leverages an upstream switch's `default_downlink_interfaces`\
+      \ using the child switch ID.  This is then used to build `uplink_switch_interfaces`\
+      \ for that child.\n  - In the case of `max_parallel_uplinks` > 1 the `default_downlink_interfaces`\
+      \ are mapped with consecutive downlinks per child ID.\n  - Example for `max_parallel_uplinks:\
+      \ 2`, downlink interfaces will be mapped as `[ <downlink1 to leaf-id1>, <downlink2\
+      \ to leaf-id1>, <downlink1 to leaf-id2>, <downlink2 to leaf-id2> ...]`\n- Please\
+      \ note that no default interfaces are defined in AVD itself. You will need to\
+      \ create your own based on the example below.\n\nExample:\n\n```yaml\ndefault_interfaces:\n\
+      \  - types: [ spine, l3leaf ]\n    platforms: [ \"7050[SC]X3\", vEOS.*, default\
+      \ ]\n    uplink_interfaces: [ Ethernet49-54/1 ]\n    mlag_interfaces: [ Ethernet55-56/1\
+      \ ]\n    downlink_interfaces: [ Ethernet1-32/1 ]\n```\n"
     items:
       type: dict
       keys:


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Add support for `cvsourceintf` (available since TerminAttr 1.23.0+) to replace `cvsourceip` (which is unique per device)

## Related Issue(s)

Fixes #2619 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->
Added `cvsourceintf` to TerminAttr flags


## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

```
daemon_terminattr:
   cvaddrs: # For single cluster
       - 192.0.2.100:9910
  cvauth:
     method: "token"
     key: "arista"
     token_file: "/tmp/token"
  cvvrf: MGMT
  ingestexclude: "/Sysdb/cell/1/agent,/Sysdb/cell/2/agent"
  smashexcludes: "ale,flexCounter,hardware,kni,pulse,strata"
  cvsourceintf: Loopback10
```

would result in 

```
daemon TerminAttr
   exec /usr/bin/TerminAttr -cvaddr=192.0.2.100:9910 -cvauth=token,/tmp/token -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs -cvsourceintf=Loopback10
   no shutdown
```

or multi-cluster streaming config:

```
daemon_terminattr:
  clusters: # For multiple cluster support
    dublin:
        cvaddrs:
        - 192.0.2.100:9910
        - 192.0.2.101:9910
        - 192.0.2.102:9910
        cvauth:
          method: "token"
          token_file: "/tmp/token"
        cvvrf: MGMT
        cvsourceintf: Loopback10
    cvaas:
        cvaddrs:
          - www.arista.io:443
        cvauth:
          method: "token-secure"
          token_file: "/tmp/prod"
        cvvrf: MGMT
        cvsourceintf: Vlan560
  ingestexclude: "/Sysdb/cell/1/agent,/Sysdb/cell/2/agent"
  smashexcludes: "ale,flexCounter,hardware,kni,pulse,strata"
```

would result in:

```
daemon TerminAttr
   exec /usr/bin/TerminAttr -cvopt cvaas.addr=www.arista.io:443 -cvopt cvaas.auth=token-secure,/tmp/prod -cvopt cvaas.vrf=MGMT -cvopt cvaas.sourceintf=Vlan560 -cvopt dublin.addr=192.0.2.100:9910,192.0.2.101:9910,192.0.2.102:9910 -cvopt dublin.auth=token,/tmp/token -cvopt dublin.vrf=MGMT -cvopt dublin.sourceintf=Loopback10 -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
   no shutdown
```


## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code has been rebased from devel before I start
- [ x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ x] My change requires a change to the documentation and documentation have been updated accordingly.
- [ x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
