### PR TITLE
Feat(eos_cli_config_gen): Add support for CVX as VXLAN controller

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/cvx.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/cvx.md
@@ -49,6 +49,7 @@ CVX is enabled
 | Service | Enabled | Settings |
 | ------- | ------- | -------- |
 | MCS | True | Redis Password Set |
+| VXLAN | True | VTEP MAC learning: control-plane |
 
 ### CVX configuration
 
@@ -61,4 +62,7 @@ cvx
    service mcs
       redis password 7 070E334ddD1D18
       no shutdown
+   service vxlan
+      no shutdown
+      vtep mac-learning control-plane
 ```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vxlan-interface.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vxlan-interface.md
@@ -44,6 +44,7 @@ interface Management1
 | Setting | Value |
 | ------- | ----- |
 | Source Interface | Loopback0 |
+| Controller Client | True |
 | MLAG Source Interface | Loopback1 |
 | UDP port | 4789 |
 | EVPN MLAG Shared Router MAC | mlag-system-id |
@@ -83,6 +84,7 @@ interface Management1
 interface Vxlan1
    description DC1-LEAF2A_VTEP
    vxlan source-interface Loopback0
+   vxlan controller-client
    vxlan virtual-router encapsulation mac-address mlag-system-id
    vxlan udp-port 4789
    vxlan flood vtep learned data-plane

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/cvx.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/cvx.cfg
@@ -14,6 +14,9 @@ cvx
    service mcs
       redis password 7 070E334ddD1D18
       no shutdown
+   service vxlan
+      no shutdown
+      vtep mac-learning control-plane
 !
 interface Management1
    description oob_management

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vxlan-interface.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vxlan-interface.cfg
@@ -15,6 +15,7 @@ interface Management1
 interface Vxlan1
    description DC1-LEAF2A_VTEP
    vxlan source-interface Loopback0
+   vxlan controller-client
    vxlan virtual-router encapsulation mac-address mlag-system-id
    vxlan udp-port 4789
    vxlan flood vtep learned data-plane

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/cvx.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/cvx.yml
@@ -10,3 +10,6 @@ cvx:
         password: 070E334ddD1D18
         password_type: 7
       shutdown: false
+    vxlan:
+      shutdown: false
+      vtep_mac_learning: "control-plane"

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vxlan-interface.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vxlan-interface.yml
@@ -5,7 +5,8 @@ vxlan_interface:
     description: DC1-LEAF2A_VTEP
     vxlan:
       source_interface: Loopback0
-      controller_client: true
+      controller_client:
+        enabled: true
       mlag_source_interface: Loopback1
       udp_port: 4789
       virtual_router_encapsulation_mac_address: mlag-system-id

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vxlan-interface.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vxlan-interface.yml
@@ -5,6 +5,7 @@ vxlan_interface:
     description: DC1-LEAF2A_VTEP
     vxlan:
       source_interface: Loopback0
+      controller_client: true
       mlag_source_interface: Loopback1
       udp_port: 4789
       virtual_router_encapsulation_mac_address: mlag-system-id

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/data_model/Authentication.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/data_model/Authentication.md
@@ -221,6 +221,9 @@ CVX server features are not supported on physical switches. See `management_cvx`
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;password</samp>](## "cvx.services.mcs.redis.password") | String |  |  |  | Hashed password using the password_type |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;password_type</samp>](## "cvx.services.mcs.redis.password_type") | String |  | 7 | Valid Values:<br>- 0<br>- 7<br>- 8a |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;shutdown</samp>](## "cvx.services.mcs.shutdown") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vxlan</samp>](## "cvx.services.vxlan") | Dictionary |  |  |  | VXLAN Controller service |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;shutdown</samp>](## "cvx.services.vxlan.shutdown") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vtep_mac_learning</samp>](## "cvx.services.vxlan.vtep_mac_learning") | String |  |  | Valid Values:<br>- control-plane<br>- data-plane |  |
 
 === "YAML"
 
@@ -235,6 +238,9 @@ CVX server features are not supported on physical switches. See `management_cvx`
             password: <str>
             password_type: <str>
           shutdown: <bool>
+        vxlan:
+          shutdown: <bool>
+          vtep_mac_learning: <str>
     ```
 
 ## Enable Password

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/data_model/Interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/data_model/Interfaces.md
@@ -1322,6 +1322,7 @@ search:
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;description</samp>](## "vxlan_interface.Vxlan1.description") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vxlan</samp>](## "vxlan_interface.Vxlan1.vxlan") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_interface</samp>](## "vxlan_interface.Vxlan1.vxlan.source_interface") | String |  |  |  | Source Interface Name |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;controller_client</samp>](## "vxlan_interface.Vxlan1.vxlan.controller_client") | Boolean |  |  |  | Client to CVX Controllers |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_source_interface</samp>](## "vxlan_interface.Vxlan1.vxlan.mlag_source_interface") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;udp_port</samp>](## "vxlan_interface.Vxlan1.vxlan.udp_port") | Integer |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;virtual_router_encapsulation_mac_address</samp>](## "vxlan_interface.Vxlan1.vxlan.virtual_router_encapsulation_mac_address") | String |  |  |  | "mlag-system-id" or ethernet_address (H.H.H)<br> |
@@ -1356,6 +1357,7 @@ search:
         description: <str>
         vxlan:
           source_interface: <str>
+          controller_client: <bool>
           mlag_source_interface: <str>
           udp_port: <int>
           virtual_router_encapsulation_mac_address: <str>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/data_model/Interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/data_model/Interfaces.md
@@ -1322,7 +1322,8 @@ search:
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;description</samp>](## "vxlan_interface.Vxlan1.description") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vxlan</samp>](## "vxlan_interface.Vxlan1.vxlan") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_interface</samp>](## "vxlan_interface.Vxlan1.vxlan.source_interface") | String |  |  |  | Source Interface Name |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;controller_client</samp>](## "vxlan_interface.Vxlan1.vxlan.controller_client") | Boolean |  |  |  | Client to CVX Controllers |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;controller_client</samp>](## "vxlan_interface.Vxlan1.vxlan.controller_client") | Dictionary |  |  |  | Client to CVX Controllers |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "vxlan_interface.Vxlan1.vxlan.controller_client.enabled") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_source_interface</samp>](## "vxlan_interface.Vxlan1.vxlan.mlag_source_interface") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;udp_port</samp>](## "vxlan_interface.Vxlan1.vxlan.udp_port") | Integer |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;virtual_router_encapsulation_mac_address</samp>](## "vxlan_interface.Vxlan1.vxlan.virtual_router_encapsulation_mac_address") | String |  |  |  | "mlag-system-id" or ethernet_address (H.H.H)<br> |
@@ -1357,7 +1358,8 @@ search:
         description: <str>
         vxlan:
           source_interface: <str>
-          controller_client: <bool>
+          controller_client:
+            enabled: <bool>
           mlag_source_interface: <str>
           udp_port: <int>
           virtual_router_encapsulation_mac_address: <str>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -15641,8 +15641,15 @@
                   "title": "Source Interface"
                 },
                 "controller_client": {
-                  "type": "boolean",
+                  "type": "object",
                   "description": "Client to CVX Controllers",
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean",
+                      "title": "Enabled"
+                    }
+                  },
+                  "additionalProperties": false,
                   "title": "Controller Client"
                 },
                 "mlag_source_interface": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -842,6 +842,26 @@
               },
               "additionalProperties": false,
               "title": "MCS"
