### PR TITLE
Refactor(eos_designs): Relax requirement for 'id' if not used

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_FABRIC.yml
@@ -324,7 +324,8 @@ l2leaf:
         tags: [ opzone, web, app ]
       nodes:
         DC1-L2LEAF3A:
-          id: 12
+          # Testing no id for an L2 Leaf when not needed
+          # id: 12
           mgmt_ip: 192.168.200.116/24
           mac_address: '0c:1d:c0:1d:62:01'
           uplink_switch_interfaces: [ Ethernet9, Ethernet9 ]

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_facts.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_facts.py
@@ -360,7 +360,7 @@ class EosDesignsFacts(AvdFacts):
     @cached_property
     def id(self) -> int | None:
         """
-        Make id not required for switches that would not use it
+        id is optional.
         """
         return get(self._switch_data_combined, "id")
 

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_facts.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_facts.py
@@ -474,9 +474,10 @@ class EosDesignsFacts(AvdFacts):
             auto_clock_identity = get(self._switch_data_combined, "ptp.auto_clock_identity", default=True)
             priority1 = get(self._switch_data_combined, "ptp.priority1", default=self.default_ptp_priority1)
             priority2 = get(self._switch_data_combined, "ptp.priority2")
-            if priority2 is None and self.id is None:
-                raise AristaAvdMissingVariableError(f"'id' is not set on '{self.hostname}' to set ptp priority2")
-            priority2 = self.id % 256
+            if priority2 is None:
+                if self.id is None:
+                    raise AristaAvdMissingVariableError(f"'id' is not set on '{self.hostname}' to set ptp priority2")
+                priority2 = self.id % 256
             if auto_clock_identity is True:
                 clock_identity_prefix = get(self._switch_data_combined, "ptp.clock_identity_prefix", default="00:1C:73")
                 default_clock_identity = f"{clock_identity_prefix}:{priority1:02x}:00:{priority2:02x}"


### PR DESCRIPTION
## Change Summary

Relax requirement for 'id' if not used

## Related Issue(s)

Fixes #2655 

## Component(s) name

`plugins`

## Proposed changes

* Make id not mandatory in `plugins/plugin_utils/eos_design_facts.py`
* Refactor all the keys requiring `self.id` with a guard.
* Removed id for a non MLAG L2LEAF in `eos_designs_unit_tests` to test


## How to test

molecule

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
