### PR TITLE
Fix(plugins): Handle git not found for verify_requirements

### DIFF
--- a/ansible_collections/arista/avd/plugins/action/verify_requirements.py
+++ b/ansible_collections/arista/avd/plugins/action/verify_requirements.py
@@ -262,15 +262,19 @@ def _get_running_collection_version(running_collection_name: str, result: dict) 
     collection_path = _get_collection_path(running_collection_name)
     version = _get_collection_version(collection_path)
 
-    # Try to detect a git tag
-    # Using subprocess for now
-    with Popen(["git", "describe", "--tags"], stdout=PIPE, stderr=PIPE, cwd=collection_path) as process:
-        output, err = process.communicate()
-        if err:
-            display.vvv("Not a git repository")
-        else:
-            display.vvv("This is a git repository, overwriting version with 'git describe --tags output'")
-            version = output.decode("UTF-8").strip()
+    try:
+        # Try to detect a git tag
+        # Using subprocess for now
+        with Popen(["git", "describe", "--tags"], stdout=PIPE, stderr=PIPE, cwd=collection_path) as process:
+            output, err = process.communicate()
+            if err:
+                display.vvv("Not a git repository")
+            else:
+                display.vvv("This is a git repository, overwriting version with 'git describe --tags output'")
+                version = output.decode("UTF-8").strip()
+    except FileNotFoundError:
+        # Handle the case where `git` is not installed or not in the PATH
+        display.vvv("Could not find 'git' executable, returning collection version")
 
     result["collection"] = {
         "name": running_collection_name,


### PR DESCRIPTION
## Change Summary

Add a try/catch block when `git` is not found for `verify_requirements` plugin

## Related Issue(s)

Reported by user via email

## Component(s) name

`plugins`

## Proposed changes

cf summary

## How to test

Added unit test

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
