### PR TITLE
CI: Make devel-push docker-build fail when the curl call fails

### DIFF
--- a/.github/workflows/devel-push.yml
+++ b/.github/workflows/devel-push.yml
@@ -65,23 +65,32 @@ jobs:
 
   # ----------------------------------- #
   # Rebuild docker base image
+  #
+  # secrets.AVD_BUILDER_TOKEN needs to be a Personal Access Token to the remote
+  # repository which is https://github.com/arista-netdevops-community/docker-avd-base
+  #
+  # The PAT needs to have specific permissions as described here
+  # https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#create-a-repository-dispatch-event
+  #
+  # PAT on arista-netdevops-community are allowed and required to be approved by
+  # admins of the organization
+  #
+  # current PAT belongs to @gmuloc
+  #
   # ----------------------------------- #
   docker_build:
     name: Webhook to Docker Hub to build image
     runs-on: ubuntu-20.04
-    container: avdteam/base:3.8-v2.0
     needs: file-changes
     if: needs.file-changes.outputs.requirements == 'true'
     steps:
       - uses: actions/checkout@v3
       - name: 'Send Webhook to docker hub'
-        env:
-          AUTH_TOKEN: ${{secrets.AVD_BUILDER_TOKEN}}
-          AVD_BASE_DISPATCH: ${{secrets.AVD_BUILDER_WEBHOOK}}
         run: |
           curl \
           -X POST \
           -H "Accept: application/vnd.github.v3+json" \
-          -H "Authorization: token $AUTH_TOKEN" \
-          https://api.github.com/repos/$AVD_BASE_DISPATCH/dispatches \
-          -d '{"event_type":"refresh"}'
+          -H "Authorization: token ${{secrets.AVD_BUILDER_TOKEN}}" \
+          https://api.github.com/repos/arista-netdevops-community/docker-avd-bas/dispatches \
+          -d '{"event_type":"refresh"}' \
+          -f

--- a/.github/workflows/devel-push.yml
+++ b/.github/workflows/devel-push.yml
@@ -81,7 +81,7 @@ jobs:
   #
   # ----------------------------------- #
   docker_build:
-    name: Webhook to Docker Hub to build image
+    name: Webhook to 'arista-netdevops-community/docker-avd-base' to build image
     runs-on: ubuntu-20.04
     needs: file-changes
     if: |
@@ -95,6 +95,6 @@ jobs:
           -X POST \
           -H "Accept: application/vnd.github.v3+json" \
           -H "Authorization: token ${{secrets.AVD_BUILDER_TOKEN}}" \
-          https://api.github.com/repos/arista-netdevops-community/docker-avd-bas/dispatches \
+          https://api.github.com/repos/arista-netdevops-community/docker-avd-base/dispatches \
           -d '{"event_type":"refresh"}' \
           -f

--- a/.github/workflows/devel-push.yml
+++ b/.github/workflows/devel-push.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - devel
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}
@@ -21,6 +22,7 @@ jobs:
       plugins: ${{ steps.filter.outputs.plugins }}
       requirements: ${{ steps.filter.outputs.requirements }}
       docs: ${{ steps.filter.outputs.docs }}
+    if: github.event_name != 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v3
       - uses: dorny/paths-filter@v2
@@ -82,10 +84,12 @@ jobs:
     name: Webhook to Docker Hub to build image
     runs-on: ubuntu-20.04
     needs: file-changes
-    if: needs.file-changes.outputs.requirements == 'true'
+    if: |
+      needs.file-changes.outputs.requirements == 'true' ||
+      (github.ref == 'refs/heads/devel' && github.event_name == 'workflow_dispatch')
     steps:
       - uses: actions/checkout@v3
-      - name: 'Send Webhook to docker hub'
+      - name: 'Trigger avd-base refresh'
         run: |
           curl \
           -X POST \


### PR DESCRIPTION
## Related Issue(s)

Fixes #2629

## Component(s) name

`ci`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
