### PR TITLE
Fix(eos_designs): Allow to return a single host subnet when IPv4/32 or IPv6/128

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/loopback_pool_one_host.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/loopback_pool_one_host.cfg
@@ -16,7 +16,7 @@ vrf instance MGMT
 interface Loopback0
    description EVPN_Overlay_Peering
    no shutdown
-   ip address 42.42.42.42/32
+   ip address 192.168.42.42/32
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
@@ -32,7 +32,7 @@ ip routing
 no ip routing vrf MGMT
 !
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
-   seq 10 permit 42.42.42.42/32 eq 32
+   seq 10 permit 192.168.42.42/32 eq 32
    seq 20 permit 1.1.1.1/32 eq 32
 !
 route-map RM-CONN-2-BGP permit 10
@@ -42,7 +42,7 @@ router bfd
    multihop interval 300 min-rx 300 multiplier 3
 !
 router bgp 65000
-   router-id 42.42.42.42
+   router-id 192.168.42.42
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/loopback_pool_one_host.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/loopback_pool_one_host.cfg
@@ -1,0 +1,72 @@
+!RANCID-CONTENT-TYPE: arista
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname loopback_pool_one_host
+!
+no enable password
+no aaa root
+!
+vrf instance MGMT
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 42.42.42.42/32
+!
+interface Loopback1
+   description VTEP_VXLAN_Tunnel_Source
+   no shutdown
+   ip address 1.1.1.1/32
+!
+interface Vxlan1
+   description loopback_pool_one_host_VTEP
+   vxlan source-interface Loopback1
+   vxlan udp-port 4789
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 42.42.42.42/32 eq 32
+   seq 20 permit 1.1.1.1/32 eq 32
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+router bfd
+   multihop interval 300 min-rx 300 multiplier 3
+!
+router bgp 65000
+   router-id 42.42.42.42
+   maximum-paths 4 ecmp 4
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor IPv4-UNDERLAY-PEERS peer group
+   neighbor IPv4-UNDERLAY-PEERS send-community
+   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   address-family evpn
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor IPv4-UNDERLAY-PEERS activate
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/loopback_pool_one_host.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/loopback_pool_one_host.yml
@@ -4,30 +4,30 @@ router_bgp:
   bgp_defaults:
   - maximum-paths 4 ecmp 4
   peer_groups:
-  - type: ipv4
+  - name: IPv4-UNDERLAY-PEERS
+    type: ipv4
     maximum_routes: 12000
     send_community: all
-    name: IPv4-UNDERLAY-PEERS
-  - type: evpn
+  - name: EVPN-OVERLAY-PEERS
+    type: evpn
     update_source: Loopback0
     bfd: true
     send_community: all
     maximum_routes: 0
     ebgp_multihop: 3
-    name: EVPN-OVERLAY-PEERS
   address_family_ipv4:
     peer_groups:
-    - activate: true
-      name: IPv4-UNDERLAY-PEERS
-    - activate: false
-      name: EVPN-OVERLAY-PEERS
+    - name: IPv4-UNDERLAY-PEERS
+      activate: true
+    - name: EVPN-OVERLAY-PEERS
+      activate: false
   redistribute_routes:
-  - route_map: RM-CONN-2-BGP
-    source_protocol: connected
+  - source_protocol: connected
+    route_map: RM-CONN-2-BGP
   address_family_evpn:
     peer_groups:
-    - activate: true
-      name: EVPN-OVERLAY-PEERS
+    - name: EVPN-OVERLAY-PEERS
+      activate: true
 service_routing_protocols_model: multi-agent
 ip_routing: true
 vlan_internal_order:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/loopback_pool_one_host.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/loopback_pool_one_host.yml
@@ -1,6 +1,6 @@
 router_bgp:
   as: '65000'
-  router_id: 42.42.42.42
+  router_id: 192.168.42.42
   bgp_defaults:
   - maximum-paths 4 ecmp 4
   peer_groups:
@@ -46,7 +46,7 @@ loopback_interfaces:
 - name: Loopback0
   description: EVPN_Overlay_Peering
   shutdown: false
-  ip_address: 42.42.42.42/32
+  ip_address: 192.168.42.42/32
 - name: Loopback1
   description: VTEP_VXLAN_Tunnel_Source
   shutdown: false
@@ -55,7 +55,7 @@ prefix_lists:
 - name: PL-LOOPBACKS-EVPN-OVERLAY
   sequence_numbers:
   - sequence: 10
-    action: permit 42.42.42.42/32 eq 32
+    action: permit 192.168.42.42/32 eq 32
   - sequence: 20
     action: permit 1.1.1.1/32 eq 32
 route_maps:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/loopback_pool_one_host.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/loopback_pool_one_host.yml
