### PR TITLE
Fix(eos_designs)!: Prevent configuration of IP routing on l2leaf

### DIFF
--- a/ansible_collections/arista/avd/docs/porting-guides/4.x.x.md
+++ b/ansible_collections/arista/avd/docs/porting-guides/4.x.x.md
@@ -6,6 +6,23 @@ and playbooks to be compatible with new default behaviors and changed data model
 Users of `eos_designs` do not have to consider the changes in `eos_cli_config_gen`, since those adaptions are
 built in to `eos_designs`.
 
+## Changes to role `arista.avd.eos_designs`
+
+### IP and IPv6 routing is no longer configured on pure L2 devices
+
+For node types like `l2leaf` where `underlay_router` is set to `false` under `node_type_keys` AVD versions below 4.0.0
+still rendered `ip routing`, `ip routing ipv6 interfaces` and/or `ipv6 unicast-routing` in the configuration.
+As of AVD version 4.0.0 these IP and IPv6 routing configurations are no longer configured for `l2leaf`
+or other node types with `underlay_router: false`.
+
+To retain the old behavior the inventory can be updated like this:
+
+```yaml
+l2leaf:
+  defaults:
+    always_configure_ip_routing: true
+```
+
 ## Changes to role `arista.avd.eos_config_deploy_cvp`
 
 ### Inventory to CloudVision containers
@@ -70,7 +87,7 @@ all:
             DC1_L3LEAFS:
 ```
 
-#### Not supported group structure
+#### Unsupported group structure
 
 ```yaml
 ---

--- a/ansible_collections/arista/avd/docs/release-notes/4.x.x.md
+++ b/ansible_collections/arista/avd/docs/release-notes/4.x.x.md
@@ -46,3 +46,9 @@ CVP_FACTS -> cvp_facts
 CVP_TOPOLOGY -> cvp_topology
 CVP_VARS -> cvp_vars
 ```
+
+#### IP routing is no longer configured on pure L2 devices
+
+For node types like `l2leaf` where `underlay_router` is set to `false` under `node_type_keys` AVD versions below 4.0.0
+still rendered `ip routing` in the configuration. With AVD version 4.0.0 `ip routing` is no longer configured for `l2leaf`
+or other node types with `underlay_router: false`.

--- a/ansible_collections/arista/avd/examples/campus-fabric/README.md
+++ b/ansible_collections/arista/avd/examples/campus-fabric/README.md
@@ -267,7 +267,7 @@ Lastly, we need to provide a way for traffic to exit the Campus Fabric via the W
 
 ``` yaml
 # Underlay Routing Protocol
-underlay_routing_protocol: OSPF
+underlay_routing_protocol: ospf
 
 #### WAN/Core Edge Links ####
 core_interfaces:

--- a/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF1A.md
+++ b/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF1A.md
@@ -1386,14 +1386,12 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
+| default | False |
 | MGMT | False |
 
 #### IP Routing Device Configuration
 
 ```eos
-!
-ip routing
 no ip routing vrf MGMT
 ```
 

--- a/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF1B.md
+++ b/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF1B.md
@@ -1386,14 +1386,12 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
+| default | False |
 | MGMT | False |
 
 #### IP Routing Device Configuration
 
 ```eos
-!
-ip routing
 no ip routing vrf MGMT
 ```
 

--- a/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF2A.md
+++ b/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF2A.md
@@ -5339,14 +5339,12 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
+| default | False |
 | MGMT | False |
 
 #### IP Routing Device Configuration
 
 ```eos
-!
-ip routing
 no ip routing vrf MGMT
 ```
 

--- a/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF3A.md
+++ b/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF3A.md
@@ -2445,14 +2445,12 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
+| default | False |
 | MGMT | False |
 
 #### IP Routing Device Configuration
 
 ```eos
-!
-ip routing
 no ip routing vrf MGMT
 ```
 

--- a/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF3B.md
+++ b/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF3B.md
@@ -2445,14 +2445,12 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
+| default | False |
 | MGMT | False |
 
 #### IP Routing Device Configuration
 
 ```eos
-!
-ip routing
 no ip routing vrf MGMT
 ```
 

--- a/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF3C.md
+++ b/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF3C.md
@@ -2315,14 +2315,12 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
+| default | False |
 | MGMT | False |
 
 #### IP Routing Device Configuration
 
 ```eos
-!
-ip routing
 no ip routing vrf MGMT
 ```
 

--- a/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF3D.md
+++ b/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF3D.md
@@ -2315,14 +2315,12 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
+| default | False |
 | MGMT | False |
 
 #### IP Routing Device Configuration
 
 ```eos
-!
-ip routing
 no ip routing vrf MGMT
 ```
 

--- a/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF3E.md
+++ b/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF3E.md
@@ -2315,14 +2315,12 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
+| default | False |
 | MGMT | False |
 
 #### IP Routing Device Configuration
 
 ```eos
-!
-ip routing
 no ip routing vrf MGMT
 ```
 

--- a/ansible_collections/arista/avd/examples/campus-fabric/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/group_vars/DC1_FABRIC.yml
@@ -131,7 +131,7 @@ leaf:
 p2p_uplinks_mtu: 1500
 
 # Underlay Routing Protocol
-underlay_routing_protocol: OSPF
+underlay_routing_protocol: ospf
 
 #### WAN/Core Edge Links ####
 core_interfaces:

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/LEAF1A.cfg
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/LEAF1A.cfg
@@ -1051,8 +1051,6 @@ interface Vlan4094
    mtu 1500
    no autostate
    ip address 192.168.0.4/31
-!
-ip routing
 no ip routing vrf MGMT
 !
 mlag configuration

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/LEAF1B.cfg
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/LEAF1B.cfg
@@ -1051,8 +1051,6 @@ interface Vlan4094
    mtu 1500
    no autostate
    ip address 192.168.0.5/31
-!
-ip routing
 no ip routing vrf MGMT
 !
 mlag configuration

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/LEAF2A.cfg
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/LEAF2A.cfg
@@ -4865,8 +4865,6 @@ interface Vlan10
    no shutdown
    mtu 1500
    ip address 10.10.10.8/24
-!
-ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 172.100.100.1

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/LEAF3A.cfg
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/LEAF3A.cfg
@@ -2055,8 +2055,6 @@ interface Vlan4094
    mtu 1500
    no autostate
    ip address 192.168.0.10/31
-!
-ip routing
 no ip routing vrf MGMT
 !
 mlag configuration

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/LEAF3B.cfg
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/LEAF3B.cfg
@@ -2055,8 +2055,6 @@ interface Vlan4094
    mtu 1500
    no autostate
    ip address 192.168.0.11/31
-!
-ip routing
 no ip routing vrf MGMT
 !
 mlag configuration

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/LEAF3C.cfg
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/LEAF3C.cfg
@@ -1985,8 +1985,6 @@ interface Vlan10
    no shutdown
    mtu 1500
    ip address 10.10.10.11/24
-!
-ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 172.100.100.1

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/LEAF3D.cfg
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/LEAF3D.cfg
@@ -1985,8 +1985,6 @@ interface Vlan10
    no shutdown
    mtu 1500
    ip address 10.10.10.12/24
-!
-ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 172.100.100.1

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/LEAF3E.cfg
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/LEAF3E.cfg
@@ -1985,8 +1985,6 @@ interface Vlan10
    no shutdown
    mtu 1500
    ip address 10.10.10.13/24
-!
-ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 172.100.100.1

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF1A.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF1A.yml
@@ -5,7 +5,6 @@ static_routes:
 - destination_address_prefix: 0.0.0.0/0
   gateway: 10.10.10.1
 service_routing_protocols_model: multi-agent
-ip_routing: true
 vlan_internal_order:
   allocation: ascending
   range:

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF1B.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF1B.yml
@@ -5,7 +5,6 @@ static_routes:
 - destination_address_prefix: 0.0.0.0/0
   gateway: 10.10.10.1
 service_routing_protocols_model: multi-agent
-ip_routing: true
 vlan_internal_order:
   allocation: ascending
   range:

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF2A.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF2A.yml
@@ -5,7 +5,6 @@ static_routes:
 - destination_address_prefix: 0.0.0.0/0
   gateway: 10.10.10.1
 service_routing_protocols_model: multi-agent
-ip_routing: true
 vlan_internal_order:
   allocation: ascending
   range:

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3A.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3A.yml
@@ -5,7 +5,6 @@ static_routes:
 - destination_address_prefix: 0.0.0.0/0
   gateway: 10.10.10.1
 service_routing_protocols_model: multi-agent
-ip_routing: true
 vlan_internal_order:
   allocation: ascending
   range:

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3B.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3B.yml
@@ -5,7 +5,6 @@ static_routes:
 - destination_address_prefix: 0.0.0.0/0
   gateway: 10.10.10.1
 service_routing_protocols_model: multi-agent
-ip_routing: true
 vlan_internal_order:
   allocation: ascending
   range:

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3C.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3C.yml
@@ -5,7 +5,6 @@ static_routes:
 - destination_address_prefix: 0.0.0.0/0
   gateway: 10.10.10.1
 service_routing_protocols_model: multi-agent
-ip_routing: true
 vlan_internal_order:
   allocation: ascending
   range:

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3D.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3D.yml
@@ -5,7 +5,6 @@ static_routes:
 - destination_address_prefix: 0.0.0.0/0
   gateway: 10.10.10.1
 service_routing_protocols_model: multi-agent
-ip_routing: true
 vlan_internal_order:
   allocation: ascending
   range:

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3E.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3E.yml
@@ -5,7 +5,6 @@ static_routes:
 - destination_address_prefix: 0.0.0.0/0
   gateway: 10.10.10.1
 service_routing_protocols_model: multi-agent
