### PR TITLE
Fix(eos_designs): Add mlag_ibgp_origin_incomplete in eos_designs schema

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-CL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-CL1A.cfg
@@ -225,10 +225,6 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 route-map RM-CONN-2-BGP permit 10
    match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
 !
-route-map RM-MLAG-PEER-IN permit 10
-   description Make routes learned over MLAG Peer-link less preferred on spines to ensure optimal routing
-   set origin incomplete
-!
 router bfd
    multihop interval 1200 min-rx 1200 multiplier 3
 !
@@ -251,7 +247,6 @@ router bgp 65108
    neighbor MLAG-PEERS password 7 15AwQNBEJ1nyF/kBEtoAGw==
    neighbor MLAG-PEERS send-community
    neighbor MLAG-PEERS maximum-routes 12000
-   neighbor MLAG-PEERS route-map RM-MLAG-PEER-IN in
    neighbor UNDERLAY-PEERS peer group
    neighbor UNDERLAY-PEERS password 7 0nsCUm70mvSTxVO0ldytrg==
    neighbor UNDERLAY-PEERS send-community

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-CL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-CL1A.yml
@@ -14,7 +14,6 @@ router_bgp:
     password: 15AwQNBEJ1nyF/kBEtoAGw==
     maximum_routes: 12000
     send_community: all
-    route_map_in: RM-MLAG-PEER-IN
   - name: UNDERLAY-PEERS
     type: ipv4
     password: 0nsCUm70mvSTxVO0ldytrg==
@@ -394,20 +393,6 @@ mlag_configuration:
   peer_link: Port-Channel1151
   reload_delay_mlag: '300'
   reload_delay_non_mlag: '330'
-route_maps:
-- name: RM-MLAG-PEER-IN
-  sequence_numbers:
-  - sequence: 10
-    type: permit
-    set:
-    - origin incomplete
-    description: Make routes learned over MLAG Peer-link less preferred on spines to ensure optimal routing
-- name: RM-CONN-2-BGP
-  sequence_numbers:
-  - sequence: 10
-    type: permit
-    match:
-    - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
 loopback_interfaces:
 - name: Loopback0
   description: EVPN_Overlay_Peering
@@ -424,6 +409,13 @@ prefix_lists:
     action: permit 192.168.255.0/24 eq 32
   - sequence: 20
     action: permit 192.168.254.0/24 eq 32
+route_maps:
+- name: RM-CONN-2-BGP
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    match:
+    - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
 router_bfd:
   multihop:
     interval: 1200

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_FABRIC.yml
@@ -248,6 +248,7 @@ l3leaf:
           bgp_as: 65108
           mgmt_ip: 192.168.200.119/24
           uplink_switch_interfaces: [ Ethernet26, Ethernet26, Ethernet26, Ethernet26 ]
