### PR TITLE
Feat(eos_cli_config_gen): Add support for bgp default ipv4-unicast under router bgp

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
@@ -51,6 +51,8 @@ interface Management1
 | bgp bestpath d-path |
 | update wait-for-convergence |
 | update wait-install |
+| no bgp default ipv4-unicast |
+| no bgp default ipv4-unicast transport ipv6 |
 | distance bgp 20 200 200 |
 | maximum-paths 32 ecmp 32 |
 
@@ -138,6 +140,8 @@ router bgp 65101
    maximum-paths 32 ecmp 32
    update wait-for-convergence
    update wait-install
+   no bgp default ipv4-unicast
+   no bgp default ipv4-unicast transport ipv6
    no bgp default ipv4-unicast
    bgp bestpath d-path
    bgp listen range 10.10.10.0/24 peer-group my-peer-group1 peer-filter my-peer-filter

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
@@ -47,7 +47,6 @@ interface Management1
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | bgp bestpath d-path |
 | update wait-for-convergence |
 | update wait-install |
@@ -142,7 +141,6 @@ router bgp 65101
    update wait-install
    no bgp default ipv4-unicast
    no bgp default ipv4-unicast transport ipv6
-   no bgp default ipv4-unicast
    bgp bestpath d-path
    bgp listen range 10.10.10.0/24 peer-group my-peer-group1 peer-filter my-peer-filter
    bgp listen range 12.10.10.0/24 peer-id include router-id peer-group my-peer-group3 remote-as 65444

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-evpn.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-evpn.md
@@ -47,11 +47,12 @@ interface Management1
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | maximum-paths 2 ecmp 2 |
+| bgp default ipv4-unicast |
+| bgp default ipv4-unicast transport ipv6 |
 
 #### Router BGP Peer Groups
 
@@ -151,7 +152,8 @@ interface Management1
 !
 router bgp 65101
    router-id 192.168.255.3
-   no bgp default ipv4-unicast
+   bgp default ipv4-unicast
+   bgp default ipv4-unicast transport ipv6
    distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-base.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-base.cfg
@@ -23,6 +23,8 @@ router bgp 65101
    update wait-for-convergence
    update wait-install
    no bgp default ipv4-unicast
+   no bgp default ipv4-unicast transport ipv6
+   no bgp default ipv4-unicast
    bgp bestpath d-path
    bgp listen range 10.10.10.0/24 peer-group my-peer-group1 peer-filter my-peer-filter
    bgp listen range 12.10.10.0/24 peer-id include router-id peer-group my-peer-group3 remote-as 65444

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-base.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-base.cfg
@@ -24,7 +24,6 @@ router bgp 65101
    update wait-install
    no bgp default ipv4-unicast
    no bgp default ipv4-unicast transport ipv6
-   no bgp default ipv4-unicast
    bgp bestpath d-path
    bgp listen range 10.10.10.0/24 peer-group my-peer-group1 peer-filter my-peer-filter
    bgp listen range 12.10.10.0/24 peer-id include router-id peer-group my-peer-group3 remote-as 65444

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-evpn.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-evpn.cfg
@@ -14,7 +14,8 @@ interface Management1
 !
 router bgp 65101
    router-id 192.168.255.3
-   no bgp default ipv4-unicast
+   bgp default ipv4-unicast
+   bgp default ipv4-unicast transport ipv6
    distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-base.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-base.yml
@@ -22,6 +22,9 @@ router_bgp:
   bgp_defaults:
     - no bgp default ipv4-unicast
   bgp:
+    default:
+      ipv4_unicast: false
+      ipv4_unicast_transport_ipv6: false
     bestpath:
       d_path: true
   listen_ranges:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-base.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-base.yml
@@ -19,8 +19,6 @@ router_bgp:
   maximum_paths:
     paths: 32
     ecmp: 32
-  bgp_defaults:
-    - no bgp default ipv4-unicast
   bgp:
     default:
       ipv4_unicast: false

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-evpn.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-evpn.yml
@@ -2,11 +2,14 @@ router_bgp:
   as: 65101
   router_id: 192.168.255.3
   bgp_defaults:
