### PR TITLE
Feat(eos_cli_config_gen): Add support for "ip_igmp_version" under "vlan_interfaces"

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
@@ -276,6 +276,7 @@ interface Vlan89
    ip helper-address 10.10.96.150 source-interface Loopback0
    ip helper-address 10.10.96.151 source-interface Loopback0
    ip igmp
+   ip igmp version 2
    ipv6 address 1b11:3a00:22b0:5200::15/64
    ipv6 nd managed-config-flag
    ipv6 nd prefix 1b11:3a00:22b0:5200::/64 infinite infinite no-autoconfig

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
@@ -127,6 +127,7 @@ interface Vlan89
    ip helper-address 10.10.96.150 source-interface Loopback0
    ip helper-address 10.10.96.151 source-interface Loopback0
    ip igmp
+   ip igmp version 2
    ipv6 address 1b11:3a00:22b0:5200::15/64
    ipv6 nd managed-config-flag
    ipv6 nd prefix 1b11:3a00:22b0:5200::/64 infinite infinite no-autoconfig

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
@@ -237,6 +237,7 @@ vlan_interfaces:
     description: SVI Description
     shutdown: false
     ip_igmp: true
+    ip_igmp_version: 2
     ip_address_virtual: 10.10.144.3/20
     ipv6_address: 1b11:3a00:22b0:5200::15/64
     ipv6_nd_managed_config_flag: true

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/data_model/Interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/data_model/Interfaces.md
@@ -1113,6 +1113,7 @@ search:
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_address_virtual_secondaries</samp>](## "vlan_interfaces.[].ip_address_virtual_secondaries") | List, items: String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "vlan_interfaces.[].ip_address_virtual_secondaries.[].&lt;str&gt;") | String |  |  |  | IPv4_address/Mask |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_igmp</samp>](## "vlan_interfaces.[].ip_igmp") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_igmp_version</samp>](## "vlan_interfaces.[].ip_igmp_version") | Integer |  |  | Min: 1<br>Max: 3 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_helpers</samp>](## "vlan_interfaces.[].ip_helpers") | List, items: Dictionary |  |  |  | List of DHCP servers |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- ip_helper</samp>](## "vlan_interfaces.[].ip_helpers.[].ip_helper") | String | Required, Unique |  |  | IP address or hostname of DHCP server |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_interface</samp>](## "vlan_interfaces.[].ip_helpers.[].source_interface") | String |  |  |  | Interface used as source for forwarded DHCP packets |
@@ -1249,6 +1250,7 @@ search:
         ip_address_virtual_secondaries:
           - <str>
         ip_igmp: <bool>
+        ip_igmp_version: <int>
         ip_helpers:
           - ip_helper: <str>
             source_interface: <str>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -17708,6 +17708,12 @@
             "type": "boolean",
             "title": "IP IGMP"
           },
+          "ip_igmp_version": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 3,
+            "title": "IP IGMP Version"
+          },
           "ip_helpers": {
             "type": "array",
             "description": "List of DHCP servers",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -10930,6 +10930,12 @@ keys:
             description: IPv4_address/Mask
         ip_igmp:
           type: bool
+        ip_igmp_version:
+          type: int
+          convert_types:
+          - str
+          min: 1
+          max: 3
         ip_helpers:
           type: list
           description: List of DHCP servers

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/vlan_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/vlan_interfaces.schema.yml
@@ -68,6 +68,12 @@ keys:
             description: IPv4_address/Mask
         ip_igmp:
           type: bool
+        ip_igmp_version:
+          type: int
+          convert_types:
+            - str
+          min: 1
+          max: 3
         ip_helpers:
           type: list
           description: List of DHCP servers

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/vlan_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/vlan_interfaces.schema.yml
@@ -71,7 +71,7 @@ keys:
         ip_igmp_version:
           type: int
           convert_types:
-            - str
+          - str
           min: 1
           max: 3
         ip_helpers:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
@@ -73,6 +73,9 @@ interface {{ vlan_interface.name }}
 {%     if vlan_interface.ip_igmp is arista.avd.defined(true) %}
    ip igmp
 {%     endif %}
+{%     if vlan_interface.ip_igmp_version is arista.avd.defined %}
+   ip igmp version {{ vlan_interface.ip_igmp_version }}
+{%     endif %}
 {%     if vlan_interface.ipv6_enable is arista.avd.defined(true) %}
    ipv6 enable
 {%     endif %}


### PR DESCRIPTION
## Change Summary

Add support for "ip_igmp_version" under "vlan_interfaces"
<!-- Enter short PR description -->

## Related Issue(s)

Part of #2790 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

Add `ip_igmp_version` under `vlan_interfaces`.

```yaml
        ip_igmp_version:
          type: int
          convert_types:
            - str
          min: 1
          max: 3
```

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Added molecule

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
