### PR TITLE
Fix(eos_designs): Avoid configuring trunk-group twice on mlag peer-link if using the same name (#2658)

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l3leaf2b.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l3leaf2b.cfg
@@ -15,25 +15,25 @@ no aaa root
 !
 vlan 200
    name svi200_with_trunk_groups
-   trunk group MLAG
+   trunk group CUSTOM_MLAG_TG_NAME
    trunk group trunk-group-tests-l2leaf4
 !
 vlan 210
    name l2vlan210_with_trunk_groups
-   trunk group MLAG
+   trunk group CUSTOM_MLAG_TG_NAME
    trunk group trunk-group-tests-l2leaf4
 !
 vlan 3199
    name MLAG_iBGP_TG_200
-   trunk group LEAF_PEER_L3
+   trunk group CUSTOM_MLAG_TG_NAME
 !
 vlan 4093
    name LEAF_PEER_L3
-   trunk group LEAF_PEER_L3
+   trunk group CUSTOM_MLAG_TG_NAME
 !
 vlan 4094
    name MLAG_PEER
-   trunk group MLAG
+   trunk group CUSTOM_MLAG_TG_NAME
 !
 vrf instance MGMT
 !
@@ -53,8 +53,7 @@ interface Port-Channel3
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
-   switchport trunk group LEAF_PEER_L3
-   switchport trunk group MLAG
+   switchport trunk group CUSTOM_MLAG_TG_NAME
 !
 interface Ethernet1
    description TRUNK-GROUP-TESTS-L2LEAF4_Ethernet2

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf2b.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf2b.yml
@@ -103,29 +103,29 @@ vlans:
     tenant: system
     name: LEAF_PEER_L3
     trunk_groups:
-    - LEAF_PEER_L3
+    - CUSTOM_MLAG_TG_NAME
   4094:
     tenant: system
     name: MLAG_PEER
     trunk_groups:
-    - MLAG
+    - CUSTOM_MLAG_TG_NAME
   200:
     trunk_groups:
     - trunk-group-tests-l2leaf4
-    - MLAG
+    - CUSTOM_MLAG_TG_NAME
     tenant: TRUNK_GROUP_TESTS
     name: svi200_with_trunk_groups
   210:
     trunk_groups:
     - trunk-group-tests-l2leaf4
-    - MLAG
+    - CUSTOM_MLAG_TG_NAME
     tenant: TRUNK_GROUP_TESTS
     name: l2vlan210_with_trunk_groups
   3199:
     tenant: TRUNK_GROUP_TESTS
     name: MLAG_iBGP_TG_200
     trunk_groups:
-    - LEAF_PEER_L3
+    - CUSTOM_MLAG_TG_NAME
 vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING
@@ -163,8 +163,7 @@ port_channel_interfaces:
     vlans: 2-4094
     mode: trunk
     trunk_groups:
-    - LEAF_PEER_L3
-    - MLAG
+    - CUSTOM_MLAG_TG_NAME
   Port-Channel1:
     description: TRUNK-GROUP-TESTS-L2LEAF4_Po1
     type: switched

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/trunk-group-tests-l3leaf2b.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/trunk-group-tests-l3leaf2b.yml
@@ -2,3 +2,11 @@
 # Testing "only_local_vlan_trunk_groups: true" set in hostvars to see
 # that only TG_200 and UPLINK are set on vlans 2xx
 only_local_vlan_trunk_groups: true
+
+# Test using the same custom name on mlag & mlag_l3
+trunk_groups:
+  mlag:
+    name: "CUSTOM_MLAG_TG_NAME"
+  mlag_l3:
+    # Testing using the same name on mlag & mlag_l3
+    name: "CUSTOM_MLAG_TG_NAME"

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/mlag/avdstructuredconfig.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/mlag/avdstructuredconfig.py
@@ -217,9 +217,10 @@ class AvdStructuredConfig(AvdFacts):
             "struct_cfg": get(self._hostvars, "switch.mlag_port_channel_structured_config"),
         }
 
-        if self._mlag_l3 is True:
+        if self._mlag_l3 is True and self._trunk_groups_mlag_l3_name != self._trunk_groups_mlag_name:
             # Add LEAF_PEER_L3 even if we reuse the MLAG trunk group for underlay peering
             # since this trunk group is also used for overlay iBGP peerings
+            # except in the case where the same trunk group name is defined.
             port_channel_interface["trunk_groups"].append(self._trunk_groups_mlag_l3_name)
             # Retain legacy order
             port_channel_interface["trunk_groups"].reverse()


### PR DESCRIPTION
Partial cherry-pick #2658 for release 3.8.5.

Note: update molecule scenario.