-ip_routing: true
 vlan_internal_order:
   allocation: ascending
   range:

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-leaf1c.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-leaf1c.md
@@ -253,14 +253,12 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
+| default | False |
 | MGMT | False |
 
 #### IP Routing Device Configuration
 
 ```eos
-!
-ip routing
 no ip routing vrf MGMT
 ```
 

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-leaf2c.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-leaf2c.md
@@ -253,14 +253,12 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
+| default | False |
 | MGMT | False |
 
 #### IP Routing Device Configuration
 
 ```eos
-!
-ip routing
 no ip routing vrf MGMT
 ```
 

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-leaf1c.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-leaf1c.md
@@ -253,14 +253,12 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
+| default | False |
 | MGMT | False |
 
 #### IP Routing Device Configuration
 
 ```eos
-!
-ip routing
 no ip routing vrf MGMT
 ```
 

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-leaf2c.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-leaf2c.md
@@ -253,14 +253,12 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
+| default | False |
 | MGMT | False |
 
 #### IP Routing Device Configuration
 
 ```eos
-!
-ip routing
 no ip routing vrf MGMT
 ```
 

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/group_vars/FABRIC.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/group_vars/FABRIC.yml
@@ -21,8 +21,8 @@ ansible_httpapi_validate_certs: false
 fabric_name: FABRIC
 
 # Define underlay and overlay routing protocol to be used
-underlay_routing_protocol: EBGP
-overlay_routing_protocol: EBGP
+underlay_routing_protocol: ebgp
+overlay_routing_protocol: ebgp
 
 # Local users
 local_users:

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-leaf1c.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-leaf1c.cfg
@@ -67,8 +67,6 @@ interface Management1
    no shutdown
    vrf MGMT
    ip address 172.16.1.151/24
-!
-ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 172.16.1.1

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-leaf2c.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-leaf2c.cfg
@@ -67,8 +67,6 @@ interface Management1
    no shutdown
    vrf MGMT
    ip address 172.16.1.152/24
-!
-ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 172.16.1.1

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-leaf1c.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-leaf1c.cfg
@@ -67,8 +67,6 @@ interface Management1
    no shutdown
    vrf MGMT
    ip address 172.16.2.251/24
-!
-ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 172.16.2.1

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-leaf2c.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-leaf2c.cfg
@@ -67,8 +67,6 @@ interface Management1
    no shutdown
    vrf MGMT
    ip address 172.16.2.252/24
-!
-ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 172.16.2.1

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf1c.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf1c.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 172.16.1.1
 service_routing_protocols_model: multi-agent
-ip_routing: true
 vlan_internal_order:
   allocation: ascending
   range:

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf2c.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf2c.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 172.16.1.1
 service_routing_protocols_model: multi-agent
-ip_routing: true
 vlan_internal_order:
   allocation: ascending
   range:

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf1c.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf1c.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 172.16.2.1
 service_routing_protocols_model: multi-agent
-ip_routing: true
 vlan_internal_order:
   allocation: ascending
   range:

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf2c.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf2c.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 172.16.2.1
 service_routing_protocols_model: multi-agent
-ip_routing: true
 vlan_internal_order:
   allocation: ascending
   range:

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/LEAF1.md
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/LEAF1.md
@@ -394,14 +394,12 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
+| default | False |
 | MGMT | False |
 
 #### IP Routing Device Configuration
 
 ```eos
-!
-ip routing
 no ip routing vrf MGMT
 ```
 

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/LEAF2.md
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/LEAF2.md
@@ -394,14 +394,12 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
+| default | False |
 | MGMT | False |
 
 #### IP Routing Device Configuration
 
 ```eos
-!
-ip routing
 no ip routing vrf MGMT
 ```
 

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/LEAF3.md
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/LEAF3.md
@@ -394,14 +394,12 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
+| default | False |
 | MGMT | False |
 
 #### IP Routing Device Configuration
 
 ```eos
-!
-ip routing
 no ip routing vrf MGMT
 ```
 

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/LEAF4.md
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/LEAF4.md
@@ -394,14 +394,12 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
+| default | False |
 | MGMT | False |
 
 #### IP Routing Device Configuration
 
 ```eos
-!
-ip routing
 no ip routing vrf MGMT
 ```
 

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/SPINE1.md
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/SPINE1.md
@@ -425,14 +425,12 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
+| default | False |
 | MGMT | False |
 
 #### IP Routing Device Configuration
 
 ```eos
-!
-ip routing
 no ip routing vrf MGMT
 ```
 

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/SPINE2.md
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/SPINE2.md
@@ -425,14 +425,12 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
+| default | False |
 | MGMT | False |
 
 #### IP Routing Device Configuration
 
 ```eos
-!
-ip routing
 no ip routing vrf MGMT
 ```
 

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/configs/LEAF1.cfg
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/configs/LEAF1.cfg
@@ -94,8 +94,6 @@ interface Vlan4094
    mtu 1500
    no autostate
    ip address 192.168.0.0/31
-!
-ip routing
 no ip routing vrf MGMT
 !
 mlag configuration

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/configs/LEAF2.cfg
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/configs/LEAF2.cfg
@@ -94,8 +94,6 @@ interface Vlan4094
    mtu 1500
    no autostate
    ip address 192.168.0.1/31
-!
-ip routing
 no ip routing vrf MGMT
 !
 mlag configuration

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/configs/LEAF3.cfg
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/configs/LEAF3.cfg
@@ -94,8 +94,6 @@ interface Vlan4094
    mtu 1500
    no autostate
    ip address 192.168.0.4/31
-!
-ip routing
 no ip routing vrf MGMT
 !
 mlag configuration

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/configs/LEAF4.cfg
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/configs/LEAF4.cfg
@@ -94,8 +94,6 @@ interface Vlan4094
    mtu 1500
    no autostate
    ip address 192.168.0.5/31
-!
-ip routing
 no ip routing vrf MGMT
 !
 mlag configuration

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/configs/SPINE1.cfg
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/configs/SPINE1.cfg
@@ -120,8 +120,6 @@ interface Vlan4094
    mtu 1500
    no autostate
    ip address 192.168.0.0/31
-!
-ip routing
 no ip routing vrf MGMT
 !
 mlag configuration

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/configs/SPINE2.cfg
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/configs/SPINE2.cfg
@@ -120,8 +120,6 @@ interface Vlan4094
    mtu 1500
    no autostate
    ip address 192.168.0.1/31
-!
-ip routing
 no ip routing vrf MGMT
 !
 mlag configuration

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF1.yml
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF1.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 172.100.100.1
 service_routing_protocols_model: multi-agent
-ip_routing: true
 vlan_internal_order:
   allocation: ascending
   range:

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF2.yml
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF2.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 172.100.100.1
 service_routing_protocols_model: multi-agent
-ip_routing: true
 vlan_internal_order:
   allocation: ascending
   range:

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF3.yml
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF3.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 172.100.100.1
 service_routing_protocols_model: multi-agent
-ip_routing: true
 vlan_internal_order:
   allocation: ascending
   range:

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF4.yml
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF4.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 172.100.100.1
 service_routing_protocols_model: multi-agent
-ip_routing: true
 vlan_internal_order:
   allocation: ascending
   range:

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/SPINE1.yml
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/SPINE1.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 172.100.100.1
 service_routing_protocols_model: multi-agent
-ip_routing: true
 vlan_internal_order:
   allocation: ascending
   range:

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/SPINE2.yml
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/SPINE2.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 172.100.100.1
 service_routing_protocols_model: multi-agent
-ip_routing: true
 vlan_internal_order:
   allocation: ascending
   range:

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/README.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/README.md
@@ -309,8 +309,8 @@ The following section specifies variables that generate configuration to be appl
 ```yaml title="FABRIC.yml"
 fabric_name: FABRIC # (1)!
 
-underlay_routing_protocol: EBGP
-overlay_routing_protocol: EBGP
+underlay_routing_protocol: ebgp
+overlay_routing_protocol: ebgp
 
 local_users: # (2)!
   ansible:

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf1c.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf1c.md
@@ -253,14 +253,12 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
+| default | False |
 | MGMT | False |
 
 #### IP Routing Device Configuration
 
 ```eos
-!
-ip routing
 no ip routing vrf MGMT
 ```
 

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf2c.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf2c.md
@@ -253,14 +253,12 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
+| default | False |
 | MGMT | False |
 
 #### IP Routing Device Configuration
 
 ```eos
-!
-ip routing
 no ip routing vrf MGMT
 ```
 

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/group_vars/FABRIC.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/group_vars/FABRIC.yml
@@ -19,8 +19,8 @@ ansible_httpapi_validate_certs: false
 fabric_name: FABRIC
 
 # Define underlay and overlay routing protocol to be used
-underlay_routing_protocol: EBGP
-overlay_routing_protocol: EBGP
+underlay_routing_protocol: ebgp
+overlay_routing_protocol: ebgp
 
 # Local users
 local_users:

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/configs/dc1-leaf1c.cfg
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/configs/dc1-leaf1c.cfg
@@ -67,8 +67,6 @@ interface Management1
    no shutdown
    vrf MGMT
    ip address 172.16.1.151/24
-!
-ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 172.16.1.1

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/configs/dc1-leaf2c.cfg
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/configs/dc1-leaf2c.cfg
@@ -67,8 +67,6 @@ interface Management1
    no shutdown
    vrf MGMT
    ip address 172.16.1.152/24
-!
-ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 172.16.1.1

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf1c.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf1c.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 172.16.1.1
 service_routing_protocols_model: multi-agent
-ip_routing: true
 vlan_internal_order:
   allocation: ascending
   range:

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf2c.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf2c.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 172.16.1.1
 service_routing_protocols_model: multi-agent
-ip_routing: true
 vlan_internal_order:
   allocation: ascending
   range:

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-L2LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-L2LEAF1A.md
@@ -307,14 +307,12 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
+| default | False |
 | MGMT | False |
 
 #### IP Routing Device Configuration
 
 ```eos
-!
-ip routing
 no ip routing vrf MGMT
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-L2LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-L2LEAF2A.md
@@ -428,14 +428,12 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
+| default | False |
 | MGMT | False |
 
 #### IP Routing Device Configuration
 
 ```eos
-!
-ip routing
 no ip routing vrf MGMT
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-L2LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-L2LEAF2B.md
@@ -428,14 +428,12 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
+| default | False |
 | MGMT | False |
 
 #### IP Routing Device Configuration
 
 ```eos
-!
-ip routing
 no ip routing vrf MGMT
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-L2LEAF1A.cfg
@@ -70,8 +70,6 @@ interface Management1
    no shutdown
    vrf MGMT
    ip address 192.168.200.112/24
-!
-ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 192.168.200.5

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-L2LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-L2LEAF2A.cfg
@@ -128,8 +128,6 @@ interface Vlan4094
    mtu 1500
    no autostate
    ip address 10.255.252.16/31
