### PR TITLE
Feat(eos_designs): Add support for serial_number

### DIFF
--- a/ansible_collections/arista/avd/examples/campus-fabric/documentation/fabric/DC1_FABRIC-documentation.md
+++ b/ansible_collections/arista/avd/examples/campus-fabric/documentation/fabric/DC1_FABRIC-documentation.md
@@ -15,18 +15,18 @@
 
 ## Fabric Switches and Management IP
 
-| POD | Type | Node | Management IP | Platform | Provisioned in CloudVision |
-| --- | ---- | ---- | ------------- | -------- | -------------------------- |
-| DC1_FABRIC | leaf | LEAF1A | 172.100.100.103/24 | cEOSLab | Provisioned |
-| DC1_FABRIC | leaf | LEAF1B | 172.100.100.104/24 | cEOSLab | Provisioned |
-| DC1_FABRIC | leaf | LEAF2A | 172.100.100.105/24 | cEOSLab | Provisioned |
-| DC1_FABRIC | leaf | LEAF3A | 172.100.100.106/24 | cEOSLab | Provisioned |
-| DC1_FABRIC | leaf | LEAF3B | 172.100.100.107/24 | cEOSLab | Provisioned |
-| DC1_FABRIC | leaf | LEAF3C | 172.100.100.108/24 | cEOSLab | Provisioned |
-| DC1_FABRIC | leaf | LEAF3D | 172.100.100.109/24 | cEOSLab | Provisioned |
-| DC1_FABRIC | leaf | LEAF3E | 172.100.100.110/24 | cEOSLab | Provisioned |
-| DC1_FABRIC | l3spine | SPINE1 | 172.100.100.101/24 | cEOSLab | Provisioned |
-| DC1_FABRIC | l3spine | SPINE2 | 172.100.100.102/24 | cEOSLab | Provisioned |
+| POD | Type | Node | Management IP | Platform | Provisioned in CloudVision | Serial Number |
+| --- | ---- | ---- | ------------- | -------- | -------------------------- | ------------- |
+| DC1_FABRIC | leaf | LEAF1A | 172.100.100.103/24 | cEOSLab | Provisioned | - |
+| DC1_FABRIC | leaf | LEAF1B | 172.100.100.104/24 | cEOSLab | Provisioned | - |
+| DC1_FABRIC | leaf | LEAF2A | 172.100.100.105/24 | cEOSLab | Provisioned | - |
+| DC1_FABRIC | leaf | LEAF3A | 172.100.100.106/24 | cEOSLab | Provisioned | - |
+| DC1_FABRIC | leaf | LEAF3B | 172.100.100.107/24 | cEOSLab | Provisioned | - |
+| DC1_FABRIC | leaf | LEAF3C | 172.100.100.108/24 | cEOSLab | Provisioned | - |
+| DC1_FABRIC | leaf | LEAF3D | 172.100.100.109/24 | cEOSLab | Provisioned | - |
+| DC1_FABRIC | leaf | LEAF3E | 172.100.100.110/24 | cEOSLab | Provisioned | - |
+| DC1_FABRIC | l3spine | SPINE1 | 172.100.100.101/24 | cEOSLab | Provisioned | - |
+| DC1_FABRIC | l3spine | SPINE2 | 172.100.100.102/24 | cEOSLab | Provisioned | - |
 
 > Provision status is based on Ansible inventory declaration and do not represent real status from CloudVision.
 

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/fabric/FABRIC-documentation.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/fabric/FABRIC-documentation.md
@@ -15,24 +15,24 @@
 
 ## Fabric Switches and Management IP
 
-| POD | Type | Node | Management IP | Platform | Provisioned in CloudVision |
-| --- | ---- | ---- | ------------- | -------- | -------------------------- |
-| FABRIC | l3leaf | dc1-leaf1a | 172.16.1.101/24 | vEOS-lab | Provisioned |
-| FABRIC | l3leaf | dc1-leaf1b | 172.16.1.102/24 | vEOS-lab | Provisioned |
-| FABRIC | l2leaf | dc1-leaf1c | 172.16.1.151/24 | vEOS-lab | Provisioned |
-| FABRIC | l3leaf | dc1-leaf2a | 172.16.1.103/24 | vEOS-lab | Provisioned |
-| FABRIC | l3leaf | dc1-leaf2b | 172.16.1.104/24 | vEOS-lab | Provisioned |
-| FABRIC | l2leaf | dc1-leaf2c | 172.16.1.152/24 | vEOS-lab | Provisioned |
-| FABRIC | spine | dc1-spine1 | 172.16.1.11/24 | vEOS-lab | Provisioned |
-| FABRIC | spine | dc1-spine2 | 172.16.1.12/24 | vEOS-lab | Provisioned |
-| FABRIC | l3leaf | dc2-leaf1a | 172.16.2.201/24 | vEOS-lab | Provisioned |
-| FABRIC | l3leaf | dc2-leaf1b | 172.16.2.202/24 | vEOS-lab | Provisioned |
-| FABRIC | l2leaf | dc2-leaf1c | 172.16.2.251/24 | vEOS-lab | Provisioned |
-| FABRIC | l3leaf | dc2-leaf2a | 172.16.2.203/24 | vEOS-lab | Provisioned |
-| FABRIC | l3leaf | dc2-leaf2b | 172.16.2.204/24 | vEOS-lab | Provisioned |
-| FABRIC | l2leaf | dc2-leaf2c | 172.16.2.252/24 | vEOS-lab | Provisioned |
-| FABRIC | spine | dc2-spine1 | 172.16.2.21/24 | vEOS-lab | Provisioned |
-| FABRIC | spine | dc2-spine2 | 172.16.2.22/24 | vEOS-lab | Provisioned |
+| POD | Type | Node | Management IP | Platform | Provisioned in CloudVision | Serial Number |
+| --- | ---- | ---- | ------------- | -------- | -------------------------- | ------------- |
+| FABRIC | l3leaf | dc1-leaf1a | 172.16.1.101/24 | vEOS-lab | Provisioned | - |
+| FABRIC | l3leaf | dc1-leaf1b | 172.16.1.102/24 | vEOS-lab | Provisioned | - |
+| FABRIC | l2leaf | dc1-leaf1c | 172.16.1.151/24 | vEOS-lab | Provisioned | - |
+| FABRIC | l3leaf | dc1-leaf2a | 172.16.1.103/24 | vEOS-lab | Provisioned | - |
+| FABRIC | l3leaf | dc1-leaf2b | 172.16.1.104/24 | vEOS-lab | Provisioned | - |
+| FABRIC | l2leaf | dc1-leaf2c | 172.16.1.152/24 | vEOS-lab | Provisioned | - |
+| FABRIC | spine | dc1-spine1 | 172.16.1.11/24 | vEOS-lab | Provisioned | - |
+| FABRIC | spine | dc1-spine2 | 172.16.1.12/24 | vEOS-lab | Provisioned | - |
+| FABRIC | l3leaf | dc2-leaf1a | 172.16.2.201/24 | vEOS-lab | Provisioned | - |
+| FABRIC | l3leaf | dc2-leaf1b | 172.16.2.202/24 | vEOS-lab | Provisioned | - |
+| FABRIC | l2leaf | dc2-leaf1c | 172.16.2.251/24 | vEOS-lab | Provisioned | - |
+| FABRIC | l3leaf | dc2-leaf2a | 172.16.2.203/24 | vEOS-lab | Provisioned | - |
+| FABRIC | l3leaf | dc2-leaf2b | 172.16.2.204/24 | vEOS-lab | Provisioned | - |
+| FABRIC | l2leaf | dc2-leaf2c | 172.16.2.252/24 | vEOS-lab | Provisioned | - |
+| FABRIC | spine | dc2-spine1 | 172.16.2.21/24 | vEOS-lab | Provisioned | - |
+| FABRIC | spine | dc2-spine2 | 172.16.2.22/24 | vEOS-lab | Provisioned | - |
 
 > Provision status is based on Ansible inventory declaration and do not represent real status from CloudVision.
 

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/fabric/DC1_FABRIC-documentation.md
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/fabric/DC1_FABRIC-documentation.md
@@ -20,14 +20,14 @@
 
 ## Fabric Switches and Management IP
 
-| POD | Type | Node | Management IP | Platform | Provisioned in CloudVision |
-| --- | ---- | ---- | ------------- | -------- | -------------------------- |
-| DC1_FABRIC | leaf | LEAF1 | 172.100.100.105/24 | cEOS-LAB | Provisioned |
-| DC1_FABRIC | leaf | LEAF2 | 172.100.100.106/24 | cEOS-LAB | Provisioned |
-| DC1_FABRIC | leaf | LEAF3 | 172.100.100.107/24 | cEOS-LAB | Provisioned |
-| DC1_FABRIC | leaf | LEAF4 | 172.100.100.108/24 | cEOS-LAB | Provisioned |
-| DC1_FABRIC | spine | SPINE1 | 172.100.100.101/24 | cEOS-LAB | Provisioned |
-| DC1_FABRIC | spine | SPINE2 | 172.100.100.102/24 | cEOS-LAB | Provisioned |
+| POD | Type | Node | Management IP | Platform | Provisioned in CloudVision | Serial Number |
+| --- | ---- | ---- | ------------- | -------- | -------------------------- | ------------- |
+| DC1_FABRIC | leaf | LEAF1 | 172.100.100.105/24 | cEOS-LAB | Provisioned | - |
+| DC1_FABRIC | leaf | LEAF2 | 172.100.100.106/24 | cEOS-LAB | Provisioned | - |
+| DC1_FABRIC | leaf | LEAF3 | 172.100.100.107/24 | cEOS-LAB | Provisioned | - |
+| DC1_FABRIC | leaf | LEAF4 | 172.100.100.108/24 | cEOS-LAB | Provisioned | - |
+| DC1_FABRIC | spine | SPINE1 | 172.100.100.101/24 | cEOS-LAB | Provisioned | - |
+| DC1_FABRIC | spine | SPINE2 | 172.100.100.102/24 | cEOS-LAB | Provisioned | - |
 
 > Provision status is based on Ansible inventory declaration and do not represent real status from CloudVision.
 

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/fabric/FABRIC-documentation.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/fabric/FABRIC-documentation.md
@@ -15,16 +15,16 @@
 
 ## Fabric Switches and Management IP
 
