### PR TITLE
Fix(eos_designs): Raise correct error message for duplicate port-channels

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/converge.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/converge.yml
@@ -1,6 +1,6 @@
 ---
 - name: Converge
-  hosts: EOS_DESIGNS_UNIT_TEST
+  hosts: EOS_DESIGNS_UNIT_TESTS
   gather_facts: false
   connection: local
   tasks:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/converge.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/converge.yml
@@ -1,6 +1,6 @@
 ---
 - name: Converge
-  hosts: all
+  hosts: EOS_DESIGNS_UNIT_TEST
   gather_facts: false
   connection: local
   tasks:
@@ -9,3 +9,19 @@
       delegate_to: 127.0.0.1
       ansible.builtin.import_role:
         name: arista.avd.eos_designs
+
+- name: Converge Negative tests
+  hosts: EOS_DESIGNS_FAILURES
+  gather_facts: false
+  connection: local
+  tasks:
+    - block:
+        - name: Trigger Error
+          ansible.builtin.import_role:
+            name: arista.avd.eos_designs
+      rescue:
+        # Verify that the role failed and the error message is as we expect
+        - ansible.builtin.assert:
+            that:
+              - ansible_failed_result is defined
+              - ansible_failed_result.msg == expected_error_message

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/converge.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/converge.yml
@@ -15,13 +15,14 @@
   gather_facts: false
   connection: local
   tasks:
-    - block:
+    - name: Run failure scenario Test
+      block:
         - name: Trigger Error
           ansible.builtin.import_role:
             name: arista.avd.eos_designs
       rescue:
-        # Verify that the role failed and the error message is as we expect
-        - ansible.builtin.assert:
+        - name: Assert eos_designs failed with the expected error message
+          ansible.builtin.assert:
             that:
               - ansible_failed_result is defined
               - ansible_failed_result.msg == expected_error_message

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/EOS_DESIGNS_FAILURES.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/EOS_DESIGNS_FAILURES.yml
@@ -1,0 +1,3 @@
+---
+# This must be the same value for all devices in the molecule scenario.
+fabric_name: EOS_DESIGNS_FAILURES

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/failure-port-channel.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/failure-port-channel.yml
@@ -1,0 +1,31 @@
+---
+# Minimum config to only test the specific feature.
+l3leaf:
+  defaults:
+    loopback_ipv4_pool: 10.42.0.0/24
+    bgp_as: 42
+    vtep_loopback_ipv4_pool: 10.43.0.0/24
+  nodes:
+    failure-port-channel:
+      id: 42
+
+type: l3leaf
+
+servers:
+  server1:
+    adapters:
+      - switch_ports: [Ethernet1]
+        switches: [failure-port-channel]
+        port_channel:
+          description: Description1
+          mode: active
+          channel_id: 42
+      - switch_ports: [Ethernet2]
+        switches: [failure-port-channel]
+        port_channel:
+          description: Description2
+          mode: active
+          channel_id: 42
+
+
+expected_error_message: "Duplicate port-channel name Port-Channel42 with conflicting configurations found while generating port-channels for connected-endpoints or network-ports"

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
@@ -319,3 +319,6 @@ all:
               children:
                 MH_LEAFS_TESTS:
                 MH_L2LEAFS_TESTS:
+    EOS_DESIGNS_FAILURES:
+      hosts:
+        failure-port-channel:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/verify.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/verify.yml
@@ -1,6 +1,6 @@
 ---
 - name: Converge
-  hosts: all
+  hosts: EOS_DESIGNS_UNIT_TESTS
   gather_facts: false
   connection: local
   tasks:

--- a/ansible_collections/arista/avd/plugins/action/eos_designs_facts.py
+++ b/ansible_collections/arista/avd/plugins/action/eos_designs_facts.py
@@ -46,7 +46,7 @@ class ActionModule(ActionBase):
         if fabric_name is None or not set(ansible_play_hosts_all).issubset(fabric_hosts):
             raise AnsibleActionFail(
                 "Invalid/missing 'fabric_name' variable."
-                "All hosts in the play must have the same 'fabric_name' value"
+                "All hosts in the play must have the same 'fabric_name' value "
                 "which must point to an Ansible Group containing the hosts."
             )
 

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/connected_endpoints/port_channel_interfaces.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/connected_endpoints/port_channel_interfaces.py
@@ -203,7 +203,7 @@ class PortChannelInterfacesMixin(UtilsMixin):
         if matching_port_channel_config != candidate_port_channel_config:
             # Found duplicate name with different generated configs
             raise AristaAvdError(
-                f"Duplicate port-channel name {port_channel_interfaces['name']} with conflicting configurations found while generating port-channels for"
+                f"Duplicate port-channel name {candidate_port_channel_config['name']} with conflicting configurations found while generating port-channels for"
                 " connected-endpoints or network-ports"
             )
 


### PR DESCRIPTION
## Change Summary

Wrong structure used to return error message

## Related Issue(s)

Raised by user while testing

## Component(s) name

`arista.avd.eos_designs`

## How to test

Tested with the faulty repo (cannot test failures in molecule)

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
