### PR TITLE
CI: Fix issue with multiple scopes in github action

### DIFF
--- a/.github/actions/rn-pr-labeler-action/action.yml
+++ b/.github/actions/rn-pr-labeler-action/action.yml
@@ -20,7 +20,7 @@ runs:
     - name: Set Label
       # Using toJSON to support ' and " in commit messages
       # https://stackoverflow.com/questions/73363167/github-actions-how-to-escape-characters-in-commit-message
-      run: echo "LABEL=$(echo ${{ toJSON(github.event.pull_request.title) }} | cut -d ':' -f 1 | tr -d ' ')" >> $GITHUB_ENV
+      run: echo "LABEL=$(echo ${{ toJSON(github.event.pull_request.title) }} | cut -d ':' -f 1 | tr -d ' ' | tr ',' '|')" >> $GITHUB_ENV
       shell: bash
       # an alternative to verifying if the target label already exist is to
       # create the label with --force in the next step, it will keep on changing

--- a/.github/generate_release.py
+++ b/.github/generate_release.py
@@ -20,6 +20,9 @@ SCOPES = [
     "eos_validate_state",
     "plugins",
     "requirements",
+    # Handle multiple scopes ',' are not supported in Github labels and so replaced with '|' by our action
+    "eos_designs|eos_cli_config_gen",
+    "eos_cli_config_gen|eos_designs",
 ]
 
 # CI and Test are excluded from Release Notes
@@ -51,6 +54,17 @@ class SafeDumper(yaml.SafeDumper):
 if __name__ == "__main__":
     exclude_list = []
     categories_list = []
+    other_scopes = [
+        scope
+        for scope in SCOPES
+        if scope
+        not in [
+            "eos_cli_config_gen",
+            "eos_designs",
+            "eos_cli_config_gen|eos_designs",
+            "eos_designs|eos_cli_config_gen",
+        ]
+    ]
 
     # First add exclude labels
     for scope in SCOPES:
@@ -85,9 +99,19 @@ if __name__ == "__main__":
             "labels": ["rn: Fix(eos_designs)"],
         }
     )
+    # Add fixes in eos_cli_config_gen|eos_designs or eos_designs|eos_cli_config_gen
+    categories_list.append(
+        {
+            "title": "Fixed issues in both eos_designs and eos_cli_config_gen",
+            "labels": [
+                "rn: Fix(eos_cli_config_gen|eos_designs)",
+                "rn: Fix(eos_designs|eos_cli_config_gen)",
+            ],
+        }
+    )
 
     # Add other fixes
-    other_fixes_labels = [f"rn: Fix({scope})" for scope in SCOPES if scope not in ["eos_cli_config_gen", "eos_designs"]]
+    other_fixes_labels = [f"rn: Fix({scope})" for scope in other_scopes]
     other_fixes_labels.append("rn: Fix")
 
     categories_list.append(
@@ -124,8 +148,19 @@ if __name__ == "__main__":
         }
     )
 
+    # Add new features in both eos_cli_config_gen|eos_designs or eos_designs|eos_cli_config_gen
+    categories_list.append(
+        {
+            "title": "New features and enhancement in both eos_designs and eos_cli_config_gen",
+            "labels": [
+                "rn: Feat(eos_cli_config_gen|eos_designs)",
+                "rn: Feat(eos_designs|eos_cli_config_gen)",
+            ],
+        }
+    )
+
     # Add other new features
