### PR TITLE
Feat(eos_cli_config_gen): Generate sFlow egress commands

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/sflow.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/sflow.md
@@ -66,6 +66,8 @@ sFlow is enabled.
 
 sFlow is disabled on all interfaces by default.
 
+Unmodified egress sFlow is enabled on all interfaces by default.
+
 sFlow hardware acceleration is enabled.
 
 sFlow hardware accelerated Sample Rate: 1024
@@ -112,6 +114,7 @@ sflow extension router
 no sflow extension switch
 no sflow extension tunnel
 sflow interface disable default
+sflow interface egress unmodified enable default
 sflow run
 sflow hardware acceleration
 sflow hardware acceleration sample 1024

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/sflow.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/sflow.md
@@ -66,8 +66,6 @@ sFlow is enabled.
 
 sFlow is disabled on all interfaces by default.
 
-Egress sFlow is enabled on all interfaces by default.
-
 Unmodified egress sFlow is enabled on all interfaces by default.
 
 sFlow hardware acceleration is enabled.
@@ -117,7 +115,6 @@ no sflow extension switch
 no sflow extension tunnel
 sflow interface disable default
 sflow interface egress unmodified enable default
-sflow interface egress enable default
 sflow run
 sflow hardware acceleration
 sflow hardware acceleration sample 1024

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/sflow.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/sflow.md
@@ -66,6 +66,8 @@ sFlow is enabled.
 
 sFlow is disabled on all interfaces by default.
 
+Egress sFlow is enabled on all interfaces by default.
+
 Unmodified egress sFlow is enabled on all interfaces by default.
 
 sFlow hardware acceleration is enabled.
@@ -115,6 +117,7 @@ no sflow extension switch
 no sflow extension tunnel
 sflow interface disable default
 sflow interface egress unmodified enable default
+sflow interface egress enable default
 sflow run
 sflow hardware acceleration
 sflow hardware acceleration sample 1024

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/sflow.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/sflow.cfg
@@ -26,6 +26,7 @@ no sflow extension switch
 no sflow extension tunnel
 sflow interface disable default
 sflow interface egress unmodified enable default
+sflow interface egress enable default
 sflow run
 sflow hardware acceleration
 sflow hardware acceleration sample 1024

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/sflow.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/sflow.cfg
@@ -26,7 +26,6 @@ no sflow extension switch
 no sflow extension tunnel
 sflow interface disable default
 sflow interface egress unmodified enable default
-sflow interface egress enable default
 sflow run
 sflow hardware acceleration
 sflow hardware acceleration sample 1024

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/sflow.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/sflow.cfg
@@ -25,6 +25,7 @@ sflow extension router
 no sflow extension switch
 no sflow extension tunnel
 sflow interface disable default
+sflow interface egress unmodified enable default
 sflow run
 sflow hardware acceleration
 sflow hardware acceleration sample 1024

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/sflow.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/sflow.yml
@@ -47,8 +47,8 @@ sflow:
     disable:
       default: true
     egress:
-      unmodified_enable_default: true
       enable_default: true
+      unmodified: true
   hardware_acceleration:
     enabled: true
     sample: 1024

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/sflow.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/sflow.yml
@@ -47,9 +47,8 @@ sflow:
     disable:
       default: true
     egress:
-      unmodified:
-        enable:
-          default: true
+      unmodified_enable_default: true
+      enable_default: true
   hardware_acceleration:
     enabled: true
     sample: 1024

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/sflow.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/sflow.yml
@@ -46,6 +46,10 @@ sflow:
   interface:
     disable:
       default: true