-| POD | Type | Node | Management IP | Platform | Provisioned in CloudVision |
-| --- | ---- | ---- | ------------- | -------- | -------------------------- |
-| FABRIC | l3leaf | dc1-leaf1a | 172.16.1.101/24 | vEOS-lab | Provisioned |
-| FABRIC | l3leaf | dc1-leaf1b | 172.16.1.102/24 | vEOS-lab | Provisioned |
-| FABRIC | l2leaf | dc1-leaf1c | 172.16.1.151/24 | vEOS-lab | Provisioned |
-| FABRIC | l3leaf | dc1-leaf2a | 172.16.1.103/24 | vEOS-lab | Provisioned |
-| FABRIC | l3leaf | dc1-leaf2b | 172.16.1.104/24 | vEOS-lab | Provisioned |
-| FABRIC | l2leaf | dc1-leaf2c | 172.16.1.152/24 | vEOS-lab | Provisioned |
-| FABRIC | spine | dc1-spine1 | 172.16.1.11/24 | vEOS-lab | Provisioned |
-| FABRIC | spine | dc1-spine2 | 172.16.1.12/24 | vEOS-lab | Provisioned |
+| POD | Type | Node | Management IP | Platform | Provisioned in CloudVision | Serial Number |
+| --- | ---- | ---- | ------------- | -------- | -------------------------- | ------------- |
+| FABRIC | l3leaf | dc1-leaf1a | 172.16.1.101/24 | vEOS-lab | Provisioned | - |
+| FABRIC | l3leaf | dc1-leaf1b | 172.16.1.102/24 | vEOS-lab | Provisioned | - |
+| FABRIC | l2leaf | dc1-leaf1c | 172.16.1.151/24 | vEOS-lab | Provisioned | - |
+| FABRIC | l3leaf | dc1-leaf2a | 172.16.1.103/24 | vEOS-lab | Provisioned | - |
+| FABRIC | l3leaf | dc1-leaf2b | 172.16.1.104/24 | vEOS-lab | Provisioned | - |
+| FABRIC | l2leaf | dc1-leaf2c | 172.16.1.152/24 | vEOS-lab | Provisioned | - |
+| FABRIC | spine | dc1-spine1 | 172.16.1.11/24 | vEOS-lab | Provisioned | - |
+| FABRIC | spine | dc1-spine2 | 172.16.1.12/24 | vEOS-lab | Provisioned | - |
 
 > Provision status is based on Ansible inventory declaration and do not represent real status from CloudVision.
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/fabric/DC1_FABRIC-documentation.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/fabric/DC1_FABRIC-documentation.md
@@ -15,22 +15,22 @@
 
 ## Fabric Switches and Management IP
 
-| POD | Type | Node | Management IP | Platform | Provisioned in CloudVision |
-| --- | ---- | ---- | ------------- | -------- | -------------------------- |
-| DC1_FABRIC | l3leaf | DC1-BL1A | 192.168.200.110/24 | vEOS-LAB | Provisioned |
-| DC1_FABRIC | l3leaf | DC1-BL1B | 192.168.200.111/24 | vEOS-LAB | Provisioned |
-| DC1_FABRIC | l2leaf | DC1-L2LEAF1A | 192.168.200.112/24 | vEOS-LAB | Provisioned |
-| DC1_FABRIC | l2leaf | DC1-L2LEAF2A | 192.168.200.113/24 | vEOS-LAB | Provisioned |
-| DC1_FABRIC | l2leaf | DC1-L2LEAF2B | 192.168.200.114/24 | vEOS-LAB | Provisioned |
-| DC1_FABRIC | l3leaf | DC1-LEAF1A | 192.168.200.105/24 | vEOS-LAB | Provisioned |
-| DC1_FABRIC | l3leaf | DC1-LEAF2A | 192.168.200.106/24 | vEOS-LAB | Provisioned |
-| DC1_FABRIC | l3leaf | DC1-LEAF2B | 192.168.200.107/24 | vEOS-LAB | Provisioned |
-| DC1_FABRIC | spine | DC1-SPINE1 | 192.168.200.101/24 | vEOS-LAB | Provisioned |
-| DC1_FABRIC | spine | DC1-SPINE2 | 192.168.200.102/24 | vEOS-LAB | Provisioned |
-| DC1_FABRIC | spine | DC1-SPINE3 | 192.168.200.103/24 | vEOS-LAB | Provisioned |
-| DC1_FABRIC | spine | DC1-SPINE4 | 192.168.200.104/24 | vEOS-LAB | Provisioned |
-| DC1_FABRIC | l3leaf | DC1-SVC3A | 192.168.200.108/24 | vEOS-LAB | Not Available |
-| DC1_FABRIC | l3leaf | DC1-SVC3B | 192.168.200.109/24 | vEOS-LAB | Not Available |
+| POD | Type | Node | Management IP | Platform | Provisioned in CloudVision | Serial Number |
+| --- | ---- | ---- | ------------- | -------- | -------------------------- | ------------- |
+| DC1_FABRIC | l3leaf | DC1-BL1A | 192.168.200.110/24 | vEOS-LAB | Provisioned | - |
+| DC1_FABRIC | l3leaf | DC1-BL1B | 192.168.200.111/24 | vEOS-LAB | Provisioned | - |
+| DC1_FABRIC | l2leaf | DC1-L2LEAF1A | 192.168.200.112/24 | vEOS-LAB | Provisioned | - |
+| DC1_FABRIC | l2leaf | DC1-L2LEAF2A | 192.168.200.113/24 | vEOS-LAB | Provisioned | - |
+| DC1_FABRIC | l2leaf | DC1-L2LEAF2B | 192.168.200.114/24 | vEOS-LAB | Provisioned | - |
+| DC1_FABRIC | l3leaf | DC1-LEAF1A | 192.168.200.105/24 | vEOS-LAB | Provisioned | - |
+| DC1_FABRIC | l3leaf | DC1-LEAF2A | 192.168.200.106/24 | vEOS-LAB | Provisioned | - |
+| DC1_FABRIC | l3leaf | DC1-LEAF2B | 192.168.200.107/24 | vEOS-LAB | Provisioned | - |
+| DC1_FABRIC | spine | DC1-SPINE1 | 192.168.200.101/24 | vEOS-LAB | Provisioned | - |
+| DC1_FABRIC | spine | DC1-SPINE2 | 192.168.200.102/24 | vEOS-LAB | Provisioned | - |
+| DC1_FABRIC | spine | DC1-SPINE3 | 192.168.200.103/24 | vEOS-LAB | Provisioned | - |
+| DC1_FABRIC | spine | DC1-SPINE4 | 192.168.200.104/24 | vEOS-LAB | Provisioned | - |
+| DC1_FABRIC | l3leaf | DC1-SVC3A | 192.168.200.108/24 | vEOS-LAB | Not Available | - |
+| DC1_FABRIC | l3leaf | DC1-SVC3B | 192.168.200.109/24 | vEOS-LAB | Not Available | - |
 
 > Provision status is based on Ansible inventory declaration and do not represent real status from CloudVision.
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/fabric/L2LS-documentation.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/fabric/L2LS-documentation.md
@@ -15,22 +15,22 @@
 
 ## Fabric Switches and Management IP
 
