### PR TITLE
Fix(eos_designs): Fix and test custom python modules for ip addressing and interface descriptions

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/custom_modules/custom_interface_descriptions.py
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/custom_modules/custom_interface_descriptions.py
@@ -1,0 +1,85 @@
+from functools import cached_property
+
+from ansible_collections.arista.avd.plugins.plugin_utils.utils import get
+from ansible_collections.arista.avd.roles.eos_designs.python_modules.interface_descriptions import AvdInterfaceDescriptions as BaseAvdInterfaceDescriptions
+
+
+class AvdInterfaceDescriptions(BaseAvdInterfaceDescriptions):
+    @cached_property
+    def _custom_description_prefix(self):
+        return get(self._hostvars, "description_prefix", "")
+
+    @cached_property
+    def _switch_type(self):
+        return get(self._hostvars, "switch.type", "")
+
+    def underlay_ethernet_interfaces(self, link_type: str, link_peer: str, link_peer_interface: str) -> str:
+        """
+        Implementation of custom code similar to jinja in
+        custom_templates/interface_descriptions/underlay/ethernet-interfaces.j2
+        """
+        link_peer = str(link_peer).upper()
+        if link_type == "underlay_p2p":
+            return f"{self._custom_description_prefix}_P2P_LINK_TO_{link_peer}_{link_peer_interface}"
+
+        if link_type == "underlay_l2":
+            return f"{self._custom_description_prefix}_{link_peer}_{link_peer_interface}"
+
+        return ""
+
+    def underlay_port_channel_interfaces(self, link_peer: str, link_peer_channel_group_id: int, link_channel_description: str) -> str:
+        """
+        Implementation of custom code similar to jinja:
+        custom_templates/interface_descriptions/underlay/port-channel-interfaces.j2
+        """
+        if link_channel_description is not None:
+            link_channel_description = str(link_channel_description).upper()
+            return f"{self._custom_description_prefix}_{link_channel_description}_Po{link_peer_channel_group_id}"
+
+        link_peer = str(link_peer).upper()
+        return f"{self._custom_description_prefix}_{link_peer}_Po{link_peer_channel_group_id}"
+
+    def mlag_ethernet_interfaces(self, mlag_interface: str) -> str:
+        """
+        Implementation of custom code similar to jinja:
+        custom_templates/interface_descriptions/mlag/ethernet-interfaces.j2
+        """
+        return f"{self._custom_description_prefix}_MLAG_PEER_{self._mlag_peer}_{mlag_interface}"
+
+    def mlag_port_channel_interfaces(self) -> str:
+        """
+        Implementation of custom code similar to jinja:
+        custom_templates/interface_descriptions/mlag/port-channel-interfaces.j2
+        """
+        return f"{self._custom_description_prefix}_MLAG_PEER_{self._mlag_peer}_Po{self._mlag_port_channel_id}"
+
+    def connected_endpoints_ethernet_interfaces(self, peer: str = None, peer_interface: str = None) -> str:
+        """
+        Implementation of custom code similar to jinja:
+        custom_templates/interface_descriptions/connected-endpoints/ethernet-interfaces.j2
+        """
+        elements = [peer, peer_interface]
+        return "_".join([str(element) for element in elements if element is not None])
+
+    def connected_endpoints_port_channel_interfaces(self, peer: str = None, adapter_port_channel_description: str = None) -> str:
+        """
+        Implementation of custom code similar to jinja:
+        custom_templates/interface_descriptions/connected-endpoints/port-channel-interfaces.j2
+        """
+        elements = [self._custom_description_prefix, peer, adapter_port_channel_description]
+        return "_".join([str(element) for element in elements if element is not None])
+
+    def overlay_loopback_interface(self, overlay_loopback_description: str = None) -> str:
+        """
+        Implementation of custom code similar to jinja:
+        custom_templates/interface_descriptions/loopbacks/overlay-loopback.j2
+        """
+        switch_type = str(self._switch_type).upper()
+        return f"{self._custom_description_prefix}_EVPN_Overlay_Peering_{switch_type}"
+
+    def vtep_loopback_interface(self) -> str:
+        """
+        Implementation of custom code similar to jinja:
+        """
+        switch_type = str(self._switch_type).upper()
+        return f"{self._custom_description_prefix}_VTEP_VXLAN_Tunnel_Source_{switch_type}"

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/custom_modules/custom_interface_descriptions.py
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/custom_modules/custom_interface_descriptions.py
@@ -1,10 +1,10 @@
 from functools import cached_property
 
 from ansible_collections.arista.avd.plugins.plugin_utils.utils import get