-!
-ip routing
 no ip routing vrf MGMT
 !
 mlag configuration

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-L2LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-L2LEAF2B.cfg
@@ -128,8 +128,6 @@ interface Vlan4094
    mtu 1500
    no autostate
    ip address 10.255.252.17/31
-!
-ip routing
 no ip routing vrf MGMT
 !
 mlag configuration

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 daemon_terminattr:
   cvaddrs:
   - 192.168.200.11:9910

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 daemon_terminattr:
   cvaddrs:
   - 192.168.200.11:9910

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 daemon_terminattr:
   cvaddrs:
   - 192.168.200.11:9910

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/cvp/cv_server_configlets.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/cvp/cv_server_configlets.yml
@@ -244,9 +244,9 @@ cvp_configlets:
     \  no shutdown\n   channel-group 1 mode active\n!\ninterface Ethernet2\n   description
     DC1-LEAF2B_Ethernet7\n   no shutdown\n   channel-group 1 mode active\n!\ninterface
     Management1\n   description oob_management\n   no shutdown\n   vrf MGMT\n   ip
-    address 192.168.200.112/24\n!\nip routing\nno ip routing vrf MGMT\n!\nip route
-    vrf MGMT 0.0.0.0/0 192.168.200.5\n!\nmanagement api http-commands\n   protocol
-    https\n   no shutdown\n   !\n   vrf MGMT\n      no shutdown\n!\nend\n"
+    address 192.168.200.112/24\nno ip routing vrf MGMT\n!\nip route vrf MGMT 0.0.0.0/0
+    192.168.200.5\n!\nmanagement api http-commands\n   protocol https\n   no shutdown\n
+    \  !\n   vrf MGMT\n      no shutdown\n!\nend\n"
   AVD_DC1-L2LEAF2A: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr
     -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
     -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
@@ -278,11 +278,11 @@ cvp_configlets:
     3 mode active\n!\ninterface Management1\n   description oob_management\n   no
     shutdown\n   vrf MGMT\n   ip address 192.168.200.113/24\n!\ninterface Vlan4094\n
     \  description MLAG_PEER\n   no shutdown\n   mtu 1500\n   no autostate\n   ip
-    address 10.255.252.16/31\n!\nip routing\nno ip routing vrf MGMT\n!\nmlag configuration\n
-    \  domain-id DC1_L2LEAF2\n   local-interface Vlan4094\n   peer-address 10.255.252.17\n
-    \  peer-link Port-Channel3\n   reload-delay mlag 300\n   reload-delay non-mlag
-    330\n!\nip route vrf MGMT 0.0.0.0/0 192.168.200.5\n!\nmanagement api http-commands\n
-    \  protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no shutdown\n!\nend\n"
+    address 10.255.252.16/31\nno ip routing vrf MGMT\n!\nmlag configuration\n   domain-id
+    DC1_L2LEAF2\n   local-interface Vlan4094\n   peer-address 10.255.252.17\n   peer-link
+    Port-Channel3\n   reload-delay mlag 300\n   reload-delay non-mlag 330\n!\nip route
+    vrf MGMT 0.0.0.0/0 192.168.200.5\n!\nmanagement api http-commands\n   protocol
+    https\n   no shutdown\n   !\n   vrf MGMT\n      no shutdown\n!\nend\n"
   AVD_DC1-L2LEAF2B: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr
     -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
     -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
@@ -314,11 +314,11 @@ cvp_configlets:
     3 mode active\n!\ninterface Management1\n   description oob_management\n   no
     shutdown\n   vrf MGMT\n   ip address 192.168.200.114/24\n!\ninterface Vlan4094\n
     \  description MLAG_PEER\n   no shutdown\n   mtu 1500\n   no autostate\n   ip
-    address 10.255.252.17/31\n!\nip routing\nno ip routing vrf MGMT\n!\nmlag configuration\n
-    \  domain-id DC1_L2LEAF2\n   local-interface Vlan4094\n   peer-address 10.255.252.16\n
-    \  peer-link Port-Channel3\n   reload-delay mlag 300\n   reload-delay non-mlag
-    330\n!\nip route vrf MGMT 0.0.0.0/0 192.168.200.5\n!\nmanagement api http-commands\n
-    \  protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no shutdown\n!\nend\n"
+    address 10.255.252.17/31\nno ip routing vrf MGMT\n!\nmlag configuration\n   domain-id
+    DC1_L2LEAF2\n   local-interface Vlan4094\n   peer-address 10.255.252.16\n   peer-link
+    Port-Channel3\n   reload-delay mlag 300\n   reload-delay non-mlag 330\n!\nip route
+    vrf MGMT 0.0.0.0/0 192.168.200.5\n!\nmanagement api http-commands\n   protocol
+    https\n   no shutdown\n   !\n   vrf MGMT\n      no shutdown\n!\nend\n"
   AVD_DC1-LEAF1A: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr
     -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
     -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/BGP-LEAF1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/BGP-LEAF1.md
@@ -168,14 +168,12 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
+| default | False |
 | MGMT | False |
 
 #### IP Routing Device Configuration
 
 ```eos
-!
-ip routing
 no ip routing vrf MGMT
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/BGP-LEAF2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/BGP-LEAF2.md
@@ -168,14 +168,12 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
+| default | False |
 | MGMT | False |
 
 #### IP Routing Device Configuration
 
 ```eos
-!
-ip routing
 no ip routing vrf MGMT
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/ISIS-LEAF1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/ISIS-LEAF1.md
@@ -174,14 +174,12 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
+| default | False |
 | MGMT | False |
 
 #### IP Routing Device Configuration
 
 ```eos
-!
-ip routing
 no ip routing vrf MGMT
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/L2ONLY-LEAF1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/L2ONLY-LEAF1.md
@@ -168,14 +168,12 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
+| default | False |
 | MGMT | False |
 
 #### IP Routing Device Configuration
 
 ```eos
-!
-ip routing
 no ip routing vrf MGMT
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/L2ONLY-LEAF2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/L2ONLY-LEAF2.md
@@ -168,14 +168,12 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
+| default | False |
 | MGMT | False |
 
 #### IP Routing Device Configuration
 
 ```eos
-!
-ip routing
 no ip routing vrf MGMT
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/OSPF-LEAF1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/OSPF-LEAF1.md
@@ -168,14 +168,12 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
+| default | False |
 | MGMT | False |
 
 #### IP Routing Device Configuration
 
 ```eos
-!
-ip routing
 no ip routing vrf MGMT
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/OSPF-LEAF2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/OSPF-LEAF2.md
@@ -168,14 +168,12 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
+| default | False |
 | MGMT | False |
 
 #### IP Routing Device Configuration
 
 ```eos
-!
-ip routing
 no ip routing vrf MGMT
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/BGP-LEAF1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/BGP-LEAF1.cfg
@@ -46,8 +46,6 @@ interface Ethernet11
    switchport access vlan 100
    switchport mode access
    switchport
-!
-ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 172.31.0.1

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/BGP-LEAF2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/BGP-LEAF2.cfg
@@ -46,8 +46,6 @@ interface Ethernet11
    switchport access vlan 100
    switchport mode access
    switchport
-!
-ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 172.31.0.1

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/ISIS-LEAF1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/ISIS-LEAF1.cfg
@@ -33,8 +33,6 @@ interface Management1
    no shutdown
    vrf MGMT
    ip address 192.168.200.105/24
-!
-ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 172.31.0.1

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/L2ONLY-LEAF1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/L2ONLY-LEAF1.cfg
@@ -46,8 +46,6 @@ interface Ethernet11
    switchport access vlan 100
    switchport mode access
    switchport
-!
-ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 172.31.0.1

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/L2ONLY-LEAF2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/L2ONLY-LEAF2.cfg
@@ -46,8 +46,6 @@ interface Ethernet11
    switchport access vlan 100
    switchport mode access
    switchport
-!
-ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 172.31.0.1

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/OSPF-LEAF1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/OSPF-LEAF1.cfg
@@ -46,8 +46,6 @@ interface Ethernet11
    switchport access vlan 100
    switchport mode access
    switchport
-!
-ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 172.31.0.1

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/OSPF-LEAF2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/OSPF-LEAF2.cfg
@@ -46,8 +46,6 @@ interface Ethernet11
    switchport access vlan 100
    switchport mode access
    switchport
-!
-ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 172.31.0.1

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-LEAF1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-LEAF1.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 172.31.0.1
 service_routing_protocols_model: multi-agent
-ip_routing: true
 vlan_internal_order:
   allocation: ascending
   range:

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-LEAF2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-LEAF2.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 172.31.0.1
 service_routing_protocols_model: multi-agent
-ip_routing: true
 vlan_internal_order:
   allocation: ascending
   range:

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/ISIS-LEAF1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/ISIS-LEAF1.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 172.31.0.1
 service_routing_protocols_model: multi-agent
-ip_routing: true
 vlan_internal_order:
   allocation: ascending
   range:

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/L2ONLY-LEAF1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/L2ONLY-LEAF1.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 172.31.0.1
 service_routing_protocols_model: multi-agent
-ip_routing: true
 vlan_internal_order:
   allocation: ascending
   range:

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/L2ONLY-LEAF2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/L2ONLY-LEAF2.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 172.31.0.1
 service_routing_protocols_model: multi-agent
-ip_routing: true
 vlan_internal_order:
   allocation: ascending
   range:

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-LEAF1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-LEAF1.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 172.31.0.1
 service_routing_protocols_model: multi-agent
-ip_routing: true
 vlan_internal_order:
   allocation: ascending
   range:

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-LEAF2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-LEAF2.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 172.31.0.1
 service_routing_protocols_model: multi-agent
-ip_routing: true
 vlan_internal_order:
   allocation: ascending
   range:

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/inventory/group_vars/L2ONLY_SPINES.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/inventory/group_vars/L2ONLY_SPINES.yml
@@ -6,6 +6,8 @@ spine:
     mlag_peer_ipv4_pool: 192.168.254.0/24
     mlag_interfaces: [ Ethernet3, Ethernet4 ]
     spanning_tree_priority: 4096
+    # Test always_configure_ip_routing on an ipv4 topology
+    always_configure_ip_routing: true
   node_groups:
     L2ONLY_SPINES:
       nodes:

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-L2LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-L2LEAF1A.md
@@ -237,14 +237,12 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
+| default | False |
 | MGMT | False |
 
 #### IP Routing Device Configuration
 
 ```eos
