### PR TITLE
Refactor(eos_designs): Optimize and fix switch facts

### DIFF
--- a/ansible_collections/arista/avd/plugins/action/set_vars.py
+++ b/ansible_collections/arista/avd/plugins/action/set_vars.py
@@ -1,0 +1,15 @@
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from ansible.plugins.action import ActionBase
+
+
+class ActionModule(ActionBase):
+    def run(self, tmp=None, task_vars=None):
+        if task_vars is None:
+            task_vars = {}
+
+        result = {}
+        result["ansible_facts"] = self._task.args
+        return result

--- a/ansible_collections/arista/avd/plugins/action/yaml_templates_to_facts.py
+++ b/ansible_collections/arista/avd/plugins/action/yaml_templates_to_facts.py
@@ -18,7 +18,7 @@ from ansible_collections.arista.avd.plugins.plugin_utils.errors import AristaAvd
 from ansible_collections.arista.avd.plugins.plugin_utils.merge import merge
 from ansible_collections.arista.avd.plugins.plugin_utils.schema.avdschematools import AvdSchemaTools
 from ansible_collections.arista.avd.plugins.plugin_utils.strip_empties import strip_null_from_data
-from ansible_collections.arista.avd.plugins.plugin_utils.utils import get_templar, load_python_class
+from ansible_collections.arista.avd.plugins.plugin_utils.utils import get, get_templar, load_python_class
 from ansible_collections.arista.avd.plugins.plugin_utils.utils import template as templater
 
 DEFAULT_PYTHON_CLASS_NAME = "AvdStructuredConfig"
@@ -69,7 +69,7 @@ class ActionModule(ActionBase):
 
         hostname = task_vars["inventory_hostname"]
 
-        task_vars["switch"] = task_vars["avd_switch_facts"][hostname]["switch"]
+        task_vars["switch"] = get(task_vars, "avd_switch_facts/hostname/switch", separator="/", default={})
 
         # Read ansible variables and perform templating to support inline jinja2
         for var in task_vars:
@@ -258,7 +258,7 @@ class ActionModule(ActionBase):
         else:
             result["ansible_facts"] = output
 
-        result["ansible_facts"]["switch"] = task_vars["switch"]
+        result["ansible_facts"]["switch"] = task_vars.get("switch")
 
         if cprofile_file:
             profiler.disable()

--- a/ansible_collections/arista/avd/plugins/action/yaml_templates_to_facts.py
+++ b/ansible_collections/arista/avd/plugins/action/yaml_templates_to_facts.py
@@ -59,7 +59,6 @@ class ActionModule(ActionBase):
             self.dest = self._task.args.get("dest", False)
             template_output = self._task.args.get("template_output", False)
             debug = self._task.args.get("debug", False)
-            remove_avd_switch_facts = self._task.args.get("remove_avd_switch_facts", False)
             conversion_mode = self._task.args.get("conversion_mode")
             validation_mode = self._task.args.get("validation_mode")
             output_schema = self._task.args.get("output_schema")
@@ -68,18 +67,21 @@ class ActionModule(ActionBase):
         else:
             raise AnsibleActionFail("The argument 'templates' must be set")
 
-        # Read ansible variables and perform templating to support inline jinja
+        hostname = task_vars["inventory_hostname"]
+
+        task_vars["switch"] = task_vars["avd_switch_facts"][hostname]["switch"]
+
+        # Read ansible variables and perform templating to support inline jinja2
         for var in task_vars:
-            if str(var).startswith(("ansible", "molecule", "hostvars", "vars")):
+            if str(var).startswith(("ansible", "molecule", "hostvars", "vars", "avd_switch_facts")):
                 continue
             if self._templar.is_template(task_vars[var]):
-                # Var contains a jinja template.
+                # Var contains a jinja2 template.
                 try:
                     task_vars[var] = self._templar.template(task_vars[var], fail_on_undefined=False)
                 except Exception as e:
                     raise AnsibleActionFail(f"Exception during templating of task_var '{var}'") from e
 
