### PR TITLE
Feat(eos_cli_config_gen): Add support for BGP session tracking

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
@@ -239,6 +239,7 @@ sFlow is disabled.
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet1
    mtu 1500
+   bgp session tracker ST1
    no switchport
    ip address 172.31.255.1/31
    bfd interval 500 min-rx 500 multiplier 5

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
@@ -317,6 +317,7 @@ interface Port-Channel3
 !
 interface Port-Channel5
    description DC1_L2LEAF1_Po1
+   bgp session tracker ST2
    switchport
    switchport trunk allowed vlan 110,201
    switchport mode trunk

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
@@ -209,8 +209,8 @@ router bgp 65101
       network 2001:db8:100::/40
       network 2001:db8:200::/40 route-map RM-BAR-MATCH
       redistribute static route-map RM-IPV6-STATIC-TO-BGP
-  session tracker ST1
-    recovery delay 666 seconds
-  session tracker ST2
-    recovery delay 42 seconds
+   session tracker ST1
+      recovery delay 666 seconds
+   session tracker ST2
+      recovery delay 42 seconds
 ```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
@@ -82,6 +82,12 @@ interface Management1
 | -------- | ----- |
 | Passive | True |
 
+##### test-session-tracker
+
+| Settings | Value |
+| -------- | ----- |
+| Session tracker | ST2 |
+
 #### BGP Neighbors
 
 | Neighbor | Remote AS | VRF | Shutdown | Send-community | Maximum-routes | Allowas-in | BFD | RIB Pre-Policy Retain | Route-Reflector Client | Passive |
@@ -109,6 +115,13 @@ interface Management1
 | 1.12.1.0/24 | True | True | RM-ATTRIBUTE | RM-MATCH | True |
 | 2.2.1.0/24 | False | False | - | - | False |
 
+#### Router BGP Session Trackers
+
+| Session Tracker Name | Recovery Delay (in seconds) |
+| -------------------- | --------------------------- |
+| ST1 | 666 |
+| ST2 | 42 |
+
 #### Router BGP Device Configuration
 
 ```eos
@@ -134,6 +147,8 @@ router bgp 65101
    neighbor test-link-bandwidth2 link-bandwidth
    neighbor test-passive peer group
    neighbor test-passive passive
+   neighbor test-session-tracker peer group
+   neighbor test-session-tracker session tracker ST2
    neighbor interface Ethernet2 peer-group PG-FOO-v4 remote-as 65102
    neighbor interface Ethernet3 peer-group PG-FOO-v4 peer-filter PF-BAR-v4
    neighbor 192.0.3.1 remote-as 65432
@@ -141,6 +156,7 @@ router bgp 65101
    neighbor 192.0.3.1 as-path prepend-own disabled
    neighbor 192.0.3.1 rib-in pre-policy retain
    neighbor 192.0.3.1 passive
+   neighbor 192.0.3.1 session tracker ST1
    neighbor 192.0.3.1 default-originate always
    neighbor 192.0.3.1 send-community
    neighbor 192.0.3.1 link-bandwidth default 100G
@@ -193,4 +209,8 @@ router bgp 65101
       network 2001:db8:100::/40
       network 2001:db8:200::/40 route-map RM-BAR-MATCH
       redistribute static route-map RM-IPV6-STATIC-TO-BGP