-!
-ip routing
 no ip routing vrf MGMT
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-L2LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-L2LEAF2A.md
@@ -369,14 +369,12 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
+| default | False |
 | MGMT | False |
 
 #### IP Routing Device Configuration
 
 ```eos
-!
-ip routing
 no ip routing vrf MGMT
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-L2LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-L2LEAF2B.md
@@ -377,14 +377,12 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
+| default | False |
 | MGMT | False |
 
 #### IP Routing Device Configuration
 
 ```eos
-!
-ip routing
 no ip routing vrf MGMT
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-L2LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-L2LEAF1A.md
@@ -245,14 +245,12 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
+| default | False |
 | MGMT | False |
 
 #### IP Routing Device Configuration
 
 ```eos
-!
-ip routing
 no ip routing vrf MGMT
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-L2LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-L2LEAF2A.md
@@ -245,14 +245,12 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
+| default | False |
 | MGMT | False |
 
 #### IP Routing Device Configuration
 
 ```eos
-!
-ip routing
 no ip routing vrf MGMT
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-L2LEAF1A.cfg
@@ -41,8 +41,6 @@ interface Vlan4085
    no shutdown
    mtu 1500
    ip address 172.21.110.4/24
-!
-ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 192.168.1.254

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-L2LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-L2LEAF2A.cfg
@@ -108,8 +108,6 @@ interface Vlan4094
    mtu 1500
    no autostate
    ip address 172.20.110.2/31
-!
-ip routing
 no ip routing vrf MGMT
 !
 mlag configuration

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-L2LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-L2LEAF2B.cfg
@@ -114,8 +114,6 @@ interface Vlan4094
    mtu 1500
    no autostate
    ip address 172.20.110.3/31
-!
-ip routing
 no ip routing vrf MGMT
 !
 mlag configuration

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-L2LEAF1A.cfg
@@ -47,8 +47,6 @@ interface Vlan4092
    no shutdown
    mtu 1500
    ip address 172.21.210.4/24
-!
-ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 192.168.1.254

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-L2LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-L2LEAF2A.cfg
@@ -47,8 +47,6 @@ interface Vlan4092
    no shutdown
    mtu 1500
    ip address 172.21.210.5/24
-!
-ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 192.168.1.254

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF1A.yml
@@ -5,7 +5,6 @@ static_routes:
 - destination_address_prefix: 0.0.0.0/0
   gateway: 172.21.110.1
 service_routing_protocols_model: multi-agent
-ip_routing: true
 vlan_internal_order:
   allocation: ascending
   range:

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF2A.yml
@@ -5,7 +5,6 @@ static_routes:
 - destination_address_prefix: 0.0.0.0/0
   gateway: 172.21.110.1
 service_routing_protocols_model: multi-agent
-ip_routing: true
 vlan_internal_order:
   allocation: ascending
   range:

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF2B.yml
@@ -5,7 +5,6 @@ static_routes:
 - destination_address_prefix: 0.0.0.0/0
   gateway: 172.21.110.1
 service_routing_protocols_model: multi-agent
-ip_routing: true
 vlan_internal_order:
   allocation: ascending
   range:

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-L2LEAF1A.yml
@@ -5,7 +5,6 @@ static_routes:
 - destination_address_prefix: 0.0.0.0/0
   gateway: 172.21.210.1
 service_routing_protocols_model: multi-agent
-ip_routing: true
 vlan_internal_order:
   allocation: ascending
   range:

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-L2LEAF2A.yml
@@ -5,7 +5,6 @@ static_routes:
 - destination_address_prefix: 0.0.0.0/0
   gateway: 172.21.210.1
 service_routing_protocols_model: multi-agent
-ip_routing: true
 vlan_internal_order:
   allocation: ascending
   range:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-L2LEAF1A.cfg
@@ -120,8 +120,6 @@ interface Vlan4091
    mtu 1500
    no autostate
    ip address 10.255.252.14/31
-!
-ip routing
 no ip routing vrf MGMT
 !
 mlag configuration

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-L2LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-L2LEAF1B.cfg
@@ -120,8 +120,6 @@ interface Vlan4091
    mtu 1500
    no autostate
    ip address 10.255.252.15/31
-!
-ip routing
 no ip routing vrf MGMT
 !
 mlag configuration

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-L2LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-L2LEAF2A.cfg
@@ -143,8 +143,6 @@ interface Vlan4091
    mtu 1500
    no autostate
    ip address 10.255.252.16/31
-!
-ip routing
 no ip routing vrf MGMT
 !
 mlag configuration

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-L2LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-L2LEAF2B.cfg
@@ -143,8 +143,6 @@ interface Vlan4091
    mtu 1500
    no autostate
    ip address 10.255.252.17/31
-!
-ip routing
 no ip routing vrf MGMT
 !
 mlag configuration

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-L2LEAF3A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-L2LEAF3A.cfg
@@ -85,8 +85,6 @@ interface Management1
    no shutdown
    vrf MGMT
    ip address 192.168.200.116/24
-!
-ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 192.168.200.5

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-L2LEAF4A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-L2LEAF4A.cfg
@@ -85,8 +85,6 @@ interface Management1
    no shutdown
    vrf MGMT
    ip address 192.168.200.119/24
-!
-ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 192.168.200.5

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1.L2LEAF5A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1.L2LEAF5A.cfg
@@ -116,8 +116,6 @@ interface Vlan4091
    mtu 1500
    no autostate
    ip address 10.255.252.26/31
-!
-ip routing
 no ip routing vrf MGMT
 !
 mlag configuration

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1.L2LEAF5B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1.L2LEAF5B.cfg
@@ -116,8 +116,6 @@ interface Vlan4091
    mtu 1500
    no autostate
    ip address 10.255.252.27/31
-!
-ip routing
 no ip routing vrf MGMT
 !
 mlag configuration

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L2LEAF1A.cfg
@@ -131,8 +131,6 @@ interface Management1
    no shutdown
    vrf MGMT
    ip address 192.168.200.109/24
-!
-ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 192.168.200.1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/IGMP-QUERIER-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/IGMP-QUERIER-L2LEAF1A.cfg
@@ -81,8 +81,6 @@ interface Management1
    no shutdown
    vrf MGMT
    ip address 192.168.200.101/24
-!
-ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 192.168.200.5

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MH-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MH-L2LEAF1A.cfg
@@ -64,8 +64,6 @@ interface Management1
    no shutdown
    vrf MGMT
    ip address 192.168.201.201/24
-!
-ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 192.168.200.5

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_CVX_SERVER1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_CVX_SERVER1.cfg
@@ -26,8 +26,6 @@ interface Management1
    no shutdown
    vrf MGMT
    ip address 192.168.254.254/23
-!
-ip routing
 no ip routing vrf MGMT
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_CVX_SERVER2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_CVX_SERVER2.cfg
@@ -26,8 +26,6 @@ interface Management1
    no shutdown
    vrf MGMT
    ip address 192.168.254.255/23
-!
-ip routing
 no ip routing vrf MGMT
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SNMP_AUTOGEN_ENGINEID.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SNMP_AUTOGEN_ENGINEID.cfg
@@ -20,8 +20,6 @@ no enable password
 no aaa root
 !
 vrf instance MGMT
-!
-ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 1.1.1.1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SNMP_SYSTEM_MAC_ENGINEID_1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SNMP_SYSTEM_MAC_ENGINEID_1.cfg
@@ -20,8 +20,6 @@ no enable password
 no aaa root
 !
 vrf instance MGMT
-!
-ip routing
 no ip routing vrf MGMT
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SNMP_SYSTEM_MAC_ENGINEID_2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SNMP_SYSTEM_MAC_ENGINEID_2.cfg
@@ -20,8 +20,6 @@ no enable password
 no aaa root
 !
 vrf instance MGMT
-!
-ip routing
 no ip routing vrf MGMT
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L2LEAF1A.cfg
@@ -30,8 +30,6 @@ interface Management1
    no shutdown
    vrf MGMT
    ip address 192.168.200.109/24
-!
-ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 192.168.200.5

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1A.cfg
@@ -75,8 +75,6 @@ interface Vlan4094
    mtu 9000
    no autostate
    ip address 10.255.252.0/31
-!
-ip routing
 no ip routing vrf MGMT
 !
 mlag configuration

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1B.cfg
@@ -75,8 +75,6 @@ interface Vlan4094
    mtu 9000
    no autostate
    ip address 10.255.252.1/31
-!
-ip routing
 no ip routing vrf MGMT
 !
 mlag configuration

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/always-configure-ip-routing.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/always-configure-ip-routing.cfg
@@ -6,13 +6,17 @@ transceiver qsfp default-mode 4x10G
 !
 service routing protocols model multi-agent
 !
-hostname no_mgmt_interface
+hostname always-configure-ip-routing
 !
 no enable password
 no aaa root
 !
 vrf instance MGMT
+!
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
+!
+ipv6 unicast-routing
 !
 management api http-commands
    protocol https

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/filter.only_vlans_in_use.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/filter.only_vlans_in_use.cfg
@@ -25,8 +25,6 @@ interface Ethernet1
    switchport trunk allowed vlan 1-2
    switchport mode trunk
    switchport
-!
-ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 10.0.0.1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/hardware_counters.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/hardware_counters.cfg
@@ -16,8 +16,6 @@ no enable password
 no aaa root
 !
 vrf instance MGMT
-!
-ip routing
 no ip routing vrf MGMT
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_default.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_default.cfg
@@ -131,8 +131,6 @@ interface Management1
    no shutdown
    vrf MGMT
    ip address 1.1.1.2
-!
-ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 1.1.1.1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_description.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_description.cfg
@@ -18,8 +18,6 @@ interface Management1
    no shutdown
    vrf MGMT
    ip address 1.1.1.2
-!
-ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 1.1.1.1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_dualstack.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_dualstack.cfg
@@ -20,8 +20,6 @@ interface Management1
    ip address 192.168.200.105
    ipv6 enable
    ipv6 address 0200::105/64
-!
-ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 10.0.10.0/24 192.168.200.5

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_fabric.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_fabric.cfg
@@ -131,8 +131,6 @@ interface MY_INTERFACE_FABRIC
    no shutdown
    vrf MGMT
    ip address 1.1.1.2
