### PR TITLE
Fix(eos_designs): Change IP addressing templates from ansible netcommon to ansible.utils

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/custom_templates/ip_addressing/mlag-ibgp-peering-ip-primary.j2
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/custom_templates/ip_addressing/mlag-ibgp-peering-ip-primary.j2
@@ -1,1 +1,1 @@
-{{ vrf.mlag_ibgp_peering_ipv4_pool | ansible.netcommon.ipaddr('subnet') | ansible.netcommon.ipmath((switch.mlag_switch_ids.primary - 1) * 2 + ip_offset_10) }}
+{{ vrf.mlag_ibgp_peering_ipv4_pool | ansible.utils.ipaddr('subnet') | ansible.utils.ipmath((switch.mlag_switch_ids.primary - 1) * 2 + ip_offset_10) }}

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/custom_templates/ip_addressing/mlag-ibgp-peering-ip-secondary.j2
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/custom_templates/ip_addressing/mlag-ibgp-peering-ip-secondary.j2
@@ -1,1 +1,1 @@
-{{ vrf.mlag_ibgp_peering_ipv4_pool | ansible.netcommon.ipaddr('subnet') | ansible.netcommon.ipmath(((switch.mlag_switch_ids.primary - 1) * 2) + 1 + ip_offset_10) }}
+{{ vrf.mlag_ibgp_peering_ipv4_pool | ansible.utils.ipaddr('subnet') | ansible.utils.ipmath(((switch.mlag_switch_ids.primary - 1) * 2) + 1 + ip_offset_10) }}

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/custom_templates/ip_addressing/mlag-ip-primary.j2
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/custom_templates/ip_addressing/mlag-ip-primary.j2
@@ -1,1 +1,1 @@
-{{ switch_data.combined.mlag_peer_ipv4_pool | ansible.netcommon.ipaddr('network') | ansible.netcommon.ipmath((mlag_primary_id - 1) * 2 + ip_offset_10) }}
+{{ switch_data.combined.mlag_peer_ipv4_pool | ansible.utils.ipaddr('network') | ansible.utils.ipmath((mlag_primary_id - 1) * 2 + ip_offset_10) }}

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/custom_templates/ip_addressing/mlag-ip-secondary.j2
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/custom_templates/ip_addressing/mlag-ip-secondary.j2
@@ -1,1 +1,1 @@
-{{ switch_data.combined.mlag_peer_ipv4_pool | ansible.netcommon.ipaddr('network') | ansible.netcommon.ipmath(((mlag_primary_id - 1) * 2) + 1 + ip_offset_10) }}
+{{ switch_data.combined.mlag_peer_ipv4_pool | ansible.utils.ipaddr('network') | ansible.utils.ipmath(((mlag_primary_id - 1) * 2) + 1 + ip_offset_10) }}

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/custom_templates/ip_addressing/mlag-l3-ip-primary.j2
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/custom_templates/ip_addressing/mlag-l3-ip-primary.j2
@@ -1,1 +1,1 @@
-{{ switch_data.combined.mlag_peer_l3_ipv4_pool | ansible.netcommon.ipaddr('network') | ansible.netcommon.ipmath((mlag_primary_id - 1) * 2 + ip_offset_10) }}
+{{ switch_data.combined.mlag_peer_l3_ipv4_pool | ansible.utils.ipaddr('network') | ansible.utils.ipmath((mlag_primary_id - 1) * 2 + ip_offset_10) }}

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/custom_templates/ip_addressing/mlag-l3-ip-secondary.j2
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/custom_templates/ip_addressing/mlag-l3-ip-secondary.j2
@@ -1,1 +1,1 @@
-{{ switch_data.combined.mlag_peer_l3_ipv4_pool | ansible.netcommon.ipaddr('network') | ansible.netcommon.ipmath(((mlag_primary_id - 1) * 2) + 1 + ip_offset_10) }}
+{{ switch_data.combined.mlag_peer_l3_ipv4_pool | ansible.utils.ipaddr('network') | ansible.utils.ipmath(((mlag_primary_id - 1) * 2) + 1 + ip_offset_10) }}

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/custom_templates/ip_addressing/p2p-uplinks-ip.j2
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/custom_templates/ip_addressing/p2p-uplinks-ip.j2
@@ -1,1 +1,1 @@
-{{ switch.uplink_ipv4_pool | ansible.netcommon.ipaddr('network') | ansible.netcommon.ipmath(((switch.id -1) * 2 * switch.max_uplink_switches * switch.max_parallel_uplinks) + (uplink_switch_index) * 2 + 1 + ip_offset_20) }}
+{{ switch.uplink_ipv4_pool | ansible.utils.ipaddr('network') | ansible.utils.ipmath(((switch.id -1) * 2 * switch.max_uplink_switches * switch.max_parallel_uplinks) + (uplink_switch_index) * 2 + 1 + ip_offset_20) }}

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/custom_templates/ip_addressing/p2p-uplinks-peer-ip.j2
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/custom_templates/ip_addressing/p2p-uplinks-peer-ip.j2
@@ -1,1 +1,1 @@
-{{ switch.uplink_ipv4_pool | ansible.netcommon.ipaddr('network') | ansible.netcommon.ipmath(((switch.id -1) * 2 * switch.max_uplink_switches * switch.max_parallel_uplinks) + (uplink_switch_index) * 2 + ip_offset_20) }}
+{{ switch.uplink_ipv4_pool | ansible.utils.ipaddr('network') | ansible.utils.ipmath(((switch.id -1) * 2 * switch.max_uplink_switches * switch.max_parallel_uplinks) + (uplink_switch_index) * 2 + ip_offset_20) }}

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/custom_templates/ip_addressing/router-id-ipv6.j2
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/custom_templates/ip_addressing/router-id-ipv6.j2
@@ -1,1 +1,1 @@
-{{ loopback_ipv6_pool | ansible.netcommon.ipaddr("network") | ansible.netcommon.ipmath(switch_id + loopback_ipv6_offset + ip_offset_20) }}
+{{ loopback_ipv6_pool | ansible.utils.ipaddr("network") | ansible.utils.ipmath(switch_id + loopback_ipv6_offset + ip_offset_20) }}

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/custom_templates/ip_addressing/router-id.j2
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/custom_templates/ip_addressing/router-id.j2
@@ -1,1 +1,1 @@
-{{ loopback_ipv4_pool | ansible.netcommon.ipaddr("network") | ansible.netcommon.ipmath(switch_id + loopback_ipv4_offset + ip_offset_20) }}
+{{ loopback_ipv4_pool | ansible.utils.ipaddr("network") | ansible.utils.ipmath(switch_id + loopback_ipv4_offset + ip_offset_20) }}

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/custom_templates/ip_addressing/vtep-ip-mlag.j2
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/custom_templates/ip_addressing/vtep-ip-mlag.j2
@@ -1,1 +1,1 @@
-{{ switch_vtep_loopback_ipv4_pool | ansible.netcommon.ipaddr('network') | ansible.netcommon.ipmath(mlag_primary_id + loopback_ipv4_offset + ip_offset_20) }}
+{{ switch_vtep_loopback_ipv4_pool | ansible.utils.ipaddr('network') | ansible.utils.ipmath(mlag_primary_id + loopback_ipv4_offset + ip_offset_20) }}

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/custom_templates/ip_addressing/vtep-ip.j2
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/custom_templates/ip_addressing/vtep-ip.j2
@@ -1,1 +1,1 @@
-{{ switch_vtep_loopback_ipv4_pool | ansible.netcommon.ipaddr('network') | ansible.netcommon.ipmath(switch_id + loopback_ipv4_offset + ip_offset_20) }}
+{{ switch_vtep_loopback_ipv4_pool | ansible.utils.ipaddr('network') | ansible.utils.ipmath(switch_id + loopback_ipv4_offset + ip_offset_20) }}