+  session tracker ST1
+    recovery delay 666 seconds
+  session tracker ST2
+    recovery delay 42 seconds
 ```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
@@ -10,6 +10,7 @@ no aaa root
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet1
    mtu 1500
+   bgp session tracker ST1
    no switchport
    ip address 172.31.255.1/31
    bfd interval 500 min-rx 500 multiplier 5

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
@@ -19,6 +19,7 @@ interface Port-Channel3
 !
 interface Port-Channel5
    description DC1_L2LEAF1_Po1
+   bgp session tracker ST2
    switchport
    switchport trunk allowed vlan 110,201
    switchport mode trunk

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-base.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-base.cfg
@@ -95,9 +95,9 @@ router bgp 65101
       network 2001:db8:100::/40
       network 2001:db8:200::/40 route-map RM-BAR-MATCH
       redistribute static route-map RM-IPV6-STATIC-TO-BGP
-  session tracker ST1
-    recovery delay 666 seconds
-  session tracker ST2
-    recovery delay 42 seconds
+   session tracker ST1
+      recovery delay 666 seconds
+   session tracker ST2
+      recovery delay 42 seconds
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-base.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-base.cfg
@@ -33,6 +33,8 @@ router bgp 65101
    neighbor test-link-bandwidth2 link-bandwidth
    neighbor test-passive peer group
    neighbor test-passive passive
+   neighbor test-session-tracker peer group
+   neighbor test-session-tracker session tracker ST2
    neighbor interface Ethernet2 peer-group PG-FOO-v4 remote-as 65102
    neighbor interface Ethernet3 peer-group PG-FOO-v4 peer-filter PF-BAR-v4
    neighbor 192.0.3.1 remote-as 65432
@@ -40,6 +42,7 @@ router bgp 65101
    neighbor 192.0.3.1 as-path prepend-own disabled
    neighbor 192.0.3.1 rib-in pre-policy retain
    neighbor 192.0.3.1 passive
+   neighbor 192.0.3.1 session tracker ST1
    neighbor 192.0.3.1 default-originate always
    neighbor 192.0.3.1 send-community
    neighbor 192.0.3.1 link-bandwidth default 100G
@@ -92,5 +95,9 @@ router bgp 65101
       network 2001:db8:100::/40
       network 2001:db8:200::/40 route-map RM-BAR-MATCH
       redistribute static route-map RM-IPV6-STATIC-TO-BGP
+  session tracker ST1
+    recovery delay 666 seconds
+  session tracker ST2
+    recovery delay 42 seconds
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
@@ -23,6 +23,8 @@ ethernet_interfaces:
       interval: 500
       min_rx: 500
       multiplier: 5
+    bgp:
+      session_tracker: ST1
     eos_cli: |
       comment
       Comment created from eos_cli under ethernet_interfaces.Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
@@ -19,6 +19,8 @@ port_channel_interfaces:
       unknown_unicast:
         level: 1
         unit: percent
+    bgp:
+      session_tracker: ST2
     eos_cli: |
       comment
       Comment created from eos_cli under port_channel_interfaces.Port-Channel5

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-base.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-base.yml
@@ -52,6 +52,8 @@ router_bgp:
         enabled: true
     test-passive:
       passive: true
+    test-session-tracker:
+      session_tracker: ST2
   aggregate_addresses:
     1.1.1.0/24:
       advertise_only: true
@@ -111,6 +113,7 @@ router_bgp:
       as_path:
         remote_as_replace_out: true
         prepend_own_disabled: true
+      session_tracker: ST1
     192.0.3.2:
       remote_as: 65433
       send_community: extended
@@ -171,3 +174,8 @@ router_bgp:
     Ethernet3:
       peer_group: PG-FOO-v4
       peer_filter: PF-BAR-v4
+  session_trackers:
+    - name: ST1
+      recovery_delay: 666
+    - name: ST2
+      recovery_delay: 42

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/data_model/Interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/data_model/Interfaces.md
@@ -247,6 +247,8 @@ search:
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;traffic_policy</samp>](## "ethernet_interfaces.[].traffic_policy") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;input</samp>](## "ethernet_interfaces.[].traffic_policy.input") | String |  |  |  | Ingress traffic policy |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;output</samp>](## "ethernet_interfaces.[].traffic_policy.output") | String |  |  |  | Egress traffic policy |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;bgp</samp>](## "ethernet_interfaces.[].bgp") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;session_tracker</samp>](## "ethernet_interfaces.[].bgp.session_tracker") | String |  |  |  | Name of session tracker |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;peer</samp>](## "ethernet_interfaces.[].peer") | String |  |  |  | Key only used for documentation or validation purposes |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;peer_interface</samp>](## "ethernet_interfaces.[].peer_interface") | String |  |  |  | Key only used for documentation or validation purposes |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;peer_type</samp>](## "ethernet_interfaces.[].peer_type") | String |  |  |  | Key only used for documentation or validation purposes |
@@ -497,6 +499,8 @@ search:
         traffic_policy:
           input: <str>
           output: <str>
+        bgp:
+          session_tracker: <str>
         peer: <str>
         peer_interface: <str>
         peer_type: <str>
@@ -774,6 +778,8 @@ search:
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "port_channel_interfaces.[].ospf_message_digest_keys.[].key") | String |  |  |  | Encrypted password |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;flow_tracker</samp>](## "port_channel_interfaces.[].flow_tracker") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;sampled</samp>](## "port_channel_interfaces.[].flow_tracker.sampled") | String |  |  |  | Flow tracker name |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;bgp</samp>](## "port_channel_interfaces.[].bgp") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;session_tracker</samp>](## "port_channel_interfaces.[].bgp.session_tracker") | String |  |  |  | Name of session tracker |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;peer</samp>](## "port_channel_interfaces.[].peer") | String |  |  |  | Key only used for documentation or validation purposes |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;peer_interface</samp>](## "port_channel_interfaces.[].peer_interface") | String |  |  |  | Key only used for documentation or validation purposes |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;peer_type</samp>](## "port_channel_interfaces.[].peer_type") | String |  |  |  | Key only used for documentation or validation purposes |
@@ -948,6 +954,8 @@ search:
             key: <str>
         flow_tracker:
           sampled: <str>
+        bgp:
+          session_tracker: <str>
         peer: <str>
         peer_interface: <str>
         peer_type: <str>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/data_model/Routing.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/data_model/Routing.md
@@ -250,6 +250,7 @@ MAC address (hh:hh:hh:hh:hh:hh)
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map_in</samp>](## "router_bgp.peer_groups.[].route_map_in") | String |  |  |  | Inbound route-map name |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map_out</samp>](## "router_bgp.peer_groups.[].route_map_out") | String |  |  |  | Outbound route-map name |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bgp_listen_range_prefix</samp>](## "router_bgp.peer_groups.[].bgp_listen_range_prefix") | String |  |  |  | IP prefix range<br>note: `bgp_listen_range_prefix` and `peer_filter` will be deprecated in AVD v4.0<br>These should not be mixed with the new `listen_ranges` key above to avoid conflicts.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;session_tracker</samp>](## "router_bgp.peer_groups.[].session_tracker") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;neighbors</samp>](## "router_bgp.neighbors") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- ip_address</samp>](## "router_bgp.neighbors.[].ip_address") | String | Required, Unique |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;peer_group</samp>](## "router_bgp.neighbors.[].peer_group") | String |  |  |  |  |
@@ -294,6 +295,7 @@ MAC address (hh:hh:hh:hh:hh:hh)
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;remove_private_as_ingress</samp>](## "router_bgp.neighbors.[].remove_private_as_ingress") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "router_bgp.neighbors.[].remove_private_as_ingress.enabled") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;replace_as</samp>](## "router_bgp.neighbors.[].remove_private_as_ingress.replace_as") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;session_tracker</samp>](## "router_bgp.neighbors.[].session_tracker") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;neighbor_interfaces</samp>](## "router_bgp.neighbor_interfaces") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "router_bgp.neighbor_interfaces.[].name") | String | Required, Unique |  |  | Interface name |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;remote_as</samp>](## "router_bgp.neighbor_interfaces.[].remote_as") | String |  |  |  |  |
@@ -609,7 +611,10 @@ MAC address (hh:hh:hh:hh:hh:hh)
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;networks</samp>](## "router_bgp.vrfs.[].address_families.[].networks") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- prefix</samp>](## "router_bgp.vrfs.[].address_families.[].networks.[].prefix") | String | Required, Unique |  |  | IPv4 prefix "A.B.C.D/E" or IPv6 prefix "A:B:C:D:E:F:G:H/I" |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "router_bgp.vrfs.[].address_families.[].networks.[].route_map") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;eos_cli</samp>](## "router_bgp.vrfs.[].eos_cli") | String |  |  |  | Multiline EOS CLI rendered directly on the Router BGP, VRF definition in the final EOS configuration |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;eos_cli</samp>](## "router_bgp.vrfs.[].eos_cli") | String |  |  |  | Multiline EOS CLI rendered directly on the Router BGP, VRF definition in the final EOS configuration<br> |
+    | [<samp>&nbsp;&nbsp;session_trackers</samp>](## "router_bgp.session_trackers") | List, items: Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "router_bgp.session_trackers.[].name") | String | Required, Unique |  |  | Name of session tracker |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;recovery_delay</samp>](## "router_bgp.session_trackers.[].recovery_delay") | Integer |  |  | Min: 1<br>Max: 3600 | Recovery delay in seconds |
 
 === "YAML"
 
@@ -695,6 +700,7 @@ MAC address (hh:hh:hh:hh:hh:hh)
           route_map_in: <str>
           route_map_out: <str>
           bgp_listen_range_prefix: <str>
+          session_tracker: <str>
       neighbors:
         - ip_address: <str>
           peer_group: <str>
@@ -739,6 +745,7 @@ MAC address (hh:hh:hh:hh:hh:hh)
           remove_private_as_ingress:
             enabled: <bool>
             replace_as: <bool>
+          session_tracker: <str>
       neighbor_interfaces:
         - name: <str>
           remote_as: <str>
@@ -1055,6 +1062,9 @@ MAC address (hh:hh:hh:hh:hh:hh)
                 - prefix: <str>
                   route_map: <str>
           eos_cli: <str>
+      session_trackers:
+        - name: <str>
+          recovery_delay: <int>
     ```
 
 ## Router General configuration

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -2767,6 +2767,18 @@
             "additionalProperties": false,
             "title": "Traffic Policy"
           },