-!
-ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 1.1.1.1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_host.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_host.cfg
@@ -136,8 +136,6 @@ interface MY_INTERFACE_HOST
 !
 hardware tcam
    system profile vxlan-routing
-!
-ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 1.1.1.1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_ipv6.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_ipv6.cfg
@@ -19,8 +19,6 @@ interface Management1
    vrf MGMT
    ipv6 enable
    ipv6 address 0200::105/64
-!
-ip routing
 no ip routing vrf MGMT
 !
 ipv6 route vrf MGMT ::/0 0200::1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_platform.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_platform.cfg
@@ -136,8 +136,6 @@ interface Management0
 !
 hardware tcam
    system profile vxlan-routing
-!
-ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 1.1.1.1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/network-ports-tests-2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/network-ports-tests-2.cfg
@@ -545,8 +545,6 @@ interface Vlan4094
    mtu 9000
    no autostate
    ip address 10.255.252.1/31
-!
-ip routing
 no ip routing vrf MGMT
 !
 mlag configuration

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/network-ports-tests.1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/network-ports-tests.1.cfg
@@ -522,8 +522,6 @@ interface Vlan4094
    mtu 9000
    no autostate
    ip address 10.255.252.0/31
-!
-ip routing
 no ip routing vrf MGMT
 !
 mlag configuration

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/no_mgmt_gateway.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/no_mgmt_gateway.cfg
@@ -18,8 +18,6 @@ interface Management1
    no shutdown
    vrf MGMT
    ip address 192.168.200.106
-!
-ip routing
 no ip routing vrf MGMT
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l2leaf1a.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l2leaf1a.cfg
@@ -127,8 +127,6 @@ interface Vlan4094
    mtu 9000
    no autostate
    ip address 10.255.248.0/31
-!
-ip routing
 no ip routing vrf MGMT
 !
 mlag configuration

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l2leaf1b.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l2leaf1b.cfg
@@ -127,8 +127,6 @@ interface Vlan4094
    mtu 9000
    no autostate
    ip address 10.255.248.1/31
-!
-ip routing
 no ip routing vrf MGMT
 !
 mlag configuration

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l2leaf3.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l2leaf3.cfg
@@ -47,8 +47,6 @@ interface Ethernet12
    switchport trunk group TG_200
    switchport trunk group TG_NOT_MATCHING_ANY_VLANS
    switchport
-!
-ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 1.1.1.1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l2leaf4.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l2leaf4.cfg
@@ -49,8 +49,6 @@ interface Ethernet12
    switchport trunk group TG_200
    switchport trunk group TG_NOT_MATCHING_ANY_VLANS
    switchport
-!
-ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 1.1.1.1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink-native-vlan-child.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink-native-vlan-child.cfg
@@ -32,8 +32,6 @@ interface Ethernet2
    description UPLINK-NATIVE-VLAN-PARENT_Ethernet2
    no shutdown
    channel-group 2 mode active
-!
-ip routing
 no ip routing vrf MGMT
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink-native-vlan-grandparent.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink-native-vlan-grandparent.cfg
@@ -28,8 +28,6 @@ interface Ethernet1
    description UPLINK-NATIVE-VLAN-PARENT_Ethernet1
    no shutdown
    channel-group 1 mode active
-!
-ip routing
 no ip routing vrf MGMT
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink-native-vlan-parent.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink-native-vlan-parent.cfg
@@ -45,8 +45,6 @@ interface Ethernet2
    description UPLINK-NATIVE-VLAN-CHILD_Ethernet2
    no shutdown
    channel-group 2 mode active
-!
-ip routing
 no ip routing vrf MGMT
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 daemon_terminattr:
   cvaddrs:
   - 192.168.200.11:9910

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF1B.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 daemon_terminattr:
   cvaddrs:
   - 192.168.200.11:9910

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 daemon_terminattr:
   cvaddrs:
   - 192.168.200.11:9910

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 daemon_terminattr:
   cvaddrs:
   - 192.168.200.11:9910

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF3A.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 daemon_terminattr:
   cvaddrs:
   - 192.168.200.11:9910

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF4A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF4A.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 daemon_terminattr:
   cvaddrs:
   - 192.168.200.11:9910

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1.L2LEAF5A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1.L2LEAF5A.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 daemon_terminattr:
   cvaddrs:
   - 192.168.200.11:9910

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1.L2LEAF5B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1.L2LEAF5B.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 daemon_terminattr:
   cvaddrs:
   - 192.168.200.11:9910

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L2LEAF1A.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.1
 service_routing_protocols_model: multi-agent
-ip_routing: true
 vlan_internal_order:
   allocation: ascending
   range:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/IGMP-QUERIER-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/IGMP-QUERIER-L2LEAF1A.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 vlan_internal_order:
   allocation: ascending
   range:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-L2LEAF1A.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 daemon_terminattr:
   cvaddrs:
   - 192.168.200.11:9910

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_CVX_SERVER1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_CVX_SERVER1.yml
@@ -1,5 +1,4 @@
 service_routing_protocols_model: multi-agent
-ip_routing: true
 vlan_internal_order:
   allocation: ascending
   range:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_CVX_SERVER2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_CVX_SERVER2.yml
@@ -1,5 +1,4 @@
 service_routing_protocols_model: multi-agent
-ip_routing: true
 vlan_internal_order:
   allocation: ascending
   range:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/SNMP_AUTOGEN_ENGINEID.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/SNMP_AUTOGEN_ENGINEID.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 1.1.1.1
 service_routing_protocols_model: multi-agent
-ip_routing: true
 vlan_internal_order:
   allocation: ascending
   range:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/SNMP_SYSTEM_MAC_ENGINEID_1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/SNMP_SYSTEM_MAC_ENGINEID_1.yml
@@ -1,6 +1,5 @@
 serial_number: A37383692F12C7DE733D9A9B8E2B37AE
 service_routing_protocols_model: multi-agent
-ip_routing: true
 vlan_internal_order:
   allocation: ascending
   range:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/SNMP_SYSTEM_MAC_ENGINEID_2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/SNMP_SYSTEM_MAC_ENGINEID_2.yml
@@ -1,5 +1,4 @@
 service_routing_protocols_model: multi-agent
-ip_routing: true
 vlan_internal_order:
   allocation: ascending
   range:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L2LEAF1A.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 vlan_internal_order:
   allocation: ascending
   range:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1A.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 vlan_internal_order:
   allocation: ascending
   range:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1B.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 vlan_internal_order:
   allocation: ascending
   range:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/always-configure-ip-routing.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/always-configure-ip-routing.yml
@@ -1,8 +1,6 @@
-static_routes:
-- vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 1.1.1.1
 service_routing_protocols_model: multi-agent
+ipv6_unicast_routing: true
+ip_routing_ipv6_interfaces: true
 vlan_internal_order:
   allocation: ascending
   range:
@@ -11,14 +9,6 @@ vlan_internal_order:
 vrfs:
 - name: MGMT
   ip_routing: false
-management_interfaces:
-- name: Management1
-  description: Custom Management Interface Description
-  shutdown: false
-  vrf: MGMT
-  ip_address: 1.1.1.2
-  gateway: 1.1.1.1
-  type: oob
 management_api_http:
   enable_vrfs:
   - name: MGMT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/filter.only_vlans_in_use.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/filter.only_vlans_in_use.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 10.0.0.1
 service_routing_protocols_model: multi-agent
-ip_routing: true
 vlan_internal_order:
   allocation: ascending
   range:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/hardware_counters.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/hardware_counters.yml
@@ -1,5 +1,4 @@
 service_routing_protocols_model: multi-agent
-ip_routing: true
 hardware_counters:
   features:
   - vlan-interface: in

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_default.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_default.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 1.1.1.1
 service_routing_protocols_model: multi-agent
-ip_routing: true
 daemon_terminattr:
   cvaddrs:
   - 192.168.200.11:9910

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_dualstack.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_dualstack.yml
@@ -13,7 +13,6 @@ ipv6_static_routes:
   destination_address_prefix: 0200:2::/64
   gateway: 0200::1
 service_routing_protocols_model: multi-agent
-ip_routing: true
 vlan_internal_order:
   allocation: ascending
   range:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_fabric.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_fabric.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 1.1.1.1
 service_routing_protocols_model: multi-agent
-ip_routing: true
 daemon_terminattr:
   cvaddrs:
   - 192.168.200.11:9910

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_host.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_host.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 1.1.1.1
 service_routing_protocols_model: multi-agent
-ip_routing: true
 daemon_terminattr:
   cvaddrs:
   - 192.168.200.11:9910

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_ipv6.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_ipv6.yml
@@ -3,7 +3,6 @@ ipv6_static_routes:
   destination_address_prefix: ::/0
   gateway: 0200::1
 service_routing_protocols_model: multi-agent
-ip_routing: true
 vlan_internal_order:
   allocation: ascending
   range:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_platform.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_platform.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 1.1.1.1
 service_routing_protocols_model: multi-agent
-ip_routing: true
 daemon_terminattr:
   cvaddrs:
   - 192.168.200.11:9910

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/network-ports-tests-2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/network-ports-tests-2.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.0.1
 service_routing_protocols_model: multi-agent
-ip_routing: true
 vlan_internal_order:
   allocation: ascending
   range:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/network-ports-tests.1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/network-ports-tests.1.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.0.1
 service_routing_protocols_model: multi-agent
-ip_routing: true
 vlan_internal_order:
   allocation: ascending
   range:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/no_mgmt_gateway.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/no_mgmt_gateway.yml
@@ -1,5 +1,4 @@
 service_routing_protocols_model: multi-agent
-ip_routing: true
 vlan_internal_order:
   allocation: ascending
   range:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/no_mgmt_interface.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/no_mgmt_interface.yml
@@ -1,5 +1,4 @@
 service_routing_protocols_model: multi-agent
-ip_routing: true
 vlan_internal_order:
   allocation: ascending
   range:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l2leaf1a.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l2leaf1a.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 1.1.1.1
 service_routing_protocols_model: multi-agent
-ip_routing: true
 vlan_internal_order:
   allocation: ascending
   range:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l2leaf1b.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l2leaf1b.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 1.1.1.1
 service_routing_protocols_model: multi-agent