+          mlag_ibgp_origin_incomplete: false
         DC1-CL1B:
           platform: 7300X3
           id: 11

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/Fabric Topology.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/Fabric Topology.md
@@ -1526,6 +1526,7 @@ default_interfaces:
     | [<samp>&nbsp;&nbsp;defaults</samp>](## "node_type.defaults") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mlag</samp>](## "node_type.defaults.mlag") | Boolean |  | True |  | Enable / Disable auto MLAG, when two nodes are defined in node group. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mlag_dual_primary_detection</samp>](## "node_type.defaults.mlag_dual_primary_detection") | Boolean |  | False |  | Enable / Disable MLAG dual primary detection. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mlag_ibgp_origin_incomplete</samp>](## "node_type.defaults.mlag_ibgp_origin_incomplete") | Boolean |  | True |  | Set origin of routes received from MLAG iBGP peer to incomplete.<br>The purpose is to optimize routing for leaf loopbacks from spine perspective and<br>avoid suboptimal routing via peerlink for control plane traffic.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mlag_interfaces</samp>](## "node_type.defaults.mlag_interfaces") | List, items: String |  |  |  | Each list item supports range syntax that can be expanded into a list of interfaces.<br>Required when MLAG leafs are present in the topology.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "node_type.defaults.mlag_interfaces.[].&lt;str&gt;") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mlag_interfaces_speed</samp>](## "node_type.defaults.mlag_interfaces_speed") | String |  |  |  | Set MLAG interface speed.<br>< interface_speed or forced interface_speed or auto interface_speed >.<br> |
@@ -1542,6 +1543,7 @@ default_interfaces:
     | [<samp>&nbsp;&nbsp;node_groups</samp>](## "node_type.node_groups") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- mlag</samp>](## "node_type.node_groups.[].mlag") | Boolean |  | True |  | Enable / Disable auto MLAG, when two nodes are defined in node group. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_dual_primary_detection</samp>](## "node_type.node_groups.[].mlag_dual_primary_detection") | Boolean |  | False |  | Enable / Disable MLAG dual primary detection. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_ibgp_origin_incomplete</samp>](## "node_type.node_groups.[].mlag_ibgp_origin_incomplete") | Boolean |  | True |  | Set origin of routes received from MLAG iBGP peer to incomplete.<br>The purpose is to optimize routing for leaf loopbacks from spine perspective and<br>avoid suboptimal routing via peerlink for control plane traffic.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_interfaces</samp>](## "node_type.node_groups.[].mlag_interfaces") | List, items: String |  |  |  | Each list item supports range syntax that can be expanded into a list of interfaces.<br>Required when MLAG leafs are present in the topology.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "node_type.node_groups.[].mlag_interfaces.[].&lt;str&gt;") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_interfaces_speed</samp>](## "node_type.node_groups.[].mlag_interfaces_speed") | String |  |  |  | Set MLAG interface speed.<br>< interface_speed or forced interface_speed or auto interface_speed >.<br> |
@@ -1558,6 +1560,7 @@ default_interfaces:
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;nodes</samp>](## "node_type.node_groups.[].nodes") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- mlag</samp>](## "node_type.node_groups.[].nodes.[].mlag") | Boolean |  | True |  | Enable / Disable auto MLAG, when two nodes are defined in node group. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_dual_primary_detection</samp>](## "node_type.node_groups.[].nodes.[].mlag_dual_primary_detection") | Boolean |  | False |  | Enable / Disable MLAG dual primary detection. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_ibgp_origin_incomplete</samp>](## "node_type.node_groups.[].nodes.[].mlag_ibgp_origin_incomplete") | Boolean |  | True |  | Set origin of routes received from MLAG iBGP peer to incomplete.<br>The purpose is to optimize routing for leaf loopbacks from spine perspective and<br>avoid suboptimal routing via peerlink for control plane traffic.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_interfaces</samp>](## "node_type.node_groups.[].nodes.[].mlag_interfaces") | List, items: String |  |  |  | Each list item supports range syntax that can be expanded into a list of interfaces.<br>Required when MLAG leafs are present in the topology.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "node_type.node_groups.[].nodes.[].mlag_interfaces.[].&lt;str&gt;") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_interfaces_speed</samp>](## "node_type.node_groups.[].nodes.[].mlag_interfaces_speed") | String |  |  |  | Set MLAG interface speed.<br>< interface_speed or forced interface_speed or auto interface_speed >.<br> |
@@ -1574,6 +1577,7 @@ default_interfaces:
     | [<samp>&nbsp;&nbsp;nodes</samp>](## "node_type.nodes") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- mlag</samp>](## "node_type.nodes.[].mlag") | Boolean |  | True |  | Enable / Disable auto MLAG, when two nodes are defined in node group. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_dual_primary_detection</samp>](## "node_type.nodes.[].mlag_dual_primary_detection") | Boolean |  | False |  | Enable / Disable MLAG dual primary detection. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_ibgp_origin_incomplete</samp>](## "node_type.nodes.[].mlag_ibgp_origin_incomplete") | Boolean |  | True |  | Set origin of routes received from MLAG iBGP peer to incomplete.<br>The purpose is to optimize routing for leaf loopbacks from spine perspective and<br>avoid suboptimal routing via peerlink for control plane traffic.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_interfaces</samp>](## "node_type.nodes.[].mlag_interfaces") | List, items: String |  |  |  | Each list item supports range syntax that can be expanded into a list of interfaces.<br>Required when MLAG leafs are present in the topology.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "node_type.nodes.[].mlag_interfaces.[].&lt;str&gt;") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_interfaces_speed</samp>](## "node_type.nodes.[].mlag_interfaces_speed") | String |  |  |  | Set MLAG interface speed.<br>< interface_speed or forced interface_speed or auto interface_speed >.<br> |
@@ -1591,6 +1595,7 @@ default_interfaces:
     | [<samp>&nbsp;&nbsp;defaults</samp>](## "&lt;node_type_keys.key&gt;.defaults") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mlag</samp>](## "&lt;node_type_keys.key&gt;.defaults.mlag") | Boolean |  | True |  | Enable / Disable auto MLAG, when two nodes are defined in node group. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mlag_dual_primary_detection</samp>](## "&lt;node_type_keys.key&gt;.defaults.mlag_dual_primary_detection") | Boolean |  | False |  | Enable / Disable MLAG dual primary detection. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mlag_ibgp_origin_incomplete</samp>](## "&lt;node_type_keys.key&gt;.defaults.mlag_ibgp_origin_incomplete") | Boolean |  | True |  | Set origin of routes received from MLAG iBGP peer to incomplete.<br>The purpose is to optimize routing for leaf loopbacks from spine perspective and<br>avoid suboptimal routing via peerlink for control plane traffic.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mlag_interfaces</samp>](## "&lt;node_type_keys.key&gt;.defaults.mlag_interfaces") | List, items: String |  |  |  | Each list item supports range syntax that can be expanded into a list of interfaces.<br>Required when MLAG leafs are present in the topology.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "&lt;node_type_keys.key&gt;.defaults.mlag_interfaces.[].&lt;str&gt;") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mlag_interfaces_speed</samp>](## "&lt;node_type_keys.key&gt;.defaults.mlag_interfaces_speed") | String |  |  |  | Set MLAG interface speed.<br>< interface_speed or forced interface_speed or auto interface_speed >.<br> |
@@ -1607,6 +1612,7 @@ default_interfaces:
     | [<samp>&nbsp;&nbsp;node_groups</samp>](## "&lt;node_type_keys.key&gt;.node_groups") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- mlag</samp>](## "&lt;node_type_keys.key&gt;.node_groups.[].mlag") | Boolean |  | True |  | Enable / Disable auto MLAG, when two nodes are defined in node group. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_dual_primary_detection</samp>](## "&lt;node_type_keys.key&gt;.node_groups.[].mlag_dual_primary_detection") | Boolean |  | False |  | Enable / Disable MLAG dual primary detection. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_ibgp_origin_incomplete</samp>](## "&lt;node_type_keys.key&gt;.node_groups.[].mlag_ibgp_origin_incomplete") | Boolean |  | True |  | Set origin of routes received from MLAG iBGP peer to incomplete.<br>The purpose is to optimize routing for leaf loopbacks from spine perspective and<br>avoid suboptimal routing via peerlink for control plane traffic.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_interfaces</samp>](## "&lt;node_type_keys.key&gt;.node_groups.[].mlag_interfaces") | List, items: String |  |  |  | Each list item supports range syntax that can be expanded into a list of interfaces.<br>Required when MLAG leafs are present in the topology.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "&lt;node_type_keys.key&gt;.node_groups.[].mlag_interfaces.[].&lt;str&gt;") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_interfaces_speed</samp>](## "&lt;node_type_keys.key&gt;.node_groups.[].mlag_interfaces_speed") | String |  |  |  | Set MLAG interface speed.<br>< interface_speed or forced interface_speed or auto interface_speed >.<br> |
@@ -1623,6 +1629,7 @@ default_interfaces:
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;nodes</samp>](## "&lt;node_type_keys.key&gt;.node_groups.[].nodes") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- mlag</samp>](## "&lt;node_type_keys.key&gt;.node_groups.[].nodes.[].mlag") | Boolean |  | True |  | Enable / Disable auto MLAG, when two nodes are defined in node group. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_dual_primary_detection</samp>](## "&lt;node_type_keys.key&gt;.node_groups.[].nodes.[].mlag_dual_primary_detection") | Boolean |  | False |  | Enable / Disable MLAG dual primary detection. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_ibgp_origin_incomplete</samp>](## "&lt;node_type_keys.key&gt;.node_groups.[].nodes.[].mlag_ibgp_origin_incomplete") | Boolean |  | True |  | Set origin of routes received from MLAG iBGP peer to incomplete.<br>The purpose is to optimize routing for leaf loopbacks from spine perspective and<br>avoid suboptimal routing via peerlink for control plane traffic.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_interfaces</samp>](## "&lt;node_type_keys.key&gt;.node_groups.[].nodes.[].mlag_interfaces") | List, items: String |  |  |  | Each list item supports range syntax that can be expanded into a list of interfaces.<br>Required when MLAG leafs are present in the topology.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "&lt;node_type_keys.key&gt;.node_groups.[].nodes.[].mlag_interfaces.[].&lt;str&gt;") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_interfaces_speed</samp>](## "&lt;node_type_keys.key&gt;.node_groups.[].nodes.[].mlag_interfaces_speed") | String |  |  |  | Set MLAG interface speed.<br>< interface_speed or forced interface_speed or auto interface_speed >.<br> |
@@ -1639,6 +1646,7 @@ default_interfaces:
     | [<samp>&nbsp;&nbsp;nodes</samp>](## "&lt;node_type_keys.key&gt;.nodes") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- mlag</samp>](## "&lt;node_type_keys.key&gt;.nodes.[].mlag") | Boolean |  | True |  | Enable / Disable auto MLAG, when two nodes are defined in node group. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_dual_primary_detection</samp>](## "&lt;node_type_keys.key&gt;.nodes.[].mlag_dual_primary_detection") | Boolean |  | False |  | Enable / Disable MLAG dual primary detection. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_ibgp_origin_incomplete</samp>](## "&lt;node_type_keys.key&gt;.nodes.[].mlag_ibgp_origin_incomplete") | Boolean |  | True |  | Set origin of routes received from MLAG iBGP peer to incomplete.<br>The purpose is to optimize routing for leaf loopbacks from spine perspective and<br>avoid suboptimal routing via peerlink for control plane traffic.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_interfaces</samp>](## "&lt;node_type_keys.key&gt;.nodes.[].mlag_interfaces") | List, items: String |  |  |  | Each list item supports range syntax that can be expanded into a list of interfaces.<br>Required when MLAG leafs are present in the topology.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "&lt;node_type_keys.key&gt;.nodes.[].mlag_interfaces.[].&lt;str&gt;") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_interfaces_speed</samp>](## "&lt;node_type_keys.key&gt;.nodes.[].mlag_interfaces_speed") | String |  |  |  | Set MLAG interface speed.<br>< interface_speed or forced interface_speed or auto interface_speed >.<br> |
@@ -1660,6 +1668,7 @@ default_interfaces:
       defaults:
         mlag: <bool>
         mlag_dual_primary_detection: <bool>
+        mlag_ibgp_origin_incomplete: <bool>
         mlag_interfaces:
           - <str>
         mlag_interfaces_speed: <str>
@@ -1676,6 +1685,7 @@ default_interfaces:
       node_groups:
         - mlag: <bool>
           mlag_dual_primary_detection: <bool>
+          mlag_ibgp_origin_incomplete: <bool>
           mlag_interfaces:
             - <str>
           mlag_interfaces_speed: <str>
@@ -1692,6 +1702,7 @@ default_interfaces:
           nodes:
             - mlag: <bool>
               mlag_dual_primary_detection: <bool>
+              mlag_ibgp_origin_incomplete: <bool>
               mlag_interfaces:
                 - <str>
               mlag_interfaces_speed: <str>
@@ -1708,6 +1719,7 @@ default_interfaces:
       nodes:
         - mlag: <bool>
           mlag_dual_primary_detection: <bool>
+          mlag_ibgp_origin_incomplete: <bool>
           mlag_interfaces:
             - <str>
           mlag_interfaces_speed: <str>
@@ -1725,6 +1737,7 @@ default_interfaces:
       defaults:
         mlag: <bool>
         mlag_dual_primary_detection: <bool>
+        mlag_ibgp_origin_incomplete: <bool>
         mlag_interfaces:
           - <str>
         mlag_interfaces_speed: <str>
@@ -1741,6 +1754,7 @@ default_interfaces:
       node_groups:
         - mlag: <bool>
           mlag_dual_primary_detection: <bool>
+          mlag_ibgp_origin_incomplete: <bool>
           mlag_interfaces:
             - <str>
           mlag_interfaces_speed: <str>
@@ -1757,6 +1771,7 @@ default_interfaces:
           nodes:
             - mlag: <bool>
               mlag_dual_primary_detection: <bool>
+              mlag_ibgp_origin_incomplete: <bool>
               mlag_interfaces:
                 - <str>
               mlag_interfaces_speed: <str>
@@ -1773,6 +1788,7 @@ default_interfaces:
       nodes:
         - mlag: <bool>
           mlag_dual_primary_detection: <bool>
+          mlag_ibgp_origin_incomplete: <bool>
           mlag_interfaces:
             - <str>
           mlag_interfaces_speed: <str>

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -861,6 +861,12 @@
               "default": false,
               "title": "MLAG Dual Primary Detection"
             },
+            "mlag_ibgp_origin_incomplete": {
+              "description": "Set origin of routes received from MLAG iBGP peer to incomplete.\nThe purpose is to optimize routing for leaf loopbacks from spine perspective and\navoid suboptimal routing via peerlink for control plane traffic.\n",
+              "type": "boolean",
+              "default": true,
+              "title": "MLAG Ibgp Origin Incomplete"
+            },
             "mlag_interfaces": {
               "description": "Each list item supports range syntax that can be expanded into a list of interfaces.\nRequired when MLAG leafs are present in the topology.\n",
               "type": "array",
@@ -1820,6 +1826,12 @@
                 "default": false,
                 "title": "MLAG Dual Primary Detection"
               },
+              "mlag_ibgp_origin_incomplete": {
+                "description": "Set origin of routes received from MLAG iBGP peer to incomplete.\nThe purpose is to optimize routing for leaf loopbacks from spine perspective and\navoid suboptimal routing via peerlink for control plane traffic.\n",
+                "type": "boolean",
+                "default": true,
+                "title": "MLAG Ibgp Origin Incomplete"
+              },
               "mlag_interfaces": {
                 "description": "Each list item supports range syntax that can be expanded into a list of interfaces.\nRequired when MLAG leafs are present in the topology.\n",
                 "type": "array",
@@ -2776,6 +2788,12 @@
                       "type": "boolean",
                       "default": false,
                       "title": "MLAG Dual Primary Detection"
+                    },
+                    "mlag_ibgp_origin_incomplete": {
+                      "description": "Set origin of routes received from MLAG iBGP peer to incomplete.\nThe purpose is to optimize routing for leaf loopbacks from spine perspective and\navoid suboptimal routing via peerlink for control plane traffic.\n",
+                      "type": "boolean",
+                      "default": true,
+                      "title": "MLAG Ibgp Origin Incomplete"
                     },
                     "mlag_interfaces": {
                       "description": "Each list item supports range syntax that can be expanded into a list of interfaces.\nRequired when MLAG leafs are present in the topology.\n",
@@ -3755,6 +3773,12 @@
                 "type": "boolean",
                 "default": false,
                 "title": "MLAG Dual Primary Detection"
+              },
+              "mlag_ibgp_origin_incomplete": {
+                "description": "Set origin of routes received from MLAG iBGP peer to incomplete.\nThe purpose is to optimize routing for leaf loopbacks from spine perspective and\navoid suboptimal routing via peerlink for control plane traffic.\n",
+                "type": "boolean",
+                "default": true,
+                "title": "MLAG Ibgp Origin Incomplete"
               },
               "mlag_interfaces": {
                 "description": "Each list item supports range syntax that can be expanded into a list of interfaces.\nRequired when MLAG leafs are present in the topology.\n",

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
@@ -1224,6 +1224,20 @@ keys:
             description: Enable / Disable MLAG dual primary detection.
             type: bool
             default: false
+          mlag_ibgp_origin_incomplete:
+            documentation_options:
+              filename: Fabric Topology
+              table: MLAG configuration management
+            description: 'Set origin of routes received from MLAG iBGP peer to incomplete.
+
+              The purpose is to optimize routing for leaf loopbacks from spine perspective
+              and
+
+              avoid suboptimal routing via peerlink for control plane traffic.
+
+              '
+            type: bool
+            default: true
           mlag_interfaces:
             documentation_options:
               filename: Fabric Topology

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/node_type.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/node_type.schema.yml
@@ -731,6 +731,16 @@ keys:
             description: Enable / Disable MLAG dual primary detection.
             type: bool
             default: false
+          mlag_ibgp_origin_incomplete:
+            documentation_options:
+              filename: Fabric Topology
+              table: MLAG configuration management
+            description: |
+              Set origin of routes received from MLAG iBGP peer to incomplete.
+              The purpose is to optimize routing for leaf loopbacks from spine perspective and
+              avoid suboptimal routing via peerlink for control plane traffic.
+            type: bool
+            default: true
           mlag_interfaces:
             documentation_options:
               filename: Fabric Topology


### PR DESCRIPTION
## Change Summary

Add missing key in `eos_designs` schema in v4.0.0-dev9

## Related Issue(s)

Fixes #2714 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

* Add the key in schema
* Add test in molecule eos_designs_unit_tests

## How to test
molecule

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
