### PR TITLE
Fix(eos_designs): Handle overlapping vlan numbers with filter.only_in_use and trunkgroups (#2628)

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/TRUNK_GROUP_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/TRUNK_GROUP_TESTS.yml
@@ -66,6 +66,27 @@ tenants:
         name: l2vlan399_without_trunk_groups
         tags: [ TRUNK_GROUP_TESTS_L3LEAF1, TRUNK_GROUP_TESTS_L2LEAF1 ]
 
+  - name: TENANT_WITH_DUPLICATE_VLANS
+    # Extra tenant with duplicate vlan numbers.
+    # This is to verify that "filter.only_vlans_in_use" properly filter on trunk_groups when there might be overlapping vlan numbers.
+    # Since "filter.only_vlans_in_use" are only configured on some devices, we have to filter this tenant away on the remaning switches.
+    # If not, there will be a duplicate vlan error (tested and verified offline).
+    # So in the end the vlans here are not configured anywhere, but will trigger duplicate checks if filtering is not implemented properly on trunk groups
+    mac_vrf_vni_base: 20000
+    vrfs:
+      - name: DUPLICATE_TG_200
+        vrf_vni: 200
+        svis:
+          - id: 200
+            name: duplicate svi200_with_trunk_groups not in use. Should not get configured anywhere
+            enabled: True
+            ip_address_virtual: 10.22.0.1/24
+            trunk_groups: [ TG_NOT_MATCHING_ANY_SERVERS ]
+    l2vlans:
+      - id: 210
+        name: duplicate l2vlan210_with_trunk_groups not in use. Should not get configured anywhere
+        trunk_groups: [ TG_NOT_MATCHING_ANY_SERVERS ]
+
 servers:
   server_with_tg_100:
     adapters:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/TRUNK_GROUP_TESTS_L2LEAF.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/TRUNK_GROUP_TESTS_L2LEAF.yml
@@ -14,6 +14,8 @@ l2leaf:
     TRUNK_GROUP_TESTS_L2LEAF1:
       filter:
         tags: []
+        # Since this group does not have filter.only_vlans_in_use, we have to avoid the TENANT_WITH_DUPLICATE_VLANS tenant.
+        tenants: [TRUNK_GROUP_TESTS]
       nodes:
         trunk-group-tests-l2leaf1a:
           id: 1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/TRUNK_GROUP_TESTS_L3LEAF.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/TRUNK_GROUP_TESTS_L3LEAF.yml
@@ -17,6 +17,8 @@ l3leaf:
     TRUNK_GROUP_TESTS_L3LEAF1:
       filter:
         tags: []
+        # Since this group does not have filter.only_vlans_in_use, we have to avoid the TENANT_WITH_DUPLICATE_VLANS tenant.
+        tenants: [TRUNK_GROUP_TESTS]
       nodes:
         trunk-group-tests-l3leaf1a:
           id: 1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/filter.only_vlans_in_use.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/filter.only_vlans_in_use.yml
@@ -26,6 +26,8 @@ tenants:
           2:
             name: vlan2
             ip_address_virtual: 10.10.10.1/24
+          4:
+            name: this_svi_will_not_be_configured_because_it_is_not_in_use
     l2vlans:
       1:
         name: vlan1

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_facts.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_facts.py
@@ -715,15 +715,15 @@ class EosDesignsFacts(AvdFacts):
         return None
 
     @cached_property
-    def _endpoint_vlans_and_trunk_groups(self):
+    def _local_endpoint_vlans_and_trunk_groups(self) -> tuple[set, set]:
         """
-        Return list of vlans and list of trunk groups used by connected_endpoints
+        Return list of vlans and list of trunk groups used by connected_endpoints on this switch
         """
         if not (self._any_network_services and self.connected_endpoints):
-            return [], []
+            return set(), set()
 
-        vlans = []
-        trunk_groups = []
+        vlans = set()
+        trunk_groups = set()
 
         port_profiles = get(self._hostvars, "port_profiles", default=[])
         # Support legacy data model by converting nested dict to list of dict
@@ -755,31 +755,31 @@ class EosDesignsFacts(AvdFacts):
                         continue
 
                     if "vlans" in adapter_settings and adapter_settings["vlans"] not in ["all", "", None]:
-                        vlans.extend(map(int, range_expand(str(adapter_settings["vlans"]))))
+                        vlans.update(map(int, range_expand(str(adapter_settings["vlans"]))))
                         if adapter_settings.get("trunk_groups"):
-                            trunk_groups.extend(adapter_settings["trunk_groups"])
+                            trunk_groups.update(adapter_settings["trunk_groups"])
                     elif "trunk" in adapter_settings.get("mode", ""):
                         if adapter_settings.get("trunk_groups"):
-                            trunk_groups.extend(adapter_settings["trunk_groups"])
+                            trunk_groups.update(adapter_settings["trunk_groups"])
                         else:
                             # No vlans or trunk_groups defined, but this is a trunk, so default is all vlans allowed
                             # No need to check further, since the list is now containing all vlans.
                             # The trunk group list may not be complete, but it will not matter, since we will
                             # configure all vlans anyway.
-                            return list(range(1, 4094)), trunk_groups
+                            return set(range(1, 4094)), trunk_groups
                     else:
                         # No vlans or mode defined so this is an access port with only vlan 1 allowed
-                        vlans.append(1)
+                        vlans.add(1)
 
                     if "native_vlan" in adapter_settings:
-                        vlans.append(int(adapter_settings["native_vlan"]))
+                        vlans.add(int(adapter_settings["native_vlan"]))
 
                     if get(adapter_settings, "port_channel.subinterfaces"):
                         for subinterface in get(adapter_settings, "port_channel.subinterfaces"):
                             if "vlan_id" in subinterface:
-                                vlans.append(int(subinterface["vlan_id"]))
+                                vlans.add(int(subinterface["vlan_id"]))
                             elif "number" in subinterface:
-                                vlans.append(int(subinterface["number"]))
+                                vlans.add(int(subinterface["number"]))
 
         network_ports = get(self._hostvars, "network_ports", default=[])
         for network_port_item in network_ports:
@@ -798,53 +798,143 @@ class EosDesignsFacts(AvdFacts):
                 adapter_settings = combine(parent_profile, adapter_profile, network_port_item, recursive=True, list_merge="replace")
 
                 if "vlans" in adapter_settings and adapter_settings["vlans"] not in ["all", "", None]:
-                    vlans.extend(map(int, range_expand(str(adapter_settings["vlans"]))))
+                    vlans.update(map(int, range_expand(str(adapter_settings["vlans"]))))
                     if adapter_settings.get("trunk_groups"):
-                        trunk_groups.extend(adapter_settings["trunk_groups"])
+                        trunk_groups.update(adapter_settings["trunk_groups"])
                 elif "trunk" in adapter_settings.get("mode", ""):
                     if adapter_settings.get("trunk_groups"):
-                        trunk_groups.extend(adapter_settings["trunk_groups"])
+                        trunk_groups.update(adapter_settings["trunk_groups"])
                     else:
                         # No vlans or trunk_groups defined, but this is a trunk, so default is all vlans allowed
                         # No need to check further, since the list is now containing all vlans.
                         # The trunk group list may not be complete, but it will not matter, since we will
                         # configure all vlans anyway.
-                        return list(range(1, 4094)), trunk_groups
+                        return set(range(1, 4094)), trunk_groups
                 else:
                     # No vlans or mode defined so this is an access port with only vlan 1 allowed
-                    vlans.append(1)
+                    vlans.add(1)
 
                 if "native_vlan" in adapter_settings:
-                    vlans.append(int(adapter_settings["native_vlan"]))
+                    vlans.add(int(adapter_settings["native_vlan"]))
 
                 if get(adapter_settings, "port_channel.subinterfaces"):
                     for subinterface in get(adapter_settings, "port_channel.subinterfaces"):
                         if "vlan_id" in subinterface:
-                            vlans.append(int(subinterface["vlan_id"]))
+                            vlans.add(int(subinterface["vlan_id"]))
                         elif "number" in subinterface:
-                            vlans.append(int(subinterface["number"]))
+                            vlans.add(int(subinterface["number"]))
 
-        # At this point "vlans" contain the full list of vlans used by locally connected endpoints
-        # Next we traverse any downstream L2 switches so ensure we can provide connectivity to any
-        # vlans used by them.
+        return vlans, trunk_groups
+
+    @cached_property
+    def _downstream_switch_endpoint_vlans_and_trunk_groups(self) -> tuple[set, set]:
+        """
+        Return set of vlans and set of trunk groups used by downstream switches.
+        Traverse any downstream L2 switches so ensure we can provide connectivity to any vlans / trunk groups used by them.
+        """
+        if not self._any_network_services:
+            return set(), set()
+
+        vlans = set()
+        trunk_groups = set()
         for fabric_switch in get(self._hostvars, "avd_switch_facts", default=[]):
             fabric_switch_facts: EosDesignsFacts = get(
                 self._hostvars, f"avd_switch_facts..{fabric_switch}..switch", required=True, separator="..", org_key=f"avd_switch_facts.{fabric_switch}.switch"
             )
             if fabric_switch_facts.uplink_type == "port-channel" and self.hostname in fabric_switch_facts.uplink_peers:
-                vlans.extend(fabric_switch_facts._vlans)
+                fabric_switch_endpoint_vlans, fabric_switch_endpoint_trunk_groups = fabric_switch_facts._endpoint_vlans_and_trunk_groups
+                vlans.update(fabric_switch_endpoint_vlans)
+                trunk_groups.update(fabric_switch_endpoint_trunk_groups)
 
-        return list(set(vlans)), list(set(trunk_groups))
+        return vlans, trunk_groups
 
     @cached_property
-    def endpoint_trunk_groups(self):
+    def _mlag_peer_endpoint_vlans_and_trunk_groups(self) -> tuple[set, set]:
         """
-        Return list of trunk_groups in use by endpoints connected to this switch
+        Return set of vlans and set of trunk groups used by connected_endpoints on the MLAG peer.
+        This could differ from local vlans and trunk groups if a connected endpoint is only connected to one leaf.
+        """
+        if not self.mlag:
+            return set(), set()
+
+        mlag_peer_facts: EosDesignsFacts = get(self._hostvars, f"avd_switch_facts..{self.mlag_peer}..switch", separator="..")
+        if not mlag_peer_facts:
+            return set(), set()
+
+        return mlag_peer_facts._endpoint_vlans_and_trunk_groups
+
+    @cached_property
+    def _endpoint_vlans_and_trunk_groups(self) -> tuple[set, set]:
+        """
+        Return set of vlans and set of trunk groups used by connected_endpoints on this switch,
+        downstream switches but NOT mlag peer (since we would have circular references then).
+        """
+        local_endpoint_vlans, local_endpoint_trunk_groups = self._local_endpoint_vlans_and_trunk_groups
+        downstream_switch_endpoint_vlans, downstream_switch_endpoint_trunk_groups = self._downstream_switch_endpoint_vlans_and_trunk_groups
+        return local_endpoint_vlans.union(downstream_switch_endpoint_vlans), local_endpoint_trunk_groups.union(downstream_switch_endpoint_trunk_groups)
+
+    @cached_property
+    def _endpoint_vlans(self) -> set[int]:
+        """
+        Return set of vlans in use by endpoints connected to this switch, downstream switches or MLAG peer.
+        Ex: {1, 20, 21, 22, 23} or set()
+        """
+        if not self.filter_only_vlans_in_use:
+            return set()
+
+        endpoint_vlans, endpoint_trunk_groups = self._endpoint_vlans_and_trunk_groups
+        if not self.mlag:
+            return endpoint_vlans
+
+        mlag_endpoint_vlans, mlag_endpoint_trunk_groups = self._mlag_peer_endpoint_vlans_and_trunk_groups
+        return endpoint_vlans.union(mlag_endpoint_vlans)
+
+    @cached_property
+    def endpoint_vlans(self) -> str | None:
+        """
+        Return compressed list of vlans in use by endpoints connected to this switch or MLAG peer.
+        Ex: "1,20-30" or ""
+        """
+        if self.filter_only_vlans_in_use:
+            return list_compress(list(self._endpoint_vlans))
+
+        return None
+
+    @cached_property
+    def _endpoint_trunk_groups(self) -> set[str]:
+        """
+        Return set of trunk_groups in use by endpoints connected to this switch, downstream switches or MLAG peer.
+        """
+        if not self.filter_only_vlans_in_use:
+            return set()
+
+        endpoint_vlans, endpoint_trunk_groups = self._endpoint_vlans_and_trunk_groups
+        if not self.mlag:
+            return endpoint_trunk_groups
+
+        mlag_endpoint_vlans, mlag_endpoint_trunk_groups = self._mlag_peer_endpoint_vlans_and_trunk_groups
+        return endpoint_trunk_groups.union(mlag_endpoint_trunk_groups)
+
+    @cached_property
+    def local_endpoint_trunk_groups(self) -> list[str]:
+        """
+        Return list of trunk_groups in use by endpoints connected to this switch only.
+        Used for only applying the trunk groups in config that are relevant on this device
+        This is a subset of endpoint_trunk_groups which is used for filtering.
         """
         if self.only_local_vlan_trunk_groups:
-            vlans_in_use, trunk_groups_in_use = self._endpoint_vlans_and_trunk_groups
-            return list(set(trunk_groups_in_use))
+            local_endpoint_vlans, local_endpoint_trunk_groups = self._local_endpoint_vlans_and_trunk_groups
+            return list(local_endpoint_trunk_groups)
+
         return []
+
+    @cached_property
+    def endpoint_trunk_groups(self) -> list[str]:
+        """
+        Return list of trunk_groups in use by endpoints connected to this switch, downstream switches or MLAG peer.
+        Used for filtering which vlans we configure on the device. This is a superset of local_endpoint_trunk_groups.
+        """
+        return list(self._endpoint_trunk_groups)
 
     @cached_property
     def _vlans(self):
@@ -862,17 +952,8 @@ class EosDesignsFacts(AvdFacts):
 
             if self.filter_only_vlans_in_use:
                 # Only include the vlans that are used by connected endpoints
-                vlans_in_use, trunk_groups_in_use = self._endpoint_vlans_and_trunk_groups
-                if self.mlag:
-                    # Make sure to also configure vlans used on the MLAG peer.
-                    # This could happen if a connected endpoint is only connected to one leaf.
-                    mlag_peer_facts: EosDesignsFacts = get(self._hostvars, f"avd_switch_facts..{self.mlag_peer}..switch", separator="..")
-                    if mlag_peer_facts:
-                        mlag_vlans_in_use, mlag_trunk_groups_in_use = mlag_peer_facts._endpoint_vlans_and_trunk_groups
-                        vlans_in_use.extend(mlag_vlans_in_use)
-                        trunk_groups_in_use.extend(mlag_trunk_groups_in_use)
-                vlans_in_use = set(vlans_in_use)
-                trunk_groups_in_use = set(trunk_groups_in_use)
+                endpoint_trunk_groups = self._endpoint_trunk_groups
+                endpoint_vlans = self._endpoint_vlans
 
             network_services_keys = get(self._hostvars, "network_services_keys", default=[])
             for network_services_key in natural_sort(network_services_keys, "name"):
@@ -901,11 +982,11 @@ class EosDesignsFacts(AvdFacts):
                             if "all" in match_tags or set(svi_tags).intersection(match_tags):
                                 if self.filter_only_vlans_in_use:
                                     # Check if vlan is in use
-                                    if int(svi["id"]) in vlans_in_use:
+                                    if int(svi["id"]) in endpoint_vlans:
                                         vlans.append(int(svi["id"]))
                                         continue
                                     # Check if vlan has a trunk group defined which is in use
-                                    if self.enable_trunk_groups and svi.get("trunk_groups") and trunk_groups_in_use.intersection(svi["trunk_groups"]):
+                                    if self.enable_trunk_groups and svi.get("trunk_groups") and endpoint_trunk_groups.intersection(svi["trunk_groups"]):
                                         vlans.append(int(svi["id"]))
                                         continue
                                     # Skip since the vlan is not in use
@@ -921,11 +1002,11 @@ class EosDesignsFacts(AvdFacts):
                         if "all" in match_tags or set(l2vlan_tags).intersection(match_tags):
                             if self.filter_only_vlans_in_use:
                                 # Check if vlan is in use
-                                if int(l2vlan["id"]) in vlans_in_use:
+                                if int(l2vlan["id"]) in endpoint_vlans:
                                     vlans.append(int(l2vlan["id"]))
                                     continue
                                 # Check if vlan has a trunk group defined which is in use
-                                if self.enable_trunk_groups and l2vlan.get("trunk_groups") and trunk_groups_in_use.intersection(l2vlan["trunk_groups"]):
+                                if self.enable_trunk_groups and l2vlan.get("trunk_groups") and endpoint_trunk_groups.intersection(l2vlan["trunk_groups"]):
                                     vlans.append(int(l2vlan["id"]))
                                     continue
                                 # Skip since the vlan is not in use

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/utils.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/utils.py
@@ -4,6 +4,7 @@ import ipaddress
 from functools import cached_property
 
 from ansible_collections.arista.avd.plugins.filter.natural_sort import natural_sort
+from ansible_collections.arista.avd.plugins.filter.range_expand import range_expand
 from ansible_collections.arista.avd.plugins.plugin_utils.errors import AristaAvdMissingVariableError
 from ansible_collections.arista.avd.plugins.plugin_utils.utils import default, get, get_item
 from ansible_collections.arista.avd.roles.eos_designs.python_modules.interface_descriptions import AvdInterfaceDescriptions
@@ -81,12 +82,27 @@ class UtilsMixin(UtilsFilteredTenantsMixin):
         return set(get(self._hostvars, "switch.endpoint_trunk_groups", default=[]))
 
     @cached_property
+    def _local_endpoint_trunk_groups(self) -> set:
+        return set(get(self._hostvars, "switch.local_endpoint_trunk_groups", default=[]))
+
+    @cached_property
+    def _filter_only_vlans_in_use(self) -> bool:
+        return get(self._hostvars, "switch.filter_only_vlans_in_use") is True
+
+    @cached_property
     def _only_local_vlan_trunk_groups(self) -> bool:
         return get(self._hostvars, "switch.only_local_vlan_trunk_groups") is True
 
     @cached_property
     def _enable_trunk_groups(self) -> bool:
         return get(self._hostvars, "switch.enable_trunk_groups") is True
+
+    @cached_property
+    def _endpoint_vlans(self) -> list:
+        endpoint_vlans = get(self._hostvars, "switch.endpoint_vlans", default="")
+        if not endpoint_vlans:
+            return []
+        return [int(id) for id in range_expand(endpoint_vlans)]
 
     @cached_property
     def _underlay_rfc5549(self) -> bool:

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/utils_filtered_tenants.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/utils_filtered_tenants.py
@@ -52,9 +52,31 @@ class UtilsFilteredTenantsMixin(object):
         l2vlans = [
             l2vlan
             for l2vlan in l2vlans
-            if (int(l2vlan["id"]) in self._accepted_vlans and ("all" in self._filter_tags or set(l2vlan.get("tags", ["all"])).intersection(self._filter_tags)))
+            if self._is_accepted_vlan(l2vlan) and ("all" in self._filter_tags or set(l2vlan.get("tags", ["all"])).intersection(self._filter_tags))
         ]
         return l2vlans
+
+    def _is_accepted_vlan(self, vlan: dict) -> bool:
+        """
+        Check if vlan is in accepted_vlans list
+        If filter.only_vlans_in_use is True also check if vlan id or trunk group is assigned to connected endpoint
+        """
+        vlan_id = int(vlan["id"])
+
+        if vlan_id not in self._accepted_vlans:
+            return False
+
+        if not self._filter_only_vlans_in_use:
+            # No further filtering
+            return True
+
+        if vlan_id in self._endpoint_vlans:
+            return True
+
+        if self._enable_trunk_groups and vlan.get("trunk_groups") and self._endpoint_trunk_groups.intersection(vlan["trunk_groups"]):
+            return True
+
+        return False
 
     @cached_property
     def _accepted_vlans(self) -> list[int]:
@@ -71,7 +93,6 @@ class UtilsFilteredTenantsMixin(object):
         if self._uplink_type != "port-channel":
             return accepted_vlans
 
-        uplink_switches = unique(get(self._hostvars, "switch.uplink_switches", default=[]))
         fabric_name = get(self._hostvars, "fabric_name", required=True)
         fabric_group = get(self._hostvars, f"groups.{fabric_name}", required=True)
         uplink_switches = unique(get(self._hostvars, "switch.uplink_switches", default=[]))
@@ -249,7 +270,7 @@ class UtilsFilteredTenantsMixin(object):
         filtered that on tags and trunk_groups.
         """
         svis: list[dict] = natural_sort(convert_dicts(vrf.get("svis", []), "id"), "id")
-        svis = [svi for svi in svis if int(svi["id"]) in self._accepted_vlans]
+        svis = [svi for svi in svis if self._is_accepted_vlan(svi)]
 
         # Handle svi_profile inheritance
         svis = [self._get_merged_svi_config(svi) for svi in svis]

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/vlans.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/vlans.py
@@ -80,7 +80,7 @@ class VlansMixin(UtilsMixin):
         if self._enable_trunk_groups:
             trunk_groups = vlan.get("trunk_groups", [])
             if self._only_local_vlan_trunk_groups:
-                trunk_groups = list(self._endpoint_trunk_groups.intersection(trunk_groups))
+                trunk_groups = list(self._local_endpoint_trunk_groups.intersection(trunk_groups))
             if self._mlag:
                 trunk_groups.append(self._trunk_groups_mlag_name)
             if self._uplink_type == "port-channel":


### PR DESCRIPTION
Cherry-pick of #2628 for 3.8.4 release