-| POD | Type | Node | Management IP | Platform | Provisioned in CloudVision |
-| --- | ---- | ---- | ------------- | -------- | -------------------------- |
-| L2LS_BGP | leaf | BGP-LEAF1 | - | - | Provisioned |
-| L2LS_BGP | leaf | BGP-LEAF2 | - | - | Provisioned |
-| L2LS_BGP | l3spine | BGP-SPINE1 | - | - | Provisioned |
-| L2LS_BGP | l3spine | BGP-SPINE2 | - | - | Provisioned |
-| L2LS_ISIS | leaf | ISIS-LEAF1 | 192.168.200.105/24 | vEOS-LAB | Provisioned |
-| L2LS_ISIS | l3spine | ISIS-SPINE1 | 192.168.200.101/24 | vEOS-LAB | Provisioned |
-| L2LS_L2ONLY | leaf | L2ONLY-LEAF1 | - | - | Provisioned |
-| L2LS_L2ONLY | leaf | L2ONLY-LEAF2 | - | - | Provisioned |
-| L2LS_L2ONLY | spine | L2ONLY-SPINE1 | - | - | Provisioned |
-| L2LS_L2ONLY | spine | L2ONLY-SPINE2 | - | - | Provisioned |
-| L2LS_OSPF | leaf | OSPF-LEAF1 | - | - | Provisioned |
-| L2LS_OSPF | leaf | OSPF-LEAF2 | - | - | Provisioned |
-| L2LS_OSPF | l3spine | OSPF-SPINE1 | - | - | Provisioned |
-| L2LS_OSPF | l3spine | OSPF-SPINE2 | - | - | Provisioned |
+| POD | Type | Node | Management IP | Platform | Provisioned in CloudVision | Serial Number |
+| --- | ---- | ---- | ------------- | -------- | -------------------------- | ------------- |
+| L2LS_BGP | leaf | BGP-LEAF1 | - | - | Provisioned | - |
+| L2LS_BGP | leaf | BGP-LEAF2 | - | - | Provisioned | - |
+| L2LS_BGP | l3spine | BGP-SPINE1 | - | - | Provisioned | - |
+| L2LS_BGP | l3spine | BGP-SPINE2 | - | - | Provisioned | - |
+| L2LS_ISIS | leaf | ISIS-LEAF1 | 192.168.200.105/24 | vEOS-LAB | Provisioned | - |
+| L2LS_ISIS | l3spine | ISIS-SPINE1 | 192.168.200.101/24 | vEOS-LAB | Provisioned | - |
+| L2LS_L2ONLY | leaf | L2ONLY-LEAF1 | - | - | Provisioned | - |
+| L2LS_L2ONLY | leaf | L2ONLY-LEAF2 | - | - | Provisioned | - |
+| L2LS_L2ONLY | spine | L2ONLY-SPINE1 | - | - | Provisioned | - |
+| L2LS_L2ONLY | spine | L2ONLY-SPINE2 | - | - | Provisioned | - |
+| L2LS_OSPF | leaf | OSPF-LEAF1 | - | - | Provisioned | - |
+| L2LS_OSPF | leaf | OSPF-LEAF2 | - | - | Provisioned | - |
+| L2LS_OSPF | l3spine | OSPF-SPINE1 | - | - | Provisioned | - |
+| L2LS_OSPF | l3spine | OSPF-SPINE2 | - | - | Provisioned | - |
 
 > Provision status is based on Ansible inventory declaration and do not represent real status from CloudVision.
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/fabric/MPLS_CORE-documentation.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/fabric/MPLS_CORE-documentation.md
@@ -21,7 +21,7 @@
 | MPLS_CORE | pe | SITE1-LER1 | 192.168.200.105/24 | 7280SR3 | Provisioned | - |
 | MPLS_CORE | pe | SITE1-LER2 | 192.168.200.106/24 | 7280SR3 | Provisioned | - |
 | MPLS_CORE | p | SITE1-LSR1 | 192.168.200.101/24 | 7280SR | Provisioned | - |
-| MPLS_CORE | p | SITE1-LSR2 | 192.168.200.102/24 |7280SR | Provisioned | - |
+| MPLS_CORE | p | SITE1-LSR2 | 192.168.200.102/24 | 7280SR | Provisioned | - |
 | MPLS_CORE | rr | SITE1-RR1 | 10.30.30.108/24 | 7280SR3 | Provisioned | - |
 | MPLS_CORE | pe | SITE2-LER1 | 192.168.200.107/24 | 7280SR3 | Provisioned | - |
 | MPLS_CORE | p | SITE2-LSR1 | 192.168.200.103/24 | 7280SR | Provisioned | - |

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/fabric/MPLS_CORE-documentation.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/fabric/MPLS_CORE-documentation.md
@@ -16,18 +16,18 @@
 
 ## Fabric Switches and Management IP
 
-| POD | Type | Node | Management IP | Platform | Provisioned in CloudVision |
-| --- | ---- | ---- | ------------- | -------- | -------------------------- |
-| MPLS_CORE | pe | SITE1-LER1 | 192.168.200.105/24 | 7280SR3 | Provisioned |
-| MPLS_CORE | pe | SITE1-LER2 | 192.168.200.106/24 | 7280SR3 | Provisioned |
-| MPLS_CORE | p | SITE1-LSR1 | 192.168.200.101/24 | 7280SR | Provisioned |
-| MPLS_CORE | p | SITE1-LSR2 | 192.168.200.102/24 | 7280SR | Provisioned |
-| MPLS_CORE | rr | SITE1-RR1 | 10.30.30.108/24 | 7280SR3 | Provisioned |
-| MPLS_CORE | pe | SITE2-LER1 | 192.168.200.107/24 | 7280SR3 | Provisioned |
-| MPLS_CORE | p | SITE2-LSR1 | 192.168.200.103/24 | 7280SR | Provisioned |
-| MPLS_CORE | p | SITE2-LSR2 | 192.168.200.104/24 | 7280SR | Provisioned |
-| MPLS_CORE | rr | SITE2-RR1 | 10.30.30.109/24 | 7280SR3 | Provisioned |
-| MPLS_CORE | pe | SITE3-LER1 | 192.168.200.110/24 | 7280SR3 | Provisioned |
+| POD | Type | Node | Management IP | Platform | Provisioned in CloudVision | Serial Number |
+| --- | ---- | ---- | ------------- | -------- | -------------------------- | ------------- |
+| MPLS_CORE | pe | SITE1-LER1 | 192.168.200.105/24 | 7280SR3 | Provisioned | - |
+| MPLS_CORE | pe | SITE1-LER2 | 192.168.200.106/24 | 7280SR3 | Provisioned | - |
+| MPLS_CORE | p | SITE1-LSR1 | 192.168.200.101/24 | 7280SR | Provisioned | - |
+| MPLS_CORE | p | SITE1-LSR2 | 192.168.200.102/24 |7280SR | Provisioned | - |
+| MPLS_CORE | rr | SITE1-RR1 | 10.30.30.108/24 | 7280SR3 | Provisioned | - |
+| MPLS_CORE | pe | SITE2-LER1 | 192.168.200.107/24 | 7280SR3 | Provisioned | - |
+| MPLS_CORE | p | SITE2-LSR1 | 192.168.200.103/24 | 7280SR | Provisioned | - |
+| MPLS_CORE | p | SITE2-LSR2 | 192.168.200.104/24 | 7280SR | Provisioned | - |
+| MPLS_CORE | rr | SITE2-RR1 | 10.30.30.109/24 | 7280SR3 | Provisioned | - |
+| MPLS_CORE | pe | SITE3-LER1 | 192.168.200.110/24 | 7280SR3 | Provisioned | - |
 
 > Provision status is based on Ansible inventory declaration and do not represent real status from CloudVision.
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/fabric/TWODC_5STAGE_CLOS-documentation.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/fabric/TWODC_5STAGE_CLOS-documentation.md
@@ -19,33 +19,33 @@
 
 ## Fabric Switches and Management IP
 