-from ansible_collections.arista.avd.roles.eos_designs.python_modules.interface_descriptions import AvdInterfaceDescriptions as BaseAvdInterfaceDescriptions
+from ansible_collections.arista.avd.roles.eos_designs.python_modules.interface_descriptions import AvdInterfaceDescriptions
 
 
-class AvdInterfaceDescriptions(BaseAvdInterfaceDescriptions):
+class CustomAvdInterfaceDescriptions(AvdInterfaceDescriptions):
     @cached_property
     def _custom_description_prefix(self):
         return get(self._hostvars, "description_prefix", "")

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/custom_modules/custom_ip_addressing.py
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/custom_modules/custom_ip_addressing.py
@@ -1,0 +1,139 @@
+from functools import cached_property
+
+from ansible_collections.arista.avd.roles.eos_designs.python_modules.ip_addressing import AvdIpAddressing as BaseAvdIpAddressing
+
+
+class AvdIpAddressing(BaseAvdIpAddressing):
+    pass
+
+    @cached_property
+    def _custom_ip_offset_10(self):
+        return self._hostvars.get("ip_offset_10", 0)
+
+    @cached_property
+    def _custom_ip_offset_10_subnets(self):
+        """
+        The jinja code did a blind addition of 10 to the resulting IP even for subnets.
+        Here we divide the offset with two, since we are calculating /31 subnets more intelligently
+        """
+        return int(self._custom_ip_offset_10 / 2)
+
+    @cached_property
+    def _custom_ip_offset_20(self):
+        return self._hostvars.get("ip_offset_20", 0)
+
+    @cached_property
+    def _custom_ip_offset_20_subnets(self):
+        """
+        The jinja code did a blind addition of 20 to the resulting IP even for subnets.
+        Here we divide the offset with two, since we are calculating /31 subnets more intelligently
+        """
+        return int(self._custom_ip_offset_20 / 2)
+
+    def mlag_ibgp_peering_ip_primary(self, mlag_ibgp_peering_ipv4_pool: str) -> str:
+        """
+        Implementation of custom code similar to jinja:
+        {{ vrf.mlag_ibgp_peering_ipv4_pool | ansible.netcommon.ipaddr('subnet') |
+           ansible.netcommon.ipmath((switch.mlag_switch_ids.primary - 1) * 2 + ip_offset_10) }}
+        """
+        offset = self._mlag_primary_id - 1 + self._custom_ip_offset_10_subnets
+        return self._ip(mlag_ibgp_peering_ipv4_pool, 31, offset, 0)
+
+    def mlag_ibgp_peering_ip_secondary(self, mlag_ibgp_peering_ipv4_pool: str) -> str:
+        """
+        Implementation of custom code similar to jinja:
+        {{ vrf.mlag_ibgp_peering_ipv4_pool | ansible.netcommon.ipaddr('subnet') |
+           ansible.netcommon.ipmath(((switch.mlag_switch_ids.primary - 1) * 2) + 1 + ip_offset_10) }}
+        """
+        offset = self._mlag_primary_id - 1 + self._custom_ip_offset_10_subnets
+        return self._ip(mlag_ibgp_peering_ipv4_pool, 31, offset, 1)
+
+    def mlag_ip_primary(self) -> str:
+        """
+        Implementation of custom code similar to jinja:
+        {{ switch_data.combined.mlag_peer_ipv4_pool | ansible.netcommon.ipaddr('network') |
+           ansible.netcommon.ipmath((mlag_primary_id - 1) * 2 + ip_offset_10) }}
+        """
+        offset = self._mlag_primary_id - 1 + self._custom_ip_offset_10_subnets
+        return self._ip(self._mlag_peer_ipv4_pool, 31, offset, 0)
+
+    def mlag_ip_secondary(self) -> str:
+        """
+        Implementation of custom code similar to jinja:
+        {{ switch_data.combined.mlag_peer_ipv4_pool | ansible.netcommon.ipaddr('network') |
+           ansible.netcommon.ipmath(((mlag_primary_id - 1) * 2) + 1 + ip_offset_10) }}
+        """
+        offset = self._mlag_primary_id - 1 + self._custom_ip_offset_10_subnets
+        return self._ip(self._mlag_peer_ipv4_pool, 31, offset, 1)
+
+    def mlag_l3_ip_primary(self) -> str:
+        """
+        Implementation of custom code similar to jinja:
+        {{ switch_data.combined.mlag_peer_l3_ipv4_pool | ansible.netcommon.ipaddr('network') |
+           ansible.netcommon.ipmath((mlag_primary_id - 1) * 2 + ip_offset_10) }}
+        """
+        offset = self._mlag_primary_id - 1 + self._custom_ip_offset_10_subnets
+        return self._ip(self._mlag_peer_l3_ipv4_pool, 31, offset, 0)
+
+    def mlag_l3_ip_secondary(self) -> str:
+        """
+        Implementation of custom code similar to jinja:
+        {{ switch_data.combined.mlag_peer_l3_ipv4_pool | ansible.netcommon.ipaddr('network') |
+           ansible.netcommon.ipmath(((mlag_primary_id - 1) * 2) + 1 + ip_offset_10) }}
+        """
+        offset = self._mlag_primary_id - 1 + self._custom_ip_offset_10_subnets
+        return self._ip(self._mlag_peer_l3_ipv4_pool, 31, offset, 1)
+
+    def p2p_uplinks_ip(self, uplink_switch_index: int) -> str:
+        """
+        Implementation of custom code similar to jinja:
+        {{ switch.uplink_ipv4_pool | ansible.netcommon.ipaddr('network') | ansible.netcommon.ipmath(((switch.id -1)
+           * 2 * switch.max_uplink_switches * switch.max_parallel_uplinks) + (uplink_switch_index) * 2 + 1 + ip_offset_20) }}
+        """
+        offset = ((self._id - 1) * self._max_uplink_switches * self._max_parallel_uplinks) + uplink_switch_index + self._custom_ip_offset_20_subnets
+        return self._ip(self._uplink_ipv4_pool, 31, offset, 1)
+
+    def p2p_uplinks_peer_ip(self, uplink_switch_index: int) -> str:
+        """
+        Implementation of custom code similar to jinja:
+        {{ switch.uplink_ipv4_pool | ansible.netcommon.ipaddr('network') | ansible.netcommon.ipmath(((switch.id -1)
+           * 2 * switch.max_uplink_switches * switch.max_parallel_uplinks) + (uplink_switch_index) * 2 + ip_offset_20) }}
+        """
+        offset = ((self._id - 1) * self._max_uplink_switches * self._max_parallel_uplinks) + uplink_switch_index + self._custom_ip_offset_20_subnets
+        return self._ip(self._uplink_ipv4_pool, 31, offset, 0)
+
+    def router_id(self) -> str:
+        """
+        Implementation of custom code similar to jinja:
+        {{ loopback_ipv4_pool | ansible.netcommon.ipaddr("network") |
+           ansible.netcommon.ipmath(switch_id + loopback_ipv4_offset + ip_offset_20) }}
+        """
+        offset = self._id + self._loopback_ipv4_offset + self._custom_ip_offset_20
+        return self._ip(self._loopback_ipv4_pool, 32, offset, 0)
+
+    def ipv6_router_id(self) -> str:
+        """
+        Implementation of custom code similar to jinja:
+        {{ loopback_ipv6_pool | ansible.netcommon.ipaddr("network") |
+           ansible.netcommon.ipmath(switch_id + loopback_ipv6_offset + ip_offset_20) }}
+        """
+        offset = self._id + self._loopback_ipv6_offset + self._custom_ip_offset_20
+        return self._ip(self._loopback_ipv6_pool, 128, offset, 0)
+
+    def vtep_ip_mlag(self) -> str:
+        """
+        Implementation of custom code similar to jinja:
+        {{ switch_vtep_loopback_ipv4_pool | ansible.netcommon.ipaddr('network') |
+           ansible.netcommon.ipmath(mlag_primary_id + loopback_ipv4_offset + ip_offset_20) }}
+        """
+        offset = self._mlag_primary_id + self._loopback_ipv4_offset + self._custom_ip_offset_20
+        return self._ip(self._vtep_loopback_ipv4_pool, 32, offset, 0)
+
+    def vtep_ip(self) -> str:
+        """
+        Implementation of custom code similar to jinja:
+        {{ switch_vtep_loopback_ipv4_pool | ansible.netcommon.ipaddr('network') |
+           ansible.netcommon.ipmath(switch_id + loopback_ipv4_offset + ip_offset_20) }}
+        """
+        offset = self._id + self._loopback_ipv4_offset + self._custom_ip_offset_20
+        return self._ip(self._vtep_loopback_ipv4_pool, 32, offset, 0)

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/custom_modules/custom_ip_addressing.py
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/custom_modules/custom_ip_addressing.py
@@ -1,9 +1,9 @@
 from functools import cached_property
 
