### PR TITLE
Fix(eos_designs): network services vlan interfaces ospf authentication message-digest

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF1A.cfg
@@ -35,6 +35,9 @@ no username admin
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
 !
+vlan 113
+   name Tenant_A_OP_Zone_4
+!
 vlan 120
    name Tenant_A_WEB_Zone_1
 !
@@ -62,6 +65,9 @@ vlan 452
 vrf instance MGMT
 !
 vrf instance Tenant_A_APP_Zone
+!
+vrf instance Tenant_A_OP_Zone
+   description Tenant_A_OP_Zone
 !
 vrf instance Tenant_A_WEB_Zone
 !
@@ -125,11 +131,27 @@ interface Loopback1
    no shutdown
    ip address 192.168.254.9/32
 !
+interface Loopback100
+   description Tenant_A_OP_Zone_VTEP_DIAGNOSTICS
+   no shutdown
+   vrf Tenant_A_OP_Zone
+   ip address 10.255.1.9/32
+!
 interface Management1
    description oob_management
    no shutdown
    vrf MGMT
    ip address 192.168.200.105/24
+!
+interface Vlan113
+   description Tenant_A_OP_Zone_4
+   no shutdown
+   vrf Tenant_A_OP_Zone
+   ip ospf network point-to-point
+   ip ospf area 0
+   ip ospf authentication message-digest
+   ip ospf message-digest-key 1 sha1 7 AQQvKeimxJu+uGQ/yYvv9w==
+   ip ospf message-digest-key 2 sha512 7 AQQvKeimxJu+uGQ/yYvv9w==
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
@@ -193,6 +215,7 @@ interface Vxlan1
    description DC1-LEAF1A_VTEP
    vxlan source-interface Loopback1
    vxlan udp-port 4789
+   vxlan vlan 113 vni 10113
    vxlan vlan 120 vni 10120
    vxlan vlan 121 vni 10121
    vxlan vlan 130 vni 10130
@@ -202,14 +225,18 @@ interface Vxlan1
    vxlan vlan 451 vni 40451
    vxlan vlan 452 vni 40452
    vxlan vrf Tenant_A_APP_Zone vni 12
+   vxlan vrf Tenant_A_OP_Zone vni 10
    vxlan vrf Tenant_A_WEB_Zone vni 11
    vxlan vrf Tenant_D_WAN_Zone vni 41
 !
 ip virtual-router mac-address 00:dc:00:00:00:0a
 !
+ip address virtual source-nat vrf Tenant_A_OP_Zone address 10.255.1.9
+!
 ip routing
 no ip routing vrf MGMT
 ip routing vrf Tenant_A_APP_Zone
+ip routing vrf Tenant_A_OP_Zone
 ip routing vrf Tenant_A_WEB_Zone
 ip routing vrf Tenant_D_WAN_Zone
 ipv6 unicast-routing vrf Tenant_D_WAN_Zone
@@ -276,6 +303,12 @@ router bgp 65101
       redistribute learned
       vlan 130-132
    !
+   vlan-aware-bundle Tenant_A_OP_Zone
+      rd 1.1.1.1:9
+      route-target both 1234:9
+      redistribute learned
+      vlan 113
+   !
    vlan-aware-bundle Tenant_A_WEB_Zone
       rd 1.1.1.1:11
       route-target both 1234:11
@@ -303,6 +336,14 @@ router bgp 65101
       router-id 192.168.255.9
       redistribute connected
    !
+   vrf Tenant_A_OP_Zone
+      rd 1.1.1.1:9
+      route-target import evpn 1234:9
+      route-target export evpn 1234:9
+      router-id 192.168.255.9
+      redistribute connected
+      redistribute ospf
+   !
    vrf Tenant_A_WEB_Zone
       rd 1.1.1.1:11
       route-target import evpn 1234:11
@@ -316,6 +357,12 @@ router bgp 65101
       route-target export evpn 1234:41
       router-id 192.168.255.9
       redistribute connected
+!
+router ospf 9 vrf Tenant_A_OP_Zone
+   router-id 192.168.255.9
+   passive-interface default
+   no passive-interface Vlan113
+   redistribute bgp
 !
 management api http-commands
    protocol https

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_false.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_false.cfg
@@ -40,6 +40,9 @@ vlan 111
 vlan 112
    name Tenant_A_OP_Zone_3
 !
+vlan 113
+   name Tenant_A_OP_Zone_4
+!
 vlan 120
    name Tenant_A_WEB_Zone_1
 !
@@ -184,6 +187,16 @@ interface Vlan112
    mtu 1560
    vrf Tenant_A_OP_Zone
    ip helper-address 2.2.2.2 vrf MGMT source-interface lo101
