### PR TITLE
Doc: Fix typo in batch_template documentation

### DIFF
--- a/ansible_collections/arista/avd/plugins/README.md
+++ b/ansible_collections/arista/avd/plugins/README.md
@@ -748,12 +748,12 @@ options:
     description: Path to Jinja2 Template file
     required: true
     type: str
-  dest_format_string:
+  dest_format_str:
     description: Format string used to specify target file for each item. 'item' is the current item from 'items'. Like "mypath/{item}.md"
     required: true
     type: str
   items:
-    description: List of strings. Each list item is passed to 'dest_format_string' as 'item' and passed to templater as 'item'
+    description: List of strings. Each list item is passed to 'dest_format_str' as 'item' and passed to templater as 'item'
     required: true
     type: list
     elements: str


### PR DESCRIPTION
Fix typo

## Related Issue(s)

Fixes #2666

## Component(s) name

`plugins`

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