+    egress:
+      unmodified:
+        enable:
+          default: true
   hardware_acceleration:
     enabled: true
     sample: 1024

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/sflow.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/sflow.md
@@ -24,6 +24,9 @@
     | [<samp>&nbsp;&nbsp;interface</samp>](## "sflow.interface") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;disable</samp>](## "sflow.interface.disable") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;default</samp>](## "sflow.interface.disable.default") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;egress</samp>](## "sflow.interface.egress") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enable_default</samp>](## "sflow.interface.egress.enable_default") | Boolean |  |  |  | Enable egress sFlow by default.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unmodified</samp>](## "sflow.interface.egress.unmodified") | Boolean |  |  |  | Enable egress sFlow unmodified.<br>Platform dependent feature.<br> |
     | [<samp>&nbsp;&nbsp;run</samp>](## "sflow.run") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;hardware_acceleration</samp>](## "sflow.hardware_acceleration") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "sflow.hardware_acceleration.enabled") | Boolean |  |  |  |  |
@@ -57,6 +60,9 @@
       interface:
         disable:
           default: <bool>
+        egress:
+          enable_default: <bool>
+          unmodified: <bool>
       run: <bool>
       hardware_acceleration:
         enabled: <bool>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -17750,6 +17750,40 @@
                 "^_.+$": {}
               },
               "title": "Disable"
+            },
+            "egress": {
+              "type": "object",
+              "properties": {
+                "unmodified": {
+                  "type": "object",
+                  "properties": {
+                    "enable": {
+                      "type": "object",
+                      "properties": {
+                        "default": {
+                          "type": "boolean",
+                          "title": "Default"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      },
+                      "title": "Enable"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "patternProperties": {
+                    "^_.+$": {}
+                  },
+                  "title": "Unmodified"
+                }
+              },
+              "additionalProperties": false,
+              "patternProperties": {
+                "^_.+$": {}
+              },
+              "title": "Egress"
             }
           },
           "additionalProperties": false,

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -17754,15 +17754,15 @@
             "egress": {
               "type": "object",
               "properties": {
-                "unmodified_enable_default": {
-                  "type": "boolean",
-                  "description": "Enable unmodified egress sFlow by default.\nPlatform dependent feature.\n",
-                  "title": "Unmodified Enable Default"
-                },
                 "enable_default": {
                   "type": "boolean",
-                  "description": "Enable egress sFlow by default.\nPlatform dependent feature.\n",
+                  "description": "Enable egress sFlow by default.\n",
                   "title": "Enable Default"
+                },
+                "unmodified": {
+                  "type": "boolean",
+                  "description": "Enable egress sFlow unmodified.\nPlatform dependent feature.\n",
+                  "title": "Unmodified"
                 }
               },
               "additionalProperties": false,

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -17754,29 +17754,13 @@
             "egress": {
               "type": "object",
               "properties": {
-                "unmodified": {
-                  "type": "object",
-                  "properties": {
-                    "enable": {
-                      "type": "object",
-                      "properties": {
-                        "default": {
-                          "type": "boolean",
-                          "title": "Default"
-                        }
-                      },
-                      "additionalProperties": false,
-                      "patternProperties": {
-                        "^_.+$": {}
-                      },
-                      "title": "Enable"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "patternProperties": {
-                    "^_.+$": {}
-                  },
-                  "title": "Unmodified"
+                "unmodified_enable_default": {
+                  "type": "boolean",
+                  "title": "Unmodified Enable Default"
+                },
+                "enable_default": {
+                  "type": "boolean",
+                  "title": "Enable Default"
                 }
               },
               "additionalProperties": false,

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -17756,10 +17756,12 @@
               "properties": {
                 "unmodified_enable_default": {
                   "type": "boolean",
+                  "description": "Enable unmodified egress sFlow by default.\nPlatform dependent feature.\n",
                   "title": "Unmodified Enable Default"
                 },
                 "enable_default": {
                   "type": "boolean",
+                  "description": "Enable egress sFlow by default.\nPlatform dependent feature.\n",
                   "title": "Enable Default"
                 }
               },

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -10333,16 +10333,14 @@ keys:
           egress:
             type: dict
             keys:
-              unmodified_enable_default:
-                type: bool
-                description: 'Enable unmodified egress sFlow by default.
-
-                  Platform dependent feature.
-
-                  '
               enable_default:
                 type: bool
                 description: 'Enable egress sFlow by default.
+
+                  '
+              unmodified:
+                type: bool
+                description: 'Enable egress sFlow unmodified.
 
                   Platform dependent feature.
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -10330,6 +10330,17 @@ keys:
             keys:
               default:
                 type: bool
+          egress:
+            type: dict
+            keys:
+              unmodified:
+                type: dict
+                keys:
+                  enable:
+                    type: dict
+                    keys:
+                      default:
+                        type: bool
       run:
         type: bool
       hardware_acceleration:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -10335,8 +10335,18 @@ keys:
             keys:
               unmodified_enable_default:
                 type: bool
+                description: 'Enable unmodified egress sFlow by default.
+
+                  Platform dependent feature.
+
+                  '
               enable_default:
                 type: bool
+                description: 'Enable egress sFlow by default.
+
+                  Platform dependent feature.
+
+                  '
       run:
         type: bool
       hardware_acceleration:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -10333,14 +10333,10 @@ keys:
           egress:
             type: dict
             keys:
-              unmodified:
-                type: dict
-                keys:
-                  enable:
-                    type: dict
-                    keys:
-                      default:
-                        type: bool
+              unmodified_enable_default:
+                type: bool
+              enable_default:
+                type: bool
       run:
         type: bool
       hardware_acceleration:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/sflow.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/sflow.schema.yml
@@ -102,14 +102,10 @@ keys:
           egress:
             type: dict
             keys:
-              unmodified:
-                type: dict
-                keys:
-                  enable:
-                    type: dict
-                    keys:
-                      default:
-                        type: bool
+              unmodified_enable_default:
+                type: bool
+              enable_default:
+                type: bool
       run:
         type: bool
       hardware_acceleration:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/sflow.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/sflow.schema.yml
@@ -102,15 +102,14 @@ keys:
           egress:
             type: dict
             keys:
-              unmodified_enable_default:
-                type: bool
-                description: |
-                  Enable unmodified egress sFlow by default.
-                  Platform dependent feature.
               enable_default:
                 type: bool
                 description: |
                   Enable egress sFlow by default.
+              unmodified:
+                type: bool
+                description: |
+                  Enable egress sFlow unmodified.
                   Platform dependent feature.
       run:
         type: bool

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/sflow.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/sflow.schema.yml
@@ -99,6 +99,17 @@ keys:
             keys:
               default:
                 type: bool
+          egress:
+            type: dict
+            keys:
+              unmodified:
+                type: dict
+                keys:
+                  enable:
+                    type: dict
+                    keys:
+                      default:
+                        type: bool
       run:
         type: bool
       hardware_acceleration:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/sflow.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/sflow.schema.yml
@@ -104,8 +104,14 @@ keys:
             keys:
               unmodified_enable_default:
                 type: bool
+                description: |
+                  Enable unmodified egress sFlow by default.
+                  Platform dependent feature.
               enable_default:
                 type: bool
+                description: |
+                  Enable egress sFlow by default.
+                  Platform dependent feature.
       run:
         type: bool
       hardware_acceleration:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/sflow.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/sflow.j2
@@ -54,7 +54,11 @@ sFlow is disabled.
 
 sFlow is disabled on all interfaces by default.
 {%     endif %}
-{%     if sflow.interface.egress.unmodified.enable.default is arista.avd.defined(true) %}
+{%     if sflow.interface.egress.enable_default is arista.avd.defined(true) %}
+
+Egress sFlow is enabled on all interfaces by default.
+{%     endif %}
+{%     if sflow.interface.egress.unmodified_enable_default is arista.avd.defined(true) %}
 
 Unmodified egress sFlow is enabled on all interfaces by default.
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/sflow.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/sflow.j2
@@ -54,11 +54,10 @@ sFlow is disabled.
 
 sFlow is disabled on all interfaces by default.
 {%     endif %}
-{%     if sflow.interface.egress.enable_default is arista.avd.defined(true) %}
+{%     if sflow.interface.egress.enable_default is arista.avd.defined(true) and sflow.interface.egress.unmodified is arista.avd.defined(false) %}
 
 Egress sFlow is enabled on all interfaces by default.
-{%     endif %}
-{%     if sflow.interface.egress.unmodified_enable_default is arista.avd.defined(true) %}
+{%     elif sflow.interface.egress.enable_default is arista.avd.defined(true) and sflow.interface.egress.unmodified is arista.avd.defined(true) %}
 
 Unmodified egress sFlow is enabled on all interfaces by default.
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/sflow.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/sflow.j2
@@ -54,6 +54,10 @@ sFlow is disabled.
 
 sFlow is disabled on all interfaces by default.
 {%     endif %}
+{%     if sflow.interface.egress.unmodified.enable.default is arista.avd.defined(true) %}
+
+Unmodified egress sFlow is enabled on all interfaces by default.
+{%     endif %}
 {%     if sflow.hardware_acceleration.enabled is arista.avd.defined(true) %}
 
 sFlow hardware acceleration is enabled.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/sflow.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/sflow.j2
@@ -50,8 +50,11 @@ no sflow extension {{ extension.name }}
 {%     if sflow.interface.disable.default is arista.avd.defined(true) %}
 sflow interface disable default
 {%     endif %}
-{%     if sflow.interface.egress.unmodified.enable.default is arista.avd.defined(true) %}
+{%     if sflow.interface.egress.unmodified_enable_default is arista.avd.defined(true) %}
 sflow interface egress unmodified enable default
+{%     endif %}
+{%     if sflow.interface.egress.enable_default is arista.avd.defined(true) %}
+sflow interface egress enable default
 {%     endif %}
 {%     if sflow.run is arista.avd.defined(true) %}
 sflow run

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/sflow.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/sflow.j2
@@ -50,11 +50,10 @@ no sflow extension {{ extension.name }}
 {%     if sflow.interface.disable.default is arista.avd.defined(true) %}
 sflow interface disable default
 {%     endif %}
-{%     if sflow.interface.egress.unmodified_enable_default is arista.avd.defined(true) %}
-sflow interface egress unmodified enable default
-{%     endif %}
-{%     if sflow.interface.egress.enable_default is arista.avd.defined(true) %}
+{%     if sflow.interface.egress.enable_default is arista.avd.defined(true) and sflow.interface.egress.unmodified is arista.avd.defined(false) %}
 sflow interface egress enable default
+{%     elif sflow.interface.egress.enable_default is arista.avd.defined(true) and sflow.interface.egress.unmodified is arista.avd.defined(true) %}
+sflow interface egress unmodified enable default
 {%     endif %}
 {%     if sflow.run is arista.avd.defined(true) %}
 sflow run

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/sflow.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/sflow.j2
@@ -50,6 +50,9 @@ no sflow extension {{ extension.name }}
 {%     if sflow.interface.disable.default is arista.avd.defined(true) %}
 sflow interface disable default
 {%     endif %}
+{%     if sflow.interface.egress.unmodified.enable.default is arista.avd.defined(true) %}
+sflow interface egress unmodified enable default
+{%     endif %}
 {%     if sflow.run is arista.avd.defined(true) %}
 sflow run
 {%     endif %}


### PR DESCRIPTION
## Change Summary

Knob to enable unmodified egress sflow on the CLI.

## Related Issue(s)

To be used in #2311 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Add a new keys to the data model:
```
sflow:
  interface:
    egress:
      unmodified_enable_default: <bool>
      enable_default: <bool>
```
## How to test
Molecule scenario added

CLI testing for command:
```
ld005(config)#sh run | i sflow
sflow interface disable default
sflow interface egress unmodified enable default
sflow run
```
This is a platform-dependent command, but adding no check following the component philosophy.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
