### PR TITLE
Refactor(eos_designs): Remove template data from avd_switch_facts

### DIFF
--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_facts.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_facts.py
@@ -256,34 +256,6 @@ class EosDesignsFacts(AvdFacts):
         return get(self._node_type_key_data, "vtep", default=False)
 
     @cached_property
-    def ip_addressing(self):
-        """
-        switch.ip_addressing.* set based on
-        templates.ip_addressing.* combined with (overridden by)
-        node_type_keys.<node_type_key>.ip_addressing.*
-        """
-        hostvar_templates = get(self._hostvars, "templates.ip_addressing", default={})
-        node_type_templates = get(self._node_type_key_data, "ip_addressing", default={})
-        if hostvar_templates or node_type_templates:
-            return combine(hostvar_templates, node_type_templates, recursive=True, list_merge="replace")
-        else:
-            return {}
-
-    @cached_property
-    def interface_descriptions(self):
-        """
-        switch.interface_descriptions.* set based on
-        templates.interface_descriptions.* combined with (overridden by)
-        node_type_keys.<node_type_key>.interface_descriptions.*
-        """
-        hostvar_templates = get(self._hostvars, "templates.interface_descriptions", default={})
-        node_type_templates = get(self._node_type_key_data, "interface_descriptions", default={})
-        if hostvar_templates or node_type_templates:
-            return combine(hostvar_templates, node_type_templates, recursive=True, list_merge="replace")
-        else:
-            return {}
-
-    @cached_property
     def _switch_data(self):
         """
         internal _switch_data containing inherited vars from fabric_topology data model

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/interface_descriptions/avdinterfacedescriptions.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/interface_descriptions/avdinterfacedescriptions.py
@@ -1,11 +1,12 @@
 from collections import ChainMap
-from functools import cached_property
 
 from ansible_collections.arista.avd.plugins.plugin_utils.avdfacts import AvdFacts
 from ansible_collections.arista.avd.plugins.plugin_utils.utils import get
 
+from .utils import UtilsMixin
 
-class AvdInterfaceDescriptions(AvdFacts):
+
+class AvdInterfaceDescriptions(AvdFacts, UtilsMixin):
 
     """
     Class used to render Interface Descriptions either from custom Jinja2 templates or using default Python Logic
@@ -21,24 +22,8 @@ class AvdInterfaceDescriptions(AvdFacts):
         template_vars = ChainMap(kwargs, self._hostvars)
         return self.template_var(template_path, template_vars)
 
-    @cached_property
-    def _default_mpls_overlay_role(self) -> str:
-        return get(self._hostvars, "switch.default_mpls_overlay_role")
-
-    @cached_property
-    def _mpls_lsr(self) -> str:
-        return get(self._hostvars, "switch.mpls_lsr")
-
-    @cached_property
-    def _mlag_peer(self) -> str:
-        return get(self._hostvars, "switch.mlag_peer", required=True)
-
-    @cached_property
-    def _mlag_port_channel_id(self) -> str:
-        return get(self._hostvars, "switch.mlag_port_channel_id", required=True)
-
     def underlay_ethernet_interfaces(self, link_type: str, link_peer: str, link_peer_interface: str) -> str:
