### PR TITLE
Cut: Remove globally defined defaults for underlay_routing_protocol and overlay_routing_protocol variables

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_designs/defaults/main/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/defaults/main/main.yml
@@ -45,8 +45,6 @@ terminattr_ingestexclude: "/Sysdb/cell/1/agent,/Sysdb/cell/2/agent"
 
 p2p_uplinks_mtu: 9000
 
-underlay_routing_protocol: BGP
-overlay_routing_protocol: BGP
 underlay_ipv6: false
 
 evpn_ebgp_multihop: 3

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/Fabric Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/Fabric Variables.md
@@ -131,7 +131,7 @@ search:
 
     | Variable | Type | Required | Default | Value Restrictions | Description |
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
-    | [<samp>underlay_routing_protocol</samp>](## "underlay_routing_protocol") | String |  |  | Valid Values:<br>- ebgp<br>- ospf<br>- isis<br>- isis-sr<br>- isis-ldp<br>- isis-sr-ldp<br>- ospf-ldp<br>- BGP | - The following underlay routing protocols are supported:<br>  - EBGP (default for l3ls-evpn)<br>  - OSPF.<br>  - ISIS.<br>  - ISIS-SR*.<br>  - ISIS-LDP*.<br>  - ISIS-SR-LDP*.<br>  - OSPF-LDP*.<br>- The variables should be applied to all devices in the fabric.<br>*Only supported with core_interfaces data model.<br> |
+    | [<samp>underlay_routing_protocol</samp>](## "underlay_routing_protocol") | String |  |  | Valid Values:<br>- ebgp<br>- ospf<br>- isis<br>- isis-sr<br>- isis-ldp<br>- isis-sr-ldp<br>- ospf-ldp | - The following underlay routing protocols are supported:<br>  - EBGP (default for l3ls-evpn)<br>  - OSPF.<br>  - ISIS.<br>  - ISIS-SR*.<br>  - ISIS-LDP*.<br>  - ISIS-SR-LDP*.<br>  - OSPF-LDP*.<br>- The variables should be applied to all devices in the fabric.<br>*Only supported with core_interfaces data model.<br> |
 
 === "YAML"
 

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -1731,8 +1731,7 @@
         "isis-sr",
         "isis-ldp",
         "isis-sr-ldp",
-        "ospf-ldp",
-        "BGP"
+        "ospf-ldp"
       ],
       "title": "Underlay Routing Protocol"
     },

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
@@ -2221,7 +2221,6 @@ keys:
     - isis-ldp
     - isis-sr-ldp
     - ospf-ldp
-    - BGP
   uplink_ptp:
     documentation_options:
       filename: Fabric Variables

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/underlay_routing_protocol.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/underlay_routing_protocol.schema.yml
@@ -27,4 +27,3 @@ keys:
       - "isis-ldp"
       - "isis-sr-ldp"
       - "ospf-ldp"
-      - "BGP" # Only supported for historic reasons - The code will change to the default


### PR DESCRIPTION
## Change Summary

Remove globally defaults for underlay_routing_protocol and overlay_routing_protocol variables
Update Schema

## Related Issue(s)

Fixes #2679

## Component(s) name

`arista.avd.eos_designs`

## How to test

No changes to molecule scenarios