-        hostname = task_vars["inventory_hostname"]
         if schema or schema_id:
             # Load schema tools and perform conversion and validation
             avdschematools = AvdSchemaTools(
@@ -256,8 +258,7 @@ class ActionModule(ActionBase):
         else:
             result["ansible_facts"] = output
 
-        if remove_avd_switch_facts:
-            result["ansible_facts"]["avd_switch_facts"] = None
+        result["ansible_facts"]["switch"] = task_vars["switch"]
 
         if cprofile_file:
             profiler.disable()

--- a/ansible_collections/arista/avd/plugins/action/yaml_templates_to_facts.py
+++ b/ansible_collections/arista/avd/plugins/action/yaml_templates_to_facts.py
@@ -69,7 +69,7 @@ class ActionModule(ActionBase):
 
         hostname = task_vars["inventory_hostname"]
 
-        task_vars["switch"] = get(task_vars, "avd_switch_facts/hostname/switch", separator="/", default={})
+        task_vars["switch"] = get(task_vars, f"avd_switch_facts..{hostname}..switch", separator="..", default={})
 
         # Read ansible variables and perform templating to support inline jinja2
         for var in task_vars:

--- a/ansible_collections/arista/avd/plugins/modules/set_vars.py
+++ b/ansible_collections/arista/avd/plugins/modules/set_vars.py
@@ -1,0 +1,36 @@
+# Copyright 2023 Arista Networks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+DOCUMENTATION = r"""
+---
+module: set_vars
+version_added: "4.0.0"
+author: Arista Ansible Team (@aristanetworks)
+short_description: Set vars as ansible_facts.
+description:
+  - Set vars as ansible_facts.
+  - Ansible will copy these into vars in the global namespace as well.
+  - Arguments are treated as a dict so all arguments will be set as vars.
+options:
+"""
+
+EXAMPLES = r"""
+- name: Remove avd_switch_facts
+  tags: [build, provision, facts, remove_avd_switch_facts]
+  arista.avd.set_vars:
+    avd_switch_facts: null
+  run_once: true
+  check_mode: false
+"""

--- a/ansible_collections/arista/avd/plugins/modules/set_vars.py
+++ b/ansible_collections/arista/avd/plugins/modules/set_vars.py
@@ -22,8 +22,8 @@ short_description: Set vars as ansible_facts.
 description:
   - Set vars as ansible_facts.
   - Ansible will copy these into vars in the global namespace as well.
-  - Arguments are treated as a dict so all arguments will be set as vars.
-options:
+  - Arguments are treated as one dict so all arguments will be set as vars.
+options: {}
 """
 
 EXAMPLES = r"""

--- a/ansible_collections/arista/avd/roles/eos_designs/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/tasks/main.yml
@@ -35,13 +35,6 @@
   check_mode: false
   run_once: true
 
-- name: Set eos_designs facts per device
-  tags: [build, provision, facts]
-  ansible.builtin.set_fact:
-    switch: "{{ avd_switch_facts[inventory_hostname].switch }}"
-  delegate_to: localhost
-  changed_when: false
-
 - name: Generate YAML file with hostvars (only for debugging)
   tags: [debug, never]
   ansible.builtin.template:
@@ -98,7 +91,7 @@
 
 - name: Remove avd_switch_facts
   tags: [build, provision, facts, remove_avd_switch_facts]
-  ansible.builtin.set_fact:
+  arista.avd.set_vars:
     avd_switch_facts: null
   run_once: true
   check_mode: false

--- a/ansible_collections/arista/avd/roles/eos_designs/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/tasks/main.yml
@@ -93,5 +93,7 @@
   tags: [build, provision, facts, remove_avd_switch_facts]
   arista.avd.set_vars:
     avd_switch_facts: null
+    avd_overlay_peers: null
+    avd_topology_peers: null
   run_once: true
   check_mode: false

--- a/ansible_collections/arista/avd/tests/sanity/ignore-2.12.txt
+++ b/ansible_collections/arista/avd/tests/sanity/ignore-2.12.txt
@@ -2,6 +2,7 @@ plugins/modules/batch_template.py validate-modules:missing-gplv3-license
 plugins/modules/configlet_build_config.py validate-modules:missing-gplv3-license
 plugins/modules/eos_designs_facts.py validate-modules:missing-gplv3-license
 plugins/modules/inventory_to_container.py validate-modules:missing-gplv3-license
+plugins/modules/set_vars.py validate-modules:missing-gplv3-license
 plugins/modules/validate_and_template.py validate-modules:missing-gplv3-license
 plugins/modules/verify_requirements.py validate-modules:missing-gplv3-license
 plugins/modules/yaml_templates_to_facts.py validate-modules:missing-gplv3-license

--- a/ansible_collections/arista/avd/tests/sanity/ignore-2.13.txt
+++ b/ansible_collections/arista/avd/tests/sanity/ignore-2.13.txt
@@ -2,6 +2,7 @@ plugins/modules/batch_template.py validate-modules:missing-gplv3-license
 plugins/modules/configlet_build_config.py validate-modules:missing-gplv3-license
 plugins/modules/eos_designs_facts.py validate-modules:missing-gplv3-license
 plugins/modules/inventory_to_container.py validate-modules:missing-gplv3-license
+plugins/modules/set_vars.py validate-modules:missing-gplv3-license
 plugins/modules/validate_and_template.py validate-modules:missing-gplv3-license
 plugins/modules/verify_requirements.py validate-modules:missing-gplv3-license
 plugins/modules/yaml_templates_to_facts.py validate-modules:missing-gplv3-license

--- a/ansible_collections/arista/avd/tests/sanity/ignore-2.14.txt
+++ b/ansible_collections/arista/avd/tests/sanity/ignore-2.14.txt
@@ -2,6 +2,7 @@ plugins/modules/batch_template.py validate-modules:missing-gplv3-license
 plugins/modules/configlet_build_config.py validate-modules:missing-gplv3-license
 plugins/modules/eos_designs_facts.py validate-modules:missing-gplv3-license
 plugins/modules/inventory_to_container.py validate-modules:missing-gplv3-license
+plugins/modules/set_vars.py validate-modules:missing-gplv3-license
 plugins/modules/validate_and_template.py validate-modules:missing-gplv3-license
 plugins/modules/verify_requirements.py validate-modules:missing-gplv3-license
 plugins/modules/yaml_templates_to_facts.py validate-modules:missing-gplv3-license


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Optimize and fix switch facts

## Related Issue(s)

When running `eos_designs` the last task is the clear `avd_switch_facts`. The purpose is to remove this very big dataset from the variable space, speeding up all following tasks significantly.

The remove task was using `set_fact` to clear `avd_switch_facts`, which had been set from `eos_designs_facts` action plugin. 

Unfortunately `set_fact` only cleared the _var_ `avd_switch_facts` but _not_ the `ansible_facts.avd_switch_facts` fact. This is just how `set_fact` works, and not anything we can change.

Ansible does not provide any other standard modules to set a fact _and_ var similar to how modules normally do, so part of this PR is a new plugin `arista.avd.set_vars` which returns any arguments into `ansible_facts` which Ansible in turn sets as _vars_.

Since this is the same way `eos_designs_facts` sets `avd_switch_facts` in the first place, we can use this method to overwrite both copies will `none`.

## Component(s) name

`arista.avd.eos_designs`
`arista.avd.set_vars`
`arista.avd.yaml_templates_to_facts`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

- New action plugin `arista.avd.set_vars` to offer a simple way to set facts with a module.
- Use `set_vars` instead of `set_fact` for clearing `avd_switch_facts`
- Move setting of `switch.*` from `avd_switch_facts[<hostname].switch` into `yaml_templates_to_facts`.
  Partially for speed and partially for future option to skip this.
- Clean up unused and undocumented `remove_avd_switch_facts` option from `yaml_templates_to_facts`

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Running eos_designs_unit_tests. Ignore the `real` time, which was likely some thermal throttling, but `user` shows 25% faster.

```sh
#devel
real    5m6,659s
user    39m27,159s
sys     1m9,590s

#PR
real    3m8,249s
user    30m24,396s
sys     0m52,351s
```

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been rebased from devel before I start
- [ ] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