+          "bgp": {
+            "type": "object",
+            "properties": {
+              "session_tracker": {
+                "type": "string",
+                "description": "Name of session tracker",
+                "title": "Session Tracker"
+              }
+            },
+            "additionalProperties": false,
+            "title": "BGP"
+          },
           "peer": {
             "type": "string",
             "description": "Key only used for documentation or validation purposes",
@@ -7678,6 +7690,18 @@
             "additionalProperties": false,
             "title": "Flow Tracker"
           },
+          "bgp": {
+            "type": "object",
+            "properties": {
+              "session_tracker": {
+                "type": "string",
+                "description": "Name of session tracker",
+                "title": "Session Tracker"
+              }
+            },
+            "additionalProperties": false,
+            "title": "BGP"
+          },
           "peer": {
             "type": "string",
             "description": "Key only used for documentation or validation purposes",
@@ -9099,6 +9123,10 @@
                 "type": "string",
                 "description": "IP prefix range\nnote: `bgp_listen_range_prefix` and `peer_filter` will be deprecated in AVD v4.0\nThese should not be mixed with the new `listen_ranges` key above to avoid conflicts.\n",
                 "title": "BGP Listen Range Prefix"
+              },
+              "session_tracker": {
+                "type": "string",
+                "title": "Session Tracker"
               }
             },
             "additionalProperties": false,