-from ansible_collections.arista.avd.roles.eos_designs.python_modules.ip_addressing import AvdIpAddressing as BaseAvdIpAddressing
+from ansible_collections.arista.avd.roles.eos_designs.python_modules.ip_addressing import AvdIpAddressing
 
 
-class AvdIpAddressing(BaseAvdIpAddressing):
+class CustomAvdIpAddressing(AvdIpAddressing):
     pass
 
     @cached_property

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-PYTHON_MODULES-L3LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-PYTHON_MODULES-L3LEAF1A.cfg
@@ -1,0 +1,198 @@
+!RANCID-CONTENT-TYPE: arista
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname CUSTOM-PYTHON_MODULES-L3LEAF1A
+!
+no spanning-tree vlan-id 4093-4094
+!
+no enable password
+no aaa root
+!
+vlan 110
+   name Tenant_A_OP_Zone_1
+!
+vlan 3000
+   name MLAG_iBGP_TEST_VRF
+   trunk group LEAF_PEER_L3
+!
+vlan 4093
+   name LEAF_PEER_L3
+   trunk group LEAF_PEER_L3
+!
+vlan 4094
+   name MLAG_PEER
+   trunk group MLAG
+!
+vrf instance MGMT
+!
+vrf instance TEST_VRF
+!
+interface Port-Channel3
+   description TEST_CUSTOM_PREFIX_MLAG_PEER_CUSTOM-PYTHON_MODULES-L3LEAF1B_Po3
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 2-4094
+   switchport mode trunk
+   switchport trunk group LEAF_PEER_L3
+   switchport trunk group MLAG
+!
+interface Ethernet1
+   description TEST_CUSTOM_PREFIX_P2P_LINK_TO_CUSTOM-PYTHON_MODULES-SPINE1_Ethernet1
+   no shutdown
+   mtu 9000
+   no switchport
+   ip address 172.31.255.21/31
+!
+interface Ethernet3
+   description TEST_CUSTOM_PREFIX_MLAG_PEER_CUSTOM-PYTHON_MODULES-L3LEAF1B_Ethernet3
+   no shutdown
+   channel-group 3 mode active
+!
+interface Ethernet4
+   description TEST_CUSTOM_PREFIX_MLAG_PEER_CUSTOM-PYTHON_MODULES-L3LEAF1B_Ethernet4
+   no shutdown
+   channel-group 3 mode active
+!
+interface Loopback0
+   description TEST_CUSTOM_PREFIX_EVPN_Overlay_Peering_L3LEAF
+   no shutdown
+   ip address 192.168.255.21/32
+!
+interface Loopback1
+   description TEST_CUSTOM_PREFIX_VTEP_VXLAN_Tunnel_Source_L3LEAF
+   no shutdown
+   ip address 192.168.254.21/32
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 192.168.200.101/24
+!
+interface Vlan110
+   description Tenant_A_OP_Zone_1
+   no shutdown
+   vrf TEST_VRF
+   ip address virtual 10.1.10.1/24
+!
+interface Vlan3000
+   description MLAG_PEER_L3_iBGP: vrf TEST_VRF
+   no shutdown
+   mtu 9000
+   vrf TEST_VRF
+   ip address 10.255.240.10/31
+!
+interface Vlan4093
+   description MLAG_PEER_L3_PEERING
+   no shutdown
+   mtu 9000
+   ip address 10.255.251.10/31
+!
+interface Vlan4094
+   description MLAG_PEER
+   no shutdown
+   mtu 9000
+   no autostate
+   ip address 10.255.252.10/31
+!
+interface Vxlan1
+   description CUSTOM-PYTHON_MODULES-L3LEAF1A_VTEP
+   vxlan source-interface Loopback1
+   vxlan virtual-router encapsulation mac-address mlag-system-id
+   vxlan udp-port 4789
+   vxlan vlan 110 vni 11110
+   vxlan vrf TEST_VRF vni 1
+!
+ip virtual-router mac-address 00:dc:00:00:00:0a
+!
+ip routing
+no ip routing vrf MGMT
+ip routing vrf TEST_VRF
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+   seq 20 permit 192.168.254.0/24 eq 32
+!
+mlag configuration
+   domain-id CUSTOM_PYTHON_MODULES_L3LEAF1
+   local-interface Vlan4094
+   peer-address 10.255.252.11
+   peer-link Port-Channel3
+   reload-delay mlag 300
+   reload-delay non-mlag 330
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.200.1
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+route-map RM-MLAG-PEER-IN permit 10
+   description Make routes learned over MLAG Peer-link less preferred on spines to ensure optimal routing
+   set origin incomplete
+!
+router bfd
+   multihop interval 300 min-rx 300 multiplier 3
+!
+router bgp 65101
+   router-id 192.168.255.21
+   maximum-paths 4 ecmp 4
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor IPv4-UNDERLAY-PEERS peer group
+   neighbor IPv4-UNDERLAY-PEERS send-community
+   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   neighbor MLAG-IPv4-UNDERLAY-PEER peer group
+   neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65101
+   neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self
+   neighbor MLAG-IPv4-UNDERLAY-PEER description CUSTOM-PYTHON_MODULES-L3LEAF1B
+   neighbor MLAG-IPv4-UNDERLAY-PEER send-community
+   neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000
+   neighbor MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN in
+   neighbor 10.255.251.11 peer group MLAG-IPv4-UNDERLAY-PEER
+   neighbor 10.255.251.11 description CUSTOM-PYTHON_MODULES-L3LEAF1B
+   neighbor 172.31.255.20 peer group IPv4-UNDERLAY-PEERS
+   neighbor 172.31.255.20 remote-as 65001
+   neighbor 172.31.255.20 description CUSTOM-PYTHON_MODULES-SPINE1_Ethernet1
+   neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.1 remote-as 65001
+   neighbor 192.168.255.1 description CUSTOM-PYTHON_MODULES-SPINE1
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   vlan 110
+      rd 192.168.255.21:11110
+      route-target both 11110:11110
+      redistribute learned
+   !
+   address-family evpn
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor IPv4-UNDERLAY-PEERS activate
+      neighbor MLAG-IPv4-UNDERLAY-PEER activate
+   !
+   vrf TEST_VRF
+      rd 192.168.255.21:1
+      route-target import evpn 1:1
+      route-target export evpn 1:1
+      router-id 192.168.255.21
+      neighbor 10.255.240.11 peer group MLAG-IPv4-UNDERLAY-PEER
+      redistribute connected
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-PYTHON_MODULES-L3LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-PYTHON_MODULES-L3LEAF1B.cfg
@@ -1,0 +1,198 @@
+!RANCID-CONTENT-TYPE: arista
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname CUSTOM-PYTHON_MODULES-L3LEAF1B
+!
+no spanning-tree vlan-id 4093-4094
+!
+no enable password
+no aaa root
+!
+vlan 110
+   name Tenant_A_OP_Zone_1
+!
+vlan 3000
+   name MLAG_iBGP_TEST_VRF
+   trunk group LEAF_PEER_L3
+!
+vlan 4093
+   name LEAF_PEER_L3
+   trunk group LEAF_PEER_L3
+!
+vlan 4094
+   name MLAG_PEER
+   trunk group MLAG
+!
+vrf instance MGMT
+!
+vrf instance TEST_VRF
+!
+interface Port-Channel3
+   description TEST_CUSTOM_PREFIX_MLAG_PEER_CUSTOM-PYTHON_MODULES-L3LEAF1A_Po3
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 2-4094
+   switchport mode trunk
+   switchport trunk group LEAF_PEER_L3
+   switchport trunk group MLAG
+!
+interface Ethernet1
+   description TEST_CUSTOM_PREFIX_P2P_LINK_TO_CUSTOM-PYTHON_MODULES-SPINE1_Ethernet2
+   no shutdown
+   mtu 9000
+   no switchport
+   ip address 172.31.255.23/31
+!
+interface Ethernet3
+   description TEST_CUSTOM_PREFIX_MLAG_PEER_CUSTOM-PYTHON_MODULES-L3LEAF1A_Ethernet3
+   no shutdown
+   channel-group 3 mode active
+!
+interface Ethernet4
+   description TEST_CUSTOM_PREFIX_MLAG_PEER_CUSTOM-PYTHON_MODULES-L3LEAF1A_Ethernet4
+   no shutdown
+   channel-group 3 mode active
+!
+interface Loopback0
+   description TEST_CUSTOM_PREFIX_EVPN_Overlay_Peering_L3LEAF
+   no shutdown
+   ip address 192.168.255.22/32
+!
+interface Loopback1
+   description TEST_CUSTOM_PREFIX_VTEP_VXLAN_Tunnel_Source_L3LEAF
+   no shutdown
+   ip address 192.168.254.21/32
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 192.168.200.102/24
+!
+interface Vlan110
+   description Tenant_A_OP_Zone_1
+   no shutdown
+   vrf TEST_VRF
+   ip address virtual 10.1.10.1/24
+!
+interface Vlan3000
+   description MLAG_PEER_L3_iBGP: vrf TEST_VRF
+   no shutdown
+   mtu 9000
+   vrf TEST_VRF
+   ip address 10.255.240.11/31
+!
+interface Vlan4093
+   description MLAG_PEER_L3_PEERING
+   no shutdown
+   mtu 9000
+   ip address 10.255.251.11/31
+!
+interface Vlan4094
+   description MLAG_PEER
+   no shutdown
+   mtu 9000
+   no autostate
+   ip address 10.255.252.11/31
+!
+interface Vxlan1
+   description CUSTOM-PYTHON_MODULES-L3LEAF1B_VTEP
+   vxlan source-interface Loopback1
+   vxlan virtual-router encapsulation mac-address mlag-system-id
+   vxlan udp-port 4789
+   vxlan vlan 110 vni 11110
+   vxlan vrf TEST_VRF vni 1
+!
+ip virtual-router mac-address 00:dc:00:00:00:0a
+!
+ip routing
+no ip routing vrf MGMT
+ip routing vrf TEST_VRF
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+   seq 20 permit 192.168.254.0/24 eq 32
+!
+mlag configuration
+   domain-id CUSTOM_PYTHON_MODULES_L3LEAF1
+   local-interface Vlan4094
+   peer-address 10.255.252.10
+   peer-link Port-Channel3
+   reload-delay mlag 300
+   reload-delay non-mlag 330
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.200.1
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+route-map RM-MLAG-PEER-IN permit 10
+   description Make routes learned over MLAG Peer-link less preferred on spines to ensure optimal routing
+   set origin incomplete
+!
+router bfd
+   multihop interval 300 min-rx 300 multiplier 3
+!
+router bgp 65101
+   router-id 192.168.255.22
+   maximum-paths 4 ecmp 4
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor IPv4-UNDERLAY-PEERS peer group
+   neighbor IPv4-UNDERLAY-PEERS send-community
+   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   neighbor MLAG-IPv4-UNDERLAY-PEER peer group
+   neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65101
+   neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self
+   neighbor MLAG-IPv4-UNDERLAY-PEER description CUSTOM-PYTHON_MODULES-L3LEAF1A
+   neighbor MLAG-IPv4-UNDERLAY-PEER send-community
+   neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000
+   neighbor MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN in
+   neighbor 10.255.251.10 peer group MLAG-IPv4-UNDERLAY-PEER
+   neighbor 10.255.251.10 description CUSTOM-PYTHON_MODULES-L3LEAF1A
+   neighbor 172.31.255.22 peer group IPv4-UNDERLAY-PEERS
+   neighbor 172.31.255.22 remote-as 65001
+   neighbor 172.31.255.22 description CUSTOM-PYTHON_MODULES-SPINE1_Ethernet2
+   neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.1 remote-as 65001
+   neighbor 192.168.255.1 description CUSTOM-PYTHON_MODULES-SPINE1
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   vlan 110
+      rd 192.168.255.22:11110
+      route-target both 11110:11110
+      redistribute learned
+   !
+   address-family evpn
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor IPv4-UNDERLAY-PEERS activate
+      neighbor MLAG-IPv4-UNDERLAY-PEER activate
+   !
+   vrf TEST_VRF
+      rd 192.168.255.22:1
+      route-target import evpn 1:1
+      route-target export evpn 1:1
+      router-id 192.168.255.22
+      neighbor 10.255.240.10 peer group MLAG-IPv4-UNDERLAY-PEER
+      redistribute connected
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-PYTHON_MODULES-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-PYTHON_MODULES-SPINE1.cfg
@@ -1,0 +1,98 @@
+!RANCID-CONTENT-TYPE: arista
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname CUSTOM-PYTHON_MODULES-SPINE1
+!
+spanning-tree mode none
+!
+no enable password
+no aaa root
+!
+vrf instance MGMT
+!
+interface Ethernet1
+   description TEST_CUSTOM_PREFIX_P2P_LINK_TO_CUSTOM-PYTHON_MODULES-L3LEAF1A_Ethernet1
+   no shutdown
+   mtu 9000
+   no switchport
+   ip address 172.31.255.20/31
+!
+interface Ethernet2
+   description TEST_CUSTOM_PREFIX_P2P_LINK_TO_CUSTOM-PYTHON_MODULES-L3LEAF1B_Ethernet1
+   no shutdown
+   mtu 9000
+   no switchport
+   ip address 172.31.255.22/31
+!
+interface Loopback0
+   description TEST_CUSTOM_PREFIX_EVPN_Overlay_Peering_SPINE
+   no shutdown
+   ip address 192.168.255.1/32
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 192.168.200.101/24
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.200.1
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+router bfd
+   multihop interval 300 min-rx 300 multiplier 3
+!
+router bgp 65001
+   router-id 192.168.255.1
+   maximum-paths 4 ecmp 4
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor IPv4-UNDERLAY-PEERS peer group
+   neighbor IPv4-UNDERLAY-PEERS send-community
+   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   neighbor 172.31.255.21 peer group IPv4-UNDERLAY-PEERS
+   neighbor 172.31.255.21 remote-as 65101
+   neighbor 172.31.255.21 description CUSTOM-PYTHON_MODULES-L3LEAF1A_Ethernet1
+   neighbor 172.31.255.23 peer group IPv4-UNDERLAY-PEERS
+   neighbor 172.31.255.23 remote-as 65101
+   neighbor 172.31.255.23 description CUSTOM-PYTHON_MODULES-L3LEAF1B_Ethernet1
+   neighbor 192.168.255.21 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.21 remote-as 65101
+   neighbor 192.168.255.21 description CUSTOM-PYTHON_MODULES-L3LEAF1A
+   neighbor 192.168.255.22 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.22 remote-as 65101
+   neighbor 192.168.255.22 description CUSTOM-PYTHON_MODULES-L3LEAF1B
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   address-family evpn
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor IPv4-UNDERLAY-PEERS activate
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-PYTHON_MODULES-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-PYTHON_MODULES-L3LEAF1A.yml
@@ -1,0 +1,255 @@
+router_bgp:
+  as: '65101'
+  router_id: 192.168.255.21
+  bgp_defaults:
+  - maximum-paths 4 ecmp 4
+  peer_groups:
+  - type: ipv4
+    remote_as: '65101'
+    next_hop_self: true
+    description: CUSTOM-PYTHON_MODULES-L3LEAF1B
+    maximum_routes: 12000
+    send_community: all
+    route_map_in: RM-MLAG-PEER-IN
+    name: MLAG-IPv4-UNDERLAY-PEER
+  - type: ipv4
+    maximum_routes: 12000
+    send_community: all
+    name: IPv4-UNDERLAY-PEERS
+  - type: evpn
+    update_source: Loopback0
+    bfd: true
+    send_community: all
+    maximum_routes: 0
+    ebgp_multihop: 3
+    name: EVPN-OVERLAY-PEERS
+  address_family_ipv4:
+    peer_groups:
+    - activate: true
+      name: MLAG-IPv4-UNDERLAY-PEER
+    - activate: true
+      name: IPv4-UNDERLAY-PEERS
+    - activate: false
+      name: EVPN-OVERLAY-PEERS
+  neighbors:
+  - peer_group: MLAG-IPv4-UNDERLAY-PEER
+    description: CUSTOM-PYTHON_MODULES-L3LEAF1B
+    ip_address: 10.255.251.11
+  - peer_group: IPv4-UNDERLAY-PEERS
+    remote_as: '65001'
+    description: CUSTOM-PYTHON_MODULES-SPINE1_Ethernet1
+    ip_address: 172.31.255.20
+  - peer_group: EVPN-OVERLAY-PEERS
+    description: CUSTOM-PYTHON_MODULES-SPINE1
+    remote_as: '65001'
+    ip_address: 192.168.255.1
+  redistribute_routes:
+  - route_map: RM-CONN-2-BGP
+    source_protocol: connected
+  address_family_evpn:
+    peer_groups:
+    - activate: true
+      name: EVPN-OVERLAY-PEERS
+  vrfs:
+  - router_id: 192.168.255.21
+    rd: 192.168.255.21:1
+    route_targets:
+      import:
+      - address_family: evpn
+        route_targets:
+        - '1:1'
+      export:
+      - address_family: evpn
+        route_targets:
+        - '1:1'
+    redistribute_routes:
+    - source_protocol: connected
+    neighbors:
+    - peer_group: MLAG-IPv4-UNDERLAY-PEER
+      ip_address: 10.255.240.11
+    name: TEST_VRF
+  vlans:
+  - tenant: CUSTOM_PYTHON_MODULES_TENANT
+    rd: 192.168.255.21:11110
+    route_targets:
+      both:
+      - 11110:11110
+    redistribute_routes:
+    - learned
+    id: 110
+static_routes:
+- vrf: MGMT
+  destination_address_prefix: 0.0.0.0/0
+  gateway: 192.168.200.1
+service_routing_protocols_model: multi-agent
+ip_routing: true
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+vrfs:
+- name: MGMT
+  ip_routing: false
+- name: TEST_VRF
+  tenant: CUSTOM_PYTHON_MODULES_TENANT
+  ip_routing: true
+management_interfaces:
+- name: Management1
+  description: oob_management
+  shutdown: false
+  vrf: MGMT
+  ip_address: 192.168.200.101/24
+  gateway: 192.168.200.1
+  type: oob
+management_api_http:
+  enable_vrfs:
+  - name: MGMT
+  enable_https: true
+spanning_tree:
+  no_spanning_tree_vlan: 4093-4094
+vlans:
+- tenant: system
+  name: LEAF_PEER_L3
+  trunk_groups:
+  - LEAF_PEER_L3
+  id: 4093
+- tenant: system
+  name: MLAG_PEER
+  trunk_groups:
+  - MLAG
+  id: 4094
+- id: 110
+  name: Tenant_A_OP_Zone_1
+  tenant: CUSTOM_PYTHON_MODULES_TENANT
+- id: 3000
+  name: MLAG_iBGP_TEST_VRF
+  trunk_groups:
+  - LEAF_PEER_L3
+  tenant: CUSTOM_PYTHON_MODULES_TENANT
+vlan_interfaces:
+- name: Vlan4093
+  description: MLAG_PEER_L3_PEERING
+  shutdown: false
+  mtu: 9000
+  ip_address: 10.255.251.10/31
+- name: Vlan4094
+  description: MLAG_PEER
+  shutdown: false
+  ip_address: 10.255.252.10/31
+  no_autostate: true
+  mtu: 9000
+- name: Vlan110
+  tenant: CUSTOM_PYTHON_MODULES_TENANT
+  tags:
+  - opzone
+  description: Tenant_A_OP_Zone_1
+  shutdown: false
+  ip_address_virtual: 10.1.10.1/24
+  vrf: TEST_VRF
+- name: Vlan3000
+  tenant: CUSTOM_PYTHON_MODULES_TENANT
+  type: underlay_peering
+  shutdown: false
+  description: 'MLAG_PEER_L3_iBGP: vrf TEST_VRF'
+  vrf: TEST_VRF
+  mtu: 9000
+  ip_address: 10.255.240.10/31
+port_channel_interfaces:
+- name: Port-Channel3
+  description: TEST_CUSTOM_PREFIX_MLAG_PEER_CUSTOM-PYTHON_MODULES-L3LEAF1B_Po3
+  type: switched
+  shutdown: false
+  vlans: 2-4094
+  mode: trunk
+  trunk_groups:
+  - LEAF_PEER_L3
+  - MLAG
+ethernet_interfaces:
+- peer: CUSTOM-PYTHON_MODULES-L3LEAF1B
+  peer_interface: Ethernet3
+  peer_type: mlag_peer
+  description: TEST_CUSTOM_PREFIX_MLAG_PEER_CUSTOM-PYTHON_MODULES-L3LEAF1B_Ethernet3
+  type: switched
+  shutdown: false
+  channel_group:
+    id: 3
+    mode: active
+  name: Ethernet3
+- peer: CUSTOM-PYTHON_MODULES-L3LEAF1B
+  peer_interface: Ethernet4
+  peer_type: mlag_peer
+  description: TEST_CUSTOM_PREFIX_MLAG_PEER_CUSTOM-PYTHON_MODULES-L3LEAF1B_Ethernet4
+  type: switched
+  shutdown: false
+  channel_group:
+    id: 3
+    mode: active
+  name: Ethernet4
+- peer: CUSTOM-PYTHON_MODULES-SPINE1
+  peer_interface: Ethernet1
+  peer_type: spine
+  description: TEST_CUSTOM_PREFIX_P2P_LINK_TO_CUSTOM-PYTHON_MODULES-SPINE1_Ethernet1
+  shutdown: false
+  mtu: 9000
+  type: routed
+  ip_address: 172.31.255.21/31
+  name: Ethernet1
+mlag_configuration:
+  domain_id: CUSTOM_PYTHON_MODULES_L3LEAF1
+  local_interface: Vlan4094
+  peer_address: 10.255.252.11
+  peer_link: Port-Channel3
+  reload_delay_mlag: '300'
+  reload_delay_non_mlag: '330'
+route_maps:
+- name: RM-MLAG-PEER-IN
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    set:
+    - origin incomplete
+    description: Make routes learned over MLAG Peer-link less preferred on spines to ensure optimal routing
+- name: RM-CONN-2-BGP
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    match:
+    - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+loopback_interfaces:
+- name: Loopback0
+  description: TEST_CUSTOM_PREFIX_EVPN_Overlay_Peering_L3LEAF
+  shutdown: false
+  ip_address: 192.168.255.21/32
+- name: Loopback1
+  description: TEST_CUSTOM_PREFIX_VTEP_VXLAN_Tunnel_Source_L3LEAF
+  shutdown: false
+  ip_address: 192.168.254.21/32
+prefix_lists:
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
+router_bfd:
+  multihop:
+    interval: 300
+    min_rx: 300
+    multiplier: 3
+ip_igmp_snooping:
+  globally_enabled: true
+ip_virtual_router_mac_address: 00:dc:00:00:00:0a
+vxlan_interface:
+  Vxlan1:
+    description: CUSTOM-PYTHON_MODULES-L3LEAF1A_VTEP
+    vxlan:
+      udp_port: 4789
+      source_interface: Loopback1
+      virtual_router_encapsulation_mac_address: mlag-system-id
+      vlans:
+      - id: 110
+        vni: 11110
+      vrfs:
+      - name: TEST_VRF
+        vni: 1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-PYTHON_MODULES-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-PYTHON_MODULES-L3LEAF1B.yml
@@ -1,0 +1,255 @@
+router_bgp:
+  as: '65101'
+  router_id: 192.168.255.22
+  bgp_defaults:
+  - maximum-paths 4 ecmp 4
+  peer_groups:
+  - type: ipv4
+    remote_as: '65101'
+    next_hop_self: true
+    description: CUSTOM-PYTHON_MODULES-L3LEAF1A
+    maximum_routes: 12000
+    send_community: all
+    route_map_in: RM-MLAG-PEER-IN
+    name: MLAG-IPv4-UNDERLAY-PEER
+  - type: ipv4
+    maximum_routes: 12000
+    send_community: all
+    name: IPv4-UNDERLAY-PEERS
+  - type: evpn
+    update_source: Loopback0
+    bfd: true
+    send_community: all
+    maximum_routes: 0
+    ebgp_multihop: 3
+    name: EVPN-OVERLAY-PEERS
+  address_family_ipv4:
+    peer_groups:
+    - activate: true
+      name: MLAG-IPv4-UNDERLAY-PEER
+    - activate: true
+      name: IPv4-UNDERLAY-PEERS
+    - activate: false
+      name: EVPN-OVERLAY-PEERS
+  neighbors:
+  - peer_group: MLAG-IPv4-UNDERLAY-PEER
+    description: CUSTOM-PYTHON_MODULES-L3LEAF1A
+    ip_address: 10.255.251.10
+  - peer_group: IPv4-UNDERLAY-PEERS
+    remote_as: '65001'
+    description: CUSTOM-PYTHON_MODULES-SPINE1_Ethernet2
+    ip_address: 172.31.255.22
+  - peer_group: EVPN-OVERLAY-PEERS
+    description: CUSTOM-PYTHON_MODULES-SPINE1
+    remote_as: '65001'
+    ip_address: 192.168.255.1
+  redistribute_routes:
+  - route_map: RM-CONN-2-BGP
+    source_protocol: connected
+  address_family_evpn:
+    peer_groups:
+    - activate: true
+      name: EVPN-OVERLAY-PEERS
+  vrfs:
+  - router_id: 192.168.255.22
+    rd: 192.168.255.22:1
+    route_targets:
+      import:
+      - address_family: evpn
+        route_targets:
+        - '1:1'
+      export:
+      - address_family: evpn
+        route_targets:
+        - '1:1'
+    redistribute_routes:
+    - source_protocol: connected
+    neighbors:
+    - peer_group: MLAG-IPv4-UNDERLAY-PEER
+      ip_address: 10.255.240.10
+    name: TEST_VRF
+  vlans:
+  - tenant: CUSTOM_PYTHON_MODULES_TENANT
+    rd: 192.168.255.22:11110
+    route_targets:
+      both:
+      - 11110:11110
+    redistribute_routes:
+    - learned
+    id: 110
+static_routes:
+- vrf: MGMT
+  destination_address_prefix: 0.0.0.0/0
+  gateway: 192.168.200.1
+service_routing_protocols_model: multi-agent
+ip_routing: true
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+vrfs:
+- name: MGMT
+  ip_routing: false
+- name: TEST_VRF
+  tenant: CUSTOM_PYTHON_MODULES_TENANT
+  ip_routing: true
+management_interfaces:
+- name: Management1
+  description: oob_management
+  shutdown: false
+  vrf: MGMT
+  ip_address: 192.168.200.102/24
+  gateway: 192.168.200.1
+  type: oob
+management_api_http:
+  enable_vrfs:
+  - name: MGMT
+  enable_https: true
+spanning_tree:
+  no_spanning_tree_vlan: 4093-4094
+vlans:
+- tenant: system
+  name: LEAF_PEER_L3
+  trunk_groups:
+  - LEAF_PEER_L3
+  id: 4093
+- tenant: system
+  name: MLAG_PEER
+  trunk_groups:
+  - MLAG
+  id: 4094
+- id: 110
+  name: Tenant_A_OP_Zone_1
+  tenant: CUSTOM_PYTHON_MODULES_TENANT
+- id: 3000
+  name: MLAG_iBGP_TEST_VRF
+  trunk_groups:
+  - LEAF_PEER_L3
+  tenant: CUSTOM_PYTHON_MODULES_TENANT
+vlan_interfaces:
+- name: Vlan4093
+  description: MLAG_PEER_L3_PEERING
+  shutdown: false
+  mtu: 9000
+  ip_address: 10.255.251.11/31
+- name: Vlan4094
+  description: MLAG_PEER
+  shutdown: false
+  ip_address: 10.255.252.11/31
+  no_autostate: true
+  mtu: 9000
+- name: Vlan110
+  tenant: CUSTOM_PYTHON_MODULES_TENANT
+  tags:
+  - opzone
+  description: Tenant_A_OP_Zone_1
+  shutdown: false
+  ip_address_virtual: 10.1.10.1/24
+  vrf: TEST_VRF
+- name: Vlan3000
+  tenant: CUSTOM_PYTHON_MODULES_TENANT
+  type: underlay_peering
+  shutdown: false
+  description: 'MLAG_PEER_L3_iBGP: vrf TEST_VRF'
+  vrf: TEST_VRF
+  mtu: 9000
+  ip_address: 10.255.240.11/31
+port_channel_interfaces:
+- name: Port-Channel3
+  description: TEST_CUSTOM_PREFIX_MLAG_PEER_CUSTOM-PYTHON_MODULES-L3LEAF1A_Po3
+  type: switched
+  shutdown: false
+  vlans: 2-4094
+  mode: trunk
+  trunk_groups:
+  - LEAF_PEER_L3
+  - MLAG
+ethernet_interfaces:
+- peer: CUSTOM-PYTHON_MODULES-L3LEAF1A
+  peer_interface: Ethernet3
+  peer_type: mlag_peer
+  description: TEST_CUSTOM_PREFIX_MLAG_PEER_CUSTOM-PYTHON_MODULES-L3LEAF1A_Ethernet3
+  type: switched
+  shutdown: false
+  channel_group:
+    id: 3
+    mode: active
+  name: Ethernet3
+- peer: CUSTOM-PYTHON_MODULES-L3LEAF1A
+  peer_interface: Ethernet4
+  peer_type: mlag_peer
+  description: TEST_CUSTOM_PREFIX_MLAG_PEER_CUSTOM-PYTHON_MODULES-L3LEAF1A_Ethernet4
+  type: switched
+  shutdown: false
+  channel_group:
+    id: 3
+    mode: active
+  name: Ethernet4
+- peer: CUSTOM-PYTHON_MODULES-SPINE1
+  peer_interface: Ethernet2
+  peer_type: spine
+  description: TEST_CUSTOM_PREFIX_P2P_LINK_TO_CUSTOM-PYTHON_MODULES-SPINE1_Ethernet2
+  shutdown: false
+  mtu: 9000
+  type: routed
+  ip_address: 172.31.255.23/31
+  name: Ethernet1
+mlag_configuration:
+  domain_id: CUSTOM_PYTHON_MODULES_L3LEAF1
+  local_interface: Vlan4094
+  peer_address: 10.255.252.10
+  peer_link: Port-Channel3
+  reload_delay_mlag: '300'
+  reload_delay_non_mlag: '330'
+route_maps:
+- name: RM-MLAG-PEER-IN
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    set:
+    - origin incomplete
+    description: Make routes learned over MLAG Peer-link less preferred on spines to ensure optimal routing
+- name: RM-CONN-2-BGP
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    match:
+    - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+loopback_interfaces:
+- name: Loopback0
+  description: TEST_CUSTOM_PREFIX_EVPN_Overlay_Peering_L3LEAF
+  shutdown: false
+  ip_address: 192.168.255.22/32
+- name: Loopback1
+  description: TEST_CUSTOM_PREFIX_VTEP_VXLAN_Tunnel_Source_L3LEAF
+  shutdown: false
+  ip_address: 192.168.254.21/32
+prefix_lists:
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
+router_bfd:
+  multihop:
+    interval: 300
+    min_rx: 300
+    multiplier: 3
+ip_igmp_snooping:
+  globally_enabled: true
+ip_virtual_router_mac_address: 00:dc:00:00:00:0a
+vxlan_interface:
+  Vxlan1:
+    description: CUSTOM-PYTHON_MODULES-L3LEAF1B_VTEP
+    vxlan:
+      udp_port: 4789
+      source_interface: Loopback1
+      virtual_router_encapsulation_mac_address: mlag-system-id
+      vlans:
+      - id: 110
+        vni: 11110
+      vrfs:
+      - name: TEST_VRF
+        vni: 1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-PYTHON_MODULES-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-PYTHON_MODULES-SPINE1.yml
@@ -1,0 +1,117 @@
+router_bgp:
+  as: '65001'
+  router_id: 192.168.255.1
+  bgp_defaults:
+  - maximum-paths 4 ecmp 4
+  peer_groups:
+  - type: ipv4
+    maximum_routes: 12000
+    send_community: all
+    name: IPv4-UNDERLAY-PEERS
+  - type: evpn
+    update_source: Loopback0
+    bfd: true
+    send_community: all
+    maximum_routes: 0
+    ebgp_multihop: 3
+    next_hop_unchanged: true
+    name: EVPN-OVERLAY-PEERS
+  address_family_ipv4:
+    peer_groups:
+    - activate: true
+      name: IPv4-UNDERLAY-PEERS
+    - activate: false
+      name: EVPN-OVERLAY-PEERS
+  redistribute_routes:
+  - route_map: RM-CONN-2-BGP
+    source_protocol: connected
+  neighbors:
+  - peer_group: IPv4-UNDERLAY-PEERS
+    remote_as: '65101'
+    description: CUSTOM-PYTHON_MODULES-L3LEAF1A_Ethernet1
+    ip_address: 172.31.255.21
+  - peer_group: IPv4-UNDERLAY-PEERS
+    remote_as: '65101'
+    description: CUSTOM-PYTHON_MODULES-L3LEAF1B_Ethernet1
+    ip_address: 172.31.255.23
+  - peer_group: EVPN-OVERLAY-PEERS
+    description: CUSTOM-PYTHON_MODULES-L3LEAF1A
+    remote_as: '65101'
+    ip_address: 192.168.255.21
+  - peer_group: EVPN-OVERLAY-PEERS
+    description: CUSTOM-PYTHON_MODULES-L3LEAF1B
+    remote_as: '65101'
+    ip_address: 192.168.255.22
+  address_family_evpn:
+    peer_groups:
+    - activate: true
+      name: EVPN-OVERLAY-PEERS
+static_routes:
+- vrf: MGMT
+  destination_address_prefix: 0.0.0.0/0
+  gateway: 192.168.200.1
+service_routing_protocols_model: multi-agent
+ip_routing: true
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+spanning_tree:
+  mode: none
+vrfs:
+- name: MGMT
+  ip_routing: false
+management_interfaces:
+- name: Management1
+  description: oob_management
+  shutdown: false
+  vrf: MGMT
+  ip_address: 192.168.200.101/24
+  gateway: 192.168.200.1
+  type: oob
+management_api_http:
+  enable_vrfs:
+  - name: MGMT
+  enable_https: true
+ethernet_interfaces:
+- peer: CUSTOM-PYTHON_MODULES-L3LEAF1A
+  peer_interface: Ethernet1
+  peer_type: l3leaf
+  description: TEST_CUSTOM_PREFIX_P2P_LINK_TO_CUSTOM-PYTHON_MODULES-L3LEAF1A_Ethernet1
+  shutdown: false
+  mtu: 9000
+  type: routed
+  ip_address: 172.31.255.20/31
+  name: Ethernet1
+- peer: CUSTOM-PYTHON_MODULES-L3LEAF1B
+  peer_interface: Ethernet1
+  peer_type: l3leaf
+  description: TEST_CUSTOM_PREFIX_P2P_LINK_TO_CUSTOM-PYTHON_MODULES-L3LEAF1B_Ethernet1
+  shutdown: false
+  mtu: 9000
+  type: routed
+  ip_address: 172.31.255.22/31
+  name: Ethernet2
+loopback_interfaces:
+- name: Loopback0
+  description: TEST_CUSTOM_PREFIX_EVPN_Overlay_Peering_SPINE
+  shutdown: false
+  ip_address: 192.168.255.1/32
+prefix_lists:
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+route_maps:
+- name: RM-CONN-2-BGP
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    match:
+    - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+router_bfd:
+  multihop:
+    interval: 300
+    min_rx: 300
+    multiplier: 3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CUSTOM_PYTHON_MODULES_L3LEAFS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CUSTOM_PYTHON_MODULES_L3LEAFS.yml
@@ -1,0 +1,44 @@
+---
+
+type: l3leaf
+
+
+l3leaf:
+  defaults:
+    platform: vEOS-LAB
+    loopback_ipv4_pool: 192.168.255.0/24
+    vtep_loopback_ipv4_pool: 192.168.254.0/24
+    virtual_router_mac_address: 00:dc:00:00:00:0a
+    mlag_peer_l3_ipv4_pool: 10.255.251.0/24
+    mlag_peer_ipv4_pool: 10.255.252.0/24
+    mlag_interfaces: [ Ethernet3, Ethernet4 ]
+    uplink_ipv4_pool: 172.31.255.0/24
+    uplink_interfaces: [Ethernet1]
+    uplink_switches: [CUSTOM-PYTHON_MODULES-SPINE1]
+  node_groups:
+    CUSTOM_PYTHON_MODULES_L3LEAF1:
+      bgp_as: 65101
+      nodes:
+        CUSTOM-PYTHON_MODULES-L3LEAF1A:
+          id: 1
+          mgmt_ip: 192.168.200.101/24
+          uplink_switch_interfaces: [Ethernet1]
+        CUSTOM-PYTHON_MODULES-L3LEAF1B:
+          id: 2
+          mgmt_ip: 192.168.200.102/24
+          uplink_switch_interfaces: [Ethernet2]
+
+tenants:
+  CUSTOM_PYTHON_MODULES_TENANT:
+    mac_vrf_vni_base: 11000
+    vrfs:
+      TEST_VRF:
+        vrf_id: 1
+        mlag_ibgp_peering_ipv4_pool: 10.255.240.0/24
+        svis:
+          # SVI as string
+          '110':
+            name: Tenant_A_OP_Zone_1
+            tags: ['opzone']
+            enabled: True
+            ip_address_virtual: 10.1.10.1/24

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CUSTOM_PYTHON_MODULES_SPINES.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CUSTOM_PYTHON_MODULES_SPINES.yml
@@ -1,0 +1,14 @@
+---
+
+type: spine
+
+# Spine Switches
+spine:
+  defaults:
+    platform: vEOS-LAB
+    bgp_as: 65001
+    loopback_ipv4_pool: 192.168.255.0/24
+  nodes:
+    CUSTOM-PYTHON_MODULES-SPINE1:
+      id: 1
+      mgmt_ip: 192.168.200.101/24

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CUSTOM_PYTHON_MODULES_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CUSTOM_PYTHON_MODULES_TESTS.yml
@@ -1,0 +1,55 @@
+---
+
+mgmt_gateway: 192.168.200.1
+
+node_type_keys:
+  spine:
+    type: spine
+    default_evpn_role: server
+    interface_descriptions:
+      # Override interface description templates with our custom templates
+      underlay_ethernet_interfaces: 'custom_templates/interface_descriptions/underlay/ethernet-interfaces.j2'
+      underlay_port_channel_interfaces: 'custom_templates/interface_descriptions/underlay/port-channel-interfaces.j2'
+      mlag_ethernet_interfaces: 'custom_templates/interface_descriptions/mlag/ethernet-interfaces.j2'
+      mlag_port_channel_interfaces: 'custom_templates/interface_descriptions/mlag/port-channel-interfaces.j2'
+      connected_endpoints_ethernet_interfaces: 'custom_templates/interface_descriptions/connected_endpoints/ethernet-interfaces.j2'
+      connected_endpoints_port_channel_interfaces: 'custom_templates/interface_descriptions/connected_endpoints/port-channel-interfaces.j2'
+      overlay_loopback_interface: 'custom_templates/interface_descriptions/loopbacks/overlay-loopback.j2'
+      vtep_loopback_interface: 'custom_templates/interface_descriptions/loopbacks/vtep-loopback.j2'
+  l3leaf:
+    type: l3leaf
+    connected_endpoints: true
+    default_evpn_role: client
+    mlag_support: true
+    network_services:
+      l2: true
+      l3: true
+    vtep: true
+    ip_addressing:
+      router_id: 'custom_templates/ip_addressing/router-id.j2'
+      router_id_ipv6: 'custom_templates/ip_addressing/router-id-ipv6.j2'
+      mlag_ip_primary: 'custom_templates/ip_addressing/mlag-ip-primary.j2'
+      mlag_ip_secondary: 'custom_templates/ip_addressing/mlag-ip-secondary.j2'
+      mlag_l3_ip_primary: 'custom_templates/ip_addressing/mlag-l3-ip-primary.j2'
+      mlag_l3_ip_secondary: 'custom_templates/ip_addressing/mlag-l3-ip-secondary.j2'
+      p2p_uplinks_ip: 'custom_templates/ip_addressing/p2p-uplinks-ip.j2'
+      p2p_uplinks_peer_ip: 'custom_templates/ip_addressing/p2p-uplinks-peer-ip.j2'
+      vtep_ip_mlag: 'custom_templates/ip_addressing/vtep-ip-mlag.j2'
+      vtep_ip: 'custom_templates/ip_addressing/vtep-ip.j2'
+      mlag_ibgp_peering_ip_primary: 'custom_templates/ip_addressing/mlag-ibgp-peering-ip-primary.j2'
+      mlag_ibgp_peering_ip_secondary: 'custom_templates/ip_addressing/mlag-ibgp-peering-ip-secondary.j2'
+    interface_descriptions:
+      # Override interface description templates with our custom templates
+      underlay_ethernet_interfaces: 'custom_templates/interface_descriptions/underlay/ethernet-interfaces.j2'
+      underlay_port_channel_interfaces: 'custom_templates/interface_descriptions/underlay/port-channel-interfaces.j2'
+      mlag_ethernet_interfaces: 'custom_templates/interface_descriptions/mlag/ethernet-interfaces.j2'
+      mlag_port_channel_interfaces: 'custom_templates/interface_descriptions/mlag/port-channel-interfaces.j2'
+      connected_endpoints_ethernet_interfaces: 'custom_templates/interface_descriptions/connected_endpoints/ethernet-interfaces.j2'
+      connected_endpoints_port_channel_interfaces: 'custom_templates/interface_descriptions/connected_endpoints/port-channel-interfaces.j2'
+      overlay_loopback_interface: 'custom_templates/interface_descriptions/loopbacks/overlay-loopback.j2'
+      vtep_loopback_interface: 'custom_templates/interface_descriptions/loopbacks/vtep-loopback.j2'
+
+ip_offset_10: 10
+ip_offset_20: 20
+
+description_prefix: "TEST_CUSTOM_PREFIX"

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CUSTOM_PYTHON_MODULES_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CUSTOM_PYTHON_MODULES_TESTS.yml
@@ -28,10 +28,12 @@ node_type_keys:
     ip_addressing:
       # Override default ip addressing with a custom python module
       python_module: custom_ip_addressing
