### PR TITLE
Feat(eos_cli_config_gen): Add ethernet_interfaces logging event options

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
@@ -335,6 +335,8 @@ interface Ethernet6
    description SRV-POD02_Eth1
    logging event link-status
    logging event congestion-drops
+   logging event spanning-tree
+   logging event storm-control
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
    switchport
@@ -414,6 +416,8 @@ interface Ethernet13
    description interface_in_mode_access_with_voice
    no logging event link-status
    no logging event congestion-drops
+   no logging event spanning-tree
+   no logging event storm-control
    switchport trunk native vlan 100
    switchport phone vlan 70
    switchport phone trunk untagged

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
@@ -101,6 +101,8 @@ interface Ethernet6
    description SRV-POD02_Eth1
    logging event link-status
    logging event congestion-drops
+   logging event spanning-tree
+   logging event storm-control
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
    switchport
@@ -180,6 +182,8 @@ interface Ethernet13
    description interface_in_mode_access_with_voice
    no logging event link-status
    no logging event congestion-drops
+   no logging event spanning-tree
+   no logging event storm-control
    switchport trunk native vlan 100
    switchport phone vlan 70
    switchport phone trunk untagged

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
@@ -153,6 +153,8 @@ ethernet_interfaces:
       event:
         link_status: true
         congestion_drops: true
+        spanning_tree: true
+        storm_control: true
     peer: SRV-POD02
     peer_interface: Eth1
     peer_type: server
@@ -264,6 +266,8 @@ ethernet_interfaces:
       event:
         link_status: false
         congestion_drops: false
+        spanning_tree: false
+        storm_control: false
     description: interface_in_mode_access_with_voice
     type: switched
     native_vlan: 100

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/data_model/Interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/data_model/Interfaces.md
@@ -188,6 +188,8 @@ search:
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;event</samp>](## "ethernet_interfaces.[].logging.event") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;link_status</samp>](## "ethernet_interfaces.[].logging.event.link_status") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;congestion_drops</samp>](## "ethernet_interfaces.[].logging.event.congestion_drops") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;spanning_tree</samp>](## "ethernet_interfaces.[].logging.event.spanning_tree") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;storm_control</samp>](## "ethernet_interfaces.[].logging.event.storm_control") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;lldp</samp>](## "ethernet_interfaces.[].lldp") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;transmit</samp>](## "ethernet_interfaces.[].lldp.transmit") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;receive</samp>](## "ethernet_interfaces.[].lldp.receive") | Boolean |  |  |  |  |
@@ -460,6 +462,8 @@ search:
           event:
             link_status: <bool>
             congestion_drops: <bool>
+            spanning_tree: <bool>
+            storm_control: <bool>
         lldp:
           transmit: <bool>
           receive: <bool>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -2868,6 +2868,14 @@
                   "congestion_drops": {
                     "type": "boolean",
                     "title": "Congestion Drops"
+                  },
+                  "spanning_tree": {
+                    "type": "boolean",
+                    "title": "Spanning Tree"
+                  },
+                  "storm_control": {
+                    "type": "boolean",
+                    "title": "Storm Control"
                   }
                 },
                 "additionalProperties": false,

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -1923,6 +1923,10 @@ keys:
                   type: bool
                 congestion_drops:
                   type: bool
+                spanning_tree:
+                  type: bool
+                storm_control:
+                  type: bool
         lldp:
           type: dict
           keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ethernet_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ethernet_interfaces.schema.yml
@@ -645,6 +645,10 @@ keys:
                   type: bool
                 congestion_drops:
                   type: bool
+                spanning_tree:
+                  type: bool
+                storm_control:
+                  type: bool
         lldp:
           type: dict
           keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -47,6 +47,16 @@ interface {{ ethernet_interface.name }}
 {%         elif ethernet_interface.logging.event.congestion_drops is arista.avd.defined(false) %}
    no logging event congestion-drops
 {%         endif %}
+{%         if ethernet_interface.logging.event.spanning_tree is arista.avd.defined(true) %}
+   logging event spanning-tree
+{%         elif ethernet_interface.logging.event.spanning_tree is arista.avd.defined(false) %}
+   no logging event spanning-tree
+{%         endif %}
+{%         if ethernet_interface.logging.event.storm_control is arista.avd.defined(true) %}
+   logging event storm-control
+{%         elif ethernet_interface.logging.event.storm_control is arista.avd.defined(false) %}
+   no logging event storm-control
+{%         endif %}
 {%     endif %}
 {%     if print_ethernet is arista.avd.defined(true) %}
 {%         if ethernet_interface.flowcontrol.received is arista.avd.defined %}


### PR DESCRIPTION
## Change Summary

EOS CLI offers four options for logging event under ethernet interface.

````code
access(config-if-Et20)#no logging event ?
  congestion-drops  Drops due to congestion
  link-status       UPDOWN messages
  spanning-tree     Spanning tree messages
  storm-control     Configure storm-control
````

Two of them were missing in AVD: `spanning-tree` and `storm-control`

## Related Issue(s)

Fixes #2781

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Adjusted data model:

````yaml
ethernet_interfaces:
  - logging:
      event:
        link_status: <bool>
        congestion_drops: <bool>
        spanning_tree: <bool>
        storm_control: <bool>
````

## How to test

Adjusted molecule tests for eos_cli_config_gen scenario:

````yaml
  - name: Ethernet6
    logging:
      event:
        link_status: true
        congestion_drops: true
        spanning_tree: true
        storm_control: true

  - name: Ethernet13
    logging:
      event:
        link_status: false
        congestion_drops: false
        spanning_tree: false
        storm_control: false
````

## Checklist

### User Checklist

- N/A

### Repository Checklist

- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