-| POD | Type | Node | Management IP | Platform | Provisioned in CloudVision |
-| --- | ---- | ---- | ------------- | -------- | -------------------------- |
-| DC1_POD1 | l2leaf | DC1-POD1-L2LEAF1A | - | vEOS-LAB | Provisioned |
-| DC1_POD1 | l2leaf | DC1-POD1-L2LEAF2A | - | vEOS-LAB | Provisioned |
-| DC1_POD1 | l2leaf | DC1-POD1-L2LEAF2B | 192.168.1.12/24 | vEOS-LAB | Provisioned |
-| DC1_POD1 | l3leaf | DC1-POD1-LEAF1A | - | vEOS-LAB | Provisioned |
-| DC1_POD1 | l3leaf | DC1-POD1-LEAF2B | 192.168.1.9/16 | vEOS-LAB | Provisioned |
-| DC1_POD1 | spine | DC1-POD1-SPINE1 | - | vEOS-LAB | Provisioned |
-| DC1_POD1 | spine | DC1-POD1-SPINE2 | 192.168.1.6/24 | vEOS-LAB | Provisioned |
-| DC1_POD2 | l3leaf | DC1-POD2-LEAF1A | 192.168.1.15/24 | vEOS-LAB | Provisioned |
-| DC1_POD2 | spine | DC1-POD2-SPINE1 | 192.168.1.13/24 | vEOS-LAB | Provisioned |
-| DC1_POD2 | spine | DC1-POD2-SPINE2 | 192.168.1.14/24 | vEOS-LAB | Provisioned |
-| DC1 | overlay-controller | DC1-RS1 | - | vEOS-LAB | Provisioned |
-| DC1 | overlay-controller | DC1-RS2 | 192.168.1.4/24 | vEOS-LAB | Provisioned |
-| DC1 | super-spine | DC1-SUPER-SPINE1 | - | vEOS-LAB | Provisioned |
-| DC1 | super-spine | DC1-SUPER-SPINE2 | 192.168.1.2/24 | vEOS-LAB | Provisioned |
-| DC1_POD1 | l3leaf | DC1.POD1.LEAF2A | - | vEOS-LAB | Provisioned |
-| DC2_POD1 | l2leaf | DC2-POD1-L2LEAF1A | 192.168.1.23/24 | vEOS-LAB | Provisioned |
-| DC2_POD1 | l2leaf | DC2-POD1-L2LEAF2A | 192.168.1.25/24 | vEOS-LAB | Provisioned |
-| DC2_POD1 | l3leaf | DC2-POD1-LEAF1A | 192.168.1.22/24 | vEOS-LAB | Provisioned |
-| DC2_POD1 | l3leaf | DC2-POD1-LEAF2A | 192.168.1.24/24 | vEOS-LAB | Provisioned |
-| DC2_POD1 | spine | DC2-POD1-SPINE1 | 192.168.1.20/24 | vEOS-LAB | Provisioned |
-| DC2_POD1 | spine | DC2-POD1-SPINE2 | 192.168.1.21/24 | vEOS-LAB | Provisioned |
-| DC2 | overlay-controller | DC2-RS1 | 192.168.1.18/24 | vEOS-LAB | Provisioned |
-| DC2 | overlay-controller | DC2-RS2 | 192.168.1.19/24 | vEOS-LAB | Provisioned |
-| DC2 | super-spine | DC2-SUPER-SPINE1 | 192.168.1.16/24 | vEOS-LAB | Provisioned |
-| DC2 | super-spine | DC2-SUPER-SPINE2 | 192.168.1.17/24 | vEOS-LAB | Provisioned |
+| POD | Type | Node | Management IP | Platform | Provisioned in CloudVision | Serial Number |
+| --- | ---- | ---- | ------------- | -------- | -------------------------- | ------------- |
+| DC1_POD1 | l2leaf | DC1-POD1-L2LEAF1A | - | vEOS-LAB | Provisioned | - |
+| DC1_POD1 | l2leaf | DC1-POD1-L2LEAF2A | - | vEOS-LAB | Provisioned | - |
+| DC1_POD1 | l2leaf | DC1-POD1-L2LEAF2B | 192.168.1.12/24 | vEOS-LAB | Provisioned | - |
+| DC1_POD1 | l3leaf | DC1-POD1-LEAF1A | - | vEOS-LAB | Provisioned | - |
+| DC1_POD1 | l3leaf | DC1-POD1-LEAF2B | 192.168.1.9/16 | vEOS-LAB | Provisioned | - |
+| DC1_POD1 | spine | DC1-POD1-SPINE1 | - | vEOS-LAB | Provisioned | - |
+| DC1_POD1 | spine | DC1-POD1-SPINE2 | 192.168.1.6/24 | vEOS-LAB | Provisioned | DEADBEEFC0FFEE |
+| DC1_POD2 | l3leaf | DC1-POD2-LEAF1A | 192.168.1.15/24 | vEOS-LAB | Provisioned | - |
+| DC1_POD2 | spine | DC1-POD2-SPINE1 | 192.168.1.13/24 | vEOS-LAB | Provisioned | - |
+| DC1_POD2 | spine | DC1-POD2-SPINE2 | 192.168.1.14/24 | vEOS-LAB | Provisioned | - |
+| DC1 | overlay-controller | DC1-RS1 | - | vEOS-LAB | Provisioned | - |
+| DC1 | overlay-controller | DC1-RS2 | 192.168.1.4/24 | vEOS-LAB | Provisioned | - |
+| DC1 | super-spine | DC1-SUPER-SPINE1 | - | vEOS-LAB | Provisioned | - |
+| DC1 | super-spine | DC1-SUPER-SPINE2 | 192.168.1.2/24 | vEOS-LAB | Provisioned | - |
+| DC1_POD1 | l3leaf | DC1.POD1.LEAF2A | - | vEOS-LAB | Provisioned | - |
+| DC2_POD1 | l2leaf | DC2-POD1-L2LEAF1A | 192.168.1.23/24 | vEOS-LAB | Provisioned | - |
+| DC2_POD1 | l2leaf | DC2-POD1-L2LEAF2A | 192.168.1.25/24 | vEOS-LAB | Provisioned | - |
+| DC2_POD1 | l3leaf | DC2-POD1-LEAF1A | 192.168.1.22/24 | vEOS-LAB | Provisioned | - |
+| DC2_POD1 | l3leaf | DC2-POD1-LEAF2A | 192.168.1.24/24 | vEOS-LAB | Provisioned | - |
+| DC2_POD1 | spine | DC2-POD1-SPINE1 | 192.168.1.20/24 | vEOS-LAB | Provisioned | - |
+| DC2_POD1 | spine | DC2-POD1-SPINE2 | 192.168.1.21/24 | vEOS-LAB | Provisioned | - |
+| DC2 | overlay-controller | DC2-RS1 | 192.168.1.18/24 | vEOS-LAB | Provisioned | - |
+| DC2 | overlay-controller | DC2-RS2 | 192.168.1.19/24 | vEOS-LAB | Provisioned | - |
+| DC2 | super-spine | DC2-SUPER-SPINE1 | 192.168.1.16/24 | vEOS-LAB | Provisioned | - |
+| DC2 | super-spine | DC2-SUPER-SPINE2 | 192.168.1.17/24 | vEOS-LAB | Provisioned | - |
 
 > Provision status is based on Ansible inventory declaration and do not represent real status from CloudVision.
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-SPINE2.yml
@@ -1,3 +1,4 @@
+serial_number: DEADBEEFC0FFEE
 router_bgp:
   as: '65110.100'
   router_id: 172.16.110.2

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/inventory/group_vars/DC1_POD1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/inventory/group_vars/DC1_POD1.yml
@@ -38,6 +38,7 @@ spine:
       evpn_role: none
       mgmt_ip: 192.168.1.6/24
       uplink_switch_interfaces: ["Ethernet2", "Ethernet2"]
+      serial_number: "DEADBEEFC0FFEE"
 
 # In DC1 we define all variables on specific node / node_group
 l3leaf:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/SNMP_SYSTEM_MAC_ENGINEID_1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/SNMP_SYSTEM_MAC_ENGINEID_1.yml
@@ -1,3 +1,4 @@
+serial_number: A37383692F12C7DE733D9A9B8E2B37AE
 service_routing_protocols_model: multi-agent
 ip_routing: true
 vlan_internal_order:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/SNMP_SYSTEM_MAC_ENGINEID_1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/SNMP_SYSTEM_MAC_ENGINEID_1.yml
@@ -12,8 +12,10 @@ l2leaf:
     SNMP_SYSTEM_MAC_ENGINEID_1:
       id: 42
       system_mac_address: "42:42:42:42:42:42"
+      serial_number: A37383692F12C7DE733D9A9B8E2B37AE
 # This variable below won't have precedence
 system_mac_address: "66:66:66:66:66:66"
+serial_number: 66666666666666666666666666666666
 
 snmp_settings:
   contact: example@example.com

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/fabric/DC1_FABRIC-documentation.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/fabric/DC1_FABRIC-documentation.md
@@ -15,24 +15,24 @@
 
 ## Fabric Switches and Management IP
 
-| POD | Type | Node | Management IP | Platform | Provisioned in CloudVision |
-| --- | ---- | ---- | ------------- | -------- | -------------------------- |
-| DC1_FABRIC | l3leaf | DC1-BL1A | 192.168.200.110/24 | 7280R | Provisioned |
-| DC1_FABRIC | l3leaf | DC1-BL1B | 192.168.200.111/24 | 7280R | Provisioned |
-| DC1_FABRIC | l2leaf | DC1-L2LEAF1A | 192.168.200.112/24 | vEOS-LAB | Provisioned |
-| DC1_FABRIC | l2leaf | DC1-L2LEAF1B | 192.168.200.115/24 | vEOS-LAB | Provisioned |
-| DC1_FABRIC | l2leaf | DC1-L2LEAF2A | 192.168.200.113/24 | vEOS-LAB | Provisioned |
-| DC1_FABRIC | l2leaf | DC1-L2LEAF2B | 192.168.200.114/24 | vEOS-LAB | Provisioned |
-| DC1_FABRIC | l2leaf | DC1-L2LEAF3A | 192.168.200.116/24 | vEOS-LAB | Provisioned |
-| DC1_FABRIC | l3leaf | DC1-LEAF1A | 192.168.200.105/24 | 7050SX3 | Provisioned |
-| DC1_FABRIC | l3leaf | DC1-LEAF2A | 192.168.200.106/24 | 7280R | Provisioned |
-| DC1_FABRIC | l3leaf | DC1-LEAF2B | 192.168.200.107/24 | 7280R | Provisioned |
-| DC1_FABRIC | spine | DC1-SPINE1 | 192.168.200.101/24 | 7050SX3 | Provisioned |
-| DC1_FABRIC | spine | DC1-SPINE2 | 192.168.200.102/24 | 7050SX3 | Provisioned |
-| DC1_FABRIC | spine | DC1-SPINE3 | 192.168.200.103/24 | 7050SX3 | Provisioned |
-| DC1_FABRIC | spine | DC1-SPINE4 | 192.168.200.104/24 | 7050SX3 | Provisioned |
-| DC1_FABRIC | l3leaf | DC1-SVC3A | 192.168.200.108/24 | 7050SX3 | Provisioned |
-| DC1_FABRIC | l3leaf | DC1-SVC3B | 192.168.200.109/24 | 7050SX3 | Provisioned |
+| POD | Type | Node | Management IP | Platform | Provisioned in CloudVision | Serial Number |
+| --- | ---- | ---- | ------------- | -------- | -------------------------- | ------------- |
+| DC1_FABRIC | l3leaf | DC1-BL1A | 192.168.200.110/24 | 7280R | Provisioned | - |
+| DC1_FABRIC | l3leaf | DC1-BL1B | 192.168.200.111/24 | 7280R | Provisioned | - |
+| DC1_FABRIC | l2leaf | DC1-L2LEAF1A | 192.168.200.112/24 | vEOS-LAB | Provisioned | - |
+| DC1_FABRIC | l2leaf | DC1-L2LEAF1B | 192.168.200.115/24 | vEOS-LAB | Provisioned | - |
+| DC1_FABRIC | l2leaf | DC1-L2LEAF2A | 192.168.200.113/24 | vEOS-LAB | Provisioned | - |
+| DC1_FABRIC | l2leaf | DC1-L2LEAF2B | 192.168.200.114/24 | vEOS-LAB | Provisioned | - |
+| DC1_FABRIC | l2leaf | DC1-L2LEAF3A | 192.168.200.116/24 | vEOS-LAB | Provisioned | - |
+| DC1_FABRIC | l3leaf | DC1-LEAF1A | 192.168.200.105/24 | 7050SX3 | Provisioned | - |
+| DC1_FABRIC | l3leaf | DC1-LEAF2A | 192.168.200.106/24 | 7280R | Provisioned | - |
+| DC1_FABRIC | l3leaf | DC1-LEAF2B | 192.168.200.107/24 | 7280R | Provisioned | - |
+| DC1_FABRIC | spine | DC1-SPINE1 | 192.168.200.101/24 | 7050SX3 | Provisioned | - |
+| DC1_FABRIC | spine | DC1-SPINE2 | 192.168.200.102/24 | 7050SX3 | Provisioned | - |
+| DC1_FABRIC | spine | DC1-SPINE3 | 192.168.200.103/24 | 7050SX3 | Provisioned | - |
+| DC1_FABRIC | spine | DC1-SPINE4 | 192.168.200.104/24 | 7050SX3 | Provisioned | - |
+| DC1_FABRIC | l3leaf | DC1-SVC3A | 192.168.200.108/24 | 7050SX3 | Provisioned | - |
+| DC1_FABRIC | l3leaf | DC1-SVC3B | 192.168.200.109/24 | 7050SX3 | Provisioned | - |
 
 > Provision status is based on Ansible inventory declaration and do not represent real status from CloudVision.
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/fabric/DC1_FABRIC-documentation.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/fabric/DC1_FABRIC-documentation.md
@@ -16,22 +16,22 @@
 
 ## Fabric Switches and Management IP
 