--- a/ansible_collections/arista/avd/roles/dhcp_provisioner/templates/ztp_configuration.j2
+++ b/ansible_collections/arista/avd/roles/dhcp_provisioner/templates/ztp_configuration.j2
@@ -39,8 +39,8 @@ ztp:
   general:
     subnets:
 {% if ztp_network_summary is arista.avd.defined %}
-      - network: {{ ztp_network_summary | ansible.netcommon.ipaddr('network') }}
-        netmask: {{ ztp_network_summary | ansible.netcommon.ipaddr('netmask') }}
+      - network: {{ ztp_network_summary | ansible.utils.ipaddr('network') }}
+        netmask: {{ ztp_network_summary | ansible.utils.ipaddr('netmask') }}
 {% endif %}
 {% if hostvars[groups[fabric_group][0]]['mgmt_gateway'] is arista.avd.defined %}
         gateway: {{ hostvars[groups[fabric_group][0]]['mgmt_gateway'] }}
@@ -67,7 +67,7 @@ ztp:
 {%             if node_types[node_type]['node_groups'][node_group]['nodes'][node].mac_address is arista.avd.defined %}
     - name: {{ node }}
       mac: '{{ node_types[node_type]['node_groups'][node_group]['nodes'][node].mac_address }}'
-      ip4: {{ node_types[node_type]['node_groups'][node_group]['nodes'][node].mgmt_ip | ansible.netcommon.ipaddr('address') }}
+      ip4: {{ node_types[node_type]['node_groups'][node_group]['nodes'][node].mgmt_ip | ansible.utils.ipaddr('address') }}
 {%             endif %}
 {%         endfor %}
 {%     endfor %}
