### PR TITLE
Fix(eos_designs): Add back dir creation wrongly removed by #2015

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_designs/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/tasks/main.yml
@@ -11,6 +11,18 @@
   run_once: true
   register: avd_requirements
 
+- name: Create required output directories if not present
+  tags: [build, provision]
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    mode: 0775
+  loop:
+    - "{{ structured_dir }}"
+    - "{{ fabric_dir }}"
+  delegate_to: localhost
+  run_once: true
+
 - name: Set eos_designs facts
   tags: [build, provision, facts]
   arista.avd.eos_designs_facts:


### PR DESCRIPTION
## Change Summary

PR #2015 removed the directory creation for 

## Related Issue(s)

Issue found in the field

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

Adding back the task in the role

## How to test

Would need to add some new kind of test for

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
