### PR TITLE
CI: Bump molecule action to 1.6

### DIFF
--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -166,7 +166,7 @@ jobs:
           echo "ANSIBLE_FORCE_COLOR=1" >> $GITHUB_ENV
       - uses: actions/checkout@v3
       - name: Run molecule action
-        uses: arista-netdevops-community/action-molecule-avd@v1.5
+        uses: arista-netdevops-community/action-molecule-avd@v1.6
         with:
           molecule_parentdir: 'ansible_collections/arista/avd'
           molecule_command: 'test'
@@ -201,7 +201,7 @@ jobs:
           echo "ANSIBLE_FORCE_COLOR=1" >> $GITHUB_ENV
       - uses: actions/checkout@v3
       - name: Run molecule action
-        uses: arista-netdevops-community/action-molecule-avd@v1.5
+        uses: arista-netdevops-community/action-molecule-avd@v1.6
         with:
           molecule_parentdir: 'ansible_collections/arista/avd'
           molecule_command: 'test'
@@ -257,7 +257,7 @@ jobs:
           echo "ANSIBLE_FORCE_COLOR=1" >> $GITHUB_ENV
       - uses: actions/checkout@v3
       - name: Run molecule action
-        uses: arista-netdevops-community/action-molecule-avd@v1.5
+        uses: arista-netdevops-community/action-molecule-avd@v1.6
         with:
           molecule_parentdir: 'ansible_collections/arista/avd'
           molecule_command: 'test'
@@ -291,7 +291,7 @@ jobs:
           echo "ANSIBLE_FORCE_COLOR=1" >> $GITHUB_ENV
       - uses: actions/checkout@v3
       - name: Run molecule action
-        uses: arista-netdevops-community/action-molecule-avd@v1.5
+        uses: arista-netdevops-community/action-molecule-avd@v1.6
         with:
           molecule_parentdir: 'ansible_collections/arista/avd'
           molecule_command: 'test'

--- a/ansible_collections/arista/avd/requirements-dev.txt
+++ b/ansible_collections/arista/avd/requirements-dev.txt
@@ -1,5 +1,4 @@
 ansible-core>=2.12.6,<2.15.0,!=2.13.0
-ansible-compat<4.0.1  # https://github.com/ansible-community/molecule/pull/3904
 ansible-lint>=6.14.0 ; python_version >= "3.9"
 ansible-lint>=6.13.0 ; python_version < "3.9"
 galaxy-importer>=0.3.1

--- a/ansible_collections/arista/avd/requirements-dev.txt
+++ b/ansible_collections/arista/avd/requirements-dev.txt
@@ -1,4 +1,5 @@
 ansible-core>=2.12.6,<2.15.0,!=2.13.0
+ansible-compat<4.0.1  # https://github.com/ansible-community/molecule/pull/3904
 ansible-lint>=6.14.0 ; python_version >= "3.9"
 ansible-lint>=6.13.0 ; python_version < "3.9"
 galaxy-importer>=0.3.1


### PR DESCRIPTION
**THIS MUST NOT BE MERGED BEFORE 1.6 HAS BEEN RELEASED AFTER THIS IS MERGED: https://github.com/arista-netdevops-community/action-molecule-avd/pull/15**

Bump molecule-action to 1.6 to handle git considering /github/workspace as unsafe in the container.

