### PR TITLE
Fix(eos_designs): Configure ptp to use the system mac

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-spine3.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-spine3.cfg
@@ -1,0 +1,84 @@
+!RANCID-CONTENT-TYPE: arista
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname ptp-tests-spine3
+!
+ptp priority1 20
+ptp priority2 3
+ptp domain 127
+ptp mode boundary
+ptp monitor threshold offset-from-master 250
+ptp monitor threshold mean-path-delay 1500
+ptp monitor sequence-id
+ptp monitor threshold missing-message announce 3 sequence-ids
+ptp monitor threshold missing-message delay-resp 3 sequence-ids
+ptp monitor threshold missing-message follow-up 3 sequence-ids
+ptp monitor threshold missing-message sync 3 sequence-ids
+!
+spanning-tree mode none
+!
+no enable password
+no aaa root
+!
+vrf instance MGMT
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 10.255.0.3/32
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 192.168.0.31/24
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 10.255.0.0/27 eq 32
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.0.1
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+router bfd
+   multihop interval 300 min-rx 300 multiplier 3
+!
+router bgp 65200
+   router-id 10.255.0.3
+   maximum-paths 4 ecmp 4
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor IPv4-UNDERLAY-PEERS peer group
+   neighbor IPv4-UNDERLAY-PEERS send-community
+   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   address-family evpn
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor IPv4-UNDERLAY-PEERS activate
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-spine3.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-spine3.yml
@@ -1,0 +1,98 @@
+router_bgp:
+  as: '65200'
+  router_id: 10.255.0.3
+  bgp_defaults:
+  - maximum-paths 4 ecmp 4
+  peer_groups:
+  - type: ipv4
+    maximum_routes: 12000
+    send_community: all
+    name: IPv4-UNDERLAY-PEERS
+  - type: evpn
+    update_source: Loopback0
+    bfd: true
+    send_community: all
+    maximum_routes: 0
+    ebgp_multihop: 3
+    next_hop_unchanged: true
+    name: EVPN-OVERLAY-PEERS
+  address_family_ipv4:
+    peer_groups:
+    - activate: true
+      name: IPv4-UNDERLAY-PEERS
+    - activate: false
+      name: EVPN-OVERLAY-PEERS
+  redistribute_routes:
+  - route_map: RM-CONN-2-BGP
+    source_protocol: connected
+  address_family_evpn:
+    peer_groups:
+    - activate: true
+      name: EVPN-OVERLAY-PEERS
+static_routes:
+- vrf: MGMT
+  destination_address_prefix: 0.0.0.0/0
+  gateway: 192.168.0.1
+service_routing_protocols_model: multi-agent
+ip_routing: true
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+spanning_tree:
+  mode: none
+vrfs:
+- name: MGMT
+  ip_routing: false
+management_interfaces:
+- name: Management1
+  description: oob_management
+  shutdown: false
+  vrf: MGMT
+  ip_address: 192.168.0.31/24
+  gateway: 192.168.0.1
+  type: oob
+management_api_http:
+  enable_vrfs:
+  - name: MGMT
+  enable_https: true
+ptp:
+  mode: boundary
+  priority1: 20
+  priority2: 3
+  domain: 127
+  monitor:
+    enabled: true
+    threshold:
+      offset_from_master: 250
+      mean_path_delay: 1500
+    missing_message:
+      sequence_ids:
+        enabled: true
+        announce: 3
+        delay_resp: 3
+        follow_up: 3
+        sync: 3
+loopback_interfaces:
+- name: Loopback0
+  description: EVPN_Overlay_Peering
+  shutdown: false
+  ip_address: 10.255.0.3/32
+prefix_lists:
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 10.255.0.0/27 eq 32
+route_maps:
+- name: RM-CONN-2-BGP
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    match:
+    - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+router_bfd:
+  multihop:
+    interval: 300
+    min_rx: 300
+    multiplier: 3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/PTP_TESTS_SPINES.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/PTP_TESTS_SPINES.yml
@@ -46,3 +46,10 @@ spine:
         clock_identity_prefix: "01:02:03"
         priority1: 20
         priority2: 10
+    # Test with "auto_clock_identity: false"
+    ptp-tests-spine3:
+      id: 3
+      mgmt_ip: 192.168.0.31/24
+      ptp:
+        enabled: true
+        auto_clock_identity: false

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
@@ -163,6 +163,7 @@ all:
               hosts:
                 ptp-tests-spine1:
                 ptp-tests-spine2:
+                ptp-tests-spine3:
             PTP_TESTS_LEAFS:
               hosts:
                 ptp-tests-leaf1:

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_facts.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_facts.py
@@ -461,6 +461,7 @@ class EosDesignsFacts(AvdFacts):
         default_ptp_enabled = get(self._hostvars, "ptp.enabled")
         default_ptp_domain = get(self._hostvars, "ptp.domain", default=127)
         default_ptp_profile = get(self._hostvars, "ptp.profile", default="aes67-r16-2016")
+        default_clock_identity = None
         ptp = {}
         ptp["enabled"] = get(self._switch_data_combined, "ptp.enabled", default=default_ptp_enabled)
         if ptp["enabled"] is True:


### PR DESCRIPTION
## Change Summary

Fix the issue when trying to configure ptp to use the system mac in ptp note_type variable -> `ptp.auto_clock_identity: false`.

```
TASK [arista.avd.eos_designs : Set eos_designs facts] **************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: UnboundLocalError: local variable 'default_clock_identity' referenced before assignment
fatal: [ptp-tests-spine1 -> 127.0.0.1]: FAILED! => {"msg": "Unexpected failure during module execution: local variable 'default_clock_identity' referenced before assignment", "stdout": ""}
```

Fixed issues by initializing `default_clock_identity = None`

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes


## How to test

See Molecule scenario


