### PR TITLE
Feat(plugins): Add OSPF pasword type 7 to encrypt/decrypt filters

### DIFF
--- a/ansible_collections/arista/avd/plugins/README.md
+++ b/ansible_collections/arista/avd/plugins/README.md
@@ -190,6 +190,10 @@ To use these filters:
 Supported types:
 
 - bgp
+- ospf
+
+!!! Note
+For now this filter only supports encryption and decryption to type `7` and not type `8a` for OSPF and BGP passwords
 
 #### BGP passwords
 
@@ -205,6 +209,35 @@ bgp_peer_groups:
     name: IPv4-UNDERLAY-PEERS
       password: "{{ bgp_vault_password | arista.avd.encrypt(passwd_type='bgp', key='IPv4-UNDERLAY-PEERS') }}"
 ```
+
+#### OSPF passwords
+
+OSPF passwords are encrypted/decrypted based on the interface name (e.g., Ethernet1) and for message-digest-key the authentication algotithm (in the list [md5, sha1, sha256, sha384, sha512]) and the key ID (between 1 and 255).
+
+An example usage for `arista.avd.encrypt` filter for PS{F is to use it in conjunction with Ansible Vault to be able to load a password and have it encrypted on the fly by AVD in `eos_designs`.
+
+**examples:**
+
+- Simple authentication
+
+    ```jinja
+    ethernet_interfaces:
+      - name: Ethernet1:
+        ospf_authentication: simple
+        ospf_authentication_key: "{{ ospf_vault_password | arista.avd.encrypt(passwd_type='ospf', key='Ethernet1') }}"
+    ```
+
+- Message Digest Keys
+
+    ```jinja
+    ethernet_interfaces:
+      - name: Ethernet1:
+        ospf_authentication: message-digest
+        ospf_message_digest_keys:
+          1:
+            hash_algorithm: md5
+            key: "{{ ospf_vault_password | arista.avd.encrypt(passwd_type='ospf', key='Ethernet1', auth_algo='md5', key_id='1') }}"
+    ```
 
 ## Plugin Tests
 

--- a/ansible_collections/arista/avd/plugins/README.md
+++ b/ansible_collections/arista/avd/plugins/README.md
@@ -190,7 +190,8 @@ To use these filters:
 Supported types:
 
 - bgp
-- ospf
+- ospf_simple
+- ospf_messaged_digest
 
 !!! Note
 For now this filter only supports encryption and decryption to type `7` and not type `8a` for OSPF and BGP passwords
@@ -212,9 +213,14 @@ bgp_peer_groups:
 
 #### OSPF passwords
 
-OSPF passwords are encrypted/decrypted based on the interface name (e.g., Ethernet1) and for message-digest-key the authentication algotithm (in the list [md5, sha1, sha256, sha384, sha512]) and the key ID (between 1 and 255).
+OSPF passwords are encrypted/decrypted based on the interface name (e.g., Ethernet1) and for message-digest-key the hash algorithm (in the list [md5, sha1, sha256, sha384, sha512]) and the key ID (between 1 and 255).
 
-An example usage for `arista.avd.encrypt` filter for PS{F is to use it in conjunction with Ansible Vault to be able to load a password and have it encrypted on the fly by AVD in `eos_designs`.
+The filters provide two types for OSPF:
+
+- `ospf_simple` for simple authentication which requires only the password and the interface name as key as inputs.
+- `ospf_messaged_digest` for message digest keys which requires the password, the interface name as key, the hash algorithm and the key id as input.
+
+An example usage for `arista.avd.encrypt` filter for OSPF is to use it in conjunction with Ansible Vault to be able to load a password and have it encrypted on the fly by AVD in `eos_designs`.
 
 **examples:**
 
@@ -236,7 +242,7 @@ An example usage for `arista.avd.encrypt` filter for PS{F is to use it in conjun
         ospf_message_digest_keys:
           1:
             hash_algorithm: md5
-            key: "{{ ospf_vault_password | arista.avd.encrypt(passwd_type='ospf', key='Ethernet1', auth_algo='md5', key_id='1') }}"
+            key: "{{ ospf_vault_password | arista.avd.encrypt(passwd_type='ospf', key='Ethernet1', hash_algorithm='md5', key_id='1') }}"
     ```
 
 ## Plugin Tests

--- a/ansible_collections/arista/avd/plugins/README.md
+++ b/ansible_collections/arista/avd/plugins/README.md
@@ -198,9 +198,9 @@ For now this filter only supports encryption and decryption to type `7` and not 
 
 #### BGP passwords
 
-BGP password are encrypted/decrypted based on the Neighbor IP or the BGP Peer Group Name in EOS.
+BGP passwords are encrypted/decrypted based on the Neighbor IP or the BGP Peer Group Name in EOS.
 
-An example usage for `arista.avd.encrypt` filter for BGP is to use it in conjunction with Ansible Vault to be able to load a password and have it encrypted on the fly by AVD in `eos_designs`.
+Example usage for `arista.avd.encrypt` filter for BGP is to use it in conjunction with Ansible Vault to be able to load a password and have it encrypted on the fly by AVD in `eos_designs`.
 
 **example:**
 
@@ -213,14 +213,14 @@ bgp_peer_groups:
 
 #### OSPF passwords
 
-OSPF passwords are encrypted/decrypted based on the interface name (e.g., Ethernet1) and for message-digest-key the hash algorithm (in the list [md5, sha1, sha256, sha384, sha512]) and the key ID (between 1 and 255).
+OSPF passwords are encrypted/decrypted based on the interface name (e.g., Ethernet1), and for message-digest-key, the hash algorithm (in the list [md5, sha1, sha256, sha384, sha512]) and the key ID (between 1 and 255).
 