+            },
+            "vxlan": {
+              "type": "object",
+              "description": "VXLAN Controller service",
+              "properties": {
+                "shutdown": {
+                  "type": "boolean",
+                  "title": "Shutdown"
+                },
+                "vtep_mac_learning": {
+                  "type": "string",
+                  "enum": [
+                    "control-plane",
+                    "data-plane"
+                  ],
+                  "title": "Vtep MAC Learning"
+                }
+              },
+              "additionalProperties": false,
+              "title": "VxLAN"
             }
           },
           "additionalProperties": false,
@@ -15619,6 +15639,11 @@
                   "type": "string",
                   "description": "Source Interface Name",
                   "title": "Source Interface"
+                },
+                "controller_client": {
+                  "type": "boolean",
+                  "description": "Client to CVX Controllers",
+                  "title": "Controller Client"
                 },
                 "mlag_source_interface": {
                   "type": "string",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -647,6 +647,17 @@ keys:
                     default: '7'
               shutdown:
                 type: bool
+          vxlan:
+            type: dict
+            description: VXLAN Controller service
+            keys:
+              shutdown:
+                type: bool
+              vtep_mac_learning:
+                type: str
+                valid_values:
+                - control-plane
+                - data-plane
   daemon_terminattr:
     documentation_options:
       filename: data_model/Monitoring
@@ -10821,6 +10832,9 @@ keys:
               source_interface:
                 type: str
                 description: Source Interface Name
+              controller_client:
+                type: bool
+                description: Client to CVX Controllers
               mlag_source_interface:
                 type: str
               udp_port:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -10833,8 +10833,11 @@ keys:
                 type: str
                 description: Source Interface Name
               controller_client:
-                type: bool
+                type: dict
                 description: Client to CVX Controllers
+                keys:
+                  enabled:
+                    type: bool
               mlag_source_interface:
                 type: str
               udp_port:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/cvx.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/cvx.schema.yml
@@ -36,3 +36,14 @@ keys:
                     default: "7"
               shutdown:
                 type: bool
+          vxlan:
+            type: dict
+            description: VXLAN Controller service
+            keys:
+              shutdown:
+                type: bool
+              vtep_mac_learning:
+                type: str
+                valid_values:
+                  - "control-plane"
+                  - "data-plane"

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/vxlan_interface.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/vxlan_interface.schema.yml
@@ -20,8 +20,11 @@ keys:
                 type: str
                 description: Source Interface Name
               controller_client:
-                type: bool
+                type: dict
                 description: Client to CVX Controllers
+                keys:
+                  enabled:
+                    type: bool
               mlag_source_interface:
                 type: str
               udp_port:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/vxlan_interface.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/vxlan_interface.schema.yml
@@ -19,6 +19,9 @@ keys:
               source_interface:
                 type: str
                 description: Source Interface Name
+              controller_client:
+                type: bool
+                description: Client to CVX Controllers
               mlag_source_interface:
                 type: str
               udp_port:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/cvx.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/cvx.j2
@@ -33,6 +33,18 @@ CVX is enabled
 {%                 endif %}
 | MCS | {{ enabled }} | {{ settings | join("<br>") }} |
 {%             endif %}
+{%             if cvx.services.vxlan is arista.avd.defined %}
+{%                 if cvx.services.vxlan.shutdown is arista.avd.defined %}
+{%                     set enabled = not cvx.services.vxlan.shutdown %}
+{%                 else %}
+{%                     set enabled = '-' %}
+{%                 endif %}
+{%                 set settings = [] %}
+{%                 if cvx.services.vxlan.vtep_mac_learning is arista.avd.defined %}
+{%                     do settings.append("VTEP MAC learning: " ~ cvx.services.vxlan.vtep_mac_learning) %}
+{%                 endif %}
+| VXLAN | {{ enabled }} | {{ settings | join("<br>") }} |
+{%             endif %}
 {%         endif %}
 {%     endif %}
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vxlan-interface.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vxlan-interface.j2
@@ -11,8 +11,8 @@
 {%     if vxlan_interface.Vxlan1.vxlan.source_interface is arista.avd.defined %}
 | Source Interface | {{ vxlan_interface.Vxlan1.vxlan.source_interface }} |
 {%     endif %}
-{%     if vxlan_interface.Vxlan1.vxlan.controller_client is arista.avd.defined %}
-| Controller Client | {{ vxlan_interface.Vxlan1.vxlan.controller_client }} |
+{%     if vxlan_interface.Vxlan1.vxlan.controller_client.enabled is arista.avd.defined %}
+| Controller Client | {{ vxlan_interface.Vxlan1.vxlan.controller_client.enabled }} |
 {%     endif %}
 {%     if vxlan_interface.Vxlan1.vxlan.mlag_source_interface is arista.avd.defined %}
 | MLAG Source Interface | {{ vxlan_interface.Vxlan1.vxlan.mlag_source_interface }} |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vxlan-interface.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vxlan-interface.j2
@@ -11,6 +11,9 @@
 {%     if vxlan_interface.Vxlan1.vxlan.source_interface is arista.avd.defined %}
 | Source Interface | {{ vxlan_interface.Vxlan1.vxlan.source_interface }} |
 {%     endif %}
+{%     if vxlan_interface.Vxlan1.vxlan.controller_client is arista.avd.defined %}
+| Controller Client | {{ vxlan_interface.Vxlan1.vxlan.controller_client }} |
+{%     endif %}
 {%     if vxlan_interface.Vxlan1.vxlan.mlag_source_interface is arista.avd.defined %}
 | MLAG Source Interface | {{ vxlan_interface.Vxlan1.vxlan.mlag_source_interface }} |
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/cvx.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/cvx.j2
@@ -22,5 +22,16 @@ cvx
       shutdown
 {%             endif %}
 {%         endif %}
+{%         if cvx.services.vxlan is arista.avd.defined %}
+   service vxlan
+{%             if cvx.services.vxlan.shutdown is arista.avd.defined(false) %}
+      no shutdown
+{%             elif cvx.services.vxlan.shutdown is arista.avd.defined(true) %}
+      shutdown
+{%             endif %}
+{%             if cvx.services.vxlan.vtep_mac_learning is arista.avd.defined %}
+      vtep mac-learning {{ cvx.services.vxlan.vtep_mac_learning }}
+{%             endif %}
+{%         endif %}
 {%     endif %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vxlan-interface.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vxlan-interface.j2
@@ -9,6 +9,9 @@ interface Vxlan1
 {%     if vxlan_interface.Vxlan1.vxlan.source_interface is arista.avd.defined %}
    vxlan source-interface {{ vxlan_interface.Vxlan1.vxlan.source_interface }}
 {%     endif %}
+{%     if vxlan_interface.Vxlan1.vxlan.controller_client is arista.avd.defined(true) %}
+   vxlan controller-client
+{%     endif %}
 {%     if vxlan_interface.Vxlan1.vxlan.virtual_router_encapsulation_mac_address is arista.avd.defined %}
    vxlan virtual-router encapsulation mac-address {{ vxlan_interface.Vxlan1.vxlan.virtual_router_encapsulation_mac_address }}
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vxlan-interface.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vxlan-interface.j2
@@ -9,7 +9,7 @@ interface Vxlan1
 {%     if vxlan_interface.Vxlan1.vxlan.source_interface is arista.avd.defined %}
    vxlan source-interface {{ vxlan_interface.Vxlan1.vxlan.source_interface }}
 {%     endif %}
-{%     if vxlan_interface.Vxlan1.vxlan.controller_client is arista.avd.defined(true) %}
+{%     if vxlan_interface.Vxlan1.vxlan.controller_client.enabled is arista.avd.defined(true) %}
    vxlan controller-client
 {%     endif %}
 {%     if vxlan_interface.Vxlan1.vxlan.virtual_router_encapsulation_mac_address is arista.avd.defined %}


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Add support for CVX as VXLAN controller

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

Added config, documentation and schema for the following new keys:

```yaml
cvx:
  services:
    vxlan:
      shutdown: <bool>
      vtep_mac_learning: <str>
```

```yaml
vxlan_interface:
  Vxlan1:
    vxlan:
      controller_client:
        enabled: <bool>
```

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Added molecule support.
Also tested with eos_designs via PR #2656 

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