-ip_routing: true
 vlan_internal_order:
   allocation: ascending
   range:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l2leaf3.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l2leaf3.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 1.1.1.1
 service_routing_protocols_model: multi-agent
-ip_routing: true
 vlan_internal_order:
   allocation: ascending
   range:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l2leaf4.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l2leaf4.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 1.1.1.1
 service_routing_protocols_model: multi-agent
-ip_routing: true
 vlan_internal_order:
   allocation: ascending
   range:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink-native-vlan-child.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink-native-vlan-child.yml
@@ -1,5 +1,4 @@
 service_routing_protocols_model: multi-agent
-ip_routing: true
 vlan_internal_order:
   allocation: ascending
   range:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink-native-vlan-grandparent.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink-native-vlan-grandparent.yml
@@ -1,5 +1,4 @@
 service_routing_protocols_model: multi-agent
-ip_routing: true
 vlan_internal_order:
   allocation: ascending
   range:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink-native-vlan-parent.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink-native-vlan-parent.yml
@@ -1,5 +1,4 @@
 service_routing_protocols_model: multi-agent
-ip_routing: true
 vlan_internal_order:
   allocation: ascending
   range:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/always-configure-ip-routing.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/always-configure-ip-routing.yml
@@ -1,0 +1,7 @@
+---
+type: l2leaf
+underlay_rfc5549: true
+
+l2leaf:
+  defaults:
+    always_configure_ip_routing: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
@@ -5,6 +5,7 @@ all:
       children:
         CLEAN_UNIT_TESTS: # Single Devices testing one specific case and only using hostvars
           hosts:
+            always-configure-ip-routing:
             cvp-instance-ips-cvaas:
             device.with.dots.in.hostname:
             filter.only_vlans_in_use:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 daemon_terminattr:
   cvaddrs:
   - 192.168.200.11:9910

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-L2LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-L2LEAF1B.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 daemon_terminattr:
   cvaddrs:
   - 192.168.200.11:9910

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 daemon_terminattr:
   cvaddrs:
   - 192.168.200.11:9910

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 daemon_terminattr:
   cvaddrs:
   - 192.168.200.11:9910

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-L2LEAF3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-L2LEAF3A.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 daemon_terminattr:
   cvaddrs:
   - 192.168.200.11:9910

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-L2LEAF4A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-L2LEAF4A.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 daemon_terminattr:
   cvaddrs:
   - 192.168.200.11:9910

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-L2LEAF5A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-L2LEAF5A.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 daemon_terminattr:
   cvaddrs:
   - 192.168.200.11:9910

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-L2LEAF5B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-L2LEAF5B.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 daemon_terminattr:
   cvaddrs:
   - 192.168.200.11:9910

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/MH-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/MH-L2LEAF1A.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 daemon_terminattr:
   cvaddrs:
   - 192.168.200.11:9910

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/mgmt_interface_default.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/mgmt_interface_default.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 daemon_terminattr:
   cvaddrs:
   - 192.168.200.11:9910

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/mgmt_interface_fabric.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/mgmt_interface_fabric.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 daemon_terminattr:
   cvaddrs:
   - 192.168.200.11:9910

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/mgmt_interface_host.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/mgmt_interface_host.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 daemon_terminattr:
   cvaddrs:
   - 192.168.200.11:9910

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/mgmt_interface_platform.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/mgmt_interface_platform.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 daemon_terminattr:
   cvaddrs:
   - 192.168.200.11:9910

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF1A.md
@@ -433,14 +433,12 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
+| default | False |
 | MGMT | False |
 
 #### IP Routing Device Configuration
 
 ```eos
-!
-ip routing
 no ip routing vrf MGMT
 ```
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF1B.md
@@ -433,14 +433,12 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
+| default | False |
 | MGMT | False |
 
 #### IP Routing Device Configuration
 
 ```eos
-!
-ip routing
 no ip routing vrf MGMT
 ```
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF2A.md
@@ -471,14 +471,12 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
+| default | False |
 | MGMT | False |
 
 #### IP Routing Device Configuration
 
 ```eos
-!
-ip routing
 no ip routing vrf MGMT
 ```
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF2B.md
@@ -471,14 +471,12 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
+| default | False |
 | MGMT | False |
 
 #### IP Routing Device Configuration
 
 ```eos
-!
-ip routing
 no ip routing vrf MGMT
 ```
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF3A.md
@@ -348,14 +348,12 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
+| default | False |
 | MGMT | False |
 
 #### IP Routing Device Configuration
 
 ```eos
-!
-ip routing
 no ip routing vrf MGMT
 ```
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF1A.cfg
@@ -127,8 +127,6 @@ interface Vlan4091
    mtu 1500
    no autostate
    ip address 10.255.247.14/31
-!
-ip routing
 no ip routing vrf MGMT
 !
 mlag configuration

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF1B.cfg
@@ -127,8 +127,6 @@ interface Vlan4091
    mtu 1500
    no autostate
    ip address 10.255.247.15/31
-!
-ip routing
 no ip routing vrf MGMT
 !
 mlag configuration

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF2A.cfg
@@ -154,8 +154,6 @@ interface Vlan4091
    mtu 1500
    no autostate
    ip address 10.255.249.16/31
-!
-ip routing
 no ip routing vrf MGMT
 !
 mlag configuration

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF2B.cfg
@@ -154,8 +154,6 @@ interface Vlan4091
    mtu 1500
    no autostate
    ip address 10.255.249.17/31
-!
-ip routing
 no ip routing vrf MGMT
 !
 mlag configuration

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF3A.cfg
@@ -96,8 +96,6 @@ interface Management1
    no shutdown
    vrf MGMT
    ip address 192.168.200.116/24
-!
-ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 192.168.200.5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 daemon_terminattr:
   cvaddrs:
   - 192.168.200.11:9910

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1B.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 daemon_terminattr:
   cvaddrs:
   - 192.168.200.11:9910

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 daemon_terminattr:
   cvaddrs:
   - 192.168.200.11:9910

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 daemon_terminattr:
   cvaddrs:
   - 192.168.200.11:9910

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF3A.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 daemon_terminattr:
   cvaddrs:
   - 192.168.200.11:9910

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-L2LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-L2LEAF1A.md
@@ -268,14 +268,12 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
+| default | False |
 | MGMT | False |
 
 #### IP Routing Device Configuration
 
 ```eos
-!
-ip routing
 no ip routing vrf MGMT
 ```
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-L2LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-L2LEAF2A.md
@@ -368,14 +368,12 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
+| default | False |
 | MGMT | False |
 
 #### IP Routing Device Configuration
 
 ```eos
-!
-ip routing
 no ip routing vrf MGMT
 ```
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-L2LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-L2LEAF2B.md
@@ -368,14 +368,12 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
+| default | False |
 | MGMT | False |
 
 #### IP Routing Device Configuration
 
 ```eos
-!
-ip routing
 no ip routing vrf MGMT
 ```
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-L2LEAF1A.cfg
@@ -50,8 +50,6 @@ interface Management1
    no shutdown
    vrf MGMT
    ip address 192.168.200.112/24
-!
-ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 192.168.200.5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-L2LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-L2LEAF2A.cfg
@@ -81,8 +81,6 @@ interface Vlan4094
    mtu 1500
    no autostate
    ip address 10.255.252.16/31
-!
-ip routing
 no ip routing vrf MGMT
 !
 mlag configuration

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-L2LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-L2LEAF2B.cfg
@@ -81,8 +81,6 @@ interface Vlan4094
    mtu 1500
    no autostate
    ip address 10.255.252.17/31
-!
-ip routing
 no ip routing vrf MGMT
 !
 mlag configuration

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 daemon_terminattr:
   cvaddrs:
   - 192.168.200.11:9910

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 daemon_terminattr:
   cvaddrs:
   - 192.168.200.11:9910

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 daemon_terminattr:
   cvaddrs:
   - 192.168.200.11:9910

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-L2LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-L2LEAF1A.md
@@ -287,14 +287,12 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
+| default | False |
 | MGMT | False |
 
 #### IP Routing Device Configuration
 
 ```eos
-!
-ip routing
 no ip routing vrf MGMT
 ```
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-L2LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-L2LEAF2A.md
@@ -372,14 +372,12 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
+| default | False |
 | MGMT | False |
 
 #### IP Routing Device Configuration
 
 ```eos
-!
-ip routing
 no ip routing vrf MGMT
 ```
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-L2LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-L2LEAF2B.md
@@ -372,14 +372,12 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
+| default | False |
 | MGMT | False |
 
 #### IP Routing Device Configuration
 
 ```eos
-!
-ip routing
 no ip routing vrf MGMT
 ```
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-L2LEAF1A.cfg
@@ -53,8 +53,6 @@ interface Management1
    no shutdown
    vrf MGMT
    ip address 192.168.200.112/24
-!
-ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 192.168.200.5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-L2LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-L2LEAF2A.cfg
@@ -84,8 +84,6 @@ interface Vlan4094
    mtu 1500
    no autostate
    ip address 10.255.252.16/31
-!
-ip routing
 no ip routing vrf MGMT
 !
 mlag configuration

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-L2LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-L2LEAF2B.cfg
@@ -84,8 +84,6 @@ interface Vlan4094
    mtu 1500
    no autostate
    ip address 10.255.252.17/31
-!
-ip routing
 no ip routing vrf MGMT
 !
 mlag configuration

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 daemon_terminattr:
   cvaddrs:
   - 192.168.200.11:9910

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 daemon_terminattr:
   cvaddrs:
   - 192.168.200.11:9910

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 daemon_terminattr:
   cvaddrs:
   - 192.168.200.11:9910

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-L2LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-L2LEAF1A.md
@@ -315,14 +315,12 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True (ipv6 interfaces) |
+| default | False |
 | MGMT | False |
 
 #### IP Routing Device Configuration
 
 ```eos
-!
-ip routing ipv6 interfaces
 no ip routing vrf MGMT
 ```
 
@@ -332,15 +330,8 @@ no ip routing vrf MGMT
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
+| default | False |
 | MGMT | false |
-
-#### IPv6 Routing Device Configuration
-
-```eos
-!
-ipv6 unicast-routing
-```
 
 ### Static Routes
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-L2LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-L2LEAF2A.md
@@ -438,14 +438,12 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True (ipv6 interfaces) |
+| default | False |
 | MGMT | False |
 
 #### IP Routing Device Configuration
 
 ```eos
-!
-ip routing ipv6 interfaces
 no ip routing vrf MGMT
 ```
 
