### PR TITLE
Fix(eos_designs): Duplicate port-channels in structured-config for network-ports

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/network-ports-tests-2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/network-ports-tests-2.cfg
@@ -40,6 +40,12 @@ interface Port-Channel2
    spanning-tree portfast
    spanning-tree bpdufilter enable
 !
+interface Port-Channel42
+   description Checking port-channels
+   no shutdown
+   switchport
+   mlag 42
+!
 interface Port-Channel101
    description MLAG_PEER_network-ports-tests.1_Po101
    no shutdown
@@ -507,6 +513,26 @@ interface Ethernet4
    switchport
    spanning-tree portfast
    spanning-tree bpdufilter enable
+!
+interface Ethernet7
+   description Checking port-channels
+   no shutdown
+   channel-group 42 mode active
+!
+interface Ethernet8
+   description Checking port-channels
+   no shutdown
+   channel-group 42 mode active
+!
+interface Ethernet9
+   description Checking port-channels
+   no shutdown
+   channel-group 42 mode active
+!
+interface Ethernet10
+   description Checking port-channels
+   no shutdown
+   channel-group 42 mode active
 !
 interface Ethernet10/1
    description MLAG_PEER_network-ports-tests.1_Ethernet10/1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/network-ports-tests-2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/network-ports-tests-2.yml
@@ -66,21 +66,6 @@ port_channel_interfaces:
   type: switched
   shutdown: false
   mlag: 42
-- name: Port-Channel42
-  description: Checking port-channels
-  type: switched
-  shutdown: false
-  mlag: 42
-- name: Port-Channel42
-  description: Checking port-channels
-  type: switched
-  shutdown: false
-  mlag: 42
-- name: Port-Channel42
-  description: Checking port-channels
-  type: switched
-  shutdown: false
-  mlag: 42
 ethernet_interfaces:
 - peer: network-ports-tests.1
   peer_interface: Ethernet10/1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/network-ports-tests-2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/network-ports-tests-2.yml
@@ -61,6 +61,26 @@ port_channel_interfaces:
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
   mlag: 2
+- name: Port-Channel42
+  description: Checking port-channels
+  type: switched
+  shutdown: false
+  mlag: 42
+- name: Port-Channel42
+  description: Checking port-channels
+  type: switched
+  shutdown: false
+  mlag: 42
+- name: Port-Channel42
+  description: Checking port-channels
+  type: switched
+  shutdown: false
+  mlag: 42
+- name: Port-Channel42
+  description: Checking port-channels
+  type: switched
+  shutdown: false
+  mlag: 42
 ethernet_interfaces:
 - peer: network-ports-tests.1
   peer_interface: Ethernet10/1
@@ -650,6 +670,42 @@ ethernet_interfaces:
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
   name: Ethernet2/48
+- peer: Checking port-channels
+  peer_type: network_port
+  description: Checking port-channels
+  type: switched
+  shutdown: false
+  channel_group:
+    id: 42
+    mode: active
+  name: Ethernet7
+- peer: Checking port-channels
+  peer_type: network_port
+  description: Checking port-channels
+  type: switched
+  shutdown: false
+  channel_group:
+    id: 42
+    mode: active
+  name: Ethernet8
+- peer: Checking port-channels
+  peer_type: network_port
+  description: Checking port-channels
+  type: switched
+  shutdown: false
+  channel_group:
+    id: 42
+    mode: active
+  name: Ethernet9
+- peer: Checking port-channels
+  peer_type: network_port
+  description: Checking port-channels
+  type: switched
+  shutdown: false
+  channel_group:
+    id: 42
+    mode: active
+  name: Ethernet10
 mlag_configuration:
   domain_id: mlag
   local_interface: Vlan4094

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/NETWORK_PORTS_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/NETWORK_PORTS_TESTS.yml
@@ -48,6 +48,15 @@ network_ports:
       - Ethernet5-6
     description: "N: blah"
 
