### PR TITLE
Fix(eos_designs)!: Remove BGP rendering on irrelevant nodes

### DIFF
--- a/ansible_collections/arista/avd/docs/porting-guides/4.x.x.md
+++ b/ansible_collections/arista/avd/docs/porting-guides/4.x.x.md
@@ -142,6 +142,33 @@ l2leaf:
     always_configure_ip_routing: true
 ```
 
+### BGP is no longer configured on irrelevant nodes
+
+An example of an "irrelevant node" is a pure L3 Spine in L3LS running ISIS or OSPF in the underlay. As long as the spine is not
+set as route-server for any overlay BGP protocol, there is no need for `router bgp <asn>` to be configured on this device.
+
+Example of default configuration previously generated but now removed:
+
+```eos
+router bgp 65000
+  router-id 192.168.255.2
+  maximum-paths 4 ecmp 4
+```
+
+To retain the old behavior the inventory can be updated like this:
+
+```yaml
+spine:
+  defaults:
+    structured_config:
+      router_bgp:
+        as: '65000'
+        router_id: 192.168.255.2
+        maximum_paths:
+          paths: 4
+          ecmp: 4
+```
+
 ## Changes to role `arista.avd.eos_cli_config_gen`
 
 ### New model for `hardware_counters.features`

--- a/ansible_collections/arista/avd/docs/release-notes/4.x.x.md
+++ b/ansible_collections/arista/avd/docs/release-notes/4.x.x.md
@@ -63,6 +63,13 @@ or other node types with `underlay_router: false`.
 
 See details in the [Porting guide for AVD 4.x.x](../porting-guides/4.x.x.md#ip-and-ipv6-routing-is-no-longer-configured-on-pure-l2-devices).
 
+#### BGP is no longer configured on irrelevant nodes
+
+An example of an "irrelevant node" is a pure L3 Spine in L3LS running ISIS or OSPF in the underlay. As long as the spine is not
+set as route-server for any overlay BGP protocol, there is no need for `router bgp <asn>` to be configured on this device.
+
+See details in the [Porting guide for AVD 4.x.x](../porting-guides/4.x.x.md#bgp-is-no-longer-configured-on-irrelevant-nodes).
+
 ### Removed eos_designs variables
 
 - `evpn_rd_type` has been removed and replaced with `overlay_rd_type`.

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE2.md
@@ -26,7 +26,6 @@
   - [IPv6 Routing](#ipv6-routing)
   - [Static Routes](#static-routes)
   - [Router ISIS](#router-isis)
-  - [Router BGP](#router-bgp)
 - [VRF Instances](#vrf-instances)
   - [VRF Instances Summary](#vrf-instances-summary)
   - [VRF Instances Device Configuration](#vrf-instances-device-configuration)
@@ -442,31 +441,6 @@ router isis EVPN_UNDERLAY
    address-family ipv4 unicast
       maximum-paths 4
    !
-```
-
-### Router BGP
-
-#### Router BGP Summary
-
-| BGP AS | Router ID |
-| ------ | --------- |
-| 65000|  192.168.255.2 |
-
-| BGP Tuning |
-| ---------- |
-| no bgp default ipv4-unicast |
-| distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
-
-#### Router BGP Device Configuration
-
-```eos
-!
-router bgp 65000
-   router-id 192.168.255.2
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
 ```
 
 ## VRF Instances

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE3.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE3.md
@@ -26,7 +26,6 @@
   - [IPv6 Routing](#ipv6-routing)
   - [Static Routes](#static-routes)
   - [Router ISIS](#router-isis)
-  - [Router BGP](#router-bgp)
 - [VRF Instances](#vrf-instances)
   - [VRF Instances Summary](#vrf-instances-summary)
   - [VRF Instances Device Configuration](#vrf-instances-device-configuration)
@@ -442,31 +441,6 @@ router isis EVPN_UNDERLAY
    address-family ipv4 unicast
       maximum-paths 4
    !
-```
-
-### Router BGP
-
-#### Router BGP Summary
-
-| BGP AS | Router ID |
-| ------ | --------- |
-| 65000|  192.168.255.3 |
-
-| BGP Tuning |
-| ---------- |
-| no bgp default ipv4-unicast |
-| distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
-
-#### Router BGP Device Configuration
-
-```eos
-!
-router bgp 65000
-   router-id 192.168.255.3
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
 ```
 
 ## VRF Instances

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SPINE2.cfg
@@ -122,12 +122,6 @@ no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 !
-router bgp 65000
-   router-id 192.168.255.2
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
-!
 router isis EVPN_UNDERLAY
    net 49.0001.0001.0000.0002.00
    is-type level-2

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SPINE3.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SPINE3.cfg
@@ -122,12 +122,6 @@ no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 !
-router bgp 65000
-   router-id 192.168.255.3
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
-!
 router isis EVPN_UNDERLAY
    net 49.0001.0001.0000.0003.00
    is-type level-2

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SPINE2.yml
@@ -1,10 +1,3 @@
-router_bgp:
-  as: '65000'
-  router_id: 192.168.255.2
-  bgp_defaults:
-  - no bgp default ipv4-unicast
-  - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
 static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SPINE3.yml
@@ -1,10 +1,3 @@
-router_bgp:
-  as: '65000'
-  router_id: 192.168.255.3
-  bgp_defaults:
-  - no bgp default ipv4-unicast
-  - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
 static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/routing.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/routing.py
@@ -116,11 +116,6 @@ class RoutingMixin:
                         f"Unable to allocate BGP AS: bgp_as range is too small ({len(bgp_as_range_expanded)}) for the id of the device"
                     ) from exc
 
-        # Hack to make mpls PR non-breaking, adds empty bgp to igp topology spines
-        # TODO: Remove this as part of AVD4.0
-        elif self.underlay_routing_protocol in ["isis", "ospf"] and self.evpn_role == "none" and get(self.hostvars, "bgp_as") is not None:
-            return str(get(self.hostvars, "bgp_as"))
-
     @cached_property
     def always_configure_ip_routing(self: SharedUtils) -> bool:
         return get(self.switch_data_combined, "always_configure_ip_routing")


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Remove BGP rendering on irrelevant nodes.
One example is a pure L3 spine in L3LS running ISIS or OSPF in the underlay.
As long as the spine does not double as route-server for any overlay BGP protocol, there is no need for `router bgp <asn>` to be configured on this device.

## Related Issue(s)

Fixes #1593 

## Component(s) name

`arista.avd.<role-name>`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

Remove old exception to general rule of only configuring BGP when needed.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Rerun molecule and see that BGP is removed from two spines in ISIS scenario, when they are not route-servers.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