+!
+interface Vlan113
+   description Tenant_A_OP_Zone_4
+   no shutdown
+   vrf Tenant_A_OP_Zone
+   ip ospf network point-to-point
+   ip ospf area 0
+   ip ospf authentication message-digest
+   ip ospf message-digest-key 1 sha1 7 AQQvKeimxJu+uGQ/yYvv9w==
+   ip ospf message-digest-key 2 sha512 7 AQQvKeimxJu+uGQ/yYvv9w==
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
@@ -347,6 +360,7 @@ interface Vxlan1
    vxlan vlan 110 vni 10110
    vxlan vlan 111 vni 50111
    vxlan vlan 112 vni 10112
+   vxlan vlan 113 vni 10113
    vxlan vlan 120 vni 10120
    vxlan vlan 121 vni 10121
    vxlan vlan 130 vni 10130
@@ -470,7 +484,7 @@ router bgp 101
       rd 192.168.255.109:9
       route-target both 9:9
       redistribute learned
-      vlan 110-112
+      vlan 110-113
    !
    vlan-aware-bundle Tenant_A_VMOTION
       rd 192.168.255.109:20160

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_true.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_true.cfg
@@ -40,6 +40,9 @@ vlan 111
 vlan 112
    name Tenant_A_OP_Zone_3
 !
+vlan 113
+   name Tenant_A_OP_Zone_4
+!
 vlan 120
    name Tenant_A_WEB_Zone_1
 !
@@ -143,6 +146,7 @@ interface Vxlan1
    vxlan vlan 110 vni 10110
    vxlan vlan 111 vni 50111
    vxlan vlan 112 vni 10112
+   vxlan vlan 113 vni 10113
    vxlan vlan 120 vni 10120
    vxlan vlan 121 vni 10121
    vxlan vlan 130 vni 10130
@@ -237,7 +241,7 @@ router bgp 101
       rd 192.168.255.109:9
       route-target both 9:9
       redistribute learned
-      vlan 110-112
+      vlan 110-113
    !
    vlan-aware-bundle Tenant_A_VMOTION
       rd 192.168.255.109:20160

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_default.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_default.cfg
@@ -40,6 +40,9 @@ vlan 111
 vlan 112
    name Tenant_A_OP_Zone_3
 !
+vlan 113
+   name Tenant_A_OP_Zone_4
+!
 vlan 120
    name Tenant_A_WEB_Zone_1
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_fabric.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_fabric.cfg
@@ -40,6 +40,9 @@ vlan 111
 vlan 112
    name Tenant_A_OP_Zone_3
 !
+vlan 113
+   name Tenant_A_OP_Zone_4
+!
 vlan 120
    name Tenant_A_WEB_Zone_1
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_host.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_host.cfg
@@ -42,6 +42,9 @@ vlan 111
 vlan 112
    name Tenant_A_OP_Zone_3
 !
+vlan 113
+   name Tenant_A_OP_Zone_4
+!
 vlan 120
    name Tenant_A_WEB_Zone_1
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_platform.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_platform.cfg
@@ -42,6 +42,9 @@ vlan 111
 vlan 112
    name Tenant_A_OP_Zone_3
 !
+vlan 113
+   name Tenant_A_OP_Zone_4
+!
 vlan 120
    name Tenant_A_WEB_Zone_1
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF1A.yml
@@ -85,6 +85,21 @@ router_bgp:
         - '1234:12'
     redistribute_routes:
     - source_protocol: connected
+  - name: Tenant_A_OP_Zone
+    router_id: 192.168.255.9
+    rd: 1.1.1.1:9
+    route_targets:
+      import:
+      - address_family: evpn
+        route_targets:
+        - '1234:9'
+      export:
+      - address_family: evpn
+        route_targets:
+        - '1234:9'
+    redistribute_routes:
+    - source_protocol: connected
+    - source_protocol: ospf
   - name: Tenant_A_WEB_Zone
     router_id: 192.168.255.9
     rd: 1.1.1.1:11
@@ -122,6 +137,14 @@ router_bgp:
     redistribute_routes:
     - learned
     vlan: 130-132
+  - name: Tenant_A_OP_Zone
+    rd: 1.1.1.1:9
+    route_targets:
+      both:
+      - '1234:9'
+    redistribute_routes:
+    - learned
+    vlan: '113'
   - name: Tenant_A_WEB_Zone
     rd: 1.1.1.1:11
     route_targets:
@@ -197,6 +220,10 @@ vrfs:
 - name: Tenant_A_APP_Zone
   tenant: Tenant_A
   ip_routing: true