@@ -76,7 +76,7 @@ ztp:
 {%         if node_types[node_type]['nodes'][node].mac_address is arista.avd.defined %}
     - name: {{ node }}
       mac: '{{ node_types[node_type]['nodes'][node].mac_address }}'
-      ip4: {{ node_types[node_type]['nodes'][node].mgmt_ip | ansible.netcommon.ipaddr('address') }}
+      ip4: {{ node_types[node_type]['nodes'][node].mgmt_ip | ansible.utils.ipaddr('address') }}
 {%         endif %}
 {%     endfor %}
 {% endfor %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/documentation/fabric-documentation.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/documentation/fabric-documentation.j2
@@ -121,8 +121,8 @@
 | Uplink IPv4 Pool | Available Addresses | Assigned addresses | Assigned Address % |
 | ---------------- | ------------------- | ------------------ | ------------------ |
 {% for uplink_ipv4_pool in uplink_ipv4_pools | arista.avd.natural_sort %}
-{%     set size = uplink_ipv4_pool | ansible.netcommon.ipaddr('size') %}
-{%     set used = assigned_ip_addresses | ansible.netcommon.ipaddr(uplink_ipv4_pool) | length %}
+{%     set size = uplink_ipv4_pool | ansible.utils.ipaddr('size') %}
+{%     set used = assigned_ip_addresses | ansible.utils.ipaddr(uplink_ipv4_pool) | length %}
 | {{ uplink_ipv4_pool }} | {{ size }} | {{ used }} | {{ (used / size * 100) | round(2,'ceil') }} % |
 {% endfor %}
 
@@ -141,8 +141,8 @@
 | Loopback Pool | Available Addresses | Assigned addresses | Assigned Address % |
 | ------------- | ------------------- | ------------------ | ------------------ |
 {% for overlay_loopback_network_summary in loopback_ipv4_pools | arista.avd.natural_sort %}
-{%     set size = overlay_loopback_network_summary | ansible.netcommon.ipaddr('size') %}
-{%     set used = assigned_ip_addresses | ansible.netcommon.ipaddr(overlay_loopback_network_summary) | length %}
+{%     set size = overlay_loopback_network_summary | ansible.utils.ipaddr('size') %}
+{%     set used = assigned_ip_addresses | ansible.utils.ipaddr(overlay_loopback_network_summary) | length %}
 | {{ overlay_loopback_network_summary }} | {{ size }} | {{ used }} | {{ (used / size * 100) | round(2,'ceil') }} % |
 {% endfor %}
 
@@ -173,8 +173,8 @@
 | VTEP Loopback Pool | Available Addresses | Assigned addresses | Assigned Address % |
 | --------------------- | ------------------- | ------------------ | ------------------ |
 {% for vtep_loopback_network_summary in vtep_loopback_ipv4_pools | arista.avd.natural_sort %}
-{%     set size = vtep_loopback_network_summary | ansible.netcommon.ipaddr('size') %}
-{%     set used = assigned_ip_addresses | ansible.netcommon.ipaddr(vtep_loopback_network_summary) | length %}
+{%     set size = vtep_loopback_network_summary | ansible.utils.ipaddr('size') %}
+{%     set used = assigned_ip_addresses | ansible.utils.ipaddr(vtep_loopback_network_summary) | length %}
 | {{ vtep_loopback_network_summary }} | {{ size }} | {{ used }} | {{ (used / size * 100) | round(2,'ceil') }} % |
 {% endfor %}
 

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/ip_addressing/avd-v2-spine-p2p-uplinks-ip.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/ip_addressing/avd-v2-spine-p2p-uplinks-ip.j2
@@ -2,7 +2,7 @@
 {# This file may still be used by older inventories #}
 {% set ip_pool = switch.uplink_ipv4_pool %}
 {# max number of hosts in subnet will be divided by max super-spine number to avoid address changes when provisioning new spines #}
-{% set ip_pool_max_hosts_in_subnet = ip_pool | ansible.netcommon.ipaddr('size') %}
+{% set ip_pool_max_hosts_in_subnet = ip_pool | ansible.utils.ipaddr('size') %}
 {% set offset = (switch.id - 1) % switch.max_parallel_uplinks %}
-{{ ip_pool | ansible.netcommon.ipaddr('network') | ansible.netcommon.ipmath(
+{{ ip_pool | ansible.utils.ipaddr('network') | ansible.utils.ipmath(
     (ip_pool_max_hosts_in_subnet / switch.max_uplink_switches) | int * (uplink_switch_index) + ((switch.id - 1) * switch.max_parallel_uplinks + offset) * 2 + 1) }}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/ip_addressing/avd-v2-spine-p2p-uplinks-peer-ip.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/ip_addressing/avd-v2-spine-p2p-uplinks-peer-ip.j2
@@ -2,7 +2,7 @@
 {# This file may still be used by older inventories #}
 {% set ip_pool = switch.uplink_ipv4_pool %}
 {# max number of hosts in subnet will be divided by max super-spine number to avoid address changes when provisioning new spines #}
-{% set ip_pool_max_hosts_in_subnet = ip_pool | ansible.netcommon.ipaddr('size') %}
+{% set ip_pool_max_hosts_in_subnet = ip_pool | ansible.utils.ipaddr('size') %}
 {% set offset = (switch.id - 1) % switch.max_parallel_uplinks %}
-{{ ip_pool | ansible.netcommon.ipaddr('network') | ansible.netcommon.ipmath(
+{{ ip_pool | ansible.utils.ipaddr('network') | ansible.utils.ipmath(
     (ip_pool_max_hosts_in_subnet / switch.max_uplink_switches) | int * (uplink_switch_index) + ((switch.id - 1) * switch.max_parallel_uplinks + offset) * 2) }}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/ip_addressing/mlag-ibgp-peering-ip-primary.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/ip_addressing/mlag-ibgp-peering-ip-primary.j2
@@ -1,1 +1,1 @@
-{{ vrf.mlag_ibgp_peering_ipv4_pool | ansible.netcommon.ipaddr('subnet') | ansible.netcommon.ipmath((switch.mlag_switch_ids.primary - 1) * 2) }}
+{{ vrf.mlag_ibgp_peering_ipv4_pool | ansible.utils.ipaddr('subnet') | ansible.utils.ipmath((switch.mlag_switch_ids.primary - 1) * 2) }}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/ip_addressing/mlag-ibgp-peering-ip-secondary.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/ip_addressing/mlag-ibgp-peering-ip-secondary.j2
@@ -1,1 +1,1 @@
-{{ vrf.mlag_ibgp_peering_ipv4_pool | ansible.netcommon.ipaddr('subnet') | ansible.netcommon.ipmath(((switch.mlag_switch_ids.primary - 1) * 2) + 1) }}
+{{ vrf.mlag_ibgp_peering_ipv4_pool | ansible.utils.ipaddr('subnet') | ansible.utils.ipmath(((switch.mlag_switch_ids.primary - 1) * 2) + 1) }}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/ip_addressing/mlag-ip-primary.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/ip_addressing/mlag-ip-primary.j2
@@ -1,1 +1,1 @@
-{{ switch_data.combined.mlag_peer_ipv4_pool | ansible.netcommon.ipaddr('network') | ansible.netcommon.ipmath((mlag_primary_id - 1) * 2) }}
+{{ switch_data.combined.mlag_peer_ipv4_pool | ansible.utils.ipaddr('network') | ansible.utils.ipmath((mlag_primary_id - 1) * 2) }}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/ip_addressing/mlag-ip-secondary.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/ip_addressing/mlag-ip-secondary.j2
@@ -1,1 +1,1 @@
-{{ switch_data.combined.mlag_peer_ipv4_pool | ansible.netcommon.ipaddr('network') | ansible.netcommon.ipmath(((mlag_primary_id - 1) * 2) + 1) }}
+{{ switch_data.combined.mlag_peer_ipv4_pool | ansible.utils.ipaddr('network') | ansible.utils.ipmath(((mlag_primary_id - 1) * 2) + 1) }}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/ip_addressing/mlag-l3-ip-primary.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/ip_addressing/mlag-l3-ip-primary.j2
@@ -1,1 +1,1 @@
-{{ switch_data.combined.mlag_peer_l3_ipv4_pool | ansible.netcommon.ipaddr('network') | ansible.netcommon.ipmath((mlag_primary_id - 1) * 2) }}
+{{ switch_data.combined.mlag_peer_l3_ipv4_pool | ansible.utils.ipaddr('network') | ansible.utils.ipmath((mlag_primary_id - 1) * 2) }}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/ip_addressing/mlag-l3-ip-secondary.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/ip_addressing/mlag-l3-ip-secondary.j2
@@ -1,1 +1,1 @@
-{{ switch_data.combined.mlag_peer_l3_ipv4_pool | ansible.netcommon.ipaddr('network') | ansible.netcommon.ipmath(((mlag_primary_id - 1) * 2) + 1) }}
+{{ switch_data.combined.mlag_peer_l3_ipv4_pool | ansible.utils.ipaddr('network') | ansible.utils.ipmath(((mlag_primary_id - 1) * 2) + 1) }}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/ip_addressing/p2p-uplinks-ip.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/ip_addressing/p2p-uplinks-ip.j2
@@ -1,1 +1,1 @@
-{{ switch.uplink_ipv4_pool | ansible.netcommon.ipaddr('network') | ansible.netcommon.ipmath(((switch.id -1) * 2 * switch.max_uplink_switches * switch.max_parallel_uplinks) + (uplink_switch_index) * 2 + 1) }}
+{{ switch.uplink_ipv4_pool | ansible.utils.ipaddr('network') | ansible.utils.ipmath(((switch.id -1) * 2 * switch.max_uplink_switches * switch.max_parallel_uplinks) + (uplink_switch_index) * 2 + 1) }}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/ip_addressing/p2p-uplinks-peer-ip.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/ip_addressing/p2p-uplinks-peer-ip.j2
@@ -1,1 +1,1 @@
-{{ switch.uplink_ipv4_pool | ansible.netcommon.ipaddr('network') | ansible.netcommon.ipmath(((switch.id -1) * 2 * switch.max_uplink_switches * switch.max_parallel_uplinks) + (uplink_switch_index) * 2) }}
+{{ switch.uplink_ipv4_pool | ansible.utils.ipaddr('network') | ansible.utils.ipmath(((switch.id -1) * 2 * switch.max_uplink_switches * switch.max_parallel_uplinks) + (uplink_switch_index) * 2) }}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/ip_addressing/router-id-ipv6.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/ip_addressing/router-id-ipv6.j2
@@ -1,1 +1,1 @@
-{{ loopback_ipv6_pool | ansible.netcommon.ipaddr("network") | ansible.netcommon.ipmath(switch_id + loopback_ipv6_offset) }}
+{{ loopback_ipv6_pool | ansible.utils.ipaddr("network") | ansible.utils.ipmath(switch_id + loopback_ipv6_offset) }}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/ip_addressing/router-id.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/ip_addressing/router-id.j2
@@ -1,1 +1,1 @@
-{{ loopback_ipv4_pool | ansible.netcommon.ipaddr("network") | ansible.netcommon.ipmath(switch_id + loopback_ipv4_offset) }}
+{{ loopback_ipv4_pool | ansible.utils.ipaddr("network") | ansible.utils.ipmath(switch_id + loopback_ipv4_offset) }}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/ip_addressing/vtep-ip-mlag.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/ip_addressing/vtep-ip-mlag.j2
@@ -1,1 +1,1 @@
-{{ switch_vtep_loopback_ipv4_pool | ansible.netcommon.ipaddr('network') | ansible.netcommon.ipmath(mlag_primary_id + loopback_ipv4_offset) }}
+{{ switch_vtep_loopback_ipv4_pool | ansible.utils.ipaddr('network') | ansible.utils.ipmath(mlag_primary_id + loopback_ipv4_offset) }}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/ip_addressing/vtep-ip.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/ip_addressing/vtep-ip.j2
@@ -1,1 +1,1 @@
-{{ switch_vtep_loopback_ipv4_pool | ansible.netcommon.ipaddr('network') | ansible.netcommon.ipmath(switch_id + loopback_ipv4_offset) }}
+{{ switch_vtep_loopback_ipv4_pool | ansible.utils.ipaddr('network') | ansible.utils.ipmath(switch_id + loopback_ipv4_offset) }}


### PR DESCRIPTION
## Change Summary

Change IP addressing templates from ansible netcommon to ansible.utils

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

- Updated builtin jinja templates used for IP addressing.
  We don't use these templates any longer for default IP addressing, but some customers might 
still point to these templates, so we should keep them updated.

- Updated the custom templates being tested in molecule.
- Updated fabric documentation template
- Updated dhcp_provisioner template

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

No changes in molecule.
Tested a few new templates on ansible templating test site.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