@@ -1,0 +1,80 @@
+router_bgp:
+  as: '65000'
+  router_id: 42.42.42.42
+  bgp_defaults:
+  - maximum-paths 4 ecmp 4
+  peer_groups:
+  - type: ipv4
+    maximum_routes: 12000
+    send_community: all
+    name: IPv4-UNDERLAY-PEERS
+  - type: evpn
+    update_source: Loopback0
+    bfd: true
+    send_community: all
+    maximum_routes: 0
+    ebgp_multihop: 3
+    name: EVPN-OVERLAY-PEERS
+  address_family_ipv4:
+    peer_groups:
+    - activate: true
+      name: IPv4-UNDERLAY-PEERS
+    - activate: false
+      name: EVPN-OVERLAY-PEERS
+  redistribute_routes:
+  - route_map: RM-CONN-2-BGP
+    source_protocol: connected
+  address_family_evpn:
+    peer_groups:
+    - activate: true
+      name: EVPN-OVERLAY-PEERS
+service_routing_protocols_model: multi-agent
+ip_routing: true
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+vrfs:
+- name: MGMT
+  ip_routing: false
+management_api_http:
+  enable_vrfs:
+  - name: MGMT
+  enable_https: true
+loopback_interfaces:
+- name: Loopback0
+  description: EVPN_Overlay_Peering
+  shutdown: false
+  ip_address: 42.42.42.42/32
+- name: Loopback1
+  description: VTEP_VXLAN_Tunnel_Source
+  shutdown: false
+  ip_address: 1.1.1.1/32
+prefix_lists:
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 42.42.42.42/32 eq 32
+  - sequence: 20
+    action: permit 1.1.1.1/32 eq 32
+route_maps:
+- name: RM-CONN-2-BGP
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    match:
+    - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+router_bfd:
+  multihop:
+    interval: 300
+    min_rx: 300
+    multiplier: 3
+ip_igmp_snooping:
+  globally_enabled: true
+vxlan_interface:
+  Vxlan1:
+    description: loopback_pool_one_host_VTEP
+    vxlan:
+      udp_port: 4789
+      source_interface: Loopback1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/loopback_pool_one_host.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/loopback_pool_one_host.yml
@@ -6,6 +6,6 @@ l3leaf:
     loopback_pool_one_host:
       id: 1
       bgp_as: 65000
-      loopback_ipv4_pool: 42.42.42.42/32
+      loopback_ipv4_pool: 192.168.42.42/32
       vtep_loopback_ipv4_pool: 1.1.1.1/32
-      loopback_ipv6_pool: dead:beef::cafe/128
+      loopback_ipv6_pool: 2001:db8::cafe/128

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/loopback_pool_one_host.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/loopback_pool_one_host.yml
@@ -1,0 +1,11 @@
+# Minimum config to only test /32 IPv4 and /128 IPv6 loopbacks pool
+type: l3leaf
+
+l3leaf:
+  nodes:
+    loopback_pool_one_host:
+      id: 1
+      bgp_as: 65000
+      loopback_ipv4_pool: 42.42.42.42/32
+      vtep_loopback_ipv4_pool: 1.1.1.1/32
+      loopback_ipv6_pool: dead:beef::cafe/128

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
@@ -17,6 +17,7 @@ all:
             mgmt_interface_description:
             mgmt_interface_ipv6:
             mgmt_interface_dualstack:
+            loopback_pool_one_host:
         CORE_UNIT_TESTS:
           hosts:
             core-1-isis-sr-ldp:

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/ip_addressing/avdipaddressing.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/ip_addressing/avdipaddressing.py
@@ -22,6 +22,12 @@ class AvdIpAddressing(AvdFacts, UtilsMixin):
     def _ip(self, pool: str, prefixlen: int, subnet_offset: int, ip_offset: int) -> str:
         pool_network = ipaddress.ip_network(pool, strict=False)
         prefixlen_diff = prefixlen - pool_network.prefixlen
+        if prefixlen == pool_network.prefixlen and (
+            (prefixlen == 32 and isinstance(pool_network, ipaddress.IPv4Network)) or (prefixlen == 128 and isinstance(pool_network, ipaddress.IPv6Network))
+        ):
+            # Ignore subnet_offset and ip_offset ?
+            return str(pool_network.network_address)
+
         subnet_size = (int(pool_network.hostmask) + 1) >> prefixlen_diff
         if (subnet_offset + 1) * subnet_size > pool_network.num_addresses:
             raise AristaAvdError(f"Unable to get {subnet_offset + 1} /{prefixlen} subnets from pool {pool}")


### PR DESCRIPTION
**CAUTION:** The code makes offset and subnet offset not being used. Probably should document this somewhere?

## Related Issue(s)

Fixes #2705

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

When the pool subnet size is a /32 and the required subnet is a /32 for IPv4, the current code is failing as it skips the `netwok_address` in the pool which is the only available. (same for /128 for IPv6). This code allows to not skip the network address in this scenario and returns the only available /32 or /128.

## How to test

molecule

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
