### PR TITLE
Bump(requirements): ansible.utils to ">=2.9.0"

### DIFF
--- a/ansible_collections/arista/avd/collections.yml
+++ b/ansible_collections/arista/avd/collections.yml
@@ -2,5 +2,7 @@
 collections:
   - name: arista.cvp
   - name: arista.eos
+  - name: ansible.utils
+    version: ">=2.9.0"
   - name: ansible.netcommon
     version: ">=2.4.0,!=2.6.0"

--- a/ansible_collections/arista/avd/galaxy.yml
+++ b/ansible_collections/arista/avd/galaxy.yml
@@ -39,6 +39,7 @@ tags: ['arista', 'network', 'networking', 'eos', 'avd', 'cloudvision', 'cvp']
 dependencies:
     "arista.cvp": ">=3.2.0"
     "arista.eos": ">=3.1.0"
+    "ansible.utils": ">=2.9.0"
     "ansible.netcommon": ">=2.4.0,!=2.6.0"
 
 # The URL of the originating SCM repository


### PR DESCRIPTION
## Change Summary

Bump ansible.utils to ">=2.9.0"

## Issue

Fixes issue seen in eos_designs documentation template seen with `ansible.utils==2.5.0`:

```shell
unsupported operand type(s) for /: 'int' and 'list'. unsupported operand type(s) for /: 'int' and 'list'. Unexpected templating type error occurred on ({% set node_types = node_type_keys | arista.avd.convert_dicts('key') | map(attribute="type") %}
```

Cause by this line:

```jinja
{% set size = vtep_loopback_network_summary | ansible.utils.ipaddr('size') %}
```