-The filters provide two types for OSPF:
+The filter provides two types for OSPF:
 
-- `ospf_simple` for simple authentication which requires only the password and the interface name as key as inputs.
-- `ospf_message_digest` for message digest keys which requires the password, the interface name as key, the hash algorithm and the key id as input.
+- `ospf_simple` for simple authentication, which requires only the password and the interface name as key inputs.
+- `ospf_message_digest` for message digest keys which requires the password, the interface name as the key, the hash algorithm, and the key id as input.
 
-An example usage for `arista.avd.encrypt` filter for OSPF is to use it in conjunction with Ansible Vault to be able to load a password and have it encrypted on the fly by AVD in `eos_designs`.
+Example usage for `arista.avd.encrypt` filter for OSPF is to use it in conjunction with Ansible Vault to be able to load a password and have it encrypted on the fly by AVD in `eos_designs`.
 
 **examples:**
 

--- a/ansible_collections/arista/avd/plugins/README.md
+++ b/ansible_collections/arista/avd/plugins/README.md
@@ -191,7 +191,7 @@ Supported types:
 
 - bgp
 - ospf_simple
-- ospf_messaged_digest
+- ospf_message_digest
 
 !!! Note
 For now this filter only supports encryption and decryption to type `7` and not type `8a` for OSPF and BGP passwords
