### PR TITLE
Fix(eos_designs): Handle overlapping vlan numbers with filter.only_in_use and trunkgroups

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/TRUNK_GROUP_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/TRUNK_GROUP_TESTS.yml
@@ -66,6 +66,27 @@ tenants:
         name: l2vlan399_without_trunk_groups
         tags: [ TRUNK_GROUP_TESTS_L3LEAF1, TRUNK_GROUP_TESTS_L2LEAF1 ]
 
+  - name: TENANT_WITH_DUPLICATE_VLANS
+    # Extra tenant with duplicate vlan numbers.
+    # This is to verify that "filter.only_vlans_in_use" properly filter on trunk_groups when there might be overlapping vlan numbers.
+    # Since "filter.only_vlans_in_use" are only configured on some devices, we have to filter this tenant away on the remaning switches.
+    # If not, there will be a duplicate vlan error (tested and verified offline).
+    # So in the end the vlans here are not configured anywhere, but will trigger duplicate checks if filtering is not implemented properly on trunk groups
+    mac_vrf_vni_base: 20000
+    vrfs:
+      - name: DUPLICATE_TG_200
+        vrf_vni: 200
+        svis:
+          - id: 200
+            name: duplicate svi200_with_trunk_groups not in use. Should not get configured anywhere
+            enabled: True
+            ip_address_virtual: 10.22.0.1/24
+            trunk_groups: [ TG_NOT_MATCHING_ANY_SERVERS ]
+    l2vlans:
+      - id: 210
+        name: duplicate l2vlan210_with_trunk_groups not in use. Should not get configured anywhere
+        trunk_groups: [ TG_NOT_MATCHING_ANY_SERVERS ]
+
 servers:
   server_with_tg_100:
     adapters:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/TRUNK_GROUP_TESTS_L2LEAF.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/TRUNK_GROUP_TESTS_L2LEAF.yml
@@ -14,6 +14,8 @@ l2leaf:
     TRUNK_GROUP_TESTS_L2LEAF1:
       filter:
         tags: []
+        # Since this group does not have filter.only_vlans_in_use, we have to avoid the TENANT_WITH_DUPLICATE_VLANS tenant.
+        tenants: [TRUNK_GROUP_TESTS]
       nodes:
         trunk-group-tests-l2leaf1a:
           id: 1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/TRUNK_GROUP_TESTS_L3LEAF.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/TRUNK_GROUP_TESTS_L3LEAF.yml
@@ -17,6 +17,8 @@ l3leaf:
     TRUNK_GROUP_TESTS_L3LEAF1:
       filter:
         tags: []
+        # Since this group does not have filter.only_vlans_in_use, we have to avoid the TENANT_WITH_DUPLICATE_VLANS tenant.
+        tenants: [TRUNK_GROUP_TESTS]
       nodes:
         trunk-group-tests-l3leaf1a:
           id: 1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/filter.only_vlans_in_use.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/filter.only_vlans_in_use.yml
@@ -26,6 +26,8 @@ tenants:
           2:
             name: vlan2
             ip_address_virtual: 10.10.10.1/24
+          4:
+            name: this_svi_will_not_be_configured_because_it_is_not_in_use
     l2vlans:
       1:
         name: vlan1

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/utils.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/utils.py
@@ -4,6 +4,7 @@ import ipaddress
 from functools import cached_property
 
 from ansible_collections.arista.avd.plugins.filter.natural_sort import natural_sort
+from ansible_collections.arista.avd.plugins.filter.range_expand import range_expand
 from ansible_collections.arista.avd.plugins.plugin_utils.errors import AristaAvdMissingVariableError
 from ansible_collections.arista.avd.plugins.plugin_utils.utils import default, get, get_item
 from ansible_collections.arista.avd.roles.eos_designs.python_modules.interface_descriptions import AvdInterfaceDescriptions
@@ -81,12 +82,27 @@ class UtilsMixin(UtilsFilteredTenantsMixin):
         return set(get(self._hostvars, "switch.endpoint_trunk_groups", default=[]))
 
     @cached_property
+    def _local_endpoint_trunk_groups(self) -> set:
+        return set(get(self._hostvars, "switch.local_endpoint_trunk_groups", default=[]))
+
+    @cached_property
+    def _filter_only_vlans_in_use(self) -> bool:
+        return get(self._hostvars, "switch.filter_only_vlans_in_use") is True
+
+    @cached_property
     def _only_local_vlan_trunk_groups(self) -> bool:
         return get(self._hostvars, "switch.only_local_vlan_trunk_groups") is True
 
     @cached_property
     def _enable_trunk_groups(self) -> bool:
         return get(self._hostvars, "switch.enable_trunk_groups") is True
