### PR TITLE
Feat(eos_cli_config_gen): Default queue-monitor thresholds

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/queue_monitor_length.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/queue_monitor_length.cfg
@@ -3,6 +3,7 @@
 transceiver qsfp default-mode 4x10G
 !
 queue-monitor length
+queue-monitor length default thresholds 100 10
 queue-monitor length log 100
 queue-monitor length notifying
 queue-monitor length cpu thresholds 200000 100000

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/queue_monitor_length_notifying.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/queue_monitor_length_notifying.cfg
@@ -3,6 +3,7 @@
 transceiver qsfp default-mode 4x10G
 !
 queue-monitor length
+queue-monitor length default threshold 100
 no queue-monitor length notifying
 !
 hostname queue_monitor_length_notifying

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/queue_monitor_length.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/queue_monitor_length.yml
@@ -1,6 +1,9 @@
 queue_monitor_length:
   # "enabled: true" will be required in AVD4.0. In AVD3.x default is true as long as queue_monitor_length is defined and not None
   enabled: true
+  default_thresholds:
+    low: 10
+    high: 100
   log: 100
   notifying: true
   cpu:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/queue_monitor_length_notifying.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/queue_monitor_length_notifying.yml
@@ -2,3 +2,6 @@ queue_monitor_length:
   enabled: true
   # test the negative case
   notifying: false
