### PR TITLE
Test(plugins): Make types import only when type checking

### DIFF
--- a/ansible_collections/arista/avd/plugins/plugin_utils/utils/get_templar.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/utils/get_templar.py
@@ -1,5 +1,10 @@
-from ansible.plugins.action import ActionBase
-from ansible.template import Templar
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ansible.plugins.action import ActionBase
+    from ansible.template import Templar
 
 from .compile_searchpath import compile_searchpath
 


### PR DESCRIPTION
## Change Summary

😢  Before

```
>>> import ansible_collections.arista.avd.roles.eos_designs.python_modules.ip_addressing.avdipaddressing as aip
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/user/ansible-avd/ansible_collections/arista/avd/roles/eos_designs/python_modules/ip_addressing/__init__.py", line 1, in <module>
    from .avdipaddressing import AvdIpAddressing
  File "/Users/user/ansible-avd/ansible_collections/arista/avd/roles/eos_designs/python_modules/ip_addressing/avdipaddressing.py", line 4, in <module>
    from ansible_collections.arista.avd.plugins.plugin_utils.avdfacts import AvdFacts
  File "/Users/user/ansible-avd/ansible_collections/arista/avd/plugins/plugin_utils/avdfacts.py", line 4, in <module>
    from ansible_collections.arista.avd.plugins.plugin_utils.utils import template_var
  File "/Users/user/ansible-avd/ansible_collections/arista/avd/plugins/plugin_utils/utils/__init__.py", line 1, in <module>
    from .get_templar import get_templar
  File "/Users/user/ansible-avd/ansible_collections/arista/avd/plugins/plugin_utils/utils/get_templar.py", line 4, in <module>
    from .compile_searchpath import compile_searchpath
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1002, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 945, in _find_spec
  File "/Users/user/.pyenv/versions/ansible-avd/lib/python3.10/site-packages/ansible/utils/collection_loader/_collection_finder.py", line 240, in find_spec
    loader = self._get_loader(fullname, path)
  File "/Users/user/.pyenv/versions/ansible-avd/lib/python3.10/site-packages/ansible/utils/collection_loader/_collection_finder.py", line 230, in _get_loader
    return initialize_loader(fullname=fullname, path_list=path)
  File "/Users/user/.pyenv/versions/ansible-avd/lib/python3.10/site-packages/ansible/utils/collection_loader/_collection_finder.py", line 360, in __init__
    self._subpackage_search_paths = self._get_subpackage_search_paths(self._candidate_paths)
  File "/Users/user/.pyenv/versions/ansible-avd/lib/python3.10/site-packages/ansible/utils/collection_loader/_collection_finder.py", line 679, in _get_subpackage_search_paths
    collection_meta = _get_collection_metadata(collection_name)
  File "/Users/user/.pyenv/versions/ansible-avd/lib/python3.10/site-packages/ansible/utils/collection_loader/_collection_finder.py", line 1159, in _get_collection_metadata
    raise ValueError('collection metadata was not loaded for collection {0}'.format(collection_name))
ValueError: collection metadata was not loaded for collection arista.avd
```

😃 After:
```
Python 3.10.3 (main, Jul 29 2022, 21:02:56) [Clang 13.0.0 (clang-1300.0.29.30)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import ansible_collections.arista.avd.roles.eos_designs.python_modules.ip_addressing.avdipaddressing as aip
>>> exit()
```

## Component(s) name

`plugins`

## Proposed changes

Make the imported types being used only when checking type

## How to test

cf summary

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