@@ -9329,6 +9357,10 @@
                 },
                 "additionalProperties": false,
                 "title": "Remove Private As Ingress"
+              },
+              "session_tracker": {
+                "type": "string",
+                "title": "Session Tracker"
               }
             },
             "additionalProperties": false,
@@ -11221,7 +11253,7 @@
               },
               "eos_cli": {
                 "type": "string",
-                "description": "Multiline EOS CLI rendered directly on the Router BGP, VRF definition in the final EOS configuration",
+                "description": "Multiline EOS CLI rendered directly on the Router BGP, VRF definition in the final EOS configuration\n",
                 "title": "EOS CLI"
               }
             },
@@ -11231,6 +11263,31 @@
             ]
           },
           "title": "VRFs"
+        },
+        "session_trackers": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Name of session tracker",
+                "title": "Name"
+              },
+              "recovery_delay": {
+                "type": "integer",
+                "description": "Recovery delay in seconds",
+                "minimum": 1,
+                "maximum": 3600,
+                "title": "Recovery Delay"
+              }
+            },
+            "additionalProperties": false,
+            "required": [
+              "name"
+            ]
+          },
+          "title": "Session Trackers"
         }
       },
       "additionalProperties": false,

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -2049,6 +2049,12 @@ keys:
             output:
               type: str
               description: Egress traffic policy
+        bgp:
+          type: dict
+          keys:
+            session_tracker:
+              type: str
+              description: Name of session tracker
         peer:
           type: str
           description: Key only used for documentation or validation purposes
@@ -5616,6 +5622,12 @@ keys:
             sampled:
               type: str
               description: Flow tracker name
+        bgp:
+          type: dict
+          keys:
+            session_tracker:
+              type: str
+              description: Name of session tracker
         peer:
           type: str
           description: Key only used for documentation or validation purposes
@@ -6644,6 +6656,8 @@ keys:
                 avoid conflicts.
 
                 '
