### PR TITLE
Fix(eos_cli_config_gen): Fix documentation template for flow tracking

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/flow-trackings.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/flow-trackings.j2
@@ -25,7 +25,7 @@ Sample: {{ flow_tracking.sample | arista.avd.default("default") }}
 {%                             do applied_on.append(ethernet_interface.name) %}
 {%                         endif %}
 {%                     endfor %}
-{%                     for port_channel_interface in port_channel_interfaces %}
+{%                     for port_channel_interface in port_channel_interfaces | arista.avd.default([]) %}
 {%                         if port_channel_interface.flow_tracker.sampled is arista.avd.defined(tracker.name) %}
 {%                             do applied_on.append(port_channel_interface.name) %}
 {%                         endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/flow-trackings.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/flow-trackings.j2
@@ -20,7 +20,7 @@ Sample: {{ flow_tracking.sample | arista.avd.default("default") }}
 {%                     set mpls = tracker.record_export.mpls | arista.avd.default("-") %}
 {%                     set count_exporter = tracker.exporters | arista.avd.default([]) | length %}
 {%                     set applied_on = [] %}
-{%                     for ethernet_interface in ethernet_interfaces %}
+{%                     for ethernet_interface in ethernet_interfaces | arista.avd.default([]) %}
 {%                         if ethernet_interface.flow_tracker.sampled is arista.avd.defined(tracker.name) %}
 {%                             do applied_on.append(ethernet_interface.name) %}
 {%                         endif %}


### PR DESCRIPTION
Fix issue where generation of flow tracking documentation for devics without port-channels was raising errors.

## Change Summary

Add `arsita.avd.default([])` to the loop to default to an empty list if `port_channel_interfaces` is not defined.

## Related Issue(s)

Fixes #2635

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Add `arsita.avd.default([])` to the loop to default to an empty list if `port_channel_interfaces` is not defined.

## How to test

To test, run eos_cli_config_gen on a structured config that has flow_trackings defined, but without having any port_channels.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
