### PR TITLE
Fix(plugins): update verify_requirements to use a color that is supported for logging

### DIFF
--- a/ansible_collections/arista/avd/plugins/action/verify_requirements.py
+++ b/ansible_collections/arista/avd/plugins/action/verify_requirements.py
@@ -314,7 +314,7 @@ class ActionModule(ActionBase):
 
         _get_running_collection_version(running_collection_name, info["ansible"])
 
-        display.display(f"AVD version {info['ansible']['collection']['version']}", color=C.COLOR_HIGHLIGHT)
+        display.display(f"AVD version {info['ansible']['collection']['version']}", color=C.COLOR_OK)
         if display.verbosity < 1:
             display.display("Use -v for details.")
 


### PR DESCRIPTION
C.COLOR_HIGHLIGHT is not supported when ansible is logging to file.

## Change Summary

When running eos_designs with ansible logging to file, an error is raised by `arista.avd.verify_requirements`.
The error is not raised if logging to file is not enabled. The root cause is that the ansible util `display` utility will try to convert the color into a log_level, and there is no mapping for `C.COLOR_HIGHLIGHT`. 

## Related Issue(s)

No issue had been raised yet.

## Component(s) name

`arista.avd.verify_requirements`

## Proposed changes
Use `C.COLOR_OK` , which will print as green on screen, and will be converted to log level info when writing to log file.


## How to test

Run `arista.avd.eos_designs` with a log file defined in `ansible.cfg` , example `log_path = ./logs.txt`.

Without this MR, running the above step would result in:
```
TASK [arista.avd.eos_designs : Verify Requirements] *****************************************************************************************************
AVD version 4.0.0-dev6
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/home/avd/.local/lib/python3.9/site-packages/ansible/utils/display.py", line 311, in display
    lvl = color_to_log_level[color]
KeyError: 'white'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.9/threading.py", line 980, in _bootstrap_inner
    self.run()
  File "/usr/local/lib/python3.9/threading.py", line 917, in run
    self._target(*self._args, **self._kwargs)
  File "/home/avd/.local/lib/python3.9/site-packages/ansible/plugins/strategy/__init__.py", line 118, in results_thread_main
    display.display(*result.args, **result.kwargs)
  File "/home/avd/.local/lib/python3.9/site-packages/ansible/utils/display.py", line 314, in display
    raise AnsibleAssertionError('Invalid color supplied to display: %s' % color)
ansible.errors.AnsibleAssertionError: Invalid color supplied to display: white

```

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
