### PR TITLE
Fix(eos_designs): Configure "ip routing ipv6 interface vrf X" for RFC5549 (#2660)

### DIFF
--- a/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF1A.md
+++ b/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF1A.md
@@ -1391,7 +1391,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF1B.md
+++ b/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF1B.md
@@ -1391,7 +1391,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF2A.md
+++ b/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF2A.md
@@ -5344,7 +5344,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF3A.md
+++ b/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF3A.md
@@ -2450,7 +2450,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF3B.md
+++ b/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF3B.md
@@ -2450,7 +2450,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF3C.md
+++ b/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF3C.md
@@ -2320,7 +2320,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF3D.md
+++ b/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF3D.md
@@ -2320,7 +2320,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF3E.md
+++ b/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF3E.md
@@ -2320,7 +2320,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/SPINE1.md
+++ b/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/SPINE1.md
@@ -590,7 +590,7 @@ ip virtual-router mac-address 00:1c:73:00:dc:01
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/SPINE2.md
+++ b/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/SPINE2.md
@@ -590,7 +590,7 @@ ip virtual-router mac-address 00:1c:73:00:dc:01
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/LEAF1.md
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/LEAF1.md
@@ -399,7 +399,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/LEAF2.md
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/LEAF2.md
@@ -399,7 +399,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/LEAF3.md
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/LEAF3.md
@@ -399,7 +399,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/LEAF4.md
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/LEAF4.md
@@ -399,7 +399,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/SPINE1.md
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/SPINE1.md
@@ -430,7 +430,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/SPINE2.md
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/SPINE2.md
@@ -430,7 +430,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf1a.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf1a.md
@@ -561,9 +561,9 @@ ip virtual-router mac-address 00:1c:73:00:00:99
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
-| VRF10 | true |
-| VRF11 | true |
+| MGMT | False |
+| VRF10 | True |
+| VRF11 | True |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf1b.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf1b.md
@@ -561,9 +561,9 @@ ip virtual-router mac-address 00:1c:73:00:00:99
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
-| VRF10 | true |
-| VRF11 | true |
+| MGMT | False |
+| VRF10 | True |
+| VRF11 | True |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf1c.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf1c.md
@@ -258,7 +258,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf2a.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf2a.md
@@ -561,9 +561,9 @@ ip virtual-router mac-address 00:1c:73:00:00:99
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
-| VRF10 | true |
-| VRF11 | true |
+| MGMT | False |
+| VRF10 | True |
+| VRF11 | True |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf2b.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf2b.md
@@ -561,9 +561,9 @@ ip virtual-router mac-address 00:1c:73:00:00:99
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
-| VRF10 | true |
-| VRF11 | true |
+| MGMT | False |
+| VRF10 | True |
+| VRF11 | True |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf2c.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf2c.md
@@ -258,7 +258,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-spine1.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-spine1.md
@@ -237,7 +237,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-spine2.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-spine2.md
@@ -237,7 +237,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-routing.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-routing.md
@@ -71,19 +71,18 @@ interface Management1
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | False |
-| default | true |
-| TEST1 | true |
-| TEST2 | false |
+| default | True (ipv6 interfaces) |
+| TEST1 | True |
+| TEST2 | True (ipv6 interfaces) |
 
 ### IP Routing Device Configuration
 
 ```eos
 !
-no ip routing
+ip routing ipv6 interfaces
 no ip icmp redirect
 ip routing vrf TEST1
-no ip routing vrf TEST2
+ip routing ipv6 interfaces vrf TEST2
 ```
 ## IPv6 Routing
 
@@ -101,9 +100,6 @@ no ip routing vrf TEST2
 ```eos
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
-!
-ipv6 unicast-routing vrf default
 ipv6 unicast-routing vrf TEST1
 no ipv6 icmp redirect
 ```
@@ -120,9 +116,8 @@ no ipv6 icmp redirect
 
 | VRF Name | IP Routing |
 | -------- | ---------- |
-| default | enabled |
 | TEST1 | enabled |
-| TEST2 | disabled |
+| TEST2 | enabled (ipv6 interface) |
 
 ## VRF Instances Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vrf-instances.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vrf-instances.md
@@ -72,9 +72,9 @@ interface Management1
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | False |
-| MGMT | false |
-| TENANT_A_PROJECT01 | true |
-| TENANT_A_PROJECT02 | true |
+| MGMT | False |
+| TENANT_A_PROJECT01 | True |
+| TENANT_A_PROJECT02 | True |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ip-routing.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ip-routing.cfg
@@ -16,15 +16,12 @@ interface Management1
    vrf MGMT
    ip address 10.73.255.122/24
 !
-no ip routing
+ip routing ipv6 interfaces
 no ip icmp redirect
 ip routing vrf TEST1
-no ip routing vrf TEST2
+ip routing ipv6 interfaces vrf TEST2
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
-!
-ipv6 unicast-routing vrf default
 ipv6 unicast-routing vrf TEST1
 no ipv6 icmp redirect
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ip-routing.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ip-routing.yml
@@ -10,8 +10,10 @@ vrfs:
   TEST2:
     ip_routing: false
     ipv6_routing: false
+    ip_routing_ipv6_interfaces: true
   default:
     ip_routing: true
     ipv6_routing: true
+    ip_routing_ipv6_interfaces: true
 ip_icmp_redirect: false
 ipv6_icmp_redirect: false

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/ip-routing.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/ip-routing.md
@@ -71,16 +71,15 @@ interface Management1
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | False |
-| default | true |
-| TEST1 | true |
-| TEST2 | false |
+| default | True (ipv6 interfaces) |
+| TEST1 | True |
+| TEST2 | False |
 
 ### IP Routing Device Configuration
 
 ```eos
 !
-no ip routing
+ip routing ipv6 interfaces
 no ip icmp redirect
 ip routing vrf TEST1
 no ip routing vrf TEST2
@@ -101,9 +100,6 @@ no ip routing vrf TEST2
 ```eos
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
-!
-ipv6 unicast-routing vrf default
 ipv6 unicast-routing vrf TEST1
 no ipv6 icmp redirect
 ```
@@ -120,7 +116,6 @@ no ipv6 icmp redirect
 
 | VRF Name | IP Routing |
 | -------- | ---------- |
-| default | enabled |
 | TEST1 | enabled |
 | TEST2 | disabled |
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/vrf-instances.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/vrf-instances.md
@@ -72,9 +72,9 @@ interface Management1
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | False |
-| MGMT | false |
-| TENANT_A_PROJECT01 | true |
-| TENANT_A_PROJECT02 | true |
+| MGMT | False |
+| TENANT_A_PROJECT01 | True |
+| TENANT_A_PROJECT02 | True |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/ip-routing.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/ip-routing.cfg
@@ -16,15 +16,12 @@ interface Management1
    vrf MGMT
    ip address 10.73.255.122/24
 !
-no ip routing
+ip routing ipv6 interfaces
 no ip icmp redirect
 ip routing vrf TEST1
 no ip routing vrf TEST2
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
-!
-ipv6 unicast-routing vrf default
 ipv6 unicast-routing vrf TEST1
 no ipv6 icmp redirect
 !

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-BL1A.md
@@ -576,10 +576,10 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
-| Tenant_A_WAN_Zone | true |
-| Tenant_B_WAN_Zone | true |
-| Tenant_C_WAN_Zone | true |
+| MGMT | False |
+| Tenant_A_WAN_Zone | True |
+| Tenant_B_WAN_Zone | True |
+| Tenant_C_WAN_Zone | True |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-BL1B.md
@@ -576,10 +576,10 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
-| Tenant_A_WAN_Zone | true |
-| Tenant_B_WAN_Zone | true |
-| Tenant_C_WAN_Zone | true |
+| MGMT | False |
+| Tenant_A_WAN_Zone | True |
+| Tenant_B_WAN_Zone | True |
+| Tenant_C_WAN_Zone | True |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-L2LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-L2LEAF1A.md
@@ -309,7 +309,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-L2LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-L2LEAF2A.md
@@ -430,7 +430,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-L2LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-L2LEAF2B.md
@@ -430,7 +430,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF1A.md
@@ -467,9 +467,9 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
-| Tenant_A_APP_Zone | true |
-| Tenant_A_WEB_Zone | true |
+| MGMT | False |
+| Tenant_A_APP_Zone | True |
+| Tenant_A_WEB_Zone | True |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF2A.md
@@ -794,13 +794,13 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
-| Tenant_A_APP_Zone | true |
-| Tenant_A_DB_Zone | true |
-| Tenant_A_OP_Zone | true |
-| Tenant_A_WEB_Zone | true |
-| Tenant_B_OP_Zone | true |
-| Tenant_C_OP_Zone | true |
+| MGMT | False |
+| Tenant_A_APP_Zone | True |
+| Tenant_A_DB_Zone | True |
+| Tenant_A_OP_Zone | True |
+| Tenant_A_WEB_Zone | True |
+| Tenant_B_OP_Zone | True |
+| Tenant_C_OP_Zone | True |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF2B.md
@@ -794,13 +794,13 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
-| Tenant_A_APP_Zone | true |
-| Tenant_A_DB_Zone | true |
-| Tenant_A_OP_Zone | true |
-| Tenant_A_WEB_Zone | true |
-| Tenant_B_OP_Zone | true |
-| Tenant_C_OP_Zone | true |
+| MGMT | False |
+| Tenant_A_APP_Zone | True |
+| Tenant_A_DB_Zone | True |
+| Tenant_A_OP_Zone | True |
+| Tenant_A_WEB_Zone | True |
+| Tenant_B_OP_Zone | True |
+| Tenant_C_OP_Zone | True |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE1.md
@@ -321,7 +321,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE2.md
@@ -321,7 +321,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE3.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE3.md
@@ -321,7 +321,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE4.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE4.md
@@ -321,7 +321,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SVC3A.md
@@ -890,16 +890,16 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
-| Tenant_A_APP_Zone | true |
-| Tenant_A_DB_Zone | true |
-| Tenant_A_OP_Zone | true |
-| Tenant_A_WAN_Zone | true |
-| Tenant_A_WEB_Zone | true |
-| Tenant_B_OP_Zone | true |
-| Tenant_B_WAN_Zone | true |
-| Tenant_C_OP_Zone | true |
-| Tenant_C_WAN_Zone | true |
+| MGMT | False |
+| Tenant_A_APP_Zone | True |
+| Tenant_A_DB_Zone | True |
+| Tenant_A_OP_Zone | True |
+| Tenant_A_WAN_Zone | True |
+| Tenant_A_WEB_Zone | True |
+| Tenant_B_OP_Zone | True |
+| Tenant_B_WAN_Zone | True |
+| Tenant_C_OP_Zone | True |
+| Tenant_C_WAN_Zone | True |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SVC3B.md
@@ -875,16 +875,16 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
-| Tenant_A_APP_Zone | true |
-| Tenant_A_DB_Zone | true |
-| Tenant_A_OP_Zone | true |
-| Tenant_A_WAN_Zone | true |
-| Tenant_A_WEB_Zone | true |
-| Tenant_B_OP_Zone | true |
-| Tenant_B_WAN_Zone | true |
-| Tenant_C_OP_Zone | true |
-| Tenant_C_WAN_Zone | true |
+| MGMT | False |
+| Tenant_A_APP_Zone | True |
+| Tenant_A_DB_Zone | True |
+| Tenant_A_OP_Zone | True |
+| Tenant_A_WAN_Zone | True |
+| Tenant_A_WEB_Zone | True |
+| Tenant_B_OP_Zone | True |
+| Tenant_B_WAN_Zone | True |
+| Tenant_C_OP_Zone | True |
+| Tenant_C_WAN_Zone | True |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/BGP-LEAF1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/BGP-LEAF1.md
@@ -176,7 +176,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/BGP-LEAF2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/BGP-LEAF2.md
@@ -176,7 +176,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/BGP-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/BGP-SPINE1.md
@@ -334,7 +334,7 @@ ip virtual-router mac-address 00:1c:73:00:00:99
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/BGP-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/BGP-SPINE2.md
@@ -334,7 +334,7 @@ ip virtual-router mac-address 00:1c:73:00:00:99
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/ISIS-LEAF1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/ISIS-LEAF1.md
@@ -182,7 +182,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/ISIS-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/ISIS-SPINE1.md
@@ -265,7 +265,7 @@ ip virtual-router mac-address 00:1c:73:00:00:9a
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/L2ONLY-LEAF1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/L2ONLY-LEAF1.md
@@ -176,7 +176,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/L2ONLY-LEAF2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/L2ONLY-LEAF2.md
@@ -176,7 +176,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/L2ONLY-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/L2ONLY-SPINE1.md
@@ -269,7 +269,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/L2ONLY-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/L2ONLY-SPINE2.md
@@ -269,7 +269,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/OSPF-LEAF1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/OSPF-LEAF1.md
@@ -176,7 +176,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/OSPF-LEAF2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/OSPF-LEAF2.md
@@ -176,7 +176,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/OSPF-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/OSPF-SPINE1.md
@@ -338,7 +338,7 @@ ip virtual-router mac-address 00:1c:73:00:00:99
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/OSPF-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/OSPF-SPINE2.md
@@ -338,7 +338,7 @@ ip virtual-router mac-address 00:1c:73:00:00:99
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER1.md
@@ -478,8 +478,8 @@ ip virtual-router mac-address 00:1c:73:00:dc:00
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
-| TENANT_B_INTRA | true |
+| MGMT | False |
+| TENANT_B_INTRA | True |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER2.md
@@ -472,9 +472,9 @@ ip virtual-router mac-address 00:1c:73:00:dc:00
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
-| TENANT_B_INTRA | true |
-| TENANT_B_WAN | true |
+| MGMT | False |
+| TENANT_B_INTRA | True |
+| TENANT_B_WAN | True |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LSR1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LSR1.md
@@ -280,7 +280,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LSR2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LSR2.md
@@ -256,7 +256,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-RR1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-RR1.md
@@ -235,7 +235,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-LER1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-LER1.md
@@ -468,9 +468,9 @@ ip virtual-router mac-address 00:1c:73:00:dc:00
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
-| TENANT_B_INTRA | true |
-| TENANT_B_WAN | true |
+| MGMT | False |
+| TENANT_B_INTRA | True |
+| TENANT_B_WAN | True |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-LSR1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-LSR1.md
@@ -280,7 +280,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-LSR2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-LSR2.md
@@ -300,7 +300,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-RR1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-RR1.md
@@ -235,7 +235,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE3-LER1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE3-LER1.md
@@ -198,7 +198,7 @@ ip virtual-router mac-address 00:1c:73:00:dc:00
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-L2LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-L2LEAF1A.md
@@ -239,7 +239,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-L2LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-L2LEAF2A.md
@@ -371,7 +371,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-L2LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-L2LEAF2B.md
@@ -379,7 +379,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF1A.md
@@ -340,7 +340,7 @@ ip virtual-router mac-address 00:1c:73:00:dc:01
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2B.md
@@ -724,11 +724,11 @@ ip virtual-router mac-address 00:1c:73:00:dc:01
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| Common_VRF | true |
-| MGMT | false |
-| vrf_with_loopbacks_dc1_pod1_only | true |
-| vrf_with_loopbacks_from_overlapping_pool | true |
-| vrf_with_loopbacks_from_pod_pools | true |
+| Common_VRF | True |
+| MGMT | False |
+| vrf_with_loopbacks_dc1_pod1_only | True |
+| vrf_with_loopbacks_from_overlapping_pool | True |
+| vrf_with_loopbacks_from_pod_pools | True |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-SPINE1.md
@@ -273,7 +273,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-SPINE2.md
@@ -290,7 +290,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-LEAF1A.md
@@ -484,11 +484,11 @@ ip virtual-router mac-address 00:1c:73:00:dc:01
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| Common_VRF | true |
-| MGMT | false |
-| vrf_with_loopbacks_dc1_pod1_only | true |
-| vrf_with_loopbacks_from_overlapping_pool | true |
-| vrf_with_loopbacks_from_pod_pools | true |
+| Common_VRF | True |
+| MGMT | False |
+| vrf_with_loopbacks_dc1_pod1_only | True |
+| vrf_with_loopbacks_from_overlapping_pool | True |
+| vrf_with_loopbacks_from_pod_pools | True |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-SPINE1.md
@@ -269,7 +269,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-SPINE2.md
@@ -261,7 +261,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-RS1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-RS1.md
@@ -219,7 +219,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-RS2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-RS2.md
@@ -247,7 +247,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-SUPER-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-SUPER-SPINE1.md
@@ -253,7 +253,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-SUPER-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-SUPER-SPINE2.md
@@ -279,7 +279,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1.POD1.LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1.POD1.LEAF2A.md
@@ -699,11 +699,11 @@ ip virtual-router mac-address 00:1c:73:00:dc:01
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| Common_VRF | true |
-| MGMT | false |
-| vrf_with_loopbacks_dc1_pod1_only | true |
-| vrf_with_loopbacks_from_overlapping_pool | true |
-| vrf_with_loopbacks_from_pod_pools | true |
+| Common_VRF | True |
+| MGMT | False |
+| vrf_with_loopbacks_dc1_pod1_only | True |
+| vrf_with_loopbacks_from_overlapping_pool | True |
+| vrf_with_loopbacks_from_pod_pools | True |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-L2LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-L2LEAF1A.md
@@ -247,7 +247,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-L2LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-L2LEAF2A.md
@@ -247,7 +247,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-LEAF1A.md
@@ -426,11 +426,11 @@ ip virtual-router mac-address 00:1c:73:00:dc:01
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| Common_VRF | true |
-| MGMT | false |
-| vrf_with_loopbacks_dc1_pod1_only | true |
-| vrf_with_loopbacks_from_overlapping_pool | true |
-| vrf_with_loopbacks_from_pod_pools | true |
+| Common_VRF | True |
+| MGMT | False |
+| vrf_with_loopbacks_dc1_pod1_only | True |
+| vrf_with_loopbacks_from_overlapping_pool | True |
+| vrf_with_loopbacks_from_pod_pools | True |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-LEAF2A.md
@@ -364,7 +364,7 @@ ip virtual-router mac-address 00:1c:73:00:dc:01
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-SPINE1.md
@@ -268,7 +268,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-SPINE2.md
@@ -267,7 +267,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-RS1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-RS1.md
@@ -238,7 +238,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-RS2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-RS2.md
@@ -236,7 +236,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-SUPER-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-SUPER-SPINE1.md
@@ -286,7 +286,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-SUPER-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-SUPER-SPINE2.md
@@ -246,7 +246,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -521,12 +521,12 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
-| Tenant_A_WAN_Zone | true |
-| Tenant_B_OP_Zone | true |
-| Tenant_B_WAN_Zone | true |
-| Tenant_C_WAN_Zone | true |
-| Tenant_L3_VRF_Zone | true |
+| MGMT | False |
+| Tenant_A_WAN_Zone | True |
+| Tenant_B_OP_Zone | True |
+| Tenant_B_WAN_Zone | True |
+| Tenant_C_WAN_Zone | True |
+| Tenant_L3_VRF_Zone | True |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -519,12 +519,12 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
-| Tenant_A_WAN_Zone | true |
-| Tenant_B_OP_Zone | true |
-| Tenant_B_WAN_Zone | true |
-| Tenant_C_WAN_Zone | true |
-| Tenant_L3_VRF_Zone | true |
+| MGMT | False |
+| Tenant_A_WAN_Zone | True |
+| Tenant_B_OP_Zone | True |
+| Tenant_B_WAN_Zone | True |
+| Tenant_C_WAN_Zone | True |
+| Tenant_L3_VRF_Zone | True |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF1A.md
@@ -435,7 +435,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF1B.md
@@ -435,7 +435,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF2A.md
@@ -473,7 +473,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF2B.md
@@ -473,7 +473,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF3A.md
@@ -350,7 +350,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
@@ -534,9 +534,9 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
-| Tenant_A_APP_Zone | true |
-| Tenant_A_WEB_Zone | true |
+| MGMT | False |
+| Tenant_A_APP_Zone | True |
+| Tenant_A_WEB_Zone | True |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -821,13 +821,13 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
-| Tenant_A_APP_Zone | true |
-| Tenant_A_DB_Zone | true |
-| Tenant_A_OP_Zone | true |
-| Tenant_A_WEB_Zone | true |
-| Tenant_B_OP_Zone | true |
-| Tenant_C_OP_Zone | true |
+| MGMT | False |
+| Tenant_A_APP_Zone | True |
+| Tenant_A_DB_Zone | True |
+| Tenant_A_OP_Zone | True |
+| Tenant_A_WEB_Zone | True |
+| Tenant_B_OP_Zone | True |
+| Tenant_C_OP_Zone | True |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -821,13 +821,13 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
-| Tenant_A_APP_Zone | true |
-| Tenant_A_DB_Zone | true |
-| Tenant_A_OP_Zone | true |
-| Tenant_A_WEB_Zone | true |
-| Tenant_B_OP_Zone | true |
-| Tenant_C_OP_Zone | true |
+| MGMT | False |
+| Tenant_A_APP_Zone | True |
+| Tenant_A_DB_Zone | True |
+| Tenant_A_OP_Zone | True |
+| Tenant_A_WEB_Zone | True |
+| Tenant_B_OP_Zone | True |
+| Tenant_C_OP_Zone | True |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE1.md
@@ -345,7 +345,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE2.md
@@ -345,7 +345,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE3.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE3.md
@@ -345,7 +345,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE4.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE4.md
@@ -345,7 +345,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -1175,16 +1175,16 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
-| Tenant_A_APP_Zone | true |
-| Tenant_A_DB_Zone | true |
-| Tenant_A_OP_Zone | true |
-| Tenant_A_WAN_Zone | true |
-| Tenant_A_WEB_Zone | true |
-| Tenant_B_OP_Zone | true |
-| Tenant_B_WAN_Zone | true |
-| Tenant_C_OP_Zone | true |
-| Tenant_C_WAN_Zone | true |
+| MGMT | False |
+| Tenant_A_APP_Zone | True |
+| Tenant_A_DB_Zone | True |
+| Tenant_A_OP_Zone | True |
+| Tenant_A_WAN_Zone | True |
+| Tenant_A_WEB_Zone | True |
+| Tenant_B_OP_Zone | True |
+| Tenant_B_WAN_Zone | True |
+| Tenant_C_OP_Zone | True |
+| Tenant_C_WAN_Zone | True |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -1175,16 +1175,16 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
-| Tenant_A_APP_Zone | true |
-| Tenant_A_DB_Zone | true |
-| Tenant_A_OP_Zone | true |
-| Tenant_A_WAN_Zone | true |
-| Tenant_A_WEB_Zone | true |
-| Tenant_B_OP_Zone | true |
-| Tenant_B_WAN_Zone | true |
-| Tenant_C_OP_Zone | true |
-| Tenant_C_WAN_Zone | true |
+| MGMT | False |
+| Tenant_A_APP_Zone | True |
+| Tenant_A_DB_Zone | True |
+| Tenant_A_OP_Zone | True |
+| Tenant_A_WAN_Zone | True |
+| Tenant_A_WEB_Zone | True |
+| Tenant_B_OP_Zone | True |
+| Tenant_B_WAN_Zone | True |
+| Tenant_C_OP_Zone | True |
+| Tenant_C_WAN_Zone | True |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1A.md
@@ -531,7 +531,7 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1B.md
@@ -517,7 +517,7 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-L2LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-L2LEAF1A.md
@@ -270,7 +270,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-L2LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-L2LEAF2A.md
@@ -370,7 +370,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-L2LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-L2LEAF2B.md
@@ -370,7 +370,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF1A.md
@@ -368,7 +368,7 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2A.md
@@ -532,7 +532,7 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2B.md
@@ -532,7 +532,7 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE1.md
@@ -360,7 +360,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE2.md
@@ -358,7 +358,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE3.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE3.md
@@ -358,7 +358,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE4.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE4.md
@@ -360,7 +360,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3A.md
@@ -525,7 +525,7 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3B.md
@@ -525,7 +525,7 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -487,7 +487,7 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -487,7 +487,7 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-L2LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-L2LEAF1A.md
@@ -289,7 +289,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-L2LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-L2LEAF2A.md
@@ -374,7 +374,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-L2LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-L2LEAF2B.md
@@ -374,7 +374,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
@@ -355,7 +355,7 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -543,8 +543,8 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
-| Tenant_B_OP_Zone | true |
+| MGMT | False |
+| Tenant_B_OP_Zone | True |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -543,8 +543,8 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
-| Tenant_B_OP_Zone | true |
+| MGMT | False |
+| Tenant_B_OP_Zone | True |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE1.md
@@ -335,7 +335,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE2.md
@@ -335,7 +335,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE3.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE3.md
@@ -335,7 +335,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE4.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE4.md
@@ -335,7 +335,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -536,8 +536,8 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
-| Tenant_B_OP_Zone | true |
+| MGMT | False |
+| Tenant_B_OP_Zone | True |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -536,8 +536,8 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
-| Tenant_B_OP_Zone | true |
+| MGMT | False |
+| Tenant_B_OP_Zone | True |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -483,17 +483,17 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
-| MGMT | false |
-| Tenant_A_WAN_Zone | true |
-| Tenant_B_WAN_Zone | true |
-| Tenant_C_WAN_Zone | true |
+| default | True (ipv6 interfaces) |
+| MGMT | False |
+| Tenant_A_WAN_Zone | True |
+| Tenant_B_WAN_Zone | True |
+| Tenant_C_WAN_Zone | True |
 
 ### IP Routing Device Configuration
 
 ```eos
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
 ip routing vrf Tenant_A_WAN_Zone
 ip routing vrf Tenant_B_WAN_Zone
@@ -516,7 +516,6 @@ ip routing vrf Tenant_C_WAN_Zone
 ```eos
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 ```
 
 ## Static Routes

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -482,17 +482,17 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
-| MGMT | false |
-| Tenant_A_WAN_Zone | true |
-| Tenant_B_WAN_Zone | true |
-| Tenant_C_WAN_Zone | true |
+| default | True (ipv6 interfaces) |
+| MGMT | False |
+| Tenant_A_WAN_Zone | True |
+| Tenant_B_WAN_Zone | True |
+| Tenant_C_WAN_Zone | True |
 
 ### IP Routing Device Configuration
 
 ```eos
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
 ip routing vrf Tenant_A_WAN_Zone
 ip routing vrf Tenant_B_WAN_Zone
@@ -515,7 +515,6 @@ ip routing vrf Tenant_C_WAN_Zone
 ```eos
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 ```
 
 ## Static Routes

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-L2LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-L2LEAF1A.md
@@ -316,14 +316,14 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
-| MGMT | false |
+| default | True (ipv6 interfaces) |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 
 ```eos
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
 ```
 ## IPv6 Routing
@@ -340,7 +340,6 @@ no ip routing vrf MGMT
 ```eos
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 ```
 
 ## Static Routes

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-L2LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-L2LEAF2A.md
@@ -439,14 +439,14 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
-| MGMT | false |
+| default | True (ipv6 interfaces) |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 
 ```eos
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
 ```
 ## IPv6 Routing
@@ -463,7 +463,6 @@ no ip routing vrf MGMT
 ```eos
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 ```
 
 ## Static Routes

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-L2LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-L2LEAF2B.md
@@ -439,14 +439,14 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
-| MGMT | false |
+| default | True (ipv6 interfaces) |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 
 ```eos
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
 ```
 ## IPv6 Routing
@@ -463,7 +463,6 @@ no ip routing vrf MGMT
 ```eos
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 ```
 
 ## Static Routes

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
@@ -489,16 +489,16 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
-| MGMT | false |
-| Tenant_A_APP_Zone | true |
-| Tenant_A_WEB_Zone | true |
+| default | True (ipv6 interfaces) |
+| MGMT | False |
+| Tenant_A_APP_Zone | True |
+| Tenant_A_WEB_Zone | True |
 
 ### IP Routing Device Configuration
 
 ```eos
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
 ip routing vrf Tenant_A_APP_Zone
 ip routing vrf Tenant_A_WEB_Zone
@@ -519,7 +519,6 @@ ip routing vrf Tenant_A_WEB_Zone
 ```eos
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 ```
 
 ## Static Routes

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -851,27 +851,27 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
-| MGMT | false |
-| Tenant_A_APP_Zone | true |
-| Tenant_A_DB_Zone | true |
-| Tenant_A_OP_Zone | true |
-| Tenant_A_WEB_Zone | true |
-| Tenant_B_OP_Zone | true |
-| Tenant_C_OP_Zone | true |
+| default | True (ipv6 interfaces) |
+| MGMT | False |
+| Tenant_A_APP_Zone | True (ipv6 interfaces) |
+| Tenant_A_DB_Zone | True (ipv6 interfaces) |
+| Tenant_A_OP_Zone | True (ipv6 interfaces) |
+| Tenant_A_WEB_Zone | True (ipv6 interfaces) |
+| Tenant_B_OP_Zone | True (ipv6 interfaces) |
+| Tenant_C_OP_Zone | True (ipv6 interfaces) |
 
 ### IP Routing Device Configuration
 
 ```eos
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
-ip routing vrf Tenant_A_APP_Zone
-ip routing vrf Tenant_A_DB_Zone
-ip routing vrf Tenant_A_OP_Zone
-ip routing vrf Tenant_A_WEB_Zone
-ip routing vrf Tenant_B_OP_Zone
-ip routing vrf Tenant_C_OP_Zone
+ip routing ipv6 interfaces vrf Tenant_A_APP_Zone
+ip routing ipv6 interfaces vrf Tenant_A_DB_Zone
+ip routing ipv6 interfaces vrf Tenant_A_OP_Zone
+ip routing ipv6 interfaces vrf Tenant_A_WEB_Zone
+ip routing ipv6 interfaces vrf Tenant_B_OP_Zone
+ip routing ipv6 interfaces vrf Tenant_C_OP_Zone
 ```
 ## IPv6 Routing
 
@@ -893,7 +893,6 @@ ip routing vrf Tenant_C_OP_Zone
 ```eos
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 ```
 
 ## Static Routes
@@ -1274,12 +1273,12 @@ route-map RM-MLAG-PEER-IN permit 10
 | VRF Name | IP Routing |
 | -------- | ---------- |
 | MGMT | disabled |
-| Tenant_A_APP_Zone | enabled |
-| Tenant_A_DB_Zone | enabled |
-| Tenant_A_OP_Zone | enabled |
-| Tenant_A_WEB_Zone | enabled |
-| Tenant_B_OP_Zone | enabled |
-| Tenant_C_OP_Zone | enabled |
+| Tenant_A_APP_Zone | enabled (ipv6 interface) |
+| Tenant_A_DB_Zone | enabled (ipv6 interface) |
+| Tenant_A_OP_Zone | enabled (ipv6 interface) |
+| Tenant_A_WEB_Zone | enabled (ipv6 interface) |
+| Tenant_B_OP_Zone | enabled (ipv6 interface) |
+| Tenant_C_OP_Zone | enabled (ipv6 interface) |
 
 ## VRF Instances Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -851,27 +851,27 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
-| MGMT | false |
-| Tenant_A_APP_Zone | true |
-| Tenant_A_DB_Zone | true |
-| Tenant_A_OP_Zone | true |
-| Tenant_A_WEB_Zone | true |
-| Tenant_B_OP_Zone | true |
-| Tenant_C_OP_Zone | true |
+| default | True (ipv6 interfaces) |
+| MGMT | False |
+| Tenant_A_APP_Zone | True (ipv6 interfaces) |
+| Tenant_A_DB_Zone | True (ipv6 interfaces) |
+| Tenant_A_OP_Zone | True (ipv6 interfaces) |
+| Tenant_A_WEB_Zone | True (ipv6 interfaces) |
+| Tenant_B_OP_Zone | True (ipv6 interfaces) |
+| Tenant_C_OP_Zone | True (ipv6 interfaces) |
 
 ### IP Routing Device Configuration
 
 ```eos
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
-ip routing vrf Tenant_A_APP_Zone
-ip routing vrf Tenant_A_DB_Zone
-ip routing vrf Tenant_A_OP_Zone
-ip routing vrf Tenant_A_WEB_Zone
-ip routing vrf Tenant_B_OP_Zone
-ip routing vrf Tenant_C_OP_Zone
+ip routing ipv6 interfaces vrf Tenant_A_APP_Zone
+ip routing ipv6 interfaces vrf Tenant_A_DB_Zone
+ip routing ipv6 interfaces vrf Tenant_A_OP_Zone
+ip routing ipv6 interfaces vrf Tenant_A_WEB_Zone
+ip routing ipv6 interfaces vrf Tenant_B_OP_Zone
+ip routing ipv6 interfaces vrf Tenant_C_OP_Zone
 ```
 ## IPv6 Routing
 
@@ -893,7 +893,6 @@ ip routing vrf Tenant_C_OP_Zone
 ```eos
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 ```
 
 ## Static Routes
@@ -1274,12 +1273,12 @@ route-map RM-MLAG-PEER-IN permit 10
 | VRF Name | IP Routing |
 | -------- | ---------- |
 | MGMT | disabled |
-| Tenant_A_APP_Zone | enabled |
-| Tenant_A_DB_Zone | enabled |
-| Tenant_A_OP_Zone | enabled |
-| Tenant_A_WEB_Zone | enabled |
-| Tenant_B_OP_Zone | enabled |
-| Tenant_C_OP_Zone | enabled |
+| Tenant_A_APP_Zone | enabled (ipv6 interface) |
+| Tenant_A_DB_Zone | enabled (ipv6 interface) |
+| Tenant_A_OP_Zone | enabled (ipv6 interface) |
+| Tenant_A_WEB_Zone | enabled (ipv6 interface) |
+| Tenant_B_OP_Zone | enabled (ipv6 interface) |
+| Tenant_C_OP_Zone | enabled (ipv6 interface) |
 
 ## VRF Instances Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF3A.md
@@ -770,27 +770,27 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
-| MGMT | false |
-| Tenant_A_APP_Zone | true |
-| Tenant_A_DB_Zone | true |
-| Tenant_A_OP_Zone | true |
-| Tenant_A_WEB_Zone | true |
-| Tenant_B_OP_Zone | true |
-| Tenant_C_OP_Zone | true |
+| default | True (ipv6 interfaces) |
+| MGMT | False |
+| Tenant_A_APP_Zone | True (ipv6 interfaces) |
+| Tenant_A_DB_Zone | True (ipv6 interfaces) |
+| Tenant_A_OP_Zone | True (ipv6 interfaces) |
+| Tenant_A_WEB_Zone | True (ipv6 interfaces) |
+| Tenant_B_OP_Zone | True (ipv6 interfaces) |
+| Tenant_C_OP_Zone | True (ipv6 interfaces) |
 
 ### IP Routing Device Configuration
 
 ```eos
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
-ip routing vrf Tenant_A_APP_Zone
-ip routing vrf Tenant_A_DB_Zone
-ip routing vrf Tenant_A_OP_Zone
-ip routing vrf Tenant_A_WEB_Zone
-ip routing vrf Tenant_B_OP_Zone
-ip routing vrf Tenant_C_OP_Zone
+ip routing ipv6 interfaces vrf Tenant_A_APP_Zone
+ip routing ipv6 interfaces vrf Tenant_A_DB_Zone
+ip routing ipv6 interfaces vrf Tenant_A_OP_Zone
+ip routing ipv6 interfaces vrf Tenant_A_WEB_Zone
+ip routing ipv6 interfaces vrf Tenant_B_OP_Zone
+ip routing ipv6 interfaces vrf Tenant_C_OP_Zone
 ```
 ## IPv6 Routing
 
@@ -812,7 +812,6 @@ ip routing vrf Tenant_C_OP_Zone
 ```eos
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 ```
 
 ## Static Routes
@@ -1201,12 +1200,12 @@ route-map RM-MLAG-PEER-IN permit 10
 | VRF Name | IP Routing |
 | -------- | ---------- |
 | MGMT | disabled |
-| Tenant_A_APP_Zone | enabled |
-| Tenant_A_DB_Zone | enabled |
-| Tenant_A_OP_Zone | enabled |
-| Tenant_A_WEB_Zone | enabled |
-| Tenant_B_OP_Zone | enabled |
-| Tenant_C_OP_Zone | enabled |
+| Tenant_A_APP_Zone | enabled (ipv6 interface) |
+| Tenant_A_DB_Zone | enabled (ipv6 interface) |
+| Tenant_A_OP_Zone | enabled (ipv6 interface) |
+| Tenant_A_WEB_Zone | enabled (ipv6 interface) |
+| Tenant_B_OP_Zone | enabled (ipv6 interface) |
+| Tenant_C_OP_Zone | enabled (ipv6 interface) |
 
 ## VRF Instances Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF3B.md
@@ -770,27 +770,27 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
-| MGMT | false |
-| Tenant_A_APP_Zone | true |
-| Tenant_A_DB_Zone | true |
-| Tenant_A_OP_Zone | true |
-| Tenant_A_WEB_Zone | true |
-| Tenant_B_OP_Zone | true |
-| Tenant_C_OP_Zone | true |
+| default | True (ipv6 interfaces) |
+| MGMT | False |
+| Tenant_A_APP_Zone | True (ipv6 interfaces) |
+| Tenant_A_DB_Zone | True (ipv6 interfaces) |
+| Tenant_A_OP_Zone | True (ipv6 interfaces) |
+| Tenant_A_WEB_Zone | True (ipv6 interfaces) |
+| Tenant_B_OP_Zone | True (ipv6 interfaces) |
+| Tenant_C_OP_Zone | True (ipv6 interfaces) |
 
 ### IP Routing Device Configuration
 
 ```eos
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
-ip routing vrf Tenant_A_APP_Zone
-ip routing vrf Tenant_A_DB_Zone
-ip routing vrf Tenant_A_OP_Zone
-ip routing vrf Tenant_A_WEB_Zone
-ip routing vrf Tenant_B_OP_Zone
-ip routing vrf Tenant_C_OP_Zone
+ip routing ipv6 interfaces vrf Tenant_A_APP_Zone
+ip routing ipv6 interfaces vrf Tenant_A_DB_Zone
+ip routing ipv6 interfaces vrf Tenant_A_OP_Zone
+ip routing ipv6 interfaces vrf Tenant_A_WEB_Zone
+ip routing ipv6 interfaces vrf Tenant_B_OP_Zone
+ip routing ipv6 interfaces vrf Tenant_C_OP_Zone
 ```
 ## IPv6 Routing
 
@@ -812,7 +812,6 @@ ip routing vrf Tenant_C_OP_Zone
 ```eos
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 ```
 
 ## Static Routes
@@ -1201,12 +1200,12 @@ route-map RM-MLAG-PEER-IN permit 10
 | VRF Name | IP Routing |
 | -------- | ---------- |
 | MGMT | disabled |
-| Tenant_A_APP_Zone | enabled |
-| Tenant_A_DB_Zone | enabled |
-| Tenant_A_OP_Zone | enabled |
-| Tenant_A_WEB_Zone | enabled |
-| Tenant_B_OP_Zone | enabled |
-| Tenant_C_OP_Zone | enabled |
+| Tenant_A_APP_Zone | enabled (ipv6 interface) |
+| Tenant_A_DB_Zone | enabled (ipv6 interface) |
+| Tenant_A_OP_Zone | enabled (ipv6 interface) |
+| Tenant_A_WEB_Zone | enabled (ipv6 interface) |
+| Tenant_B_OP_Zone | enabled (ipv6 interface) |
+| Tenant_C_OP_Zone | enabled (ipv6 interface) |
 
 ## VRF Instances Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF4A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF4A.md
@@ -770,27 +770,27 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
-| MGMT | false |
-| Tenant_A_APP_Zone | true |
-| Tenant_A_DB_Zone | true |
-| Tenant_A_OP_Zone | true |
-| Tenant_A_WEB_Zone | true |
-| Tenant_B_OP_Zone | true |
-| Tenant_C_OP_Zone | true |
+| default | True (ipv6 interfaces) |
+| MGMT | False |
+| Tenant_A_APP_Zone | True (ipv6 interfaces) |
+| Tenant_A_DB_Zone | True (ipv6 interfaces) |
+| Tenant_A_OP_Zone | True (ipv6 interfaces) |
+| Tenant_A_WEB_Zone | True (ipv6 interfaces) |
+| Tenant_B_OP_Zone | True (ipv6 interfaces) |
+| Tenant_C_OP_Zone | True (ipv6 interfaces) |
 
 ### IP Routing Device Configuration
 
 ```eos
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
-ip routing vrf Tenant_A_APP_Zone
-ip routing vrf Tenant_A_DB_Zone
-ip routing vrf Tenant_A_OP_Zone
-ip routing vrf Tenant_A_WEB_Zone
-ip routing vrf Tenant_B_OP_Zone
-ip routing vrf Tenant_C_OP_Zone
+ip routing ipv6 interfaces vrf Tenant_A_APP_Zone
+ip routing ipv6 interfaces vrf Tenant_A_DB_Zone
+ip routing ipv6 interfaces vrf Tenant_A_OP_Zone
+ip routing ipv6 interfaces vrf Tenant_A_WEB_Zone
+ip routing ipv6 interfaces vrf Tenant_B_OP_Zone
+ip routing ipv6 interfaces vrf Tenant_C_OP_Zone
 ```
 ## IPv6 Routing
 
@@ -812,7 +812,6 @@ ip routing vrf Tenant_C_OP_Zone
 ```eos
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 ```
 
 ## Static Routes
@@ -1201,12 +1200,12 @@ route-map RM-MLAG-PEER-IN permit 10
 | VRF Name | IP Routing |
 | -------- | ---------- |
 | MGMT | disabled |
-| Tenant_A_APP_Zone | enabled |
-| Tenant_A_DB_Zone | enabled |
-| Tenant_A_OP_Zone | enabled |
-| Tenant_A_WEB_Zone | enabled |
-| Tenant_B_OP_Zone | enabled |
-| Tenant_C_OP_Zone | enabled |
+| Tenant_A_APP_Zone | enabled (ipv6 interface) |
+| Tenant_A_DB_Zone | enabled (ipv6 interface) |
+| Tenant_A_OP_Zone | enabled (ipv6 interface) |
+| Tenant_A_WEB_Zone | enabled (ipv6 interface) |
+| Tenant_B_OP_Zone | enabled (ipv6 interface) |
+| Tenant_C_OP_Zone | enabled (ipv6 interface) |
 
 ## VRF Instances Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF4B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF4B.md
@@ -770,27 +770,27 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
-| MGMT | false |
-| Tenant_A_APP_Zone | true |
-| Tenant_A_DB_Zone | true |
-| Tenant_A_OP_Zone | true |
-| Tenant_A_WEB_Zone | true |
-| Tenant_B_OP_Zone | true |
-| Tenant_C_OP_Zone | true |
+| default | True (ipv6 interfaces) |
+| MGMT | False |
+| Tenant_A_APP_Zone | True (ipv6 interfaces) |
+| Tenant_A_DB_Zone | True (ipv6 interfaces) |
+| Tenant_A_OP_Zone | True (ipv6 interfaces) |
+| Tenant_A_WEB_Zone | True (ipv6 interfaces) |
+| Tenant_B_OP_Zone | True (ipv6 interfaces) |
+| Tenant_C_OP_Zone | True (ipv6 interfaces) |
 
 ### IP Routing Device Configuration
 
 ```eos
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
-ip routing vrf Tenant_A_APP_Zone
-ip routing vrf Tenant_A_DB_Zone
-ip routing vrf Tenant_A_OP_Zone
-ip routing vrf Tenant_A_WEB_Zone
-ip routing vrf Tenant_B_OP_Zone
-ip routing vrf Tenant_C_OP_Zone
+ip routing ipv6 interfaces vrf Tenant_A_APP_Zone
+ip routing ipv6 interfaces vrf Tenant_A_DB_Zone
+ip routing ipv6 interfaces vrf Tenant_A_OP_Zone
+ip routing ipv6 interfaces vrf Tenant_A_WEB_Zone
+ip routing ipv6 interfaces vrf Tenant_B_OP_Zone
+ip routing ipv6 interfaces vrf Tenant_C_OP_Zone
 ```
 ## IPv6 Routing
 
@@ -812,7 +812,6 @@ ip routing vrf Tenant_C_OP_Zone
 ```eos
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 ```
 
 ## Static Routes
@@ -1201,12 +1200,12 @@ route-map RM-MLAG-PEER-IN permit 10
 | VRF Name | IP Routing |
 | -------- | ---------- |
 | MGMT | disabled |
-| Tenant_A_APP_Zone | enabled |
-| Tenant_A_DB_Zone | enabled |
-| Tenant_A_OP_Zone | enabled |
-| Tenant_A_WEB_Zone | enabled |
-| Tenant_B_OP_Zone | enabled |
-| Tenant_C_OP_Zone | enabled |
+| Tenant_A_APP_Zone | enabled (ipv6 interface) |
+| Tenant_A_DB_Zone | enabled (ipv6 interface) |
+| Tenant_A_OP_Zone | enabled (ipv6 interface) |
+| Tenant_A_WEB_Zone | enabled (ipv6 interface) |
+| Tenant_B_OP_Zone | enabled (ipv6 interface) |
+| Tenant_C_OP_Zone | enabled (ipv6 interface) |
 
 ## VRF Instances Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE1.md
@@ -320,14 +320,14 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
-| MGMT | false |
+| default | True (ipv6 interfaces) |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 
 ```eos
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
 ```
 ## IPv6 Routing
@@ -344,7 +344,6 @@ no ip routing vrf MGMT
 ```eos
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 ```
 
 ## Static Routes

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE2.md
@@ -320,14 +320,14 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
-| MGMT | false |
+| default | True (ipv6 interfaces) |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 
 ```eos
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
 ```
 ## IPv6 Routing
@@ -344,7 +344,6 @@ no ip routing vrf MGMT
 ```eos
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 ```
 
 ## Static Routes

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE3.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE3.md
@@ -320,14 +320,14 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
-| MGMT | false |
+| default | True (ipv6 interfaces) |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 
 ```eos
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
 ```
 ## IPv6 Routing
@@ -344,7 +344,6 @@ no ip routing vrf MGMT
 ```eos
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 ```
 
 ## Static Routes

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE4.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE4.md
@@ -320,14 +320,14 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
-| MGMT | false |
+| default | True (ipv6 interfaces) |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 
 ```eos
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
 ```
 ## IPv6 Routing
@@ -344,7 +344,6 @@ no ip routing vrf MGMT
 ```eos
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 ```
 
 ## Static Routes

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE5.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE5.md
@@ -282,14 +282,14 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
-| MGMT | false |
+| default | True (ipv6 interfaces) |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 
 ```eos
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
 ```
 ## IPv6 Routing
@@ -306,7 +306,6 @@ no ip routing vrf MGMT
 ```eos
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 ```
 
 ## Static Routes

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE6.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE6.md
@@ -282,14 +282,14 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
-| MGMT | false |
+| default | True (ipv6 interfaces) |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 
 ```eos
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
 ```
 ## IPv6 Routing
@@ -306,7 +306,6 @@ no ip routing vrf MGMT
 ```eos
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 ```
 
 ## Static Routes

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -1016,33 +1016,33 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
-| MGMT | false |
-| Tenant_A_APP_Zone | true |
-| Tenant_A_DB_Zone | true |
-| Tenant_A_OP_Zone | true |
-| Tenant_A_WAN_Zone | true |
-| Tenant_A_WEB_Zone | true |
-| Tenant_B_OP_Zone | true |
-| Tenant_B_WAN_Zone | true |
-| Tenant_C_OP_Zone | true |
-| Tenant_C_WAN_Zone | true |
+| default | True (ipv6 interfaces) |
+| MGMT | False |
+| Tenant_A_APP_Zone | True (ipv6 interfaces) |
+| Tenant_A_DB_Zone | True (ipv6 interfaces) |
+| Tenant_A_OP_Zone | True (ipv6 interfaces) |
+| Tenant_A_WAN_Zone | True (ipv6 interfaces) |
+| Tenant_A_WEB_Zone | True (ipv6 interfaces) |
+| Tenant_B_OP_Zone | True (ipv6 interfaces) |
+| Tenant_B_WAN_Zone | True (ipv6 interfaces) |
+| Tenant_C_OP_Zone | True (ipv6 interfaces) |
+| Tenant_C_WAN_Zone | True (ipv6 interfaces) |
 
 ### IP Routing Device Configuration
 
 ```eos
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
-ip routing vrf Tenant_A_APP_Zone
-ip routing vrf Tenant_A_DB_Zone
-ip routing vrf Tenant_A_OP_Zone
-ip routing vrf Tenant_A_WAN_Zone
-ip routing vrf Tenant_A_WEB_Zone
-ip routing vrf Tenant_B_OP_Zone
-ip routing vrf Tenant_B_WAN_Zone
-ip routing vrf Tenant_C_OP_Zone
-ip routing vrf Tenant_C_WAN_Zone
+ip routing ipv6 interfaces vrf Tenant_A_APP_Zone
+ip routing ipv6 interfaces vrf Tenant_A_DB_Zone
+ip routing ipv6 interfaces vrf Tenant_A_OP_Zone
+ip routing ipv6 interfaces vrf Tenant_A_WAN_Zone
+ip routing ipv6 interfaces vrf Tenant_A_WEB_Zone
+ip routing ipv6 interfaces vrf Tenant_B_OP_Zone
+ip routing ipv6 interfaces vrf Tenant_B_WAN_Zone
+ip routing ipv6 interfaces vrf Tenant_C_OP_Zone
+ip routing ipv6 interfaces vrf Tenant_C_WAN_Zone
 ```
 ## IPv6 Routing
 
@@ -1067,7 +1067,6 @@ ip routing vrf Tenant_C_WAN_Zone
 ```eos
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 ```
 
 ## Static Routes
@@ -1499,15 +1498,15 @@ route-map RM-MLAG-PEER-IN permit 10
 | VRF Name | IP Routing |
 | -------- | ---------- |
 | MGMT | disabled |
-| Tenant_A_APP_Zone | enabled |
-| Tenant_A_DB_Zone | enabled |
-| Tenant_A_OP_Zone | enabled |
-| Tenant_A_WAN_Zone | enabled |
-| Tenant_A_WEB_Zone | enabled |
-| Tenant_B_OP_Zone | enabled |
-| Tenant_B_WAN_Zone | enabled |
-| Tenant_C_OP_Zone | enabled |
-| Tenant_C_WAN_Zone | enabled |
+| Tenant_A_APP_Zone | enabled (ipv6 interface) |
+| Tenant_A_DB_Zone | enabled (ipv6 interface) |
+| Tenant_A_OP_Zone | enabled (ipv6 interface) |
+| Tenant_A_WAN_Zone | enabled (ipv6 interface) |
+| Tenant_A_WEB_Zone | enabled (ipv6 interface) |
+| Tenant_B_OP_Zone | enabled (ipv6 interface) |
+| Tenant_B_WAN_Zone | enabled (ipv6 interface) |
+| Tenant_C_OP_Zone | enabled (ipv6 interface) |
+| Tenant_C_WAN_Zone | enabled (ipv6 interface) |
 
 ## VRF Instances Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -1001,33 +1001,33 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
-| MGMT | false |
-| Tenant_A_APP_Zone | true |
-| Tenant_A_DB_Zone | true |
-| Tenant_A_OP_Zone | true |
-| Tenant_A_WAN_Zone | true |
-| Tenant_A_WEB_Zone | true |
-| Tenant_B_OP_Zone | true |
-| Tenant_B_WAN_Zone | true |
-| Tenant_C_OP_Zone | true |
-| Tenant_C_WAN_Zone | true |
+| default | True (ipv6 interfaces) |
+| MGMT | False |
+| Tenant_A_APP_Zone | True (ipv6 interfaces) |
+| Tenant_A_DB_Zone | True (ipv6 interfaces) |
+| Tenant_A_OP_Zone | True (ipv6 interfaces) |
+| Tenant_A_WAN_Zone | True (ipv6 interfaces) |
+| Tenant_A_WEB_Zone | True (ipv6 interfaces) |
+| Tenant_B_OP_Zone | True (ipv6 interfaces) |
+| Tenant_B_WAN_Zone | True (ipv6 interfaces) |
+| Tenant_C_OP_Zone | True (ipv6 interfaces) |
+| Tenant_C_WAN_Zone | True (ipv6 interfaces) |
 
 ### IP Routing Device Configuration
 
 ```eos
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
-ip routing vrf Tenant_A_APP_Zone
-ip routing vrf Tenant_A_DB_Zone
-ip routing vrf Tenant_A_OP_Zone
-ip routing vrf Tenant_A_WAN_Zone
-ip routing vrf Tenant_A_WEB_Zone
-ip routing vrf Tenant_B_OP_Zone
-ip routing vrf Tenant_B_WAN_Zone
-ip routing vrf Tenant_C_OP_Zone
-ip routing vrf Tenant_C_WAN_Zone
+ip routing ipv6 interfaces vrf Tenant_A_APP_Zone
+ip routing ipv6 interfaces vrf Tenant_A_DB_Zone
+ip routing ipv6 interfaces vrf Tenant_A_OP_Zone
+ip routing ipv6 interfaces vrf Tenant_A_WAN_Zone
+ip routing ipv6 interfaces vrf Tenant_A_WEB_Zone
+ip routing ipv6 interfaces vrf Tenant_B_OP_Zone
+ip routing ipv6 interfaces vrf Tenant_B_WAN_Zone
+ip routing ipv6 interfaces vrf Tenant_C_OP_Zone
+ip routing ipv6 interfaces vrf Tenant_C_WAN_Zone
 ```
 ## IPv6 Routing
 
@@ -1052,7 +1052,6 @@ ip routing vrf Tenant_C_WAN_Zone
 ```eos
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 ```
 
 ## Static Routes
@@ -1484,15 +1483,15 @@ route-map RM-MLAG-PEER-IN permit 10
 | VRF Name | IP Routing |
 | -------- | ---------- |
 | MGMT | disabled |
-| Tenant_A_APP_Zone | enabled |
-| Tenant_A_DB_Zone | enabled |
-| Tenant_A_OP_Zone | enabled |
-| Tenant_A_WAN_Zone | enabled |
-| Tenant_A_WEB_Zone | enabled |
-| Tenant_B_OP_Zone | enabled |
-| Tenant_B_WAN_Zone | enabled |
-| Tenant_C_OP_Zone | enabled |
-| Tenant_C_WAN_Zone | enabled |
+| Tenant_A_APP_Zone | enabled (ipv6 interface) |
+| Tenant_A_DB_Zone | enabled (ipv6 interface) |
+| Tenant_A_OP_Zone | enabled (ipv6 interface) |
+| Tenant_A_WAN_Zone | enabled (ipv6 interface) |
+| Tenant_A_WEB_Zone | enabled (ipv6 interface) |
+| Tenant_B_OP_Zone | enabled (ipv6 interface) |
+| Tenant_B_WAN_Zone | enabled (ipv6 interface) |
+| Tenant_C_OP_Zone | enabled (ipv6 interface) |
+| Tenant_C_WAN_Zone | enabled (ipv6 interface) |
 
 ## VRF Instances Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-BL1A.cfg
@@ -144,14 +144,13 @@ hardware tcam
 !
 ip virtual-router mac-address 00:dc:00:00:00:0a
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
 ip routing vrf Tenant_A_WAN_Zone
 ip routing vrf Tenant_B_WAN_Zone
 ip routing vrf Tenant_C_WAN_Zone
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 !
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.168.255.0/24 eq 32

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-BL1B.cfg
@@ -144,14 +144,13 @@ hardware tcam
 !
 ip virtual-router mac-address 00:dc:00:00:00:0a
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
 ip routing vrf Tenant_A_WAN_Zone
 ip routing vrf Tenant_B_WAN_Zone
 ip routing vrf Tenant_C_WAN_Zone
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 !
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.168.255.0/24 eq 32

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-L2LEAF1A.cfg
@@ -77,11 +77,10 @@ interface Management1
    vrf MGMT
    ip address 192.168.200.112/24
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 !
 ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-L2LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-L2LEAF2A.cfg
@@ -135,11 +135,10 @@ interface Vlan4094
    no autostate
    ip address 10.255.252.16/31
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 !
 mlag configuration
    domain-id DC1_L2LEAF2

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-L2LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-L2LEAF2B.cfg
@@ -135,11 +135,10 @@ interface Vlan4094
    no autostate
    ip address 10.255.252.17/31
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 !
 mlag configuration
    domain-id DC1_L2LEAF2

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF1A.cfg
@@ -154,13 +154,12 @@ hardware tcam
 !
 ip virtual-router mac-address 00:dc:00:00:00:0a
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
 ip routing vrf Tenant_A_APP_Zone
 ip routing vrf Tenant_A_WEB_Zone
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 !
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.168.255.0/24 eq 32

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
@@ -402,17 +402,16 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 !
 ip address virtual source-nat vrf Tenant_A_OP_Zone address 10.255.1.6
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
-ip routing vrf Tenant_A_APP_Zone
-ip routing vrf Tenant_A_DB_Zone
-ip routing vrf Tenant_A_OP_Zone
-ip routing vrf Tenant_A_WEB_Zone
-ip routing vrf Tenant_B_OP_Zone
-ip routing vrf Tenant_C_OP_Zone
+ip routing ipv6 interfaces vrf Tenant_A_APP_Zone
+ip routing ipv6 interfaces vrf Tenant_A_DB_Zone
+ip routing ipv6 interfaces vrf Tenant_A_OP_Zone
+ip routing ipv6 interfaces vrf Tenant_A_WEB_Zone
+ip routing ipv6 interfaces vrf Tenant_B_OP_Zone
+ip routing ipv6 interfaces vrf Tenant_C_OP_Zone
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 !
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.168.255.0/24 eq 32

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
@@ -402,17 +402,16 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 !
 ip address virtual source-nat vrf Tenant_A_OP_Zone address 10.255.1.7
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
-ip routing vrf Tenant_A_APP_Zone
-ip routing vrf Tenant_A_DB_Zone
-ip routing vrf Tenant_A_OP_Zone
-ip routing vrf Tenant_A_WEB_Zone
-ip routing vrf Tenant_B_OP_Zone
-ip routing vrf Tenant_C_OP_Zone
+ip routing ipv6 interfaces vrf Tenant_A_APP_Zone
+ip routing ipv6 interfaces vrf Tenant_A_DB_Zone
+ip routing ipv6 interfaces vrf Tenant_A_OP_Zone
+ip routing ipv6 interfaces vrf Tenant_A_WEB_Zone
+ip routing ipv6 interfaces vrf Tenant_B_OP_Zone
+ip routing ipv6 interfaces vrf Tenant_C_OP_Zone
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 !
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.168.255.0/24 eq 32

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF3A.cfg
@@ -331,17 +331,16 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 !
 ip address virtual source-nat vrf Tenant_A_OP_Zone address 10.255.1.12
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
-ip routing vrf Tenant_A_APP_Zone
-ip routing vrf Tenant_A_DB_Zone
-ip routing vrf Tenant_A_OP_Zone
-ip routing vrf Tenant_A_WEB_Zone
-ip routing vrf Tenant_B_OP_Zone
-ip routing vrf Tenant_C_OP_Zone
+ip routing ipv6 interfaces vrf Tenant_A_APP_Zone
+ip routing ipv6 interfaces vrf Tenant_A_DB_Zone
+ip routing ipv6 interfaces vrf Tenant_A_OP_Zone
+ip routing ipv6 interfaces vrf Tenant_A_WEB_Zone
+ip routing ipv6 interfaces vrf Tenant_B_OP_Zone
+ip routing ipv6 interfaces vrf Tenant_C_OP_Zone
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 !
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.168.255.0/24 eq 32

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF3B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF3B.cfg
@@ -331,17 +331,16 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 !
 ip address virtual source-nat vrf Tenant_A_OP_Zone address 10.255.1.13
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
-ip routing vrf Tenant_A_APP_Zone
-ip routing vrf Tenant_A_DB_Zone
-ip routing vrf Tenant_A_OP_Zone
-ip routing vrf Tenant_A_WEB_Zone
-ip routing vrf Tenant_B_OP_Zone
-ip routing vrf Tenant_C_OP_Zone
+ip routing ipv6 interfaces vrf Tenant_A_APP_Zone
+ip routing ipv6 interfaces vrf Tenant_A_DB_Zone
+ip routing ipv6 interfaces vrf Tenant_A_OP_Zone
+ip routing ipv6 interfaces vrf Tenant_A_WEB_Zone
+ip routing ipv6 interfaces vrf Tenant_B_OP_Zone
+ip routing ipv6 interfaces vrf Tenant_C_OP_Zone
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 !
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.168.255.0/24 eq 32

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF4A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF4A.cfg
@@ -331,17 +331,16 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 !
 ip address virtual source-nat vrf Tenant_A_OP_Zone address 10.255.1.14
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
-ip routing vrf Tenant_A_APP_Zone
-ip routing vrf Tenant_A_DB_Zone
-ip routing vrf Tenant_A_OP_Zone
-ip routing vrf Tenant_A_WEB_Zone
-ip routing vrf Tenant_B_OP_Zone
-ip routing vrf Tenant_C_OP_Zone
+ip routing ipv6 interfaces vrf Tenant_A_APP_Zone
+ip routing ipv6 interfaces vrf Tenant_A_DB_Zone
+ip routing ipv6 interfaces vrf Tenant_A_OP_Zone
+ip routing ipv6 interfaces vrf Tenant_A_WEB_Zone
+ip routing ipv6 interfaces vrf Tenant_B_OP_Zone
+ip routing ipv6 interfaces vrf Tenant_C_OP_Zone
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 !
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.168.255.0/24 eq 32

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF4B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF4B.cfg
@@ -331,17 +331,16 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 !
 ip address virtual source-nat vrf Tenant_A_OP_Zone address 10.255.1.15
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
-ip routing vrf Tenant_A_APP_Zone
-ip routing vrf Tenant_A_DB_Zone
-ip routing vrf Tenant_A_OP_Zone
-ip routing vrf Tenant_A_WEB_Zone
-ip routing vrf Tenant_B_OP_Zone
-ip routing vrf Tenant_C_OP_Zone
+ip routing ipv6 interfaces vrf Tenant_A_APP_Zone
+ip routing ipv6 interfaces vrf Tenant_A_DB_Zone
+ip routing ipv6 interfaces vrf Tenant_A_OP_Zone
+ip routing ipv6 interfaces vrf Tenant_A_WEB_Zone
+ip routing ipv6 interfaces vrf Tenant_B_OP_Zone
+ip routing ipv6 interfaces vrf Tenant_C_OP_Zone
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 !
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.168.255.0/24 eq 32

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE1.cfg
@@ -87,11 +87,10 @@ interface Management1
    vrf MGMT
    ip address 192.168.200.101/24
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 !
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.168.255.0/24 eq 32

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE2.cfg
@@ -87,11 +87,10 @@ interface Management1
    vrf MGMT
    ip address 192.168.200.102/24
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 !
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.168.255.0/24 eq 32

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE3.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE3.cfg
@@ -87,11 +87,10 @@ interface Management1
    vrf MGMT
    ip address 192.168.200.103/24
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 !
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.168.255.0/24 eq 32

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE4.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE4.cfg
@@ -87,11 +87,10 @@ interface Management1
    vrf MGMT
    ip address 192.168.200.104/24
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 !
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.168.255.0/24 eq 32

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE5.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE5.cfg
@@ -53,11 +53,10 @@ interface Management1
    vrf MGMT
    ip address 192.168.200.105/24
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 !
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.168.255.0/24 eq 32

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE6.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE6.cfg
@@ -53,11 +53,10 @@ interface Management1
    vrf MGMT
    ip address 192.168.200.105/24
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 !
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.168.255.0/24 eq 32

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
@@ -544,20 +544,19 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 !
 ip address virtual source-nat vrf Tenant_A_OP_Zone address 10.255.1.8
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
-ip routing vrf Tenant_A_APP_Zone
-ip routing vrf Tenant_A_DB_Zone
-ip routing vrf Tenant_A_OP_Zone
-ip routing vrf Tenant_A_WAN_Zone
-ip routing vrf Tenant_A_WEB_Zone
-ip routing vrf Tenant_B_OP_Zone
-ip routing vrf Tenant_B_WAN_Zone
-ip routing vrf Tenant_C_OP_Zone
-ip routing vrf Tenant_C_WAN_Zone
+ip routing ipv6 interfaces vrf Tenant_A_APP_Zone
+ip routing ipv6 interfaces vrf Tenant_A_DB_Zone
+ip routing ipv6 interfaces vrf Tenant_A_OP_Zone
+ip routing ipv6 interfaces vrf Tenant_A_WAN_Zone
+ip routing ipv6 interfaces vrf Tenant_A_WEB_Zone
+ip routing ipv6 interfaces vrf Tenant_B_OP_Zone
+ip routing ipv6 interfaces vrf Tenant_B_WAN_Zone
+ip routing ipv6 interfaces vrf Tenant_C_OP_Zone
+ip routing ipv6 interfaces vrf Tenant_C_WAN_Zone
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 !
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.168.255.0/24 eq 32

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
@@ -531,20 +531,19 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 !
 ip address virtual source-nat vrf Tenant_A_OP_Zone address 10.255.1.9
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
-ip routing vrf Tenant_A_APP_Zone
-ip routing vrf Tenant_A_DB_Zone
-ip routing vrf Tenant_A_OP_Zone
-ip routing vrf Tenant_A_WAN_Zone
-ip routing vrf Tenant_A_WEB_Zone
-ip routing vrf Tenant_B_OP_Zone
-ip routing vrf Tenant_B_WAN_Zone
-ip routing vrf Tenant_C_OP_Zone
-ip routing vrf Tenant_C_WAN_Zone
+ip routing ipv6 interfaces vrf Tenant_A_APP_Zone
+ip routing ipv6 interfaces vrf Tenant_A_DB_Zone
+ip routing ipv6 interfaces vrf Tenant_A_OP_Zone
+ip routing ipv6 interfaces vrf Tenant_A_WAN_Zone
+ip routing ipv6 interfaces vrf Tenant_A_WEB_Zone
+ip routing ipv6 interfaces vrf Tenant_B_OP_Zone
+ip routing ipv6 interfaces vrf Tenant_B_WAN_Zone
+ip routing ipv6 interfaces vrf Tenant_C_OP_Zone
+ip routing ipv6 interfaces vrf Tenant_C_WAN_Zone
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 !
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.168.255.0/24 eq 32

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
@@ -181,7 +181,6 @@ static_routes:
   gateway: 1.2.3.4
   vrf: Tenant_A_WAN_Zone
 service_routing_protocols_model: multi-agent
-ip_routing: true
 ipv6_unicast_routing: true
 ip_routing_ipv6_interfaces: true
 daemon_terminattr:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
@@ -181,7 +181,6 @@ static_routes:
   gateway: 1.2.3.4
   vrf: Tenant_A_WAN_Zone
 service_routing_protocols_model: multi-agent
-ip_routing: true
 ipv6_unicast_routing: true
 ip_routing_ipv6_interfaces: true
 daemon_terminattr:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 ipv6_unicast_routing: true
 ip_routing_ipv6_interfaces: true
 daemon_terminattr:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 ipv6_unicast_routing: true
 ip_routing_ipv6_interfaces: true
 daemon_terminattr:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 ipv6_unicast_routing: true
 ip_routing_ipv6_interfaces: true
 daemon_terminattr:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
@@ -119,7 +119,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 ipv6_unicast_routing: true
 ip_routing_ipv6_interfaces: true
 daemon_terminattr:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -307,22 +307,22 @@ vrfs:
     ip_routing: false
   Tenant_A_APP_Zone:
     tenant: Tenant_A
-    ip_routing: true
+    ip_routing_ipv6_interfaces: true
   Tenant_A_DB_Zone:
     tenant: Tenant_A
-    ip_routing: true
+    ip_routing_ipv6_interfaces: true
   Tenant_A_OP_Zone:
     tenant: Tenant_A
-    ip_routing: true
+    ip_routing_ipv6_interfaces: true
   Tenant_A_WEB_Zone:
     tenant: Tenant_A
-    ip_routing: true
+    ip_routing_ipv6_interfaces: true
   Tenant_B_OP_Zone:
     tenant: Tenant_B
-    ip_routing: true
+    ip_routing_ipv6_interfaces: true
   Tenant_C_OP_Zone:
     tenant: Tenant_C
-    ip_routing: true
+    ip_routing_ipv6_interfaces: true
 management_interfaces:
   Management1:
     description: oob_management

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -264,7 +264,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 ipv6_unicast_routing: true
 ip_routing_ipv6_interfaces: true
 daemon_terminattr:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -307,22 +307,22 @@ vrfs:
     ip_routing: false
   Tenant_A_APP_Zone:
     tenant: Tenant_A
-    ip_routing: true
+    ip_routing_ipv6_interfaces: true
   Tenant_A_DB_Zone:
     tenant: Tenant_A
-    ip_routing: true
+    ip_routing_ipv6_interfaces: true
   Tenant_A_OP_Zone:
     tenant: Tenant_A
-    ip_routing: true
+    ip_routing_ipv6_interfaces: true
   Tenant_A_WEB_Zone:
     tenant: Tenant_A
-    ip_routing: true
+    ip_routing_ipv6_interfaces: true
   Tenant_B_OP_Zone:
     tenant: Tenant_B
-    ip_routing: true
+    ip_routing_ipv6_interfaces: true
   Tenant_C_OP_Zone:
     tenant: Tenant_C
-    ip_routing: true
+    ip_routing_ipv6_interfaces: true
 management_interfaces:
   Management1:
     description: oob_management

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -264,7 +264,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 ipv6_unicast_routing: true
 ip_routing_ipv6_interfaces: true
 daemon_terminattr:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF3A.yml
@@ -246,7 +246,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 ipv6_unicast_routing: true
 ip_routing_ipv6_interfaces: true
 daemon_terminattr:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF3A.yml
@@ -289,22 +289,22 @@ vrfs:
     ip_routing: false
   Tenant_A_APP_Zone:
     tenant: Tenant_A
-    ip_routing: true
+    ip_routing_ipv6_interfaces: true
   Tenant_A_DB_Zone:
     tenant: Tenant_A
-    ip_routing: true
+    ip_routing_ipv6_interfaces: true
   Tenant_A_OP_Zone:
     tenant: Tenant_A
-    ip_routing: true
+    ip_routing_ipv6_interfaces: true
   Tenant_A_WEB_Zone:
     tenant: Tenant_A
-    ip_routing: true
+    ip_routing_ipv6_interfaces: true
   Tenant_B_OP_Zone:
     tenant: Tenant_B
-    ip_routing: true
+    ip_routing_ipv6_interfaces: true
   Tenant_C_OP_Zone:
     tenant: Tenant_C
-    ip_routing: true
+    ip_routing_ipv6_interfaces: true
 management_interfaces:
   Management1:
     description: oob_management

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF3B.yml
@@ -246,7 +246,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 ipv6_unicast_routing: true
 ip_routing_ipv6_interfaces: true
 daemon_terminattr:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF3B.yml
@@ -289,22 +289,22 @@ vrfs:
     ip_routing: false
   Tenant_A_APP_Zone:
     tenant: Tenant_A
-    ip_routing: true
+    ip_routing_ipv6_interfaces: true
   Tenant_A_DB_Zone:
     tenant: Tenant_A
-    ip_routing: true
+    ip_routing_ipv6_interfaces: true
   Tenant_A_OP_Zone:
     tenant: Tenant_A
-    ip_routing: true
+    ip_routing_ipv6_interfaces: true
   Tenant_A_WEB_Zone:
     tenant: Tenant_A
-    ip_routing: true
+    ip_routing_ipv6_interfaces: true
   Tenant_B_OP_Zone:
     tenant: Tenant_B
-    ip_routing: true
+    ip_routing_ipv6_interfaces: true
   Tenant_C_OP_Zone:
     tenant: Tenant_C
-    ip_routing: true
+    ip_routing_ipv6_interfaces: true
 management_interfaces:
   Management1:
     description: oob_management

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF4A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF4A.yml
@@ -246,7 +246,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 ipv6_unicast_routing: true
 ip_routing_ipv6_interfaces: true
 daemon_terminattr:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF4A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF4A.yml
@@ -289,22 +289,22 @@ vrfs:
     ip_routing: false
   Tenant_A_APP_Zone:
     tenant: Tenant_A
-    ip_routing: true
+    ip_routing_ipv6_interfaces: true
   Tenant_A_DB_Zone:
     tenant: Tenant_A
-    ip_routing: true
+    ip_routing_ipv6_interfaces: true
   Tenant_A_OP_Zone:
     tenant: Tenant_A
-    ip_routing: true
+    ip_routing_ipv6_interfaces: true
   Tenant_A_WEB_Zone:
     tenant: Tenant_A
-    ip_routing: true
+    ip_routing_ipv6_interfaces: true
   Tenant_B_OP_Zone:
     tenant: Tenant_B
-    ip_routing: true
+    ip_routing_ipv6_interfaces: true
   Tenant_C_OP_Zone:
     tenant: Tenant_C
-    ip_routing: true
+    ip_routing_ipv6_interfaces: true
 management_interfaces:
   Management1:
     description: oob_management

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF4B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF4B.yml
@@ -246,7 +246,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 ipv6_unicast_routing: true
 ip_routing_ipv6_interfaces: true
 daemon_terminattr:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF4B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF4B.yml
@@ -289,22 +289,22 @@ vrfs:
     ip_routing: false
   Tenant_A_APP_Zone:
     tenant: Tenant_A
-    ip_routing: true
+    ip_routing_ipv6_interfaces: true
   Tenant_A_DB_Zone:
     tenant: Tenant_A
-    ip_routing: true
+    ip_routing_ipv6_interfaces: true
   Tenant_A_OP_Zone:
     tenant: Tenant_A
-    ip_routing: true
+    ip_routing_ipv6_interfaces: true
   Tenant_A_WEB_Zone:
     tenant: Tenant_A
-    ip_routing: true
+    ip_routing_ipv6_interfaces: true
   Tenant_B_OP_Zone:
     tenant: Tenant_B
-    ip_routing: true
+    ip_routing_ipv6_interfaces: true
   Tenant_C_OP_Zone:
     tenant: Tenant_C
-    ip_routing: true
+    ip_routing_ipv6_interfaces: true
 management_interfaces:
   Management1:
     description: oob_management

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE1.yml
@@ -98,7 +98,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 ipv6_unicast_routing: true
 ip_routing_ipv6_interfaces: true
 daemon_terminattr:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE2.yml
@@ -98,7 +98,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 ipv6_unicast_routing: true
 ip_routing_ipv6_interfaces: true
 daemon_terminattr:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE3.yml
@@ -98,7 +98,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 ipv6_unicast_routing: true
 ip_routing_ipv6_interfaces: true
 daemon_terminattr:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE4.yml
@@ -98,7 +98,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 ipv6_unicast_routing: true
 ip_routing_ipv6_interfaces: true
 daemon_terminattr:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE5.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE5.yml
@@ -62,7 +62,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 ipv6_unicast_routing: true
 ip_routing_ipv6_interfaces: true
 daemon_terminattr:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE6.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE6.yml
@@ -62,7 +62,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 ipv6_unicast_routing: true
 ip_routing_ipv6_interfaces: true
 daemon_terminattr:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -382,31 +382,31 @@ vrfs:
     ip_routing: false
   Tenant_A_APP_Zone:
     tenant: Tenant_A
-    ip_routing: true
+    ip_routing_ipv6_interfaces: true
   Tenant_A_DB_Zone:
     tenant: Tenant_A
-    ip_routing: true
+    ip_routing_ipv6_interfaces: true
   Tenant_A_OP_Zone:
     tenant: Tenant_A
-    ip_routing: true
+    ip_routing_ipv6_interfaces: true
   Tenant_A_WAN_Zone:
     tenant: Tenant_A
-    ip_routing: true
+    ip_routing_ipv6_interfaces: true
   Tenant_A_WEB_Zone:
     tenant: Tenant_A
-    ip_routing: true
+    ip_routing_ipv6_interfaces: true
   Tenant_B_OP_Zone:
     tenant: Tenant_B
-    ip_routing: true
+    ip_routing_ipv6_interfaces: true
   Tenant_B_WAN_Zone:
     tenant: Tenant_B
-    ip_routing: true
+    ip_routing_ipv6_interfaces: true
   Tenant_C_OP_Zone:
     tenant: Tenant_C
-    ip_routing: true
+    ip_routing_ipv6_interfaces: true
   Tenant_C_WAN_Zone:
     tenant: Tenant_C
-    ip_routing: true
+    ip_routing_ipv6_interfaces: true
 management_interfaces:
   Management1:
     description: oob_management

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -339,7 +339,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 ipv6_unicast_routing: true
 ip_routing_ipv6_interfaces: true
 daemon_terminattr:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -382,31 +382,31 @@ vrfs:
     ip_routing: false
   Tenant_A_APP_Zone:
     tenant: Tenant_A
-    ip_routing: true
+    ip_routing_ipv6_interfaces: true
   Tenant_A_DB_Zone:
     tenant: Tenant_A
-    ip_routing: true
+    ip_routing_ipv6_interfaces: true
   Tenant_A_OP_Zone:
     tenant: Tenant_A
-    ip_routing: true
+    ip_routing_ipv6_interfaces: true
   Tenant_A_WAN_Zone:
     tenant: Tenant_A
-    ip_routing: true
+    ip_routing_ipv6_interfaces: true
   Tenant_A_WEB_Zone:
     tenant: Tenant_A
-    ip_routing: true
+    ip_routing_ipv6_interfaces: true
   Tenant_B_OP_Zone:
     tenant: Tenant_B
-    ip_routing: true
+    ip_routing_ipv6_interfaces: true
   Tenant_B_WAN_Zone:
     tenant: Tenant_B
-    ip_routing: true
+    ip_routing_ipv6_interfaces: true
   Tenant_C_OP_Zone:
     tenant: Tenant_C
-    ip_routing: true
+    ip_routing_ipv6_interfaces: true
   Tenant_C_WAN_Zone:
     tenant: Tenant_C
-    ip_routing: true
+    ip_routing_ipv6_interfaces: true
 management_interfaces:
   Management1:
     description: oob_management

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -339,7 +339,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 ipv6_unicast_routing: true
 ip_routing_ipv6_interfaces: true
 daemon_terminattr:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-L2LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-L2LEAF1A.md
@@ -239,7 +239,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-L2LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-L2LEAF2A.md
@@ -351,7 +351,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-L2LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-L2LEAF2B.md
@@ -359,7 +359,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF1A.md
@@ -340,7 +340,7 @@ ip virtual-router mac-address 00:1c:73:00:dc:01
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2A.md
@@ -592,8 +592,8 @@ ip virtual-router mac-address 00:1c:73:00:dc:01
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| Common_VRF | true |
-| MGMT | false |
+| Common_VRF | True |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2B.md
@@ -619,8 +619,8 @@ ip virtual-router mac-address 00:1c:73:00:dc:01
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| Common_VRF | true |
-| MGMT | false |
+| Common_VRF | True |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-SPINE1.md
@@ -251,7 +251,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-SPINE2.md
@@ -268,7 +268,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-LEAF1A.md
@@ -394,8 +394,8 @@ ip virtual-router mac-address 00:1c:73:00:dc:01
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| Common_VRF | true |
-| MGMT | false |
+| Common_VRF | True |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-SPINE1.md
@@ -267,7 +267,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-SPINE2.md
@@ -259,7 +259,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-RS1.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-RS1.md
@@ -219,7 +219,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-RS2.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-RS2.md
@@ -247,7 +247,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-SUPER-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-SUPER-SPINE1.md
@@ -249,7 +249,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-SUPER-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-SUPER-SPINE2.md
@@ -275,7 +275,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-L2LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-L2LEAF1A.md
@@ -247,7 +247,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-LEAF1A.md
@@ -388,8 +388,8 @@ ip virtual-router mac-address 00:1c:73:00:dc:01
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| Common_VRF | true |
-| MGMT | false |
+| Common_VRF | True |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-SPINE1.md
@@ -258,7 +258,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-SPINE2.md
@@ -257,7 +257,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC2-RS1.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC2-RS1.md
@@ -238,7 +238,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC2-RS2.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC2-RS2.md
@@ -236,7 +236,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC2-SUPER-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC2-SUPER-SPINE1.md
@@ -286,7 +286,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC2-SUPER-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC2-SUPER-SPINE2.md
@@ -246,7 +246,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -523,12 +523,12 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
-| Tenant_A_WAN_Zone | true |
-| Tenant_B_OP_Zone | true |
-| Tenant_B_WAN_Zone | true |
-| Tenant_C_WAN_Zone | true |
-| Tenant_L3_VRF_Zone | true |
+| MGMT | False |
+| Tenant_A_WAN_Zone | True |
+| Tenant_B_OP_Zone | True |
+| Tenant_B_WAN_Zone | True |
+| Tenant_C_WAN_Zone | True |
+| Tenant_L3_VRF_Zone | True |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -521,12 +521,12 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
-| Tenant_A_WAN_Zone | true |
-| Tenant_B_OP_Zone | true |
-| Tenant_B_WAN_Zone | true |
-| Tenant_C_WAN_Zone | true |
-| Tenant_L3_VRF_Zone | true |
+| MGMT | False |
+| Tenant_A_WAN_Zone | True |
+| Tenant_B_OP_Zone | True |
+| Tenant_B_WAN_Zone | True |
+| Tenant_C_WAN_Zone | True |
+| Tenant_L3_VRF_Zone | True |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF1A.md
@@ -419,7 +419,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF1B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF1B.md
@@ -419,7 +419,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF2A.md
@@ -457,7 +457,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF2B.md
@@ -457,7 +457,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF3A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF3A.md
@@ -334,7 +334,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
@@ -498,9 +498,9 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
-| Tenant_A_APP_Zone | true |
-| Tenant_A_WEB_Zone | true |
+| MGMT | False |
+| Tenant_A_APP_Zone | True |
+| Tenant_A_WEB_Zone | True |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -771,13 +771,13 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
-| Tenant_A_APP_Zone | true |
-| Tenant_A_DB_Zone | true |
-| Tenant_A_OP_Zone | true |
-| Tenant_A_WEB_Zone | true |
-| Tenant_B_OP_Zone | true |
-| Tenant_C_OP_Zone | true |
+| MGMT | False |
+| Tenant_A_APP_Zone | True |
+| Tenant_A_DB_Zone | True |
+| Tenant_A_OP_Zone | True |
+| Tenant_A_WEB_Zone | True |
+| Tenant_B_OP_Zone | True |
+| Tenant_C_OP_Zone | True |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -771,13 +771,13 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
-| Tenant_A_APP_Zone | true |
-| Tenant_A_DB_Zone | true |
-| Tenant_A_OP_Zone | true |
-| Tenant_A_WEB_Zone | true |
-| Tenant_B_OP_Zone | true |
-| Tenant_C_OP_Zone | true |
+| MGMT | False |
+| Tenant_A_APP_Zone | True |
+| Tenant_A_DB_Zone | True |
+| Tenant_A_OP_Zone | True |
+| Tenant_A_WEB_Zone | True |
+| Tenant_B_OP_Zone | True |
+| Tenant_C_OP_Zone | True |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE1.md
@@ -345,7 +345,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE2.md
@@ -345,7 +345,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE3.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE3.md
@@ -345,7 +345,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE4.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE4.md
@@ -345,7 +345,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -1110,16 +1110,16 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
-| Tenant_A_APP_Zone | true |
-| Tenant_A_DB_Zone | true |
-| Tenant_A_OP_Zone | true |
-| Tenant_A_WAN_Zone | true |
-| Tenant_A_WEB_Zone | true |
-| Tenant_B_OP_Zone | true |
-| Tenant_B_WAN_Zone | true |
-| Tenant_C_OP_Zone | true |
-| Tenant_C_WAN_Zone | true |
+| MGMT | False |
+| Tenant_A_APP_Zone | True |
+| Tenant_A_DB_Zone | True |
+| Tenant_A_OP_Zone | True |
+| Tenant_A_WAN_Zone | True |
+| Tenant_A_WEB_Zone | True |
+| Tenant_B_OP_Zone | True |
+| Tenant_B_WAN_Zone | True |
+| Tenant_C_OP_Zone | True |
+| Tenant_C_WAN_Zone | True |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -1110,16 +1110,16 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
-| Tenant_A_APP_Zone | true |
-| Tenant_A_DB_Zone | true |
-| Tenant_A_OP_Zone | true |
-| Tenant_A_WAN_Zone | true |
-| Tenant_A_WEB_Zone | true |
-| Tenant_B_OP_Zone | true |
-| Tenant_B_WAN_Zone | true |
-| Tenant_C_OP_Zone | true |
-| Tenant_C_WAN_Zone | true |
+| MGMT | False |
+| Tenant_A_APP_Zone | True |
+| Tenant_A_DB_Zone | True |
+| Tenant_A_OP_Zone | True |
+| Tenant_A_WAN_Zone | True |
+| Tenant_A_WEB_Zone | True |
+| Tenant_B_OP_Zone | True |
+| Tenant_B_WAN_Zone | True |
+| Tenant_C_OP_Zone | True |
+| Tenant_C_WAN_Zone | True |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1A.md
@@ -517,7 +517,7 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1B.md
@@ -517,7 +517,7 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-L2LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-L2LEAF1A.md
@@ -270,7 +270,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-L2LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-L2LEAF2A.md
@@ -370,7 +370,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-L2LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-L2LEAF2B.md
@@ -370,7 +370,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF1A.md
@@ -378,7 +378,7 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2A.md
@@ -532,7 +532,7 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2B.md
@@ -532,7 +532,7 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE1.md
@@ -360,7 +360,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE2.md
@@ -358,7 +358,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE3.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE3.md
@@ -358,7 +358,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE4.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE4.md
@@ -360,7 +360,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3A.md
@@ -538,7 +538,7 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3B.md
@@ -538,7 +538,7 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -487,7 +487,7 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -487,7 +487,7 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-L2LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-L2LEAF1A.md
@@ -270,7 +270,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-L2LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-L2LEAF2A.md
@@ -370,7 +370,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-L2LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-L2LEAF2B.md
@@ -370,7 +370,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
@@ -355,7 +355,7 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -502,7 +502,7 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -502,7 +502,7 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE1.md
@@ -335,7 +335,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE2.md
@@ -335,7 +335,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE3.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE3.md
@@ -335,7 +335,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE4.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE4.md
@@ -335,7 +335,7 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -508,7 +508,7 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -508,7 +508,7 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| MGMT | false |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -467,17 +467,17 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
-| MGMT | false |
-| Tenant_A_WAN_Zone | true |
-| Tenant_B_WAN_Zone | true |
-| Tenant_C_WAN_Zone | true |
+| default | True (ipv6 interfaces) |
+| MGMT | False |
+| Tenant_A_WAN_Zone | True |
+| Tenant_B_WAN_Zone | True |
+| Tenant_C_WAN_Zone | True |
 
 ### IP Routing Device Configuration
 
 ```eos
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
 ip routing vrf Tenant_A_WAN_Zone
 ip routing vrf Tenant_B_WAN_Zone
@@ -500,7 +500,6 @@ ip routing vrf Tenant_C_WAN_Zone
 ```eos
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 ```
 
 ## Static Routes

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -466,17 +466,17 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
-| MGMT | false |
-| Tenant_A_WAN_Zone | true |
-| Tenant_B_WAN_Zone | true |
-| Tenant_C_WAN_Zone | true |
+| default | True (ipv6 interfaces) |
+| MGMT | False |
+| Tenant_A_WAN_Zone | True |
+| Tenant_B_WAN_Zone | True |
+| Tenant_C_WAN_Zone | True |
 
 ### IP Routing Device Configuration
 
 ```eos
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
 ip routing vrf Tenant_A_WAN_Zone
 ip routing vrf Tenant_B_WAN_Zone
@@ -499,7 +499,6 @@ ip routing vrf Tenant_C_WAN_Zone
 ```eos
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 ```
 
 ## Static Routes

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-L2LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-L2LEAF1A.md
@@ -316,14 +316,14 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
-| MGMT | false |
+| default | True (ipv6 interfaces) |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 
 ```eos
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
 ```
 ## IPv6 Routing
@@ -340,7 +340,6 @@ no ip routing vrf MGMT
 ```eos
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 ```
 
 ## Static Routes

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-L2LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-L2LEAF2A.md
@@ -439,14 +439,14 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
-| MGMT | false |
+| default | True (ipv6 interfaces) |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 
 ```eos
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
 ```
 ## IPv6 Routing
@@ -463,7 +463,6 @@ no ip routing vrf MGMT
 ```eos
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 ```
 
 ## Static Routes

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-L2LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-L2LEAF2B.md
@@ -439,14 +439,14 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
-| MGMT | false |
+| default | True (ipv6 interfaces) |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 
 ```eos
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
 ```
 ## IPv6 Routing
@@ -463,7 +463,6 @@ no ip routing vrf MGMT
 ```eos
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 ```
 
 ## Static Routes

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
@@ -489,16 +489,16 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
-| MGMT | false |
-| Tenant_A_APP_Zone | true |
-| Tenant_A_WEB_Zone | true |
+| default | True (ipv6 interfaces) |
+| MGMT | False |
+| Tenant_A_APP_Zone | True |
+| Tenant_A_WEB_Zone | True |
 
 ### IP Routing Device Configuration
 
 ```eos
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
 ip routing vrf Tenant_A_APP_Zone
 ip routing vrf Tenant_A_WEB_Zone
@@ -519,7 +519,6 @@ ip routing vrf Tenant_A_WEB_Zone
 ```eos
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 ```
 
 ## Static Routes

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -851,20 +851,20 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
-| MGMT | false |
-| Tenant_A_APP_Zone | true |
-| Tenant_A_DB_Zone | true |
-| Tenant_A_OP_Zone | true |
-| Tenant_A_WEB_Zone | true |
-| Tenant_B_OP_Zone | true |
-| Tenant_C_OP_Zone | true |
+| default | True (ipv6 interfaces) |
+| MGMT | False |
+| Tenant_A_APP_Zone | True |
+| Tenant_A_DB_Zone | True |
+| Tenant_A_OP_Zone | True |
+| Tenant_A_WEB_Zone | True |
+| Tenant_B_OP_Zone | True |
+| Tenant_C_OP_Zone | True |
 
 ### IP Routing Device Configuration
 
 ```eos
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
 ip routing vrf Tenant_A_APP_Zone
 ip routing vrf Tenant_A_DB_Zone
@@ -893,7 +893,6 @@ ip routing vrf Tenant_C_OP_Zone
 ```eos
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 ```
 
 ## Static Routes

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -851,20 +851,20 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
-| MGMT | false |
-| Tenant_A_APP_Zone | true |
-| Tenant_A_DB_Zone | true |
-| Tenant_A_OP_Zone | true |
-| Tenant_A_WEB_Zone | true |
-| Tenant_B_OP_Zone | true |
-| Tenant_C_OP_Zone | true |
+| default | True (ipv6 interfaces) |
+| MGMT | False |
+| Tenant_A_APP_Zone | True |
+| Tenant_A_DB_Zone | True |
+| Tenant_A_OP_Zone | True |
+| Tenant_A_WEB_Zone | True |
+| Tenant_B_OP_Zone | True |
+| Tenant_C_OP_Zone | True |
 
 ### IP Routing Device Configuration
 
 ```eos
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
 ip routing vrf Tenant_A_APP_Zone
 ip routing vrf Tenant_A_DB_Zone
@@ -893,7 +893,6 @@ ip routing vrf Tenant_C_OP_Zone
 ```eos
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 ```
 
 ## Static Routes

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE1.md
@@ -320,14 +320,14 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
-| MGMT | false |
+| default | True (ipv6 interfaces) |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 
 ```eos
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
 ```
 ## IPv6 Routing
@@ -344,7 +344,6 @@ no ip routing vrf MGMT
 ```eos
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 ```
 
 ## Static Routes

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE2.md
@@ -320,14 +320,14 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
-| MGMT | false |
+| default | True (ipv6 interfaces) |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 
 ```eos
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
 ```
 ## IPv6 Routing
@@ -344,7 +344,6 @@ no ip routing vrf MGMT
 ```eos
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 ```
 
 ## Static Routes

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE3.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE3.md
@@ -320,14 +320,14 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
-| MGMT | false |
+| default | True (ipv6 interfaces) |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 
 ```eos
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
 ```
 ## IPv6 Routing
@@ -344,7 +344,6 @@ no ip routing vrf MGMT
 ```eos
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 ```
 
 ## Static Routes

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE4.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE4.md
@@ -320,14 +320,14 @@ service routing protocols model multi-agent
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
-| MGMT | false |
+| default | True (ipv6 interfaces) |
+| MGMT | False |
 
 ### IP Routing Device Configuration
 
 ```eos
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
 ```
 ## IPv6 Routing
@@ -344,7 +344,6 @@ no ip routing vrf MGMT
 ```eos
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 ```
 
 ## Static Routes

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -1016,23 +1016,23 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
-| MGMT | false |
-| Tenant_A_APP_Zone | true |
-| Tenant_A_DB_Zone | true |
-| Tenant_A_OP_Zone | true |
-| Tenant_A_WAN_Zone | true |
-| Tenant_A_WEB_Zone | true |
-| Tenant_B_OP_Zone | true |
-| Tenant_B_WAN_Zone | true |
-| Tenant_C_OP_Zone | true |
-| Tenant_C_WAN_Zone | true |
+| default | True (ipv6 interfaces) |
+| MGMT | False |
+| Tenant_A_APP_Zone | True |
+| Tenant_A_DB_Zone | True |
+| Tenant_A_OP_Zone | True |
+| Tenant_A_WAN_Zone | True |
+| Tenant_A_WEB_Zone | True |
+| Tenant_B_OP_Zone | True |
+| Tenant_B_WAN_Zone | True |
+| Tenant_C_OP_Zone | True |
+| Tenant_C_WAN_Zone | True |
 
 ### IP Routing Device Configuration
 
 ```eos
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
 ip routing vrf Tenant_A_APP_Zone
 ip routing vrf Tenant_A_DB_Zone
@@ -1067,7 +1067,6 @@ ip routing vrf Tenant_C_WAN_Zone
 ```eos
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 ```
 
 ## Static Routes

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -1001,23 +1001,23 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | True |
-| MGMT | false |
-| Tenant_A_APP_Zone | true |
-| Tenant_A_DB_Zone | true |
-| Tenant_A_OP_Zone | true |
-| Tenant_A_WAN_Zone | true |
-| Tenant_A_WEB_Zone | true |
-| Tenant_B_OP_Zone | true |
-| Tenant_B_WAN_Zone | true |
-| Tenant_C_OP_Zone | true |
-| Tenant_C_WAN_Zone | true |
+| default | True (ipv6 interfaces) |
+| MGMT | False |
+| Tenant_A_APP_Zone | True |
+| Tenant_A_DB_Zone | True |
+| Tenant_A_OP_Zone | True |
+| Tenant_A_WAN_Zone | True |
+| Tenant_A_WEB_Zone | True |
+| Tenant_B_OP_Zone | True |
+| Tenant_B_WAN_Zone | True |
+| Tenant_C_OP_Zone | True |
+| Tenant_C_WAN_Zone | True |
 
 ### IP Routing Device Configuration
 
 ```eos
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
 ip routing vrf Tenant_A_APP_Zone
 ip routing vrf Tenant_A_DB_Zone
@@ -1052,7 +1052,6 @@ ip routing vrf Tenant_C_WAN_Zone
 ```eos
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 ```
 
 ## Static Routes

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-BL1A.cfg
@@ -130,14 +130,13 @@ hardware tcam
 !
 ip virtual-router mac-address 00:dc:00:00:00:0a
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
 ip routing vrf Tenant_A_WAN_Zone
 ip routing vrf Tenant_B_WAN_Zone
 ip routing vrf Tenant_C_WAN_Zone
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 !
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.168.255.0/24 eq 32

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-BL1B.cfg
@@ -130,14 +130,13 @@ hardware tcam
 !
 ip virtual-router mac-address 00:dc:00:00:00:0a
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
 ip routing vrf Tenant_A_WAN_Zone
 ip routing vrf Tenant_B_WAN_Zone
 ip routing vrf Tenant_C_WAN_Zone
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 !
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.168.255.0/24 eq 32

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-L2LEAF1A.cfg
@@ -77,11 +77,10 @@ interface Management1
    vrf MGMT
    ip address 192.168.200.112/24
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 !
 ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 !

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-L2LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-L2LEAF2A.cfg
@@ -135,11 +135,10 @@ interface Vlan4094
    no autostate
    ip address 10.255.252.16/31
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 !
 mlag configuration
    domain-id DC1_L2LEAF2

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-L2LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-L2LEAF2B.cfg
@@ -135,11 +135,10 @@ interface Vlan4094
    no autostate
    ip address 10.255.252.17/31
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 !
 mlag configuration
    domain-id DC1_L2LEAF2

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF1A.cfg
@@ -154,13 +154,12 @@ hardware tcam
 !
 ip virtual-router mac-address 00:dc:00:00:00:0a
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
 ip routing vrf Tenant_A_APP_Zone
 ip routing vrf Tenant_A_WEB_Zone
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 !
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.168.255.0/24 eq 32

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
@@ -402,7 +402,7 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 !
 ip address virtual source-nat vrf Tenant_A_OP_Zone address 10.255.1.6
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
 ip routing vrf Tenant_A_APP_Zone
 ip routing vrf Tenant_A_DB_Zone
@@ -412,7 +412,6 @@ ip routing vrf Tenant_B_OP_Zone
 ip routing vrf Tenant_C_OP_Zone
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 !
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.168.255.0/24 eq 32

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
@@ -402,7 +402,7 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 !
 ip address virtual source-nat vrf Tenant_A_OP_Zone address 10.255.1.7
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
 ip routing vrf Tenant_A_APP_Zone
 ip routing vrf Tenant_A_DB_Zone
@@ -412,7 +412,6 @@ ip routing vrf Tenant_B_OP_Zone
 ip routing vrf Tenant_C_OP_Zone
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 !
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.168.255.0/24 eq 32

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE1.cfg
@@ -87,11 +87,10 @@ interface Management1
    vrf MGMT
    ip address 192.168.200.101/24
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 !
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.168.255.0/24 eq 32

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE2.cfg
@@ -87,11 +87,10 @@ interface Management1
    vrf MGMT
    ip address 192.168.200.102/24
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 !
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.168.255.0/24 eq 32

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE3.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE3.cfg
@@ -87,11 +87,10 @@ interface Management1
    vrf MGMT
    ip address 192.168.200.103/24
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 !
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.168.255.0/24 eq 32

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE4.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE4.cfg
@@ -87,11 +87,10 @@ interface Management1
    vrf MGMT
    ip address 192.168.200.104/24
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 !
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.168.255.0/24 eq 32

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
@@ -544,7 +544,7 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 !
 ip address virtual source-nat vrf Tenant_A_OP_Zone address 10.255.1.8
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
 ip routing vrf Tenant_A_APP_Zone
 ip routing vrf Tenant_A_DB_Zone
@@ -557,7 +557,6 @@ ip routing vrf Tenant_C_OP_Zone
 ip routing vrf Tenant_C_WAN_Zone
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 !
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.168.255.0/24 eq 32

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
@@ -531,7 +531,7 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 !
 ip address virtual source-nat vrf Tenant_A_OP_Zone address 10.255.1.9
 !
-ip routing
+ip routing ipv6 interfaces
 no ip routing vrf MGMT
 ip routing vrf Tenant_A_APP_Zone
 ip routing vrf Tenant_A_DB_Zone
@@ -544,7 +544,6 @@ ip routing vrf Tenant_C_OP_Zone
 ip routing vrf Tenant_C_WAN_Zone
 !
 ipv6 unicast-routing
-ip routing ipv6 interfaces
 !
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.168.255.0/24 eq 32

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
@@ -175,7 +175,6 @@ static_routes:
   gateway: 1.2.3.4
   vrf: Tenant_A_WAN_Zone
 service_routing_protocols_model: multi-agent
-ip_routing: true
 ipv6_unicast_routing: true
 ip_routing_ipv6_interfaces: true
 daemon_terminattr:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
@@ -175,7 +175,6 @@ static_routes:
   gateway: 1.2.3.4
   vrf: Tenant_A_WAN_Zone
 service_routing_protocols_model: multi-agent
-ip_routing: true
 ipv6_unicast_routing: true
 ip_routing_ipv6_interfaces: true
 daemon_terminattr:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 ipv6_unicast_routing: true
 ip_routing_ipv6_interfaces: true
 daemon_terminattr:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 ipv6_unicast_routing: true
 ip_routing_ipv6_interfaces: true
 daemon_terminattr:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -3,7 +3,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 ipv6_unicast_routing: true
 ip_routing_ipv6_interfaces: true
 daemon_terminattr:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
@@ -121,7 +121,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 ipv6_unicast_routing: true
 ip_routing_ipv6_interfaces: true
 daemon_terminattr:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -254,7 +254,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 ipv6_unicast_routing: true
 ip_routing_ipv6_interfaces: true
 daemon_terminattr:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -254,7 +254,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 ipv6_unicast_routing: true
 ip_routing_ipv6_interfaces: true
 daemon_terminattr:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE1.yml
@@ -98,7 +98,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 ipv6_unicast_routing: true
 ip_routing_ipv6_interfaces: true
 daemon_terminattr:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE2.yml
@@ -98,7 +98,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 ipv6_unicast_routing: true
 ip_routing_ipv6_interfaces: true
 daemon_terminattr:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE3.yml
@@ -98,7 +98,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 ipv6_unicast_routing: true
 ip_routing_ipv6_interfaces: true
 daemon_terminattr:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE4.yml
@@ -98,7 +98,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 ipv6_unicast_routing: true
 ip_routing_ipv6_interfaces: true
 daemon_terminattr:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -323,7 +323,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 ipv6_unicast_routing: true
 ip_routing_ipv6_interfaces: true
 daemon_terminattr:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -323,7 +323,6 @@ static_routes:
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
-ip_routing: true
 ipv6_unicast_routing: true
 ip_routing_ipv6_interfaces: true
 daemon_terminattr:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -6709,6 +6709,10 @@ vmtracer_sessions:
 
 ## VRFs
 
+### Description
+
+These keys are ignored if the name of the vrf is 'default'
+
 ### Variables
 
 | Variable | Type | Required | Default | Value Restrictions | Description |
@@ -6718,6 +6722,7 @@ vmtracer_sessions:
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;description</samp>](## "vrfs.[].description") | String |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_routing</samp>](## "vrfs.[].ip_routing") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_routing</samp>](## "vrfs.[].ipv6_routing") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_routing_ipv6_interfaces</samp>](## "vrfs.[].ip_routing_ipv6_interfaces") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;tenant</samp>](## "vrfs.[].tenant") | String |  |  |  | Key only used for documentation or validation purposes |
 
 ### YAML
@@ -6728,6 +6733,7 @@ vrfs:
     description: <str>
     ip_routing: <bool>
     ipv6_routing: <bool>
+    ip_routing_ipv6_interfaces: <bool>
     tenant: <str>
 ```
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -15103,6 +15103,7 @@
     },
     "vrfs": {
       "type": "array",
+      "description": "These keys are ignored if the name of the vrf is 'default'\n",
       "items": {
         "type": "object",
         "properties": {
@@ -15122,6 +15123,10 @@
           "ipv6_routing": {
             "type": "boolean",
             "title": "IPv6 Routing"
+          },
+          "ip_routing_ipv6_interfaces": {
+            "type": "boolean",
+            "title": "IP Routing IPv6 Interfaces"
           },
           "tenant": {
             "type": "string",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -10185,6 +10185,9 @@ keys:
   vrfs:
     type: list
     primary_key: name
+    description: 'These keys are ignored if the name of the vrf is ''default''
+
+      '
     convert_types:
     - dict
     items:
@@ -10198,6 +10201,8 @@ keys:
         ip_routing:
           type: bool
         ipv6_routing:
+          type: bool
+        ip_routing_ipv6_interfaces:
           type: bool
         tenant:
           type: str

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/vrfs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/vrfs.schema.yml
@@ -6,6 +6,8 @@ keys:
   vrfs:
     type: list
     primary_key: name
+    description: |
+      These keys are ignored if the name of the vrf is 'default'
     convert_types:
       - dict
     items:
@@ -19,6 +21,8 @@ keys:
         ip_routing:
           type: bool
         ipv6_routing:
+          type: bool
+        ip_routing_ipv6_interfaces:
           type: bool
         tenant:
           type: str

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ip-routing.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ip-routing.j2
@@ -6,13 +6,18 @@
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | {{ ip_routing | arista.avd.default(false) }} |
-{% for vrf in vrfs | arista.avd.natural_sort('name') %}
-{%     if vrf.ip_routing is arista.avd.defined(true) %}
-| {{ vrf.name }} | true |
-{%     elif vrf.ip_routing is arista.avd.defined(false) %}
-| {{ vrf.name }} | false |
+{# TODO - this currently does not handle when vrf default enables ip routing #}
+{% set default_ip_routing = ip_routing | arista.avd.default(false) %}
+{% if ip_routing_ipv6_interfaces | arista.avd.default(false) %}
+{%     set default_ip_routing = "True (ipv6 interfaces)" %}
+{% endif %}
+| default | {{ default_ip_routing }} |
+{% for vrf in vrfs | arista.avd.default([]) | rejectattr("name", "arista.avd.defined", "default") | arista.avd.natural_sort('name') %}
+{%     set ip_routing = vrf.ip_routing | arista.avd.default("-") %}
+{%     if vrf.ip_routing_ipv6_interfaces | arista.avd.default(false) %}
+{%         set ip_routing = "True (ipv6 interfaces)" %}
 {%     endif %}
+| {{ vrf.name }} | {{ ip_routing }} |
 {% endfor %}
 
 ### IP Routing Device Configuration

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ipv6-unicast-routing.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ipv6-unicast-routing.j2
@@ -22,7 +22,6 @@
 
 ```eos
 {%     include 'eos/ipv6-unicast-routing.j2' %}
-{%     include 'eos/ip-routing-ipv6-interfaces.j2' %}
 {%     include 'eos/ipv6-unicast-routing-vrfs.j2' %}
 {%     include 'eos/ipv6-icmp-redirect.j2' %}
 {%     include 'eos/ipv6-hardware.j2' %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vrfs.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vrfs.j2
@@ -7,8 +7,10 @@
 
 | VRF Name | IP Routing |
 | -------- | ---------- |
-{%     for vrf in vrfs | arista.avd.natural_sort('name') %}
-{%         if vrf.ip_routing is arista.avd.defined(true) %}
+{%     for vrf in vrfs | arista.avd.default([]) | rejectattr("name", "arista.avd.defined", "default") | arista.avd.natural_sort('name') %}
+{%         if vrf.ip_routing_ipv6_interfaces is arista.avd.defined(true) %}
+{%             set ip_routing = "enabled (ipv6 interface)" %}
+{%         elif vrf.ip_routing is arista.avd.defined(true) %}
 {%             set ip_routing = 'enabled' %}
 {%         else %}
 {%             set ip_routing = 'disabled' %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-intended-config.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-intended-config.j2
@@ -170,8 +170,6 @@
 {% include 'eos/ip-routing-vrfs.j2' %}
 {# IPv6 Unicast Routing #}
 {% include 'eos/ipv6-unicast-routing.j2' %}
-{# eos - IP Routing IPv6 Interfaces #}
-{% include 'eos/ip-routing-ipv6-interfaces.j2' %}
 {# eos - IPv6 Unicast Routing VRFs #}
 {% include 'eos/ipv6-unicast-routing-vrfs.j2' %}
 {# eos - IPv6 ICMP Redirect #}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ip-routing-ipv6-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ip-routing-ipv6-interfaces.j2
@@ -1,4 +1,0 @@
-{# eos - ip routing ipv6 interfaces #}
-{% if ip_routing_ipv6_interfaces is arista.avd.defined(true) %}
-ip routing ipv6 interfaces
-{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ip-routing-vrfs.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ip-routing-vrfs.j2
@@ -1,6 +1,8 @@
 {# eos - ip routing vrfs #}
 {% for vrf in vrfs | arista.avd.natural_sort('name') %}
-{%     if vrf.ip_routing is arista.avd.defined(true) and vrf.name != 'default' %}
+{%     if vrf.ip_routing_ipv6_interfaces is arista.avd.defined(true) and vrf.name != 'default' %}
+ip routing ipv6 interfaces vrf {{ vrf.name }}
+{%     elif vrf.ip_routing is arista.avd.defined(true) and vrf.name != 'default' %}
 ip routing vrf {{ vrf.name }}
 {%     elif vrf.ip_routing is arista.avd.defined(false) and vrf.name != 'default' %}
 no ip routing vrf {{ vrf.name }}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ip-routing.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ip-routing.j2
@@ -1,5 +1,9 @@
 {# eos - ip routing #}
-{% if ip_routing is arista.avd.defined(true) %}
+{# TODO - this currently does not handle when vrf default enables ip routing #}
+{% if ip_routing_ipv6_interfaces is arista.avd.defined(true) %}
+!
+ip routing ipv6 interfaces
+{% elif ip_routing is arista.avd.defined(true) %}
 !
 ip routing
 {% elif ip_routing is arista.avd.defined(false) %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ipv6-unicast-routing-vrfs.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ipv6-unicast-routing-vrfs.j2
@@ -1,6 +1,6 @@
 {# eos - ipv6 unicast routing vrfs #}
 {% for vrf in vrfs | arista.avd.natural_sort('name') %}
-{%     if vrf.ipv6_routing is arista.avd.defined(true) %}
+{%     if vrf.ipv6_routing is arista.avd.defined(true) and vrf.name != 'default' %}
 {%         if loop.first %}
 !
 {%         endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/base/avdstructuredconfig.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/base/avdstructuredconfig.py
@@ -115,8 +115,11 @@ class AvdStructuredConfig(AvdFacts):
     @cached_property
     def ip_routing(self):
         """
-        ip_routing set to True
+        ip routing set to False if ip_routing_ipv6_interfaces is set to True as the command will have precedence
+        ip_routing set to True otherwise
         """
+        if self.ip_routing_ipv6_interfaces is True:
+            return None
         return True
 
     @cached_property

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/vrfs.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/vrfs.py
@@ -40,8 +40,14 @@ class VrfsMixin(UtilsMixin):
 
                 new_vrf = {
                     "tenant": tenant["name"],
-                    "ip_routing": True,
                 }
+
+                # MLAG IBGP Peering VLANs per VRF
+                if self._overlay_mlag_rfc5549 and self._mlag_ibgp_peering_enabled(vrf, tenant):
+                    new_vrf["ip_routing_ipv6_interfaces"] = True
+                else:
+                    new_vrf["ip_routing"] = True
+
                 if self._has_ipv6(vrf):
                     new_vrf["ipv6_routing"] = True
 


### PR DESCRIPTION
Partial Cherry-pick #2660

- addressed conflicts in molecule scenario
- addressed conflicts on eos_cli_config_gen/templates/documentation/ipv6-unicast-routing.j2
- addressed conflicts on eos_cli_config_gen/templates/documentation/ip-routing.j2