-        if template_path := get(self._hostvars, "switch.interface_descriptions.underlay_ethernet_interfaces"):
+        if template_path := self._interface_descriptions_templates.get("underlay_ethernet_interfaces"):
             return self._template(
                 template_path,
                 link={
@@ -63,10 +48,7 @@ class AvdInterfaceDescriptions(AvdFacts):
         link_peer_channel_group_id: int,
         link_channel_description: str,
     ) -> str:
-        if template_path := get(
-            self._hostvars,
-            "switch.interface_descriptions.underlay_port_channel_interfaces",
-        ):
+        if template_path := self._interface_descriptions_templates.get("underlay_port_channel_interfaces"):
             return self._template(
                 template_path,
                 link={
@@ -84,32 +66,26 @@ class AvdInterfaceDescriptions(AvdFacts):
         return f"{link_peer}_Po{link_peer_channel_group_id}"
 
     def mlag_ethernet_interfaces(self, mlag_interface: str) -> str:
-        if template_path := get(self._hostvars, "switch.interface_descriptions.mlag_ethernet_interfaces"):
+        if template_path := self._interface_descriptions_templates.get("mlag_ethernet_interfaces"):
             return self._template(template_path, mlag_interface=mlag_interface)
 
         return f"MLAG_PEER_{self._mlag_peer}_{mlag_interface}"
 
     def mlag_port_channel_interfaces(self) -> str:
-        if template_path := get(self._hostvars, "switch.interface_descriptions.mlag_port_channel_interfaces"):
+        if template_path := self._interface_descriptions_templates.get("mlag_port_channel_interfaces"):
             return self._template(template_path)
 
         return f"MLAG_PEER_{self._mlag_peer}_Po{self._mlag_port_channel_id}"
 
     def connected_endpoints_ethernet_interfaces(self, peer: str = None, peer_interface: str = None) -> str:
-        if template_path := get(
-            self._hostvars,
-            "switch.interface_descriptions.connected_endpoints_ethernet_interfaces",
-        ):
+        if template_path := self._interface_descriptions_templates.get("connected_endpoints_ethernet_interfaces"):
             return self._template(template_path, peer=peer, peer_interface=peer_interface)
 
         elements = [peer, peer_interface]
         return "_".join([str(element) for element in elements if element is not None])
 
     def connected_endpoints_port_channel_interfaces(self, peer: str = None, adapter_port_channel_description: str = None) -> str:
-        if template_path := get(
-            self._hostvars,
-            "switch.interface_descriptions.connected_endpoints_port_channel_interfaces",
-        ):
+        if template_path := self._interface_descriptions_templates.get("connected_endpoints_port_channel_interfaces"):
             return self._template(
                 template_path,
                 peer=peer,
@@ -120,7 +96,7 @@ class AvdInterfaceDescriptions(AvdFacts):
         return "_".join([str(element) for element in elements if element is not None])
 
     def overlay_loopback_interface(self, overlay_loopback_description: str = None) -> str:
-        if template_path := get(self._hostvars, "switch.interface_descriptions.overlay_loopback_interface"):
+        if template_path := self._interface_descriptions_templates.get("overlay_loopback_interface"):
             return self._template(template_path, overlay_loopback_description=overlay_loopback_description)
 
         if overlay_loopback_description is not None:
@@ -140,7 +116,7 @@ class AvdInterfaceDescriptions(AvdFacts):
         return "EVPN_Overlay_Peering"
 
     def vtep_loopback_interface(self) -> str:
-        if template_path := get(self._hostvars, "switch.interface_descriptions.vtep_loopback_interface"):
+        if template_path := self._interface_descriptions_templates.get("vtep_loopback_interface"):
             return self._template(template_path)
 
         return "VTEP_VXLAN_Tunnel_Source"

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/interface_descriptions/load_interface_descriptions.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/interface_descriptions/load_interface_descriptions.py
@@ -1,6 +1,7 @@
-from ansible_collections.arista.avd.plugins.plugin_utils.utils import get, load_python_class
+from ansible_collections.arista.avd.plugins.plugin_utils.utils import load_python_class
 
 from .avdinterfacedescriptions import AvdInterfaceDescriptions
+from .utils import get_interface_descriptions_templates
 
 DEFAULT_AVD_INTERFACE_DESCRIPTIONS_PYTHON_MODULE = "ansible_collections.arista.avd.roles.eos_designs.python_modules.interface_descriptions"
 DEFAULT_AVD_INTERFACE_DESCRIPTIONS_PYTHON_CLASS_NAME = "AvdInterfaceDescriptions"
@@ -11,16 +12,10 @@ def load_interfacedescriptions(hostvars, templar) -> AvdInterfaceDescriptions:
     Load the python_module defined in `templates.interface_descriptions.python_module`
     Return the class defined by `templates.interface_descriptions.python_class_name`
     """
-    module_path = get(
-        hostvars,
-        "switch.interface_descriptions.python_module",
-        default=DEFAULT_AVD_INTERFACE_DESCRIPTIONS_PYTHON_MODULE,
-    )
-    class_name = get(
-        hostvars,
-        "switch.interface_descriptions.python_class_name",
-        default=DEFAULT_AVD_INTERFACE_DESCRIPTIONS_PYTHON_CLASS_NAME,
-    )
+    interface_descriptions_templates = get_interface_descriptions_templates(hostvars)
+
+    module_path = interface_descriptions_templates.get("python_module", DEFAULT_AVD_INTERFACE_DESCRIPTIONS_PYTHON_MODULE)
+    class_name = interface_descriptions_templates.get("python_class_name", DEFAULT_AVD_INTERFACE_DESCRIPTIONS_PYTHON_CLASS_NAME)
 
     cls = load_python_class(
         module_path,

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/interface_descriptions/utils.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/interface_descriptions/utils.py
@@ -1,0 +1,67 @@
+from functools import cached_property
+
+from ansible_collections.arista.avd.plugins.filter.convert_dicts import convert_dicts
+from ansible_collections.arista.avd.plugins.plugin_utils.errors.errors import AristaAvdMissingVariableError
+from ansible_collections.arista.avd.plugins.plugin_utils.merge import merge
+from ansible_collections.arista.avd.plugins.plugin_utils.utils import get
+
+
+def get_interface_descriptions_templates(hostvars) -> dict:
+    """
+    Return dict with interface_descriptions templates set based on
+    templates.interface_descriptions.* combined with (overridden by)
+    node_type_keys.<node_type_key>.interface_descriptions.*
+    """
+    node_type_key_data = get_node_type_key_data(hostvars)
+
+    hostvar_templates = get(hostvars, "templates.interface_descriptions", default={})
+    node_type_templates = get(node_type_key_data, "interface_descriptions", default={})
+    if hostvar_templates or node_type_templates:
+        return merge(hostvar_templates, node_type_templates, list_merge="replace", destructive_merge=False)
+    else:
+        return {}
+
+
+def get_node_type_key_data(hostvars) -> dict:
+    """
+    internal _node_type_key_data containing settings for this node_type.
+    """
+    node_type = get(hostvars, "switch.type", required=True)
+
+    node_type_keys = get(hostvars, "node_type_keys", required=True)
+    node_type_keys = convert_dicts(node_type_keys, "key")
+    for node_type_key in node_type_keys:
+        if node_type_key["type"] == node_type:
+            return node_type_key
+
+    # Not found
+    raise AristaAvdMissingVariableError(f"node_type_keys.<>.type=={node_type}")
+
+
+class UtilsMixin:
+    """
+    Mixin Class with internal functions.
+    Class should only be used as Mixin to an AvdInterfaceDescriptions class
+    """
+
+    _hostvars: dict
+
+    @cached_property
+    def _interface_descriptions_templates(self) -> dict:
+        return get_interface_descriptions_templates(self._hostvars)
+
+    @cached_property
+    def _default_mpls_overlay_role(self) -> str:
+        return get(self._hostvars, "switch.default_mpls_overlay_role")
+
+    @cached_property
+    def _mpls_lsr(self) -> str:
+        return get(self._hostvars, "switch.mpls_lsr")
+
+    @cached_property
+    def _mlag_peer(self) -> str:
+        return get(self._hostvars, "switch.mlag_peer", required=True)
+
+    @cached_property
+    def _mlag_port_channel_id(self) -> str:
+        return get(self._hostvars, "switch.mlag_port_channel_id", required=True)

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/ip_addressing/avdipaddressing.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/ip_addressing/avdipaddressing.py
@@ -1,13 +1,13 @@
 import ipaddress
 from collections import ChainMap
-from functools import cached_property
 
 from ansible_collections.arista.avd.plugins.plugin_utils.avdfacts import AvdFacts
 from ansible_collections.arista.avd.plugins.plugin_utils.errors import AristaAvdError
-from ansible_collections.arista.avd.plugins.plugin_utils.utils import get
+
+from .utils import UtilsMixin
 
 
-class AvdIpAddressing(AvdFacts):
+class AvdIpAddressing(AvdFacts, UtilsMixin):
 
     """
     Class used to render IP addresses either from custom Jinja2 templates or using default Python Logic
@@ -36,65 +36,13 @@ class AvdIpAddressing(AvdFacts):
         template_vars = ChainMap(kwargs, self._hostvars)
         return self.template_var(template_path, template_vars)
 
-    @cached_property
-    def _mlag_primary_id(self) -> int:
-        return int(get(self._hostvars, "switch.mlag_switch_ids.primary", required=True))
-
-    @cached_property
-    def _mlag_secondary_id(self) -> int:
-        return int(get(self._hostvars, "switch.mlag_switch_ids.secondary", required=True))
-
-    @cached_property
-    def _mlag_peer_ipv4_pool(self) -> str:
-        return get(self._hostvars, "switch.mlag_peer_ipv4_pool", required=True)
-
-    @cached_property
-    def _mlag_peer_l3_ipv4_pool(self) -> str:
-        return get(self._hostvars, "switch.mlag_peer_l3_ipv4_pool", required=True)
-
-    @cached_property
-    def _uplink_ipv4_pool(self) -> str:
-        return get(self._hostvars, "switch.uplink_ipv4_pool", required=True)
-
-    @cached_property
-    def _id(self) -> int:
-        return int(get(self._hostvars, "switch.id", required=True))
-
-    @cached_property
-    def _max_uplink_switches(self) -> int:
-        return int(get(self._hostvars, "switch.max_uplink_switches", required=True))
-
-    @cached_property
-    def _max_parallel_uplinks(self) -> int:
-        return int(get(self._hostvars, "switch.max_parallel_uplinks", required=True))
-
-    @cached_property
-    def _loopback_ipv4_pool(self) -> str:
-        return get(self._hostvars, "switch.loopback_ipv4_pool", required=True)
-
-    @cached_property
-    def _loopback_ipv4_offset(self) -> int:
-        return get(self._hostvars, "switch.loopback_ipv4_offset", required=True)
-
-    @cached_property
-    def _loopback_ipv6_pool(self) -> str:
-        return get(self._hostvars, "switch.loopback_ipv6_pool", required=True)
-
-    @cached_property
-    def _loopback_ipv6_offset(self) -> int:
-        return get(self._hostvars, "switch.loopback_ipv6_offset", required=True)
-
-    @cached_property
-    def _vtep_loopback_ipv4_pool(self) -> str:
-        return get(self._hostvars, "switch.vtep_loopback_ipv4_pool", required=True)
-
     def mlag_ibgp_peering_ip_primary(self, mlag_ibgp_peering_ipv4_pool: str) -> str:
         """
         Return IP for L3 Peerings in VRFs for MLAG Primary
 
         Default offset from pool is `(mlag_primary_id - 1) * 2`
         """
-        if template_path := get(self._hostvars, "switch.ip_addressing.mlag_ibgp_peering_ip_primary"):
+        if template_path := self._ip_addressing_templates.get("mlag_ibgp_peering_ip_primary"):
             return self._template(
                 template_path,
                 vrf={"mlag_ibgp_peering_ipv4_pool": mlag_ibgp_peering_ipv4_pool},
@@ -109,7 +57,7 @@ class AvdIpAddressing(AvdFacts):
 
         Default offset from pool is `((mlag_primary_id - 1) * 2) + 1`
         """
-        if template_path := get(self._hostvars, "switch.ip_addressing.mlag_ibgp_peering_ip_secondary"):
+        if template_path := self._ip_addressing_templates.get("mlag_ibgp_peering_ip_secondary"):
             return self._template(
                 template_path,
                 vrf={"mlag_ibgp_peering_ipv4_pool": mlag_ibgp_peering_ipv4_pool},
@@ -125,7 +73,7 @@ class AvdIpAddressing(AvdFacts):
         Default pool is "switch.mlag_peer_ipv4_pool"
         Default offset from pool is `(mlag_primary_id - 1) * 2`
         """
-        if template_path := get(self._hostvars, "switch.ip_addressing.mlag_ip_primary"):
+        if template_path := self._ip_addressing_templates.get("mlag_ip_primary"):
             return self._template(
                 template_path,
                 mlag_primary_id=self._mlag_primary_id,
@@ -143,7 +91,7 @@ class AvdIpAddressing(AvdFacts):
         Default pool is "switch.mlag_peer_ipv4_pool"
         Default offset from pool is `((mlag_primary_id - 1) * 2) + 1`
         """
-        if template_path := get(self._hostvars, "switch.ip_addressing.mlag_ip_secondary"):
+        if template_path := self._ip_addressing_templates.get("mlag_ip_secondary"):
             return self._template(
                 template_path,
                 mlag_primary_id=self._mlag_primary_id,
@@ -161,7 +109,7 @@ class AvdIpAddressing(AvdFacts):
         Default pool is "switch.mlag_peer_l3_ipv4_pool"
         Default offset from pool is `(mlag_primary_id - 1) * 2`
         """
-        if template_path := get(self._hostvars, "switch.ip_addressing.mlag_l3_ip_primary"):
+        if template_path := self._ip_addressing_templates.get("mlag_l3_ip_primary"):
             return self._template(
                 template_path,
                 mlag_primary_id=self._mlag_primary_id,
@@ -179,7 +127,7 @@ class AvdIpAddressing(AvdFacts):
         Default pool is "switch.mlag_peer_l3_ipv4_pool"
         Default offset from pool is `((mlag_primary_id - 1) * 2) + 1`
         """
-        if template_path := get(self._hostvars, "switch.ip_addressing.mlag_l3_ip_secondary"):
+        if template_path := self._ip_addressing_templates.get("mlag_l3_ip_secondary"):
             return self._template(
                 template_path,
                 mlag_primary_id=self._mlag_primary_id,
@@ -198,7 +146,7 @@ class AvdIpAddressing(AvdFacts):
         Default offset from pool is `((switch.id - 1) * 2 * switch.max_uplink_switches * switch.max_parallel_uplinks) + (uplink_switch_index * 2) + 1`
         """
         uplink_switch_index = int(uplink_switch_index)
-        if template_path := get(self._hostvars, "switch.ip_addressing.p2p_uplinks_ip"):
+        if template_path := self._ip_addressing_templates.get("p2p_uplinks_ip"):
             return self._template(
                 template_path,
                 uplink_switch_index=uplink_switch_index,
@@ -215,7 +163,7 @@ class AvdIpAddressing(AvdFacts):
         Default offset from pool is `((switch.id - 1) * 2 * switch.max_uplink_switches * switch.max_parallel_uplinks) + (uplink_switch_index * 2)`
         """
         uplink_switch_index = int(uplink_switch_index)
-        if template_path := get(self._hostvars, "switch.ip_addressing.p2p_uplinks_peer_ip"):
+        if template_path := self._ip_addressing_templates.get("p2p_uplinks_peer_ip"):
             return self._template(
                 template_path,
                 uplink_switch_index=uplink_switch_index,
@@ -231,7 +179,7 @@ class AvdIpAddressing(AvdFacts):
         Default pool is "switch.loopback_ipv4_pool"
         Default offset from pool is `switch.id + switch.loopback_ipv4_offset`
         """
-        if template_path := get(self._hostvars, "switch.ip_addressing.router_id"):
+        if template_path := self._ip_addressing_templates.get("router_id"):
             return self._template(
                 template_path,
                 switch_id=self._id,
@@ -249,7 +197,7 @@ class AvdIpAddressing(AvdFacts):
         Default pool is "switch.loopback_ipv6_pool"
         Default offset from pool is `switch.id + switch.loopback_ipv6_offset`
         """
-        if template_path := get(self._hostvars, "switch.ip_addressing.ipv6_router_id"):
+        if template_path := self._ip_addressing_templates.get("ipv6_router_id"):
             return self._template(
                 template_path,
                 switch_id=self._id,
@@ -267,7 +215,7 @@ class AvdIpAddressing(AvdFacts):
         Default pool is "switch.vtep_loopback_ipv4_pool"
         Default offset from pool is `mlag_primary_id + switch.loopback_ipv4_offset`
         """
-        if template_path := get(self._hostvars, "switch.ip_addressing.vtep_ip_mlag"):
+        if template_path := self._ip_addressing_templates.get("vtep_ip_mlag"):
             return self._template(
                 template_path,
                 switch_id=self._id,
@@ -287,7 +235,7 @@ class AvdIpAddressing(AvdFacts):
         Default pool is "switch.vtep_loopback_ipv4_pool"
         Default offset from pool is `switch.id + switch.loopback_ipv4_offset`
         """
-        if template_path := get(self._hostvars, "switch.ip_addressing.vtep_ip"):
+        if template_path := self._ip_addressing_templates.get("vtep_ip"):
             return self._template(
                 template_path,
                 switch_id=self._id,

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/ip_addressing/load_ip_addressing.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/ip_addressing/load_ip_addressing.py
@@ -1,6 +1,7 @@
-from ansible_collections.arista.avd.plugins.plugin_utils.utils import get, load_python_class
+from ansible_collections.arista.avd.plugins.plugin_utils.utils import load_python_class
 
 from .avdipaddressing import AvdIpAddressing
+from .utils import get_ip_addressing_templates
 
 DEFAULT_AVD_IP_ADDRESSING_PYTHON_MODULE = "ansible_collections.arista.avd.roles.eos_designs.python_modules.ip_addressing"
 DEFAULT_AVD_IP_ADDRESSING_PYTHON_CLASS_NAME = "AvdIpAddressing"
@@ -11,16 +12,10 @@ def load_ip_addressing(hostvars, templar) -> AvdIpAddressing:
     Load the python_module defined in `templates.ip_addressing.python_module`
     Return the class defined by `templates.ip_addressing.python_class_name`
     """
-    module_path = get(
-        hostvars,
-        "switch.ip_addressing.python_module",
-        default=DEFAULT_AVD_IP_ADDRESSING_PYTHON_MODULE,
-    )
-    class_name = get(
-        hostvars,
-        "switch.ip_addressing.python_class_name",
-        default=DEFAULT_AVD_IP_ADDRESSING_PYTHON_CLASS_NAME,
-    )
+    ip_addressing_templates = get_ip_addressing_templates(hostvars)
+
+    module_path = ip_addressing_templates.get("python_module", DEFAULT_AVD_IP_ADDRESSING_PYTHON_MODULE)
+    class_name = ip_addressing_templates.get("python_class_name", DEFAULT_AVD_IP_ADDRESSING_PYTHON_CLASS_NAME)
 
     cls = load_python_class(
         module_path,

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/ip_addressing/utils.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/ip_addressing/utils.py
@@ -1,0 +1,103 @@
+from functools import cached_property
+
+from ansible_collections.arista.avd.plugins.filter.convert_dicts import convert_dicts
+from ansible_collections.arista.avd.plugins.plugin_utils.errors.errors import AristaAvdMissingVariableError
+from ansible_collections.arista.avd.plugins.plugin_utils.merge import merge
+from ansible_collections.arista.avd.plugins.plugin_utils.utils import get
+
+
+def get_ip_addressing_templates(hostvars) -> dict:
+    """
+    Return dict with ip_addressing templates set based on
+    templates.ip_addressing.* combined with (overridden by)
+    node_type_keys.<node_type_key>.ip_addressing.*
+    """
+    node_type_key_data = get_node_type_key_data(hostvars)
+
+    hostvar_templates = get(hostvars, "templates.ip_addressing", default={})
+    node_type_templates = get(node_type_key_data, "ip_addressing", default={})
+    if hostvar_templates or node_type_templates:
+        return merge(hostvar_templates, node_type_templates, list_merge="replace", destructive_merge=False)
+    else:
+        return {}
+
+
+def get_node_type_key_data(hostvars) -> dict:
+    """
+    internal _node_type_key_data containing settings for this node_type.
+    """
+    node_type = get(hostvars, "switch.type", required=True)
+
+    node_type_keys = get(hostvars, "node_type_keys", required=True)
+    node_type_keys = convert_dicts(node_type_keys, "key")
+    for node_type_key in node_type_keys:
+        if node_type_key["type"] == node_type:
+            return node_type_key
+
+    # Not found
+    raise AristaAvdMissingVariableError(f"node_type_keys.<>.type=={node_type}")
+
+
+class UtilsMixin:
+    """
+    Mixin Class with internal functions.
+    Class should only be used as Mixin to an AvdIpAddressing class
+    """
+
+    _hostvars: dict
+
+    @cached_property
+    def _ip_addressing_templates(self) -> dict:
+        return get_ip_addressing_templates(self._hostvars)
+
+    @cached_property
+    def _mlag_primary_id(self) -> int:
+        return int(get(self._hostvars, "switch.mlag_switch_ids.primary", required=True))
+
+    @cached_property
+    def _mlag_secondary_id(self) -> int:
+        return int(get(self._hostvars, "switch.mlag_switch_ids.secondary", required=True))
+
+    @cached_property
+    def _mlag_peer_ipv4_pool(self) -> str:
+        return get(self._hostvars, "switch.mlag_peer_ipv4_pool", required=True)
+
+    @cached_property
+    def _mlag_peer_l3_ipv4_pool(self) -> str:
+        return get(self._hostvars, "switch.mlag_peer_l3_ipv4_pool", required=True)
+
+    @cached_property
+    def _uplink_ipv4_pool(self) -> str:
+        return get(self._hostvars, "switch.uplink_ipv4_pool", required=True)
+
+    @cached_property
+    def _id(self) -> int:
+        return int(get(self._hostvars, "switch.id", required=True))
+
+    @cached_property
+    def _max_uplink_switches(self) -> int:
+        return int(get(self._hostvars, "switch.max_uplink_switches", required=True))
+
+    @cached_property
+    def _max_parallel_uplinks(self) -> int:
+        return int(get(self._hostvars, "switch.max_parallel_uplinks", required=True))
+
+    @cached_property
+    def _loopback_ipv4_pool(self) -> str:
+        return get(self._hostvars, "switch.loopback_ipv4_pool", required=True)
+
+    @cached_property
+    def _loopback_ipv4_offset(self) -> int:
+        return get(self._hostvars, "switch.loopback_ipv4_offset", required=True)
+
+    @cached_property
+    def _loopback_ipv6_pool(self) -> str:
+        return get(self._hostvars, "switch.loopback_ipv6_pool", required=True)
+
+    @cached_property
+    def _loopback_ipv6_offset(self) -> int:
+        return get(self._hostvars, "switch.loopback_ipv6_offset", required=True)
+
+    @cached_property
+    def _vtep_loopback_ipv4_pool(self) -> str:
+        return get(self._hostvars, "switch.vtep_loopback_ipv4_pool", required=True)


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Remove template data from avd_switch_facts

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

- Refactor `ip_addressing` and `interface_descriptions` python modules adding `UtilsMixin`
- Remove the keys `ip_addressing` and `interface_descriptions` from `avd_switch_facts`.
  The keys contained a list of jinja2 templates to use for ip addressing and descriptions.
- Instead fetch the template lists (if any) inside the python modules rendering ip addresses 
  or descriptions.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

No change to molecule

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