-| POD | Type | Node | Management IP | Platform | Provisioned in CloudVision |
-| --- | ---- | ---- | ------------- | -------- | -------------------------- |
-| DC1_FABRIC | l3leaf | DC1-BL1A | 192.168.200.110/24 | vEOS-LAB | Provisioned |
-| DC1_FABRIC | l3leaf | DC1-BL1B | 192.168.200.111/24 | vEOS-LAB | Provisioned |
-| DC1_FABRIC | l2leaf | DC1-L2LEAF1A | 192.168.200.112/24 | vEOS-LAB | Provisioned |
-| DC1_FABRIC | l2leaf | DC1-L2LEAF2A | 192.168.200.113/24 | vEOS-LAB | Provisioned |
-| DC1_FABRIC | l2leaf | DC1-L2LEAF2B | 192.168.200.114/24 | vEOS-LAB | Provisioned |
-| DC1_FABRIC | l3leaf | DC1-LEAF1A | 192.168.200.105/24 | vEOS-LAB | Provisioned |
-| DC1_FABRIC | l3leaf | DC1-LEAF2A | 192.168.200.106/24 | vEOS-LAB | Provisioned |
-| DC1_FABRIC | l3leaf | DC1-LEAF2B | 192.168.200.107/24 | vEOS-LAB | Provisioned |
-| DC1_FABRIC | spine | DC1-SPINE1 | 192.168.200.101/24 | vEOS-LAB | Provisioned |
-| DC1_FABRIC | spine | DC1-SPINE2 | 192.168.200.102/24 | vEOS-LAB | Provisioned |
-| DC1_FABRIC | spine | DC1-SPINE3 | 192.168.200.103/24 | vEOS-LAB | Provisioned |
-| DC1_FABRIC | spine | DC1-SPINE4 | 192.168.200.104/24 | vEOS-LAB | Provisioned |
-| DC1_FABRIC | l3leaf | DC1-SVC3A | 192.168.200.108/24 | vEOS-LAB | Provisioned |
-| DC1_FABRIC | l3leaf | DC1-SVC3B | 192.168.200.109/24 | vEOS-LAB | Provisioned |
+| POD | Type | Node | Management IP | Platform | Provisioned in CloudVision | Serial Number |
+| --- | ---- | ---- | ------------- | -------- | -------------------------- | ------------- |
+| DC1_FABRIC | l3leaf | DC1-BL1A | 192.168.200.110/24 | vEOS-LAB | Provisioned | - |
+| DC1_FABRIC | l3leaf | DC1-BL1B | 192.168.200.111/24 | vEOS-LAB | Provisioned | - |
+| DC1_FABRIC | l2leaf | DC1-L2LEAF1A | 192.168.200.112/24 | vEOS-LAB | Provisioned | - |
+| DC1_FABRIC | l2leaf | DC1-L2LEAF2A | 192.168.200.113/24 | vEOS-LAB | Provisioned | - |
+| DC1_FABRIC | l2leaf | DC1-L2LEAF2B | 192.168.200.114/24 | vEOS-LAB | Provisioned | - |
+| DC1_FABRIC | l3leaf | DC1-LEAF1A | 192.168.200.105/24 | vEOS-LAB | Provisioned | - |
+| DC1_FABRIC | l3leaf | DC1-LEAF2A | 192.168.200.106/24 | vEOS-LAB | Provisioned | - |
+| DC1_FABRIC | l3leaf | DC1-LEAF2B | 192.168.200.107/24 | vEOS-LAB | Provisioned | - |
+| DC1_FABRIC | spine | DC1-SPINE1 | 192.168.200.101/24 | vEOS-LAB | Provisioned | - |
+| DC1_FABRIC | spine | DC1-SPINE2 | 192.168.200.102/24 | vEOS-LAB | Provisioned | - |
+| DC1_FABRIC | spine | DC1-SPINE3 | 192.168.200.103/24 | vEOS-LAB | Provisioned | - |
+| DC1_FABRIC | spine | DC1-SPINE4 | 192.168.200.104/24 | vEOS-LAB | Provisioned | - |
+| DC1_FABRIC | l3leaf | DC1-SVC3A | 192.168.200.108/24 | vEOS-LAB | Provisioned | - |
+| DC1_FABRIC | l3leaf | DC1-SVC3B | 192.168.200.109/24 | vEOS-LAB | Provisioned | - |
 
 > Provision status is based on Ansible inventory declaration and do not represent real status from CloudVision.
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/fabric/DC1_FABRIC-documentation.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/fabric/DC1_FABRIC-documentation.md
@@ -15,22 +15,22 @@
 
 ## Fabric Switches and Management IP
 
-| POD | Type | Node | Management IP | Platform | Provisioned in CloudVision |
-| --- | ---- | ---- | ------------- | -------- | -------------------------- |
-| DC1_FABRIC | l3leaf | DC1-BL1A | 192.168.200.110/24 | vEOS-LAB | Provisioned |
-| DC1_FABRIC | l3leaf | DC1-BL1B | 192.168.200.111/24 | vEOS-LAB | Provisioned |
-| DC1_FABRIC | l2leaf | DC1-L2LEAF1A | 192.168.200.112/24 | vEOS-LAB | Provisioned |
-| DC1_FABRIC | l2leaf | DC1-L2LEAF2A | 192.168.200.113/24 | vEOS-LAB | Provisioned |
-| DC1_FABRIC | l2leaf | DC1-L2LEAF2B | 192.168.200.114/24 | vEOS-LAB | Provisioned |
-| DC1_FABRIC | l3leaf | DC1-LEAF1A | 192.168.200.105/24 | vEOS-LAB | Provisioned |
-| DC1_FABRIC | l3leaf | DC1-LEAF2A | 192.168.200.106/24 | vEOS-LAB | Provisioned |
-| DC1_FABRIC | l3leaf | DC1-LEAF2B | 192.168.200.107/24 | vEOS-LAB | Provisioned |
-| DC1_FABRIC | spine | DC1-SPINE1 | 192.168.200.101/24 | vEOS-LAB | Provisioned |
-| DC1_FABRIC | spine | DC1-SPINE2 | 192.168.200.102/24 | vEOS-LAB | Provisioned |
-| DC1_FABRIC | spine | DC1-SPINE3 | 192.168.200.103/24 | vEOS-LAB | Provisioned |
-| DC1_FABRIC | spine | DC1-SPINE4 | 192.168.200.104/24 | vEOS-LAB | Provisioned |
-| DC1_FABRIC | l3leaf | DC1-SVC3A | 192.168.200.108/24 | vEOS-LAB | Provisioned |
-| DC1_FABRIC | l3leaf | DC1-SVC3B | 192.168.200.109/24 | vEOS-LAB | Provisioned |
+| POD | Type | Node | Management IP | Platform | Provisioned in CloudVision | Serial Number |
+| --- | ---- | ---- | ------------- | -------- | -------------------------- | ------------- |
+| DC1_FABRIC | l3leaf | DC1-BL1A | 192.168.200.110/24 | vEOS-LAB | Provisioned | - |
+| DC1_FABRIC | l3leaf | DC1-BL1B | 192.168.200.111/24 | vEOS-LAB | Provisioned | - |
+| DC1_FABRIC | l2leaf | DC1-L2LEAF1A | 192.168.200.112/24 | vEOS-LAB | Provisioned | - |
+| DC1_FABRIC | l2leaf | DC1-L2LEAF2A | 192.168.200.113/24 | vEOS-LAB | Provisioned | - |
+| DC1_FABRIC | l2leaf | DC1-L2LEAF2B | 192.168.200.114/24 | vEOS-LAB | Provisioned | - |
+| DC1_FABRIC | l3leaf | DC1-LEAF1A | 192.168.200.105/24 | vEOS-LAB | Provisioned | - |
+| DC1_FABRIC | l3leaf | DC1-LEAF2A | 192.168.200.106/24 | vEOS-LAB | Provisioned | - |
+| DC1_FABRIC | l3leaf | DC1-LEAF2B | 192.168.200.107/24 | vEOS-LAB | Provisioned | - |
+| DC1_FABRIC | spine | DC1-SPINE1 | 192.168.200.101/24 | vEOS-LAB | Provisioned | - |
+| DC1_FABRIC | spine | DC1-SPINE2 | 192.168.200.102/24 | vEOS-LAB | Provisioned | - |
+| DC1_FABRIC | spine | DC1-SPINE3 | 192.168.200.103/24 | vEOS-LAB | Provisioned | - |
+| DC1_FABRIC | spine | DC1-SPINE4 | 192.168.200.104/24 | vEOS-LAB | Provisioned | - |
+| DC1_FABRIC | l3leaf | DC1-SVC3A | 192.168.200.108/24 | vEOS-LAB | Provisioned | - |
+| DC1_FABRIC | l3leaf | DC1-SVC3B | 192.168.200.109/24 | vEOS-LAB | Provisioned | - |
 
 > Provision status is based on Ansible inventory declaration and do not represent real status from CloudVision.
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/fabric/DC1_FABRIC-documentation.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/fabric/DC1_FABRIC-documentation.md
@@ -15,28 +15,28 @@
 
 ## Fabric Switches and Management IP
 
