### PR TITLE
Feat(eos_designs)!: fabric variable for bgp default ipv4 unicast

### DIFF
--- a/ansible_collections/arista/avd/docs/getting-started/intro-to-ansible-and-avd.md
+++ b/ansible_collections/arista/avd/docs/getting-started/intro-to-ansible-and-avd.md
@@ -217,7 +217,6 @@ spine:
       # The two following commands must not be enabled when using vEOS-lab
       # - update wait-for-convergence
       # - update wait-install
-      - no bgp default ipv4-unicast
       - distance bgp 20 200 200
       - graceful-restart restart-time 300
       - graceful-restart

--- a/ansible_collections/arista/avd/docs/how-to/first-project.md
+++ b/ansible_collections/arista/avd/docs/how-to/first-project.md
@@ -190,7 +190,6 @@ spine:
     loopback_ipv4_pool: 192.168.255.0/24
     # Recommended for vEOS
     bgp_defaults:
-      - 'no bgp default ipv4-unicast'
       - 'distance bgp 20 200 200'
       - 'graceful-restart restart-time 300'
       - 'graceful-restart'

--- a/ansible_collections/arista/avd/docs/porting-guides/4.x.x.md
+++ b/ansible_collections/arista/avd/docs/porting-guides/4.x.x.md
@@ -15,9 +15,9 @@ built in to `eos_designs`.
 
 ### Fabric variables
 
-**BGP variables:**
+#### BGP variables
 
-A new key, `bgp_default_ipv4_unicast: <bool> -> default false` was introduced to implement the best practice of disabling the default activation of IPv4 unicast address-family on all IPv4 neighbors.
+A new key, `bgp_default_ipv4_unicast: <bool> -> default false` was introduced to implement the best practice of disabling the default activation of IPv4 unicast address-family.
 
 To change the default behavior, set the key to true:
 

--- a/ansible_collections/arista/avd/docs/porting-guides/4.x.x.md
+++ b/ansible_collections/arista/avd/docs/porting-guides/4.x.x.md
@@ -15,7 +15,29 @@ built in to `eos_designs`.
 
 ### Fabric variables
 
-**BGP peer groups variables:**
+**BGP variables:**
+
+A new key, `bgp_default_ipv4_unicast: <bool> -> default false` was introduced to implement the best practice of disabling the default activation of IPv4 unicast address-family on all IPv4 neighbors.
+
+To change the default behavior, set the key to true:
+
+```yaml
+bgp_default_ipv4_unicast: true
+```
+
+Configuration under the `<node_type_key>.defaults.bgp_defaults` should also be removed to avoid duplicate entries in the configuration.
+
+Example:
+
+```yaml
+l3leaf:
+  defaults:
+    bgp_defaults:
+      # - no bgp default ipv4-unicast <--- remove this item to avoid duplicates
+```
+
+!!! note
+    This will now explicitly activate or deactivate bgp_default_ipv4_unicast in the EOS configuration.
 
 The following keys under `bgp_peer_groups` have been replaced to avoid upper-case variables.
 