@@ -455,15 +453,8 @@ no ip routing vrf MGMT
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
+| default | False |
 | MGMT | false |
-
-#### IPv6 Routing Device Configuration
-
-```eos
-!
-ipv6 unicast-routing
-```
 
 ### Static Routes
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-L2LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-L2LEAF2B.md
@@ -438,14 +438,12 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True (ipv6 interfaces) |
+| default | False |
 | MGMT | False |
 
 #### IP Routing Device Configuration
 
 ```eos
-!
-ip routing ipv6 interfaces
 no ip routing vrf MGMT
 ```
 
@@ -455,15 +453,8 @@ no ip routing vrf MGMT
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
+| default | False |
 | MGMT | false |
-
-#### IPv6 Routing Device Configuration
-
-```eos
-!
-ipv6 unicast-routing
-```
 
 ### Static Routes
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-L2LEAF1A.cfg
@@ -76,11 +76,7 @@ interface Management1
    no shutdown
    vrf MGMT
    ip address 192.168.200.112/24
-!
-ip routing ipv6 interfaces
 no ip routing vrf MGMT
-!
-ipv6 unicast-routing
 !
 ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-L2LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-L2LEAF2A.cfg
@@ -134,11 +134,7 @@ interface Vlan4094
    mtu 1500
    no autostate
    ip address 10.255.252.16/31
-!
-ip routing ipv6 interfaces
 no ip routing vrf MGMT
-!
-ipv6 unicast-routing
 !
 mlag configuration
    domain-id DC1_L2LEAF2

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-L2LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-L2LEAF2B.cfg
@@ -134,11 +134,7 @@ interface Vlan4094
    mtu 1500
    no autostate
    ip address 10.255.252.17/31
-!
-ip routing ipv6 interfaces
 no ip routing vrf MGMT
-!
-ipv6 unicast-routing
 !
 mlag configuration
    domain-id DC1_L2LEAF2

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -3,8 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ipv6_unicast_routing: true
-ip_routing_ipv6_interfaces: true
 daemon_terminattr:
   cvaddrs:
   - 192.168.200.11:9910

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -3,8 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ipv6_unicast_routing: true
-ip_routing_ipv6_interfaces: true
 daemon_terminattr:
   cvaddrs:
   - 192.168.200.11:9910

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -3,8 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ipv6_unicast_routing: true
-ip_routing_ipv6_interfaces: true
 daemon_terminattr:
   cvaddrs:
   - 192.168.200.11:9910

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_facts.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_facts.py
@@ -381,6 +381,10 @@ class EosDesignsFacts(AvdFacts):
         return get(self._switch_data_combined, "platform")
 
     @cached_property
+    def always_configure_ip_routing(self):
+        return get(self._switch_data_combined, "always_configure_ip_routing")
+
+    @cached_property
     def max_parallel_uplinks(self):
         return get(self._switch_data_combined, "max_parallel_uplinks", default=1)
 
@@ -1069,7 +1073,9 @@ class EosDesignsFacts(AvdFacts):
 
     @cached_property
     def underlay_multicast(self):
-        return get(self._hostvars, "underlay_multicast")
+        if self.underlay_router is True:
+            return get(self._hostvars, "underlay_multicast")
+        return None
 
     @cached_property
     def overlay_rd_type_admin_subfield(self):

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-topology.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-topology.md
@@ -220,6 +220,10 @@ defaults <- node_group <- node_group.node <- node
       # Useful when a "connected-endpoint" is connected to switches in different "node_groups".
       offset: < offset_for_lacp_port_id_range | default -> 0 >
 