@@ -218,7 +218,7 @@ OSPF passwords are encrypted/decrypted based on the interface name (e.g., Ethern
 The filters provide two types for OSPF:
 
 - `ospf_simple` for simple authentication which requires only the password and the interface name as key as inputs.
-- `ospf_messaged_digest` for message digest keys which requires the password, the interface name as key, the hash algorithm and the key id as input.
+- `ospf_message_digest` for message digest keys which requires the password, the interface name as key, the hash algorithm and the key id as input.
 
 An example usage for `arista.avd.encrypt` filter for OSPF is to use it in conjunction with Ansible Vault to be able to load a password and have it encrypted on the fly by AVD in `eos_designs`.
 
@@ -230,7 +230,7 @@ An example usage for `arista.avd.encrypt` filter for OSPF is to use it in conjun
     ethernet_interfaces:
       - name: Ethernet1:
         ospf_authentication: simple
-        ospf_authentication_key: "{{ ospf_vault_password | arista.avd.encrypt(passwd_type='ospf', key='Ethernet1') }}"
+        ospf_authentication_key: "{{ ospf_vault_password | arista.avd.encrypt(passwd_type='ospf_simple', key='Ethernet1') }}"
     ```
 
 - Message Digest Keys
@@ -240,9 +240,9 @@ An example usage for `arista.avd.encrypt` filter for OSPF is to use it in conjun
       - name: Ethernet1:
         ospf_authentication: message-digest
         ospf_message_digest_keys:
-          1:
+          - id: 1
             hash_algorithm: md5
-            key: "{{ ospf_vault_password | arista.avd.encrypt(passwd_type='ospf', key='Ethernet1', hash_algorithm='md5', key_id='1') }}"
+            key: "{{ ospf_vault_password | arista.avd.encrypt(passwd_type='ospf_message_digest', key='Ethernet1', hash_algorithm='md5', key_id='1') }}"
     ```
 
 ## Plugin Tests

--- a/ansible_collections/arista/avd/plugins/filter/password.py
+++ b/ansible_collections/arista/avd/plugins/filter/password.py
@@ -1,6 +1,7 @@
 """
 Encrypt / Decrypt filters
 """
+from __future__ import annotations
 
 from ansible_collections.arista.avd.plugins.plugin_utils.errors import AristaAvdError, AristaAvdMissingVariableError
 from ansible_collections.arista.avd.plugins.plugin_utils.password_utils import cbc_decrypt, cbc_encrypt

--- a/ansible_collections/arista/avd/plugins/filter/password.py
+++ b/ansible_collections/arista/avd/plugins/filter/password.py
@@ -7,79 +7,116 @@ from ansible_collections.arista.avd.plugins.plugin_utils.errors import AristaAvd
 from ansible_collections.arista.avd.plugins.plugin_utils.password_utils import cbc_decrypt, cbc_encrypt
 
 
-##############
-# OSPF
-##############
-def ospf_encrypt(password: str, key: str, auth_algo: str | None = None, key_id: str | None = None) -> str:
+def _validate_password_and_key(password: str, key: str) -> None:
     """
-    Encrypt a password.
+    Validates the password and key values
 
-    <key> should be the interface name e.g. "Ethernet1"
-
-    The key is transformed to either::
-        <key>_passwd for simple authentication
-    or
-        <key>_<auth_algo>Key_<key_id> for message digest keys
-
-    Returns the encrypted password as a string
+    Raises AristaAvdMissingVariableError if one is missinge
+    Raises AristaAvdError if Password is not a string
     """
     if not key:
-        raise AristaAvdMissingVariableError("Key is required for OSPF encryption")
+        raise AristaAvdMissingVariableError("Key is required for encryption")
 
     if not password:
-        raise AristaAvdMissingVariableError("Password is required for OSPF encryption")
+        raise AristaAvdMissingVariableError("Password is required for encryption")
 
     if not isinstance(password, str):
         raise AristaAvdError(f"Password MUST be of type 'str' but is of type {type(password)}")
 
-    data = bytes(password, encoding="UTF-8")
 
-    if auth_algo is not None and key_id is not None:
-        # message digest authentication
-        key_b = bytes(f"{key}_{auth_algo}Key_{key_id}", encoding="UTF-8")
-    elif auth_algo is not None or key_id is not None:
-        raise AristaAvdError("For OSPF message digest keys, both auth_algo and key_id are required")
-    else:
-        # None set - assumes simple authentication
-        key_b = bytes(f"{key}_passwd", encoding="UTF-8")
+##############
+# OSPF
+##############
+def ospf_simple_encrypt(password: str, key: str) -> str:
+    """
+    Encrypt a password for OSPF simple authentication
+
+    <key> should be the interface name e.g. "Ethernet1"
+
+    The key is transformed to : <key>_passwd for simple authentication
+
+    Returns the encrypted password as a string
+    """
+    _validate_password_and_key(password, key)
+
+    data = bytes(password, encoding="UTF-8")
+    key_b = bytes(f"{key}_passwd", encoding="UTF-8")
 
     return cbc_encrypt(key_b, data).decode()
 
 
-def ospf_decrypt(password: str, key: str, auth_algo: str | None = None, key_id: str | None = None) -> str:
+def ospf_simple_decrypt(password: str, key: str) -> str:
     """
-    Decrypt a password.
+    Decrypt a password for OSPF simple authentication
 
     <key> should be the interface name e.g. "Ethernet1"
 
-    The key is transformed to either::
-        <key>_passwd for simple authentication
-    or
-        <key>_<auth_algo>Key_<key_id> for message digest keys
+    The key is transformed to either: <key>_passwd for simple authentication
 
     Returns the decrypted password as a string
 
     Raises AristaAvdError is decryption fails
     """
-    if not key:
-        raise AristaAvdMissingVariableError("Key is required for OSPF decryption")
-
-    if not password:
-        raise AristaAvdMissingVariableError("Password is required for OSPF decryption")
-
-    if not isinstance(password, str):
-        raise AristaAvdError(f"Password MUST be of type 'str' but is of type {type(password)}")
+    _validate_password_and_key(password, key)
 
     data = bytes(password, encoding="UTF-8")
+    key_b = bytes(f"{key}_passwd", encoding="UTF-8")
 
-    if auth_algo is not None and key_id is not None:
-        # message digest authentication
-        key_b = bytes(f"{key}_{auth_algo}Key_{key_id}", encoding="UTF-8")
-    elif auth_algo is not None or key_id is not None:
-        raise AristaAvdError("For OSPF message digest keys, both auth_algo and key_id are required")
-    else:
-        # None set - assumes simple authentication
-        key_b = bytes(f"{key}_passwd", encoding="UTF-8")
+    try:
+        return cbc_decrypt(key_b, data).decode()
+    except Exception as exc:
+        raise AristaAvdError("OSPF password decryption failed - check the input parameters") from exc
+
+
+OSPF_MESSAGE_DIGEST_HASH_ALGORITHMS = ["md5", "sha1", "sha256", "sha384", "sha512"]
+
+
+def ospf_message_digest_encrypt(password: str, key: str, hash_algorithm: str | None = None, key_id: str | None = None) -> str:
+    """
+    Encrypt a password for Message Digest Keys
+
+    <key> should be the interface name e.g. "Ethernet1"
+    <hash_algorithm>  MUST be in  ["md5", "sha1", "sha256", "sha384", "sha512"]
+    <key_id> MUST be set
+
+    The key is transformed to either:: <key>_<hash_algorithm>Key_<key_id> for message digest keys
+
+    Returns the encrypted password as a string
+    """
+    _validate_password_and_key(password, key)
+    if hash_algorithm is None or key_id is None:
+        raise AristaAvdMissingVariableError("For OSPF message digest keys, both hash_algorithm and key_id are required")
+    if hash_algorithm not in OSPF_MESSAGE_DIGEST_HASH_ALGORITHMS:
+        raise AristaAvdError(f"For OSPF message digest keys, `hash_algorithm` must be in {OSPF_MESSAGE_DIGEST_HASH_ALGORITHMS}")
+
+    data = bytes(password, encoding="UTF-8")
+    key_b = bytes(f"{key}_{hash_algorithm}Key_{key_id}", encoding="UTF-8")
+
+    return cbc_encrypt(key_b, data).decode()
+
+
+def ospf_message_digest_decrypt(password: str, key: str, hash_algorithm: str | None = None, key_id: str | None = None) -> str:
+    """
+    Decrypt a password for Message Digest Keys
+
+    <key> should be the interface name e.g. "Ethernet1"
+    <hash_algorithm>  MUST be in  ["md5", "sha1", "sha256", "sha384", "sha512"]
+    <key_id> MUST be set
+
+    The key is transformed to either:: <key>_<hash_algorithm>Key_<key_id> for message digest keys
+
+    Returns the decrypted password as a string
+
+    Raises AristaAvdError is decryption fails
+    """
+    _validate_password_and_key(password, key)
+    if hash_algorithm is None or key_id is None:
+        raise AristaAvdMissingVariableError("For OSPF message digest keys, both hash_algorithm and key_id are required")
+    if hash_algorithm not in OSPF_MESSAGE_DIGEST_HASH_ALGORITHMS:
+        raise AristaAvdError(f"For OSPF message digest keys, `hash_algorithm` must be in {OSPF_MESSAGE_DIGEST_HASH_ALGORITHMS}")
+
+    data = bytes(password, encoding="UTF-8")
+    key_b = bytes(f"{key}_{hash_algorithm}Key_{key_id}", encoding="UTF-8")
 
     try:
         return cbc_decrypt(key_b, data).decode()
@@ -96,14 +133,7 @@ def bgp_encrypt(password: str, key) -> str:
 
     Returns the encrypted password as a string
     """
-    if not key:
-        raise AristaAvdMissingVariableError("Key is required for BGP encryption")
-
-    if not password:
-        raise AristaAvdMissingVariableError("Password is required for BGP encryption")
-
-    if not isinstance(password, str):
-        raise AristaAvdError(f"Password MUST be of type 'str' but is of type {type(password)}")
+    _validate_password_and_key(password, key)
 
     data = bytes(password, encoding="UTF-8")
     key = bytes(f"{key}_passwd", encoding="UTF-8")
@@ -119,14 +149,7 @@ def bgp_decrypt(password: str, key) -> str:
 
     Raises AristaAvdError is decryption fails
     """
-    if not key:
-        raise AristaAvdMissingVariableError("Key is required for BGP decryption")
-
-    if not password:
-        raise AristaAvdMissingVariableError("Password is required for BGP decryption")
-
-    if not isinstance(password, str):
-        raise AristaAvdError(f"Password MUST be of type 'str' but is of type {type(password)}")
+    _validate_password_and_key(password, key)
 
     data = bytes(password, encoding="UTF-8")
     key = bytes(f"{key}_passwd", encoding="UTF-8")
@@ -142,7 +165,8 @@ def bgp_decrypt(password: str, key) -> str:
 ##############
 METHODS_DIR = {
     "bgp": (bgp_encrypt, bgp_decrypt),
-    "ospf": (ospf_encrypt, ospf_decrypt),
+    "ospf_simple": (ospf_simple_encrypt, ospf_simple_decrypt),
+    "ospf_message_digest": (ospf_message_digest_encrypt, ospf_message_digest_decrypt),
 }
 
 
@@ -155,7 +179,7 @@ def encrypt(value, passwd_type=None, key=None, **kwargs) -> str:
     try:
         encrypt_method = METHODS_DIR[passwd_type][0]
     except KeyError as exc:
-        raise AristaAvdError("Type {passwd_type} is not supported for the encrypt filter") from exc
+        raise AristaAvdError(f"Type {passwd_type} is not supported for the encrypt filter") from exc
     return encrypt_method(str(value), key=key, **kwargs)
 
 
@@ -168,7 +192,7 @@ def decrypt(value, passwd_type=None, key=None, **kwargs) -> str:
     try:
         decrypt_method = METHODS_DIR[passwd_type][1]
     except KeyError as exc:
-        raise AristaAvdError("Type {passwd_type} is not supported for the decrypt filter") from exc
+        raise AristaAvdError(f"Type {passwd_type} is not supported for the decrypt filter") from exc
     return decrypt_method(str(value), key=key, **kwargs)
 
 

--- a/ansible_collections/arista/avd/plugins/plugin_utils/password_utils.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/password_utils.py
@@ -3,7 +3,7 @@ This code original credit goes to Kristian Kohntopp @isotopp who authorized to r
 
 https://blog.koehntopp.info/2021/11/22/arista-type-7-passwords.html
 
-It is used in bgp_encrypt and bgp_decrypt filters as well as in bgp_valid_password test
+It is used  in the encrypt and decrypt filters
 """
 
 import base64
@@ -196,7 +196,8 @@ def cbc_decrypt(key: bytes, data: bytes) -> bytes:
     """
     Decrypt a password. The key is either <PEER_GROUP_NAME>_passwd or <NEIGHBOR_IP>_passwd
 
-    raises TODO
+    raises:
+      * ValueError: if the length of the provided data is not a multiple of the block length.
     """
     if not HAS_CRYPTOGRAPHY:
         raise AristaAvdError("AVD could not import the required 'cryptography' Python library")

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/data_model/Interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/data_model/Interfaces.md
@@ -116,11 +116,11 @@ search:
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ospf_area</samp>](## "ethernet_interfaces.[].ospf_area") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ospf_cost</samp>](## "ethernet_interfaces.[].ospf_cost") | Integer |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ospf_authentication</samp>](## "ethernet_interfaces.[].ospf_authentication") | String |  |  | Valid Values:<br>- none<br>- simple<br>- message-digest |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ospf_authentication_key</samp>](## "ethernet_interfaces.[].ospf_authentication_key") | String |  |  |  | Encrypted password |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ospf_authentication_key</samp>](## "ethernet_interfaces.[].ospf_authentication_key") | String |  |  |  | Encrypted password - only type 7 supported |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ospf_message_digest_keys</samp>](## "ethernet_interfaces.[].ospf_message_digest_keys") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- id</samp>](## "ethernet_interfaces.[].ospf_message_digest_keys.[].id") | Integer | Required, Unique |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hash_algorithm</samp>](## "ethernet_interfaces.[].ospf_message_digest_keys.[].hash_algorithm") | String |  |  | Valid Values:<br>- md5<br>- sha1<br>- sha256<br>- sha384<br>- sha512 |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "ethernet_interfaces.[].ospf_message_digest_keys.[].key") | String |  |  |  | Encrypted password |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "ethernet_interfaces.[].ospf_message_digest_keys.[].key") | String |  |  |  | Encrypted password - only type 7 supported |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;pim</samp>](## "ethernet_interfaces.[].pim") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4</samp>](## "ethernet_interfaces.[].pim.ipv4") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dr_priority</samp>](## "ethernet_interfaces.[].pim.ipv4.dr_priority") | Integer |  |  | Min: 0<br>Max: 429467295 |  |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -1945,7 +1945,7 @@
           },
           "ospf_authentication_key": {
             "type": "string",
-            "description": "Encrypted password",
+            "description": "Encrypted password - only type 7 supported",
             "title": "OSPF Authentication Key"
           },
           "ospf_message_digest_keys": {
@@ -1970,7 +1970,7 @@
                 },
                 "key": {
                   "type": "string",
-                  "description": "Encrypted password",
+                  "description": "Encrypted password - only type 7 supported",
                   "title": "Key"
                 }
               },

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -1505,7 +1505,7 @@ keys:
           - message-digest
         ospf_authentication_key:
           type: str
-          description: Encrypted password
+          description: Encrypted password - only type 7 supported
         ospf_message_digest_keys:
           type: list
           primary_key: id
@@ -1529,7 +1529,7 @@ keys:
                 - sha512
               key:
                 type: str
-                description: Encrypted password
+                description: Encrypted password - only type 7 supported
         pim:
           type: dict
           keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ethernet_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ethernet_interfaces.schema.yml
@@ -383,7 +383,7 @@ keys:
           valid_values: ["none", "simple", "message-digest"]
         ospf_authentication_key:
           type: str
-          description: Encrypted password
+          description: Encrypted password - only type 7 supported
         ospf_message_digest_keys:
           type: list
           primary_key: id
@@ -402,7 +402,7 @@ keys:
                 valid_values: ["md5", "sha1", "sha256", "sha384", "sha512"]
               key:
                 type: str
-                description: Encrypted password
+                description: Encrypted password - only type 7 supported
         pim:
           type: dict
           keys:

--- a/ansible_collections/arista/avd/tests/integration/targets/filter_password/tasks/main.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/filter_password/tasks/main.yml
@@ -11,7 +11,7 @@
 - name: Test Encrypt & Decrypt for OSPF passwords
   ansible.builtin.assert:
     that:
-      - "{{ ospf.clear_password | arista.avd.encrypt(passwd_type='ospf', key=ospf.interface_name) == ospf.expected_ospf_simple_auth_encrypted_password }}"
-      - "{{ ospf.clear_password | arista.avd.encrypt(passwd_type='ospf', key=ospf.interface_name, auth_algo=ospf.auth_algo, key_id=ospf.key_id) == ospf.expected_ospf_message_digest_encrypted_password }}"
-      - "{{ ospf.expected_ospf_simple_auth_encrypted_password | arista.avd.decrypt(passwd_type='ospf', key=ospf.interface_name) == ospf.clear_password }}"
-      - "{{ ospf.expected_ospf_message_digest_encrypted_password | arista.avd.decrypt(passwd_type='ospf', key=ospf.interface_name, auth_algo=ospf.auth_algo, key_id=ospf.key_id) == ospf.clear_password }}"
+      - "{{ ospf.clear_password | arista.avd.encrypt(passwd_type='ospf_simple', key=ospf.interface_name) == ospf.expected_ospf_simple_auth_encrypted_password }}"
+      - "{{ ospf.clear_password | arista.avd.encrypt(passwd_type='ospf_message_digest', key=ospf.interface_name, hash_algorithm=ospf.hash_algorithm, key_id=ospf.key_id) == ospf.expected_ospf_message_digest_encrypted_password }}"
+      - "{{ ospf.expected_ospf_simple_auth_encrypted_password | arista.avd.decrypt(passwd_type='ospf_simple', key=ospf.interface_name) == ospf.clear_password }}"
+      - "{{ ospf.expected_ospf_message_digest_encrypted_password | arista.avd.decrypt(passwd_type='ospf_message_digest', key=ospf.interface_name, hash_algorithm=ospf.hash_algorithm, key_id=ospf.key_id) == ospf.clear_password }}"

--- a/ansible_collections/arista/avd/tests/integration/targets/filter_password/tasks/main.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/filter_password/tasks/main.yml
@@ -2,8 +2,16 @@
 - name: Test Encrypt & Decrypt for BGP passwords
   ansible.builtin.assert:
     that:
-      - "{{ clear_password | arista.avd.encrypt(passwd_type='bgp', key=neighbor_ip) == neighbor_encrypted_password }}"
-      - "{{ clear_password | arista.avd.encrypt(passwd_type='bgp', key=peer_group) == peer_group_encrypted_password }}"
-      - "{{ non_string_clear_password | arista.avd.encrypt(passwd_type='bgp', key=peer_group) == expected_non_string_pg_encrypted_password }}"
-      - "{{ neighbor_encrypted_password | arista.avd.decrypt(passwd_type='bgp', key=neighbor_ip) == clear_password }}"
-      - "{{ peer_group_encrypted_password | arista.avd.decrypt(passwd_type='bgp', key=peer_group) == clear_password }}"
+      - "{{ bgp.clear_password | arista.avd.encrypt(passwd_type='bgp', key=bgp.neighbor_ip) == bgp.neighbor_encrypted_password }}"
+      - "{{ bgp.clear_password | arista.avd.encrypt(passwd_type='bgp', key=bgp.peer_group) == bgp.peer_group_encrypted_password }}"
+      - "{{ bgp.non_string_clear_password | arista.avd.encrypt(passwd_type='bgp', key=bgp.peer_group) == bgp.expected_non_string_pg_encrypted_password }}"
+      - "{{ bgp.neighbor_encrypted_password | arista.avd.decrypt(passwd_type='bgp', key=bgp.neighbor_ip) == bgp.clear_password }}"
+      - "{{ bgp.peer_group_encrypted_password | arista.avd.decrypt(passwd_type='bgp', key=bgp.peer_group) == bgp.clear_password }}"
+
+- name: Test Encrypt & Decrypt for OSPF passwords
+  ansible.builtin.assert:
+    that:
+      - "{{ ospf.clear_password | arista.avd.encrypt(passwd_type='ospf', key=ospf.interface_name) == ospf.expected_ospf_simple_auth_encrypted_password }}"
+      - "{{ ospf.clear_password | arista.avd.encrypt(passwd_type='ospf', key=ospf.interface_name, auth_algo=ospf.auth_algo, key_id=ospf.key_id) == ospf.expected_ospf_message_digest_encrypted_password }}"
+      - "{{ ospf.expected_ospf_simple_auth_encrypted_password | arista.avd.decrypt(passwd_type='ospf', key=ospf.interface_name) == ospf.clear_password }}"
+      - "{{ ospf.expected_ospf_message_digest_encrypted_password | arista.avd.decrypt(passwd_type='ospf', key=ospf.interface_name, auth_algo=ospf.auth_algo, key_id=ospf.key_id) == ospf.clear_password }}"

--- a/ansible_collections/arista/avd/tests/integration/targets/filter_password/vars/main.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/filter_password/vars/main.yml
@@ -16,5 +16,5 @@ ospf:
   expected_ospf_simple_auth_encrypted_password: CCWomIssEBxlSKwscoXVqw==
   # message digest keys value
   key_id: 42
-  auth_algo: sha384
+  hash_algorithm: sha384
   expected_ospf_message_digest_encrypted_password: kkUHfrLewxAxiqER3KUSFQ==

--- a/ansible_collections/arista/avd/tests/integration/targets/filter_password/vars/main.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/filter_password/vars/main.yml
@@ -1,8 +1,20 @@
 ---
-neighbor_ip: 42.42.42.42
-peer_group: AVD-TEST
-neighbor_encrypted_password: 3QGcqpU2YTwKh2jVQ4Vj/A==
-peer_group_encrypted_password: bM7t58t04qSqLHAfZR/Szg==
-clear_password: arista
-non_string_clear_password: 42
-expected_non_string_pg_encrypted_password: "njKpGaHRjn8="
+bgp:
+  neighbor_ip: 42.42.42.42
+  peer_group: AVD-TEST
+  neighbor_encrypted_password: 3QGcqpU2YTwKh2jVQ4Vj/A==
+  peer_group_encrypted_password: bM7t58t04qSqLHAfZR/Szg==
+  clear_password: arista
+  non_string_clear_password: 42
+  expected_non_string_pg_encrypted_password: "njKpGaHRjn8="
+
+ospf:
+  # common values
+  interface_name: Ethernet42
+  clear_password: arista
+  # simple authentication
+  expected_ospf_simple_auth_encrypted_password: CCWomIssEBxlSKwscoXVqw==
+  # message digest keys value
+  key_id: 42
+  auth_algo: sha384
+  expected_ospf_message_digest_encrypted_password: kkUHfrLewxAxiqER3KUSFQ==

--- a/ansible_collections/arista/avd/tests/unit/plugins/filter/test_password.py
+++ b/ansible_collections/arista/avd/tests/unit/plugins/filter/test_password.py
@@ -6,30 +6,30 @@ from contextlib import nullcontext as does_not_raise
 
 import pytest
 
-from ansible_collections.arista.avd.plugins.filter.password import FilterModule, bgp_decrypt, bgp_encrypt, decrypt, encrypt
+from ansible_collections.arista.avd.plugins.filter.password import FilterModule, bgp_decrypt, bgp_encrypt, decrypt, encrypt, ospf_decrypt, ospf_encrypt
 from ansible_collections.arista.avd.plugins.plugin_utils.errors import AristaAvdError, AristaAvdMissingVariableError
 
 ##########
 # BGP
 ##########
 
-INPUT_DICT_ENCRYPT_EXPECTED = [
+BGP_INPUT_DICT_ENCRYPT_EXPECTED = [
     ("42.42.42.42", "arista", "3QGcqpU2YTwKh2jVQ4Vj/A=="),
     ("AVD-TEST", "arista", "bM7t58t04qSqLHAfZR/Szg=="),
 ]
 # password used is "arista"
-VALID_INPUT_DICT_DECRYPT_EXPECTED = [
+BGP_VALID_INPUT_DICT_DECRYPT_EXPECTED = [
     ("42.42.42.42", "3QGcqpU2YTwKh2jVQ4Vj/A==", "arista"),
     ("AVD-TEST", "bM7t58t04qSqLHAfZR/Szg==", "arista"),
 ]
-INVALID_INPUT_DICT_DECRYPT = [
+BGP_INVALID_INPUT_DICT_DECRYPT = [
     ("10.42.42.43", "3QGcqpU2YTwKh2jVQ4Vj/A=="),
     ("AVD-TEST-DUMMY", "bM7t58t04qSqLHAfZR/Szg=="),
 ]
 # The following list uses all the molecule BGP passwords available
 # and the expected encryption
 # The password is always arista123
-MOLECULE_PASSWORDS_TEST = [
+BGP_MOLECULE_PASSWORDS_TEST = [
     ("UNDERLAY-PEERS", "arista123", "0nsCUm70mvSTxVO0ldytrg=="),
     ("UNDERLAY_PEERS", "arista123", "af6F4WLl4wUrWRZcwbEwkQ=="),
     ("123.1.1.10", "arista123", "oBztv71m2uhR7hh58/OCNA=="),
@@ -54,7 +54,7 @@ MOLECULE_PASSWORDS_TEST = [
 f = FilterModule()
 
 
-@pytest.mark.parametrize("key, password, expected", INPUT_DICT_ENCRYPT_EXPECTED)
+@pytest.mark.parametrize("key, password, expected", BGP_INPUT_DICT_ENCRYPT_EXPECTED)
 def test_bgp_encrypt(key, password, expected):
     """
     Test bgp_encrypt
@@ -62,7 +62,7 @@ def test_bgp_encrypt(key, password, expected):
     assert bgp_encrypt(password, key=key) == expected
 
 
-@pytest.mark.parametrize("key, password,, expected", VALID_INPUT_DICT_DECRYPT_EXPECTED)
+@pytest.mark.parametrize("key, password,, expected", BGP_VALID_INPUT_DICT_DECRYPT_EXPECTED)
 def test_bgp_decrypt_success(key, password, expected):
     """
     Test bgp_decrypt successful cases
@@ -70,7 +70,7 @@ def test_bgp_decrypt_success(key, password, expected):
     assert bgp_decrypt(password, key=key) == expected
 
 
-@pytest.mark.parametrize("key, password", INVALID_INPUT_DICT_DECRYPT)
+@pytest.mark.parametrize("key, password", BGP_INVALID_INPUT_DICT_DECRYPT)
 def test_bgp_decrypt_failure(key, password):
     """
     Test bgp_decrypt failure cases
@@ -79,7 +79,7 @@ def test_bgp_decrypt_failure(key, password):
         bgp_decrypt(password, key=key)
 
 
-@pytest.mark.parametrize("key, password, expected", MOLECULE_PASSWORDS_TEST)
+@pytest.mark.parametrize("key, password, expected", BGP_MOLECULE_PASSWORDS_TEST)
 def test_molecule_bgp_encrypt(key, password, expected):
     """
     Test bgp_encrypt
@@ -88,39 +88,101 @@ def test_molecule_bgp_encrypt(key, password, expected):
 
 
 ##########
+# OSPF
+##########
+OSPF_INPUT_DICT_ENCRYPT_EXPECTED = [
+    ("Ethernet1", "arista", None, None, "qCTcuwOSntAmLZaW2QjKcA=="),
+    ("Ethernet1", "arista", "md5", 42, "aPW9RqfXquTBASVDMYxSJw=="),
+    ("Ethernet1", "arista", "sha512", 66, "tDvJjUyf8///ktvy/xpfeQ=="),
+]
+# password used is "arista"
+OSPF_VALID_INPUT_DICT_DECRYPT_EXPECTED = [
+    ("Ethernet1", "qCTcuwOSntAmLZaW2QjKcA==", None, None, "arista"),
+    ("Ethernet1", "aPW9RqfXquTBASVDMYxSJw==", "md5", 42, "arista"),
+    ("Ethernet1", "tDvJjUyf8///ktvy/xpfeQ==", "sha512", 66, "arista"),
+]
+OSPF_INVALID_INPUT_DICT_DECRYPT = [
+    pytest.param("Ethernet1", "3QGcqpU2YTwKh2jVQ4Vj/A==", None, None, id="Wrong password simple auth"),
+    pytest.param("Ethernet1", "bM7t58t04qSqLHAfZR/Szg==", "sha512", 42, id="Wrong password message digest key"),
+    pytest.param("Ethernet1", "bM7t58t04qSqLHAfZR/Szg==", "sha512", None, id="Missing key id"),
+    pytest.param("Ethernet1", "bM7t58t04qSqLHAfZR/Szg==", None, 42, id="Missing auth_algo"),
+]
+# The following list uses all the molecule OSPF passwords available
+# and the expected encryption
+# The password is always arista123
+# TODO
+OSPF_MOLECULE_PASSWORDS_TEST = []
+
+
+@pytest.mark.parametrize("key, password, auth_algo, key_id, expected", OSPF_INPUT_DICT_ENCRYPT_EXPECTED)
+def test_ospf_encrypt(key, password, expected, auth_algo, key_id):
+    """
+    Test ospf_encrypt
+    """
+    assert ospf_encrypt(password, key=key, auth_algo=auth_algo, key_id=key_id) == expected
+
+
+@pytest.mark.parametrize("key, password, auth_algo, key_id, expected", OSPF_VALID_INPUT_DICT_DECRYPT_EXPECTED)
+def test_ospf_decrypt_success(key, password, auth_algo, key_id, expected):
+    """
+    Test ospf_decrypt successful cases
+    """
+    assert ospf_decrypt(password, key=key, auth_algo=auth_algo, key_id=key_id) == expected
+
+
+@pytest.mark.parametrize("key, password, auth_algo, key_id", OSPF_INVALID_INPUT_DICT_DECRYPT)
+def test_ospf_decrypt_failure(key, password, auth_algo, key_id):
+    """
+    Test ospf_decrypt failure cases
+    """
+    with pytest.raises(AristaAvdError):
+        ospf_decrypt(password, key=key, auth_algo=auth_algo, key_id=key_id)
+
+
+@pytest.mark.parametrize("key, password, auth_algo, key_id, expected", OSPF_MOLECULE_PASSWORDS_TEST)
+def test_molecule_ospf_encrypt(key, password, auth_algo, key_id, expected):
+    """
+    Test ospf_encrypt
+    """
+    assert ospf_encrypt(password, key=key, auth_algo=auth_algo, key_id=key_id) == expected
+
+
+##########
 # GENERIC
 ##########
 @pytest.mark.parametrize(
-    "password, passwd_type, key, expected_raise",
+    "password, passwd_type, key, kwargs, expected_raise",
     [
-        pytest.param("dummy", None, "dummy", pytest.raises(AristaAvdMissingVariableError), id="Missing Type"),
-        pytest.param("dummy", "ospf", "dummy", pytest.raises(AristaAvdError), id="Wrong Type"),
-        pytest.param("arista", "bgp", "42.42.42.42", does_not_raise(), id="Implemented Type"),
-        pytest.param(42, "bgp", "42.42.42.42", does_not_raise(), id="Password in not a string"),
+        pytest.param("dummy", None, "dummy", {}, pytest.raises(AristaAvdMissingVariableError), id="Missing Type"),
+        pytest.param("dummy", "eigrp", "dummy", {}, pytest.raises(AristaAvdError), id="Wrong Type"),
+        pytest.param(42, "bgp", "42.42.42.42", {}, does_not_raise(), id="Password is not a string"),
+        pytest.param("arista", "bgp", "42.42.42.42", {}, does_not_raise(), id="Implemented Type BPG"),
+        pytest.param("arista", "ospf", "Ethernet1", {"auth_algo": "sha512", "key_id": 66}, does_not_raise(), id="Implemented Type OSPF"),
     ],
 )
-def test_encrypt(password, passwd_type, key, expected_raise):
+def test_encrypt(password, passwd_type, key, kwargs, expected_raise):
     """
     Test encrypt method for non existing and existing type
     """
     with expected_raise:
-        encrypt(password, passwd_type=passwd_type, key=key)
+        encrypt(password, passwd_type=passwd_type, key=key, **kwargs)
 
 
 @pytest.mark.parametrize(
-    "password, passwd_type, key, expected_raise",
+    "password, passwd_type, key, kwargs, expected_raise",
     [
-        pytest.param("dummy", None, "dummy", pytest.raises(AristaAvdMissingVariableError), id="Missing Type"),
-        pytest.param("dummy", "ospf", "dummy", pytest.raises(AristaAvdError), id="Wrong Type"),
-        pytest.param("3QGcqpU2YTwKh2jVQ4Vj/A==", "bgp", "42.42.42.42", does_not_raise(), id="Implemented Type"),
+        pytest.param("dummy", None, "dummy", {}, pytest.raises(AristaAvdMissingVariableError), id="Missing Type"),
+        pytest.param("dummy", "eigrp", "dummy", {}, pytest.raises(AristaAvdError), id="Wrong Type"),
+        pytest.param("3QGcqpU2YTwKh2jVQ4Vj/A==", "bgp", "42.42.42.42", {}, does_not_raise(), id="Implemented Type BGP"),
+        pytest.param("tDvJjUyf8///ktvy/xpfeQ==", "ospf", "Ethernet1", {"auth_algo": "sha512", "key_id": 66}, does_not_raise(), id="Implemented Type OSPF"),
     ],
 )
-def test_decrypt(password, passwd_type, key, expected_raise):
+def test_decrypt(password, passwd_type, key, kwargs, expected_raise):
     """
     Test decrypt method for non existing and existing type
     """
     with expected_raise:
-        decrypt(password, passwd_type=passwd_type, key=key)
+        decrypt(password, passwd_type=passwd_type, key=key, **kwargs)
 
 
 def test_password_module():

--- a/ansible_collections/arista/avd/tests/unit/plugins/plugin_utils/test_password_utils.py
+++ b/ansible_collections/arista/avd/tests/unit/plugins/plugin_utils/test_password_utils.py
@@ -4,7 +4,7 @@ __metaclass__ = type
 
 import pytest
 
-from ansible_collections.arista.avd.plugins.plugin_utils.bgp_utils import cbc_check_password, cbc_decrypt, cbc_encrypt
+from ansible_collections.arista.avd.plugins.plugin_utils.password_utils import cbc_check_password, cbc_decrypt, cbc_encrypt
 
 # password used is "arista"
 VALID_PASSWORD_KEY_PAIRS = [("42.42.42.42", b"3QGcqpU2YTwKh2jVQ4Vj/A=="), ("AVD-TEST", b"bM7t58t04qSqLHAfZR/Szg==")]
@@ -27,6 +27,21 @@ def test_cbc_decrypt(key, password):
     """
     augmented_key = bytes(f"{key}_passwd", encoding="utf-8")
     assert cbc_decrypt(augmented_key, password) == b"arista"
+
+
+@pytest.mark.parametrize(
+    "key, password, expected_raise",
+    [
+        pytest.param("TOTO", b"3QGcqpU2YTwKh2jVQ4Vj/A==", ValueError, id="ValueError"),
+    ],
+)
+def test_cbc_decrypt_failure(key, password, expected_raise):
+    """
+    Valid cases for both neighbor IP and peer group name
+    """
+    augmented_key = bytes(f"{key}_passwd", encoding="utf-8")
+    with pytest.raises(expected_raise):
+        cbc_decrypt(augmented_key, password)
 
 
 @pytest.mark.parametrize("key, password", VALID_PASSWORD_KEY_PAIRS)


### PR DESCRIPTION
## Change Summary

Add OSPF pasword type 7 to encrypt/decrypt filters leveraging knowledge from this article:
https://medium.com/@what_if/encrypting-decrypting-arista-bgp-bmp-ospf-passwords-ff2072460942

## Component(s) name

`arista.avd.plugins`

## Proposed changes

Adding support for OSPF type in the plugins leveraging existing code

## How to test

ansible unit tests and integration tests added

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