--- a/ansible_collections/arista/avd/docs/release-notes/4.x.x.md
+++ b/ansible_collections/arista/avd/docs/release-notes/4.x.x.md
@@ -98,6 +98,12 @@ See details in the [Porting guide for AVD 4.x.x](../porting-guides/4.x.x.md#fabr
 
 See details in the [Porting guide for AVD 4.x.x](../porting-guides/4.x.x.md#fabric-variables).
 
+### change in defaults eos_designs in BGP variables
+
+A new key, `bgp_default_ipv4_unicast: <bool> -> default false` was introduced to implement the best practice of disabling the default activation of IPv4 unicast address-family on all IPv4 neighbors.
+
+See details in the [Porting guide for AVD 4.x.x](../porting-guides/4.x.x.md#fabric-variables).
+
 ### Change in eos_designs behavior in core_interfaces variables
 
 - `core_interfaces.p2p_links.[].ptp_enable` requires the `ptp.enabled: true` to be set at the fabric level.

--- a/ansible_collections/arista/avd/docs/release-notes/4.x.x.md
+++ b/ansible_collections/arista/avd/docs/release-notes/4.x.x.md
@@ -100,7 +100,7 @@ See details in the [Porting guide for AVD 4.x.x](../porting-guides/4.x.x.md#fabr
 
 ### change in defaults eos_designs in BGP variables
 
-A new key, `bgp_default_ipv4_unicast: <bool> -> default false` was introduced to implement the best practice of disabling the default activation of IPv4 unicast address-family on all IPv4 neighbors.
+A new key, `bgp_default_ipv4_unicast: <bool> -> default false` was introduced to implement the best practice of disabling the default activation of IPv4 unicast address-family.
 
 See details in the [Porting guide for AVD 4.x.x](../porting-guides/4.x.x.md#fabric-variables).
 

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/README.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/README.md
@@ -260,7 +260,6 @@ spine:
     loopback_ipv4_pool: 10.255.128.0/27 # (3)!
     bgp_as: 65200 # (4)!
     bgp_defaults: # (5)!
-      - no bgp default ipv4-unicast
       - distance bgp 20 200 200
       - graceful-restart restart-time 300
       - graceful-restart
@@ -300,7 +299,6 @@ l3leaf:
     mlag_peer_ipv4_pool: 10.255.129.64/27 # (9)!
     mlag_peer_l3_ipv4_pool: 10.255.129.96/27 # (10)!
     bgp_defaults:
-      - no bgp default ipv4-unicast
       - distance bgp 20 200 200
       - graceful-restart restart-time 300
       - graceful-restart

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-leaf1a.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-leaf1a.md
@@ -608,11 +608,11 @@ ip route vrf MGMT 0.0.0.0/0 172.16.1.1
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-leaf1b.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-leaf1b.md
@@ -608,11 +608,11 @@ ip route vrf MGMT 0.0.0.0/0 172.16.1.1
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-leaf2a.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-leaf2a.md
@@ -616,11 +616,11 @@ ip route vrf MGMT 0.0.0.0/0 172.16.1.1
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-leaf2b.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-leaf2b.md
@@ -616,11 +616,11 @@ ip route vrf MGMT 0.0.0.0/0 172.16.1.1
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-spine1.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-spine1.md
@@ -277,11 +277,11 @@ ip route vrf MGMT 0.0.0.0/0 172.16.1.1
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-spine2.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-spine2.md
@@ -277,11 +277,11 @@ ip route vrf MGMT 0.0.0.0/0 172.16.1.1
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-leaf1a.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-leaf1a.md
@@ -608,11 +608,11 @@ ip route vrf MGMT 0.0.0.0/0 172.16.2.1
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-leaf1b.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-leaf1b.md
@@ -608,11 +608,11 @@ ip route vrf MGMT 0.0.0.0/0 172.16.2.1
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-leaf2a.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-leaf2a.md
@@ -616,11 +616,11 @@ ip route vrf MGMT 0.0.0.0/0 172.16.2.1
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-leaf2b.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-leaf2b.md
@@ -616,11 +616,11 @@ ip route vrf MGMT 0.0.0.0/0 172.16.2.1
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-spine1.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-spine1.md
@@ -277,11 +277,11 @@ ip route vrf MGMT 0.0.0.0/0 172.16.2.1
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-spine2.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-spine2.md
@@ -277,11 +277,11 @@ ip route vrf MGMT 0.0.0.0/0 172.16.2.1
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/group_vars/DC1.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/group_vars/DC1.yml
@@ -19,7 +19,6 @@ spine:
       # The two following commands must not be enabled when using vEOS-lab
       # - update wait-for-convergence
       # - update wait-install
-      - no bgp default ipv4-unicast
       - distance bgp 20 200 200
       - graceful-restart restart-time 300
       - graceful-restart
@@ -66,7 +65,6 @@ l3leaf:
     bgp_defaults:
       # The following command must not be enabled when using vEOS-lab
       # - update wait-install
-      - no bgp default ipv4-unicast
       - distance bgp 20 200 200
       - graceful-restart restart-time 300
       - graceful-restart

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/group_vars/DC2.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/group_vars/DC2.yml
@@ -19,7 +19,6 @@ spine:
       # The two following commands must not be enabled when using vEOS-lab
       # - update wait-for-convergence
       # - update wait-install
-      - no bgp default ipv4-unicast
       - distance bgp 20 200 200
       - graceful-restart restart-time 300
       - graceful-restart
@@ -66,7 +65,6 @@ l3leaf:
     bgp_defaults:
       # The following command must not be enabled when using vEOS-lab
       # - update wait-install
-      - no bgp default ipv4-unicast
       - distance bgp 20 200 200
       - graceful-restart restart-time 300
       - graceful-restart

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf1a.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf1a.yml
@@ -2,11 +2,13 @@ router_bgp:
   as: '65101'
   router_id: 10.255.0.3
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - graceful-restart restart-time 300
   - graceful-restart
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf1b.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf1b.yml
@@ -2,11 +2,13 @@ router_bgp:
   as: '65101'
   router_id: 10.255.0.4
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - graceful-restart restart-time 300
   - graceful-restart
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf2a.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf2a.yml
@@ -2,11 +2,13 @@ router_bgp:
   as: '65102'
   router_id: 10.255.0.5
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - graceful-restart restart-time 300
   - graceful-restart
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf2b.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf2b.yml
@@ -2,11 +2,13 @@ router_bgp:
   as: '65102'
   router_id: 10.255.0.6
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - graceful-restart restart-time 300
   - graceful-restart
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-spine1.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-spine1.yml
@@ -2,11 +2,13 @@ router_bgp:
   as: '65100'
   router_id: 10.255.0.1
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - graceful-restart restart-time 300
   - graceful-restart
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-spine2.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-spine2.yml
@@ -2,11 +2,13 @@ router_bgp:
   as: '65100'
   router_id: 10.255.0.2
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - graceful-restart restart-time 300
   - graceful-restart
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf1a.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf1a.yml
@@ -2,11 +2,13 @@ router_bgp:
   as: '65201'
   router_id: 10.255.128.13
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - graceful-restart restart-time 300
   - graceful-restart
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf1b.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf1b.yml
@@ -2,11 +2,13 @@ router_bgp:
   as: '65201'
   router_id: 10.255.128.14
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - graceful-restart restart-time 300
   - graceful-restart
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf2a.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf2a.yml
@@ -2,11 +2,13 @@ router_bgp:
   as: '65202'
   router_id: 10.255.128.15
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - graceful-restart restart-time 300
   - graceful-restart
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf2b.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf2b.yml
@@ -2,11 +2,13 @@ router_bgp:
   as: '65202'
   router_id: 10.255.128.16
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - graceful-restart restart-time 300
   - graceful-restart
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-spine1.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-spine1.yml
@@ -2,11 +2,13 @@ router_bgp:
   as: '65200'
   router_id: 10.255.128.11
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - graceful-restart restart-time 300
   - graceful-restart
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-spine2.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-spine2.yml
@@ -2,11 +2,13 @@ router_bgp:
   as: '65200'
   router_id: 10.255.128.12
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - graceful-restart restart-time 300
   - graceful-restart
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/README.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/README.md
@@ -352,7 +352,6 @@ spine:
     loopback_ipv4_pool: 10.255.0.0/27 # (3)!
     bgp_as: 65100 # (4)!
     bgp_defaults: # (5)!
-      - no bgp default ipv4-unicast
       - distance bgp 20 200 200
       - graceful-restart restart-time 300
       - graceful-restart
@@ -392,7 +391,6 @@ l3leaf:
     mlag_peer_ipv4_pool: 10.255.1.64/27 # (9)!
     mlag_peer_l3_ipv4_pool: 10.255.1.96/27 # (10)!
     bgp_defaults:
-      - no bgp default ipv4-unicast
       - distance bgp 20 200 200
       - graceful-restart restart-time 300
       - graceful-restart

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf1a.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf1a.md
@@ -608,11 +608,11 @@ ip route vrf MGMT 0.0.0.0/0 172.16.1.1
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf1b.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf1b.md
@@ -608,11 +608,11 @@ ip route vrf MGMT 0.0.0.0/0 172.16.1.1
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf2a.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf2a.md
@@ -608,11 +608,11 @@ ip route vrf MGMT 0.0.0.0/0 172.16.1.1
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf2b.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf2b.md
@@ -608,11 +608,11 @@ ip route vrf MGMT 0.0.0.0/0 172.16.1.1
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-spine1.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-spine1.md
@@ -277,11 +277,11 @@ ip route vrf MGMT 0.0.0.0/0 172.16.1.1
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-spine2.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-spine2.md
@@ -277,11 +277,11 @@ ip route vrf MGMT 0.0.0.0/0 172.16.1.1
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/group_vars/DC1.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/group_vars/DC1.yml
@@ -17,7 +17,6 @@ spine:
       # The two following commands must not be enabled when using vEOS-lab
       # - update wait-for-convergence
       # - update wait-install
-      - no bgp default ipv4-unicast
       - distance bgp 20 200 200
       - graceful-restart restart-time 300
       - graceful-restart
@@ -64,7 +63,6 @@ l3leaf:
     bgp_defaults:
       # The following command must not be enabled when using vEOS-lab
       # - update wait-install
-      - no bgp default ipv4-unicast
       - distance bgp 20 200 200
       - graceful-restart restart-time 300
       - graceful-restart

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf1a.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf1a.yml
@@ -2,11 +2,13 @@ router_bgp:
   as: '65101'
   router_id: 10.255.0.3
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - graceful-restart restart-time 300
   - graceful-restart
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf1b.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf1b.yml
@@ -2,11 +2,13 @@ router_bgp:
   as: '65101'
   router_id: 10.255.0.4
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - graceful-restart restart-time 300
   - graceful-restart
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf2a.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf2a.yml
@@ -2,11 +2,13 @@ router_bgp:
   as: '65102'
   router_id: 10.255.0.5
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - graceful-restart restart-time 300
   - graceful-restart
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf2b.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf2b.yml
@@ -2,11 +2,13 @@ router_bgp:
   as: '65102'
   router_id: 10.255.0.6
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - graceful-restart restart-time 300
   - graceful-restart
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-spine1.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-spine1.yml
@@ -2,11 +2,13 @@ router_bgp:
   as: '65100'
   router_id: 10.255.0.1
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - graceful-restart restart-time 300
   - graceful-restart
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-spine2.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-spine2.yml
@@ -2,11 +2,13 @@ router_bgp:
   as: '65100'
   router_id: 10.255.0.2
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - graceful-restart restart-time 300
   - graceful-restart
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/dhcp_provisioning/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/dhcp_provisioning/inventory/group_vars/DC1_FABRIC.yml
@@ -168,12 +168,10 @@ l2leaf:
 spine_bgp_defaults:
 #  - update wait-for-convergence
 #  - update wait-install
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
 
 leaf_bgp_defaults:
 #  - update wait-install
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
 
 # Update p2p mtu 9000 -> 1500

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-BL1A.md
@@ -629,9 +629,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-BL1B.md
@@ -629,9 +629,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF1A.md
@@ -517,9 +517,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF2A.md
@@ -856,9 +856,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF2B.md
@@ -856,9 +856,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE1.md
@@ -364,9 +364,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE2.md
@@ -364,9 +364,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE3.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE3.md
@@ -364,9 +364,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE4.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE4.md
@@ -364,9 +364,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SVC3A.md
@@ -972,9 +972,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SVC3B.md
@@ -946,9 +946,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-BL1A.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65104'
   router_id: 192.168.255.10
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-BL1B.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65104'
   router_id: 192.168.255.11
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF1A.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65101'
   router_id: 192.168.255.5
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF2A.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65102'
   router_id: 192.168.255.6
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF2B.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65102'
   router_id: 192.168.255.7
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SPINE1.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65001'
   router_id: 192.168.255.1
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SPINE2.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65001'
   router_id: 192.168.255.2
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SPINE3.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65001'
   router_id: 192.168.255.3
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SPINE4.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65001'
   router_id: 192.168.255.4
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SVC3A.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65103'
   router_id: 192.168.255.8
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SVC3B.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65103'
   router_id: 192.168.255.9
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/inventory/group_vars/DC1_FABRIC.yml
@@ -22,7 +22,7 @@ spine:
     platform: vEOS-LAB
     bgp_as: 65001
     loopback_ipv4_pool: 192.168.255.0/24
-    bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']
+    bgp_defaults: ['distance bgp 20 200 200']
   nodes:
     DC1-SPINE1:
       id: 1
@@ -47,7 +47,7 @@ l3leaf:
     loopback_ipv4_offset: 4
     vtep_loopback_ipv4_pool: 192.168.254.0/24
     uplink_ipv4_pool: 172.31.255.0/24
-    bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']
+    bgp_defaults: ['distance bgp 20 200 200']
     platform: vEOS-LAB
     bgp_as: 65100
     uplink_switches: [ DC1-SPINE1, DC1-SPINE2, DC1-SPINE3, DC1-SPINE4 ]

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/BGP-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/BGP-SPINE1.md
@@ -373,6 +373,7 @@ ip route vrf MGMT 0.0.0.0/0 172.31.0.1
 | BGP Tuning |
 | ---------- |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 
@@ -407,6 +408,7 @@ ip route vrf MGMT 0.0.0.0/0 172.31.0.1
 !
 router bgp 65001
    router-id 192.168.255.1
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS send-community

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/BGP-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/BGP-SPINE2.md
@@ -375,6 +375,7 @@ ip route 10.0.0.0/8 10.1.100.100
 | BGP Tuning |
 | ---------- |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 
@@ -409,6 +410,7 @@ ip route 10.0.0.0/8 10.1.100.100
 !
 router bgp 65001
    router-id 192.168.255.2
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS send-community

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/BGP-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/BGP-SPINE1.cfg
@@ -112,6 +112,7 @@ route-map RM-MLAG-PEER-IN permit 10
 !
 router bgp 65001
    router-id 192.168.255.1
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS send-community

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/BGP-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/BGP-SPINE2.cfg
@@ -113,6 +113,7 @@ route-map RM-MLAG-PEER-IN permit 10
 !
 router bgp 65001
    router-id 192.168.255.2
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS send-community

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-SPINE1.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 192.168.255.1
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-SPINE2.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 192.168.255.2
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER1.md
@@ -629,11 +629,11 @@ router isis CORE
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER2.md
@@ -594,11 +594,11 @@ router isis CORE
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-RR1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-RR1.md
@@ -352,12 +352,12 @@ router isis CORE
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | bgp route-reflector preserve-attributes always |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 
@@ -432,8 +432,8 @@ router isis CORE
 !
 router bgp 65000
    router-id 100.70.0.8
-   bgp cluster-id 1.1.1.1
    no bgp default ipv4-unicast
+   bgp cluster-id 1.1.1.1
    distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-LER1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-LER1.md
@@ -631,11 +631,11 @@ router isis CORE
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-RR1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-RR1.md
@@ -352,12 +352,12 @@ router isis CORE
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | bgp route-reflector preserve-attributes always |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 
@@ -432,8 +432,8 @@ router isis CORE
 !
 router bgp 65000
    router-id 100.70.0.9
-   bgp cluster-id 1.1.1.1
    no bgp default ipv4-unicast
+   bgp cluster-id 1.1.1.1
    distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE1-RR1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE1-RR1.cfg
@@ -65,8 +65,8 @@ router bfd
 !
 router bgp 65000
    router-id 100.70.0.8
-   bgp cluster-id 1.1.1.1
    no bgp default ipv4-unicast
+   bgp cluster-id 1.1.1.1
    distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE2-RR1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE2-RR1.cfg
@@ -65,8 +65,8 @@ router bfd
 !
 router bgp 65000
    router-id 100.70.0.9
-   bgp cluster-id 1.1.1.1
    no bgp default ipv4-unicast
+   bgp cluster-id 1.1.1.1
    distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LER1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LER1.yml
@@ -2,11 +2,13 @@ router_bgp:
   as: '65000'
   router_id: 100.70.0.5
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - graceful-restart restart-time 300
   - graceful-restart
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MPLS-OVERLAY-PEERS
     type: mpls

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LER2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LER2.yml
@@ -2,11 +2,13 @@ router_bgp:
   as: '65000'
   router_id: 100.70.0.6
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - graceful-restart restart-time 300
   - graceful-restart
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MPLS-OVERLAY-PEERS
     type: mpls

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-RR1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-RR1.yml
@@ -2,12 +2,14 @@ router_bgp:
   as: '65000'
   router_id: 100.70.0.8
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - graceful-restart restart-time 300
   - graceful-restart
   - bgp route-reflector preserve-attributes always
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   bgp_cluster_id: 1.1.1.1
   peer_groups:
   - name: MPLS-OVERLAY-PEERS

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE2-LER1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE2-LER1.yml
@@ -2,11 +2,13 @@ router_bgp:
   as: '65000'
   router_id: 100.70.0.7
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - graceful-restart restart-time 300
   - graceful-restart
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MPLS-OVERLAY-PEERS
     type: mpls

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE2-RR1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE2-RR1.yml
@@ -2,12 +2,14 @@ router_bgp:
   as: '65000'
   router_id: 100.70.0.9
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - graceful-restart restart-time 300
   - graceful-restart
   - bgp route-reflector preserve-attributes always
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   bgp_cluster_id: 1.1.1.1
   peer_groups:
   - name: MPLS-OVERLAY-PEERS

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/inventory/group_vars/MPLS_CORE.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/inventory/group_vars/MPLS_CORE.yml
@@ -84,7 +84,6 @@ pe:
     spanning_tree_mode: mstp
     overlay_address_families: [ evpn, vpn-ipv4, vpn-ipv6 ]
     bgp_defaults:
-      - 'no bgp default ipv4-unicast'
       - 'distance bgp 20 200 200'
       - 'graceful-restart restart-time 300'
       - 'graceful-restart'
@@ -138,7 +137,6 @@ rr:
     overlay_address_families: [ evpn, vpn-ipv4, vpn-ipv6 ]
     mpls_route_reflectors: [ SITE1-RR1, SITE2-RR1 ]
     bgp_defaults:
-      - 'no bgp default ipv4-unicast'
       - 'distance bgp 20 200 200'
       - 'graceful-restart restart-time 300'
       - 'graceful-restart'

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF1A.md
@@ -385,11 +385,11 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2B.md
@@ -783,11 +783,11 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-SPINE1.md
@@ -320,11 +320,11 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-SPINE2.md
@@ -335,11 +335,11 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-LEAF1A.md
@@ -542,11 +542,11 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-SPINE1.md
@@ -313,11 +313,11 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-SPINE2.md
@@ -305,11 +305,11 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-RS1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-RS1.md
@@ -262,11 +262,11 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-RS2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-RS2.md
@@ -290,11 +290,11 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-SUPER-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-SUPER-SPINE1.md
@@ -296,11 +296,11 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-SUPER-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-SUPER-SPINE2.md
@@ -322,11 +322,11 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1.POD1.LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1.POD1.LEAF2A.md
@@ -758,11 +758,11 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-LEAF1A.md
@@ -482,11 +482,11 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-LEAF2A.md
@@ -408,11 +408,11 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-SPINE1.md
@@ -311,11 +311,11 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-SPINE2.md
@@ -310,11 +310,11 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-RS1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-RS1.md
@@ -281,11 +281,11 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-RS2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-RS2.md
@@ -279,11 +279,11 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-SUPER-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-SUPER-SPINE1.md
@@ -329,11 +329,11 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-SUPER-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-SUPER-SPINE2.md
@@ -289,11 +289,11 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF1A.yml
@@ -2,11 +2,13 @@ router_bgp:
   as: '65111.100'
   router_id: 172.16.110.3
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - graceful-restart restart-time 300
   - graceful-restart
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2B.yml
@@ -2,11 +2,13 @@ router_bgp:
   as: '65112.100'
   router_id: 172.16.110.5
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - graceful-restart restart-time 300
   - graceful-restart
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-SPINE1.yml
@@ -2,11 +2,13 @@ router_bgp:
   as: '65110.100'
   router_id: 172.16.110.1
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - graceful-restart restart-time 300
   - graceful-restart
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-SPINE2.yml
@@ -3,11 +3,13 @@ router_bgp:
   as: '65110.100'
   router_id: 172.16.110.2
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - graceful-restart restart-time 300
   - graceful-restart
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD2-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD2-LEAF1A.yml
@@ -2,11 +2,13 @@ router_bgp:
   as: '65121'
   router_id: 172.16.120.3
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - graceful-restart restart-time 300
   - graceful-restart
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD2-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD2-SPINE1.yml
@@ -2,11 +2,13 @@ router_bgp:
   as: '65120'
   router_id: 172.16.120.1
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - graceful-restart restart-time 300
   - graceful-restart
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD2-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD2-SPINE2.yml
@@ -2,11 +2,13 @@ router_bgp:
   as: '65120'
   router_id: 172.16.120.2
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - graceful-restart restart-time 300
   - graceful-restart
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-RS1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-RS1.yml
@@ -2,11 +2,13 @@ router_bgp:
   as: '65101'
   router_id: 172.16.10.1
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - graceful-restart restart-time 300
   - graceful-restart
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-RS2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-RS2.yml
@@ -2,11 +2,13 @@ router_bgp:
   as: '65102'
   router_id: 172.16.10.2
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - graceful-restart restart-time 300
   - graceful-restart
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-SUPER-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-SUPER-SPINE1.yml
@@ -2,11 +2,13 @@ router_bgp:
   as: '65100'
   router_id: 172.16.100.1
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - graceful-restart restart-time 300
   - graceful-restart
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-SUPER-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-SUPER-SPINE2.yml
@@ -2,11 +2,13 @@ router_bgp:
   as: '65100'
   router_id: 172.16.100.2
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - graceful-restart restart-time 300
   - graceful-restart
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1.POD1.LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1.POD1.LEAF2A.yml
@@ -2,11 +2,13 @@ router_bgp:
   as: '65112.100'
   router_id: 172.16.110.4
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - graceful-restart restart-time 300
   - graceful-restart
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-LEAF1A.yml
@@ -2,11 +2,13 @@ router_bgp:
   as: '65211'
   router_id: 172.16.210.3
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - graceful-restart restart-time 300
   - graceful-restart
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-LEAF2A.yml
@@ -2,11 +2,13 @@ router_bgp:
   as: '65212'
   router_id: 172.16.210.4
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - graceful-restart restart-time 300
   - graceful-restart
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-SPINE1.yml
@@ -2,11 +2,13 @@ router_bgp:
   as: '65210'
   router_id: 172.16.210.1
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - graceful-restart restart-time 300
   - graceful-restart
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-SPINE2.yml
@@ -2,11 +2,13 @@ router_bgp:
   as: '65210'
   router_id: 172.16.210.2
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - graceful-restart restart-time 300
   - graceful-restart
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-RS1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-RS1.yml
@@ -2,11 +2,13 @@ router_bgp:
   as: '65201'
   router_id: 172.16.20.1
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - graceful-restart restart-time 300
   - graceful-restart
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-RS2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-RS2.yml
@@ -2,11 +2,13 @@ router_bgp:
   as: '65201'
   router_id: 172.16.20.2
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - graceful-restart restart-time 300
   - graceful-restart
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-SUPER-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-SUPER-SPINE1.yml
@@ -2,11 +2,13 @@ router_bgp:
   as: '65200'
   router_id: 172.16.200.1
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - graceful-restart restart-time 300
   - graceful-restart
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-SUPER-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-SUPER-SPINE2.yml
@@ -2,11 +2,13 @@ router_bgp:
   as: '65200'
   router_id: 172.16.200.2
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - graceful-restart restart-time 300
   - graceful-restart
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/inventory/group_vars/DC1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/inventory/group_vars/DC1.yml
@@ -15,7 +15,6 @@ super_spine:
     bgp_as: 65100
     loopback_ipv4_pool: 172.16.100.0/24
     bgp_defaults:
-      - 'no bgp default ipv4-unicast'
       - 'distance bgp 20 200 200'
       - 'graceful-restart restart-time 300'
       - 'graceful-restart'
@@ -40,7 +39,6 @@ overlay_controller:
     max_uplink_switches: 4
     uplink_ipv4_pool: 172.17.10.0/24
     bgp_defaults:
-      - 'no bgp default ipv4-unicast'
       - 'distance bgp 20 200 200'
       - 'graceful-restart restart-time 300'
       - 'graceful-restart'

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/inventory/group_vars/DC1_POD1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/inventory/group_vars/DC1_POD1.yml
@@ -20,7 +20,6 @@ spine:
     uplink_macsec:
       profile: MACSEC_PROFILE
     bgp_defaults:
-      - "no bgp default ipv4-unicast"
       - "distance bgp 20 200 200"
       - "graceful-restart restart-time 300"
       - "graceful-restart"
@@ -54,7 +53,6 @@ l3leaf:
     uplink_macsec:
       profile: MACSEC_PROFILE
     bgp_defaults:
-      - "no bgp default ipv4-unicast"
       - "distance bgp 20 200 200"
       - "graceful-restart restart-time 300"
       - "graceful-restart"

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/inventory/group_vars/DC1_POD2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/inventory/group_vars/DC1_POD2.yml
@@ -15,7 +15,6 @@ spine:
     uplink_macsec:
       profile: MACSEC_PROFILE
     bgp_defaults:
-      - "no bgp default ipv4-unicast"
       - "distance bgp 20 200 200"
       - "graceful-restart restart-time 300"
       - "graceful-restart"
@@ -46,7 +45,6 @@ l3leaf:
     uplink_macsec:
       profile: MACSEC_PROFILE
     bgp_defaults:
-      - "no bgp default ipv4-unicast"
       - "distance bgp 20 200 200"
       - "graceful-restart restart-time 300"
       - "graceful-restart"

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/inventory/group_vars/DC2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/inventory/group_vars/DC2.yml
@@ -7,7 +7,7 @@ super_spine:
     platform: vEOS-LAB
     bgp_as: 65200
     loopback_ipv4_pool: 172.16.200.0/24
-    bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200', 'graceful-restart restart-time 300', 'graceful-restart']
+    bgp_defaults: ['distance bgp 20 200 200', 'graceful-restart restart-time 300', 'graceful-restart']
   nodes:
     DC2-SUPER-SPINE1:
       id: 1
@@ -29,7 +29,6 @@ overlay_controller:
     max_uplink_switches: 4
     uplink_ipv4_pool: 172.17.20.0/24
     bgp_defaults:
-      - 'no bgp default ipv4-unicast'
       - 'distance bgp 20 200 200'
       - 'graceful-restart restart-time 300'
       - 'graceful-restart'

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/inventory/group_vars/DC2_POD1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/inventory/group_vars/DC2_POD1.yml
@@ -13,7 +13,6 @@ spine:
     uplink_ptp:
       enable: True
     bgp_defaults:
-      - 'no bgp default ipv4-unicast'
       - 'distance bgp 20 200 200'
       - 'graceful-restart restart-time 300'
       - 'graceful-restart'
@@ -45,7 +44,6 @@ l3leaf:
     uplink_ipv4_pool: 172.17.210.0/24
     uplink_ptp: {'enable': True}
     bgp_defaults:
-      - 'no bgp default ipv4-unicast'
       - 'distance bgp 20 200 200'
       - 'graceful-restart restart-time 300'
       - 'graceful-restart'

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-PYTHON_MODULES-L3LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-PYTHON_MODULES-L3LEAF1A.cfg
@@ -140,6 +140,7 @@ router bfd
 !
 router bgp 65101
    router-id 192.168.255.21
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-PYTHON_MODULES-L3LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-PYTHON_MODULES-L3LEAF1B.cfg
@@ -140,6 +140,7 @@ router bfd
 !
 router bgp 65101
    router-id 192.168.255.22
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-PYTHON_MODULES-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-PYTHON_MODULES-SPINE1.cfg
@@ -56,6 +56,7 @@ router bfd
 !
 router bgp 65001
    router-id 192.168.255.1
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-TEMPLATES-L3LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-TEMPLATES-L3LEAF1A.cfg
@@ -140,6 +140,7 @@ router bfd
 !
 router bgp 65101
    router-id 192.168.255.21
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-TEMPLATES-L3LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-TEMPLATES-L3LEAF1B.cfg
@@ -140,6 +140,7 @@ router bfd
 !
 router bgp 65101
    router-id 192.168.255.22
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-TEMPLATES-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-TEMPLATES-SPINE1.cfg
@@ -56,6 +56,7 @@ router bfd
 !
 router bgp 65001
    router-id 192.168.255.1
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF1A.cfg
@@ -259,7 +259,7 @@ router bfd
 !
 router bgp 65101
    router-id 192.168.255.9
-   no bgp default ipv4-unicast
+   bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF1A.cfg
@@ -806,6 +806,7 @@ router bfd
 !
 router bgp 65101
    router-id 192.168.255.3
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF1B.cfg
@@ -806,6 +806,7 @@ router bfd
 !
 router bgp 65101
    router-id 192.168.255.4
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF2A.cfg
@@ -545,6 +545,7 @@ router bfd
 !
 router bgp 65103
    router-id 192.168.255.5
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF3A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF3A.cfg
@@ -567,6 +567,7 @@ router bfd
 !
 router bgp 65104
    router-id 192.168.255.6
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF3B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF3B.cfg
@@ -567,6 +567,7 @@ router bfd
 !
 router bgp 65105
    router-id 192.168.255.7
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-SPINE1.cfg
@@ -82,6 +82,7 @@ router bfd
 !
 router bgp 65001
    router-id 192.168.255.1
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/IGMP-QUERIER-L3LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/IGMP-QUERIER-L3LEAF1A.cfg
@@ -241,6 +241,7 @@ router bfd
 !
 router bgp 65101
    router-id 192.168.255.1
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MH-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MH-LEAF1A.cfg
@@ -344,6 +344,7 @@ router bfd
 !
 router bgp 65151
    router-id 192.168.255.33
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MH-LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MH-LEAF1B.cfg
@@ -344,6 +344,7 @@ router bfd
 !
 router bgp 65152
    router-id 192.168.255.34
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MH-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MH-LEAF2A.cfg
@@ -160,6 +160,7 @@ router bfd
 !
 router bgp 65153
    router-id 192.168.255.35
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MLAG-OSPF-L3LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MLAG-OSPF-L3LEAF1A.cfg
@@ -116,6 +116,7 @@ router bfd
 !
 router bgp 65161
    router-id 192.168.255.36
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MLAG-OSPF-L3LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MLAG-OSPF-L3LEAF1B.cfg
@@ -116,6 +116,7 @@ router bfd
 !
 router bgp 65161
    router-id 192.168.255.37
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_CVX_L3LEAF1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_CVX_L3LEAF1.cfg
@@ -61,6 +61,7 @@ route-map RM-CONN-2-BGP permit 10
 !
 router bgp 65001
    router-id 192.168.254.1
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS send-community

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_CVX_L3LEAF2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_CVX_L3LEAF2.cfg
@@ -61,6 +61,7 @@ route-map RM-CONN-2-BGP permit 10
 !
 router bgp 65002
    router-id 192.168.254.2
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS send-community

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF1.cfg
@@ -88,6 +88,7 @@ route-map RM-CONN-2-BGP permit 10
 !
 router bgp 65001
    router-id 192.168.254.1
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS send-community

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF2.cfg
@@ -88,6 +88,7 @@ route-map RM-CONN-2-BGP permit 10
 !
 router bgp 65002
    router-id 192.168.254.2
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS send-community

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3A.cfg
@@ -138,6 +138,7 @@ route-map RM-MLAG-PEER-IN permit 10
 !
 router bgp 65003
    router-id 192.168.254.3
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS send-community

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3B.cfg
@@ -138,6 +138,7 @@ route-map RM-MLAG-PEER-IN permit 10
 !
 router bgp 65003
    router-id 192.168.254.4
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS send-community

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF1.cfg
@@ -78,6 +78,7 @@ router bfd
 !
 router bgp 65001
    router-id 192.168.255.1
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF2.cfg
@@ -78,6 +78,7 @@ router bfd
 !
 router bgp 65002
    router-id 192.168.255.2
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF3.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF3.cfg
@@ -78,6 +78,7 @@ router bfd
 !
 router bgp 65003
    router-id 192.168.255.3
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF4.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF4.cfg
@@ -78,6 +78,7 @@ router bfd
 !
 router bgp 65004
    router-id 192.168.255.4
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF5.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF5.cfg
@@ -78,6 +78,7 @@ router bfd
 !
 router bgp 65005
    router-id 192.168.255.5
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF6.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF6.cfg
@@ -78,6 +78,7 @@ router bfd
 !
 router bgp 65006
    router-id 192.168.255.6
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF7.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF7.cfg
@@ -78,6 +78,7 @@ router bfd
 !
 router bgp 65007
    router-id 192.168.255.7
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SVI_PROFILE_NODE_1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SVI_PROFILE_NODE_1.cfg
@@ -241,6 +241,7 @@ router bfd
 !
 router bgp 65001
    router-id 192.168.255.1
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SVI_PROFILE_NODE_2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SVI_PROFILE_NODE_2.cfg
@@ -241,6 +241,7 @@ router bfd
 !
 router bgp 65002
    router-id 192.168.255.1
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L3LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L3LEAF1A.cfg
@@ -135,6 +135,7 @@ router bfd
 !
 router bgp 65101
    router-id 192.168.255.3
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L3LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L3LEAF1B.cfg
@@ -122,6 +122,7 @@ router bfd
 !
 router bgp 65101
    router-id 192.168.255.4
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L3LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L3LEAF2A.cfg
@@ -112,6 +112,7 @@ router bfd
 !
 router bgp 65102
    router-id 192.168.255.5
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L3LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L3LEAF2B.cfg
@@ -112,6 +112,7 @@ router bfd
 !
 router bgp 65102
    router-id 192.168.255.6
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-SPINE1.cfg
@@ -74,6 +74,7 @@ router bfd
 !
 router bgp 65001
    router-id 192.168.255.1
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-SPINE2.cfg
@@ -70,6 +70,7 @@ router bfd
 !
 router bgp 65001
    router-id 192.168.255.2
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY_FILTER_PEER_AS_L3LEAF1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY_FILTER_PEER_AS_L3LEAF1.cfg
@@ -54,6 +54,7 @@ route-map RM-BGP-AS65000-OUT permit 20
 !
 router bgp 65001
    router-id 192.168.255.3
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS send-community

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY_FILTER_PEER_AS_SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY_FILTER_PEER_AS_SPINE1.cfg
@@ -43,6 +43,7 @@ route-map RM-CONN-2-BGP permit 10
 !
 router bgp 65000
    router-id 192.168.255.1
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS send-community

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY_FILTER_PEER_AS_SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY_FILTER_PEER_AS_SPINE2.cfg
@@ -43,6 +43,7 @@ route-map RM-CONN-2-BGP permit 10
 !
 router bgp 65000
    router-id 192.168.255.2
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS send-community

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1A.cfg
@@ -138,6 +138,7 @@ router bfd
 !
 router bgp 65101
    router-id 192.168.255.3
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1B.cfg
@@ -138,6 +138,7 @@ router bfd
 !
 router bgp 65101
    router-id 192.168.255.4
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UPLINK-MLAG-STRUCTURED-CONFIG-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UPLINK-MLAG-STRUCTURED-CONFIG-SPINE1.cfg
@@ -58,6 +58,7 @@ router bfd
 !
 router bgp 65001
    router-id 192.168.255.1
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/bgp-peer-groups-structured-config-1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/bgp-peer-groups-structured-config-1.cfg
@@ -95,6 +95,7 @@ router bfd
 !
 router bgp 65001
    router-id 192.168.255.111
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS remote-as 65001

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/bgp-peer-groups-structured-config-2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/bgp-peer-groups-structured-config-2.cfg
@@ -95,6 +95,7 @@ router bfd
 !
 router bgp 65001
    router-id 192.168.255.112
+   no bgp default ipv4-unicast
    bgp cluster-id 192.168.255.112
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/bgp-peer-groups-structured-config-3.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/bgp-peer-groups-structured-config-3.cfg
@@ -31,6 +31,7 @@ router bfd
 !
 router bgp 65001
    router-id 192.168.255.114
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    bgp bestpath d-path
    neighbor IPVPN-GATEWAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cvp-instance-ips-cvaas.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cvp-instance-ips-cvaas.cfg
@@ -40,6 +40,7 @@ router bfd
 !
 router bgp 1234
    router-id 1.2.3.1
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/default_overlay_protocol_cvx.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/default_overlay_protocol_cvx.cfg
@@ -31,6 +31,7 @@ route-map RM-CONN-2-BGP permit 10
 !
 router bgp 65000
    router-id 192.168.0.42
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS send-community

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/default_overlay_protocol_her.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/default_overlay_protocol_her.cfg
@@ -31,6 +31,7 @@ route-map RM-CONN-2-BGP permit 10
 !
 router bgp 65000
    router-id 192.168.0.42
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS send-community

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/device.with.dots.in.hostname.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/device.with.dots.in.hostname.cfg
@@ -36,6 +36,7 @@ router bfd
 !
 router bgp 1234
    router-id 1.2.3.1
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_false.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_false.cfg
@@ -439,6 +439,7 @@ router bfd
 !
 router bgp 101
    router-id 192.168.255.109
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_true.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_true.cfg
@@ -193,6 +193,7 @@ router bfd
 !
 router bgp 101
    router-id 192.168.255.109
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/l3_edge_bgp.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/l3_edge_bgp.cfg
@@ -100,6 +100,7 @@ route-map RM-CONN-2-BGP permit 10
 !
 router bgp 65000
    router-id 1.2.3.1
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS send-community

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-leaf1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-leaf1.cfg
@@ -149,6 +149,7 @@ router bfd
 !
 router bgp 65101
    router-id 10.254.1.1
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-leaf2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-leaf2.cfg
@@ -130,6 +130,7 @@ router bfd
 !
 router bgp 65102
    router-id 10.254.1.2
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-spine1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-spine1.cfg
@@ -155,6 +155,7 @@ router bfd
 !
 router bgp 65200
    router-id 10.255.0.1
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-spine2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-spine2.cfg
@@ -111,6 +111,7 @@ router bfd
 !
 router bgp 65200
    router-id 10.255.0.2
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-spine3.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-spine3.cfg
@@ -54,6 +54,7 @@ router bfd
 !
 router bgp 65200
    router-id 10.255.0.3
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l3leaf1a.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l3leaf1a.cfg
@@ -306,6 +306,7 @@ router bfd
 !
 router bgp 65001
    router-id 192.168.250.9
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l3leaf1b.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l3leaf1b.cfg
@@ -286,6 +286,7 @@ router bfd
 !
 router bgp 65001
    router-id 192.168.250.10
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l3leaf2a.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l3leaf2a.cfg
@@ -152,6 +152,7 @@ router bfd
 !
 router bgp 65002
    router-id 192.168.250.11
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l3leaf2b.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l3leaf2b.cfg
@@ -147,6 +147,7 @@ router bfd
 !
 router bgp 65002
    router-id 192.168.250.12
+   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF1A.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65101'
   router_id: 192.168.255.3
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF1B.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65102'
   router_id: 192.168.255.4
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF2.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65103'
   router_id: 192.168.255.5
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF3A.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65105'
   router_id: 192.168.255.7
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF3B.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65105'
   router_id: 192.168.255.8
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF4A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF4A.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65222'
   router_id: 192.168.255.9
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF4B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF4B.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65222'
   router_id: 192.168.255.10
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF5A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF5A.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65333'
   router_id: 192.168.255.11
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF7A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF7A.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65222.0'
   router_id: 192.168.255.13
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF7B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF7B.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65222.0'
   router_id: 192.168.255.14
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF8A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF8A.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65222.12'
   router_id: 192.168.255.15
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF8B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF8B.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65222.13'
   router_id: 192.168.255.16
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_UNGROUPED_LEAF6.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_UNGROUPED_LEAF6.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65110'
   router_id: 192.168.255.12
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_NODE_TYPE_LEAF01.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_NODE_TYPE_LEAF01.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65101'
   router_id: 192.168.255.3
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_NODE_TYPE_SPINE01.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_NODE_TYPE_SPINE01.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65100'
   router_id: 192.168.255.1
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_NODE_TYPE_SPINE02.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_NODE_TYPE_SPINE02.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65100'
   router_id: 192.168.255.2
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_NODE_TYPE_UNGROUPED_LEAF02.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_NODE_TYPE_UNGROUPED_LEAF02.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65102'
   router_id: 192.168.255.4
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-PYTHON_MODULES-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-PYTHON_MODULES-L3LEAF1A.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 192.168.255.21
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-PYTHON_MODULES-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-PYTHON_MODULES-L3LEAF1B.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 192.168.255.22
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-PYTHON_MODULES-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-PYTHON_MODULES-SPINE1.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 192.168.255.1
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-TEMPLATES-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-TEMPLATES-L3LEAF1A.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 192.168.255.21
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-TEMPLATES-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-TEMPLATES-L3LEAF1B.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 192.168.255.22
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-TEMPLATES-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-TEMPLATES-SPINE1.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 192.168.255.1
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1A.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65104'
   router_id: 192.168.255.14
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1B.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65105'
   router_id: 192.168.255.15
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL2A.yml
@@ -2,9 +2,13 @@ router_bgp:
   as: '65106'
   router_id: 192.168.255.16
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
+    bestpath:
+      d_path: true
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4
@@ -108,9 +112,6 @@ router_bgp:
       enabled: true
       expiry_timeout: 10
     domain_identifier: '65000:3'
-  bgp:
-    bestpath:
-      d_path: true
   address_family_vpn_ipv4:
     neighbor_default_encapsulation_mpls_next_hop_self:
       source_interface: Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL2B.yml
@@ -2,9 +2,13 @@ router_bgp:
   as: '65107'
   router_id: 192.168.255.17
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
+    bestpath:
+      d_path: true
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4
@@ -104,9 +108,6 @@ router_bgp:
       enabled: true
       expiry_timeout: 10
     domain_identifier: '65000:3'
-  bgp:
-    bestpath:
-      d_path: true
   address_family_vpn_ipv4:
     neighbor_default_encapsulation_mpls_next_hop_self:
       source_interface: Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-CL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-CL1A.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65108'
   router_id: 192.168.255.18
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-CL1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-CL1B.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65109'
   router_id: 192.168.255.19
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF1A.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65101'
   router_id: 192.168.255.9
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: true
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65102'
   router_id: 192.168.255.10
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65102'
   router_id: 192.168.255.11
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SPINE1.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65001'
   router_id: 192.168.255.1
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SPINE2.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65001'
   router_id: 192.168.255.2
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SPINE3.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65001'
   router_id: 192.168.255.3
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SPINE4.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65001'
   router_id: 192.168.255.4
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3A.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65103'
   router_id: 192.168.255.12
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3B.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65103'
   router_id: 192.168.255.13
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1_UNDEPLOYED_LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1_UNDEPLOYED_LEAF1A.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65110'
   router_id: 192.168.255.21
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1_UNDEPLOYED_LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1_UNDEPLOYED_LEAF1B.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65111'
   router_id: 192.168.255.22
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF1A.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 192.168.255.3
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF1B.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 192.168.255.4
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF2A.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 192.168.255.5
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF3A.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 192.168.255.6
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF3B.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 192.168.255.7
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-SPINE1.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 192.168.255.1
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/IGMP-QUERIER-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/IGMP-QUERIER-L3LEAF1A.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 192.168.255.1
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF1A.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 192.168.255.33
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF1B.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 192.168.255.34
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF2A.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 192.168.255.35
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG-OSPF-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG-OSPF-L3LEAF1A.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 192.168.255.36
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: EVPN-OVERLAY-PEERS
     type: evpn

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG-OSPF-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG-OSPF-L3LEAF1B.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 192.168.255.37
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: EVPN-OVERLAY-PEERS
     type: evpn

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_CVX_L3LEAF1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_CVX_L3LEAF1.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 192.168.254.1
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_CVX_L3LEAF2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_CVX_L3LEAF2.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 192.168.254.2
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF1.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 192.168.254.1
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF2.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 192.168.254.2
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3A.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 192.168.254.3
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3B.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 192.168.254.4
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF1.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 192.168.255.1
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF2.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 192.168.255.2
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF3.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF3.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 192.168.255.3
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF4.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF4.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 192.168.255.4
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF5.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF5.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 192.168.255.5
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF6.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF6.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 192.168.255.6
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF7.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF7.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 192.168.255.7
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/SVI_PROFILE_NODE_1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/SVI_PROFILE_NODE_1.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 192.168.255.1
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/SVI_PROFILE_NODE_2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/SVI_PROFILE_NODE_2.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 192.168.255.1
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF1A.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 192.168.255.3
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF1B.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 192.168.255.4
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF2A.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 192.168.255.5
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF2B.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 192.168.255.6
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-SPINE1.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 192.168.255.1
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-SPINE2.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 192.168.255.2
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY_FILTER_PEER_AS_L3LEAF1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY_FILTER_PEER_AS_L3LEAF1.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 192.168.255.3
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY_FILTER_PEER_AS_SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY_FILTER_PEER_AS_SPINE1.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 192.168.255.1
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY_FILTER_PEER_AS_SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY_FILTER_PEER_AS_SPINE2.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 192.168.255.2
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1A.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 192.168.255.3
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1B.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 192.168.255.4
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-SPINE1.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 192.168.255.1
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-structured-config-1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-structured-config-1.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 192.168.255.111
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-structured-config-2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-structured-config-2.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 192.168.255.112
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-structured-config-3.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-structured-config-3.yml
@@ -3,6 +3,11 @@ router_bgp:
   router_id: 192.168.255.114
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
+    bestpath:
+      d_path: true
   peer_groups:
   - name: MPLS-OVERLAY-PEERS
     type: mpls
@@ -33,9 +38,6 @@ router_bgp:
     - name: MPLS-OVERLAY-PEERS
       activate: true
     domain_identifier: '65535:1'
-  bgp:
-    bestpath:
-      d_path: true
   address_family_vpn_ipv4:
     neighbor_default_encapsulation_mpls_next_hop_self:
       source_interface: Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cvp-instance-ips-cvaas.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cvp-instance-ips-cvaas.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 1.2.3.1
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/default_overlay_protocol_cvx.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/default_overlay_protocol_cvx.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 192.168.0.42
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/default_overlay_protocol_her.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/default_overlay_protocol_her.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 192.168.0.42
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/device.with.dots.in.hostname.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/device.with.dots.in.hostname.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 1.2.3.1
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_false.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_false.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 192.168.255.109
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_true.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_true.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 192.168.255.109
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/l3_edge_bgp.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/l3_edge_bgp.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 1.2.3.1
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-leaf1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-leaf1.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 10.254.1.1
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-leaf2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-leaf2.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 10.254.1.2
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-spine1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-spine1.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 10.255.0.1
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-spine2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-spine2.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 10.255.0.2
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-spine3.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-spine3.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 10.255.0.3
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf1a.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf1a.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 192.168.250.9
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf1b.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf1b.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 192.168.250.10
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf2a.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf2a.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 192.168.250.11
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf2b.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf2b.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 192.168.250.12
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/AUTO_BGP_ASN.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/AUTO_BGP_ASN.yml
@@ -10,7 +10,7 @@ l3leaf:
     uplink_interfaces: []
     uplink_switches: []
     uplink_ipv4_pool: 172.31.255.0/24
-    bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']
+    bgp_defaults: ['distance bgp 20 200 200']
     mlag_interfaces: [ Ethernet3, Ethernet4 ]
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
     mlag_peer_ipv4_pool: 10.255.252.0/24

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/AUTO_NODE_TYPE.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/AUTO_NODE_TYPE.yml
@@ -12,7 +12,7 @@ spine:
   defaults:
     platform: vEOS-LAB
     loopback_ipv4_pool: 192.168.255.0/24
-    bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']
+    bgp_defaults: ['distance bgp 20 200 200']
     bgp_as: 65100
   node_groups:
     AUTO_NODE_TYPE_SPINE:
@@ -32,7 +32,7 @@ l3leaf:
     uplink_interfaces: [Ethernet1, Ethernet2]
     uplink_switches: [AUTO_NODE_TYPE_SPINE01, AUTO_NODE_TYPE_SPINE02]
     uplink_ipv4_pool: 172.31.255.0/24
-    bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']
+    bgp_defaults: ['distance bgp 20 200 200']
     mlag_interfaces: [ Ethernet3, Ethernet4 ]
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
     mlag_peer_ipv4_pool: 10.255.252.0/24

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_FABRIC.yml
@@ -28,7 +28,7 @@ bgp_peer_groups:
 
 # test with inline jinja2 targeting eos_designs_facts
 spine_platform: "7050SX3"
-spine_bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']
+spine_bgp_defaults: ['distance bgp 20 200 200']
 
 # Spine Switches
 spine:
@@ -75,7 +75,7 @@ l3leaf:
     max_uplink_switches: 8
     uplink_ipv4_pool: 172.31.254.0/23
     uplink_interface_speed: forced 100gfull
-    bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']
+    bgp_defaults: ['distance bgp 20 200 200']
     platform: 7280R
     bgp_as: 65101
     # Commented out for automatic mlag allocation

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_LEAF1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_LEAF1.yml
@@ -1,4 +1,6 @@
 ---
+bgp_default_ipv4_unicast: true
+
 overlay_rd_type:
 #   # admin_subfield: < "overlay_loopback" | "vtep_loopback" | "leaf_asn" | "spine_asn" | < IPv4 Address > | <0-65535> | <0-4294967295> | default -> "overlay_loopback" >
   admin_subfield: 1.1.1.1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-BL1A.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65104'
   router_id: 192.168.255.14
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-BL1B.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65105'
   router_id: 192.168.255.15
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-BL2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-BL2A.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65106'
   router_id: 192.168.255.16
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-BL2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-BL2B.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65107'
   router_id: 192.168.255.17
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-CL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-CL1A.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65108'
   router_id: 192.168.255.18
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-CL1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-CL1B.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65109'
   router_id: 192.168.255.19
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-LEAF1A.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65101'
   router_id: 192.168.255.9
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-LEAF2A.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65102'
   router_id: 192.168.255.10
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-LEAF2B.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65102'
   router_id: 192.168.255.11
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SPINE1.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65001'
   router_id: 192.168.255.1
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SPINE2.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65001'
   router_id: 192.168.255.2
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SPINE3.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65001'
   router_id: 192.168.255.3
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SPINE4.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65001'
   router_id: 192.168.255.4
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SVC3A.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65103'
   router_id: 192.168.255.12
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SVC3B.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65103'
   router_id: 192.168.255.13
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/MH-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/MH-LEAF1A.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 192.168.255.33
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/MH-LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/MH-LEAF1B.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 192.168.255.34
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/MH-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/MH-LEAF2A.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 192.168.255.35
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/cvp-instance-ips-cvaas.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/cvp-instance-ips-cvaas.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 1.2.3.1
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/evpn_services_l2_only_false.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/evpn_services_l2_only_false.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 192.168.255.109
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/evpn_services_l2_only_true.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/evpn_services_l2_only_true.yml
@@ -3,6 +3,9 @@ router_bgp:
   router_id: 192.168.255.109
   bgp_defaults:
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/inventory/group_vars/DC1_FABRIC.yml
@@ -26,7 +26,7 @@ spine:
     platform: 7050SX3
     bgp_as: "65001"
     loopback_ipv4_pool: 192.168.255.0/24
-    bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']
+    bgp_defaults: ['distance bgp 20 200 200']
   nodes:
     - name: DC1-SPINE1
       id: 1
@@ -62,7 +62,7 @@ l3leaf:
     max_uplink_switches: 8
     uplink_ipv4_pool: 172.31.255.0/24
     uplink_interface_speed: forced 100gfull
-    bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']
+    bgp_defaults: ['distance bgp 20 200 200']
     platform: 7280R
     bgp_as: "65101"
     mlag_interfaces: [ Ethernet5, Ethernet6 ]

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -588,9 +588,9 @@ ip route vrf Tenant_A_WAN_Zone 10.3.5.0/24 Null0
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -586,9 +586,9 @@ ip route vrf Tenant_A_WAN_Zone 10.3.5.0/24 Null0
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
@@ -584,9 +584,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -883,9 +883,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -883,9 +883,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE1.md
@@ -388,9 +388,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE2.md
@@ -388,9 +388,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE3.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE3.md
@@ -388,9 +388,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE4.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE4.md
@@ -388,9 +388,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -1248,9 +1248,9 @@ ip route vrf Tenant_A_WAN_Zone 10.3.5.0/24 Null0
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -1248,9 +1248,9 @@ ip route vrf Tenant_A_WAN_Zone 10.3.5.0/24 Null0
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65104'
   router_id: 192.168.255.14
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65105'
   router_id: 192.168.255.15
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65101'
   router_id: 192.168.255.9
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65102'
   router_id: 192.168.255.10
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65102'
   router_id: 192.168.255.11
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE1.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65001'
   router_id: 192.168.255.1
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE2.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65001'
   router_id: 192.168.255.2
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE3.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65001'
   router_id: 192.168.255.3
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE4.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65001'
   router_id: 192.168.255.4
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65103'
   router_id: 192.168.255.12
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65103'
   router_id: 192.168.255.13
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_FABRIC.yml
@@ -82,7 +82,7 @@ spine:
     platform: 7050SX3
     bgp_as: 65001
     loopback_ipv4_pool: 192.168.255.0/24
-    bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']
+    bgp_defaults: ['distance bgp 20 200 200']
   nodes:
     DC1-SPINE1:
       id: 1
@@ -115,7 +115,7 @@ l3leaf:
     max_uplink_switches: 8
     uplink_ipv4_pool: 172.31.255.0/24
     uplink_interface_speed: forced 100gfull
-    bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']
+    bgp_defaults: ['distance bgp 20 200 200']
     platform: 7280R
     bgp_as: 65101
     mlag_interfaces: [ Ethernet5, Ethernet6 ]

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1A.md
@@ -626,9 +626,9 @@ router isis EVPN_UNDERLAY
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1B.md
@@ -611,9 +611,9 @@ router isis EVPN_UNDERLAY
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF1A.md
@@ -460,9 +460,9 @@ router isis EVPN_UNDERLAY
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2A.md
@@ -626,9 +626,9 @@ router isis EVPN_UNDERLAY
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2B.md
@@ -626,9 +626,9 @@ router isis EVPN_UNDERLAY
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE1.md
@@ -460,9 +460,9 @@ router isis EVPN_UNDERLAY
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 
@@ -504,8 +504,8 @@ router isis EVPN_UNDERLAY
 !
 router bgp 65000
    router-id 192.168.255.1
-   bgp cluster-id 192.168.255.1
    no bgp default ipv4-unicast
+   bgp cluster-id 192.168.255.1
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE4.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE4.md
@@ -460,9 +460,9 @@ router isis EVPN_UNDERLAY
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 
@@ -504,8 +504,8 @@ router isis EVPN_UNDERLAY
 !
 router bgp 65000
    router-id 192.168.255.4
-   bgp cluster-id 192.168.255.4
    no bgp default ipv4-unicast
+   bgp cluster-id 192.168.255.4
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3A.md
@@ -619,9 +619,9 @@ router isis EVPN_UNDERLAY
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3B.md
@@ -619,9 +619,9 @@ router isis EVPN_UNDERLAY
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SPINE1.cfg
@@ -127,8 +127,8 @@ router bfd
 !
 router bgp 65000
    router-id 192.168.255.1
-   bgp cluster-id 192.168.255.1
    no bgp default ipv4-unicast
+   bgp cluster-id 192.168.255.1
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SPINE4.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SPINE4.cfg
@@ -127,8 +127,8 @@ router bfd
 !
 router bgp 65000
    router-id 192.168.255.4
-   bgp cluster-id 192.168.255.4
    no bgp default ipv4-unicast
+   bgp cluster-id 192.168.255.4
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-BL1A.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65000'
   router_id: 192.168.255.10
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: OVERLAY-PEERS
     type: evpn

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-BL1B.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65000'
   router_id: 192.168.255.11
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: OVERLAY-PEERS
     type: evpn

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF1A.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65000'
   router_id: 192.168.255.5
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: OVERLAY-PEERS
     type: evpn

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65000'
   router_id: 192.168.255.6
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: OVERLAY-PEERS
     type: evpn

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65000'
   router_id: 192.168.255.7
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: OVERLAY-PEERS
     type: evpn

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SPINE1.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65000'
   router_id: 192.168.255.1
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   bgp_cluster_id: 192.168.255.1
   peer_groups:
   - name: OVERLAY-PEERS

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SPINE4.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65000'
   router_id: 192.168.255.4
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   bgp_cluster_id: 192.168.255.4
   peer_groups:
   - name: OVERLAY-PEERS

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SVC3A.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65000'
   router_id: 192.168.255.8
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: OVERLAY-PEERS
     type: evpn

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SVC3B.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65000'
   router_id: 192.168.255.9
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: OVERLAY-PEERS
     type: evpn

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/inventory/group_vars/DC1_FABRIC.yml
@@ -30,7 +30,6 @@ spine:
     bgp_as: 65001
     loopback_ipv4_pool: 192.168.255.0/24
     bgp_defaults:
-      - 'no bgp default ipv4-unicast'
       - 'distance bgp 20 200 200'
     isis_system_id_prefix: '0001.0000'
     isis_maximum_paths: 4
@@ -62,7 +61,7 @@ l3leaf:
     uplink_interfaces: ['Ethernet1', 'Ethernet2', 'Ethernet3', 'Ethernet4']
     uplink_switches: ['DC1-SPINE1', 'DC1-SPINE2', 'DC1-SPINE3', 'DC1-SPINE4']
     uplink_ipv4_pool: 172.31.255.0/24
-    bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']
+    bgp_defaults: ['distance bgp 20 200 200']
     isis_system_id_prefix: '0001.0001'
     isis_maximum_paths: 4
     platform: vEOS-LAB

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -566,9 +566,9 @@ router ospf 101
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | maximum-paths 10 ecmp 10 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -566,9 +566,9 @@ router ospf 101
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | maximum-paths 10 ecmp 10 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
@@ -432,9 +432,9 @@ router ospf 101
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | maximum-paths 10 ecmp 10 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -626,9 +626,9 @@ router ospf 101
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | maximum-paths 10 ecmp 10 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -626,9 +626,9 @@ router ospf 101
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | maximum-paths 10 ecmp 10 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE1.md
@@ -416,9 +416,9 @@ router ospf 101
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | maximum-paths 10 ecmp 10 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE2.md
@@ -416,9 +416,9 @@ router ospf 101
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | maximum-paths 10 ecmp 10 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE3.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE3.md
@@ -416,9 +416,9 @@ router ospf 101
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | maximum-paths 10 ecmp 10 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE4.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE4.md
@@ -416,9 +416,9 @@ router ospf 101
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | maximum-paths 10 ecmp 10 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -619,9 +619,9 @@ router ospf 101
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | maximum-paths 10 ecmp 10 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -619,9 +619,9 @@ router ospf 101
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | maximum-paths 10 ecmp 10 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65104'
   router_id: 192.168.255.10
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 10 ecmp 10
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: EVPN-OVERLAY-PEERS
     type: evpn

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65104'
   router_id: 192.168.255.11
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 10 ecmp 10
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: EVPN-OVERLAY-PEERS
     type: evpn

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65101'
   router_id: 192.168.255.5
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 10 ecmp 10
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: EVPN-OVERLAY-PEERS
     type: evpn

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65102'
   router_id: 192.168.255.6
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 10 ecmp 10
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: EVPN-OVERLAY-PEERS
     type: evpn

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65102'
   router_id: 192.168.255.7
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 10 ecmp 10
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: EVPN-OVERLAY-PEERS
     type: evpn

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SPINE1.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65001'
   router_id: 192.168.255.1
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 10 ecmp 10
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: EVPN-OVERLAY-PEERS
     type: evpn

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SPINE2.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65001'
   router_id: 192.168.255.2
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 10 ecmp 10
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: EVPN-OVERLAY-PEERS
     type: evpn

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SPINE3.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65001'
   router_id: 192.168.255.3
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 10 ecmp 10
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: EVPN-OVERLAY-PEERS
     type: evpn

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SPINE4.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65001'
   router_id: 192.168.255.4
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 10 ecmp 10
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: EVPN-OVERLAY-PEERS
     type: evpn

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65103'
   router_id: 192.168.255.8
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 10 ecmp 10
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: EVPN-OVERLAY-PEERS
     type: evpn

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65103'
   router_id: 192.168.255.9
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 10 ecmp 10
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: EVPN-OVERLAY-PEERS
     type: evpn

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/inventory/group_vars/DC1_FABRIC.yml
@@ -52,7 +52,6 @@ spine:
     bgp_as: 65001
     loopback_ipv4_pool: 192.168.255.0/24
     bgp_defaults:
-      - 'no bgp default ipv4-unicast'
       - 'distance bgp 20 200 200'
   nodes:
     DC1-SPINE1:
@@ -80,7 +79,7 @@ l3leaf:
     uplink_interfaces: ['Ethernet1', 'Ethernet2', 'Ethernet3', 'Ethernet4']
     uplink_switches: ['DC1-SPINE1', 'DC1-SPINE2', 'DC1-SPINE3', 'DC1-SPINE4']
     uplink_ipv4_pool: 172.31.255.0/24
-    bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']
+    bgp_defaults: ['distance bgp 20 200 200']
     platform: vEOS-LAB
     bgp_as: 65100
     mlag_interfaces: [ Ethernet5, Ethernet6 ]

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -568,9 +568,9 @@ router general
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -545,9 +545,9 @@ ip route vrf Tenant_A_WAN_Zone 10.3.4.0/24 1.2.3.4
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
@@ -547,9 +547,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -921,9 +921,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -921,9 +921,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF3A.md
@@ -840,9 +840,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF3B.md
@@ -840,9 +840,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF4A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF4A.md
@@ -840,9 +840,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF4B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF4B.md
@@ -840,9 +840,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE1.md
@@ -371,9 +371,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE2.md
@@ -371,9 +371,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE3.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE3.md
@@ -371,9 +371,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE4.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE4.md
@@ -371,9 +371,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE5.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE5.md
@@ -333,9 +333,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE6.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE6.md
@@ -333,9 +333,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -1106,9 +1106,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -1080,9 +1080,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 | BGP Tuning |
 | ---------- |
-| no bgp default ipv4-unicast |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65104'
   router_id: 192.168.255.10
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: UNDERLAY_PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65105'
   router_id: 192.168.255.11
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: UNDERLAY_PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65101'
   router_id: 192.168.255.5
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: UNDERLAY_PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65102'
   router_id: 192.168.255.6
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG_PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65102'
   router_id: 192.168.255.7
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG_PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF3A.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65106'
   router_id: 192.168.255.12
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG_PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF3B.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65106'
   router_id: 192.168.255.13
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG_PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF4A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF4A.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65107'
   router_id: 192.168.255.14
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG_PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF4B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF4B.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65107'
   router_id: 192.168.255.15
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG_PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE1.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65001'
   router_id: 192.168.255.1
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: UNDERLAY_PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE2.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65001'
   router_id: 192.168.255.2
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: UNDERLAY_PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE3.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65001'
   router_id: 192.168.255.3
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: UNDERLAY_PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE4.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65001'
   router_id: 192.168.255.4
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: UNDERLAY_PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE5.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE5.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65001'
   router_id: 192.168.255.5
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: UNDERLAY_PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE6.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE6.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65001'
   router_id: 192.168.255.6
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: UNDERLAY_PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65103'
   router_id: 192.168.255.8
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG_PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -2,9 +2,11 @@ router_bgp:
   as: '65103'
   router_id: 192.168.255.9
   bgp_defaults:
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
+  bgp:
+    default:
+      ipv4_unicast: false
   peer_groups:
   - name: MLAG_PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/inventory/group_vars/DC1_FABRIC.yml
@@ -39,7 +39,7 @@ spine:
     platform: vEOS-LAB
     bgp_as: 65001
     loopback_ipv4_pool: 192.168.255.0/24
-    bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']
+    bgp_defaults: ['distance bgp 20 200 200']
   nodes:
     DC1-SPINE1:
       id: 1
@@ -81,7 +81,7 @@ l3leaf:
     vtep_loopback_ipv4_pool: 192.168.254.0/24
     uplink_interfaces: ['Ethernet1', 'Ethernet2', 'Ethernet3', 'Ethernet4']
     uplink_switches: ['DC1-SPINE1', 'DC1-SPINE2', 'DC1-SPINE3', 'DC1-SPINE4']
-    bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']
+    bgp_defaults: ['distance bgp 20 200 200']
     platform: 7280R
     bgp_as: 65101
     mlag_interfaces: [ Ethernet5, Ethernet6 ]

--- a/ansible_collections/arista/avd/roles/eos_designs/README.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/README.md
@@ -137,14 +137,12 @@ However, because vEOS-LAB implements a virtual data plane, there are known cavea
 spine_bgp_defaults:
 #  - update wait-for-convergence
 #  - update wait-install
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - graceful-restart restart-time 300
   - graceful-restart
 
 leaf_bgp_defaults:
 #  - update wait-install
-  - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - graceful-restart restart-time 300
   - graceful-restart

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/Fabric Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/Fabric Variables.md
@@ -56,6 +56,7 @@ search:
     | Variable | Type | Required | Default | Value Restrictions | Description |
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
     | [<samp>bgp_as</samp>](## "bgp_as") | String |  |  |  | AS number to use to configure overlay when "overlay_routing_protocol" == ibgp |
+    | [<samp>bgp_default_ipv4_unicast</samp>](## "bgp_default_ipv4_unicast") | Boolean |  | False |  | Default activation of IPv4 unicast address-family on all IPv4 neighbors.<br>It is best practice to disable activation.<br> |
     | [<samp>bgp_mesh_pes</samp>](## "bgp_mesh_pes") | Boolean |  | False |  | Whether to configure an iBGP full mesh between PEs, either because there is no RR used or other reasons. |
     | [<samp>underlay_filter_peer_as</samp>](## "underlay_filter_peer_as") | Boolean |  | False |  | Configure route-map on eBGP sessions towards underlay peers, where prefixes with the peer's ASN in the AS Path are filtered away.<br>This is very useful in very large scale networks not using EVPN overlays, where convergence will be quicker by not having to return<br>all updates received from Spine-1 to Spine-2 just for Spine-2 to throw them away because of AS Path loop detection.<br>Note this key is ignored when EVPN is configured.<br> |
 
@@ -63,6 +64,7 @@ search:
 
     ```yaml
     bgp_as: <str>
+    bgp_default_ipv4_unicast: <bool>
     bgp_mesh_pes: <bool>
     underlay_filter_peer_as: <bool>
     ```

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/base/avdstructuredconfig.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/base/avdstructuredconfig.py
@@ -31,6 +31,8 @@ class AvdStructuredConfig(AvdFacts):
 
         bgp_defaults = get(self.shared_utils.switch_data_combined, "bgp_defaults", default=[])
 
+        bgp_default_ipv4_unicast = get(self._hostvars, "bgp_default_ipv4_unicast", default=False)
+
         if (bgp_maximum_paths := get(self._hostvars, "bgp_maximum_paths")) is not None:
             max_paths_str = f"maximum-paths {bgp_maximum_paths}"
             if (bgp_ecmp := get(self._hostvars, "bgp_ecmp")) is not None:
@@ -41,6 +43,11 @@ class AvdStructuredConfig(AvdFacts):
             "as": self.shared_utils.bgp_as,
             "router_id": self.shared_utils.router_id,
             "bgp_defaults": bgp_defaults,
+            "bgp": {
+                "default": {
+                    "ipv4_unicast": bgp_default_ipv4_unicast,
+                },
+            },
         }
 
     @cached_property

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -38,6 +38,12 @@
       "type": "string",
       "title": "BGP As"
     },
+    "bgp_default_ipv4_unicast": {
+      "description": "Default activation of IPv4 unicast address-family on all IPv4 neighbors.\nIt is best practice to disable activation.\n",
+      "type": "boolean",
+      "default": false,
+      "title": "BGP Default IPv4 Unicast"
+    },
     "bgp_ecmp": {
       "description": "Maximum ECMP for BGP multi-path",
       "type": "integer",

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
@@ -39,6 +39,17 @@ keys:
     type: str
     convert_types:
     - int
+  bgp_default_ipv4_unicast:
+    documentation_options:
+      filename: Fabric Variables
+      table: BGP Settings
+    description: 'Default activation of IPv4 unicast address-family on all IPv4 neighbors.
+
+      It is best practice to disable activation.
+
+      '
+    type: bool
+    default: false
   bgp_ecmp:
     documentation_options:
       filename: Fabric Variables

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/bgp_default_ipv4_unicast.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/bgp_default_ipv4_unicast.schema.yml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  bgp_default_ipv4_unicast:
+    documentation_options:
+      filename: Fabric Variables
+      table: BGP Settings
+    description: |
+      Default activation of IPv4 unicast address-family on all IPv4 neighbors.
+      It is best practice to disable activation.
+    type: bool
+    default: false

--- a/ansible_collections/arista/avd/tests/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/tests/inventory/group_vars/DC1_FABRIC.yml
@@ -23,7 +23,6 @@ spine:
     bgp_as: 65001
     loopback_ipv4_pool: 192.168.255.0/24
     bgp_defaults:
-      - 'no bgp default ipv4-unicast'
       - 'distance bgp 20 200 200'
       - 'graceful-restart restart-time 300'
       - 'graceful-restart'
@@ -55,7 +54,6 @@ l3leaf:
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
     virtual_router_mac_address: 00:1c:73:00:dc:01
     bgp_defaults:
-      - 'no bgp default ipv4-unicast'
       - 'distance bgp 20 200 200'
       - 'graceful-restart restart-time 300'
       - 'graceful-restart'


### PR DESCRIPTION
## Change Summary

Add fabric variable for `bgp default ipv4 unicast`, and enforce best practice (disable)

- updated documentation to remove references in bgp_defaults:


## Related Issue(s)

fixes aristanetworks/avd-internal#100

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

```yaml
bgp_default_ipv4_unicast: <bool> -> default false
```

## How to test

See molecule test results 

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