+            session_tracker:
+              type: str
       neighbors:
         type: list
         primary_key: ip_address
@@ -6791,6 +6805,8 @@ keys:
                   type: bool
                 replace_as:
                   type: bool
+            session_tracker:
+              type: str
       neighbor_interfaces:
         type: list
         primary_key: name
@@ -7921,8 +7937,26 @@ keys:
                           type: str
             eos_cli:
               type: str
-              description: Multiline EOS CLI rendered directly on the Router BGP,
+              description: 'Multiline EOS CLI rendered directly on the Router BGP,
                 VRF definition in the final EOS configuration
+
+                '
+      session_trackers:
+        type: list
+        primary_key: name
+        items:
+          type: dict
+          keys:
+            name:
+              type: str
+              description: Name of session tracker
+            recovery_delay:
+              type: int
+              description: Recovery delay in seconds
+              convert_types:
+              - str
+              min: 1
+              max: 3600
   router_general:
     documentation_options:
       filename: data_model/Routing

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ethernet_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ethernet_interfaces.schema.yml
@@ -848,6 +848,12 @@ keys:
             output:
               type: str
               description: Egress traffic policy
+        bgp:
+          type: dict
+          keys:
+            session_tracker:
+              type: str
+              description: Name of session tracker
         peer:
           type: str
           description: Key only used for documentation or validation purposes

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/port_channel_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/port_channel_interfaces.schema.yml
@@ -669,6 +669,12 @@ keys:
             sampled:
               type: str
               description: Flow tracker name
+        bgp:
+          type: dict
+          keys:
+            session_tracker:
+              type: str
+              description: Name of session tracker
         peer:
           type: str
           description: Key only used for documentation or validation purposes

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_bgp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_bgp.schema.yml
@@ -301,6 +301,8 @@ keys:
                 IP prefix range
                 note: `bgp_listen_range_prefix` and `peer_filter` will be deprecated in AVD v4.0
                 These should not be mixed with the new `listen_ranges` key above to avoid conflicts.
+            session_tracker:
+              type: str
       neighbors:
         type: list
         primary_key: ip_address
@@ -442,6 +444,8 @@ keys:
                   type: bool
                 replace_as:
                   type: bool
+            session_tracker:
+              type: str
       neighbor_interfaces:
         type: list
         primary_key: name
@@ -1555,3 +1559,19 @@ keys:
               type: str
               description: |
                 Multiline EOS CLI rendered directly on the Router BGP, VRF definition in the final EOS configuration
+      session_trackers:
+        type: list
+        primary_key: name
+        items:
+          type: dict
+          keys:
+            name:
+              type: str
+              description: Name of session tracker
+            recovery_delay:
+              type: int
+              description: Recovery delay in seconds
+              convert_types:
+                - str
+              min: 1
+              max: 3600

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
@@ -161,6 +161,9 @@
 {%             if peer_group.default_originate.enabled is arista.avd.defined(true) %}
 | Default originate | True |
 {%             endif %}
+{%             if peer_group.session_tracker is arista.avd.defined %}
+| Session tracker | {{ peer_group.session_tracker }} |
+{%             endif %}
 {%             if peer_group.send_community is arista.avd.defined %}
 | Send community | {{ peer_group.send_community }} |
 {%             endif %}
@@ -692,6 +695,16 @@
 {%             else %}
 | {{ vrf.name }} | {{ route_distinguisher }} | {{ redistribute | join("<br>") }} |
 {%             endif %}
+{%         endfor %}
+{%     endif %}
+{%     if router_bgp.session_trackers is arista.avd.defined %}
+
+#### Router BGP Session Trackers
+
+| Session Tracker Name | Recovery Delay (in seconds) |
+| -------------------- | --------------------------- |
+{%         for session_tracker in router_bgp.session_trackers | arista.avd.natural_sort('name') %}
+| {{ session_tracker.name }} | {{ session_tracker.recovery_delay }} |
 {%         endfor %}
 {%     endif %}
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -60,6 +60,9 @@ interface {{ ethernet_interface.name }}
    l2 mtu {{ ethernet_interface.l2_mtu }}
 {%         endif %}
 {%     endif %}
