### PR TITLE
Fix(eos_cli_config_gen): Checks for missing "vlans" key on access port-channel (#2701)

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
@@ -228,6 +228,8 @@ interface Ethernet50
 | Port-Channel109 | Molecule ACLs | switched | access | 110 | - | - | - | - | - | - |
 | Port-Channel112 | LACP fallback individual | switched | trunk | 112 | - | - | 5 | individual | - | - |
 | Port-Channel115 | native-vlan-tag-precedence | switched | trunk | - | tag | - | - | - | - | - |
+| Port-Channel121 | access_port_with_no_vlans | switched | access | - | - | - | - | - | - | - |
+| Port-Channel122 | trunk_port_with_no_vlans | switched | trunk | - | - | - | - | - | - | - |
 
 #### Encapsulation Dot1q Interfaces
 
@@ -598,6 +600,31 @@ interface Port-Channel115
    description native-vlan-tag-precedence
    switchport
    switchport trunk native vlan tag
+   switchport mode trunk
+!
+interface Port-Channel117
+   description interface_with_sflow_ingress_egress_enabled
+   no switchport
+!
+interface Port-Channel118
+   description interface_with_sflow_ingress_egress_unmodified_enabled
+   no switchport
+!
+interface Port-Channel119
+   description interface_with_sflow_ingress_egress_disabled
+   no switchport
+!
+interface Port-Channel120
+   description interface_with_sflow_ingress_egress_unmodified_disabled
+   no switchport
+!
+interface Port-Channel121
+   description access_port_with_no_vlans
+   switchport
+!
+interface Port-Channel122
+   description trunk_port_with_no_vlans
+   switchport
    switchport mode trunk
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
@@ -602,22 +602,6 @@ interface Port-Channel115
    switchport trunk native vlan tag
    switchport mode trunk
 !
-interface Port-Channel117
-   description interface_with_sflow_ingress_egress_enabled
-   no switchport
-!
-interface Port-Channel118
-   description interface_with_sflow_ingress_egress_unmodified_enabled
-   no switchport
-!
-interface Port-Channel119
-   description interface_with_sflow_ingress_egress_disabled
-   no switchport
-!
-interface Port-Channel120
-   description interface_with_sflow_ingress_egress_unmodified_disabled
-   no switchport
-!
 interface Port-Channel121
    description access_port_with_no_vlans
    switchport

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
@@ -299,22 +299,6 @@ interface Port-Channel115
    switchport trunk native vlan tag
    switchport mode trunk
 !
-interface Port-Channel117
-   description interface_with_sflow_ingress_egress_enabled
-   no switchport
-!
-interface Port-Channel118
-   description interface_with_sflow_ingress_egress_unmodified_enabled
-   no switchport
-!
-interface Port-Channel119
-   description interface_with_sflow_ingress_egress_disabled
-   no switchport
-!
-interface Port-Channel120
-   description interface_with_sflow_ingress_egress_unmodified_disabled
-   no switchport
-!
 interface Port-Channel121
    description access_port_with_no_vlans
    switchport

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
@@ -299,6 +299,31 @@ interface Port-Channel115
    switchport trunk native vlan tag
    switchport mode trunk
 !
+interface Port-Channel117
+   description interface_with_sflow_ingress_egress_enabled
+   no switchport
+!
+interface Port-Channel118
+   description interface_with_sflow_ingress_egress_unmodified_enabled
+   no switchport
+!
+interface Port-Channel119
+   description interface_with_sflow_ingress_egress_disabled
+   no switchport
+!
+interface Port-Channel120
+   description interface_with_sflow_ingress_egress_unmodified_disabled
+   no switchport
+!
+interface Port-Channel121
+   description access_port_with_no_vlans
+   switchport
+!
+interface Port-Channel122
+   description trunk_port_with_no_vlans
+   switchport
+   switchport mode trunk
+!
 interface Ethernet3
    description MLAG_PEER_DC1-LEAF1B_Ethernet3
    channel-group 3 mode active

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
@@ -345,22 +345,6 @@ port_channel_interfaces:
     native_vlan: 100
     mode: trunk
 
-  Port-Channel117:
-    description: interface_with_sflow_ingress_egress_enabled
-    type: routed
-
-  Port-Channel118:
-    description: interface_with_sflow_ingress_egress_unmodified_enabled
-    type: routed
-
-  Port-Channel119:
-    description: interface_with_sflow_ingress_egress_disabled
-    type: routed
-
-  Port-Channel120:
-    description: interface_with_sflow_ingress_egress_unmodified_disabled
-    type: routed
-
   Port-Channel121:
     description: access_port_with_no_vlans
     type: switched

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
@@ -345,6 +345,32 @@ port_channel_interfaces:
     native_vlan: 100
     mode: trunk
 
+  Port-Channel117:
+    description: interface_with_sflow_ingress_egress_enabled
+    type: routed
+
+  Port-Channel118:
+    description: interface_with_sflow_ingress_egress_unmodified_enabled
+    type: routed
+
+  Port-Channel119:
+    description: interface_with_sflow_ingress_egress_disabled
+    type: routed
+
+  Port-Channel120:
+    description: interface_with_sflow_ingress_egress_unmodified_disabled
+    type: routed
+
+  Port-Channel121:
+    description: access_port_with_no_vlans
+    type: switched
+    mode: access
+
+  Port-Channel122:
+    description: trunk_port_with_no_vlans
+    type: switched
+    mode: trunk
+
 # Children interfaces
 ethernet_interfaces:
   Ethernet5:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
@@ -51,7 +51,7 @@ interface {{ port_channel_interface.name }}
 {%     else %}
    switchport
 {%     endif %}
-{%     if port_channel_interface.mode is arista.avd.defined("access") %}
+{%     if port_channel_interface.vlans is arista.avd.defined and port_channel_interface.mode is arista.avd.defined("access") %}
    switchport access vlan {{ port_channel_interface.vlans }}
 {%     endif %}
 {%     if port_channel_interface.vlans is arista.avd.defined and port_channel_interface.mode is arista.avd.defined("trunk") %}


### PR DESCRIPTION
Partial cherry-pick #2701 for release 3.8.5

Note: updated molecule scenario