+
+    @cached_property
+    def _endpoint_vlans(self) -> list:
+        endpoint_vlans = get(self._hostvars, "switch.endpoint_vlans", default="")
+        if not endpoint_vlans:
+            return []
+        return [int(id) for id in range_expand(endpoint_vlans)]
 
     @cached_property
     def _underlay_rfc5549(self) -> bool:

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/utils_filtered_tenants.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/utils_filtered_tenants.py
@@ -59,7 +59,7 @@ class UtilsFilteredTenantsMixin(object):
     def _is_accepted_vlan(self, vlan: dict) -> bool:
         """
         Check if vlan is in accepted_vlans list
-        If filter.only_vlans_in_use also check if vlan id or trunk group is assigned to connected endpoint
+        If filter.only_vlans_in_use is True also check if vlan id or trunk group is assigned to connected endpoint
         """
         vlan_id = int(vlan["id"])
 

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/vlans.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/vlans.py
@@ -91,7 +91,7 @@ class VlansMixin(UtilsMixin):
         if self._enable_trunk_groups:
             trunk_groups = vlan.get("trunk_groups", [])
             if self._only_local_vlan_trunk_groups:
-                trunk_groups = list(self._endpoint_trunk_groups.intersection(trunk_groups))
+                trunk_groups = list(self._local_endpoint_trunk_groups.intersection(trunk_groups))
             if self._mlag:
                 trunk_groups.append(self._trunk_groups_mlag_name)
             if self._uplink_type == "port-channel":


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Handle overlapping vlan numbers with filter.only_vlans_in_use and trunkgroups

## Related Issue(s)

Issue seen in deployment, where duplicate vlans were erroneously configured because the matching on trunk groups was done too lazy (converting to vlan numbers and thereby loosing information about trunk group)

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

Refactor vlan filtering to address corner cases
- Set list of trunk groups as fact so filtering can be done on trunk groups in network_services code
- Split `endpoint_vlans` and `endpoint_trunk_groups` into separate properties for local, mlag and downstream switches.
- Use sets instead of converting back and forth in internal functions.
- Various optimizations.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

First commit in this PR adds a molecule example of the issue. This is a snip from the output  with only that commit:
```sh
TASK [arista.avd.eos_designs : Generate device configuration in structured format] ***
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ansible_collections.arista.avd.plugins.plugin_utils.errors.errors.AristaAvdError: Duplicate VLAN ID '200' found in Tenant 'TRUNK_GROUP_TESTS' during configuration of SVI in VRF 'TG_200'. Other VLAN is in Tenant 'TENANT_WITH_DUPLICATE_VLANS'.
fatal: [trunk-group-tests-l2leaf4 -> localhost]: FAILED! => {"changed": false, "msg": "Duplicate VLAN ID '200' found in Tenant 'TRUNK_GROUP_TESTS' during configuration of SVI in VRF 'TG_200'. Other VLAN is in Tenant 'TENANT_WITH_DUPLICATE_VLANS'."}
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ansible_collections.arista.avd.plugins.plugin_utils.errors.errors.AristaAvdError: Duplicate VLAN ID '200' found in Tenant 'TRUNK_GROUP_TESTS' during configuration of SVI in VRF 'TG_200'. Other VLAN is in Tenant 'TENANT_WITH_DUPLICATE_VLANS'.
fatal: [trunk-group-tests-l3leaf2a -> localhost]: FAILED! => {"changed": false, "msg": "Duplicate VLAN ID '200' found in Tenant 'TRUNK_GROUP_TESTS' during configuration of SVI in VRF 'TG_200'. Other VLAN is in Tenant 'TENANT_WITH_DUPLICATE_VLANS'."}
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ansible_collections.arista.avd.plugins.plugin_utils.errors.errors.AristaAvdError: Duplicate VLAN ID '200' found in Tenant 'TRUNK_GROUP_TESTS' during configuration of SVI in VRF 'TG_200'. Other VLAN is in Tenant 'TENANT_WITH_DUPLICATE_VLANS'.
fatal: [trunk-group-tests-l3leaf2b -> localhost]: FAILED! => {"changed": false, "msg": "Duplicate VLAN ID '200' found in Tenant 'TRUNK_GROUP_TESTS' during configuration of SVI in VRF 'TG_200'. Other VLAN is in Tenant 'TENANT_WITH_DUPLICATE_VLANS'."}
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ansible_collections.arista.avd.plugins.plugin_utils.errors.errors.AristaAvdError: Duplicate VLAN ID '200' found in Tenant 'TRUNK_GROUP_TESTS' during configuration of SVI in VRF 'TG_200'. Other VLAN is in Tenant 'TENANT_WITH_DUPLICATE_VLANS'.
fatal: [trunk-group-tests-l2leaf3 -> localhost]: FAILED! => {"changed": false, "msg": "Duplicate VLAN ID '200' found in Tenant 'TRUNK_GROUP_TESTS' during configuration of SVI in VRF 'TG_200'. Other VLAN is in Tenant 'TENANT_WITH_DUPLICATE_VLANS'."}
```

The second commit contains the fix.

No configurations are changed as part of this fix/refactor.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been rebased from devel before I start
- [ ] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