+    # Force configuration of "ip routing" even on L2 devices | Optional
+    # Use this to retain behavior of AVD versions below 4.0.0.
+    always_configure_ip_routing: < true | false | default -> false >
+
     # EOS CLI rendered directly on the root level of the final EOS configuration | Optional
     raw_eos_cli: |
       < multiline eos cli >

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-variables-v4.0.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-variables-v4.0.md
@@ -22,11 +22,11 @@
 
 ```yaml
 # Underlay routing protocol | Required.
-underlay_routing_protocol: < EBGP | OSPF | ISIS | ISIS-SR | ISIS-LDP | ISIS-SR-LDP | OSPF-LDP | default for l3ls-evpn -> EBGP >
-overlay_routing_protocol: < EBGP | IBGP | default for l3ls-evpn -> EBGP >
+underlay_routing_protocol: < ebgp | ospf | isis | isis-sr | isis-ldp | isis-sr-ldp | ospf-ldp | default for l3ls-evpn -> ebgp >
+overlay_routing_protocol: < ebgp | ibgp | default for l3ls-evpn -> ebgp >
 
 # Point to Point Underlay with RFC 5549(eBGP), i.e. IPv6 Unnumbered.
-# Requires "underlay_routing_protocol: EBGP"
+# Requires "underlay_routing_protocol: ebgp"
 underlay_rfc5549: < true | false | default -> false >
 
 # Underlay OSFP | Required when < underlay_routing_protocol > == OSPF variants

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/Fabric Topology.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/Fabric Topology.md
@@ -871,6 +871,7 @@ default_interfaces:
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "node_type.defaults.lacp_port_id_range.enabled") | Boolean |  | False |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;size</samp>](## "node_type.defaults.lacp_port_id_range.size") | Integer |  | 128 |  | Recommended size > = number of ports in the switch. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;offset</samp>](## "node_type.defaults.lacp_port_id_range.offset") | Integer |  | 0 |  | Offset is used to avoid overlapping port-id ranges of different switches.<br>Useful when a "connected-endpoint" is connected to switches in different "node_groups".<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;always_configure_ip_routing</samp>](## "node_type.defaults.always_configure_ip_routing") | Boolean |  | False |  | Force configuration of "ip routing" even on L2 devices.<br>Use this to retain behavior of AVD versions below 4.0.0.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;raw_eos_cli</samp>](## "node_type.defaults.raw_eos_cli") | String |  |  |  | EOS CLI rendered directly on the root level of the final EOS configuration. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;structured_config</samp>](## "node_type.defaults.structured_config") | Dictionary |  |  |  | Custom structured config for eos_cli_config_gen. |
     | [<samp>&nbsp;&nbsp;node_groups</samp>](## "node_type.node_groups") | List, items: Dictionary |  |  |  |  |
@@ -893,6 +894,7 @@ default_interfaces:
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "node_type.node_groups.[].lacp_port_id_range.enabled") | Boolean |  | False |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;size</samp>](## "node_type.node_groups.[].lacp_port_id_range.size") | Integer |  | 128 |  | Recommended size > = number of ports in the switch. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;offset</samp>](## "node_type.node_groups.[].lacp_port_id_range.offset") | Integer |  | 0 |  | Offset is used to avoid overlapping port-id ranges of different switches.<br>Useful when a "connected-endpoint" is connected to switches in different "node_groups".<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;always_configure_ip_routing</samp>](## "node_type.node_groups.[].always_configure_ip_routing") | Boolean |  | False |  | Force configuration of "ip routing" even on L2 devices.<br>Use this to retain behavior of AVD versions below 4.0.0.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;raw_eos_cli</samp>](## "node_type.node_groups.[].raw_eos_cli") | String |  |  |  | EOS CLI rendered directly on the root level of the final EOS configuration. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;structured_config</samp>](## "node_type.node_groups.[].structured_config") | Dictionary |  |  |  | Custom structured config for eos_cli_config_gen. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;nodes</samp>](## "node_type.node_groups.[].nodes") | List, items: Dictionary |  |  |  |  |
@@ -915,6 +917,7 @@ default_interfaces:
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "node_type.node_groups.[].nodes.[].lacp_port_id_range.enabled") | Boolean |  | False |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;size</samp>](## "node_type.node_groups.[].nodes.[].lacp_port_id_range.size") | Integer |  | 128 |  | Recommended size > = number of ports in the switch. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;offset</samp>](## "node_type.node_groups.[].nodes.[].lacp_port_id_range.offset") | Integer |  | 0 |  | Offset is used to avoid overlapping port-id ranges of different switches.<br>Useful when a "connected-endpoint" is connected to switches in different "node_groups".<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;always_configure_ip_routing</samp>](## "node_type.node_groups.[].nodes.[].always_configure_ip_routing") | Boolean |  | False |  | Force configuration of "ip routing" even on L2 devices.<br>Use this to retain behavior of AVD versions below 4.0.0.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;raw_eos_cli</samp>](## "node_type.node_groups.[].nodes.[].raw_eos_cli") | String |  |  |  | EOS CLI rendered directly on the root level of the final EOS configuration. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;structured_config</samp>](## "node_type.node_groups.[].nodes.[].structured_config") | Dictionary |  |  |  | Custom structured config for eos_cli_config_gen. |
     | [<samp>&nbsp;&nbsp;nodes</samp>](## "node_type.nodes") | List, items: Dictionary |  |  |  |  |
@@ -937,6 +940,7 @@ default_interfaces:
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "node_type.nodes.[].lacp_port_id_range.enabled") | Boolean |  | False |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;size</samp>](## "node_type.nodes.[].lacp_port_id_range.size") | Integer |  | 128 |  | Recommended size > = number of ports in the switch. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;offset</samp>](## "node_type.nodes.[].lacp_port_id_range.offset") | Integer |  | 0 |  | Offset is used to avoid overlapping port-id ranges of different switches.<br>Useful when a "connected-endpoint" is connected to switches in different "node_groups".<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;always_configure_ip_routing</samp>](## "node_type.nodes.[].always_configure_ip_routing") | Boolean |  | False |  | Force configuration of "ip routing" even on L2 devices.<br>Use this to retain behavior of AVD versions below 4.0.0.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;raw_eos_cli</samp>](## "node_type.nodes.[].raw_eos_cli") | String |  |  |  | EOS CLI rendered directly on the root level of the final EOS configuration. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;structured_config</samp>](## "node_type.nodes.[].structured_config") | Dictionary |  |  |  | Custom structured config for eos_cli_config_gen. |
     | [<samp>&lt;node_type_keys.key&gt;</samp>](## "&lt;node_type_keys.key&gt;") | Dictionary |  |  |  |  |
@@ -960,6 +964,7 @@ default_interfaces:
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "&lt;node_type_keys.key&gt;.defaults.lacp_port_id_range.enabled") | Boolean |  | False |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;size</samp>](## "&lt;node_type_keys.key&gt;.defaults.lacp_port_id_range.size") | Integer |  | 128 |  | Recommended size > = number of ports in the switch. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;offset</samp>](## "&lt;node_type_keys.key&gt;.defaults.lacp_port_id_range.offset") | Integer |  | 0 |  | Offset is used to avoid overlapping port-id ranges of different switches.<br>Useful when a "connected-endpoint" is connected to switches in different "node_groups".<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;always_configure_ip_routing</samp>](## "&lt;node_type_keys.key&gt;.defaults.always_configure_ip_routing") | Boolean |  | False |  | Force configuration of "ip routing" even on L2 devices.<br>Use this to retain behavior of AVD versions below 4.0.0.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;raw_eos_cli</samp>](## "&lt;node_type_keys.key&gt;.defaults.raw_eos_cli") | String |  |  |  | EOS CLI rendered directly on the root level of the final EOS configuration. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;structured_config</samp>](## "&lt;node_type_keys.key&gt;.defaults.structured_config") | Dictionary |  |  |  | Custom structured config for eos_cli_config_gen. |
     | [<samp>&nbsp;&nbsp;node_groups</samp>](## "&lt;node_type_keys.key&gt;.node_groups") | List, items: Dictionary |  |  |  |  |
@@ -982,6 +987,7 @@ default_interfaces:
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "&lt;node_type_keys.key&gt;.node_groups.[].lacp_port_id_range.enabled") | Boolean |  | False |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;size</samp>](## "&lt;node_type_keys.key&gt;.node_groups.[].lacp_port_id_range.size") | Integer |  | 128 |  | Recommended size > = number of ports in the switch. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;offset</samp>](## "&lt;node_type_keys.key&gt;.node_groups.[].lacp_port_id_range.offset") | Integer |  | 0 |  | Offset is used to avoid overlapping port-id ranges of different switches.<br>Useful when a "connected-endpoint" is connected to switches in different "node_groups".<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;always_configure_ip_routing</samp>](## "&lt;node_type_keys.key&gt;.node_groups.[].always_configure_ip_routing") | Boolean |  | False |  | Force configuration of "ip routing" even on L2 devices.<br>Use this to retain behavior of AVD versions below 4.0.0.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;raw_eos_cli</samp>](## "&lt;node_type_keys.key&gt;.node_groups.[].raw_eos_cli") | String |  |  |  | EOS CLI rendered directly on the root level of the final EOS configuration. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;structured_config</samp>](## "&lt;node_type_keys.key&gt;.node_groups.[].structured_config") | Dictionary |  |  |  | Custom structured config for eos_cli_config_gen. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;nodes</samp>](## "&lt;node_type_keys.key&gt;.node_groups.[].nodes") | List, items: Dictionary |  |  |  |  |
@@ -1004,6 +1010,7 @@ default_interfaces:
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "&lt;node_type_keys.key&gt;.node_groups.[].nodes.[].lacp_port_id_range.enabled") | Boolean |  | False |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;size</samp>](## "&lt;node_type_keys.key&gt;.node_groups.[].nodes.[].lacp_port_id_range.size") | Integer |  | 128 |  | Recommended size > = number of ports in the switch. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;offset</samp>](## "&lt;node_type_keys.key&gt;.node_groups.[].nodes.[].lacp_port_id_range.offset") | Integer |  | 0 |  | Offset is used to avoid overlapping port-id ranges of different switches.<br>Useful when a "connected-endpoint" is connected to switches in different "node_groups".<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;always_configure_ip_routing</samp>](## "&lt;node_type_keys.key&gt;.node_groups.[].nodes.[].always_configure_ip_routing") | Boolean |  | False |  | Force configuration of "ip routing" even on L2 devices.<br>Use this to retain behavior of AVD versions below 4.0.0.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;raw_eos_cli</samp>](## "&lt;node_type_keys.key&gt;.node_groups.[].nodes.[].raw_eos_cli") | String |  |  |  | EOS CLI rendered directly on the root level of the final EOS configuration. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;structured_config</samp>](## "&lt;node_type_keys.key&gt;.node_groups.[].nodes.[].structured_config") | Dictionary |  |  |  | Custom structured config for eos_cli_config_gen. |
     | [<samp>&nbsp;&nbsp;nodes</samp>](## "&lt;node_type_keys.key&gt;.nodes") | List, items: Dictionary |  |  |  |  |
@@ -1026,6 +1033,7 @@ default_interfaces:
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "&lt;node_type_keys.key&gt;.nodes.[].lacp_port_id_range.enabled") | Boolean |  | False |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;size</samp>](## "&lt;node_type_keys.key&gt;.nodes.[].lacp_port_id_range.size") | Integer |  | 128 |  | Recommended size > = number of ports in the switch. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;offset</samp>](## "&lt;node_type_keys.key&gt;.nodes.[].lacp_port_id_range.offset") | Integer |  | 0 |  | Offset is used to avoid overlapping port-id ranges of different switches.<br>Useful when a "connected-endpoint" is connected to switches in different "node_groups".<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;always_configure_ip_routing</samp>](## "&lt;node_type_keys.key&gt;.nodes.[].always_configure_ip_routing") | Boolean |  | False |  | Force configuration of "ip routing" even on L2 devices.<br>Use this to retain behavior of AVD versions below 4.0.0.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;raw_eos_cli</samp>](## "&lt;node_type_keys.key&gt;.nodes.[].raw_eos_cli") | String |  |  |  | EOS CLI rendered directly on the root level of the final EOS configuration. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;structured_config</samp>](## "&lt;node_type_keys.key&gt;.nodes.[].structured_config") | Dictionary |  |  |  | Custom structured config for eos_cli_config_gen. |
 
@@ -1053,6 +1061,7 @@ default_interfaces:
           enabled: <bool>
           size: <int>
           offset: <int>
+        always_configure_ip_routing: <bool>
         raw_eos_cli: <str>
         structured_config:
       node_groups:
@@ -1075,6 +1084,7 @@ default_interfaces:
             enabled: <bool>
             size: <int>
             offset: <int>
+          always_configure_ip_routing: <bool>
           raw_eos_cli: <str>
           structured_config:
           nodes:
@@ -1097,6 +1107,7 @@ default_interfaces:
                 enabled: <bool>
                 size: <int>
                 offset: <int>
+              always_configure_ip_routing: <bool>
               raw_eos_cli: <str>
               structured_config:
       nodes:
@@ -1119,6 +1130,7 @@ default_interfaces:
             enabled: <bool>
             size: <int>
             offset: <int>
+          always_configure_ip_routing: <bool>
           raw_eos_cli: <str>
           structured_config:
     <node_type_keys.key>:
@@ -1142,6 +1154,7 @@ default_interfaces:
           enabled: <bool>
           size: <int>
           offset: <int>
+        always_configure_ip_routing: <bool>
         raw_eos_cli: <str>
         structured_config:
       node_groups:
@@ -1164,6 +1177,7 @@ default_interfaces:
             enabled: <bool>
             size: <int>
             offset: <int>
+          always_configure_ip_routing: <bool>
           raw_eos_cli: <str>
           structured_config:
           nodes:
@@ -1186,6 +1200,7 @@ default_interfaces:
                 enabled: <bool>
                 size: <int>
                 offset: <int>
+              always_configure_ip_routing: <bool>
               raw_eos_cli: <str>
               structured_config:
       nodes:
@@ -1208,6 +1223,7 @@ default_interfaces:
             enabled: <bool>
             size: <int>
             offset: <int>
+          always_configure_ip_routing: <bool>
           raw_eos_cli: <str>
           structured_config:
     ```

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -378,6 +378,12 @@
               "additionalProperties": false,
               "title": "LACP Port ID Range"
             },
+            "always_configure_ip_routing": {
+              "type": "boolean",
+              "default": false,
+              "description": "Force configuration of \"ip routing\" even on L2 devices.\nUse this to retain behavior of AVD versions below 4.0.0.\n",
+              "title": "Always Configure IP Routing"
+            },
             "raw_eos_cli": {
               "description": "EOS CLI rendered directly on the root level of the final EOS configuration.",
               "type": "string",

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
@@ -533,6 +533,17 @@ keys:
                 convert_types:
                 - str
                 default: 0
+          always_configure_ip_routing:
+            documentation_options:
+              filename: Fabric Topology
+              table: Generic configuration management
+            type: bool
+            default: false
+            description: 'Force configuration of "ip routing" even on L2 devices.
+
+              Use this to retain behavior of AVD versions below 4.0.0.
+
+              '
           raw_eos_cli:
             documentation_options:
               filename: Fabric Topology

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/node_type.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/node_type.schema.yml
@@ -173,6 +173,15 @@ keys:
                 convert_types:
                   - str
                 default: 0
+          always_configure_ip_routing:
+            documentation_options:
+              filename: Fabric Topology
+              table: Generic configuration management
+            type: bool
+            default: false
+            description: |
+              Force configuration of "ip routing" even on L2 devices.
+              Use this to retain behavior of AVD versions below 4.0.0.
           raw_eos_cli:
             documentation_options:
               filename: Fabric Topology


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Prevent configuration of IP routing on l2leaf

## Related Issue(s)

Fixes #1988 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

### IP and IPv6 routing is no longer configured on pure L2 devices

For node types like `l2leaf` where `underlay_router` is set to `false` under `node_type_keys` AVD versions below 4.0.0
still rendered `ip routing`, `ip routing ipv6 interfaces` and/or `ipv6 unicast-routing` in the configuration.
As of AVD version 4.0.0 these IP and IPv6 routing configurations are no longer configured for `l2leaf`
or other node types with `underlay_router: false`.

To retain the old behavior the inventory can be updated like this:

```yaml
l2leaf:
  defaults:
    always_configure_ip_routing: true
```

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Most molecule scenarios remove the config, but I have added a unit test combined with rfc5549 and also set `always_configure_ip_routing` on the spines in the `eos_designs-l2ls` scenario to test with ipv4 (IMO not worth another host in unit tests).

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