+- name: Tenant_A_OP_Zone
+  tenant: Tenant_A
+  ip_routing: true
+  description: Tenant_A_OP_Zone
 - name: Tenant_A_WEB_Zone
   tenant: Tenant_A
   ip_routing: true
@@ -291,6 +318,11 @@ loopback_interfaces:
   description: VTEP_VXLAN_Tunnel_Source
   shutdown: false
   ip_address: 192.168.254.9/32
+- name: Loopback100
+  description: Tenant_A_OP_Zone_VTEP_DIAGNOSTICS
+  shutdown: false
+  vrf: Tenant_A_OP_Zone
+  ip_address: 10.255.1.9/32
 prefix_lists:
 - name: PL-LOOPBACKS-EVPN-OVERLAY
   sequence_numbers:
@@ -319,6 +351,9 @@ vlans:
   tenant: Tenant_A
 - id: 132
   name: Tenant_A_APP_Zone_3
+  tenant: Tenant_A
+- id: 113
+  name: Tenant_A_OP_Zone_4
   tenant: Tenant_A
 - id: 120
   name: Tenant_A_WEB_Zone_1
@@ -371,6 +406,23 @@ vlan_interfaces:
   - 10.2.32.254/24
   - 10.3.32.254/24
   vrf: Tenant_A_APP_Zone
+- name: Vlan113
+  tenant: Tenant_A
+  tags:
+  - DC1_LEAF1
+  description: Tenant_A_OP_Zone_4
+  shutdown: false
+  vrf: Tenant_A_OP_Zone
+  ospf_area: '0'
+  ospf_network_point_to_point: true
+  ospf_authentication: message-digest
+  ospf_message_digest_keys:
+  - id: 1
+    hash_algorithm: sha1
+    key: AQQvKeimxJu+uGQ/yYvv9w==
+  - id: 2
+    hash_algorithm: sha512
+    key: AQQvKeimxJu+uGQ/yYvv9w==
 - name: Vlan120
   tenant: Tenant_A
   tags:
@@ -426,6 +478,16 @@ vlan_interfaces:
   ipv6_address_virtuals:
   - 2001:db8:412::1/64
   vrf: Tenant_D_WAN_Zone
+router_ospf:
+  process_ids:
+  - id: 9
+    vrf: Tenant_A_OP_Zone
+    passive_interface_default: true
+    router_id: 192.168.255.9
+    no_passive_interfaces:
+    - Vlan113
+    redistribute:
+      bgp: {}
 vxlan_interface:
   Vxlan1:
     description: DC1-LEAF1A_VTEP
@@ -439,6 +501,8 @@ vxlan_interface:
         vni: 10131
       - id: 132
         vni: 10132
+      - id: 113
+        vni: 10113
       - id: 120
         vni: 10120
       - id: 121
@@ -452,7 +516,12 @@ vxlan_interface:
       vrfs:
       - name: Tenant_A_APP_Zone
         vni: 12
+      - name: Tenant_A_OP_Zone
+        vni: 10
       - name: Tenant_A_WEB_Zone
         vni: 11
       - name: Tenant_D_WAN_Zone
         vni: 41
+virtual_source_nat_vrfs:
+- name: Tenant_A_OP_Zone
+  ip_address: 10.255.1.9

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_false.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_false.yml
@@ -216,7 +216,7 @@ router_bgp:
       - '9:9'
     redistribute_routes:
     - learned
-    vlan: 110-112
+    vlan: 110-113
   - name: Tenant_A_WAN_Zone
     rd: 192.168.255.109:14
     route_targets:
@@ -462,6 +462,9 @@ vlans:
 - id: 112
   name: Tenant_A_OP_Zone_3
   tenant: Tenant_A
+- id: 113
+  name: Tenant_A_OP_Zone_4
+  tenant: Tenant_A
 - id: 150
   name: Tenant_A_WAN_Zone_1
   tenant: Tenant_A
@@ -611,6 +614,23 @@ vlan_interfaces:
   - ip_helper: 2.2.2.2
     source_interface: lo101
     vrf: MGMT
+- name: Vlan113
+  tenant: Tenant_A
+  tags:
+  - DC1_LEAF1
+  description: Tenant_A_OP_Zone_4
+  shutdown: false
+  vrf: Tenant_A_OP_Zone
+  ospf_area: '0'
+  ospf_network_point_to_point: true
+  ospf_authentication: message-digest
+  ospf_message_digest_keys:
+  - id: 1
+    hash_algorithm: sha1
+    key: AQQvKeimxJu+uGQ/yYvv9w==
+  - id: 2
+    hash_algorithm: sha512
+    key: AQQvKeimxJu+uGQ/yYvv9w==
 - name: Vlan150
   tenant: Tenant_A
   tags:
@@ -810,6 +830,8 @@ vxlan_interface:
         vni: 50111
       - id: 112
         vni: 10112
+      - id: 113
+        vni: 10113
       - id: 150
         vni: 10150
       - id: 151

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_true.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_true.yml
@@ -59,7 +59,7 @@ router_bgp:
       - '9:9'
     redistribute_routes:
     - learned
-    vlan: 110-112
+    vlan: 110-113
   - name: Tenant_A_WAN_Zone
     rd: 192.168.255.109:14
     route_targets:
@@ -260,6 +260,9 @@ vlans:
 - id: 112
   name: Tenant_A_OP_Zone_3
   tenant: Tenant_A
+- id: 113
+  name: Tenant_A_OP_Zone_4
+  tenant: Tenant_A
 - id: 150
   name: Tenant_A_WAN_Zone_1
   tenant: Tenant_A
@@ -357,6 +360,8 @@ vxlan_interface:
         vni: 50111
       - id: 112
         vni: 10112
+      - id: 113
+        vni: 10113
       - id: 150
         vni: 10150
       - id: 151

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_default.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_default.yml
@@ -77,6 +77,9 @@ vlans:
 - id: 112
   name: Tenant_A_OP_Zone_3
   tenant: Tenant_A
+- id: 113
+  name: Tenant_A_OP_Zone_4
+  tenant: Tenant_A
 - id: 150
   name: Tenant_A_WAN_Zone_1
   tenant: Tenant_A

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_fabric.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_fabric.yml
@@ -77,6 +77,9 @@ vlans:
 - id: 112
   name: Tenant_A_OP_Zone_3
   tenant: Tenant_A
+- id: 113
+  name: Tenant_A_OP_Zone_4
+  tenant: Tenant_A
 - id: 150
   name: Tenant_A_WAN_Zone_1
   tenant: Tenant_A

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_host.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_host.yml
@@ -83,6 +83,9 @@ vlans:
 - id: 112
   name: Tenant_A_OP_Zone_3
   tenant: Tenant_A
+- id: 113
+  name: Tenant_A_OP_Zone_4
+  tenant: Tenant_A
 - id: 150
   name: Tenant_A_WAN_Zone_1
   tenant: Tenant_A

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_platform.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_platform.yml
@@ -83,6 +83,9 @@ vlans:
 - id: 112
   name: Tenant_A_OP_Zone_3
   tenant: Tenant_A
+- id: 113
+  name: Tenant_A_OP_Zone_4
+  tenant: Tenant_A
 - id: 150
   name: Tenant_A_WAN_Zone_1
   tenant: Tenant_A

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_A.yml
@@ -33,6 +33,26 @@ tenant_a:
           profile: DERIVED_DHCP
           tags: ['opzone']
           enabled: True
+        #test ospf authentication on vlan interface
+        113:
+          name: Tenant_A_OP_Zone_4
+          tags: [ DC1_LEAF1 ]
+          enabled: True
+          ospf:
+            enabled: true
+            area: 0
+            authentication: message-digest
+            point_to_point: true
+            message_digest_keys:
+              - id: 1
+                hash_algorithm: sha1
+                key: "AQQvKeimxJu+uGQ/yYvv9w=="
+              - id: 2
+                key: "AQQvKeimxJu+uGQ/yYvv9w=="
+      ospf:
+        enabled: true
+        nodes:
+          - DC1-LEAF1A
     Tenant_A_WEB_Zone:
       vrf_vni: 11
       mlag_ibgp_peering_ipv4_pool: 172.31.11.0/24

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/vlan_interfaces.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/vlan_interfaces.py
@@ -145,6 +145,7 @@ class VlanInterfacesMixin(UtilsMixin):
 
                     ospf_keys.append({"id": ospf_key["id"], "hash_algorithm": ospf_key.get("hash_algorithm", "sha512"), "key": ospf_key["key"]})
                 if ospf_keys:
+                    vlan_interface_config["ospf_authentication"] = ospf_authentication
                     vlan_interface_config["ospf_message_digest_keys"] = ospf_keys
 
         # Strip None values from vlan_interface_config before adding to list


### PR DESCRIPTION
## Change Summary

Fix missing "ip ospf authentication message-digest" configuration on vlan interfaces when "authentication: message-digest" is defined

adding 

## Related Issue(s)

Fixes #2726 

## Component(s) name

`arista.avd.eos_designs

## Proposed changes
add "vlan_interface_config["ospf_authentication"] = ospf_authentication" at line 148 or vlan_interfaces.py python module

## Checklist

### User Checklist

- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