+      python_class_name: CustomAvdIpAddressing
 
     interface_descriptions:
       # Override default interface description with a custom python module
       python_module: custom_interface_descriptions
+      python_class_name: CustomAvdInterfaceDescriptions
 
 ip_offset_10: 10
 ip_offset_20: 20

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CUSTOM_PYTHON_MODULES_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CUSTOM_PYTHON_MODULES_TESTS.yml
@@ -32,14 +32,6 @@ node_type_keys:
     interface_descriptions:
       # Override default interface description with a custom python module
       python_module: custom_interface_descriptions
-      underlay_ethernet_interfaces: 'custom_templates/interface_descriptions/underlay/ethernet-interfaces.j2'
-      underlay_port_channel_interfaces: 'custom_templates/interface_descriptions/underlay/port-channel-interfaces.j2'
-      mlag_ethernet_interfaces: 'custom_templates/interface_descriptions/mlag/ethernet-interfaces.j2'
-      mlag_port_channel_interfaces: 'custom_templates/interface_descriptions/mlag/port-channel-interfaces.j2'
-      connected_endpoints_ethernet_interfaces: 'custom_templates/interface_descriptions/connected_endpoints/ethernet-interfaces.j2'
-      connected_endpoints_port_channel_interfaces: 'custom_templates/interface_descriptions/connected_endpoints/port-channel-interfaces.j2'
-      overlay_loopback_interface: 'custom_templates/interface_descriptions/loopbacks/overlay-loopback.j2'
-      vtep_loopback_interface: 'custom_templates/interface_descriptions/loopbacks/vtep-loopback.j2'
 
 ip_offset_10: 10
 ip_offset_20: 20

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CUSTOM_PYTHON_MODULES_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CUSTOM_PYTHON_MODULES_TESTS.yml
@@ -26,20 +26,12 @@ node_type_keys:
       l3: true
     vtep: true
     ip_addressing:
-      router_id: 'custom_templates/ip_addressing/router-id.j2'
-      router_id_ipv6: 'custom_templates/ip_addressing/router-id-ipv6.j2'
-      mlag_ip_primary: 'custom_templates/ip_addressing/mlag-ip-primary.j2'
-      mlag_ip_secondary: 'custom_templates/ip_addressing/mlag-ip-secondary.j2'
-      mlag_l3_ip_primary: 'custom_templates/ip_addressing/mlag-l3-ip-primary.j2'
-      mlag_l3_ip_secondary: 'custom_templates/ip_addressing/mlag-l3-ip-secondary.j2'
-      p2p_uplinks_ip: 'custom_templates/ip_addressing/p2p-uplinks-ip.j2'
-      p2p_uplinks_peer_ip: 'custom_templates/ip_addressing/p2p-uplinks-peer-ip.j2'
-      vtep_ip_mlag: 'custom_templates/ip_addressing/vtep-ip-mlag.j2'
-      vtep_ip: 'custom_templates/ip_addressing/vtep-ip.j2'
-      mlag_ibgp_peering_ip_primary: 'custom_templates/ip_addressing/mlag-ibgp-peering-ip-primary.j2'
-      mlag_ibgp_peering_ip_secondary: 'custom_templates/ip_addressing/mlag-ibgp-peering-ip-secondary.j2'
+      # Override default ip addressing with a custom python module
+      python_module: custom_ip_addressing
+
     interface_descriptions:
