### PR TITLE
Refactor(plugins): Optimize schema tooling

### DIFF
--- a/ansible_collections/arista/avd/plugins/plugin_utils/schema/avddataconverter.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/schema/avddataconverter.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Generator
 
 from ansible_collections.arista.avd.plugins.filter.convert_dicts import convert_dicts
-from ansible_collections.arista.avd.plugins.plugin_utils.errors import AristaAvdError, AvdConversionWarning, AvdDeprecationWarning
+from ansible_collections.arista.avd.plugins.plugin_utils.errors import AvdConversionWarning, AvdDeprecationWarning
 from ansible_collections.arista.avd.plugins.plugin_utils.utils import get_all
 
 SCHEMA_TO_PY_TYPE_MAP = {
@@ -45,14 +45,7 @@ class AvdDataConverter:
         """
         if schema is None:
             # Get fully resolved schema (where all $ref has been expanded recursively)
-            # Performs inplace update of the argument so we give an empty dict.
-            # By default it will resolve the full schema
-            schema = {}
-            resolve_errors = self._avdschema.resolve(schema)
-            for resolve_error in resolve_errors:
-                if isinstance(resolve_error, Exception):
-                    # TODO: Raise/yield multiple errors
-                    raise AristaAvdError(resolve_error)
+            schema = self._avdschema.resolved_schema
 
         if path is None:
             path = []

--- a/ansible_collections/arista/avd/plugins/plugin_utils/schema/avdschema.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/schema/avdschema.py
@@ -72,6 +72,9 @@ class AvdSchema:
             ID of AVD Schema. Either 'eos_cli_config_gen' or 'eos_designs'
         """
 
+        # Clear cached resolved_schema if any
+        self.__dict__.pop("resolved_schema", None)
+
         if schema:
             # Validate the schema
             for validation_error in self.validate_schema(schema):
@@ -93,18 +96,15 @@ class AvdSchema:
         except Exception as e:
             raise AristaAvdError("An error occured during creation of the validator") from e
 
+    def extend_schema(self, schema: dict):
         # Clear cached resolved_schema if any
         self.__dict__.pop("resolved_schema", None)
 
-    def extend_schema(self, schema: dict):
         for validation_error in self.validate_schema(schema):
             raise validation_error
         always_merger.merge(self._schema, schema)
         for validation_error in self.validate_schema(self._schema):
             raise validation_error
-
-        # Clear cached resolved_schema if any
-        self.__dict__.pop("resolved_schema", None)
 
     def validate(self, data):
         validation_errors = self._validator.iter_errors(data)

--- a/ansible_collections/arista/avd/plugins/plugin_utils/schema/avdschema.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/schema/avdschema.py
@@ -97,11 +97,8 @@ class AvdSchema:
         for validation_error in self.validate_schema(self._schema):
             raise validation_error
 
-    def validate(self, data, schema: dict = None):
-        if schema:
-            validation_errors = self._validator.iter_errors(data, _schema=schema)
-        else:
-            validation_errors = self._validator.iter_errors(data)
+    def validate(self, data):
+        validation_errors = self._validator.iter_errors(data)
 
         try:
             for validation_error in validation_errors:
@@ -109,11 +106,8 @@ class AvdSchema:
         except Exception as error:
             yield self._error_handler(error)
 
-    def convert(self, data, schema: dict = None):
-        if schema:
-            conversion_errors = self._dataconverter.convert_data(data, schema=schema)
-        else:
-            conversion_errors = self._dataconverter.convert_data(data)
+    def convert(self, data):
+        conversion_errors = self._dataconverter.convert_data(data)
 
         try:
             for conversion_error in conversion_errors:
@@ -150,10 +144,8 @@ class AvdSchema:
             return AvdSchemaError(error=error)
         return AvdSchemaError(str(error))
 
-    def is_valid(self, data, schema: dict = None):
+    def is_valid(self, data):
         try:
-            if schema:
-                return self._validator.is_valid(data, _schema=schema)
             return self._validator.is_valid(data)
         except Exception as error:
             # TODO: Find a way to wrap multiple schema errors in a single raise
@@ -235,9 +227,12 @@ class AvdSchema:
         raise AvdSchemaError(f"The datapath '{datapath}' could not be found in the schema")
 
     def get_resolved_schema(self, schema):
-        # Get fully resolved schema (where all $ref has been expanded recursively)
-        # Performs inplace update of the argument so we give an empty dict.
-        # By default it will resolve the full schema
+        """
+        Get fully resolved schema (where all $ref has been expanded recursively)
+        Performs inplace update of the argument so we give an empty dict.
+
+        The given schema is _not_ validated.
+        """
         resolved_schema = {}
         resolve_errors = self.resolve(resolved_schema, schema)
         for resolve_error in resolve_errors:

--- a/ansible_collections/arista/avd/plugins/plugin_utils/schema/avdschema.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/schema/avdschema.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from copy import deepcopy
+from functools import cached_property
+
 from ansible_collections.arista.avd.plugins.plugin_utils.errors import AristaAvdError, AvdSchemaError, AvdValidationError
 from ansible_collections.arista.avd.plugins.plugin_utils.schema.avddataconverter import AvdDataConverter
 from ansible_collections.arista.avd.plugins.plugin_utils.schema.avdschemaresolver import AvdSchemaResolver
@@ -90,12 +93,18 @@ class AvdSchema:
         except Exception as e:
             raise AristaAvdError("An error occured during creation of the validator") from e
 
+        # Clear cached resolved_schema if any
+        self.__dict__.pop("resolved_schema", None)
+
     def extend_schema(self, schema: dict):
         for validation_error in self.validate_schema(schema):
             raise validation_error
         always_merger.merge(self._schema, schema)
         for validation_error in self.validate_schema(self._schema):
             raise validation_error
+
+        # Clear cached resolved_schema if any
+        self.__dict__.pop("resolved_schema", None)
 
     def validate(self, data):
         validation_errors = self._validator.iter_errors(data)
@@ -115,25 +124,21 @@ class AvdSchema:
         except Exception as error:
             yield self._error_handler(error)
 
-    def resolve(self, resolved_schema: dict, schema: dict = None):
+    @cached_property
+    def resolved_schema(self):
         """
-        resolved_schema is a placeholder for the resulting schema where all $ref has been resolved recursively
-        schema is the schema to resolve
+        Get fully resolved schema (where all $ref has been expanded recursively)
+        _schemaresolver performs inplace update of the argument so we give it a copy of the existing schema.
 
-        returns a Generator of resolve errors
+        The resolved schema is cached on the instance of AvdSchema.
         """
-        if schema:
-            resolved_schema.update(schema)
-            resolve_errors = self._schemaresolver.iter_errors(resolved_schema, _schema=schema)
-        else:
-            resolved_schema.update(self._schema)
-            resolve_errors = self._schemaresolver.iter_errors(resolved_schema)
-
-        try:
-            for resolve_error in resolve_errors:
-                yield self._error_handler(resolve_error)
-        except Exception as error:
-            yield self._error_handler(error)
+        resolved_schema = deepcopy(self._schema)
+        resolve_errors = self._schemaresolver.iter_errors(resolved_schema)
+        for resolve_error in resolve_errors:
+            if isinstance(resolve_error, Exception):
+                # TODO: Raise multiple errors or abstract them
+                raise self._error_handler(resolve_error)
+        return resolved_schema
 
     def _error_handler(self, error: Exception):
         if isinstance(error, AristaAvdError):
@@ -144,10 +149,9 @@ class AvdSchema:
             return AvdSchemaError(error=error)
         return AvdSchemaError(str(error))
 
-    def subschema(self, datapath: list, schema: dict = None):
+    def subschema(self, datapath: list):
         """
         Takes datapath elements as a list and returns the subschema for this datapath.
-        Optionally the schema can be supplied. This is primarily used for recursive calls.
 
         Example
         -------
@@ -195,41 +199,30 @@ class AvdSchema:
         if not isinstance(datapath, list):
             raise AvdSchemaError(f"The datapath argument must be a list. Got {type(datapath)}")
 
-        if not schema:
-            schema = self._schema
+        schema = self.resolved_schema
 
-        if len(datapath) == 0:
-            return schema
+        def recursive_function(datapath, schema):
+            """
+            Walk through schema following the datapath
+            """
+            if len(datapath) == 0:
+                return schema
 
-        # More items in datapath, so we run recursively with subschema
-        key = datapath[0]
-        if not isinstance(key, str):
-            raise AvdSchemaError(f"All datapath items must be strings. Got {type(key)}")
+            # More items in datapath, so we run recursively with recursive_function
+            key = datapath[0]
+            if not isinstance(key, str):
+                raise AvdSchemaError(f"All datapath items must be strings. Got {type(key)}")
 
-        resolved_schema = self.get_resolved_schema(schema)
-        if resolved_schema["type"] == "dict":
-            if key in resolved_schema.get("keys", []):
-                return self.subschema(datapath[1:], resolved_schema["keys"][key])
-            if key in resolved_schema.get("dynamic_keys", []):
-                return self.subschema(datapath[1:], resolved_schema["dynamic_keys"][key])
+            if schema["type"] == "dict":
+                if key in schema.get("keys", []):
+                    return recursive_function(datapath[1:], schema["keys"][key])
+                if key in schema.get("dynamic_keys", []):
+                    return recursive_function(datapath[1:], schema["dynamic_keys"][key])
 
-        if resolved_schema["type"] == "list" and key in resolved_schema.get("items", {}).get("keys", []):
-            return self.subschema(datapath[1:], resolved_schema["items"]["keys"][key])
+            if schema["type"] == "list" and key in schema.get("items", {}).get("keys", []):
+                return recursive_function(datapath[1:], schema["items"]["keys"][key])
 
-        # Falling through here in case the schema is not covering the requested datapath
-        raise AvdSchemaError(f"The datapath '{datapath}' could not be found in the schema")
+            # Falling through here in case the schema is not covering the requested datapath
+            raise AvdSchemaError(f"The datapath '{datapath}' could not be found in the schema")
 
-    def get_resolved_schema(self, schema):
-        """
-        Get fully resolved schema (where all $ref has been expanded recursively)
-        Performs inplace update of the argument so we give an empty dict.
-
-        The given schema is _not_ validated.
-        """
-        resolved_schema = {}
-        resolve_errors = self.resolve(resolved_schema, schema)
-        for resolve_error in resolve_errors:
-            if isinstance(resolve_error, Exception):
-                # TODO: Raise multiple errors or abstract them
-                raise AristaAvdError("AvdToDocumentationSchemaConverter: Resolve Error during conversion of schema") from resolve_error
-        return resolved_schema
+        return recursive_function(datapath, schema)

--- a/ansible_collections/arista/avd/plugins/plugin_utils/schema/avdschema.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/schema/avdschema.py
@@ -99,10 +99,6 @@ class AvdSchema:
 
     def validate(self, data, schema: dict = None):
         if schema:
-            for schema_validation_error in self.validate_schema(schema):
-                yield schema_validation_error
-                return
-
             validation_errors = self._validator.iter_errors(data, _schema=schema)
         else:
             validation_errors = self._validator.iter_errors(data)
@@ -115,10 +111,6 @@ class AvdSchema:
 
     def convert(self, data, schema: dict = None):
         if schema:
-            for schema_validation_error in self.validate_schema(schema):
-                yield schema_validation_error
-                return
-
             conversion_errors = self._dataconverter.convert_data(data, schema=schema)
         else:
             conversion_errors = self._dataconverter.convert_data(data)
@@ -137,10 +129,6 @@ class AvdSchema:
         returns a Generator of resolve errors
         """
         if schema:
-            for schema_validation_error in self.validate_schema(schema):
-                yield schema_validation_error
-                return
-
             resolved_schema.update(schema)
             resolve_errors = self._schemaresolver.iter_errors(resolved_schema, _schema=schema)
         else:
@@ -163,10 +151,6 @@ class AvdSchema:
         return AvdSchemaError(str(error))
 
     def is_valid(self, data, schema: dict = None):
-        if schema:
-            for schema_validation_error in self.validate_schema(schema):
-                # TODO: Find a way to wrap multiple schema errors in a single raise
-                raise schema_validation_error
         try:
             if schema:
                 return self._validator.is_valid(data, _schema=schema)
@@ -226,10 +210,7 @@ class AvdSchema:
         if not isinstance(datapath, list):
             raise AvdSchemaError(f"The datapath argument must be a list. Got {type(datapath)}")
 
-        if schema:
-            for validation_error in self.validate_schema(schema):
-                raise validation_error
-        else:
+        if not schema:
             schema = self._schema
 
         if len(datapath) == 0:

--- a/ansible_collections/arista/avd/plugins/plugin_utils/schema/avdschema.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/schema/avdschema.py
@@ -144,13 +144,6 @@ class AvdSchema:
             return AvdSchemaError(error=error)
         return AvdSchemaError(str(error))
 
-    def is_valid(self, data):
-        try:
-            return self._validator.is_valid(data)
-        except Exception as error:
-            # TODO: Find a way to wrap multiple schema errors in a single raise
-            raise self._error_handler(error) from error
-
     def subschema(self, datapath: list, schema: dict = None):
         """
         Takes datapath elements as a list and returns the subschema for this datapath.

--- a/ansible_collections/arista/avd/plugins/plugin_utils/schema/avdschemaresolver.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/schema/avdschemaresolver.py
@@ -33,7 +33,7 @@ def _keys(validator, keys: dict, resolved_schema: dict, schema: dict):
             _ref_on_child(validator, childschema["$ref"], resolved_schema["keys"][key])
         yield from validator.descend(
             resolved_schema["keys"][key],
-            childschema,
+            resolved_schema["keys"][key],
             path=key,
             schema_path=key,
         )
@@ -46,7 +46,7 @@ def _dynamic_keys(validator, dynamic_keys: dict, resolved_schema: dict, schema: 
             _ref_on_child(validator, childschema["$ref"], resolved_schema["dynamic_keys"][key])
         yield from validator.descend(
             resolved_schema["dynamic_keys"][key],
-            childschema,
+            resolved_schema["dynamic_keys"][key],
             path=key,
             schema_path=key,
         )
@@ -58,7 +58,7 @@ def _items(validator, items: dict, resolved_schema: dict, schema: dict):
         _ref_on_child(validator, items["$ref"], resolved_schema["items"])
     yield from validator.descend(
         resolved_schema["items"],
-        items,
+        resolved_schema["items"],
         path=0,
         schema_path=0,
     )
@@ -86,7 +86,7 @@ class AvdSchemaResolver:
         It is used to generate full documentation covering all nested schemas.
 
         Since we return generators, we cannot also return the resolved schema.
-        Instead we use the "instance" of jsonschema - the variable normally holding
+        Instead we use the "instance" in jsonschema - the variable normally holding
         the data to be validated - called "resolved_schema" above.
         The "resolved_schema" must contain a copy of the original schema, and then
         the $ref resolver will merge in the resolved schema and do in-place update.

--- a/ansible_collections/arista/avd/plugins/plugin_utils/schema/avdtodocumentationschemaconverter.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/schema/avdtodocumentationschemaconverter.py
@@ -95,12 +95,7 @@ class AvdToDocumentationSchemaConverter:
         output = {}
 
         # Get fully resolved schema (where all $ref has been expanded recursively)
-        # Performs inplace update of the argument so we give an empty dict.
-        # By default it will resolve the full schema
-        resolve_errors = self._avdschema.resolve(schema)
-        for resolve_error in resolve_errors:
-            if isinstance(resolve_error, Exception):
-                raise AristaAvdError(resolve_error)
+        schema = self._avdschema.resolved_schema
 
         filenames = self._get_filenames(schema)
 

--- a/ansible_collections/arista/avd/tests/unit/plugins/plugin_utils/schema/test_avdschema.py
+++ b/ansible_collections/arista/avd/tests/unit/plugins/plugin_utils/schema/test_avdschema.py
@@ -121,23 +121,6 @@ class TestAvdSchema:
             assert False, f"AvdSchema(TEST_SCHEMA).validate(TEST_DATA) raised an exception: {e}"
         assert True
 
-    @pytest.mark.parametrize("TEST_SCHEMA", VALID_TEST_SCHEMAS)
-    @pytest.mark.parametrize("TEST_DATA", TEST_DATA_SETS)
-    def test_avd_schema_validate_with_adhoc_schema(self, TEST_SCHEMA, TEST_DATA):
-        try:
-            for validation_error in AvdSchema().validate(TEST_DATA, TEST_SCHEMA):
-                assert False, f"Validation Error '{validation_error.message}' returned"
-        except Exception as e:
-            assert False, f"AvdSchema().validate(TEST_DATA, TEST_SCHEMA) raised an exception: {e}"
-        assert True
-
-    def test_avd_schema_validate_with_invalid_adhoc_schema(self):
-        try:
-            for validation_error in AvdSchema().validate({}, INVALID_SCHEMA):
-                assert isinstance(validation_error, AvdValidationError)
-        except Exception as e:
-            assert False, f"AvdSchema().validate({{}}, INVALID_SCHEMA) raised an exception: {e}"
-
     @pytest.mark.parametrize("INVALID_DATA", INVALID_ACL_DATA)
     def test_avd_schema_validate_with_invalid_data(self, INVALID_DATA):
         try:
@@ -158,15 +141,6 @@ class TestAvdSchema:
     @pytest.mark.parametrize("TEST_DATA", TEST_DATA_SETS)
     def test_avd_schema_is_valid_with_loaded_schema(self, TEST_SCHEMA, TEST_DATA):
         assert AvdSchema(TEST_SCHEMA).is_valid(TEST_DATA) is True
-
-    @pytest.mark.parametrize("TEST_SCHEMA", VALID_TEST_SCHEMAS)
-    @pytest.mark.parametrize("TEST_DATA", TEST_DATA_SETS)
-    def test_avd_schema_is_valid_with_adhoc_schema(self, TEST_SCHEMA, TEST_DATA):
-        assert AvdSchema().is_valid(TEST_DATA, TEST_SCHEMA) is True
-
-    def test_avd_schema_is_valid_with_invalid_adhoc_schema(self):
-        with pytest.raises(AvdValidationError):
-            AvdSchema().is_valid({}, INVALID_SCHEMA)
 
     @pytest.mark.parametrize("INVALID_DATA", INVALID_ACL_DATA)
     def test_avd_schema_is_valid_with_invalid_data(self, INVALID_DATA):
@@ -233,11 +207,6 @@ class TestAvdSchema:
             assert subschema == EXPECTED_SUBSCHEMAS["_empty"]
         else:
             assert subschema == EXPECTED_SUBSCHEMAS[".".join(TEST_PATH)]
-
-    def test_avd_schema_subschema_empty_list_invalid_adhoc_schema(self):
-        with pytest.raises(AvdValidationError):
-            avdschema = AvdSchema()
-            avdschema.subschema([], INVALID_SCHEMA)
 
     def test_avd_schema_subschema_with_ref_to_store_schemas(self):
         test_schema = {"type": "dict", "keys": {}}

--- a/ansible_collections/arista/avd/tests/unit/plugins/plugin_utils/schema/test_avdschema.py
+++ b/ansible_collections/arista/avd/tests/unit/plugins/plugin_utils/schema/test_avdschema.py
@@ -165,18 +165,6 @@ class TestAvdSchema:
             avdschema.extend_schema(INVALID_SCHEMA)
 
     @pytest.mark.parametrize("TEST_PATH", TEST_DATA_PATHS)
-    def test_avd_schema_subschema_with_adhoc_schema(self, TEST_PATH):
-        try:
-            avdschema = AvdSchema()
-            subschema = avdschema.subschema(TEST_PATH, combined_schema)
-        except Exception as e:
-            assert False, f"subschema(TEST_PATH, combined_schema) raised an exception: {e}"
-        if len(TEST_PATH) == 0:
-            assert subschema == EXPECTED_SUBSCHEMAS["_empty"]
-        else:
-            assert subschema == EXPECTED_SUBSCHEMAS[".".join(TEST_PATH)]
-
-    @pytest.mark.parametrize("TEST_PATH", TEST_DATA_PATHS)
     def test_avd_schema_subschema_with_loaded_schema(self, TEST_PATH):
         try:
             avdschema = AvdSchema(combined_schema)

--- a/ansible_collections/arista/avd/tests/unit/plugins/plugin_utils/schema/test_avdschema.py
+++ b/ansible_collections/arista/avd/tests/unit/plugins/plugin_utils/schema/test_avdschema.py
@@ -133,26 +133,6 @@ class TestAvdSchema:
         with pytest.raises(TypeError):
             AvdSchema().validate()
 
-    @pytest.mark.parametrize("TEST_DATA", TEST_DATA_SETS)
-    def test_avd_schema_is_valid_without_schema(self, TEST_DATA):
-        assert AvdSchema().is_valid(TEST_DATA) is True
-
-    @pytest.mark.parametrize("TEST_SCHEMA", VALID_TEST_SCHEMAS)
-    @pytest.mark.parametrize("TEST_DATA", TEST_DATA_SETS)
-    def test_avd_schema_is_valid_with_loaded_schema(self, TEST_SCHEMA, TEST_DATA):
-        assert AvdSchema(TEST_SCHEMA).is_valid(TEST_DATA) is True
-
-    @pytest.mark.parametrize("INVALID_DATA", INVALID_ACL_DATA)
-    def test_avd_schema_is_valid_with_invalid_data(self, INVALID_DATA):
-        assert AvdSchema(combined_schema).is_valid(INVALID_DATA) is False
-
-    def test_avd_schema_is_valid_with_missing_data(self):
-        with pytest.raises(TypeError):
-            AvdSchema().is_valid()
-
-    def test_avd_schema_is_valid_with_none(self):
-        assert AvdSchema().is_valid(None) is False
-
     @pytest.mark.parametrize("TEST_SCHEMA", VALID_TEST_SCHEMAS)
     def test_avd_schema_load_valid_schema(self, TEST_SCHEMA):
         try:


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Optimize schema tooling

## Component(s) name

`arista.avd.plugins`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

- Remove redundant validation of schemas.
- Remove support for adhoc schemas (not used in our plugins)
- Remove `is_valid` on `AvdSchema` class (not used in our plugins)

Only risk is if someone is using our tooling outside of AVD, don't load the schema first, and is not providing a valid schema.

I see huge speed improvements after adding removing the redundant validations.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

No changes expected anywhere - except much better runtime.

When comparing `eos_designs_units_tests`:

```sh
#devel
real    4m19,687s
user    30m52,599s
sys     0m55,736s

#pr2672
real    3m23,947s
user    20m11,712s
sys     0m54,875s
```

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
