### PR TITLE
Fix(eos_designs): Configure "ipv6 enable" on SVIs with Anycast IPv6

### DIFF
--- a/ansible_collections/arista/avd/docs/porting-guides/4.x.x.md
+++ b/ansible_collections/arista/avd/docs/porting-guides/4.x.x.md
@@ -169,6 +169,55 @@ spine:
           ecmp: 4
 ```
 
+### Link-local IPv6 addressing is implicitly enabled when configuring IPv6 Anycast IP
+
+Per Arista best practice, all SVIs configured with `ipv6 address virtual` should also have
+`ipv6 enable` configured, to use link-local IPv6 addresses for NDv6 operations.
+
+With AVD version 4.0.0 this best practice is now implemented by default.
+
+Example input:
+
+```yaml
+tenants:
+  - name: mytenant
+    <...>
+    vrfs:
+      - name: myvrf
+        <...>
+        svis:
+          - id: 123
+            <...>
+            ipv6_address_virtuals:
+              - 2001:db8:12::1/64
+```
+
+Now renders:
+
+```eos
+interface Vlan123
+  <...>
+  ipv6 enable                  ! <-- New command
+  ipv6 address virtual 2001:db8:12::1/64
+```
+
+To retain the old behavior the inventory can be updated like this:
+
+```yaml
+tenants:
+  - name: mytenant
+    <...>
+    vrfs:
+      - name: myvrf
+        <...>
+        svis:
+          - id: 123
+            <...>
+            ipv6_address_virtuals:
+              - 2001:db8:12::1/64
+            ipv6_enable: false # <--- Overriding the new default behavior
+```
+
 ## Changes to role `arista.avd.eos_cli_config_gen`
 
 ### New model for `hardware_counters.features`

--- a/ansible_collections/arista/avd/docs/release-notes/4.x.x.md
+++ b/ansible_collections/arista/avd/docs/release-notes/4.x.x.md
@@ -70,6 +70,15 @@ set as route-server for any overlay BGP protocol, there is no need for `router b
 
 See details in the [Porting guide for AVD 4.x.x](../porting-guides/4.x.x.md#bgp-is-no-longer-configured-on-irrelevant-nodes).
 
+#### Link-local IPv6 addressing is implicitly enabled when configuring IPv6 Anycast IP
+
+Per Arista best practice, all SVIs configured with `ipv6 address virtual` should also have
+`ipv6 enable` configured, to use link-local IPv6 addresses for NDv6 operations.
+
+With AVD version 4.0.0 this best practice is now implemented by default.
+
+See details in the [Porting guide for AVD 4.x.x](../porting-guides/4.x.x.md#link-local-ipv6-addressing-is-implicitly-enabled-when-configuring-ipv6-anycast-ip).
+
 ### Removed eos_designs variables
 
 - `evpn_rd_type` has been removed and replaced with `overlay_rd_type`.

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF1A.cfg
@@ -194,6 +194,7 @@ interface Vlan450
    description Tenant_D_v6_WAN_Zone_1
    no shutdown
    vrf Tenant_D_WAN_Zone
+   ipv6 enable
    ipv6 address virtual 2001:db8:355::1/64
 !
 interface Vlan451
@@ -201,6 +202,7 @@ interface Vlan451
    no shutdown
    mtu 1560
    vrf Tenant_D_WAN_Zone
+   ipv6 enable
    ipv6 address virtual 2001:db8:451::1/64
 !
 interface Vlan452

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2A.cfg
@@ -483,6 +483,7 @@ interface Vlan410
    description Tenant_D_v6_OP_Zone_1
    no shutdown
    vrf Tenant_D_OP_Zone
+   ipv6 enable
    ipv6 address virtual 2001:db8:310::1/64
    ipv6 address virtual 2001:db8:311::1/64
    ipv6 address virtual 2001:db8:312::1/64
@@ -520,6 +521,7 @@ interface Vlan450
    description Tenant_D_v6_WAN_Zone_1
    no shutdown
    vrf Tenant_D_WAN_Zone
+   ipv6 enable
    ipv6 address virtual 2001:db8:355::1/64
 !
 interface Vlan451
@@ -527,6 +529,7 @@ interface Vlan451
    no shutdown
    mtu 1560
    vrf Tenant_D_WAN_Zone
+   ipv6 enable
    ipv6 address virtual 2001:db8:451::1/64
 !
 interface Vlan452

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2B.cfg
@@ -447,6 +447,7 @@ interface Vlan410
    description Tenant_D_v6_OP_Zone_1
    no shutdown
    vrf Tenant_D_OP_Zone
+   ipv6 enable
    ipv6 address virtual 2001:db8:310::1/64
    ipv6 address virtual 2001:db8:311::1/64
    ipv6 address virtual 2001:db8:312::1/64
@@ -484,6 +485,7 @@ interface Vlan450
    description Tenant_D_v6_WAN_Zone_1
    no shutdown
    vrf Tenant_D_WAN_Zone
+   ipv6 enable
    ipv6 address virtual 2001:db8:355::1/64
 !
 interface Vlan451
@@ -491,6 +493,7 @@ interface Vlan451
    no shutdown
    mtu 1560
    vrf Tenant_D_WAN_Zone
+   ipv6 enable
    ipv6 address virtual 2001:db8:451::1/64
 !
 interface Vlan452

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_false.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_false.cfg
@@ -299,6 +299,7 @@ interface Vlan410
    description Tenant_D_v6_OP_Zone_1
    no shutdown
    vrf Tenant_D_OP_Zone
+   ipv6 enable
    ipv6 address virtual 2001:db8:310::1/64
    ipv6 address virtual 2001:db8:311::1/64
    ipv6 address virtual 2001:db8:312::1/64
@@ -336,6 +337,7 @@ interface Vlan450
    description Tenant_D_v6_WAN_Zone_1
    no shutdown
    vrf Tenant_D_WAN_Zone
+   ipv6 enable
    ipv6 address virtual 2001:db8:355::1/64
 !
 interface Vlan451
@@ -343,6 +345,7 @@ interface Vlan451
    no shutdown
    mtu 1560
    vrf Tenant_D_WAN_Zone
+   ipv6 enable
    ipv6 address virtual 2001:db8:451::1/64
 !
 interface Vlan452

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF1A.yml
@@ -453,6 +453,7 @@ vlan_interfaces:
   - v6wan
   description: Tenant_D_v6_WAN_Zone_1
   shutdown: false
+  ipv6_enable: true
   ipv6_address_virtuals:
   - 2001:db8:355::1/64
   vrf: Tenant_D_WAN_Zone
@@ -462,6 +463,7 @@ vlan_interfaces:
   - v6wan
   description: Tenant_D_v6_WAN_Zone_2
   shutdown: false
+  ipv6_enable: true
   mtu: 1560
   ipv6_address_virtuals:
   - 2001:db8:451::1/64
@@ -472,6 +474,7 @@ vlan_interfaces:
   - v6wan
   description: Tenant_D_v6_WAN_Zone_3
   shutdown: false
+  ipv6_enable: false
   mtu: 1560
   ip_address_virtual: 10.4.12.254/24
   ipv6_address_virtuals:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
@@ -997,6 +997,7 @@ vlan_interfaces:
   - v6opzone
   description: Tenant_D_v6_OP_Zone_1
   shutdown: false
+  ipv6_enable: true
   ip_address_virtual: 10.3.10.1/24
   ipv6_address_virtuals:
   - 2001:db8:310::1/64
@@ -1022,6 +1023,7 @@ vlan_interfaces:
   - v6opzone
   description: Tenant_D_v6_OP_Zone_1
   shutdown: false
+  ipv6_enable: false
   mtu: 1560
   ip_address_virtual: 10.4.12.254/24
   ipv6_address_virtuals:
@@ -1051,6 +1053,7 @@ vlan_interfaces:
   - v6wan
   description: Tenant_D_v6_WAN_Zone_1
   shutdown: false
+  ipv6_enable: true
   ipv6_address_virtuals:
   - 2001:db8:355::1/64
   vrf: Tenant_D_WAN_Zone
@@ -1060,6 +1063,7 @@ vlan_interfaces:
   - v6wan
   description: Tenant_D_v6_WAN_Zone_2
   shutdown: false
+  ipv6_enable: true
   mtu: 1560
   ipv6_address_virtuals:
   - 2001:db8:451::1/64
@@ -1070,6 +1074,7 @@ vlan_interfaces:
   - v6wan
   description: Tenant_D_v6_WAN_Zone_3
   shutdown: false
+  ipv6_enable: false
   mtu: 1560
   ip_address_virtual: 10.4.12.254/24
   ipv6_address_virtuals:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
@@ -941,6 +941,7 @@ vlan_interfaces:
   - v6opzone
   description: Tenant_D_v6_OP_Zone_1
   shutdown: false
+  ipv6_enable: true
   ip_address_virtual: 10.3.10.1/24
   ipv6_address_virtuals:
   - 2001:db8:310::1/64
@@ -966,6 +967,7 @@ vlan_interfaces:
   - v6opzone
   description: Tenant_D_v6_OP_Zone_1
   shutdown: false
+  ipv6_enable: false
   mtu: 1560
   ip_address_virtual: 10.4.12.254/24
   ipv6_address_virtuals:
@@ -995,6 +997,7 @@ vlan_interfaces:
   - v6wan
   description: Tenant_D_v6_WAN_Zone_1
   shutdown: false
+  ipv6_enable: true
   ipv6_address_virtuals:
   - 2001:db8:355::1/64
   vrf: Tenant_D_WAN_Zone
@@ -1004,6 +1007,7 @@ vlan_interfaces:
   - v6wan
   description: Tenant_D_v6_WAN_Zone_2
   shutdown: false
+  ipv6_enable: true
   mtu: 1560
   ipv6_address_virtuals:
   - 2001:db8:451::1/64
@@ -1014,6 +1018,7 @@ vlan_interfaces:
   - v6wan
   description: Tenant_D_v6_WAN_Zone_3
   shutdown: false
+  ipv6_enable: false
   mtu: 1560
   ip_address_virtual: 10.4.12.254/24
   ipv6_address_virtuals:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_false.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_false.yml
@@ -728,6 +728,7 @@ vlan_interfaces:
   - v6opzone
   description: Tenant_D_v6_OP_Zone_1
   shutdown: false
+  ipv6_enable: true
   ip_address_virtual: 10.3.10.1/24
   ipv6_address_virtuals:
   - 2001:db8:310::1/64
@@ -753,6 +754,7 @@ vlan_interfaces:
   - v6opzone
   description: Tenant_D_v6_OP_Zone_1
   shutdown: false
+  ipv6_enable: false
   mtu: 1560
   ip_address_virtual: 10.4.12.254/24
   ipv6_address_virtuals:
@@ -782,6 +784,7 @@ vlan_interfaces:
   - v6wan
   description: Tenant_D_v6_WAN_Zone_1
   shutdown: false
+  ipv6_enable: true
   ipv6_address_virtuals:
   - 2001:db8:355::1/64
   vrf: Tenant_D_WAN_Zone
@@ -791,6 +794,7 @@ vlan_interfaces:
   - v6wan
   description: Tenant_D_v6_WAN_Zone_2
   shutdown: false
+  ipv6_enable: true
   mtu: 1560
   ipv6_address_virtuals:
   - 2001:db8:451::1/64
@@ -801,6 +805,7 @@ vlan_interfaces:
   - v6wan
   description: Tenant_D_v6_WAN_Zone_3
   shutdown: false
+  ipv6_enable: false
   mtu: 1560
   ip_address_virtual: 10.4.12.254/24
   ipv6_address_virtuals:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/main.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/main.yml
@@ -21,6 +21,7 @@ svi_profiles:
     enabled: false
     ip_address_virtual: 10.4.12.254/24
     ipv6_address_virtual: 2001:db8:412::1/64
+    ipv6_enable: false
   TEST_SVI_NODE_INHERIT:
     name: Test the SVI and node config inheritance
     mtu: 1560

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
@@ -356,6 +356,9 @@ mac_address_table:
               - < IPv6_address/Mask >
               - < IPv6_address/Mask >
 
+            # ipv6_enable to explicitly enable/disable link-local IPv6 addressing | Optional
+            ipv6_enable: <true | false>
+
             # ip virtual-router address
             # note, also requires an IP address to be configured on the SVI where it is applied.
             # Optional

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/vlan_interfaces.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/vlan_interfaces.py
@@ -64,6 +64,7 @@ class VlanInterfacesMixin(UtilsMixin):
             "shutdown": not (svi.get("enabled", False)),
             "ip_address": svi.get("ip_address"),
             "ipv6_address": svi.get("ipv6_address"),
+            "ipv6_enable": svi.get("ipv6_enable"),
             "mtu": svi.get("mtu"),
             "eos_cli": svi.get("raw_eos_cli"),
             "struct_cfg": svi.get("structured_config"),
@@ -112,6 +113,10 @@ class VlanInterfacesMixin(UtilsMixin):
                 vlan_interface_config.setdefault("ipv6_address_virtuals", []).extend(ipv6_address_virtuals)
 
             _check_virtual_router_mac_address(vlan_interface_config, ["ipv6_address_virtuals"])
+
+            if vlan_interface_config.get("ipv6_address_virtuals"):
+                # If any anycast IPs are set, we also enable link-local IPv6 per best practice, unless specifically disabled with 'ipv6_enable: false'
+                vlan_interface_config["ipv6_enable"] = default(vlan_interface_config["ipv6_enable"], True)
 
         if vrf["name"] != "default":
             vlan_interface_config["vrf"] = vrf["name"]


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Configure "ipv6 enable" on SVIs with Anycast IPv6

## Related Issue(s)

Fixes #2390 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->


Per Arista best practice, all SVIs configured with `ipv6 address virtual` should also have
`ipv6 enable` configured, to use link-local IPv6 addresses for NDv6 operations.

With AVD version 4.0.0 this best practice is now implemented by default.

Example input:

```yaml
tenants:
  - name: mytenant
    <...>
    vrfs:
      - name: myvrf
        <...>
        svis:
          - id: 123
            <...>
            ipv6_address_virtuals:
              - 2001:db8:12::1/64
```

Now renders:

```eos
interface Vlan123
  <...>
  ipv6 enable                  ! <-- New command
  ipv6 address virtual 2001:db8:12::1/64
```

To retain the old behavior the inventory can be updated like this:

```yaml
tenants:
  - name: mytenant
    <...>
    vrfs:
      - name: myvrf
        <...>
        svis:
          - id: 123
            <...>
            ipv6_address_virtuals:
              - 2001:db8:12::1/64
            ipv6_enable: false # <--- Overriding the new default behavior
```

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Existing molecules updates automatically. Added a single override to retain old behavior.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