-| POD | Type | Node | Management IP | Platform | Provisioned in CloudVision |
-| --- | ---- | ---- | ------------- | -------- | -------------------------- |
-| DC1_FABRIC | l3leaf | DC1-BL1A | 192.168.200.110/24 | 7280R | Provisioned |
-| DC1_FABRIC | l3leaf | DC1-BL1B | 192.168.200.111/24 | 7280R | Provisioned |
-| DC1_FABRIC | l2leaf | DC1-L2LEAF1A | 192.168.200.112/24 | vEOS-LAB | Provisioned |
-| DC1_FABRIC | l2leaf | DC1-L2LEAF2A | 192.168.200.113/24 | vEOS-LAB | Provisioned |
-| DC1_FABRIC | l2leaf | DC1-L2LEAF2B | 192.168.200.114/24 | vEOS-LAB | Provisioned |
-| DC1_FABRIC | l3leaf | DC1-LEAF1A | 192.168.200.105/24 | 7280R | Provisioned |
-| DC1_FABRIC | l3leaf | DC1-LEAF2A | 192.168.200.106/24 | 7280R | Provisioned |
-| DC1_FABRIC | l3leaf | DC1-LEAF2B | 192.168.200.107/24 | 7280R | Provisioned |
-| DC1_FABRIC | l3leaf | DC1-LEAF3A | 192.168.200.106/24 | 7280R | Provisioned |
-| DC1_FABRIC | l3leaf | DC1-LEAF3B | 192.168.200.107/24 | 7280R | Provisioned |
-| DC1_FABRIC | l3leaf | DC1-LEAF4A | 192.168.200.106/24 | 7280R | Provisioned |
-| DC1_FABRIC | l3leaf | DC1-LEAF4B | 192.168.200.107/24 | 7280R | Provisioned |
-| DC1_FABRIC | spine | DC1-SPINE1 | 192.168.200.101/24 | vEOS-LAB | Provisioned |
-| DC1_FABRIC | spine | DC1-SPINE2 | 192.168.200.102/24 | vEOS-LAB | Provisioned |
-| DC1_FABRIC | spine | DC1-SPINE3 | 192.168.200.103/24 | vEOS-LAB | Provisioned |
-| DC1_FABRIC | spine | DC1-SPINE4 | 192.168.200.104/24 | vEOS-LAB | Provisioned |
-| DC1_FABRIC | spine | DC1-SPINE5 | 192.168.200.105/24 | vEOS-LAB | Provisioned |
-| DC1_FABRIC | spine | DC1-SPINE6 | 192.168.200.105/24 | vEOS-LAB | Provisioned |
-| DC1_FABRIC | l3leaf | DC1-SVC3A | 192.168.200.108/24 | 7280R | Provisioned |
-| DC1_FABRIC | l3leaf | DC1-SVC3B | 192.168.200.109/24 | 7280R | Provisioned |
+| POD | Type | Node | Management IP | Platform | Provisioned in CloudVision | Serial Number |
+| --- | ---- | ---- | ------------- | -------- | -------------------------- | ------------- |
+| DC1_FABRIC | l3leaf | DC1-BL1A | 192.168.200.110/24 | 7280R | Provisioned | - |
+| DC1_FABRIC | l3leaf | DC1-BL1B | 192.168.200.111/24 | 7280R | Provisioned | - |
+| DC1_FABRIC | l2leaf | DC1-L2LEAF1A | 192.168.200.112/24 | vEOS-LAB | Provisioned | - |
+| DC1_FABRIC | l2leaf | DC1-L2LEAF2A | 192.168.200.113/24 | vEOS-LAB | Provisioned | - |
+| DC1_FABRIC | l2leaf | DC1-L2LEAF2B | 192.168.200.114/24 | vEOS-LAB | Provisioned | - |
+| DC1_FABRIC | l3leaf | DC1-LEAF1A | 192.168.200.105/24 | 7280R | Provisioned | - |
+| DC1_FABRIC | l3leaf | DC1-LEAF2A | 192.168.200.106/24 | 7280R | Provisioned | - |
+| DC1_FABRIC | l3leaf | DC1-LEAF2B | 192.168.200.107/24 | 7280R | Provisioned | - |
+| DC1_FABRIC | l3leaf | DC1-LEAF3A | 192.168.200.106/24 | 7280R | Provisioned | - |
+| DC1_FABRIC | l3leaf | DC1-LEAF3B | 192.168.200.107/24 | 7280R | Provisioned | - |
+| DC1_FABRIC | l3leaf | DC1-LEAF4A | 192.168.200.106/24 | 7280R | Provisioned | - |
+| DC1_FABRIC | l3leaf | DC1-LEAF4B | 192.168.200.107/24 | 7280R | Provisioned | - |
+| DC1_FABRIC | spine | DC1-SPINE1 | 192.168.200.101/24 | vEOS-LAB | Provisioned | - |
+| DC1_FABRIC | spine | DC1-SPINE2 | 192.168.200.102/24 | vEOS-LAB | Provisioned | - |
+| DC1_FABRIC | spine | DC1-SPINE3 | 192.168.200.103/24 | vEOS-LAB | Provisioned | - |
+| DC1_FABRIC | spine | DC1-SPINE4 | 192.168.200.104/24 | vEOS-LAB | Provisioned | - |
+| DC1_FABRIC | spine | DC1-SPINE5 | 192.168.200.105/24 | vEOS-LAB | Provisioned | - |
+| DC1_FABRIC | spine | DC1-SPINE6 | 192.168.200.105/24 | vEOS-LAB | Provisioned | - |
+| DC1_FABRIC | l3leaf | DC1-SVC3A | 192.168.200.108/24 | 7280R | Provisioned | - |
+| DC1_FABRIC | l3leaf | DC1-SVC3B | 192.168.200.109/24 | 7280R | Provisioned | - |
 
 > Provision status is based on Ansible inventory declaration and do not represent real status from CloudVision.
 

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_facts.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_facts.py
@@ -602,10 +602,19 @@ class EosDesignsFacts(AvdFacts):
     def system_mac_address(self):
         """
         system_mac_address is inherited from
-        Host variable var system_mac_address ->
-          Fabric Topology data model system_mac_address
+        Fabric Topology data model system_mac_address ->
+            Host variable var system_mac_address ->
         """
         return default(get(self._switch_data_combined, "system_mac_address"), get(self._hostvars, "system_mac_address"))
+
+    @cached_property
+    def serial_number(self):
+        """
+        serial_number is inherited from
+        Fabric Topology data model serial_number ->
+            Host variable var serial_number
+        """
+        return default(get(self._switch_data_combined, "serial_number"), get(self._hostvars, "serial_number"))
 
     @cached_property
     def underlay_routing_protocol(self):

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-topology.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-topology.md
@@ -173,6 +173,8 @@ defaults <- node_group <- node_group.node <- node
       system_mac_address: < "xx:xx:xx:xx:xx:xx" >
       # Serial Number | Optional
       # Set to the Serial Number of the device
+      # For  now only used for documentation purpose in the fabric
+      # documentation.
       # "serial_number" can also be set directly as a hostvar.
       # If both are set, the setting under "Fabric Topology" takes precedence.
       serial_number: < string >

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-topology.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-topology.md
@@ -171,6 +171,12 @@ defaults <- node_group <- node_group.node <- node
       # "system_mac_address" can also be set directly as a hostvar.
       # If both are set, the setting under "Fabric Topology" takes precedence.
       system_mac_address: < "xx:xx:xx:xx:xx:xx" >