-      # Override interface description templates with our custom templates
+      # Override default interface description with a custom python module
+      python_module: custom_interface_descriptions
       underlay_ethernet_interfaces: 'custom_templates/interface_descriptions/underlay/ethernet-interfaces.j2'
       underlay_port_channel_interfaces: 'custom_templates/interface_descriptions/underlay/port-channel-interfaces.j2'
       mlag_ethernet_interfaces: 'custom_templates/interface_descriptions/mlag/ethernet-interfaces.j2'

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
@@ -121,6 +121,15 @@ all:
               hosts:
                 CUSTOM-TEMPLATES-L3LEAF1A:
                 CUSTOM-TEMPLATES-L3LEAF1B:
+        CUSTOM_PYTHON_MODULES_TESTS:
+          children:
+            CUSTOM_PYTHON_MODULES_SPINES:
+              hosts:
+                CUSTOM-PYTHON_MODULES-SPINE1:
+            CUSTOM_PYTHON_MODULES_L3LEAFS:
+              hosts:
+                CUSTOM-PYTHON_MODULES-L3LEAF1A:
+                CUSTOM-PYTHON_MODULES-L3LEAF1B:
         AUTO_BGP_ASN:
           hosts:
             AUTO_BGP_ASN_LEAF1A:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/molecule.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/molecule.yml