+{%     if ethernet_interface.bgp.session_tracker is arista.avd.defined %}
+   bgp session tracker {{ ethernet_interface.bgp.session_tracker }}
+{%     endif %}
 {%     if ethernet_interface.mac_security.profile is arista.avd.defined %}
    mac security profile {{ ethernet_interface.mac_security.profile }}
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
@@ -18,6 +18,9 @@ interface {{ port_channel_interface.name }}
 {%     if port_channel_interface.mtu is arista.avd.defined %}
    mtu {{ port_channel_interface.mtu }}
 {%     endif %}
+{%     if port_channel_interface.bgp.session_tracker is arista.avd.defined %}
+   bgp session tracker {{ port_channel_interface.bgp.session_tracker }}
+{%     endif %}
 {%     if port_channel_interface.type is arista.avd.defined("routed") %}
    no switchport
 {%     elif port_channel_interface.type | arista.avd.default in ['l3dot1q', 'l2dot1q'] %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -165,6 +165,9 @@ router bgp {{ router_bgp.as }}
 {%         if peer_group.passive is arista.avd.defined(true) %}
    neighbor {{ peer_group.name }} passive
 {%         endif %}
+{%         if peer_group.session_tracker is arista.avd.defined %}
+   neighbor {{ peer_group.name }} session tracker {{ peer_group.session_tracker }}
+{%         endif %}
 {%         if peer_group.send_community is arista.avd.defined('all') %}
    neighbor {{ peer_group.name }} send-community
 {%         elif peer_group.send_community is arista.avd.defined %}
@@ -292,6 +295,9 @@ router bgp {{ router_bgp.as }}
 {%         endif %}
 {%         if neighbor.weight is arista.avd.defined %}
    neighbor {{ neighbor.ip_address }} weight {{ neighbor.weight }}
+{%         endif %}
+{%         if neighbor.session_tracker is arista.avd.defined() %}
+   neighbor {{ neighbor.ip_address }} session tracker {{ neighbor.session_tracker }}
 {%         endif %}
 {%         if neighbor.timers is arista.avd.defined %}
    neighbor {{ neighbor.ip_address }} timers {{ neighbor.timers }}
@@ -1086,6 +1092,13 @@ router bgp {{ router_bgp.as }}
 {%         if vrf.eos_cli is arista.avd.defined %}
       !
       {{ vrf.eos_cli | indent(6, false) }}
+{%         endif %}
+{%     endfor %}
+{# BGP session tracker #}
+{%     for session_tracker in router_bgp.session_trackers | arista.avd.natural_sort('name') %}
+  session tracker {{ session_tracker.name }}
+{%         if session_tracker.recovery_delay is arista.avd.defined %}
+    recovery delay {{ session_tracker.recovery_delay }} seconds
 {%         endif %}
 {%     endfor %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -1096,9 +1096,9 @@ router bgp {{ router_bgp.as }}
 {%     endfor %}
 {# BGP session tracker #}
 {%     for session_tracker in router_bgp.session_trackers | arista.avd.natural_sort('name') %}
-  session tracker {{ session_tracker.name }}
+   session tracker {{ session_tracker.name }}
 {%         if session_tracker.recovery_delay is arista.avd.defined %}
-    recovery delay {{ session_tracker.recovery_delay }} seconds
+      recovery delay {{ session_tracker.recovery_delay }} seconds
 {%         endif %}
 {%     endfor %}
 {% endif %}


### PR DESCRIPTION
## Change Summary

Implement BGP session tracker

## Related Issue(s)

Fixes #2653 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Added the following schema to router-bgp

```
bgp:
  neighbors:
    type: list
    primary_key: ip_address
    item:
      type: dict
      keys:
+       session_tracker:
+       type: str
  peer_groups:
    type: list
    primary_key: name
    item:
      type: dict
      keys:
+       session_tracker:
+       type: str
[...]
+      session_trackers:
+        type: list
+        primary_key: name
+        items:
+          type: dict
+          keys:
+            name:
+              type: str
+              description: Name of session tracker
+            recovery_delay:
+              type: int
+              description: Recovery delay in seconds
+              convert_types:
+                - str
+              min: 1
+              max: 3600
```

Added the following schema to ethernet interfaces and port-channel interfaces

```
        bgp:
          type: dict
          keys:
            session_tracker:
              type: str
              description: Name of session tracker
```

## How to test

Added tests to molecule eos_cli_config_gen scenario

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