+  - switches:
+      - network-ports-tests.2
+    switch_ports:
+      - Ethernet7-10
+    description: "Checking port-channels"
+    port_channel:
+      channel_id: 42
+      mode: "active"
+
 # Only creating network services required to test the filter "only_vlans_in_use" combined with network ports
 tenants:
   TEST:

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/connected-endpoints.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/connected-endpoints.md
@@ -606,7 +606,7 @@ network_ports:
 ```
 
 This will generate the following config:
- 
+
 ```shell
 interface Port-Channel42
    description Multiple interfaces in the same port-channel

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/connected-endpoints.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/connected-endpoints.md
@@ -23,8 +23,9 @@ Both data models support variable inheritance from profiles defined under [`port
 
 - `network_ports` is intended to be used with `port_profiles` and `parent_profiles` to keep the configuration generic and compact, but all
   features and keys supported under `connected_endpoints.adapters` is also supported directly under `network_ports`.
-- Since all ranges defined under `network_ports` will be expanded to individual port configurations, it is not possible to configure a
-  port-channel with multiple interfaces on the same device. For this special case `connected_endpoints` should be used.
+- Since all ranges defined under `network_ports` will be expanded to individual port configurations, by default each port will be configured
+  in a port-channel with one member when leveraging automatic channel-id generation. To configure multiple ports as member of the same port-channel,
+  set the channel-id key (cf examples below).
 
 ## Variables and Options
 
@@ -301,8 +302,10 @@ Both data models support variable inheritance from profiles defined under [`port
 The `network_ports` data model is intended to be used with `port_profiles` and `parent_profiles` to keep the configuration generic and compact,
 but all features and keys supported under `connected_endpoints.adapters` is also supported directly under `network_ports`.
 
-Since all ranges defined under `network_ports` will be expanded to individual port configurations, it is not possible to configure a
-port-channel with multiple interfaces on the same device. For this special case `connected_endpoints` should be used.
+Since all ranges defined under `network_ports` will be expanded to individual port configurations, by default each port will be configured
+in a port-channel with one member when leveraging automatic channel-id generation. To configure multiple ports as member of the same port-channel,
+set the channel-id key (cf examples below).
+To leverage automatic channel-id computation and configure port-channel with multiple members, `connected_endpoints` should be used.
 
 The expansiont to individual port configurations also lead to inconsistent configurations when used with `short_esi: auto` or
 `designated_forwarder_algorithm: auto`, since those rely on information from multiple switches and interfaces.
@@ -583,4 +586,42 @@ network_ports:
       - Ethernet2/1-48
     profile: pc
     description: PCs
+```
+
+### Example using network ports to configure multiple ports in the same port-channel
+
+```yaml
+# Network Ports
+# By setting the channel_id key under port-channel, interfaces Ethernet3-4 will
+# be configured under the same port-channel.
+network_ports:
+  - switches:
+      - network-ports-tests-1
+    switch_ports:
+      - Ethernet3-4
+    description: Multiple interfaces in the same port-channel
+    port_channel:
+      mode: active
+      channel_id: 42
+```
+
+This will generate the following config:
+ 
+```shell
+interface Port-Channel42
+   description Multiple interfaces in the same port-channel
+   no shutdown
+   switchport
+!
+!
+interface Ethernet3
+   description Multiple interfaces in the same port-channel
+   no shutdown
+   channel-group 42 mode active
+!
+interface Ethernet4
+   description Multiple interfaces in the same port-channel
+   no shutdown
+   channel-group 42 mode active
+!
 ```

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/connected_endpoints/port_channel_interfaces.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/connected_endpoints/port_channel_interfaces.py
@@ -203,7 +203,7 @@ class PortChannelInterfacesMixin(UtilsMixin):
         if matching_port_channel_config != candidate_port_channel_config:
             # Found duplicate name with different generated configs
             raise AristaAvdError(
-                f"Duplicate port-channel name {port_channel_interfaces['name']} with conflicting configruations found while generating port-channels for"
+                f"Duplicate port-channel name {port_channel_interfaces['name']} with conflicting configurations found while generating port-channels for"
                 " connected-endpoints or network-ports"
             )
 

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/connected_endpoints/port_channel_interfaces.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/connected_endpoints/port_channel_interfaces.py
@@ -6,6 +6,7 @@ from functools import cached_property
 
 from ansible_collections.arista.avd.plugins.filter.esi_management import generate_esi, generate_lacp_id, generate_route_target
 from ansible_collections.arista.avd.plugins.filter.range_expand import range_expand
+from ansible_collections.arista.avd.plugins.plugin_utils.errors import AristaAvdError
 from ansible_collections.arista.avd.plugins.plugin_utils.strip_empties import strip_null_from_data
 from ansible_collections.arista.avd.plugins.plugin_utils.utils import get
 
@@ -21,7 +22,7 @@ class PortChannelInterfacesMixin(UtilsMixin):
     @cached_property
     def port_channel_interfaces(self) -> list | None:
         """
-        Return structured config for ethernet_interfaces
+        Return structured config for port_channel_interfaces
         """
         port_channel_interfaces = []
         for connected_endpoint in self._filtered_connected_endpoints:
@@ -33,7 +34,8 @@ class PortChannelInterfacesMixin(UtilsMixin):
                 channel_group_id = get(adapter, "port_channel.channel_id", default=default_channel_group_id)
 
                 port_channel_interface_name = f"Port-Channel{channel_group_id}"
-                port_channel_interfaces.append(self._get_port_channel_interface_cfg(adapter, port_channel_interface_name, channel_group_id, connected_endpoint))
+                port_channel_config = self._get_port_channel_interface_cfg(adapter, port_channel_interface_name, channel_group_id, connected_endpoint)
+                self._check_duplicate(port_channel_config, port_channel_interfaces)
 
                 if (subinterfaces := get(adapter, "port_channel.subinterfaces")) is None:
                     continue
@@ -43,9 +45,10 @@ class PortChannelInterfacesMixin(UtilsMixin):
                         continue
 
                     port_channel_subinterface_name = f"Port-Channel{channel_group_id}.{subinterface['number']}"
-                    port_channel_interfaces.append(
-                        self._get_port_channel_subinterface_cfg(subinterface, adapter, port_channel_subinterface_name, channel_group_id)
+                    port_channel_subinterface_config = self._get_port_channel_subinterface_cfg(
+                        subinterface, adapter, port_channel_subinterface_name, channel_group_id
                     )
+                    self._check_duplicate(port_channel_subinterface_config, port_channel_interfaces)
 
         for network_port in self._filtered_network_ports:
             if get(network_port, "port_channel.mode") is None:
@@ -72,9 +75,8 @@ class PortChannelInterfacesMixin(UtilsMixin):
                 channel_group_id = get(tmp_network_port, "port_channel.channel_id", default=default_channel_group_id)
 
                 port_channel_interface_name = f"Port-Channel{channel_group_id}"
-                port_channel_interfaces.append(
-                    self._get_port_channel_interface_cfg(tmp_network_port, port_channel_interface_name, channel_group_id, connected_endpoint)
-                )
+                port_channel_config = self._get_port_channel_interface_cfg(tmp_network_port, port_channel_interface_name, channel_group_id, connected_endpoint)
+                self._check_duplicate(port_channel_config, port_channel_interfaces)
 
         if port_channel_interfaces:
             return port_channel_interfaces
@@ -174,3 +176,32 @@ class PortChannelInterfacesMixin(UtilsMixin):
             }
 
         return strip_null_from_data(port_channel_interface)
+
+    def _check_duplicate(self, candidate_port_channel_config, port_channel_interfaces) -> None:
+        """
+        This function assumes that port_channel_interfaces list DO NOT contain duplicate port-channel names
+
+        This check function does two things:
+        1. Check if the port_channel_config["name"] is alreadt present in port_channel_interfaces computed so far
+        2. if 1 is True, check if the port_channel_config object is exactly the same as the existing one in port_channel_interfaces,
+
+        If 1 is True and 2 is False, then the function raise an AristaAvdError because a duplicate port-channel name would be generating two
+        different structured configurations and so there is a conflict
+
+        If 1 and 2 are True, it means the candidate_port_channel_config is the same as the existing configuration already generated so no
+        problem - the return value is True
+
+        If 1 is False for every port-channel in the port_channle_interfaces, it is a new port-channel and it is appended to the list
+        """
+        for port_channel_config in port_channel_interfaces:
+            if port_channel_config["name"] != candidate_port_channel_config["name"]:
+                continue
+            if port_channel_config != candidate_port_channel_config:
+                # Found duplicate name with different generated configs
+                raise AristaAvdError(
+                    f"Duplicate port-channel name {port_channel_interfaces['name']} with conflicting configruations found while generating port-channels for"
+                    " connected-endpoints or network-ports"
+                )
+            # Duplicate name with same configuration - nothing to do
+            return
+        port_channel_interfaces.append(candidate_port_channel_config)

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/connected_endpoints/port_channel_interfaces.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/connected_endpoints/port_channel_interfaces.py
@@ -192,7 +192,7 @@ class PortChannelInterfacesMixin(UtilsMixin):
         If 1 and 2 are True, it means the candidate_port_channel_config is the same as the existing configuration already generated so no
         action is needed.
 
-        If 1 is False for every port-channel in the port_channle_interfaces, it is a new port-channel and it is appended to the list.
+        If 1 is False for every port-channel in the port_channel_interfaces, it is a new port-channel and it is appended to the list.
         """
         if (matching_port_channel_config := get_item(port_channel_interfaces, "name", candidate_port_channel_config["name"])) is None:
             # No port_channel_interface found with the same name in port_channel_interfaces

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/connected_endpoints/port_channel_interfaces.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/connected_endpoints/port_channel_interfaces.py
@@ -8,7 +8,7 @@ from ansible_collections.arista.avd.plugins.filter.esi_management import generat
 from ansible_collections.arista.avd.plugins.filter.range_expand import range_expand
 from ansible_collections.arista.avd.plugins.plugin_utils.errors import AristaAvdError
 from ansible_collections.arista.avd.plugins.plugin_utils.strip_empties import strip_null_from_data
-from ansible_collections.arista.avd.plugins.plugin_utils.utils import get
+from ansible_collections.arista.avd.plugins.plugin_utils.utils import get, get_item
 
 from .utils import UtilsMixin
 
@@ -35,7 +35,7 @@ class PortChannelInterfacesMixin(UtilsMixin):
 
                 port_channel_interface_name = f"Port-Channel{channel_group_id}"
                 port_channel_config = self._get_port_channel_interface_cfg(adapter, port_channel_interface_name, channel_group_id, connected_endpoint)
-                self._check_duplicate(port_channel_config, port_channel_interfaces)
+                self._add_if_not_duplicate(port_channel_config, port_channel_interfaces)
 
                 if (subinterfaces := get(adapter, "port_channel.subinterfaces")) is None:
                     continue
@@ -48,7 +48,7 @@ class PortChannelInterfacesMixin(UtilsMixin):
                     port_channel_subinterface_config = self._get_port_channel_subinterface_cfg(
                         subinterface, adapter, port_channel_subinterface_name, channel_group_id
                     )
-                    self._check_duplicate(port_channel_subinterface_config, port_channel_interfaces)
+                    self._add_if_not_duplicate(port_channel_subinterface_config, port_channel_interfaces)
 
         for network_port in self._filtered_network_ports:
             if get(network_port, "port_channel.mode") is None:
@@ -76,7 +76,7 @@ class PortChannelInterfacesMixin(UtilsMixin):
 
                 port_channel_interface_name = f"Port-Channel{channel_group_id}"
                 port_channel_config = self._get_port_channel_interface_cfg(tmp_network_port, port_channel_interface_name, channel_group_id, connected_endpoint)
-                self._check_duplicate(port_channel_config, port_channel_interfaces)
+                self._add_if_not_duplicate(port_channel_config, port_channel_interfaces)
 
         if port_channel_interfaces:
             return port_channel_interfaces
@@ -177,31 +177,35 @@ class PortChannelInterfacesMixin(UtilsMixin):
 
         return strip_null_from_data(port_channel_interface)
 
-    def _check_duplicate(self, candidate_port_channel_config, port_channel_interfaces) -> None:
+    def _add_if_not_duplicate(self, candidate_port_channel_config, port_channel_interfaces) -> None:
         """
-        This function assumes that port_channel_interfaces list DO NOT contain duplicate port-channel names
+        This function assumes that port_channel_interfaces list DO NOT contain duplicate port-channel names.
+        It CAN modify the input variable port_channel_interfaces by appending candidate_port_channel_config to it.
 
         This check function does two things:
-        1. Check if the port_channel_config["name"] is alreadt present in port_channel_interfaces computed so far
-        2. if 1 is True, check if the port_channel_config object is exactly the same as the existing one in port_channel_interfaces,
+            1. Check if the candidate_port_channel_config["name"] is already present in port_channel_interfaces computed so far
+            2. if 1 is True, check if the candidate_port_channel_config object is exactly the same as the existing one in port_channel_interfaces,
 
         If 1 is True and 2 is False, then the function raise an AristaAvdError because a duplicate port-channel name would be generating two
         different structured configurations and so there is a conflict
 
         If 1 and 2 are True, it means the candidate_port_channel_config is the same as the existing configuration already generated so no
-        problem - the return value is True
+        action is needed.
 
-        If 1 is False for every port-channel in the port_channle_interfaces, it is a new port-channel and it is appended to the list
+        If 1 is False for every port-channel in the port_channle_interfaces, it is a new port-channel and it is appended to the list.
         """
-        for port_channel_config in port_channel_interfaces:
-            if port_channel_config["name"] != candidate_port_channel_config["name"]:
-                continue
-            if port_channel_config != candidate_port_channel_config:
-                # Found duplicate name with different generated configs
-                raise AristaAvdError(
-                    f"Duplicate port-channel name {port_channel_interfaces['name']} with conflicting configruations found while generating port-channels for"
-                    " connected-endpoints or network-ports"
-                )
-            # Duplicate name with same configuration - nothing to do
+        if (matching_port_channel_config := get_item(port_channel_interfaces, "name", candidate_port_channel_config["name"])) is None:
+            # No port_channel_interface found with the same name in port_channel_interfaces
+            # append to the list and return
+            port_channel_interfaces.append(candidate_port_channel_config)
             return
-        port_channel_interfaces.append(candidate_port_channel_config)
+
+        if matching_port_channel_config != candidate_port_channel_config:
+            # Found duplicate name with different generated configs
+            raise AristaAvdError(
+                f"Duplicate port-channel name {port_channel_interfaces['name']} with conflicting configruations found while generating port-channels for"
+                " connected-endpoints or network-ports"
+            )
+
+        # Duplicate name with same configuration - nothing to do
+        return


### PR DESCRIPTION
## Change Summary

When using port-channels for network-ports, the current code will generate multiple time the port channel interface.
This PR intends to address this.

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

Fix the code in eos_designs connected-endpoints python module

## How to test

Added molecule test

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
