### PR TITLE
Fix: add guard to dot1x mac_based_authentication

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/dot1x-2.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/dot1x-2.md
@@ -1,0 +1,52 @@
+# dot1x-2
+
+## Table of Contents
+
+- [Management](#management)
+  - [Management Interfaces](#management-interfaces)
+- [802.1X Port Security](#8021x-port-security)
+  - [802.1X Summary](#8021x-summary)
+
+## Management
+
+### Management Interfaces
+
+#### Management Interfaces Summary
+
+##### IPv4
+
+| Management Interface | description | Type | VRF | IP Address | Gateway |
+| -------------------- | ----------- | ---- | --- | ---------- | ------- |
+| Management1 | oob_management | oob | MGMT | 10.73.255.122/24 | 10.73.255.2 |
+
+##### IPv6
+
+| Management Interface | description | Type | VRF | IPv6 Address | IPv6 Gateway |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ |
+| Management1 | oob_management | oob | MGMT | - | - |
+
+#### Management Interfaces Device Configuration
+
+```eos
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+```
+
+## 802.1X Port Security
+
+### 802.1X Summary
+
+#### 802.1X Global
+
+| System Auth Control | Protocol LLDP Bypass | Dynamic Authorization |
+| ------------------- | -------------------- | ----------------------|
+| True | True | True |
+
+#### 802.1X Radius AV pair
+
+| Service type | Framed MTU |
+| ------------ | ---------- |
+| True | 1500 |

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/dot1x-2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/dot1x-2.cfg
@@ -1,0 +1,22 @@
+!RANCID-CONTENT-TYPE: arista
+!
+transceiver qsfp default-mode 4x10G
+!
+hostname dot1x-2
+!
+no enable password
+no aaa root
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+!
+dot1x system-auth-control
+dot1x protocol lldp bypass
+dot1x dynamic-authorization
+dot1x
+   radius av-pair service-type
+   radius av-pair framed-mtu 1500
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/dot1x-2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/dot1x-2.yml
@@ -1,0 +1,11 @@
+---
+### 802.1x Global ###
+# this needs to be in another test than dot1x host because
+# we verify that PR 2764 is not happenign again
+dot1x:
+  system_auth_control: true
+  protocol_lldp_bypass: true
+  dynamic_authorization: true
+  radius_av_pair:
+    service_type: true
+    framed_mtu: 1500

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts.ini
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts.ini
@@ -17,6 +17,7 @@ daemons
 dns-ntp
 dhcp-relay
 dot1x
+dot1x-2
 enable-password
 errdisable
 ethernet-interfaces

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/dot1x.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/dot1x.j2
@@ -10,7 +10,7 @@ dot1x protocol lldp bypass
 {%     if dot1x.dynamic_authorization is arista.avd.defined(true) %}
 dot1x dynamic-authorization
 {%     endif %}
-{%     if dot1x.mac_based_authentication or dot1x.radius_av_pair is arista.avd.defined %}
+{%     if dot1x.mac_based_authentication is arista.avd.defined or dot1x.radius_av_pair is arista.avd.defined %}
 dot1x
 {%         if dot1x.mac_based_authentication is arista.avd.defined %}
 {%             if dot1x.mac_based_authentication.delay is arista.avd.defined %}


### PR DESCRIPTION
## Change Summary

Fix missing guard for mac_based_authentication

```
fatal: [SWITCH -> localhost]: FAILED! => 
  msg: '''dict object'' has no attribute ''mac_based_authentication'''
```

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