@@ -40,5 +40,9 @@ provisioner:
       host_vars: 'inventory/host_vars/'
   ansible_args:
     - --skip-tags=documentation
+  env:
+    # Custom pythonpath to allow loading custom ip_addressing and descriptions modules.
+    # See CUSTOM_PYTHON_MODULES_TESTS group vars for details.
+    PYTHONPATH: ${PYTHONPATH}:${MOLECULE_SCENARIO_DIRECTORY}/custom_modules
 verifier:
   name: ansible

--- a/ansible_collections/arista/avd/plugins/action/eos_designs_facts.py
+++ b/ansible_collections/arista/avd/plugins/action/eos_designs_facts.py
@@ -174,9 +174,6 @@ class ActionModule(ActionBase):
             # This is used to access EosDesignsFacts objects of other switches during rendering of one switch.
             host_hostvars["avd_switch_facts"] = avd_switch_facts
             avd_switch_facts[host] = {"switch": EosDesignsFacts(hostvars=host_hostvars, templar=self.templar)}
-            # Add reference to EosDesignsFacts object inside hostvars.
-            # This is used to allow templates to access the facts object directly with "switch.*"
-            host_hostvars["switch"] = avd_switch_facts[host]["switch"]
 
         return avd_switch_facts
 

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_facts.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_facts.py
@@ -49,6 +49,10 @@ class EosDesignsFacts(AvdFacts):
     '''
 
     def __init__(self, hostvars, templar):
+        # Add reference to this instance of EosDesignsFacts object inside hostvars.
+        # This is used to allow templates to access the facts object directly with "switch.*"
+        hostvars["switch"] = self
+
         super().__init__(hostvars, templar)
         self.avd_ip_addressing = load_ip_addressing(self._hostvars, self._templar)
 

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/Node Types.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/Node Types.md
@@ -59,6 +59,8 @@ This should be defined in top level group_var for the fabric.
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vtep</samp>](## "node_type_keys.[].vtep") | Boolean |  | False |  | Is this switch an EVPN VTEP. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mpls_lsr</samp>](## "node_type_keys.[].mpls_lsr") | Boolean |  | False |  | Is this switch an MPLS LSR. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_addressing</samp>](## "node_type_keys.[].ip_addressing") | Dictionary |  |  |  | Override ip_addressing templates. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;python_module</samp>](## "node_type_keys.[].ip_addressing.python_module") | String |  |  |  | Python Module to import for IP addressing - default inherited from templates.ip_addressing.python_module |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;python_class_name</samp>](## "node_type_keys.[].ip_addressing.python_class_name") | String |  |  |  | Name of Python Class to import for IP addressing  - default inherited from templates.ip_addressing.python_class_name |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;router_id</samp>](## "node_type_keys.[].ip_addressing.router_id") | String |  |  |  | Path to J2 template - default inherited from templates.ip_addressing.router_id. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;router_id_ipv6</samp>](## "node_type_keys.[].ip_addressing.router_id_ipv6") | String |  |  |  | Path to J2 template - default inherited from templates.ip_addressing.router_id_ipv6. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_ip_primary</samp>](## "node_type_keys.[].ip_addressing.mlag_ip_primary") | String |  |  |  | Path to J2 template - default inherited from templates.ip_addressing.mlag_ip_primary. |
@@ -72,6 +74,8 @@ This should be defined in top level group_var for the fabric.
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vtep_ip_mlag</samp>](## "node_type_keys.[].ip_addressing.vtep_ip_mlag") | String |  |  |  | Path to J2 template - default inherited from templates.ip_addressing.vtep_ip_mlag. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vtep_ip</samp>](## "node_type_keys.[].ip_addressing.vtep_ip") | String |  |  |  | Path to J2 template - default inherited from templates.ip_addressing.vtep_ip. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;interface_descriptions</samp>](## "node_type_keys.[].interface_descriptions") | Dictionary |  |  |  | Override interface_descriptions templates<br>If description templates use Jinja2, they have to strip whitespaces using {%- -%} on any code blocks.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;python_module</samp>](## "node_type_keys.[].interface_descriptions.python_module") | String |  |  |  | Python Module to import for interface descriptions - default inherited from templates.interface_descriptions.python_module |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;python_class_name</samp>](## "node_type_keys.[].interface_descriptions.python_class_name") | String |  |  |  | Name of Python Class to import for interface descriptions - default inherited from templates.interface_descriptions.python_class_name |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;underlay_ethernet_interfaces</samp>](## "node_type_keys.[].interface_descriptions.underlay_ethernet_interfaces") | String |  |  |  | Path to J2 template - default inherited from templates.interface_descriptions.underlay_ethernet_interfaces. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;underlay_port_channel_interfaces</samp>](## "node_type_keys.[].interface_descriptions.underlay_port_channel_interfaces") | String |  |  |  | Path to J2 template - default inherited from templates.interface_descriptions.underlay_port_channel_interfaces. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_ethernet_interfaces</samp>](## "node_type_keys.[].interface_descriptions.mlag_ethernet_interfaces") | String |  |  |  | Path to J2 template - default inherited from templates.interface_descriptions.mlag_ethernet_interfaces. |
@@ -106,6 +110,8 @@ This should be defined in top level group_var for the fabric.
         vtep: <bool>
         mpls_lsr: <bool>
         ip_addressing:
+          python_module: <str>
+          python_class_name: <str>
           router_id: <str>
           router_id_ipv6: <str>
           mlag_ip_primary: <str>
@@ -119,6 +125,8 @@ This should be defined in top level group_var for the fabric.
           vtep_ip_mlag: <str>
           vtep_ip: <str>
         interface_descriptions:
+          python_module: <str>
+          python_class_name: <str>
           underlay_ethernet_interfaces: <str>
           underlay_port_channel_interfaces: <str>
           mlag_ethernet_interfaces: <str>

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -1210,6 +1210,16 @@
             "type": "object",
             "description": "Override ip_addressing templates.",
             "properties": {
+              "python_module": {
+                "type": "string",
+                "description": "Python Module to import for IP addressing - default inherited from templates.ip_addressing.python_module",
+                "title": "Python Module"
+              },
+              "python_class_name": {
+                "type": "string",
+                "description": "Name of Python Class to import for IP addressing  - default inherited from templates.ip_addressing.python_class_name",
+                "title": "Python Class Name"
+              },
               "router_id": {
                 "type": "string",
                 "description": "Path to J2 template - default inherited from templates.ip_addressing.router_id.",
@@ -1278,6 +1288,16 @@
             "type": "object",
             "description": "Override interface_descriptions templates\nIf description templates use Jinja2, they have to strip whitespaces using {%- -%} on any code blocks.\n",
             "properties": {
+              "python_module": {
+                "type": "string",
+                "description": "Python Module to import for interface descriptions - default inherited from templates.interface_descriptions.python_module",
+                "title": "Python Module"
+              },
+              "python_class_name": {
+                "type": "string",
+                "description": "Name of Python Class to import for interface descriptions - default inherited from templates.interface_descriptions.python_class_name",
+                "title": "Python Class Name"
+              },
               "underlay_ethernet_interfaces": {
                 "type": "string",
                 "description": "Path to J2 template - default inherited from templates.interface_descriptions.underlay_ethernet_interfaces.",

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
@@ -1660,6 +1660,14 @@ keys:
           type: dict
           description: Override ip_addressing templates.
           keys:
+            python_module:
+              type: str
+              description: Python Module to import for IP addressing - default inherited
+                from templates.ip_addressing.python_module
+            python_class_name:
+              type: str
+              description: Name of Python Class to import for IP addressing  - default
+                inherited from templates.ip_addressing.python_class_name
             router_id:
               type: str
               description: Path to J2 template - default inherited from templates.ip_addressing.router_id.
@@ -1705,6 +1713,14 @@ keys:
 
             '
           keys:
+            python_module:
+              type: str
+              description: Python Module to import for interface descriptions - default
+                inherited from templates.interface_descriptions.python_module
+            python_class_name:
+              type: str
+              description: Name of Python Class to import for interface descriptions
+                - default inherited from templates.interface_descriptions.python_class_name
             underlay_ethernet_interfaces:
               type: str
               description: Path to J2 template - default inherited from templates.interface_descriptions.underlay_ethernet_interfaces.

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/node_type_keys.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/node_type_keys.schema.yml
@@ -139,6 +139,12 @@ keys:
           type: dict
           description: Override ip_addressing templates.
           keys:
+            python_module:
+              type: str
+              description: Python Module to import for IP addressing - default inherited from templates.ip_addressing.python_module
+            python_class_name:
+              type: str
+              description: Name of Python Class to import for IP addressing  - default inherited from templates.ip_addressing.python_class_name
             router_id:
               type: str
               description: Path to J2 template - default inherited from templates.ip_addressing.router_id.
@@ -181,6 +187,12 @@ keys:
             Override interface_descriptions templates
             If description templates use Jinja2, they have to strip whitespaces using {%- -%} on any code blocks.
           keys:
+            python_module:
+              type: str
+              description: Python Module to import for interface descriptions - default inherited from templates.interface_descriptions.python_module
+            python_class_name:
+              type: str
+              description: Name of Python Class to import for interface descriptions - default inherited from templates.interface_descriptions.python_class_name
             underlay_ethernet_interfaces:
               type: str
               description: Path to J2 template - default inherited from templates.interface_descriptions.underlay_ethernet_interfaces.


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Fix and test custom python modules for ip addressing and interface descriptions

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

- Add molecule coverage for custom python modules for ip_addressing and interface_descriptions.
- Fix issue in eos_designs_facts to load the configured modules correctly

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Added in molecule.
First commit use existing Jinja templates set in custom_templates.
Next refactor to custom python modules and check that nothing changes.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