-    other_feat_labels = [f"rn: Feat({scope})" for scope in SCOPES if scope not in ["eos_cli_config_gen", "eos_designs"]]
+    other_feat_labels = [f"rn: Feat({scope})" for scope in other_scopes]
     other_feat_labels.append("rn: Feat")
 
     categories_list.append(

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -23,6 +23,10 @@ changelog:
       - 'rn: CI(plugins)'
       - 'rn: Test(requirements)'
       - 'rn: CI(requirements)'
+      - 'rn: Test(eos_designs|eos_cli_config_gen)'
+      - 'rn: CI(eos_designs|eos_cli_config_gen)'
+      - 'rn: Test(eos_cli_config_gen|eos_designs)'
+      - 'rn: CI(eos_cli_config_gen|eos_designs)'
       - 'rn: Test'
       - 'rn: CI'
   categories:
@@ -39,6 +43,8 @@ changelog:
         - 'rn: Feat(eos_validate_state)!'
         - 'rn: Feat(plugins)!'
         - 'rn: Feat(requirements)!'
+        - 'rn: Feat(eos_designs|eos_cli_config_gen)!'
+        - 'rn: Feat(eos_cli_config_gen|eos_designs)!'
         - 'rn: Fix(build_output_folders)!'
         - 'rn: Fix(cvp_configlet_upload)!'
         - 'rn: Fix(dhcp_provisioner)!'
@@ -50,6 +56,8 @@ changelog:
         - 'rn: Fix(eos_validate_state)!'
         - 'rn: Fix(plugins)!'
         - 'rn: Fix(requirements)!'
+        - 'rn: Fix(eos_designs|eos_cli_config_gen)!'
+        - 'rn: Fix(eos_cli_config_gen|eos_designs)!'
         - 'rn: Cut(build_output_folders)!'
         - 'rn: Cut(cvp_configlet_upload)!'
         - 'rn: Cut(dhcp_provisioner)!'
@@ -61,6 +69,8 @@ changelog:
         - 'rn: Cut(eos_validate_state)!'
         - 'rn: Cut(plugins)!'
         - 'rn: Cut(requirements)!'
+        - 'rn: Cut(eos_designs|eos_cli_config_gen)!'
+        - 'rn: Cut(eos_cli_config_gen|eos_designs)!'
         - 'rn: Revert(build_output_folders)!'
         - 'rn: Revert(cvp_configlet_upload)!'
         - 'rn: Revert(dhcp_provisioner)!'
@@ -72,6 +82,8 @@ changelog:
         - 'rn: Revert(eos_validate_state)!'
         - 'rn: Revert(plugins)!'
         - 'rn: Revert(requirements)!'
+        - 'rn: Revert(eos_designs|eos_cli_config_gen)!'
+        - 'rn: Revert(eos_cli_config_gen|eos_designs)!'
         - 'rn: Refactor(build_output_folders)!'
         - 'rn: Refactor(cvp_configlet_upload)!'
         - 'rn: Refactor(dhcp_provisioner)!'
@@ -83,6 +95,8 @@ changelog:
         - 'rn: Refactor(eos_validate_state)!'
         - 'rn: Refactor(plugins)!'
         - 'rn: Refactor(requirements)!'
+        - 'rn: Refactor(eos_designs|eos_cli_config_gen)!'
+        - 'rn: Refactor(eos_cli_config_gen|eos_designs)!'
         - 'rn: Bump(build_output_folders)!'
         - 'rn: Bump(cvp_configlet_upload)!'
         - 'rn: Bump(dhcp_provisioner)!'
@@ -94,6 +108,8 @@ changelog:
         - 'rn: Bump(eos_validate_state)!'
         - 'rn: Bump(plugins)!'
         - 'rn: Bump(requirements)!'
+        - 'rn: Bump(eos_designs|eos_cli_config_gen)!'
+        - 'rn: Bump(eos_cli_config_gen|eos_designs)!'
         - 'rn: Feat!'
         - 'rn: Fix!'
         - 'rn: Cut!'
@@ -106,6 +122,10 @@ changelog:
     - title: Fixed issues in eos_designs
       labels:
         - 'rn: Fix(eos_designs)'
+    - title: Fixed issues in both eos_designs and eos_cli_config_gen
+      labels:
+        - 'rn: Fix(eos_cli_config_gen|eos_designs)'
+        - 'rn: Fix(eos_designs|eos_cli_config_gen)'
     - title: Other Fixed issues
       labels:
         - 'rn: Fix(build_output_folders)'
@@ -131,6 +151,8 @@ changelog:
         - 'rn: Doc(eos_validate_state)'
         - 'rn: Doc(plugins)'
         - 'rn: Doc(requirements)'
+        - 'rn: Doc(eos_designs|eos_cli_config_gen)'
+        - 'rn: Doc(eos_cli_config_gen|eos_designs)'
         - 'rn: Doc'
     - title: New features and enhancements in eos_cli_config_gen
       labels:
@@ -138,6 +160,10 @@ changelog:
     - title: New features and enhancements in eos_designs
       labels:
         - 'rn: Feat(eos_designs)'
+    - title: New features and enhancement in both eos_designs and eos_cli_config_gen
+      labels:
+        - 'rn: Feat(eos_cli_config_gen|eos_designs)'
+        - 'rn: Feat(eos_designs|eos_cli_config_gen)'
     - title: Other new features and enhancements
       labels:
         - 'rn: Feat(build_output_folders)'


### PR DESCRIPTION
## Related Issue(s)

Fixes #2682

## Component(s) name

`ci`

## Proposed changes

* Replace `,` with `|` supported by github labels
* Add support in release notes  for `eos_designs|eos_cli_config_gen` and `eos_cli_config_gen|eos_designs` with specific categories for Fix and Feat (sadly release.yml is match first)

## How to test
cf action for this PR in external repo used for testing: https://github.com/gmuloc/test-pr-workflow/pull/39

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