-    - no bgp default ipv4-unicast
     - distance bgp 20 200 200
     - graceful-restart restart-time 300
     - graceful-restart
     - maximum-paths 2 ecmp 2
+  bgp:
+    default:
+      ipv4_unicast: true
+      ipv4_unicast_transport_ipv6: true
   peer_groups:
     - name: EVPN-OVERLAY-PEERS
       type: evpn

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/data_model/Routing.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/data_model/Routing.md
@@ -194,6 +194,9 @@ MAC address (hh:hh:hh:hh:hh:hh)
     | [<samp>&nbsp;&nbsp;bgp_defaults</samp>](## "router_bgp.bgp_defaults") | List, items: String |  |  |  | BGP command as string |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "router_bgp.bgp_defaults.[].&lt;str&gt;") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;bgp</samp>](## "router_bgp.bgp") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;default</samp>](## "router_bgp.bgp.default") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_unicast</samp>](## "router_bgp.bgp.default.ipv4_unicast") | Boolean |  |  |  | Enable or disable IPv4 unicast address family on all IPv4 neighbors. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_unicast_transport_ipv6</samp>](## "router_bgp.bgp.default.ipv4_unicast_transport_ipv6") | Boolean |  |  |  | Enable or disable IPv4 unicast address family on all IPv6 neighbors. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;bestpath</samp>](## "router_bgp.bgp.bestpath") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;d_path</samp>](## "router_bgp.bgp.bestpath.d_path") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;listen_ranges</samp>](## "router_bgp.listen_ranges") | List, items: Dictionary |  |  |  | Improved "listen_ranges" data model to support multiple listen ranges and additional filter capabilities<br> |
@@ -644,6 +647,9 @@ MAC address (hh:hh:hh:hh:hh:hh)
       bgp_defaults:
         - <str>
       bgp:
+        default:
+          ipv4_unicast: <bool>
+          ipv4_unicast_transport_ipv6: <bool>
         bestpath:
           d_path: <bool>
       listen_ranges:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/data_model/Routing.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/data_model/Routing.md
@@ -195,8 +195,8 @@ MAC address (hh:hh:hh:hh:hh:hh)
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "router_bgp.bgp_defaults.[].&lt;str&gt;") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;bgp</samp>](## "router_bgp.bgp") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;default</samp>](## "router_bgp.bgp.default") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_unicast</samp>](## "router_bgp.bgp.default.ipv4_unicast") | Boolean |  |  |  | Enable or disable IPv4 unicast address family on all IPv4 neighbors. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_unicast_transport_ipv6</samp>](## "router_bgp.bgp.default.ipv4_unicast_transport_ipv6") | Boolean |  |  |  | Enable or disable IPv4 unicast address family on all IPv6 neighbors. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_unicast</samp>](## "router_bgp.bgp.default.ipv4_unicast") | Boolean |  |  |  | Default activation of IPv4 unicast address-family on all IPv4 neighbors (EOS default = True). |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_unicast_transport_ipv6</samp>](## "router_bgp.bgp.default.ipv4_unicast_transport_ipv6") | Boolean |  |  |  | Default activation of IPv4 unicast address-family on all IPv6 neighbors (EOS default == False). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;bestpath</samp>](## "router_bgp.bgp.bestpath") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;d_path</samp>](## "router_bgp.bgp.bestpath.d_path") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;listen_ranges</samp>](## "router_bgp.listen_ranges") | List, items: Dictionary |  |  |  | Improved "listen_ranges" data model to support multiple listen ranges and additional filter capabilities<br> |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -10940,12 +10940,12 @@
               "properties": {
                 "ipv4_unicast": {
                   "type": "boolean",
-                  "description": "Enable or disable IPv4 unicast address family on all IPv4 neighbors.",
+                  "description": "Default activation of IPv4 unicast address-family on all IPv4 neighbors (EOS default = True).",
                   "title": "IPv4 Unicast"
                 },
                 "ipv4_unicast_transport_ipv6": {
                   "type": "boolean",
-                  "description": "Enable or disable IPv4 unicast address family on all IPv6 neighbors.",
+                  "description": "Default activation of IPv4 unicast address-family on all IPv6 neighbors (EOS default == False).",
                   "title": "IPv4 Unicast Transport IPv6"
                 }
               },

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -10935,6 +10935,26 @@
         "bgp": {
           "type": "object",
           "properties": {
+            "default": {
+              "type": "object",
+              "properties": {
+                "ipv4_unicast": {
+                  "type": "boolean",
+                  "description": "Enable or disable IPv4 unicast address family on all IPv4 neighbors.",
+                  "title": "IPv4 Unicast"
+                },
+                "ipv4_unicast_transport_ipv6": {
+                  "type": "boolean",
+                  "description": "Enable or disable IPv4 unicast address family on all IPv6 neighbors.",
+                  "title": "IPv4 Unicast Transport IPv6"
+                }
+              },
+              "additionalProperties": false,
+              "patternProperties": {
+                "^_.+$": {}
+              },
+              "title": "Default"
+            },
             "bestpath": {
               "type": "object",
               "properties": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -7074,6 +7074,17 @@ keys:
       bgp:
         type: dict
         keys:
+          default:
+            type: dict
+            keys:
+              ipv4_unicast:
+                type: bool
+                description: Enable or disable IPv4 unicast address family on all
+                  IPv4 neighbors.
+              ipv4_unicast_transport_ipv6:
+                type: bool
+                description: Enable or disable IPv4 unicast address family on all
+                  IPv6 neighbors.
           bestpath:
             type: dict
             keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -7079,12 +7079,12 @@ keys:
             keys:
               ipv4_unicast:
                 type: bool
-                description: Enable or disable IPv4 unicast address family on all
-                  IPv4 neighbors.
+                description: Default activation of IPv4 unicast address-family on
+                  all IPv4 neighbors (EOS default = True).
               ipv4_unicast_transport_ipv6:
                 type: bool
-                description: Enable or disable IPv4 unicast address family on all
-                  IPv6 neighbors.
+                description: Default activation of IPv4 unicast address-family on
+                  all IPv6 neighbors (EOS default == False).
           bestpath:
             type: dict
             keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_bgp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_bgp.schema.yml
@@ -114,10 +114,10 @@ keys:
             keys:
               ipv4_unicast:
                 type: bool
-                description: Enable or disable IPv4 unicast address family on all IPv4 neighbors.
+                description: Default activation of IPv4 unicast address-family on all IPv4 neighbors (EOS default = True).
               ipv4_unicast_transport_ipv6:
                 type: bool
-                description: Enable or disable IPv4 unicast address family on all IPv6 neighbors.
+                description: Default activation of IPv4 unicast address-family on all IPv6 neighbors (EOS default == False).
           bestpath:
             type: dict
             keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_bgp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_bgp.schema.yml
@@ -109,6 +109,15 @@ keys:
       bgp:
         type: dict
         keys:
+          default:
+            type: dict
+            keys:
+              ipv4_unicast:
+                type: bool
+                description: Enable or disable IPv4 unicast address family on all IPv4 neighbors.
+              ipv4_unicast_transport_ipv6:
+                type: bool
+                description: Enable or disable IPv4 unicast address family on all IPv6 neighbors.
           bestpath:
             type: dict
             keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
@@ -30,6 +30,18 @@
 {%         if router_bgp.updates.wait_install is arista.avd.defined(true) %}
 | update wait-install |
 {%         endif %}
+{%         if router_bgp.bgp.default.ipv4_unicast is arista.avd.defined(true) %}
+| bgp default ipv4-unicast |
+{%         endif %}
+{%         if router_bgp.bgp.default.ipv4_unicast is arista.avd.defined(false) %}
+| no bgp default ipv4-unicast |
+{%         endif %}
+{%         if router_bgp.bgp.default.ipv4_unicast_transport_ipv6 is arista.avd.defined(true) %}
+| bgp default ipv4-unicast transport ipv6 |
+{%         endif %}
+{%         if router_bgp.bgp.default.ipv4_unicast_transport_ipv6 is arista.avd.defined(false) %}
+| no bgp default ipv4-unicast transport ipv6 |
+{%         endif %}
 {%         if router_bgp.distance.external_routes is arista.avd.defined %}
 {%             set distance_cli = "distance bgp " ~ router_bgp.distance.external_routes %}
 {%             if router_bgp.distance.internal_routes is arista.avd.defined and router_bgp.distance.local_routes is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
@@ -32,14 +32,12 @@
 {%         endif %}
 {%         if router_bgp.bgp.default.ipv4_unicast is arista.avd.defined(true) %}
 | bgp default ipv4-unicast |
-{%         endif %}
-{%         if router_bgp.bgp.default.ipv4_unicast is arista.avd.defined(false) %}
+{%         elif router_bgp.bgp.default.ipv4_unicast is arista.avd.defined(false) %}
 | no bgp default ipv4-unicast |
 {%         endif %}
 {%         if router_bgp.bgp.default.ipv4_unicast_transport_ipv6 is arista.avd.defined(true) %}
 | bgp default ipv4-unicast transport ipv6 |
-{%         endif %}
-{%         if router_bgp.bgp.default.ipv4_unicast_transport_ipv6 is arista.avd.defined(false) %}
+{%         elif router_bgp.bgp.default.ipv4_unicast_transport_ipv6 is arista.avd.defined(false) %}
 | no bgp default ipv4-unicast transport ipv6 |
 {%         endif %}
 {%         if router_bgp.distance.external_routes is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -43,6 +43,18 @@ router bgp {{ router_bgp.as }}
 {%     if router_bgp.updates.wait_install is arista.avd.defined(true) %}
    update wait-install
 {%     endif %}
+{%     if router_bgp.bgp.default.ipv4_unicast is arista.avd.defined(true) %}
+   bgp default ipv4-unicast
+{%     endif %}
+{%     if router_bgp.bgp.default.ipv4_unicast is arista.avd.defined(false) %}
+   no bgp default ipv4-unicast
+{%     endif %}
+{%     if router_bgp.bgp.default.ipv4_unicast_transport_ipv6 is arista.avd.defined(true) %}
+   bgp default ipv4-unicast transport ipv6
+{%     endif %}
+{%     if router_bgp.bgp.default.ipv4_unicast_transport_ipv6 is arista.avd.defined(false) %}
+   no bgp default ipv4-unicast transport ipv6
+{%     endif %}
 {%     if router_bgp.bgp_cluster_id is arista.avd.defined %}
    bgp cluster-id {{ router_bgp.bgp_cluster_id }}
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -45,14 +45,12 @@ router bgp {{ router_bgp.as }}
 {%     endif %}
 {%     if router_bgp.bgp.default.ipv4_unicast is arista.avd.defined(true) %}
    bgp default ipv4-unicast
-{%     endif %}
-{%     if router_bgp.bgp.default.ipv4_unicast is arista.avd.defined(false) %}
+{%     elif router_bgp.bgp.default.ipv4_unicast is arista.avd.defined(false) %}
    no bgp default ipv4-unicast
 {%     endif %}
 {%     if router_bgp.bgp.default.ipv4_unicast_transport_ipv6 is arista.avd.defined(true) %}
    bgp default ipv4-unicast transport ipv6
-{%     endif %}
-{%     if router_bgp.bgp.default.ipv4_unicast_transport_ipv6 is arista.avd.defined(false) %}
+{%     elif router_bgp.bgp.default.ipv4_unicast_transport_ipv6 is arista.avd.defined(false) %}
    no bgp default ipv4-unicast transport ipv6
 {%     endif %}
 {%     if router_bgp.bgp_cluster_id is arista.avd.defined %}


### PR DESCRIPTION
## Change Summary

Add support for bgp default ipv4-unicast under router bgp

Fixes #2786

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

See issue #2786 for details

## How to test

See molecule results.

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
