### PR TITLE
Doc: Fix typo in custom structured configuration documentation example

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_designs/doc/custom-structured-configuration-v4.0.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/custom-structured-configuration-v4.0.md
@@ -163,7 +163,7 @@ name_servers:
   - 10.10.10.11
 
 custom_structured_configuration_list_merge: append
-custom_structured_configuration_list_prefix: [ override_ ]
+custom_structured_configuration_prefix: [ override_ ]
 
 override_ip_name_servers:
   - ip_address: 10.10.10.12

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/custom-structured-configuration.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/custom-structured-configuration.md
@@ -313,7 +313,7 @@ name_servers:
   - 10.10.10.11
 
 custom_structured_configuration_list_merge: append
-custom_structured_configuration_list_prefix: [ override_ ]
+custom_structured_configuration_prefix: [ override_ ]
 
 override_ip_name_servers:
   - ip_address: 10.10.10.12


### PR DESCRIPTION
## Change Summary

fix a typo in custom structured configuration documentation example

## Related Issue(s)

N/A

## Component(s) name

`arista.avd.eos_design`

## Proposed changes

in the Example with append list_merge strategy, the referenced key is custom_structured_configuration_list_prefix which does not exist.  the correct key is custom_structured_configuration_prefix:


## How to test
No test required

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