+  # test with only the high threshold set
+  default_thresholds:
+    high: 100

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/data_model/Quality of Service.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/data_model/Quality of Service.md
@@ -209,7 +209,7 @@ search:
     | [<samp>&nbsp;&nbsp;enabled</samp>](## "queue_monitor_length.enabled") | Boolean |  |  |  | "enabled: true" will be required in AVD4.0.<br>In AVD3.x default is true as long as queue_monitor_length is defined and not None<br> |
     | [<samp>&nbsp;&nbsp;default_thresholds</samp>](## "queue_monitor_length.default_thresholds") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;high</samp>](## "queue_monitor_length.default_thresholds.high") | Integer | Required |  |  | Default high threshold for Ethernet Interfaces.<br> |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;low</samp>](## "queue_monitor_length.default_thresholds.low") | Integer |  |  |  | Default low threshold for Ethernet Interfaces<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;low</samp>](## "queue_monitor_length.default_thresholds.low") | Integer |  |  |  | Default low threshold for Ethernet Interfaces.<br>Low threshold support is platform dependent.<br> |
     | [<samp>&nbsp;&nbsp;log</samp>](## "queue_monitor_length.log") | Integer |  |  |  | Logging interval in seconds |
     | [<samp>&nbsp;&nbsp;notifying</samp>](## "queue_monitor_length.notifying") | Boolean |  |  |  | should only be used for platforms supporting the "queue-monitor length notifying" CLI |
     | [<samp>&nbsp;&nbsp;cpu</samp>](## "queue_monitor_length.cpu") | Dictionary |  |  |  |  |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/data_model/Quality of Service.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/data_model/Quality of Service.md
@@ -207,6 +207,9 @@ search:
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
     | [<samp>queue_monitor_length</samp>](## "queue_monitor_length") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;enabled</samp>](## "queue_monitor_length.enabled") | Boolean |  |  |  | "enabled: true" will be required in AVD4.0.<br>In AVD3.x default is true as long as queue_monitor_length is defined and not None<br> |
+    | [<samp>&nbsp;&nbsp;default_thresholds</samp>](## "queue_monitor_length.default_thresholds") | Dictionary |  |  |  | Set the default high and low thresholds for Etherent Interfaces<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;high</samp>](## "queue_monitor_length.default_thresholds.high") | Integer | Required |  |  | Set the default high threshold for Ethernet Interfaces<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;low</samp>](## "queue_monitor_length.default_thresholds.low") | Integer |  |  |  | Set the default low threshold for Etherenet Interfaces<br> |
     | [<samp>&nbsp;&nbsp;log</samp>](## "queue_monitor_length.log") | Integer |  |  |  | Logging interval in seconds |
     | [<samp>&nbsp;&nbsp;notifying</samp>](## "queue_monitor_length.notifying") | Boolean |  |  |  | should only be used for platforms supporting the "queue-monitor length notifying" CLI |
     | [<samp>&nbsp;&nbsp;cpu</samp>](## "queue_monitor_length.cpu") | Dictionary |  |  |  |  |
@@ -219,6 +222,9 @@ search:
     ```yaml
     queue_monitor_length:
       enabled: <bool>
+      default_thresholds:
+        high: <int>
+        low: <int>
       log: <int>
       notifying: <bool>
       cpu:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/data_model/Quality of Service.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/data_model/Quality of Service.md
@@ -207,9 +207,9 @@ search:
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
     | [<samp>queue_monitor_length</samp>](## "queue_monitor_length") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;enabled</samp>](## "queue_monitor_length.enabled") | Boolean |  |  |  | "enabled: true" will be required in AVD4.0.<br>In AVD3.x default is true as long as queue_monitor_length is defined and not None<br> |
-    | [<samp>&nbsp;&nbsp;default_thresholds</samp>](## "queue_monitor_length.default_thresholds") | Dictionary |  |  |  | Set the default high and low thresholds for Etherent Interfaces<br> |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;high</samp>](## "queue_monitor_length.default_thresholds.high") | Integer | Required |  |  | Set the default high threshold for Ethernet Interfaces<br> |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;low</samp>](## "queue_monitor_length.default_thresholds.low") | Integer |  |  |  | Set the default low threshold for Etherenet Interfaces<br> |
+    | [<samp>&nbsp;&nbsp;default_thresholds</samp>](## "queue_monitor_length.default_thresholds") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;high</samp>](## "queue_monitor_length.default_thresholds.high") | Integer | Required |  |  | Default high threshold for Ethernet Interfaces.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;low</samp>](## "queue_monitor_length.default_thresholds.low") | Integer |  |  |  | Default low threshold for Ethernet Interfaces<br> |
     | [<samp>&nbsp;&nbsp;log</samp>](## "queue_monitor_length.log") | Integer |  |  |  | Logging interval in seconds |
     | [<samp>&nbsp;&nbsp;notifying</samp>](## "queue_monitor_length.notifying") | Boolean |  |  |  | should only be used for platforms supporting the "queue-monitor length notifying" CLI |
     | [<samp>&nbsp;&nbsp;cpu</samp>](## "queue_monitor_length.cpu") | Dictionary |  |  |  |  |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -10309,7 +10309,7 @@
             },
             "low": {
               "type": "integer",
-              "description": "Default low threshold for Ethernet Interfaces\n",
+              "description": "Default low threshold for Ethernet Interfaces.\nLow threshold support is platform dependent.\n",
               "title": "Low"
             }
           },

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -10300,7 +10300,6 @@
         },
         "default_thresholds": {
           "type": "object",
-          "description": "",
           "properties": {
             "high": {
               "type": "integer",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -10292,16 +10292,16 @@
         },
         "default_thresholds": {
           "type": "object",
-          "description": "Set the default high and low thresholds for Etherent Interfaces\n",
+          "description": "",
           "properties": {
             "high": {
               "type": "integer",
-              "description": "Set the default high threshold for Ethernet Interfaces\n",
+              "description": "Default high threshold for Ethernet Interfaces.\n",
               "title": "High"
             },
             "low": {
               "type": "integer",
-              "description": "Set the default low threshold for Etherenet Interfaces\n",
+              "description": "Default low threshold for Ethernet Interfaces\n",
               "title": "Low"
             }
           },

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -10290,6 +10290,30 @@
           "description": "\"enabled: true\" will be required in AVD4.0.\nIn AVD3.x default is true as long as queue_monitor_length is defined and not None\n",
           "title": "Enabled"
         },
+        "default_thresholds": {
+          "type": "object",
+          "description": "Set the default high and low thresholds for Etherent Interfaces\n",
+          "properties": {
+            "high": {
+              "type": "integer",
+              "description": "Set the default high threshold for Ethernet Interfaces\n",
+              "title": "High"
+            },
+            "low": {
+              "type": "integer",
+              "description": "Set the default low threshold for Etherenet Interfaces\n",
+              "title": "Low"
+            }
+          },
+          "required": [
+            "high"
+          ],
+          "additionalProperties": false,
+          "patternProperties": {
+            "^_.+$": {}
+          },
+          "title": "Default Thresholds"
+        },
         "log": {
           "type": "integer",
           "description": "Logging interval in seconds",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -6680,7 +6680,6 @@ keys:
           '
       default_thresholds:
         type: dict
-        description: ''
         keys:
           high:
             type: int

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -6676,23 +6676,21 @@ keys:
           '
       default_thresholds:
         type: dict
-        description: 'Set the default high and low thresholds for Etherent Interfaces
-
-          '
+        description: ''
         keys:
           high:
             type: int
             required: true
             convert_types:
             - str
-            description: 'Set the default high threshold for Ethernet Interfaces
+            description: 'Default high threshold for Ethernet Interfaces.
 
               '
           low:
             type: int
             convert_types:
             - str
-            description: 'Set the default low threshold for Etherenet Interfaces
+            description: 'Default low threshold for Ethernet Interfaces
 
               '
       log:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -6674,6 +6674,27 @@ keys:
           not None
 
           '
+      default_thresholds:
+        type: dict
+        description: 'Set the default high and low thresholds for Etherent Interfaces
+
+          '
+        keys:
+          high:
+            type: int
+            required: true
+            convert_types:
+            - str
+            description: 'Set the default high threshold for Ethernet Interfaces
+
+              '
+          low:
+            type: int
+            convert_types:
+            - str
+            description: 'Set the default low threshold for Etherenet Interfaces
+
+              '
       log:
         type: int
         convert_types:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -6694,7 +6694,9 @@ keys:
             type: int
             convert_types:
             - str
-            description: 'Default low threshold for Ethernet Interfaces
+            description: 'Default low threshold for Ethernet Interfaces.
+
+              Low threshold support is platform dependent.
 
               '
       log:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/queue_monitor_length.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/queue_monitor_length.schema.yml
@@ -29,7 +29,8 @@ keys:
             convert_types:
               - str
             description: |
-              Default low threshold for Ethernet Interfaces
+              Default low threshold for Ethernet Interfaces.
+              Low threshold support is platform dependent.
       log:
         type: int
         convert_types:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/queue_monitor_length.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/queue_monitor_length.schema.yml
@@ -16,7 +16,6 @@ keys:
       default_thresholds:
         type: dict
         description: |
-          Set the default high and low thresholds for Etherent Interfaces
         keys:
           high:
             type: int

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/queue_monitor_length.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/queue_monitor_length.schema.yml
@@ -30,7 +30,7 @@ keys:
             convert_types:
               - str
             description: |
-              Set the default low threshold for Etherenet Interfaces
+              Default low threshold for Ethernet Interfaces
       log:
         type: int
         convert_types:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/queue_monitor_length.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/queue_monitor_length.schema.yml
@@ -15,7 +15,6 @@ keys:
           In AVD3.x default is true as long as queue_monitor_length is defined and not None
       default_thresholds:
         type: dict
-        description: |
         keys:
           high:
             type: int

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/queue_monitor_length.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/queue_monitor_length.schema.yml
@@ -13,6 +13,24 @@ keys:
         description: |
           "enabled: true" will be required in AVD4.0.
           In AVD3.x default is true as long as queue_monitor_length is defined and not None
+      default_thresholds:
+        type: dict
+        description: |
+          Set the default high and low thresholds for Etherent Interfaces
+        keys:
+          high:
+            type: int
+            required: true
+            convert_types:
+              - str
+            description: |
+              Set the default high threshold for Ethernet Interfaces
+          low:
+            type: int
+            convert_types:
+              - str
+            description: |
+              Set the default low threshold for Etherenet Interfaces
       log:
         type: int
         convert_types:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/queue_monitor_length.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/queue_monitor_length.schema.yml
@@ -24,7 +24,7 @@ keys:
             convert_types:
               - str
             description: |
-              Set the default high threshold for Ethernet Interfaces
+              Default high threshold for Ethernet Interfaces.
           low:
             type: int
             convert_types:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/queue-monitor-length.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/queue-monitor-length.j2
@@ -2,10 +2,14 @@
 {% if queue_monitor_length is arista.avd.defined and queue_monitor_length.enabled is not arista.avd.defined(false) %}
 !
 queue-monitor length
-{%     if queue_monitor_length.default_thresholds.high is arista.avd.defined  and queue_monitor_length.default_thresholds.low is not arista.avd.defined %}
-queue-monitor length default threshold {{ queue_monitor_length.default_thresholds.high }}
-{%     elif queue_monitor_length.default_thresholds.high is arista.avd.defined  and queue_monitor_length.default_thresholds.low is arista.avd.defined %}
-queue-monitor length default thresholds {{ queue_monitor_length.default_thresholds.high }} {{ queue_monitor_length.default_thresholds.low }}
+{%     if queue_monitor_length.default_thresholds.high is arista.avd.defined %}
+{%         set default_thresholds_cli = "queue-monitor length default threshold" %}
+{%         if queue_monitor_length.default_thresholds.low is arista.avd.defined %}
+{%             set default_thresholds_cli = default_thresholds_cli ~ "s " ~ queue_monitor_length.default_thresholds.high ~ " " ~ queue_monitor_length.default_thresholds.low %}
+{%         else %}
+{%             set default_thresholds_cli = default_thresholds_cli ~ " " ~ queue_monitor_length.default_thresholds.high %}
+{%         endif %}
+{{ default_thresholds_cli }}
 {%     endif %}
 {%     if queue_monitor_length.log is arista.avd.defined %}
 queue-monitor length log {{ queue_monitor_length.log }}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/queue-monitor-length.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/queue-monitor-length.j2
@@ -2,6 +2,11 @@
 {% if queue_monitor_length is arista.avd.defined and queue_monitor_length.enabled is not arista.avd.defined(false) %}
 !
 queue-monitor length
+{%     if queue_monitor_length.default_thresholds.high is arista.avd.defined  and queue_monitor_length.default_thresholds.low is not arista.avd.defined %}
+queue-monitor length default threshold {{ queue_monitor_length.default_thresholds.high }}
+{%     elif queue_monitor_length.default_thresholds.high is arista.avd.defined  and queue_monitor_length.default_thresholds.low is arista.avd.defined %}
+queue-monitor length default thresholds {{ queue_monitor_length.default_thresholds.high }} {{ queue_monitor_length.default_thresholds.low }}
+{%     endif %}
 {%     if queue_monitor_length.log is arista.avd.defined %}
 queue-monitor length log {{ queue_monitor_length.log }}
 {%     endif %}


### PR DESCRIPTION
## Change Summary
Add support for specifying the default high and low thresholds for queue-monitor on ethernet interfaces.
This change supports both specifying the high threshold only, or both high and low. 

<!-- Enter short PR description -->

## Related Issue(s)

No Issues raised.
Customers are already using this via custom templates & eos_cli commands.

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

- Add support for the command `queue-monitor length default thresholds <high> <low>`
- Add support for the command `queue-monitor length default threshold <high>`

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

- Run the molecule scenario `eos_cli_config_gen` and verify the configuration that is generated

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
