### PR TITLE
Fix(eos_cli_config_gen): Checks for missing "vlans" key on access port-channel

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
@@ -225,6 +225,8 @@ interface Ethernet50
 | Port-Channel109 | Molecule ACLs | switched | access | 110 | - | - | - | - | - | - |
 | Port-Channel112 | LACP fallback individual | switched | trunk | 112 | - | - | 5 | individual | - | - |
 | Port-Channel115 | native-vlan-tag-precedence | switched | trunk | - | tag | - | - | - | - | - |
+| Port-Channel121 | access_port_with_no_vlans | switched | access | - | - | - | - | - | - | - |
+| Port-Channel122 | trunk_port_with_no_vlans | switched | trunk | - | - | - | - | - | - | - |
 
 ##### Encapsulation Dot1q Interfaces
 
@@ -621,6 +623,15 @@ interface Port-Channel120
    no switchport
    no sflow enable
    no sflow egress unmodified enable
+!
+interface Port-Channel121
+   description access_port_with_no_vlans
+   switchport
+!
+interface Port-Channel122
+   description trunk_port_with_no_vlans
+   switchport
+   switchport mode trunk
 ```
 
 ## BFD

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
@@ -324,6 +324,15 @@ interface Port-Channel120
    no sflow enable
    no sflow egress unmodified enable
 !
+interface Port-Channel121
+   description access_port_with_no_vlans
+   switchport
+!
+interface Port-Channel122
+   description trunk_port_with_no_vlans
+   switchport
+   switchport mode trunk
+!
 interface Ethernet3
    description MLAG_PEER_DC1-LEAF1B_Ethernet3
    channel-group 3 mode active

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
@@ -379,6 +379,16 @@ port_channel_interfaces:
       egress:
         unmodified_enable: false
 
+  - name: Port-Channel121
+    description: access_port_with_no_vlans
+    type: switched
+    mode: access
+
+  - name: Port-Channel122
+    description: trunk_port_with_no_vlans
+    type: switched
+    mode: trunk
+
 # Children interfaces
 ethernet_interfaces:
   - name: Ethernet5

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
@@ -54,7 +54,7 @@ interface {{ port_channel_interface.name }}
 {%     else %}
    switchport
 {%     endif %}
-{%     if port_channel_interface.mode is arista.avd.defined("access") %}
+{%     if port_channel_interface.vlans is arista.avd.defined and port_channel_interface.mode is arista.avd.defined("access") %}
    switchport access vlan {{ port_channel_interface.vlans }}
 {%     endif %}
 {%     if port_channel_interface.vlans is arista.avd.defined and port_channel_interface.mode is arista.avd.defined("trunk") %}


### PR DESCRIPTION
## Change Summary

A port-channel interface in mode access in structured_config with no vlans will cause a failure:

```
fatal: [mls00126 -> localhost]: FAILED! => 
  msg: '''dict object'' has no attribute ''vlans''. ''dict object'' has no attribute ''vlans'''
```
## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Simple check for key before using it.

## How to test
Molecule test cases added to molecule for both access and trunk port-channels.

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