+      # Serial Number | Optional
+      # Set to the Serial Number of the device
+      # "serial_number" can also be set directly as a hostvar.
+      # If both are set, the setting under "Fabric Topology" takes precedence.
+      serial_number: < string >
+
 ```
 
 ## Node Variables details

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/management-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/management-settings.md
@@ -85,6 +85,8 @@ system_mac_address: < "xx:xx:xx:xx:xx:xx" >
 
 # Serial Number | Optional
 # Set to the Serial Number of the device
+# For  now only used for documentation purpose in the fabric
+# documentation.
 # "serial_number" can also be set under "Fabric Topology".
 # If both are set, the setting under "Fabric Topology" takes precedence.
 serial_number: < string >

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/management-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/management-settings.md
@@ -83,6 +83,12 @@ name_servers:
 # If both are set, the setting under "Fabric Topology" takes precedence.
 system_mac_address: < "xx:xx:xx:xx:xx:xx" >
 
+# Serial Number | Optional
+# Set to the Serial Number of the device
+# "serial_number" can also be set under "Fabric Topology".
+# If both are set, the setting under "Fabric Topology" takes precedence.
+serial_number: < string >
+
 # Set SNMP settings | Optional
 snmp_settings:
   contact: < contact_info >

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/Fabric Topology.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/Fabric Topology.md
@@ -856,6 +856,7 @@ default_interfaces:
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;platform</samp>](## "node_type.defaults.platform") | String |  |  |  | Arista platform family. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mac_address</samp>](## "node_type.defaults.mac_address") | String |  |  |  | Leverage to document management interface mac address. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;system_mac_address</samp>](## "node_type.defaults.system_mac_address") | String |  |  |  | System MAC Address in this following format: "xx:xx:xx:xx:xx:xx".<br>Set to the same MAC address as available in "show version" on the device.<br>"system_mac_address" can also be set directly as a hostvar.<br>If both are set, the setting under "Fabric Topology" takes precedence.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;serial_number</samp>](## "node_type.defaults.serial_number") | String |  |  |  | Set to the Serial Number of the device<br>For  now only used for documentation purpose in the fabric documentation<br>and part of the structured_config<br>"serial_number" can also be set directly as a hostvar.<br>If both are set, the setting under "Fabric Topology" takes precedence.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;rack</samp>](## "node_type.defaults.rack") | String |  |  |  | Rack that the switch is located in (only used in snmp_settings location). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mgmt_ip</samp>](## "node_type.defaults.mgmt_ip") | String |  |  | Format: cidr | Node management interface IPv4 address. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_mgmt_ip</samp>](## "node_type.defaults.ipv6_mgmt_ip") | String |  |  | Format: cidr | Node management interface IPv6 address. |
@@ -877,6 +878,7 @@ default_interfaces:
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;platform</samp>](## "node_type.node_groups.[].platform") | String |  |  |  | Arista platform family. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mac_address</samp>](## "node_type.node_groups.[].mac_address") | String |  |  |  | Leverage to document management interface mac address. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;system_mac_address</samp>](## "node_type.node_groups.[].system_mac_address") | String |  |  |  | System MAC Address in this following format: "xx:xx:xx:xx:xx:xx".<br>Set to the same MAC address as available in "show version" on the device.<br>"system_mac_address" can also be set directly as a hostvar.<br>If both are set, the setting under "Fabric Topology" takes precedence.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;serial_number</samp>](## "node_type.node_groups.[].serial_number") | String |  |  |  | Set to the Serial Number of the device<br>For  now only used for documentation purpose in the fabric documentation<br>and part of the structured_config<br>"serial_number" can also be set directly as a hostvar.<br>If both are set, the setting under "Fabric Topology" takes precedence.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rack</samp>](## "node_type.node_groups.[].rack") | String |  |  |  | Rack that the switch is located in (only used in snmp_settings location). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mgmt_ip</samp>](## "node_type.node_groups.[].mgmt_ip") | String |  |  | Format: cidr | Node management interface IPv4 address. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_mgmt_ip</samp>](## "node_type.node_groups.[].ipv6_mgmt_ip") | String |  |  | Format: cidr | Node management interface IPv6 address. |
@@ -898,6 +900,7 @@ default_interfaces:
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;platform</samp>](## "node_type.node_groups.[].nodes.[].platform") | String |  |  |  | Arista platform family. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mac_address</samp>](## "node_type.node_groups.[].nodes.[].mac_address") | String |  |  |  | Leverage to document management interface mac address. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;system_mac_address</samp>](## "node_type.node_groups.[].nodes.[].system_mac_address") | String |  |  |  | System MAC Address in this following format: "xx:xx:xx:xx:xx:xx".<br>Set to the same MAC address as available in "show version" on the device.<br>"system_mac_address" can also be set directly as a hostvar.<br>If both are set, the setting under "Fabric Topology" takes precedence.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;serial_number</samp>](## "node_type.node_groups.[].nodes.[].serial_number") | String |  |  |  | Set to the Serial Number of the device<br>For  now only used for documentation purpose in the fabric documentation<br>and part of the structured_config<br>"serial_number" can also be set directly as a hostvar.<br>If both are set, the setting under "Fabric Topology" takes precedence.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rack</samp>](## "node_type.node_groups.[].nodes.[].rack") | String |  |  |  | Rack that the switch is located in (only used in snmp_settings location). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mgmt_ip</samp>](## "node_type.node_groups.[].nodes.[].mgmt_ip") | String |  |  | Format: cidr | Node management interface IPv4 address. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_mgmt_ip</samp>](## "node_type.node_groups.[].nodes.[].ipv6_mgmt_ip") | String |  |  | Format: cidr | Node management interface IPv6 address. |
@@ -919,6 +922,7 @@ default_interfaces:
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;platform</samp>](## "node_type.nodes.[].platform") | String |  |  |  | Arista platform family. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mac_address</samp>](## "node_type.nodes.[].mac_address") | String |  |  |  | Leverage to document management interface mac address. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;system_mac_address</samp>](## "node_type.nodes.[].system_mac_address") | String |  |  |  | System MAC Address in this following format: "xx:xx:xx:xx:xx:xx".<br>Set to the same MAC address as available in "show version" on the device.<br>"system_mac_address" can also be set directly as a hostvar.<br>If both are set, the setting under "Fabric Topology" takes precedence.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;serial_number</samp>](## "node_type.nodes.[].serial_number") | String |  |  |  | Set to the Serial Number of the device<br>For  now only used for documentation purpose in the fabric documentation<br>and part of the structured_config<br>"serial_number" can also be set directly as a hostvar.<br>If both are set, the setting under "Fabric Topology" takes precedence.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rack</samp>](## "node_type.nodes.[].rack") | String |  |  |  | Rack that the switch is located in (only used in snmp_settings location). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mgmt_ip</samp>](## "node_type.nodes.[].mgmt_ip") | String |  |  | Format: cidr | Node management interface IPv4 address. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_mgmt_ip</samp>](## "node_type.nodes.[].ipv6_mgmt_ip") | String |  |  | Format: cidr | Node management interface IPv6 address. |
@@ -941,6 +945,7 @@ default_interfaces:
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;platform</samp>](## "&lt;node_type_keys.key&gt;.defaults.platform") | String |  |  |  | Arista platform family. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mac_address</samp>](## "&lt;node_type_keys.key&gt;.defaults.mac_address") | String |  |  |  | Leverage to document management interface mac address. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;system_mac_address</samp>](## "&lt;node_type_keys.key&gt;.defaults.system_mac_address") | String |  |  |  | System MAC Address in this following format: "xx:xx:xx:xx:xx:xx".<br>Set to the same MAC address as available in "show version" on the device.<br>"system_mac_address" can also be set directly as a hostvar.<br>If both are set, the setting under "Fabric Topology" takes precedence.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;serial_number</samp>](## "&lt;node_type_keys.key&gt;.defaults.serial_number") | String |  |  |  | Set to the Serial Number of the device<br>For  now only used for documentation purpose in the fabric documentation<br>and part of the structured_config<br>"serial_number" can also be set directly as a hostvar.<br>If both are set, the setting under "Fabric Topology" takes precedence.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;rack</samp>](## "&lt;node_type_keys.key&gt;.defaults.rack") | String |  |  |  | Rack that the switch is located in (only used in snmp_settings location). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mgmt_ip</samp>](## "&lt;node_type_keys.key&gt;.defaults.mgmt_ip") | String |  |  | Format: cidr | Node management interface IPv4 address. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_mgmt_ip</samp>](## "&lt;node_type_keys.key&gt;.defaults.ipv6_mgmt_ip") | String |  |  | Format: cidr | Node management interface IPv6 address. |
@@ -962,6 +967,7 @@ default_interfaces:
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;platform</samp>](## "&lt;node_type_keys.key&gt;.node_groups.[].platform") | String |  |  |  | Arista platform family. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mac_address</samp>](## "&lt;node_type_keys.key&gt;.node_groups.[].mac_address") | String |  |  |  | Leverage to document management interface mac address. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;system_mac_address</samp>](## "&lt;node_type_keys.key&gt;.node_groups.[].system_mac_address") | String |  |  |  | System MAC Address in this following format: "xx:xx:xx:xx:xx:xx".<br>Set to the same MAC address as available in "show version" on the device.<br>"system_mac_address" can also be set directly as a hostvar.<br>If both are set, the setting under "Fabric Topology" takes precedence.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;serial_number</samp>](## "&lt;node_type_keys.key&gt;.node_groups.[].serial_number") | String |  |  |  | Set to the Serial Number of the device<br>For  now only used for documentation purpose in the fabric documentation<br>and part of the structured_config<br>"serial_number" can also be set directly as a hostvar.<br>If both are set, the setting under "Fabric Topology" takes precedence.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rack</samp>](## "&lt;node_type_keys.key&gt;.node_groups.[].rack") | String |  |  |  | Rack that the switch is located in (only used in snmp_settings location). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mgmt_ip</samp>](## "&lt;node_type_keys.key&gt;.node_groups.[].mgmt_ip") | String |  |  | Format: cidr | Node management interface IPv4 address. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_mgmt_ip</samp>](## "&lt;node_type_keys.key&gt;.node_groups.[].ipv6_mgmt_ip") | String |  |  | Format: cidr | Node management interface IPv6 address. |
@@ -983,6 +989,7 @@ default_interfaces:
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;platform</samp>](## "&lt;node_type_keys.key&gt;.node_groups.[].nodes.[].platform") | String |  |  |  | Arista platform family. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mac_address</samp>](## "&lt;node_type_keys.key&gt;.node_groups.[].nodes.[].mac_address") | String |  |  |  | Leverage to document management interface mac address. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;system_mac_address</samp>](## "&lt;node_type_keys.key&gt;.node_groups.[].nodes.[].system_mac_address") | String |  |  |  | System MAC Address in this following format: "xx:xx:xx:xx:xx:xx".<br>Set to the same MAC address as available in "show version" on the device.<br>"system_mac_address" can also be set directly as a hostvar.<br>If both are set, the setting under "Fabric Topology" takes precedence.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;serial_number</samp>](## "&lt;node_type_keys.key&gt;.node_groups.[].nodes.[].serial_number") | String |  |  |  | Set to the Serial Number of the device<br>For  now only used for documentation purpose in the fabric documentation<br>and part of the structured_config<br>"serial_number" can also be set directly as a hostvar.<br>If both are set, the setting under "Fabric Topology" takes precedence.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rack</samp>](## "&lt;node_type_keys.key&gt;.node_groups.[].nodes.[].rack") | String |  |  |  | Rack that the switch is located in (only used in snmp_settings location). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mgmt_ip</samp>](## "&lt;node_type_keys.key&gt;.node_groups.[].nodes.[].mgmt_ip") | String |  |  | Format: cidr | Node management interface IPv4 address. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_mgmt_ip</samp>](## "&lt;node_type_keys.key&gt;.node_groups.[].nodes.[].ipv6_mgmt_ip") | String |  |  | Format: cidr | Node management interface IPv6 address. |
@@ -1004,6 +1011,7 @@ default_interfaces:
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;platform</samp>](## "&lt;node_type_keys.key&gt;.nodes.[].platform") | String |  |  |  | Arista platform family. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mac_address</samp>](## "&lt;node_type_keys.key&gt;.nodes.[].mac_address") | String |  |  |  | Leverage to document management interface mac address. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;system_mac_address</samp>](## "&lt;node_type_keys.key&gt;.nodes.[].system_mac_address") | String |  |  |  | System MAC Address in this following format: "xx:xx:xx:xx:xx:xx".<br>Set to the same MAC address as available in "show version" on the device.<br>"system_mac_address" can also be set directly as a hostvar.<br>If both are set, the setting under "Fabric Topology" takes precedence.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;serial_number</samp>](## "&lt;node_type_keys.key&gt;.nodes.[].serial_number") | String |  |  |  | Set to the Serial Number of the device<br>For  now only used for documentation purpose in the fabric documentation<br>and part of the structured_config<br>"serial_number" can also be set directly as a hostvar.<br>If both are set, the setting under "Fabric Topology" takes precedence.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rack</samp>](## "&lt;node_type_keys.key&gt;.nodes.[].rack") | String |  |  |  | Rack that the switch is located in (only used in snmp_settings location). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mgmt_ip</samp>](## "&lt;node_type_keys.key&gt;.nodes.[].mgmt_ip") | String |  |  | Format: cidr | Node management interface IPv4 address. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_mgmt_ip</samp>](## "&lt;node_type_keys.key&gt;.nodes.[].ipv6_mgmt_ip") | String |  |  | Format: cidr | Node management interface IPv6 address. |
@@ -1030,6 +1038,7 @@ default_interfaces:
         platform: <str>
         mac_address: <str>
         system_mac_address: <str>
+        serial_number: <str>
         rack: <str>
         mgmt_ip: <str>
         ipv6_mgmt_ip: <str>
@@ -1051,6 +1060,7 @@ default_interfaces:
           platform: <str>
           mac_address: <str>
           system_mac_address: <str>
+          serial_number: <str>
           rack: <str>
           mgmt_ip: <str>
           ipv6_mgmt_ip: <str>
@@ -1072,6 +1082,7 @@ default_interfaces:
               platform: <str>
               mac_address: <str>
               system_mac_address: <str>
+              serial_number: <str>
               rack: <str>
               mgmt_ip: <str>
               ipv6_mgmt_ip: <str>
@@ -1093,6 +1104,7 @@ default_interfaces:
           platform: <str>
           mac_address: <str>
           system_mac_address: <str>
+          serial_number: <str>
           rack: <str>
           mgmt_ip: <str>
           ipv6_mgmt_ip: <str>
@@ -1115,6 +1127,7 @@ default_interfaces:
         platform: <str>
         mac_address: <str>
         system_mac_address: <str>
+        serial_number: <str>
         rack: <str>
         mgmt_ip: <str>
         ipv6_mgmt_ip: <str>
@@ -1136,6 +1149,7 @@ default_interfaces:
           platform: <str>
           mac_address: <str>
           system_mac_address: <str>
+          serial_number: <str>
           rack: <str>
           mgmt_ip: <str>
           ipv6_mgmt_ip: <str>
@@ -1157,6 +1171,7 @@ default_interfaces:
               platform: <str>
               mac_address: <str>
               system_mac_address: <str>
+              serial_number: <str>
               rack: <str>
               mgmt_ip: <str>
               ipv6_mgmt_ip: <str>
@@ -1178,6 +1193,7 @@ default_interfaces:
           platform: <str>
           mac_address: <str>
           system_mac_address: <str>
+          serial_number: <str>
           rack: <str>
           mgmt_ip: <str>
           ipv6_mgmt_ip: <str>

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/base/avdstructuredconfig.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/base/avdstructuredconfig.py
@@ -71,6 +71,13 @@ class AvdStructuredConfig(AvdFacts):
         return get(self._hostvars, "switch.system_mac_address")
 
     @cached_property
+    def serial_number(self) -> str | None:
+        """
+        serial_number variable set based on switch.serial_number fact
+        """
+        return get(self._hostvars, "switch.serial_number")
+
+    @cached_property
     def router_bgp(self) -> dict | None:
         """
         router_bgp set based on switch.bgp_as, switch.bgp_defaults, switch.router_id facts

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -115,6 +115,11 @@
               "description": "System MAC Address in this following format: \"xx:xx:xx:xx:xx:xx\".\nSet to the same MAC address as available in \"show version\" on the device.\n\"system_mac_address\" can also be set directly as a hostvar.\nIf both are set, the setting under \"Fabric Topology\" takes precedence.\n",
               "title": "System MAC Address"
             },
+            "serial_number": {
+              "type": "string",
+              "description": "Set to the Serial Number of the device\nFor  now only used for documentation purpose in the fabric documentation\nand part of the structured_config\n\"serial_number\" can also be set directly as a hostvar.\nIf both are set, the setting under \"Fabric Topology\" takes precedence.\n",
+              "title": "Serial Number"
+            },
             "rack": {
               "description": "Rack that the switch is located in (only used in snmp_settings location).",
               "type": "string",

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
@@ -135,6 +135,22 @@ keys:
               If both are set, the setting under "Fabric Topology" takes precedence.
 
               '
+          serial_number:
+            documentation_options:
+              filename: Fabric Topology
+              table: Generic configuration management
+            type: str
+            description: 'Set to the Serial Number of the device
+
+              For  now only used for documentation purpose in the fabric documentation
+
+              and part of the structured_config
+
+              "serial_number" can also be set directly as a hostvar.
+
+              If both are set, the setting under "Fabric Topology" takes precedence.
+
+              '
           rack:
             documentation_options:
               filename: Fabric Topology

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/node_type.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/node_type.schema.yml
@@ -45,6 +45,17 @@ keys:
               Set to the same MAC address as available in "show version" on the device.
               "system_mac_address" can also be set directly as a hostvar.
               If both are set, the setting under "Fabric Topology" takes precedence.
+          serial_number:
+            documentation_options:
+              filename: Fabric Topology
+              table: Generic configuration management
+            type: str
+            description: |
+              Set to the Serial Number of the device
+              For  now only used for documentation purpose in the fabric documentation
+              and part of the structured_config
+              "serial_number" can also be set directly as a hostvar.
+              If both are set, the setting under "Fabric Topology" takes precedence.
           rack:
             documentation_options:
               filename: Fabric Topology

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/documentation/fabric-documentation.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/documentation/fabric-documentation.j2
@@ -25,6 +25,7 @@
 {%         set fabric_switch.inband_management_ip = node_facts.switch.inband_management_ip | arista.avd.default(none) %}
 {%         set fabric_switch.platform = node_facts.switch.platform | arista.avd.default('-') %}
 {%         set fabric_switch.provisioned = 'Not Available' if node_hostvars.is_deployed is arista.avd.defined(false) else 'Provisioned' %}
+{%         set fabric_switch.serial_number = node_facts.switch.serial_number | arista.avd.default("-") %}
 {%         if node_hostvars.loopback_interfaces is arista.avd.defined %}
 {%             set loopback0 = (node_hostvars.loopback_interfaces | arista.avd.convert_dicts("name") | selectattr("name", "arista.avd.defined", "Loopback0"))[0] | arista.avd.default %}
 {%             if loopback0.ip_address is arista.avd.defined %}
@@ -88,10 +89,10 @@
 
 ## Fabric Switches and Management IP
 
-| POD | Type | Node | Management IP | Platform | Provisioned in CloudVision |
-| --- | ---- | ---- | ------------- | -------- | -------------------------- |
+| POD | Type | Node | Management IP | Platform | Provisioned in CloudVision | Serial Number |
+| --- | ---- | ---- | ------------- | -------- | -------------------------- | ------------- |
 {% for fabric_switch in fabric_switches %}
-| {{ fabric_switch.pod }} | {{ fabric_switch.type }} | {{ fabric_switch.node }} | {{ fabric_switch.mgmt_ip }} | {{ fabric_switch.platform }} | {{ fabric_switch.provisioned }} |
+| {{ fabric_switch.pod }} | {{ fabric_switch.type }} | {{ fabric_switch.node }} | {{ fabric_switch.mgmt_ip }} | {{ fabric_switch.platform }} | {{ fabric_switch.provisioned }} | {{ fabric_switch.serial_number }} |
 {% endfor %}
 
 > Provision status is based on Ansible inventory declaration and do not represent real status from CloudVision.


### PR DESCRIPTION
## Change Summary

* Support to define serial number as hostvar or fabric topology var, the latter having precedence. For now only used for documentation purposes in the fabric documentation.

## Related Issue(s)

None

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

in management_settings:

```yaml
# Serial Number | Optional
# Set to the Serial Number of the device
# "serial_number" can also be set under "Fabric Topology".
# If both are set, the setting under "Fabric Topology" takes precedence.
serial_number: < string >
```

In fabric topology:

```yaml
<node_type_key>:
  [...]
  nodes:
    <node inventory hostname>:
      [...]
      # "system_mac_address" can also be set directly as a hostvar.
      # If both are set, the setting under "Fabric Topology" takes precedence.
      system_mac_address: < "xx:xx:xx:xx:xx:xx" >
      # Serial Number | Optional
      # Set to the Serial Number of the device
      # "serial_number" can also be set directly as a hostvar.
      # If both are set, the setting under "Fabric Topology" takes precedence.
      serial_number: < string >
```

## How to test

molecule tests added

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
