### PR TITLE
Refactor(plugins): Optimize convert_dicts

### DIFF
--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF1A.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF1A.yml
@@ -49,11 +49,11 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 110
   name: IDF1-Data
   tenant: MY_FABRIC
@@ -63,9 +63,9 @@ vlans:
 - id: 130
   name: IDF1-Guest
   tenant: MY_FABRIC
-- tenant: system
+- id: 10
+  tenant: system
   name: L2LEAF_INBAND_MGMT
-  id: 10
 vlan_interfaces:
 - name: Vlan4094
   description: MLAG_PEER
@@ -90,7 +90,8 @@ port_channel_interfaces:
   vlans: 10,110,120,130
   mlag: 51
 ethernet_interfaces:
-- peer: LEAF1B
+- name: Ethernet53
+  peer: LEAF1B
   peer_interface: Ethernet53
   peer_type: mlag_peer
   description: MLAG_PEER_LEAF1B_Ethernet53
@@ -99,8 +100,8 @@ ethernet_interfaces:
   channel_group:
     id: 53
     mode: active
-  name: Ethernet53
-- peer: LEAF1B
+- name: Ethernet54
+  peer: LEAF1B
   peer_interface: Ethernet54
   peer_type: mlag_peer
   description: MLAG_PEER_LEAF1B_Ethernet54
@@ -109,7 +110,6 @@ ethernet_interfaces:
   channel_group:
     id: 53
     mode: active
-  name: Ethernet54
 - name: Ethernet51
   peer: SPINE1
   peer_interface: Ethernet1

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF1B.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF1B.yml
@@ -49,11 +49,11 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 110
   name: IDF1-Data
   tenant: MY_FABRIC
@@ -63,9 +63,9 @@ vlans:
 - id: 130
   name: IDF1-Guest
   tenant: MY_FABRIC
-- tenant: system
+- id: 10
+  tenant: system
   name: L2LEAF_INBAND_MGMT
-  id: 10
 vlan_interfaces:
 - name: Vlan4094
   description: MLAG_PEER
@@ -90,7 +90,8 @@ port_channel_interfaces:
   vlans: 10,110,120,130
   mlag: 51
 ethernet_interfaces:
-- peer: LEAF1A
+- name: Ethernet53
+  peer: LEAF1A
   peer_interface: Ethernet53
   peer_type: mlag_peer
   description: MLAG_PEER_LEAF1A_Ethernet53
@@ -99,8 +100,8 @@ ethernet_interfaces:
   channel_group:
     id: 53
     mode: active
-  name: Ethernet53
-- peer: LEAF1A
+- name: Ethernet54
+  peer: LEAF1A
   peer_interface: Ethernet54
   peer_type: mlag_peer
   description: MLAG_PEER_LEAF1A_Ethernet54
@@ -109,7 +110,6 @@ ethernet_interfaces:
   channel_group:
     id: 53
     mode: active
-  name: Ethernet54
 - name: Ethernet51
   peer: SPINE2
   peer_interface: Ethernet1

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF2A.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF2A.yml
@@ -7525,8 +7525,8 @@ vlans:
 - id: 230
   name: IDF2-Guest
   tenant: MY_FABRIC
-- tenant: system
+- id: 10
+  tenant: system
   name: L2LEAF_INBAND_MGMT
-  id: 10
 ip_igmp_snooping:
   globally_enabled: true

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3A.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3A.yml
@@ -49,11 +49,11 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 310
   name: IDF3-Data
   tenant: MY_FABRIC
@@ -63,9 +63,9 @@ vlans:
 - id: 330
   name: IDF3-Guest
   tenant: MY_FABRIC
-- tenant: system
+- id: 10
+  tenant: system
   name: L2LEAF_INBAND_MGMT
-  id: 10
 vlan_interfaces:
 - name: Vlan4094
   description: MLAG_PEER
@@ -111,7 +111,8 @@ port_channel_interfaces:
   vlans: 10,310,320,330
   mlag: 981
 ethernet_interfaces:
-- peer: LEAF3B
+- name: Ethernet98/3
+  peer: LEAF3B
   peer_interface: Ethernet98/3
   peer_type: mlag_peer
   description: MLAG_PEER_LEAF3B_Ethernet98/3
@@ -120,8 +121,8 @@ ethernet_interfaces:
   channel_group:
     id: 983
     mode: active
-  name: Ethernet98/3
-- peer: LEAF3B
+- name: Ethernet98/4
+  peer: LEAF3B
   peer_interface: Ethernet98/4
   peer_type: mlag_peer
   description: MLAG_PEER_LEAF3B_Ethernet98/4
@@ -130,7 +131,6 @@ ethernet_interfaces:
   channel_group:
     id: 983
     mode: active
-  name: Ethernet98/4
 - name: Ethernet97/1
   peer: SPINE1
   peer_interface: Ethernet50/1

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3B.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3B.yml
@@ -49,11 +49,11 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 310
   name: IDF3-Data
   tenant: MY_FABRIC
@@ -63,9 +63,9 @@ vlans:
 - id: 330
   name: IDF3-Guest
   tenant: MY_FABRIC
-- tenant: system
+- id: 10
+  tenant: system
   name: L2LEAF_INBAND_MGMT
-  id: 10
 vlan_interfaces:
 - name: Vlan4094
   description: MLAG_PEER
@@ -111,7 +111,8 @@ port_channel_interfaces:
   vlans: 10,310,320,330
   mlag: 981
 ethernet_interfaces:
-- peer: LEAF3A
+- name: Ethernet98/3
+  peer: LEAF3A
   peer_interface: Ethernet98/3
   peer_type: mlag_peer
   description: MLAG_PEER_LEAF3A_Ethernet98/3
@@ -120,8 +121,8 @@ ethernet_interfaces:
   channel_group:
     id: 983
     mode: active
-  name: Ethernet98/3
-- peer: LEAF3A
+- name: Ethernet98/4
+  peer: LEAF3A
   peer_interface: Ethernet98/4
   peer_type: mlag_peer
   description: MLAG_PEER_LEAF3A_Ethernet98/4
@@ -130,7 +131,6 @@ ethernet_interfaces:
   channel_group:
     id: 983
     mode: active
-  name: Ethernet98/4
 - name: Ethernet97/1
   peer: SPINE1
   peer_interface: Ethernet51/1

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3C.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3C.yml
@@ -3061,8 +3061,8 @@ vlans:
 - id: 330
   name: IDF3-Guest
   tenant: MY_FABRIC
-- tenant: system
+- id: 10
+  tenant: system
   name: L2LEAF_INBAND_MGMT
-  id: 10
 ip_igmp_snooping:
   globally_enabled: true

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3D.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3D.yml
@@ -3061,8 +3061,8 @@ vlans:
 - id: 330
   name: IDF3-Guest
   tenant: MY_FABRIC
-- tenant: system
+- id: 10
+  tenant: system
   name: L2LEAF_INBAND_MGMT
-  id: 10
 ip_igmp_snooping:
   globally_enabled: true

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3E.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3E.yml
@@ -3061,8 +3061,8 @@ vlans:
 - id: 330
   name: IDF3-Guest
   tenant: MY_FABRIC
-- tenant: system
+- id: 10
+  tenant: system
   name: L2LEAF_INBAND_MGMT
-  id: 10
 ip_igmp_snooping:
   globally_enabled: true

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/SPINE1.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/SPINE1.yml
@@ -41,16 +41,16 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4093
+  tenant: system
   name: LEAF_PEER_L3
   trunk_groups:
   - LEAF_PEER_L3
-  id: 4093
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 110
   name: IDF1-Data
   tenant: MY_FABRIC
@@ -78,9 +78,9 @@ vlans:
 - id: 330
   name: IDF3-Guest
   tenant: MY_FABRIC
-- tenant: system
+- id: 10
+  tenant: system
   name: L2LEAF_INBAND_MGMT
-  id: 10
 vlan_interfaces:
 - name: Vlan4093
   description: MLAG_PEER_L3_PEERING
@@ -218,7 +218,8 @@ port_channel_interfaces:
   vlans: 10,310,320,330
   mlag: 501
 ethernet_interfaces:
-- peer: SPINE2
+- name: Ethernet55/1
+  peer: SPINE2
   peer_interface: Ethernet55/1
   peer_type: mlag_peer
   description: MLAG_PEER_SPINE2_Ethernet55/1
@@ -227,8 +228,8 @@ ethernet_interfaces:
   channel_group:
     id: 551
     mode: active
-  name: Ethernet55/1
-- peer: SPINE2
+- name: Ethernet56/1
+  peer: SPINE2
   peer_interface: Ethernet56/1
   peer_type: mlag_peer
   description: MLAG_PEER_SPINE2_Ethernet56/1
@@ -237,7 +238,6 @@ ethernet_interfaces:
   channel_group:
     id: 551
     mode: active
-  name: Ethernet56/1
 - name: Ethernet1
   peer: LEAF1A
   peer_interface: Ethernet51

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/SPINE2.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/SPINE2.yml
@@ -41,16 +41,16 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4093
+  tenant: system
   name: LEAF_PEER_L3
   trunk_groups:
   - LEAF_PEER_L3
-  id: 4093
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 110
   name: IDF1-Data
   tenant: MY_FABRIC
@@ -78,9 +78,9 @@ vlans:
 - id: 330
   name: IDF3-Guest
   tenant: MY_FABRIC
-- tenant: system
+- id: 10
+  tenant: system
   name: L2LEAF_INBAND_MGMT
-  id: 10
 vlan_interfaces:
 - name: Vlan4093
   description: MLAG_PEER_L3_PEERING
@@ -218,7 +218,8 @@ port_channel_interfaces:
   vlans: 10,310,320,330
   mlag: 501
 ethernet_interfaces:
-- peer: SPINE1
+- name: Ethernet55/1
+  peer: SPINE1
   peer_interface: Ethernet55/1
   peer_type: mlag_peer
   description: MLAG_PEER_SPINE1_Ethernet55/1
@@ -227,8 +228,8 @@ ethernet_interfaces:
   channel_group:
     id: 551
     mode: active
-  name: Ethernet55/1
-- peer: SPINE1
+- name: Ethernet56/1
+  peer: SPINE1
   peer_interface: Ethernet56/1
   peer_type: mlag_peer
   description: MLAG_PEER_SPINE1_Ethernet56/1
@@ -237,7 +238,6 @@ ethernet_interfaces:
   channel_group:
     id: 551
     mode: active
-  name: Ethernet56/1
 - name: Ethernet1
   peer: LEAF1B
   peer_interface: Ethernet51

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf1a.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf1a.yml
@@ -197,16 +197,16 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4093
+  tenant: system
   name: LEAF_PEER_L3
   trunk_groups:
   - LEAF_PEER_L3
-  id: 4093
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 11
   name: VRF10_VLAN11
   tenant: TENANT1
@@ -314,7 +314,8 @@ port_channel_interfaces:
   spanning_tree_portfast: edge
   mlag: 5
 ethernet_interfaces:
-- peer: dc1-leaf1b
+- name: Ethernet3
+  peer: dc1-leaf1b
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_dc1-leaf1b_Ethernet3
@@ -323,8 +324,8 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet3
-- peer: dc1-leaf1b
+- name: Ethernet4
+  peer: dc1-leaf1b
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_dc1-leaf1b_Ethernet4
@@ -333,7 +334,6 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet4
 - name: Ethernet1
   peer: dc1-spine1
   peer_interface: Ethernet1

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf1b.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf1b.yml
@@ -197,16 +197,16 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4093
+  tenant: system
   name: LEAF_PEER_L3
   trunk_groups:
   - LEAF_PEER_L3
-  id: 4093
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 11
   name: VRF10_VLAN11
   tenant: TENANT1
@@ -314,7 +314,8 @@ port_channel_interfaces:
   spanning_tree_portfast: edge
   mlag: 5
 ethernet_interfaces:
-- peer: dc1-leaf1a
+- name: Ethernet3
+  peer: dc1-leaf1a
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_dc1-leaf1a_Ethernet3
@@ -323,8 +324,8 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet3
-- peer: dc1-leaf1a
+- name: Ethernet4
+  peer: dc1-leaf1a
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_dc1-leaf1a_Ethernet4
@@ -333,7 +334,6 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet4
 - name: Ethernet1
   peer: dc1-spine1
   peer_interface: Ethernet2

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf2a.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf2a.yml
@@ -257,16 +257,16 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4093
+  tenant: system
   name: LEAF_PEER_L3
   trunk_groups:
   - LEAF_PEER_L3
-  id: 4093
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 11
   name: VRF10_VLAN11
   tenant: TENANT1
@@ -374,7 +374,8 @@ port_channel_interfaces:
   spanning_tree_portfast: edge
   mlag: 5
 ethernet_interfaces:
-- peer: dc1-leaf2b
+- name: Ethernet3
+  peer: dc1-leaf2b
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_dc1-leaf2b_Ethernet3
@@ -383,8 +384,8 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet3
-- peer: dc1-leaf2b
+- name: Ethernet4
+  peer: dc1-leaf2b
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_dc1-leaf2b_Ethernet4
@@ -393,7 +394,6 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet4
 - name: Ethernet1
   peer: dc1-spine1
   peer_interface: Ethernet3

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf2b.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf2b.yml
@@ -257,16 +257,16 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4093
+  tenant: system
   name: LEAF_PEER_L3
   trunk_groups:
   - LEAF_PEER_L3
-  id: 4093
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 11
   name: VRF10_VLAN11
   tenant: TENANT1
@@ -374,7 +374,8 @@ port_channel_interfaces:
   spanning_tree_portfast: edge
   mlag: 5
 ethernet_interfaces:
-- peer: dc1-leaf2a
+- name: Ethernet3
+  peer: dc1-leaf2a
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_dc1-leaf2a_Ethernet3
@@ -383,8 +384,8 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet3
-- peer: dc1-leaf2a
+- name: Ethernet4
+  peer: dc1-leaf2a
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_dc1-leaf2a_Ethernet4
@@ -393,7 +394,6 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet4
 - name: Ethernet1
   peer: dc1-spine1
   peer_interface: Ethernet4

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf1a.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf1a.yml
@@ -197,16 +197,16 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4093
+  tenant: system
   name: LEAF_PEER_L3
   trunk_groups:
   - LEAF_PEER_L3
-  id: 4093
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 11
   name: VRF10_VLAN11
   tenant: TENANT1
@@ -314,7 +314,8 @@ port_channel_interfaces:
   spanning_tree_portfast: edge
   mlag: 5
 ethernet_interfaces:
-- peer: dc2-leaf1b
+- name: Ethernet3
+  peer: dc2-leaf1b
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_dc2-leaf1b_Ethernet3
@@ -323,8 +324,8 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet3
-- peer: dc2-leaf1b
+- name: Ethernet4
+  peer: dc2-leaf1b
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_dc2-leaf1b_Ethernet4
@@ -333,7 +334,6 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet4
 - name: Ethernet1
   peer: dc2-spine1
   peer_interface: Ethernet1

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf1b.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf1b.yml
@@ -197,16 +197,16 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4093
+  tenant: system
   name: LEAF_PEER_L3
   trunk_groups:
   - LEAF_PEER_L3
-  id: 4093
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 11
   name: VRF10_VLAN11
   tenant: TENANT1
@@ -314,7 +314,8 @@ port_channel_interfaces:
   spanning_tree_portfast: edge
   mlag: 5
 ethernet_interfaces:
-- peer: dc2-leaf1a
+- name: Ethernet3
+  peer: dc2-leaf1a
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_dc2-leaf1a_Ethernet3
@@ -323,8 +324,8 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet3
-- peer: dc2-leaf1a
+- name: Ethernet4
+  peer: dc2-leaf1a
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_dc2-leaf1a_Ethernet4
@@ -333,7 +334,6 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet4
 - name: Ethernet1
   peer: dc2-spine1
   peer_interface: Ethernet2

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf2a.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf2a.yml
@@ -257,16 +257,16 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4093
+  tenant: system
   name: LEAF_PEER_L3
   trunk_groups:
   - LEAF_PEER_L3
-  id: 4093
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 11
   name: VRF10_VLAN11
   tenant: TENANT1
@@ -374,7 +374,8 @@ port_channel_interfaces:
   spanning_tree_portfast: edge
   mlag: 5
 ethernet_interfaces:
-- peer: dc2-leaf2b
+- name: Ethernet3
+  peer: dc2-leaf2b
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_dc2-leaf2b_Ethernet3
@@ -383,8 +384,8 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet3
-- peer: dc2-leaf2b
+- name: Ethernet4
+  peer: dc2-leaf2b
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_dc2-leaf2b_Ethernet4
@@ -393,7 +394,6 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet4
 - name: Ethernet1
   peer: dc2-spine1
   peer_interface: Ethernet3

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf2b.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf2b.yml
@@ -257,16 +257,16 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4093
+  tenant: system
   name: LEAF_PEER_L3
   trunk_groups:
   - LEAF_PEER_L3
-  id: 4093
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 11
   name: VRF10_VLAN11
   tenant: TENANT1
@@ -374,7 +374,8 @@ port_channel_interfaces:
   spanning_tree_portfast: edge
   mlag: 5
 ethernet_interfaces:
-- peer: dc2-leaf2a
+- name: Ethernet3
+  peer: dc2-leaf2a
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_dc2-leaf2a_Ethernet3
@@ -383,8 +384,8 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet3
-- peer: dc2-leaf2a
+- name: Ethernet4
+  peer: dc2-leaf2a
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_dc2-leaf2a_Ethernet4
@@ -393,7 +394,6 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet4
 - name: Ethernet1
   peer: dc2-spine1
   peer_interface: Ethernet4

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF1.yml
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF1.yml
@@ -44,11 +44,11 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 10
   name: BLUE-NET
   tenant: MY_FABRIC
@@ -79,7 +79,8 @@ port_channel_interfaces:
   vlans: 10,20
   mlag: 1
 ethernet_interfaces:
-- peer: LEAF2
+- name: Ethernet47
+  peer: LEAF2
   peer_interface: Ethernet47
   peer_type: mlag_peer
   description: MLAG_PEER_LEAF2_Ethernet47
@@ -88,8 +89,8 @@ ethernet_interfaces:
   channel_group:
     id: 47
     mode: active
-  name: Ethernet47
-- peer: LEAF2
+- name: Ethernet48
+  peer: LEAF2
   peer_interface: Ethernet48
   peer_type: mlag_peer
   description: MLAG_PEER_LEAF2_Ethernet48
@@ -98,7 +99,6 @@ ethernet_interfaces:
   channel_group:
     id: 47
     mode: active
-  name: Ethernet48
 - name: Ethernet1
   peer: SPINE1
   peer_interface: Ethernet1

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF2.yml
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF2.yml
@@ -44,11 +44,11 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 10
   name: BLUE-NET
   tenant: MY_FABRIC
@@ -79,7 +79,8 @@ port_channel_interfaces:
   vlans: 10,20
   mlag: 1
 ethernet_interfaces:
-- peer: LEAF1
+- name: Ethernet47
+  peer: LEAF1
   peer_interface: Ethernet47
   peer_type: mlag_peer
   description: MLAG_PEER_LEAF1_Ethernet47
@@ -88,8 +89,8 @@ ethernet_interfaces:
   channel_group:
     id: 47
     mode: active
-  name: Ethernet47
-- peer: LEAF1
+- name: Ethernet48
+  peer: LEAF1
   peer_interface: Ethernet48
   peer_type: mlag_peer
   description: MLAG_PEER_LEAF1_Ethernet48
@@ -98,7 +99,6 @@ ethernet_interfaces:
   channel_group:
     id: 47
     mode: active
-  name: Ethernet48
 - name: Ethernet1
   peer: SPINE1
   peer_interface: Ethernet2

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF3.yml
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF3.yml
@@ -44,11 +44,11 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 10
   name: BLUE-NET
   tenant: MY_FABRIC
@@ -79,7 +79,8 @@ port_channel_interfaces:
   vlans: 10,30
   mlag: 1
 ethernet_interfaces:
-- peer: LEAF4
+- name: Ethernet47
+  peer: LEAF4
   peer_interface: Ethernet47
   peer_type: mlag_peer
   description: MLAG_PEER_LEAF4_Ethernet47
@@ -88,8 +89,8 @@ ethernet_interfaces:
   channel_group:
     id: 47
     mode: active
-  name: Ethernet47
-- peer: LEAF4
+- name: Ethernet48
+  peer: LEAF4
   peer_interface: Ethernet48
   peer_type: mlag_peer
   description: MLAG_PEER_LEAF4_Ethernet48
@@ -98,7 +99,6 @@ ethernet_interfaces:
   channel_group:
     id: 47
     mode: active
-  name: Ethernet48
 - name: Ethernet1
   peer: SPINE1
   peer_interface: Ethernet3

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF4.yml
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF4.yml
@@ -44,11 +44,11 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 10
   name: BLUE-NET
   tenant: MY_FABRIC
@@ -79,7 +79,8 @@ port_channel_interfaces:
   vlans: 10,30
   mlag: 1
 ethernet_interfaces:
-- peer: LEAF3
+- name: Ethernet47
+  peer: LEAF3
   peer_interface: Ethernet47
   peer_type: mlag_peer
   description: MLAG_PEER_LEAF3_Ethernet47
@@ -88,8 +89,8 @@ ethernet_interfaces:
   channel_group:
     id: 47
     mode: active
-  name: Ethernet47
-- peer: LEAF3
+- name: Ethernet48
+  peer: LEAF3
   peer_interface: Ethernet48
   peer_type: mlag_peer
   description: MLAG_PEER_LEAF3_Ethernet48
@@ -98,7 +99,6 @@ ethernet_interfaces:
   channel_group:
     id: 47
     mode: active
-  name: Ethernet48
 - name: Ethernet1
   peer: SPINE1
   peer_interface: Ethernet4

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/SPINE1.yml
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/SPINE1.yml
@@ -44,11 +44,11 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 10
   name: BLUE-NET
   tenant: MY_FABRIC
@@ -96,7 +96,8 @@ port_channel_interfaces:
   vlans: 10,20,30
   mlag: 5
 ethernet_interfaces:
-- peer: SPINE2
+- name: Ethernet47
+  peer: SPINE2
   peer_interface: Ethernet47
   peer_type: mlag_peer
   description: MLAG_PEER_SPINE2_Ethernet47
@@ -105,8 +106,8 @@ ethernet_interfaces:
   channel_group:
     id: 47
     mode: active
-  name: Ethernet47
-- peer: SPINE2
+- name: Ethernet48
+  peer: SPINE2
   peer_interface: Ethernet48
   peer_type: mlag_peer
   description: MLAG_PEER_SPINE2_Ethernet48
@@ -115,7 +116,6 @@ ethernet_interfaces:
   channel_group:
     id: 47
     mode: active
-  name: Ethernet48
 - name: Ethernet1
   peer: LEAF1
   peer_interface: Ethernet1

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/SPINE2.yml
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/SPINE2.yml
@@ -44,11 +44,11 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 10
   name: BLUE-NET
   tenant: MY_FABRIC
@@ -96,7 +96,8 @@ port_channel_interfaces:
   vlans: 10,20,30
   mlag: 5
 ethernet_interfaces:
-- peer: SPINE1
+- name: Ethernet47
+  peer: SPINE1
   peer_interface: Ethernet47
   peer_type: mlag_peer
   description: MLAG_PEER_SPINE1_Ethernet47
@@ -105,8 +106,8 @@ ethernet_interfaces:
   channel_group:
     id: 47
     mode: active
-  name: Ethernet47
-- peer: SPINE1
+- name: Ethernet48
+  peer: SPINE1
   peer_interface: Ethernet48
   peer_type: mlag_peer
   description: MLAG_PEER_SPINE1_Ethernet48
@@ -115,7 +116,6 @@ ethernet_interfaces:
   channel_group:
     id: 47
     mode: active
-  name: Ethernet48
 - name: Ethernet1
   peer: LEAF1
   peer_interface: Ethernet2

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf1a.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf1a.yml
@@ -197,16 +197,16 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4093
+  tenant: system
   name: LEAF_PEER_L3
   trunk_groups:
   - LEAF_PEER_L3
-  id: 4093
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 11
   name: VRF10_VLAN11
   tenant: TENANT1
@@ -314,7 +314,8 @@ port_channel_interfaces:
   spanning_tree_portfast: edge
   mlag: 5
 ethernet_interfaces:
-- peer: dc1-leaf1b
+- name: Ethernet3
+  peer: dc1-leaf1b
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_dc1-leaf1b_Ethernet3
@@ -323,8 +324,8 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet3
-- peer: dc1-leaf1b
+- name: Ethernet4
+  peer: dc1-leaf1b
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_dc1-leaf1b_Ethernet4
@@ -333,7 +334,6 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet4
 - name: Ethernet1
   peer: dc1-spine1
   peer_interface: Ethernet1

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf1b.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf1b.yml
@@ -197,16 +197,16 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4093
+  tenant: system
   name: LEAF_PEER_L3
   trunk_groups:
   - LEAF_PEER_L3
-  id: 4093
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 11
   name: VRF10_VLAN11
   tenant: TENANT1
@@ -314,7 +314,8 @@ port_channel_interfaces:
   spanning_tree_portfast: edge
   mlag: 5
 ethernet_interfaces:
-- peer: dc1-leaf1a
+- name: Ethernet3
+  peer: dc1-leaf1a
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_dc1-leaf1a_Ethernet3
@@ -323,8 +324,8 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet3
-- peer: dc1-leaf1a
+- name: Ethernet4
+  peer: dc1-leaf1a
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_dc1-leaf1a_Ethernet4
@@ -333,7 +334,6 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet4
 - name: Ethernet1
   peer: dc1-spine1
   peer_interface: Ethernet2

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf2a.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf2a.yml
@@ -197,16 +197,16 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4093
+  tenant: system
   name: LEAF_PEER_L3
   trunk_groups:
   - LEAF_PEER_L3
-  id: 4093
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 11
   name: VRF10_VLAN11
   tenant: TENANT1
@@ -314,7 +314,8 @@ port_channel_interfaces:
   spanning_tree_portfast: edge
   mlag: 5
 ethernet_interfaces:
-- peer: dc1-leaf2b
+- name: Ethernet3
+  peer: dc1-leaf2b
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_dc1-leaf2b_Ethernet3
@@ -323,8 +324,8 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet3
-- peer: dc1-leaf2b
+- name: Ethernet4
+  peer: dc1-leaf2b
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_dc1-leaf2b_Ethernet4
@@ -333,7 +334,6 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet4
 - name: Ethernet1
   peer: dc1-spine1
   peer_interface: Ethernet3

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf2b.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf2b.yml
@@ -197,16 +197,16 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4093
+  tenant: system
   name: LEAF_PEER_L3
   trunk_groups:
   - LEAF_PEER_L3
-  id: 4093
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 11
   name: VRF10_VLAN11
   tenant: TENANT1
@@ -314,7 +314,8 @@ port_channel_interfaces:
   spanning_tree_portfast: edge
   mlag: 5
 ethernet_interfaces:
-- peer: dc1-leaf2a
+- name: Ethernet3
+  peer: dc1-leaf2a
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_dc1-leaf2a_Ethernet3
@@ -323,8 +324,8 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet3
-- peer: dc1-leaf2a
+- name: Ethernet4
+  peer: dc1-leaf2a
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_dc1-leaf2a_Ethernet4
@@ -333,7 +334,6 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet4
 - name: Ethernet1
   peer: dc1-spine1
   peer_interface: Ethernet4

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-BL1A.yml
@@ -222,16 +222,16 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4093
+  tenant: system
   name: LEAF_PEER_L3
   trunk_groups:
   - LEAF_PEER_L3
-  id: 4093
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 150
   name: Tenant_A_WAN_Zone_1
   tenant: Tenant_A
@@ -327,7 +327,8 @@ port_channel_interfaces:
   - LEAF_PEER_L3
   - MLAG
 ethernet_interfaces:
-- peer: DC1-BL1B
+- name: Ethernet5
+  peer: DC1-BL1B
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-BL1B_Ethernet5
@@ -336,8 +337,8 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
-  name: Ethernet5
-- peer: DC1-BL1B
+- name: Ethernet6
+  peer: DC1-BL1B
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-BL1B_Ethernet6
@@ -346,7 +347,6 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
-  name: Ethernet6
 - name: Ethernet1
   peer: DC1-SPINE1
   peer_interface: Ethernet6

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-BL1B.yml
@@ -222,16 +222,16 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4093
+  tenant: system
   name: LEAF_PEER_L3
   trunk_groups:
   - LEAF_PEER_L3
-  id: 4093
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 150
   name: Tenant_A_WAN_Zone_1
   tenant: Tenant_A
@@ -327,7 +327,8 @@ port_channel_interfaces:
   - LEAF_PEER_L3
   - MLAG
 ethernet_interfaces:
-- peer: DC1-BL1A
+- name: Ethernet5
+  peer: DC1-BL1A
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-BL1A_Ethernet5
@@ -336,8 +337,8 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
-  name: Ethernet5
-- peer: DC1-BL1A
+- name: Ethernet6
+  peer: DC1-BL1A
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-BL1A_Ethernet6
@@ -346,7 +347,6 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
-  name: Ethernet6
 - name: Ethernet1
   peer: DC1-SPINE1
   peer_interface: Ethernet7

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -54,11 +54,11 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 130
   name: Tenant_A_APP_Zone_1
   tenant: Tenant_A
@@ -128,7 +128,8 @@ port_channel_interfaces:
   vlans: 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350
   mlag: 1
 ethernet_interfaces:
-- peer: DC1-L2LEAF2B
+- name: Ethernet3
+  peer: DC1-L2LEAF2B
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2B_Ethernet3
@@ -137,8 +138,8 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet3
-- peer: DC1-L2LEAF2B
+- name: Ethernet4
+  peer: DC1-L2LEAF2B
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2B_Ethernet4
@@ -147,7 +148,6 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet4
 - name: Ethernet1
   peer: DC1-SVC3A
   peer_interface: Ethernet7

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -54,11 +54,11 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 130
   name: Tenant_A_APP_Zone_1
   tenant: Tenant_A
@@ -128,7 +128,8 @@ port_channel_interfaces:
   vlans: 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350
   mlag: 1
 ethernet_interfaces:
-- peer: DC1-L2LEAF2A
+- name: Ethernet3
+  peer: DC1-L2LEAF2A
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2A_Ethernet3
@@ -137,8 +138,8 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet3
-- peer: DC1-L2LEAF2A
+- name: Ethernet4
+  peer: DC1-L2LEAF2A
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2A_Ethernet4
@@ -147,7 +148,6 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet4
 - name: Ethernet1
   peer: DC1-SVC3A
   peer_interface: Ethernet8

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF2A.yml
@@ -306,16 +306,16 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4093
+  tenant: system
   name: LEAF_PEER_L3
   trunk_groups:
   - LEAF_PEER_L3
-  id: 4093
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 130
   name: Tenant_A_APP_Zone_1
   tenant: Tenant_A
@@ -575,7 +575,8 @@ port_channel_interfaces:
   vlans: 210-211
   mlag: 10
 ethernet_interfaces:
-- peer: DC1-LEAF2B
+- name: Ethernet5
+  peer: DC1-LEAF2B
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF2B_Ethernet5
@@ -584,8 +585,8 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
-  name: Ethernet5
-- peer: DC1-LEAF2B
+- name: Ethernet6
+  peer: DC1-LEAF2B
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF2B_Ethernet6
@@ -594,7 +595,6 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
-  name: Ethernet6
 - name: Ethernet1
   peer: DC1-SPINE1
   peer_interface: Ethernet2

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF2B.yml
@@ -306,16 +306,16 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4093
+  tenant: system
   name: LEAF_PEER_L3
   trunk_groups:
   - LEAF_PEER_L3
-  id: 4093
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 130
   name: Tenant_A_APP_Zone_1
   tenant: Tenant_A
@@ -575,7 +575,8 @@ port_channel_interfaces:
   vlans: 210-211
   mlag: 10
 ethernet_interfaces:
-- peer: DC1-LEAF2A
+- name: Ethernet5
+  peer: DC1-LEAF2A
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF2A_Ethernet5
@@ -584,8 +585,8 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
-  name: Ethernet5
-- peer: DC1-LEAF2A
+- name: Ethernet6
+  peer: DC1-LEAF2A
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF2A_Ethernet6
@@ -594,7 +595,6 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
-  name: Ethernet6
 - name: Ethernet1
   peer: DC1-SPINE1
   peer_interface: Ethernet3

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SVC3A.yml
@@ -390,16 +390,16 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4093
+  tenant: system
   name: LEAF_PEER_L3
   trunk_groups:
   - LEAF_PEER_L3
-  id: 4093
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 130
   name: Tenant_A_APP_Zone_1
   tenant: Tenant_A
@@ -734,7 +734,8 @@ port_channel_interfaces:
     route_target: 03:03:02:02:01:01
   lacp_id: 0303.0202.0101
 ethernet_interfaces:
-- peer: DC1-SVC3B
+- name: Ethernet5
+  peer: DC1-SVC3B
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-SVC3B_Ethernet5
@@ -743,8 +744,8 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
-  name: Ethernet5
-- peer: DC1-SVC3B
+- name: Ethernet6
+  peer: DC1-SVC3B
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-SVC3B_Ethernet6
@@ -753,7 +754,6 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
-  name: Ethernet6
 - name: Ethernet1
   peer: DC1-SPINE1
   peer_interface: Ethernet4

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SVC3B.yml
@@ -390,16 +390,16 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4093
+  tenant: system
   name: LEAF_PEER_L3
   trunk_groups:
   - LEAF_PEER_L3
-  id: 4093
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 130
   name: Tenant_A_APP_Zone_1
   tenant: Tenant_A
@@ -724,7 +724,8 @@ port_channel_interfaces:
   vlans: 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350
   mlag: 7
 ethernet_interfaces:
-- peer: DC1-SVC3A
+- name: Ethernet5
+  peer: DC1-SVC3A
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-SVC3A_Ethernet5
@@ -733,8 +734,8 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
-  name: Ethernet5
-- peer: DC1-SVC3A
+- name: Ethernet6
+  peer: DC1-SVC3A
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-SVC3A_Ethernet6
@@ -743,7 +744,6 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
-  name: Ethernet6
 - name: Ethernet1
   peer: DC1-SPINE1
   peer_interface: Ethernet5

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-SPINE1.yml
@@ -53,11 +53,11 @@ management_api_http:
 spanning_tree:
   no_spanning_tree_vlan: '4094'
 vlans:
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 100
   name: SVI_100
   tenant: L2LS_BGP
@@ -98,7 +98,8 @@ port_channel_interfaces:
   vlans: '100'
   mlag: 2
 ethernet_interfaces:
-- peer: BGP-SPINE2
+- name: Ethernet3
+  peer: BGP-SPINE2
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_BGP-SPINE2_Ethernet3
@@ -107,8 +108,8 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet3
-- peer: BGP-SPINE2
+- name: Ethernet4
+  peer: BGP-SPINE2
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_BGP-SPINE2_Ethernet4
@@ -117,7 +118,6 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet4
 - name: Ethernet1
   peer: BGP-LEAF1
   peer_interface: Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-SPINE2.yml
@@ -57,11 +57,11 @@ management_api_http:
 spanning_tree:
   no_spanning_tree_vlan: '4094'
 vlans:
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 100
   name: SVI_100
   tenant: L2LS_BGP
@@ -102,7 +102,8 @@ port_channel_interfaces:
   vlans: '100'
   mlag: 2
 ethernet_interfaces:
-- peer: BGP-SPINE1
+- name: Ethernet3
+  peer: BGP-SPINE1
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_BGP-SPINE1_Ethernet3
@@ -111,8 +112,8 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet3
-- peer: BGP-SPINE1
+- name: Ethernet4
+  peer: BGP-SPINE1
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_BGP-SPINE1_Ethernet4
@@ -121,7 +122,6 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet4
 - name: Ethernet1
   peer: BGP-LEAF1
   peer_interface: Ethernet2

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/L2ONLY-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/L2ONLY-SPINE1.yml
@@ -19,11 +19,11 @@ management_api_http:
 spanning_tree:
   no_spanning_tree_vlan: '4094'
 vlans:
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 100
   name: L2VLAN_100
   tenant: L2LS_L2ONLY
@@ -58,7 +58,8 @@ port_channel_interfaces:
   vlans: '100'
   mlag: 2
 ethernet_interfaces:
-- peer: L2ONLY-SPINE2
+- name: Ethernet3
+  peer: L2ONLY-SPINE2
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_L2ONLY-SPINE2_Ethernet3
@@ -67,8 +68,8 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet3
-- peer: L2ONLY-SPINE2
+- name: Ethernet4
+  peer: L2ONLY-SPINE2
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_L2ONLY-SPINE2_Ethernet4
@@ -77,7 +78,6 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet4
 - name: Ethernet1
   peer: L2ONLY-LEAF1
   peer_interface: Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/L2ONLY-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/L2ONLY-SPINE2.yml
@@ -19,11 +19,11 @@ management_api_http:
 spanning_tree:
   no_spanning_tree_vlan: '4094'
 vlans:
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 100
   name: L2VLAN_100
   tenant: L2LS_L2ONLY
@@ -58,7 +58,8 @@ port_channel_interfaces:
   vlans: '100'
   mlag: 2
 ethernet_interfaces:
-- peer: L2ONLY-SPINE1
+- name: Ethernet3
+  peer: L2ONLY-SPINE1
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_L2ONLY-SPINE1_Ethernet3
@@ -67,8 +68,8 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet3
-- peer: L2ONLY-SPINE1
+- name: Ethernet4
+  peer: L2ONLY-SPINE1
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_L2ONLY-SPINE1_Ethernet4
@@ -77,7 +78,6 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet4
 - name: Ethernet1
   peer: L2ONLY-LEAF1
   peer_interface: Ethernet2

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-SPINE1.yml
@@ -19,11 +19,11 @@ management_api_http:
 spanning_tree:
   no_spanning_tree_vlan: '4094'
 vlans:
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 100
   name: SVI_100
   tenant: L2LS_OSPF
@@ -66,7 +66,8 @@ port_channel_interfaces:
   vlans: '100'
   mlag: 2
 ethernet_interfaces:
-- peer: OSPF-SPINE2
+- name: Ethernet3
+  peer: OSPF-SPINE2
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_OSPF-SPINE2_Ethernet3
@@ -75,8 +76,8 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet3
-- peer: OSPF-SPINE2
+- name: Ethernet4
+  peer: OSPF-SPINE2
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_OSPF-SPINE2_Ethernet4
@@ -85,7 +86,6 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet4
 - name: Ethernet1
   peer: OSPF-LEAF1
   peer_interface: Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-SPINE2.yml
@@ -22,11 +22,11 @@ management_api_http:
 spanning_tree:
   no_spanning_tree_vlan: '4094'
 vlans:
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 100
   name: SVI_100
   tenant: L2LS_OSPF
@@ -69,7 +69,8 @@ port_channel_interfaces:
   vlans: '100'
   mlag: 2
 ethernet_interfaces:
-- peer: OSPF-SPINE1
+- name: Ethernet3
+  peer: OSPF-SPINE1
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_OSPF-SPINE1_Ethernet3
@@ -78,8 +79,8 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet3
-- peer: OSPF-SPINE1
+- name: Ethernet4
+  peer: OSPF-SPINE1
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_OSPF-SPINE1_Ethernet4
@@ -88,7 +89,6 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet4
 - name: Ethernet1
   peer: OSPF-LEAF1
   peer_interface: Ethernet2

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF1A.yml
@@ -52,9 +52,9 @@ port_channel_interfaces:
 ip_igmp_snooping:
   globally_enabled: true
 vlans:
-- tenant: system
+- id: 4085
+  tenant: system
   name: L2LEAF_INBAND_MGMT
-  id: 4085
 management_interfaces:
 - name: Vlan4085
   description: L2LEAF_INBAND_MGMT

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF2A.yml
@@ -33,11 +33,11 @@ management_api_http:
 eos_cli: "interface Loopback1002\n  description Loopback created from raw_eos_cli under l2leaf node-group RACK2_MLAG\n\ninterface Loopback1111\n
   \ description Loopback created from raw_eos_cli under platform_settings vEOS-LAB\n"
 vlans:
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 110
   name: Tenant_A_OP_Zone_1
   tenant: Tenant_A
@@ -68,9 +68,9 @@ vlans:
 - id: 2601
   name: l2vlan_with_no_vxlan
   tenant: Tenant_A
-- tenant: system
+- id: 4085
+  tenant: system
   name: L2LEAF_INBAND_MGMT
-  id: 4085
 vlan_interfaces:
 - name: Vlan4094
   description: MLAG_PEER
@@ -97,7 +97,8 @@ port_channel_interfaces:
   vlans: 110-113,1100-1102,2500,2600-2601,4085
   mlag: 1
 ethernet_interfaces:
-- peer: DC1-POD1-L2LEAF2B
+- name: Ethernet3
+  peer: DC1-POD1-L2LEAF2B
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-POD1-L2LEAF2B_Ethernet3
@@ -106,8 +107,8 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet3
-- peer: DC1-POD1-L2LEAF2B
+- name: Ethernet4
+  peer: DC1-POD1-L2LEAF2B
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-POD1-L2LEAF2B_Ethernet4
@@ -116,7 +117,6 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet4
 - name: Ethernet1
   peer: DC1.POD1.LEAF2A
   peer_interface: Ethernet3

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF2B.yml
@@ -48,11 +48,11 @@ management_api_http:
 eos_cli: "interface Loopback1003\n  description Loopback created from raw_eos_cli under l2leaf node DC1-POD1-L2LEAF2B\n\ninterface Loopback1111\n
   \ description Loopback created from raw_eos_cli under platform_settings vEOS-LAB\n"
 vlans:
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 110
   name: Tenant_A_OP_Zone_1
   tenant: Tenant_A
@@ -83,9 +83,9 @@ vlans:
 - id: 2601
   name: l2vlan_with_no_vxlan
   tenant: Tenant_A
-- tenant: system
+- id: 4085
+  tenant: system
   name: L2LEAF_INBAND_MGMT
-  id: 4085
 vlan_interfaces:
 - name: Vlan4094
   description: MLAG_PEER
@@ -112,7 +112,8 @@ port_channel_interfaces:
   vlans: 110-113,1100-1102,2500,2600-2601,4085
   mlag: 1
 ethernet_interfaces:
-- peer: DC1-POD1-L2LEAF2A
+- name: Ethernet3
+  peer: DC1-POD1-L2LEAF2A
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-POD1-L2LEAF2A_Ethernet3
@@ -121,8 +122,8 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet3
-- peer: DC1-POD1-L2LEAF2A
+- name: Ethernet4
+  peer: DC1-POD1-L2LEAF2A
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-POD1-L2LEAF2A_Ethernet4
@@ -131,7 +132,6 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet4
 - name: Ethernet1
   peer: DC1.POD1.LEAF2A
   peer_interface: Ethernet4

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF1A.yml
@@ -228,9 +228,9 @@ vxlan_interface:
       udp_port: 4789
       source_interface: Loopback1
 vlans:
-- tenant: system
+- id: 4085
+  tenant: system
   name: L2LEAF_INBAND_MGMT
-  id: 4085
 vlan_interfaces:
 - name: Vlan4085
   description: L2LEAF_INBAND_MGMT

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2B.yml
@@ -336,11 +336,11 @@ eos_cli: "interface Loopback1002\n  description Loopback created from raw_eos_cl
   \ description Loopback created from raw_eos_cli under platform_settings vEOS-LAB\n\ninterface Loopback1000\n  description Loopback
   created from raw_eos_cli under VRF Common_VRF\n"
 vlans:
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 110
   name: Tenant_A_OP_Zone_1
   tenant: Tenant_A
@@ -371,9 +371,9 @@ vlans:
 - id: 2601
   name: l2vlan_with_no_vxlan
   tenant: Tenant_A
-- tenant: system
+- id: 4085
+  tenant: system
   name: L2LEAF_INBAND_MGMT
-  id: 4085
 vlan_interfaces:
 - name: Vlan4094
   description: MLAG_PEER
@@ -523,7 +523,8 @@ port_channel_interfaces:
   vlans: '110'
   mlag: 19
 ethernet_interfaces:
-- peer: DC1.POD1.LEAF2A
+- name: Ethernet5
+  peer: DC1.POD1.LEAF2A
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1.POD1.LEAF2A_Ethernet5
@@ -532,8 +533,8 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
-  name: Ethernet5
-- peer: DC1.POD1.LEAF2A
+- name: Ethernet6
+  peer: DC1.POD1.LEAF2A
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1.POD1.LEAF2A_Ethernet6
@@ -542,7 +543,6 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
-  name: Ethernet6
 - name: Ethernet1
   peer: DC1-POD1-SPINE1
   peer_interface: Ethernet5

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1.POD1.LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1.POD1.LEAF2A.yml
@@ -296,11 +296,11 @@ eos_cli: "interface Loopback1002\n  description Loopback created from raw_eos_cl
   \ description Loopback created from raw_eos_cli under platform_settings vEOS-LAB\n\ninterface Loopback1000\n  description Loopback
   created from raw_eos_cli under VRF Common_VRF\n"
 vlans:
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 110
   name: Tenant_A_OP_Zone_1
   tenant: Tenant_A
@@ -331,9 +331,9 @@ vlans:
 - id: 2601
   name: l2vlan_with_no_vxlan
   tenant: Tenant_A
-- tenant: system
+- id: 4085
+  tenant: system
   name: L2LEAF_INBAND_MGMT
-  id: 4085
 vlan_interfaces:
 - name: Vlan4094
   description: MLAG_PEER
@@ -483,7 +483,8 @@ port_channel_interfaces:
   vlans: '110'
   mlag: 19
 ethernet_interfaces:
-- peer: DC1-POD1-LEAF2B
+- name: Ethernet5
+  peer: DC1-POD1-LEAF2B
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-POD1-LEAF2B_Ethernet5
@@ -492,8 +493,8 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
-  name: Ethernet5
-- peer: DC1-POD1-LEAF2B
+- name: Ethernet6
+  peer: DC1-POD1-LEAF2B
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-POD1-LEAF2B_Ethernet6
@@ -502,7 +503,6 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
-  name: Ethernet6
 - name: Ethernet1
   peer: DC1-POD1-SPINE1
   peer_interface: Ethernet4

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-L2LEAF1A.yml
@@ -68,6 +68,6 @@ port_channel_interfaces:
 ip_igmp_snooping:
   globally_enabled: true
 vlans:
-- tenant: system
+- id: 4092
+  tenant: system
   name: L2LEAF_INBAND_MGMT
-  id: 4092

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-L2LEAF2A.yml
@@ -68,6 +68,6 @@ port_channel_interfaces:
 ip_igmp_snooping:
   globally_enabled: true
 vlans:
-- tenant: system
+- id: 4092
+  tenant: system
   name: L2LEAF_INBAND_MGMT
-  id: 4092

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-LEAF1A.yml
@@ -293,10 +293,10 @@ route_maps:
     type: permit
     match:
     - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
-  - type: permit
+  - sequence: 20
+    type: permit
     match:
     - ip address prefix-list PL-L2LEAF-INBAND-MGMT
-    sequence: 20
 router_bfd:
   multihop:
     interval: 300
@@ -326,9 +326,9 @@ virtual_source_nat_vrfs:
 - name: vrf_with_loopbacks_from_pod_pools
   ip_address: 10.101.201.3
 vlans:
-- tenant: system
+- id: 4092
+  tenant: system
   name: L2LEAF_INBAND_MGMT
-  id: 4092
 vlan_interfaces:
 - name: Vlan4092
   description: L2LEAF_INBAND_MGMT

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-LEAF2A.yml
@@ -158,10 +158,10 @@ route_maps:
     type: permit
     match:
     - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
-  - type: permit
+  - sequence: 20
+    type: permit
     match:
     - ip address prefix-list PL-L2LEAF-INBAND-MGMT
-    sequence: 20
 router_bfd:
   multihop:
     interval: 300
@@ -176,9 +176,9 @@ vxlan_interface:
       udp_port: 4789
       source_interface: Loopback1
 vlans:
-- tenant: system
+- id: 4092
+  tenant: system
   name: L2LEAF_INBAND_MGMT
-  id: 4092
 vlan_interfaces:
 - name: Vlan4092
   description: L2LEAF_INBAND_MGMT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF3A.yml
@@ -77,16 +77,16 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4093
+  tenant: system
   name: LEAF_PEER_L3
   trunk_groups:
   - LEAF_PEER_L3
-  id: 4093
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 vlan_interfaces:
 - name: Vlan4093
   description: MLAG_PEER_L3_PEERING
@@ -110,7 +110,8 @@ port_channel_interfaces:
   - LEAF_PEER_L3
   - MLAG
 ethernet_interfaces:
-- peer: AUTO_BGP_ASN_LEAF3B
+- name: Ethernet3
+  peer: AUTO_BGP_ASN_LEAF3B
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_AUTO_BGP_ASN_LEAF3B_Ethernet3
@@ -119,8 +120,8 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet3
-- peer: AUTO_BGP_ASN_LEAF3B
+- name: Ethernet4
+  peer: AUTO_BGP_ASN_LEAF3B
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_AUTO_BGP_ASN_LEAF3B_Ethernet4
@@ -129,7 +130,6 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet4
 mlag_configuration:
   domain_id: AUTO_BGP_ASN_LEAF3_MLAG
   local_interface: Vlan4094

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF3B.yml
@@ -77,16 +77,16 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4093
+  tenant: system
   name: LEAF_PEER_L3
   trunk_groups:
   - LEAF_PEER_L3
-  id: 4093
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 vlan_interfaces:
 - name: Vlan4093
   description: MLAG_PEER_L3_PEERING
@@ -110,7 +110,8 @@ port_channel_interfaces:
   - LEAF_PEER_L3
   - MLAG
 ethernet_interfaces:
-- peer: AUTO_BGP_ASN_LEAF3A
+- name: Ethernet3
+  peer: AUTO_BGP_ASN_LEAF3A
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_AUTO_BGP_ASN_LEAF3A_Ethernet3
@@ -119,8 +120,8 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet3
-- peer: AUTO_BGP_ASN_LEAF3A
+- name: Ethernet4
+  peer: AUTO_BGP_ASN_LEAF3A
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_AUTO_BGP_ASN_LEAF3A_Ethernet4
@@ -129,7 +130,6 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet4
 mlag_configuration:
   domain_id: AUTO_BGP_ASN_LEAF3_MLAG
   local_interface: Vlan4094

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF4A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF4A.yml
@@ -77,16 +77,16 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4093
+  tenant: system
   name: LEAF_PEER_L3
   trunk_groups:
   - LEAF_PEER_L3
-  id: 4093
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 vlan_interfaces:
 - name: Vlan4093
   description: MLAG_PEER_L3_PEERING
@@ -110,7 +110,8 @@ port_channel_interfaces:
   - LEAF_PEER_L3
   - MLAG
 ethernet_interfaces:
-- peer: AUTO_BGP_ASN_LEAF4B
+- name: Ethernet3
+  peer: AUTO_BGP_ASN_LEAF4B
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_AUTO_BGP_ASN_LEAF4B_Ethernet3
@@ -119,8 +120,8 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet3
-- peer: AUTO_BGP_ASN_LEAF4B
+- name: Ethernet4
+  peer: AUTO_BGP_ASN_LEAF4B
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_AUTO_BGP_ASN_LEAF4B_Ethernet4
@@ -129,7 +130,6 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet4
 mlag_configuration:
   domain_id: AUTO_BGP_ASN_LEAF4_MLAG_OVERRIDE
   local_interface: Vlan4094

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF4B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF4B.yml
@@ -77,16 +77,16 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4093
+  tenant: system
   name: LEAF_PEER_L3
   trunk_groups:
   - LEAF_PEER_L3
-  id: 4093
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 vlan_interfaces:
 - name: Vlan4093
   description: MLAG_PEER_L3_PEERING
@@ -110,7 +110,8 @@ port_channel_interfaces:
   - LEAF_PEER_L3
   - MLAG
 ethernet_interfaces:
-- peer: AUTO_BGP_ASN_LEAF4A
+- name: Ethernet3
+  peer: AUTO_BGP_ASN_LEAF4A
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_AUTO_BGP_ASN_LEAF4A_Ethernet3
@@ -119,8 +120,8 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet3
-- peer: AUTO_BGP_ASN_LEAF4A
+- name: Ethernet4
+  peer: AUTO_BGP_ASN_LEAF4A
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_AUTO_BGP_ASN_LEAF4A_Ethernet4
@@ -129,7 +130,6 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet4
 mlag_configuration:
   domain_id: AUTO_BGP_ASN_LEAF4_MLAG_OVERRIDE
   local_interface: Vlan4094

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF7A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF7A.yml
@@ -77,16 +77,16 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4093
+  tenant: system
   name: LEAF_PEER_L3
   trunk_groups:
   - LEAF_PEER_L3
-  id: 4093
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 vlan_interfaces:
 - name: Vlan4093
   description: MLAG_PEER_L3_PEERING
@@ -110,7 +110,8 @@ port_channel_interfaces:
   - LEAF_PEER_L3
   - MLAG
 ethernet_interfaces:
-- peer: AUTO_BGP_ASN_LEAF7B
+- name: Ethernet3
+  peer: AUTO_BGP_ASN_LEAF7B
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_AUTO_BGP_ASN_LEAF7B_Ethernet3
@@ -119,8 +120,8 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet3
-- peer: AUTO_BGP_ASN_LEAF7B
+- name: Ethernet4
+  peer: AUTO_BGP_ASN_LEAF7B
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_AUTO_BGP_ASN_LEAF7B_Ethernet4
@@ -129,7 +130,6 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet4
 mlag_configuration:
   domain_id: AUTO_BGP_ASN_LEAF5_4BYTE_DOTZERO
   local_interface: Vlan4094

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF7B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF7B.yml
@@ -77,16 +77,16 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4093
+  tenant: system
   name: LEAF_PEER_L3
   trunk_groups:
   - LEAF_PEER_L3
-  id: 4093
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 vlan_interfaces:
 - name: Vlan4093
   description: MLAG_PEER_L3_PEERING
@@ -110,7 +110,8 @@ port_channel_interfaces:
   - LEAF_PEER_L3
   - MLAG
 ethernet_interfaces:
-- peer: AUTO_BGP_ASN_LEAF7A
+- name: Ethernet3
+  peer: AUTO_BGP_ASN_LEAF7A
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_AUTO_BGP_ASN_LEAF7A_Ethernet3
@@ -119,8 +120,8 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet3
-- peer: AUTO_BGP_ASN_LEAF7A
+- name: Ethernet4
+  peer: AUTO_BGP_ASN_LEAF7A
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_AUTO_BGP_ASN_LEAF7A_Ethernet4
@@ -129,7 +130,6 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet4
 mlag_configuration:
   domain_id: AUTO_BGP_ASN_LEAF5_4BYTE_DOTZERO
   local_interface: Vlan4094

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-PYTHON_MODULES-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-PYTHON_MODULES-L3LEAF1A.yml
@@ -109,16 +109,16 @@ management_api_http:
 spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 vlans:
-- tenant: system
+- id: 4093
+  tenant: system
   name: LEAF_PEER_L3
   trunk_groups:
   - LEAF_PEER_L3
-  id: 4093
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 110
   name: Tenant_A_OP_Zone_1
   tenant: CUSTOM_PYTHON_MODULES_TENANT
@@ -166,7 +166,8 @@ port_channel_interfaces:
   - LEAF_PEER_L3
   - MLAG
 ethernet_interfaces:
-- peer: CUSTOM-PYTHON_MODULES-L3LEAF1B
+- name: Ethernet3
+  peer: CUSTOM-PYTHON_MODULES-L3LEAF1B
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: TEST_CUSTOM_PREFIX_MLAG_PEER_CUSTOM-PYTHON_MODULES-L3LEAF1B_Ethernet3
@@ -175,8 +176,8 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet3
-- peer: CUSTOM-PYTHON_MODULES-L3LEAF1B
+- name: Ethernet4
+  peer: CUSTOM-PYTHON_MODULES-L3LEAF1B
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: TEST_CUSTOM_PREFIX_MLAG_PEER_CUSTOM-PYTHON_MODULES-L3LEAF1B_Ethernet4
@@ -185,7 +186,6 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet4
 - name: Ethernet1
   peer: CUSTOM-PYTHON_MODULES-SPINE1
   peer_interface: Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-PYTHON_MODULES-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-PYTHON_MODULES-L3LEAF1B.yml
@@ -109,16 +109,16 @@ management_api_http:
 spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 vlans:
-- tenant: system
+- id: 4093
+  tenant: system
   name: LEAF_PEER_L3
   trunk_groups:
   - LEAF_PEER_L3
-  id: 4093
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 110
   name: Tenant_A_OP_Zone_1
   tenant: CUSTOM_PYTHON_MODULES_TENANT
@@ -166,7 +166,8 @@ port_channel_interfaces:
   - LEAF_PEER_L3
   - MLAG
 ethernet_interfaces:
-- peer: CUSTOM-PYTHON_MODULES-L3LEAF1A
+- name: Ethernet3
+  peer: CUSTOM-PYTHON_MODULES-L3LEAF1A
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: TEST_CUSTOM_PREFIX_MLAG_PEER_CUSTOM-PYTHON_MODULES-L3LEAF1A_Ethernet3
@@ -175,8 +176,8 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet3
-- peer: CUSTOM-PYTHON_MODULES-L3LEAF1A
+- name: Ethernet4
+  peer: CUSTOM-PYTHON_MODULES-L3LEAF1A
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: TEST_CUSTOM_PREFIX_MLAG_PEER_CUSTOM-PYTHON_MODULES-L3LEAF1A_Ethernet4
@@ -185,7 +186,6 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet4
 - name: Ethernet1
   peer: CUSTOM-PYTHON_MODULES-SPINE1
   peer_interface: Ethernet2

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-TEMPLATES-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-TEMPLATES-L3LEAF1A.yml
@@ -109,16 +109,16 @@ management_api_http:
 spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 vlans:
-- tenant: system
+- id: 4093
+  tenant: system
   name: LEAF_PEER_L3
   trunk_groups:
   - LEAF_PEER_L3
-  id: 4093
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 110
   name: Tenant_A_OP_Zone_1
   tenant: CUSTOM_TEMPLATES_TENANT
@@ -166,7 +166,8 @@ port_channel_interfaces:
   - LEAF_PEER_L3
   - MLAG
 ethernet_interfaces:
-- peer: CUSTOM-TEMPLATES-L3LEAF1B
+- name: Ethernet3
+  peer: CUSTOM-TEMPLATES-L3LEAF1B
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: TEST_CUSTOM_PREFIX_MLAG_PEER_CUSTOM-TEMPLATES-L3LEAF1B_Ethernet3
@@ -175,8 +176,8 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet3
-- peer: CUSTOM-TEMPLATES-L3LEAF1B
+- name: Ethernet4
+  peer: CUSTOM-TEMPLATES-L3LEAF1B
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: TEST_CUSTOM_PREFIX_MLAG_PEER_CUSTOM-TEMPLATES-L3LEAF1B_Ethernet4
@@ -185,7 +186,6 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet4
 - name: Ethernet1
   peer: CUSTOM-TEMPLATES-SPINE1
   peer_interface: Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-TEMPLATES-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-TEMPLATES-L3LEAF1B.yml
@@ -109,16 +109,16 @@ management_api_http:
 spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 vlans:
-- tenant: system
+- id: 4093
+  tenant: system
   name: LEAF_PEER_L3
   trunk_groups:
   - LEAF_PEER_L3
-  id: 4093
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 110
   name: Tenant_A_OP_Zone_1
   tenant: CUSTOM_TEMPLATES_TENANT
@@ -166,7 +166,8 @@ port_channel_interfaces:
   - LEAF_PEER_L3
   - MLAG
 ethernet_interfaces:
-- peer: CUSTOM-TEMPLATES-L3LEAF1A
+- name: Ethernet3
+  peer: CUSTOM-TEMPLATES-L3LEAF1A
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: TEST_CUSTOM_PREFIX_MLAG_PEER_CUSTOM-TEMPLATES-L3LEAF1A_Ethernet3
@@ -175,8 +176,8 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet3
-- peer: CUSTOM-TEMPLATES-L3LEAF1A
+- name: Ethernet4
+  peer: CUSTOM-TEMPLATES-L3LEAF1A
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: TEST_CUSTOM_PREFIX_MLAG_PEER_CUSTOM-TEMPLATES-L3LEAF1A_Ethernet4
@@ -185,7 +186,6 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet4
 - name: Ethernet1
   peer: CUSTOM-TEMPLATES-SPINE1
   peer_interface: Ethernet2

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1A.yml
@@ -291,13 +291,13 @@ vlan_internal_order:
     beginning: 1006
     ending: 1199
 event_handlers:
-- action_type: bash
+- name: evpn-blacklist-recovery
+  action_type: bash
   action: FastCli -p 15 -c "clear bgp evpn host-flap"
   delay: 300
   trigger: on-logging
   regex: EVPN-3-BLACKLISTED_DUPLICATE_MAC
   asynchronous: true
-  name: evpn-blacklist-recovery
 ip_name_servers:
 - ip_address: 192.168.200.5
   vrf: MGMT
@@ -458,7 +458,8 @@ ethernet_interfaces:
   - id: 2
     hash_algorithm: sha512
     key: AQQvKeimxJu+uGQ/yYvv9w==
-- description: My test
+- name: Ethernet4000
+  description: My test
   ip_address: 10.3.2.1/21
   shutdown: false
   type: routed
@@ -466,7 +467,6 @@ ethernet_interfaces:
   peer: MY-own-peer
   peer_interface: Ethernet123
   peer_type: my_precious
-  name: Ethernet4000
 loopback_interfaces:
 - name: Loopback0
   description: MY_OVERLAY_LOOPBACK
@@ -594,9 +594,9 @@ vxlan_interface:
         vni: 31
 sflow:
   vrfs:
-  - destinations:
+  - name: OOB
+    destinations:
     - destination: 192.168.200.10
     - destination: 10.0.200.90
     source_interface: Management1
-    name: OOB
 ntp: null

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1B.yml
@@ -435,7 +435,8 @@ ethernet_interfaces:
   description: test
   type: routed
   vrf: Tenant_A_WAN_Zone
-- description: My second test
+- name: Ethernet4000
+  description: My second test
   ip_address: 10.1.2.3/12
   shutdown: false
   type: routed
@@ -443,7 +444,6 @@ ethernet_interfaces:
   peer: MY-own-peer
   peer_interface: Ethernet123
   peer_type: my_precious
-  name: Ethernet4000
 loopback_interfaces:
 - name: Loopback0
   description: EVPN_Overlay_Peering
@@ -566,9 +566,9 @@ vxlan_interface:
         vni: 31
 sflow:
   vrfs:
-  - destinations:
+  - name: OOB
+    destinations:
     - destination: 192.168.200.10
     - destination: 10.0.200.90
     source_interface: Management1
-    name: OOB
 ntp: null

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-CL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-CL1A.yml
@@ -236,16 +236,16 @@ management_api_http:
   enable_https: true
   default_services: false
 vlans:
-- tenant: system
+- id: 4090
+  tenant: system
   name: LEAF_PEER_L3
   trunk_groups:
   - LEAF_PEER_L3
-  id: 4090
-- tenant: system
+- id: 4092
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4092
 - id: 130
   name: Tenant_A_APP_Zone_1
   tenant: Tenant_A
@@ -323,7 +323,8 @@ port_channel_interfaces:
   - LEAF_PEER_L3
   - MLAG
 ethernet_interfaces:
-- peer: DC1-CL1B
+- name: Ethernet1/15/1
+  peer: DC1-CL1B
   peer_interface: Ethernet1/15/1
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-CL1B_Ethernet1/15/1
@@ -333,8 +334,8 @@ ethernet_interfaces:
     id: 1151
     mode: active
   speed: 100g
-  name: Ethernet1/15/1
-- peer: DC1-CL1B
+- name: Ethernet1/16/1
+  peer: DC1-CL1B
   peer_interface: Ethernet1/16/1
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-CL1B_Ethernet1/16/1
@@ -344,7 +345,6 @@ ethernet_interfaces:
     id: 1151
     mode: active
   speed: 100g
-  name: Ethernet1/16/1
 - name: Ethernet1
   peer: DC1-SPINE1
   peer_interface: Ethernet26

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-CL1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-CL1B.yml
@@ -237,16 +237,16 @@ management_api_http:
   enable_https: true
   default_services: false
 vlans:
-- tenant: system
+- id: 4090
+  tenant: system
   name: LEAF_PEER_L3
   trunk_groups:
   - LEAF_PEER_L3
-  id: 4090
-- tenant: system
+- id: 4092
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4092
 - id: 130
   name: Tenant_A_APP_Zone_1
   tenant: Tenant_A
@@ -324,7 +324,8 @@ port_channel_interfaces:
   - LEAF_PEER_L3
   - MLAG
 ethernet_interfaces:
-- peer: DC1-CL1A
+- name: Ethernet1/31/1
+  peer: DC1-CL1A
   peer_interface: Ethernet1/31/1
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-CL1A_Ethernet1/31/1
@@ -334,8 +335,8 @@ ethernet_interfaces:
     id: 1311
     mode: active
   speed: 100g
-  name: Ethernet1/31/1
-- peer: DC1-CL1A
+- name: Ethernet1/32/1
+  peer: DC1-CL1A
   peer_interface: Ethernet1/32/1
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-CL1A_Ethernet1/32/1
@@ -345,7 +346,6 @@ ethernet_interfaces:
     id: 1311
     mode: active
   speed: 100g
-  name: Ethernet1/32/1
 - name: Ethernet1
   peer: DC1-SPINE1
   peer_interface: Ethernet27

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -58,11 +58,11 @@ management_api_http:
   enable_https: true
   default_services: false
 vlans:
-- tenant: system
+- id: 4091
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4091
 - id: 130
   name: Tenant_A_APP_Zone_1
   tenant: Tenant_A
@@ -114,7 +114,8 @@ port_channel_interfaces:
   vlans: 110-112,120-121,130-131,160-161
   mlag: 1
 ethernet_interfaces:
-- peer: DC1-L2LEAF1B
+- name: Ethernet3
+  peer: DC1-L2LEAF1B
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF1B_Ethernet3
@@ -124,8 +125,8 @@ ethernet_interfaces:
     id: 3
     mode: active
   speed: forced 40gfull
-  name: Ethernet3
-- peer: DC1-L2LEAF1B
+- name: Ethernet4
+  peer: DC1-L2LEAF1B
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF1B_Ethernet4
@@ -135,7 +136,6 @@ ethernet_interfaces:
     id: 3
     mode: active
   speed: forced 40gfull
-  name: Ethernet4
 - name: Ethernet1
   peer: DC1-LEAF2A
   peer_interface: Ethernet7

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF1B.yml
@@ -58,11 +58,11 @@ management_api_http:
   enable_https: true
   default_services: false
 vlans:
-- tenant: system
+- id: 4091
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4091
 - id: 130
   name: Tenant_A_APP_Zone_1
   tenant: Tenant_A
@@ -114,7 +114,8 @@ port_channel_interfaces:
   vlans: 110-112,120-121,130-131,160-161
   mlag: 1
 ethernet_interfaces:
-- peer: DC1-L2LEAF1A
+- name: Ethernet3
+  peer: DC1-L2LEAF1A
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF1A_Ethernet3
@@ -124,8 +125,8 @@ ethernet_interfaces:
     id: 3
     mode: active
   speed: forced 40gfull
-  name: Ethernet3
-- peer: DC1-L2LEAF1A
+- name: Ethernet4
+  peer: DC1-L2LEAF1A
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF1A_Ethernet4
@@ -135,7 +136,6 @@ ethernet_interfaces:
     id: 3
     mode: active
   speed: forced 40gfull
-  name: Ethernet4
 - name: Ethernet1
   peer: DC1-LEAF2A
   peer_interface: Ethernet8

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -58,11 +58,11 @@ management_api_http:
   enable_https: true
   default_services: false
 vlans:
-- tenant: system
+- id: 4091
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4091
 - id: 130
   name: Tenant_A_APP_Zone_1
   tenant: Tenant_A
@@ -141,7 +141,8 @@ port_channel_interfaces:
   vlans: 110-112,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350
   mlag: 1
 ethernet_interfaces:
-- peer: DC1-L2LEAF2B
+- name: Ethernet3
+  peer: DC1-L2LEAF2B
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2B_Ethernet3
@@ -150,8 +151,8 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet3
-- peer: DC1-L2LEAF2B
+- name: Ethernet4
+  peer: DC1-L2LEAF2B
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2B_Ethernet4
@@ -160,7 +161,6 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet4
 - name: Ethernet1
   peer: DC1-SVC3A
   peer_interface: Ethernet7

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -58,11 +58,11 @@ management_api_http:
   enable_https: true
   default_services: false
 vlans:
-- tenant: system
+- id: 4091
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4091
 - id: 130
   name: Tenant_A_APP_Zone_1
   tenant: Tenant_A
@@ -141,7 +141,8 @@ port_channel_interfaces:
   vlans: 110-112,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350
   mlag: 1
 ethernet_interfaces:
-- peer: DC1-L2LEAF2A
+- name: Ethernet3
+  peer: DC1-L2LEAF2A
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2A_Ethernet3
@@ -150,8 +151,8 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet3
-- peer: DC1-L2LEAF2A
+- name: Ethernet4
+  peer: DC1-L2LEAF2A
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2A_Ethernet4
@@ -160,7 +161,6 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet4
 - name: Ethernet1
   peer: DC1-SVC3A
   peer_interface: Ethernet8

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3A.yml
@@ -421,16 +421,16 @@ management_api_http:
   enable_https: true
   default_services: false
 vlans:
-- tenant: system
+- id: 4090
+  tenant: system
   name: LEAF_PEER_L3
   trunk_groups:
   - LEAF_PEER_L3
-  id: 4090
-- tenant: system
+- id: 4092
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4092
 - id: 130
   name: Tenant_A_APP_Zone_1
   tenant: Tenant_A
@@ -960,7 +960,8 @@ port_channel_interfaces:
   vlans: '110'
   mlag: 1291
 ethernet_interfaces:
-- peer: DC1-SVC3B
+- name: Ethernet53/1
+  peer: DC1-SVC3B
   peer_interface: Ethernet53/1
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-SVC3B_Ethernet53/1
@@ -970,8 +971,8 @@ ethernet_interfaces:
     id: 2000
     mode: active
   speed: 100g
-  name: Ethernet53/1
-- peer: DC1-SVC3B
+- name: Ethernet54/1
+  peer: DC1-SVC3B
   peer_interface: Ethernet54/1
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-SVC3B_Ethernet54/1
@@ -981,7 +982,6 @@ ethernet_interfaces:
     id: 2000
     mode: active
   speed: 100g
-  name: Ethernet54/1
 - name: Ethernet7
   peer: DC1-L2LEAF2A
   peer_interface: Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3B.yml
@@ -421,16 +421,16 @@ management_api_http:
   enable_https: true
   default_services: false
 vlans:
-- tenant: system
+- id: 4090
+  tenant: system
   name: LEAF_PEER_L3
   trunk_groups:
   - LEAF_PEER_L3
-  id: 4090
-- tenant: system
+- id: 4092
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4092
 - id: 130
   name: Tenant_A_APP_Zone_1
   tenant: Tenant_A
@@ -950,7 +950,8 @@ port_channel_interfaces:
   vlans: '110'
   mlag: 1291
 ethernet_interfaces:
-- peer: DC1-SVC3A
+- name: Ethernet53/1
+  peer: DC1-SVC3A
   peer_interface: Ethernet53/1
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-SVC3A_Ethernet53/1
@@ -960,8 +961,8 @@ ethernet_interfaces:
     id: 2000
     mode: active
   speed: 100g
-  name: Ethernet53/1
-- peer: DC1-SVC3A
+- name: Ethernet54/1
+  peer: DC1-SVC3A
   peer_interface: Ethernet54/1
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-SVC3A_Ethernet54/1
@@ -971,7 +972,6 @@ ethernet_interfaces:
     id: 2000
     mode: active
   speed: 100g
-  name: Ethernet54/1
 - name: Ethernet7
   peer: DC1-L2LEAF2A
   peer_interface: Ethernet2

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1.L2LEAF5A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1.L2LEAF5A.yml
@@ -58,11 +58,11 @@ management_api_http:
   enable_https: true
   default_services: false
 vlans:
-- tenant: system
+- id: 4091
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4091
 - id: 130
   name: Tenant_A_APP_Zone_1
   tenant: Tenant_A
@@ -114,7 +114,8 @@ port_channel_interfaces:
   vlans: 110-112,120-121,130-131,160-161
   mlag: 1
 ethernet_interfaces:
-- peer: DC1.L2LEAF5B
+- name: Ethernet3
+  peer: DC1.L2LEAF5B
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_DC1.L2LEAF5B_Ethernet3
@@ -123,8 +124,8 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet3
-- peer: DC1.L2LEAF5B
+- name: Ethernet4
+  peer: DC1.L2LEAF5B
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_DC1.L2LEAF5B_Ethernet4
@@ -133,7 +134,6 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet4
 - name: Ethernet1
   peer: DC1-LEAF2A
   peer_interface: Ethernet14/1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1.L2LEAF5B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1.L2LEAF5B.yml
@@ -58,11 +58,11 @@ management_api_http:
   enable_https: true
   default_services: false
 vlans:
-- tenant: system
+- id: 4091
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4091
 - id: 130
   name: Tenant_A_APP_Zone_1
   tenant: Tenant_A
@@ -114,7 +114,8 @@ port_channel_interfaces:
   vlans: 110-112,120-121,130-131,160-161
   mlag: 1
 ethernet_interfaces:
-- peer: DC1.L2LEAF5A
+- name: Ethernet3
+  peer: DC1.L2LEAF5A
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_DC1.L2LEAF5A_Ethernet3
@@ -123,8 +124,8 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet3
-- peer: DC1.L2LEAF5A
+- name: Ethernet4
+  peer: DC1.L2LEAF5A
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_DC1.L2LEAF5A_Ethernet4
@@ -133,7 +134,6 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet4
 - name: Ethernet1
   peer: DC1-LEAF2A
   peer_interface: Ethernet15/1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1_UNDEPLOYED_LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1_UNDEPLOYED_LEAF1A.yml
@@ -437,16 +437,16 @@ management_api_http:
   enable_https: true
   default_services: false
 vlans:
-- tenant: system
+- id: 4090
+  tenant: system
   name: LEAF_PEER_L3
   trunk_groups:
   - LEAF_PEER_L3
-  id: 4090
-- tenant: system
+- id: 4092
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4092
 - id: 130
   name: Tenant_A_APP_Zone_1
   tenant: Tenant_A
@@ -793,7 +793,8 @@ port_channel_interfaces:
   - LEAF_PEER_L3
   - MLAG
 ethernet_interfaces:
-- peer: DC1_UNDEPLOYED_LEAF1B
+- name: Ethernet57/1
+  peer: DC1_UNDEPLOYED_LEAF1B
   peer_interface: Ethernet57/1
   peer_type: mlag_peer
   description: MLAG_PEER_DC1_UNDEPLOYED_LEAF1B_Ethernet57/1
@@ -803,8 +804,8 @@ ethernet_interfaces:
     id: 571
     mode: active
   speed: 100g
-  name: Ethernet57/1
-- peer: DC1_UNDEPLOYED_LEAF1B
+- name: Ethernet58/1
+  peer: DC1_UNDEPLOYED_LEAF1B
   peer_interface: Ethernet58/1
   peer_type: mlag_peer
   description: MLAG_PEER_DC1_UNDEPLOYED_LEAF1B_Ethernet58/1
@@ -814,7 +815,6 @@ ethernet_interfaces:
     id: 571
     mode: active
   speed: 100g
-  name: Ethernet58/1
 - name: Ethernet49/1
   peer: DC1-SPINE1
   peer_interface: Ethernet28

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1_UNDEPLOYED_LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1_UNDEPLOYED_LEAF1B.yml
@@ -437,16 +437,16 @@ management_api_http:
   enable_https: true
   default_services: false
 vlans:
-- tenant: system
+- id: 4090
+  tenant: system
   name: LEAF_PEER_L3
   trunk_groups:
   - LEAF_PEER_L3
-  id: 4090
-- tenant: system
+- id: 4092
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4092
 - id: 130
   name: Tenant_A_APP_Zone_1
   tenant: Tenant_A
@@ -793,7 +793,8 @@ port_channel_interfaces:
   - LEAF_PEER_L3
   - MLAG
 ethernet_interfaces:
-- peer: DC1_UNDEPLOYED_LEAF1A
+- name: Ethernet57/1
+  peer: DC1_UNDEPLOYED_LEAF1A
   peer_interface: Ethernet57/1
   peer_type: mlag_peer
   description: MLAG_PEER_DC1_UNDEPLOYED_LEAF1A_Ethernet57/1
@@ -803,8 +804,8 @@ ethernet_interfaces:
     id: 571
     mode: active
   speed: 100g
-  name: Ethernet57/1
-- peer: DC1_UNDEPLOYED_LEAF1A
+- name: Ethernet58/1
+  peer: DC1_UNDEPLOYED_LEAF1A
   peer_interface: Ethernet58/1
   peer_type: mlag_peer
   description: MLAG_PEER_DC1_UNDEPLOYED_LEAF1A_Ethernet58/1
@@ -814,7 +815,6 @@ ethernet_interfaces:
     id: 571
     mode: active
   speed: 100g
-  name: Ethernet58/1
 - name: Ethernet49/1
   peer: DC1-SPINE1
   peer_interface: Ethernet29

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF1A.yml
@@ -619,16 +619,16 @@ management_api_http:
 spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 vlans:
-- tenant: system
+- id: 4093
+  tenant: system
   name: LEAF_PEER_L3
   trunk_groups:
   - LEAF_PEER_L3
-  id: 4093
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 310
   name: MULTICAST_DISABLED_310
   tenant: Tenant_A
@@ -1194,7 +1194,8 @@ port_channel_interfaces:
   vlans: 1-9,110-111,130-131,140-141,150,210-211,230-231,240-241,250,256-257,260,310-311,330-331,550,4092
   mlag: 6
 ethernet_interfaces:
-- peer: EVPN-MULTICAST-L3LEAF1B
+- name: Ethernet3
+  peer: EVPN-MULTICAST-L3LEAF1B
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_EVPN-MULTICAST-L3LEAF1B_Ethernet3
@@ -1203,8 +1204,8 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet3
-- peer: EVPN-MULTICAST-L3LEAF1B
+- name: Ethernet4
+  peer: EVPN-MULTICAST-L3LEAF1B
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_EVPN-MULTICAST-L3LEAF1B_Ethernet4
@@ -1213,7 +1214,6 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet4
 - name: Ethernet1
   peer: EVPN-MULTICAST-SPINE1
   peer_interface: Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF1B.yml
@@ -619,16 +619,16 @@ management_api_http:
 spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 vlans:
-- tenant: system
+- id: 4093
+  tenant: system
   name: LEAF_PEER_L3
   trunk_groups:
   - LEAF_PEER_L3
-  id: 4093
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 310
   name: MULTICAST_DISABLED_310
   tenant: Tenant_A
@@ -1194,7 +1194,8 @@ port_channel_interfaces:
   vlans: 1-9,110-111,130-131,140-141,150,210-211,230-231,240-241,250,256-257,260,310-311,330-331,550,4092
   mlag: 6
 ethernet_interfaces:
-- peer: EVPN-MULTICAST-L3LEAF1A
+- name: Ethernet3
+  peer: EVPN-MULTICAST-L3LEAF1A
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_EVPN-MULTICAST-L3LEAF1A_Ethernet3
@@ -1203,8 +1204,8 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet3
-- peer: EVPN-MULTICAST-L3LEAF1A
+- name: Ethernet4
+  peer: EVPN-MULTICAST-L3LEAF1A
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_EVPN-MULTICAST-L3LEAF1A_Ethernet4
@@ -1213,7 +1214,6 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet4
 - name: Ethernet1
   peer: EVPN-MULTICAST-SPINE1
   peer_interface: Ethernet2

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG-OSPF-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG-OSPF-L3LEAF1A.yml
@@ -87,11 +87,11 @@ management_api_http:
 spanning_tree:
   no_spanning_tree_vlan: '4094'
 vlans:
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 vlan_interfaces:
 - name: Vlan4094
   description: MLAG_PEER
@@ -112,7 +112,8 @@ port_channel_interfaces:
   - LEAF_PEER_L3
   - MLAG
 ethernet_interfaces:
-- peer: MLAG-OSPF-L3LEAF1B
+- name: Ethernet5
+  peer: MLAG-OSPF-L3LEAF1B
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_MLAG-OSPF-L3LEAF1B_Ethernet5
@@ -121,8 +122,8 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
-  name: Ethernet5
-- peer: MLAG-OSPF-L3LEAF1B
+- name: Ethernet6
+  peer: MLAG-OSPF-L3LEAF1B
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_MLAG-OSPF-L3LEAF1B_Ethernet6
@@ -131,7 +132,6 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
-  name: Ethernet6
 - name: Ethernet1
   peer: DC1-SPINE1
   peer_interface: Ethernet18

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG-OSPF-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG-OSPF-L3LEAF1B.yml
@@ -87,11 +87,11 @@ management_api_http:
 spanning_tree:
   no_spanning_tree_vlan: '4094'
 vlans:
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 vlan_interfaces:
 - name: Vlan4094
   description: MLAG_PEER
@@ -112,7 +112,8 @@ port_channel_interfaces:
   - LEAF_PEER_L3
   - MLAG
 ethernet_interfaces:
-- peer: MLAG-OSPF-L3LEAF1A
+- name: Ethernet5
+  peer: MLAG-OSPF-L3LEAF1A
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_MLAG-OSPF-L3LEAF1A_Ethernet5
@@ -121,8 +122,8 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
-  name: Ethernet5
-- peer: MLAG-OSPF-L3LEAF1A
+- name: Ethernet6
+  peer: MLAG-OSPF-L3LEAF1A
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_MLAG-OSPF-L3LEAF1A_Ethernet6
@@ -131,7 +132,6 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
-  name: Ethernet6
 - name: Ethernet1
   peer: DC1-SPINE1
   peer_interface: Ethernet220

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3A.yml
@@ -49,16 +49,16 @@ management_api_http:
 spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 vlans:
-- tenant: system
+- id: 4093
+  tenant: system
   name: LEAF_PEER_L3
   trunk_groups:
   - LEAF_PEER_L3
-  id: 4093
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 3900
   name: SVI_ON_ALL_LEAFS
   tenant: TEST
@@ -124,7 +124,8 @@ port_channel_interfaces:
   - LEAF_PEER_L3
   - MLAG
 ethernet_interfaces:
-- peer: OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3B
+- name: Eth1
+  peer: OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3B
   peer_interface: Eth1
   peer_type: mlag_peer
   description: MLAG_PEER_OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3B_Eth1
@@ -133,8 +134,8 @@ ethernet_interfaces:
   channel_group:
     id: 1
     mode: active
-  name: Eth1
-- peer: OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3B
+- name: Eth2
+  peer: OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3B
   peer_interface: Eth2
   peer_type: mlag_peer
   description: MLAG_PEER_OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3B_Eth2
@@ -143,7 +144,6 @@ ethernet_interfaces:
   channel_group:
     id: 1
     mode: active
-  name: Eth2
 mlag_configuration:
   domain_id: OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3
   local_interface: Vlan4094

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3B.yml
@@ -49,16 +49,16 @@ management_api_http:
 spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 vlans:
-- tenant: system
+- id: 4093
+  tenant: system
   name: LEAF_PEER_L3
   trunk_groups:
   - LEAF_PEER_L3
-  id: 4093
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 3900
   name: SVI_ON_ALL_LEAFS
   tenant: TEST
@@ -124,7 +124,8 @@ port_channel_interfaces:
   - LEAF_PEER_L3
   - MLAG
 ethernet_interfaces:
-- peer: OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3A
+- name: Eth1
+  peer: OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3A
   peer_interface: Eth1
   peer_type: mlag_peer
   description: MLAG_PEER_OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3A_Eth1
@@ -133,8 +134,8 @@ ethernet_interfaces:
   channel_group:
     id: 1
     mode: active
-  name: Eth1
-- peer: OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3A
+- name: Eth2
+  peer: OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3A
   peer_interface: Eth2
   peer_type: mlag_peer
   description: MLAG_PEER_OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3A_Eth2
@@ -143,7 +144,6 @@ ethernet_interfaces:
   channel_group:
     id: 1
     mode: active
-  name: Eth2
 mlag_configuration:
   domain_id: OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3
   local_interface: Vlan4094

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF1A.yml
@@ -90,16 +90,16 @@ management_api_http:
 spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 vlans:
-- tenant: system
+- id: 4093
+  tenant: system
   name: LEAF_PEER_L3
   trunk_groups:
   - LEAF_PEER_L3
-  id: 4093
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 vlan_interfaces:
 - name: Vlan4093
   description: MLAG_PEER_L3_PEERING
@@ -133,7 +133,8 @@ port_channel_interfaces:
   vlans: none
   mlag: 6
 ethernet_interfaces:
-- peer: UNDERLAY-MULTICAST-L3LEAF1B
+- name: Ethernet3
+  peer: UNDERLAY-MULTICAST-L3LEAF1B
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_UNDERLAY-MULTICAST-L3LEAF1B_Ethernet3
@@ -142,8 +143,8 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet3
-- peer: UNDERLAY-MULTICAST-L3LEAF1B
+- name: Ethernet4
+  peer: UNDERLAY-MULTICAST-L3LEAF1B
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_UNDERLAY-MULTICAST-L3LEAF1B_Ethernet4
@@ -152,7 +153,6 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet4
 - name: Ethernet1
   peer: UNDERLAY-MULTICAST-SPINE1
   peer_interface: Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF1B.yml
@@ -90,16 +90,16 @@ management_api_http:
 spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 vlans:
-- tenant: system
+- id: 4093
+  tenant: system
   name: LEAF_PEER_L3
   trunk_groups:
   - LEAF_PEER_L3
-  id: 4093
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 vlan_interfaces:
 - name: Vlan4093
   description: MLAG_PEER_L3_PEERING
@@ -126,7 +126,8 @@ port_channel_interfaces:
   - LEAF_PEER_L3
   - MLAG
 ethernet_interfaces:
-- peer: UNDERLAY-MULTICAST-L3LEAF1A
+- name: Ethernet3
+  peer: UNDERLAY-MULTICAST-L3LEAF1A
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_UNDERLAY-MULTICAST-L3LEAF1A_Ethernet3
@@ -135,8 +136,8 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet3
-- peer: UNDERLAY-MULTICAST-L3LEAF1A
+- name: Ethernet4
+  peer: UNDERLAY-MULTICAST-L3LEAF1A
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_UNDERLAY-MULTICAST-L3LEAF1A_Ethernet4
@@ -145,7 +146,6 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet4
 - name: Ethernet1
   peer: UNDERLAY-MULTICAST-SPINE1
   peer_interface: Ethernet2

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF2A.yml
@@ -90,11 +90,11 @@ management_api_http:
 spanning_tree:
   no_spanning_tree_vlan: '4094'
 vlans:
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 vlan_interfaces:
 - name: Vlan4094
   description: MLAG_PEER
@@ -116,7 +116,8 @@ port_channel_interfaces:
   - LEAF_PEER_L3
   - MLAG
 ethernet_interfaces:
-- peer: UNDERLAY-MULTICAST-L3LEAF2B
+- name: Ethernet3
+  peer: UNDERLAY-MULTICAST-L3LEAF2B
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_UNDERLAY-MULTICAST-L3LEAF2B_Ethernet3
@@ -125,8 +126,8 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet3
-- peer: UNDERLAY-MULTICAST-L3LEAF2B
+- name: Ethernet4
+  peer: UNDERLAY-MULTICAST-L3LEAF2B
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_UNDERLAY-MULTICAST-L3LEAF2B_Ethernet4
@@ -135,7 +136,6 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet4
 - name: Ethernet1
   peer: UNDERLAY-MULTICAST-SPINE1
   peer_interface: Ethernet3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF2B.yml
@@ -90,11 +90,11 @@ management_api_http:
 spanning_tree:
   no_spanning_tree_vlan: '4094'
 vlans:
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 vlan_interfaces:
 - name: Vlan4094
   description: MLAG_PEER
@@ -116,7 +116,8 @@ port_channel_interfaces:
   - LEAF_PEER_L3
   - MLAG
 ethernet_interfaces:
-- peer: UNDERLAY-MULTICAST-L3LEAF2A
+- name: Ethernet3
+  peer: UNDERLAY-MULTICAST-L3LEAF2A
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_UNDERLAY-MULTICAST-L3LEAF2A_Ethernet3
@@ -125,8 +126,8 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet3
-- peer: UNDERLAY-MULTICAST-L3LEAF2A
+- name: Ethernet4
+  peer: UNDERLAY-MULTICAST-L3LEAF2A
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_UNDERLAY-MULTICAST-L3LEAF2A_Ethernet4
@@ -135,7 +136,6 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet4
 - name: Ethernet1
   peer: UNDERLAY-MULTICAST-SPINE1
   peer_interface: Ethernet4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1A.yml
@@ -30,11 +30,11 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 vlan_interfaces:
 - name: Vlan4094
   description: MLAG_PEER
@@ -71,7 +71,8 @@ port_channel_interfaces:
       level: '25'
   native_vlan_tag: true
 ethernet_interfaces:
-- peer: UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1B
+- name: Ethernet3
+  peer: UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1B
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1B_Ethernet3
@@ -80,8 +81,8 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet3
-- peer: UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1B
+- name: Ethernet4
+  peer: UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1B
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1B_Ethernet4
@@ -90,7 +91,6 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet4
 - name: Ethernet1
   peer: UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1A
   peer_interface: Ethernet5

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1B.yml
@@ -30,11 +30,11 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 vlan_interfaces:
 - name: Vlan4094
   description: MLAG_PEER
@@ -71,7 +71,8 @@ port_channel_interfaces:
       level: '25'
   native_vlan_tag: true
 ethernet_interfaces:
-- peer: UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1A
+- name: Ethernet3
+  peer: UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1A
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1A_Ethernet3
@@ -80,8 +81,8 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet3
-- peer: UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1A
+- name: Ethernet4
+  peer: UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1A
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1A_Ethernet4
@@ -90,7 +91,6 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet4
 - name: Ethernet1
   peer: UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1A
   peer_interface: Ethernet6

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1A.yml
@@ -83,16 +83,16 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4093
+  tenant: system
   name: LEAF_PEER_L3
   trunk_groups:
   - LEAF_PEER_L3
-  id: 4093
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 vlan_interfaces:
 - name: Vlan4093
   description: MLAG_PEER_L3_PEERING
@@ -132,7 +132,8 @@ port_channel_interfaces:
       level: '25'
   native_vlan_tag: true
 ethernet_interfaces:
-- peer: UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1B
+- name: Ethernet3
+  peer: UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1B
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1B_Ethernet3
@@ -141,8 +142,8 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet3
-- peer: UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1B
+- name: Ethernet4
+  peer: UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1B
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1B_Ethernet4
@@ -151,7 +152,6 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet4
 - name: Ethernet1
   peer: UPLINK-MLAG-STRUCTURED-CONFIG-SPINE1
   peer_interface: Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1B.yml
@@ -83,16 +83,16 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4093
+  tenant: system
   name: LEAF_PEER_L3
   trunk_groups:
   - LEAF_PEER_L3
-  id: 4093
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 vlan_interfaces:
 - name: Vlan4093
   description: MLAG_PEER_L3_PEERING
@@ -132,7 +132,8 @@ port_channel_interfaces:
       level: '25'
   native_vlan_tag: true
 ethernet_interfaces:
-- peer: UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1A
+- name: Ethernet3
+  peer: UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1A
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1A_Ethernet3
@@ -141,8 +142,8 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet3
-- peer: UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1A
+- name: Ethernet4
+  peer: UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1A
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1A_Ethernet4
@@ -151,7 +152,6 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet4
 - name: Ethernet1
   peer: UPLINK-MLAG-STRUCTURED-CONFIG-SPINE1
   peer_interface: Ethernet2

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-structured-config-1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-structured-config-1.yml
@@ -71,11 +71,11 @@ management_api_http:
 spanning_tree:
   no_spanning_tree_vlan: '4094'
 vlans:
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 vlan_interfaces:
 - name: Vlan4094
   description: MLAG_PEER
@@ -94,7 +94,8 @@ port_channel_interfaces:
   - LEAF_PEER_L3
   - MLAG
 ethernet_interfaces:
-- peer: bgp-peer-groups-structured-config-2
+- name: Ethernet3
+  peer: bgp-peer-groups-structured-config-2
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_bgp-peer-groups-structured-config-2_Ethernet3
@@ -103,7 +104,6 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet3
 mlag_configuration:
   domain_id: mlag
   local_interface: Vlan4094

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-structured-config-2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-structured-config-2.yml
@@ -88,11 +88,11 @@ management_api_http:
 spanning_tree:
   no_spanning_tree_vlan: '4094'
 vlans:
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 vlan_interfaces:
 - name: Vlan4094
   description: MLAG_PEER
@@ -111,7 +111,8 @@ port_channel_interfaces:
   - LEAF_PEER_L3
   - MLAG
 ethernet_interfaces:
-- peer: bgp-peer-groups-structured-config-1
+- name: Ethernet3
+  peer: bgp-peer-groups-structured-config-1
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_bgp-peer-groups-structured-config-1_Ethernet3
@@ -120,7 +121,6 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet3
 mlag_configuration:
   domain_id: mlag
   local_interface: Vlan4094

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/network-ports-tests-2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/network-ports-tests-2.yml
@@ -18,11 +18,11 @@ management_api_http:
 spanning_tree:
   no_spanning_tree_vlan: '4094'
 vlans:
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 100
   name: VLAN100_ON_L2LEAF_1_AND_2
   tenant: TEST
@@ -66,7 +66,8 @@ port_channel_interfaces:
   shutdown: false
   mlag: 42
 ethernet_interfaces:
-- peer: network-ports-tests.1
+- name: Ethernet10/1
+  peer: network-ports-tests.1
   peer_interface: Ethernet10/1
   peer_type: mlag_peer
   description: MLAG_PEER_network-ports-tests.1_Ethernet10/1
@@ -75,7 +76,6 @@ ethernet_interfaces:
   channel_group:
     id: 101
     mode: active
-  name: Ethernet10/1
 - name: Ethernet1
   peer: AP1 with port_channel
   peer_type: network_port

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/network-ports-tests.1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/network-ports-tests.1.yml
@@ -18,11 +18,11 @@ management_api_http:
 spanning_tree:
   no_spanning_tree_vlan: '4094'
 vlans:
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 100
   name: VLAN100_ON_L2LEAF_1_AND_2
   tenant: TEST
@@ -46,7 +46,8 @@ port_channel_interfaces:
   trunk_groups:
   - MLAG
 ethernet_interfaces:
-- peer: network-ports-tests-2
+- name: Ethernet10/1
+  peer: network-ports-tests-2
   peer_interface: Ethernet10/1
   peer_type: mlag_peer
   description: MLAG_PEER_network-ports-tests-2_Ethernet10/1
@@ -55,7 +56,6 @@ ethernet_interfaces:
   channel_group:
     id: 101
     mode: active
-  name: Ethernet10/1
 - name: Ethernet1
   peer: PCs
   peer_type: network_port

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l2leaf1a.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l2leaf1a.yml
@@ -18,11 +18,11 @@ management_api_http:
 spanning_tree:
   no_spanning_tree_vlan: '4094'
 vlans:
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 100
   name: svi100_with_trunk_groups
   tenant: TRUNK_GROUP_TESTS
@@ -117,7 +117,8 @@ port_channel_interfaces:
   - TG_300
   mlag: 13
 ethernet_interfaces:
-- peer: trunk-group-tests-l2leaf1b
+- name: Ethernet3
+  peer: trunk-group-tests-l2leaf1b
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_trunk-group-tests-l2leaf1b_Ethernet3
@@ -126,8 +127,8 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet3
-- peer: trunk-group-tests-l2leaf1b
+- name: Ethernet4
+  peer: trunk-group-tests-l2leaf1b
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_trunk-group-tests-l2leaf1b_Ethernet4
@@ -136,7 +137,6 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet4
 - name: Ethernet1
   peer: trunk-group-tests-l3leaf1a
   peer_interface: Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l2leaf1b.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l2leaf1b.yml
@@ -18,11 +18,11 @@ management_api_http:
 spanning_tree:
   no_spanning_tree_vlan: '4094'
 vlans:
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - CUSTOM_MLAG_TG_NAME
-  id: 4094
 - id: 100
   name: svi100_with_trunk_groups
   tenant: TRUNK_GROUP_TESTS
@@ -109,7 +109,8 @@ port_channel_interfaces:
   - TG_300
   mlag: 13
 ethernet_interfaces:
-- peer: trunk-group-tests-l2leaf1a
+- name: Ethernet3
+  peer: trunk-group-tests-l2leaf1a
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_trunk-group-tests-l2leaf1a_Ethernet3
@@ -118,8 +119,8 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet3
-- peer: trunk-group-tests-l2leaf1a
+- name: Ethernet4
+  peer: trunk-group-tests-l2leaf1a
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_trunk-group-tests-l2leaf1a_Ethernet4
@@ -128,7 +129,6 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet4
 - name: Ethernet1
   peer: trunk-group-tests-l3leaf1a
   peer_interface: Ethernet2

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf1a.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf1a.yml
@@ -205,76 +205,76 @@ management_api_http:
 spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 vlans:
-- tenant: system
+- id: 4093
+  tenant: system
   name: LEAF_PEER_L3
   trunk_groups:
   - LEAF_PEER_L3
-  id: 4093
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
-- trunk_groups:
+- id: 100
+  trunk_groups:
   - TRUNK_GROUP_TESTS_L2LEAF1
   - TG_100
   - TG_NOT_MATCHING_ANY_SERVERS
   - MLAG
-  id: 100
   name: svi100_with_trunk_groups
   tenant: TRUNK_GROUP_TESTS
-- trunk_groups:
+- id: 110
+  trunk_groups:
   - TRUNK_GROUP_TESTS_L2LEAF1
   - TG_100
   - TG_NOT_MATCHING_ANY_SERVERS
   - MLAG
-  id: 110
   name: l2vlan110_with_trunk_groups
   tenant: TRUNK_GROUP_TESTS
-- trunk_groups:
+- id: 200
+  trunk_groups:
   - trunk-group-tests-l2leaf3
   - TRUNK_GROUP_TESTS_L2LEAF1
   - TG_200
   - TG_NOT_MATCHING_ANY_SERVERS
   - MLAG
-  id: 200
   name: svi200_with_trunk_groups
   tenant: TRUNK_GROUP_TESTS
-- trunk_groups:
+- id: 210
+  trunk_groups:
   - trunk-group-tests-l2leaf3
   - TRUNK_GROUP_TESTS_L2LEAF1
   - TG_200
   - TG_NOT_MATCHING_ANY_SERVERS
   - MLAG
-  id: 210
   name: l2vlan210_with_trunk_groups
   tenant: TRUNK_GROUP_TESTS
-- trunk_groups:
+- id: 300
+  trunk_groups:
   - TRUNK_GROUP_TESTS_L2LEAF1
   - TG_300
   - TG_NOT_MATCHING_ANY_SERVERS
   - MLAG
-  id: 300
   name: svi300_with_trunk_groups
   tenant: TRUNK_GROUP_TESTS
-- trunk_groups:
+- id: 310
+  trunk_groups:
   - TRUNK_GROUP_TESTS_L2LEAF1
   - TG_300
   - TG_NOT_MATCHING_ANY_SERVERS
   - MLAG
-  id: 310
   name: l2vlan310_with_trunk_groups
   tenant: TRUNK_GROUP_TESTS
-- trunk_groups:
+- id: 398
+  trunk_groups:
   - TRUNK_GROUP_TESTS_L2LEAF1
   - MLAG
-  id: 398
   name: svi398_without_trunk_groups
   tenant: TRUNK_GROUP_TESTS
-- trunk_groups:
+- id: 399
+  trunk_groups:
   - TRUNK_GROUP_TESTS_L2LEAF1
   - MLAG
-  id: 399
   name: l2vlan399_without_trunk_groups
   tenant: TRUNK_GROUP_TESTS
 - id: 3099
@@ -422,7 +422,8 @@ port_channel_interfaces:
   - TG_300
   mlag: 13
 ethernet_interfaces:
-- peer: trunk-group-tests-l3leaf1b
+- name: Ethernet3
+  peer: trunk-group-tests-l3leaf1b
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_trunk-group-tests-l3leaf1b_Ethernet3
@@ -431,8 +432,8 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet3
-- peer: trunk-group-tests-l3leaf1b
+- name: Ethernet4
+  peer: trunk-group-tests-l3leaf1b
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_trunk-group-tests-l3leaf1b_Ethernet4
@@ -441,7 +442,6 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet4
 - name: Ethernet1
   peer: trunk-group-tests-l2leaf1a
   peer_interface: Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf1b.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf1b.yml
@@ -205,66 +205,66 @@ management_api_http:
 spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 vlans:
-- tenant: system
+- id: 4093
+  tenant: system
   name: LEAF_PEER_L3
   trunk_groups:
   - CUSTOM_LEAF_PEER_L3_TG_NAME
-  id: 4093
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - CUSTOM_MLAG_TG_NAME
-  id: 4094
-- trunk_groups:
+- id: 100
+  trunk_groups:
   - TRUNK_GROUP_TESTS_L2LEAF1
   - CUSTOM_MLAG_TG_NAME
-  id: 100
   name: svi100_with_trunk_groups
   tenant: TRUNK_GROUP_TESTS
-- trunk_groups:
+- id: 110
+  trunk_groups:
   - TRUNK_GROUP_TESTS_L2LEAF1
   - CUSTOM_MLAG_TG_NAME
-  id: 110
   name: l2vlan110_with_trunk_groups
   tenant: TRUNK_GROUP_TESTS
-- trunk_groups:
+- id: 200
+  trunk_groups:
   - trunk-group-tests-l2leaf3
   - TRUNK_GROUP_TESTS_L2LEAF1
   - CUSTOM_MLAG_TG_NAME
-  id: 200
   name: svi200_with_trunk_groups
   tenant: TRUNK_GROUP_TESTS
-- trunk_groups:
+- id: 210
+  trunk_groups:
   - trunk-group-tests-l2leaf3
   - TRUNK_GROUP_TESTS_L2LEAF1
   - CUSTOM_MLAG_TG_NAME
-  id: 210
   name: l2vlan210_with_trunk_groups
   tenant: TRUNK_GROUP_TESTS
-- trunk_groups:
+- id: 300
+  trunk_groups:
   - TRUNK_GROUP_TESTS_L2LEAF1
   - TG_300
   - CUSTOM_MLAG_TG_NAME
-  id: 300
   name: svi300_with_trunk_groups
   tenant: TRUNK_GROUP_TESTS
-- trunk_groups:
+- id: 310
+  trunk_groups:
   - TRUNK_GROUP_TESTS_L2LEAF1
   - TG_300
   - CUSTOM_MLAG_TG_NAME
-  id: 310
   name: l2vlan310_with_trunk_groups
   tenant: TRUNK_GROUP_TESTS
-- trunk_groups:
+- id: 398
+  trunk_groups:
   - TRUNK_GROUP_TESTS_L2LEAF1
   - CUSTOM_MLAG_TG_NAME
-  id: 398
   name: svi398_without_trunk_groups
   tenant: TRUNK_GROUP_TESTS
-- trunk_groups:
+- id: 399
+  trunk_groups:
   - TRUNK_GROUP_TESTS_L2LEAF1
   - CUSTOM_MLAG_TG_NAME
-  id: 399
   name: l2vlan399_without_trunk_groups
   tenant: TRUNK_GROUP_TESTS
 - id: 3099
@@ -410,7 +410,8 @@ port_channel_interfaces:
   - TG_300
   mlag: 13
 ethernet_interfaces:
-- peer: trunk-group-tests-l3leaf1a
+- name: Ethernet3
+  peer: trunk-group-tests-l3leaf1a
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_trunk-group-tests-l3leaf1a_Ethernet3
@@ -419,8 +420,8 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet3
-- peer: trunk-group-tests-l3leaf1a
+- name: Ethernet4
+  peer: trunk-group-tests-l3leaf1a
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_trunk-group-tests-l3leaf1a_Ethernet4
@@ -429,7 +430,6 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet4
 - name: Ethernet1
   peer: trunk-group-tests-l2leaf1a
   peer_interface: Ethernet2

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf2a.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf2a.yml
@@ -101,30 +101,30 @@ management_api_http:
 spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 vlans:
-- tenant: system
+- id: 4093
+  tenant: system
   name: LEAF_PEER_L3
   trunk_groups:
   - LEAF_PEER_L3
-  id: 4093
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
-- trunk_groups:
+- id: 200
+  trunk_groups:
   - trunk-group-tests-l2leaf4
   - TG_200
   - TG_NOT_MATCHING_ANY_SERVERS
   - MLAG
-  id: 200
   name: svi200_with_trunk_groups
   tenant: TRUNK_GROUP_TESTS
-- trunk_groups:
+- id: 210
+  trunk_groups:
   - trunk-group-tests-l2leaf4
   - TG_200
   - TG_NOT_MATCHING_ANY_SERVERS
   - MLAG
-  id: 210
   name: l2vlan210_with_trunk_groups
   tenant: TRUNK_GROUP_TESTS
 - id: 3199
@@ -180,7 +180,8 @@ port_channel_interfaces:
   - trunk-group-tests-l2leaf4
   mlag: 1
 ethernet_interfaces:
-- peer: trunk-group-tests-l3leaf2b
+- name: Ethernet3
+  peer: trunk-group-tests-l3leaf2b
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_trunk-group-tests-l3leaf2b_Ethernet3
@@ -189,8 +190,8 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet3
-- peer: trunk-group-tests-l3leaf2b
+- name: Ethernet4
+  peer: trunk-group-tests-l3leaf2b
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_trunk-group-tests-l3leaf2b_Ethernet4
@@ -199,7 +200,6 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet4
 - name: Ethernet1
   peer: trunk-group-tests-l2leaf4
   peer_interface: Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf2b.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf2b.yml
@@ -101,26 +101,26 @@ management_api_http:
 spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 vlans:
-- tenant: system
+- id: 4093
+  tenant: system
   name: LEAF_PEER_L3
   trunk_groups:
   - CUSTOM_MLAG_TG_NAME
-  id: 4093
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - CUSTOM_MLAG_TG_NAME
-  id: 4094
-- trunk_groups:
+- id: 200
+  trunk_groups:
   - trunk-group-tests-l2leaf4
   - CUSTOM_MLAG_TG_NAME
-  id: 200
   name: svi200_with_trunk_groups
   tenant: TRUNK_GROUP_TESTS
-- trunk_groups:
+- id: 210
+  trunk_groups:
   - trunk-group-tests-l2leaf4
   - CUSTOM_MLAG_TG_NAME
-  id: 210
   name: l2vlan210_with_trunk_groups
   tenant: TRUNK_GROUP_TESTS
 - id: 3199
@@ -175,7 +175,8 @@ port_channel_interfaces:
   - trunk-group-tests-l2leaf4
   mlag: 1
 ethernet_interfaces:
-- peer: trunk-group-tests-l3leaf2a
+- name: Ethernet3
+  peer: trunk-group-tests-l3leaf2a
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_trunk-group-tests-l3leaf2a_Ethernet3
@@ -184,8 +185,8 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet3
-- peer: trunk-group-tests-l3leaf2a
+- name: Ethernet4
+  peer: trunk-group-tests-l3leaf2a
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_trunk-group-tests-l3leaf2a_Ethernet4
@@ -194,7 +195,6 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet4
 - name: Ethernet1
   peer: trunk-group-tests-l2leaf4
   peer_interface: Ethernet2

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink-native-vlan-child.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink-native-vlan-child.yml
@@ -12,9 +12,9 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- name: NATIVE
+- id: 200
+  name: NATIVE
   state: suspend
-  id: 200
 - id: 100
   name: NETWORK_SERVICES_VLAN
   tenant: test

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink-native-vlan-parent.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink-native-vlan-parent.yml
@@ -12,9 +12,9 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- name: NATIVE
+- id: 200
+  name: NATIVE
   state: suspend
-  id: 200
 - id: 100
   name: NETWORK_SERVICES_VLAN
   tenant: test

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
@@ -413,7 +413,8 @@ ethernet_interfaces:
   type: routed
   peer_type: l3_interface
   shutdown: false
-- description: My test
+- name: Ethernet4000
+  description: My test
   ip_address: 10.3.2.1/21
   shutdown: false
   type: routed
@@ -421,7 +422,6 @@ ethernet_interfaces:
   peer: MY-own-peer
   peer_interface: Ethernet123
   peer_type: my_precious
-  name: Ethernet4000
 loopback_interfaces:
 - name: Loopback0
   description: CUSTOM_EVPN_Overlay_Peering_L3LEAF

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
@@ -411,7 +411,8 @@ ethernet_interfaces:
   type: routed
   peer_type: l3_interface
   shutdown: false
-- description: My second test
+- name: Ethernet4000
+  description: My second test
   ip_address: 10.1.2.3/12
   shutdown: false
   type: routed
@@ -419,7 +420,6 @@ ethernet_interfaces:
   peer: MY-own-peer
   peer_interface: Ethernet123
   peer_type: my_precious
-  name: Ethernet4000
 loopback_interfaces:
 - name: Loopback0
   description: CUSTOM_EVPN_Overlay_Peering_L3LEAF

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -60,11 +60,11 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4091
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4091
 - id: 130
   name: Tenant_A_APP_Zone_1
   tenant: Tenant_A
@@ -125,7 +125,8 @@ port_channel_interfaces:
   vlans: 110-111,120-124,130-131,160-162
   mlag: 1
 ethernet_interfaces:
-- peer: DC1-L2LEAF1B
+- name: Ethernet3
+  peer: DC1-L2LEAF1B
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF1B_Ethernet3
@@ -134,8 +135,8 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet3
-- peer: DC1-L2LEAF1B
+- name: Ethernet4
+  peer: DC1-L2LEAF1B
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF1B_Ethernet4
@@ -144,7 +145,6 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet4
 - name: Ethernet1
   peer: DC1-LEAF2A
   peer_interface: Ethernet7

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1B.yml
@@ -60,11 +60,11 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4091
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4091
 - id: 130
   name: Tenant_A_APP_Zone_1
   tenant: Tenant_A
@@ -125,7 +125,8 @@ port_channel_interfaces:
   vlans: 110-111,120-124,130-131,160-162
   mlag: 1
 ethernet_interfaces:
-- peer: DC1-L2LEAF1A
+- name: Ethernet3
+  peer: DC1-L2LEAF1A
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF1A_Ethernet3
@@ -134,8 +135,8 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet3
-- peer: DC1-L2LEAF1A
+- name: Ethernet4
+  peer: DC1-L2LEAF1A
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF1A_Ethernet4
@@ -144,7 +145,6 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet4
 - name: Ethernet1
   peer: DC1-LEAF2A
   peer_interface: Ethernet8

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -60,11 +60,11 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4091
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4091
 - id: 130
   name: Tenant_A_APP_Zone_1
   tenant: Tenant_A
@@ -152,7 +152,8 @@ port_channel_interfaces:
   vlans: 110-111,120-124,130-131,140-141,150,160-162,210-211,250,310-311,350
   mlag: 1
 ethernet_interfaces:
-- peer: DC1-L2LEAF2B
+- name: Ethernet3
+  peer: DC1-L2LEAF2B
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2B_Ethernet3
@@ -161,8 +162,8 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet3
-- peer: DC1-L2LEAF2B
+- name: Ethernet4
+  peer: DC1-L2LEAF2B
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2B_Ethernet4
@@ -171,7 +172,6 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet4
 - name: Ethernet1
   peer: DC1-SVC3A
   peer_interface: Ethernet7

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -60,11 +60,11 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4091
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4091
 - id: 130
   name: Tenant_A_APP_Zone_1
   tenant: Tenant_A
@@ -152,7 +152,8 @@ port_channel_interfaces:
   vlans: 110-111,120-124,130-131,140-141,150,160-162,210-211,250,310-311,350
   mlag: 1
 ethernet_interfaces:
-- peer: DC1-L2LEAF2A
+- name: Ethernet3
+  peer: DC1-L2LEAF2A
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2A_Ethernet3
@@ -161,8 +162,8 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet3
-- peer: DC1-L2LEAF2A
+- name: Ethernet4
+  peer: DC1-L2LEAF2A
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2A_Ethernet4
@@ -171,7 +172,6 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet4
 - name: Ethernet1
   peer: DC1-SVC3A
   peer_interface: Ethernet8

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -426,11 +426,11 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4092
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4092
 - id: 130
   name: Tenant_A_APP_Zone_1
   tenant: Tenant_A
@@ -943,7 +943,8 @@ port_channel_interfaces:
   vlans: '110'
   mlag: 22
 ethernet_interfaces:
-- peer: DC1-SVC3B
+- name: Ethernet5
+  peer: DC1-SVC3B
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: CUSTOM_MLAG_PEER_DC1-SVC3B_Ethernet5
@@ -952,8 +953,8 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
-  name: Ethernet5
-- peer: DC1-SVC3B
+- name: Ethernet6
+  peer: DC1-SVC3B
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: CUSTOM_MLAG_PEER_DC1-SVC3B_Ethernet6
@@ -962,7 +963,6 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
-  name: Ethernet6
 - name: Ethernet7
   peer: DC1-L2LEAF2A
   peer_interface: Ethernet1

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -426,11 +426,11 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4092
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4092
 - id: 130
   name: Tenant_A_APP_Zone_1
   tenant: Tenant_A
@@ -943,7 +943,8 @@ port_channel_interfaces:
   vlans: '110'
   mlag: 22
 ethernet_interfaces:
-- peer: DC1-SVC3A
+- name: Ethernet5
+  peer: DC1-SVC3A
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: CUSTOM_MLAG_PEER_DC1-SVC3A_Ethernet5
@@ -952,8 +953,8 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
-  name: Ethernet5
-- peer: DC1-SVC3A
+- name: Ethernet6
+  peer: DC1-SVC3A
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: CUSTOM_MLAG_PEER_DC1-SVC3A_Ethernet6
@@ -962,7 +963,6 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
-  name: Ethernet6
 - name: Ethernet7
   peer: DC1-L2LEAF2A
   peer_interface: Ethernet2

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-BL1A.yml
@@ -88,16 +88,16 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4093
+  tenant: system
   name: LEAF_PEER_L3
   trunk_groups:
   - LEAF_PEER_L3
-  id: 4093
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 vlan_interfaces:
 - name: Vlan4093
   description: MLAG_PEER_L3_PEERING
@@ -124,7 +124,8 @@ port_channel_interfaces:
   - LEAF_PEER_L3
   - MLAG
 ethernet_interfaces:
-- peer: DC1-BL1B
+- name: Ethernet5
+  peer: DC1-BL1B
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-BL1B_Ethernet5
@@ -133,8 +134,8 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
-  name: Ethernet5
-- peer: DC1-BL1B
+- name: Ethernet6
+  peer: DC1-BL1B
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-BL1B_Ethernet6
@@ -143,7 +144,6 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
-  name: Ethernet6
 - name: Ethernet1
   peer: DC1-SPINE1
   peer_interface: Ethernet6

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-BL1B.yml
@@ -88,16 +88,16 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4093
+  tenant: system
   name: LEAF_PEER_L3
   trunk_groups:
   - LEAF_PEER_L3
-  id: 4093
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 vlan_interfaces:
 - name: Vlan4093
   description: MLAG_PEER_L3_PEERING
@@ -124,7 +124,8 @@ port_channel_interfaces:
   - LEAF_PEER_L3
   - MLAG
 ethernet_interfaces:
-- peer: DC1-BL1A
+- name: Ethernet5
+  peer: DC1-BL1A
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-BL1A_Ethernet5
@@ -133,8 +134,8 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
-  name: Ethernet5
-- peer: DC1-BL1A
+- name: Ethernet6
+  peer: DC1-BL1A
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-BL1A_Ethernet6
@@ -143,7 +144,6 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
-  name: Ethernet6
 - name: Ethernet1
   peer: DC1-SPINE1
   peer_interface: Ethernet7

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -54,11 +54,11 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 vlan_interfaces:
 - name: Vlan4094
   description: MLAG_PEER
@@ -83,7 +83,8 @@ port_channel_interfaces:
   vlans: none
   mlag: 1
 ethernet_interfaces:
-- peer: DC1-L2LEAF2B
+- name: Ethernet3
+  peer: DC1-L2LEAF2B
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2B_Ethernet3
@@ -92,8 +93,8 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet3
-- peer: DC1-L2LEAF2B
+- name: Ethernet4
+  peer: DC1-L2LEAF2B
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2B_Ethernet4
@@ -102,7 +103,6 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet4
 - name: Ethernet1
   peer: DC1-SVC3A
   peer_interface: Ethernet7

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -54,11 +54,11 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 vlan_interfaces:
 - name: Vlan4094
   description: MLAG_PEER
@@ -83,7 +83,8 @@ port_channel_interfaces:
   vlans: none
   mlag: 1
 ethernet_interfaces:
-- peer: DC1-L2LEAF2A
+- name: Ethernet3
+  peer: DC1-L2LEAF2A
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2A_Ethernet3
@@ -92,8 +93,8 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet3
-- peer: DC1-L2LEAF2A
+- name: Ethernet4
+  peer: DC1-L2LEAF2A
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2A_Ethernet4
@@ -102,7 +103,6 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet4
 - name: Ethernet1
   peer: DC1-SVC3A
   peer_interface: Ethernet8

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -88,16 +88,16 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4093
+  tenant: system
   name: LEAF_PEER_L3
   trunk_groups:
   - LEAF_PEER_L3
-  id: 4093
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 vlan_interfaces:
 - name: Vlan4093
   description: MLAG_PEER_L3_PEERING
@@ -131,7 +131,8 @@ port_channel_interfaces:
   vlans: none
   mlag: 7
 ethernet_interfaces:
-- peer: DC1-LEAF2B
+- name: Ethernet5
+  peer: DC1-LEAF2B
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF2B_Ethernet5
@@ -140,8 +141,8 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
-  name: Ethernet5
-- peer: DC1-LEAF2B
+- name: Ethernet6
+  peer: DC1-LEAF2B
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF2B_Ethernet6
@@ -150,7 +151,6 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
-  name: Ethernet6
 - name: Ethernet1
   peer: DC1-SPINE1
   peer_interface: Ethernet2

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -88,16 +88,16 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4093
+  tenant: system
   name: LEAF_PEER_L3
   trunk_groups:
   - LEAF_PEER_L3
-  id: 4093
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 vlan_interfaces:
 - name: Vlan4093
   description: MLAG_PEER_L3_PEERING
@@ -131,7 +131,8 @@ port_channel_interfaces:
   vlans: none
   mlag: 7
 ethernet_interfaces:
-- peer: DC1-LEAF2A
+- name: Ethernet5
+  peer: DC1-LEAF2A
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF2A_Ethernet5
@@ -140,8 +141,8 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
-  name: Ethernet5
-- peer: DC1-LEAF2A
+- name: Ethernet6
+  peer: DC1-LEAF2A
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF2A_Ethernet6
@@ -150,7 +151,6 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
-  name: Ethernet6
 - name: Ethernet1
   peer: DC1-SPINE1
   peer_interface: Ethernet3

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SVC3A.yml
@@ -88,11 +88,11 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 vlan_interfaces:
 - name: Vlan4094
   description: MLAG_PEER
@@ -121,7 +121,8 @@ port_channel_interfaces:
   vlans: none
   mlag: 7
 ethernet_interfaces:
-- peer: DC1-SVC3B
+- name: Ethernet5
+  peer: DC1-SVC3B
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-SVC3B_Ethernet5
@@ -130,8 +131,8 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
-  name: Ethernet5
-- peer: DC1-SVC3B
+- name: Ethernet6
+  peer: DC1-SVC3B
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-SVC3B_Ethernet6
@@ -140,7 +141,6 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
-  name: Ethernet6
 - name: Ethernet1
   peer: DC1-SPINE1
   peer_interface: Ethernet4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SVC3B.yml
@@ -88,11 +88,11 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 vlan_interfaces:
 - name: Vlan4094
   description: MLAG_PEER
@@ -121,7 +121,8 @@ port_channel_interfaces:
   vlans: none
   mlag: 7
 ethernet_interfaces:
-- peer: DC1-SVC3A
+- name: Ethernet5
+  peer: DC1-SVC3A
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-SVC3A_Ethernet5
@@ -130,8 +131,8 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
-  name: Ethernet5
-- peer: DC1-SVC3A
+- name: Ethernet6
+  peer: DC1-SVC3A
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-SVC3A_Ethernet6
@@ -140,7 +141,6 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
-  name: Ethernet6
 - name: Ethernet1
   peer: DC1-SPINE1
   peer_interface: Ethernet5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
@@ -100,16 +100,16 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4093
+  tenant: system
   name: LEAF_PEER_L3
   trunk_groups:
   - LEAF_PEER_L3
-  id: 4093
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 vlan_interfaces:
 - name: Vlan4093
   description: MLAG_PEER_L3_PEERING
@@ -135,7 +135,8 @@ port_channel_interfaces:
   - LEAF_PEER_L3
   - MLAG
 ethernet_interfaces:
-- peer: DC1-BL1B
+- name: Ethernet5
+  peer: DC1-BL1B
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-BL1B_Ethernet5
@@ -144,8 +145,8 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
-  name: Ethernet5
-- peer: DC1-BL1B
+- name: Ethernet6
+  peer: DC1-BL1B
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-BL1B_Ethernet6
@@ -154,7 +155,6 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
-  name: Ethernet6
 - name: Ethernet1
   peer: DC1-SPINE1
   peer_interface: Ethernet6

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
@@ -100,16 +100,16 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4093
+  tenant: system
   name: LEAF_PEER_L3
   trunk_groups:
   - LEAF_PEER_L3
-  id: 4093
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 vlan_interfaces:
 - name: Vlan4093
   description: MLAG_PEER_L3_PEERING
@@ -135,7 +135,8 @@ port_channel_interfaces:
   - LEAF_PEER_L3
   - MLAG
 ethernet_interfaces:
-- peer: DC1-BL1A
+- name: Ethernet5
+  peer: DC1-BL1A
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-BL1A_Ethernet5
@@ -144,8 +145,8 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
-  name: Ethernet5
-- peer: DC1-BL1A
+- name: Ethernet6
+  peer: DC1-BL1A
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-BL1A_Ethernet6
@@ -154,7 +155,6 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
-  name: Ethernet6
 - name: Ethernet1
   peer: DC1-SPINE1
   peer_interface: Ethernet7

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -54,11 +54,11 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 210
   name: Tenant_B_OP_Zone_1
   tenant: Tenant_A
@@ -86,7 +86,8 @@ port_channel_interfaces:
   vlans: '210'
   mlag: 1
 ethernet_interfaces:
-- peer: DC1-L2LEAF2B
+- name: Ethernet3
+  peer: DC1-L2LEAF2B
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2B_Ethernet3
@@ -95,8 +96,8 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet3
-- peer: DC1-L2LEAF2B
+- name: Ethernet4
+  peer: DC1-L2LEAF2B
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2B_Ethernet4
@@ -105,7 +106,6 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet4
 - name: Ethernet1
   peer: DC1-SVC3A
   peer_interface: Ethernet7

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -54,11 +54,11 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 210
   name: Tenant_B_OP_Zone_1
   tenant: Tenant_A
@@ -86,7 +86,8 @@ port_channel_interfaces:
   vlans: '210'
   mlag: 1
 ethernet_interfaces:
-- peer: DC1-L2LEAF2A
+- name: Ethernet3
+  peer: DC1-L2LEAF2A
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2A_Ethernet3
@@ -95,8 +96,8 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet3
-- peer: DC1-L2LEAF2A
+- name: Ethernet4
+  peer: DC1-L2LEAF2A
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2A_Ethernet4
@@ -105,7 +106,6 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet4
 - name: Ethernet1
   peer: DC1-SVC3A
   peer_interface: Ethernet8

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -141,16 +141,16 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4093
+  tenant: system
   name: LEAF_PEER_L3
   trunk_groups:
   - LEAF_PEER_L3
-  id: 4093
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 210
   name: Tenant_B_OP_Zone_1
   tenant: Tenant_A
@@ -207,7 +207,8 @@ port_channel_interfaces:
   vlans: '210'
   mlag: 7
 ethernet_interfaces:
-- peer: DC1-LEAF2B
+- name: Ethernet5
+  peer: DC1-LEAF2B
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF2B_Ethernet5
@@ -216,8 +217,8 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
-  name: Ethernet5
-- peer: DC1-LEAF2B
+- name: Ethernet6
+  peer: DC1-LEAF2B
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF2B_Ethernet6
@@ -226,7 +227,6 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
-  name: Ethernet6
 - name: Ethernet1
   peer: DC1-SPINE1
   peer_interface: Ethernet2

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -141,16 +141,16 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4093
+  tenant: system
   name: LEAF_PEER_L3
   trunk_groups:
   - LEAF_PEER_L3
-  id: 4093
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 210
   name: Tenant_B_OP_Zone_1
   tenant: Tenant_A
@@ -207,7 +207,8 @@ port_channel_interfaces:
   vlans: '210'
   mlag: 7
 ethernet_interfaces:
-- peer: DC1-LEAF2A
+- name: Ethernet5
+  peer: DC1-LEAF2A
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF2A_Ethernet5
@@ -216,8 +217,8 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
-  name: Ethernet5
-- peer: DC1-LEAF2A
+- name: Ethernet6
+  peer: DC1-LEAF2A
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF2A_Ethernet6
@@ -226,7 +227,6 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
-  name: Ethernet6
 - name: Ethernet1
   peer: DC1-SPINE1
   peer_interface: Ethernet3

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -141,11 +141,11 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 210
   name: Tenant_B_OP_Zone_1
   tenant: Tenant_A
@@ -197,7 +197,8 @@ port_channel_interfaces:
   vlans: '210'
   mlag: 7
 ethernet_interfaces:
-- peer: DC1-SVC3B
+- name: Ethernet5
+  peer: DC1-SVC3B
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-SVC3B_Ethernet5
@@ -206,8 +207,8 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
-  name: Ethernet5
-- peer: DC1-SVC3B
+- name: Ethernet6
+  peer: DC1-SVC3B
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-SVC3B_Ethernet6
@@ -216,7 +217,6 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
-  name: Ethernet6
 - name: Ethernet1
   peer: DC1-SPINE1
   peer_interface: Ethernet4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -141,11 +141,11 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 210
   name: Tenant_B_OP_Zone_1
   tenant: Tenant_A
@@ -197,7 +197,8 @@ port_channel_interfaces:
   vlans: '210'
   mlag: 7
 ethernet_interfaces:
-- peer: DC1-SVC3A
+- name: Ethernet5
+  peer: DC1-SVC3A
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-SVC3A_Ethernet5
@@ -206,8 +207,8 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
-  name: Ethernet5
-- peer: DC1-SVC3A
+- name: Ethernet6
+  peer: DC1-SVC3A
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-SVC3A_Ethernet6
@@ -216,7 +217,6 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
-  name: Ethernet6
 - name: Ethernet1
   peer: DC1-SPINE1
   peer_interface: Ethernet5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
@@ -308,7 +308,8 @@ ethernet_interfaces:
   shutdown: false
   mtu: 1500
   ipv6_enable: true
-- description: My test
+- name: Ethernet4000
+  description: My test
   ip_address: 10.1.2.3/12
   shutdown: false
   type: routed
@@ -316,7 +317,6 @@ ethernet_interfaces:
   peer: MY-own-peer
   peer_interface: Ethernet123
   peer_type: my_precious
-  name: Ethernet4000
 loopback_interfaces:
 - name: Loopback0
   description: EVPN_Overlay_Peering
@@ -417,9 +417,9 @@ vxlan_interface:
         vni: 31
 router_general:
   vrfs:
-  - leak_routes:
+  - name: Tenant_B_OP_Zone
+    leak_routes:
     - source_vrf: Tenant_A_OP_Zone
       subscribe_policy: RM-CONN-2-BGP
     - source_vrf: Tenant_C_OP_Zone
       subscribe_policy: RM-CONN-2-BGP
-    name: Tenant_B_OP_Zone

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
@@ -308,7 +308,8 @@ ethernet_interfaces:
   shutdown: false
   mtu: 1500
   ipv6_enable: true
-- description: My test
+- name: Ethernet4000
+  description: My test
   ip_address: 10.1.2.3/12
   shutdown: false
   type: routed
@@ -316,7 +317,6 @@ ethernet_interfaces:
   peer: MY-own-peer
   peer_interface: Ethernet123
   peer_type: my_precious
-  name: Ethernet4000
 loopback_interfaces:
 - name: Loopback0
   description: EVPN_Overlay_Peering

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -54,11 +54,11 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 130
   name: Tenant_A_APP_Zone_1
   tenant: Tenant_A
@@ -134,7 +134,8 @@ port_channel_interfaces:
   vlans: 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350
   mlag: 1
 ethernet_interfaces:
-- peer: DC1-L2LEAF2B
+- name: Ethernet3
+  peer: DC1-L2LEAF2B
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2B_Ethernet3
@@ -143,8 +144,8 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet3
-- peer: DC1-L2LEAF2B
+- name: Ethernet4
+  peer: DC1-L2LEAF2B
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2B_Ethernet4
@@ -153,7 +154,6 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet4
 - name: Ethernet1
   peer: DC1-SVC3A
   peer_interface: Ethernet7

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -54,11 +54,11 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 130
   name: Tenant_A_APP_Zone_1
   tenant: Tenant_A
@@ -134,7 +134,8 @@ port_channel_interfaces:
   vlans: 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350
   mlag: 1
 ethernet_interfaces:
-- peer: DC1-L2LEAF2A
+- name: Ethernet3
+  peer: DC1-L2LEAF2A
   peer_interface: Ethernet3
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2A_Ethernet3
@@ -143,8 +144,8 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet3
-- peer: DC1-L2LEAF2A
+- name: Ethernet4
+  peer: DC1-L2LEAF2A
   peer_interface: Ethernet4
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-L2LEAF2A_Ethernet4
@@ -153,7 +154,6 @@ ethernet_interfaces:
   channel_group:
     id: 3
     mode: active
-  name: Ethernet4
 - name: Ethernet1
   peer: DC1-SVC3A
   peer_interface: Ethernet8

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -353,16 +353,16 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4093
+  tenant: system
   name: LEAF_PEER_L3
   trunk_groups:
   - LEAF_PEER_L3
-  id: 4093
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 130
   name: Tenant_A_APP_Zone_1
   tenant: Tenant_A
@@ -642,7 +642,8 @@ port_channel_interfaces:
   mtu: 1601
   mlag: 12
 ethernet_interfaces:
-- peer: DC1-LEAF2B
+- name: Ethernet5
+  peer: DC1-LEAF2B
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF2B_Ethernet5
@@ -651,8 +652,8 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
-  name: Ethernet5
-- peer: DC1-LEAF2B
+- name: Ethernet6
+  peer: DC1-LEAF2B
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF2B_Ethernet6
@@ -661,7 +662,6 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
-  name: Ethernet6
 - name: Ethernet1
   peer: DC1-SPINE1
   peer_interface: Ethernet2

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -353,16 +353,16 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4093
+  tenant: system
   name: LEAF_PEER_L3
   trunk_groups:
   - LEAF_PEER_L3
-  id: 4093
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 130
   name: Tenant_A_APP_Zone_1
   tenant: Tenant_A
@@ -642,7 +642,8 @@ port_channel_interfaces:
   mtu: 1601
   mlag: 12
 ethernet_interfaces:
-- peer: DC1-LEAF2A
+- name: Ethernet5
+  peer: DC1-LEAF2A
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF2A_Ethernet5
@@ -651,8 +652,8 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
-  name: Ethernet5
-- peer: DC1-LEAF2A
+- name: Ethernet6
+  peer: DC1-LEAF2A
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF2A_Ethernet6
@@ -661,7 +662,6 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
-  name: Ethernet6
 - name: Ethernet1
   peer: DC1-SPINE1
   peer_interface: Ethernet3

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF3A.yml
@@ -335,16 +335,16 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4093
+  tenant: system
   name: LEAF_PEER_L3
   trunk_groups:
   - LEAF_PEER_L3
-  id: 4093
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 130
   name: Tenant_A_APP_Zone_1
   tenant: Tenant_A
@@ -596,7 +596,8 @@ port_channel_interfaces:
   - LEAF_PEER_L3
   - MLAG
 ethernet_interfaces:
-- peer: DC1-LEAF3B
+- name: Ethernet5
+  peer: DC1-LEAF3B
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF3B_Ethernet5
@@ -605,8 +606,8 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
-  name: Ethernet5
-- peer: DC1-LEAF3B
+- name: Ethernet6
+  peer: DC1-LEAF3B
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF3B_Ethernet6
@@ -615,7 +616,6 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
-  name: Ethernet6
 - name: Ethernet1
   peer: DC1-SPINE5
   peer_interface: Ethernet1

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF3B.yml
@@ -335,16 +335,16 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4093
+  tenant: system
   name: LEAF_PEER_L3
   trunk_groups:
   - LEAF_PEER_L3
-  id: 4093
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 130
   name: Tenant_A_APP_Zone_1
   tenant: Tenant_A
@@ -596,7 +596,8 @@ port_channel_interfaces:
   - LEAF_PEER_L3
   - MLAG
 ethernet_interfaces:
-- peer: DC1-LEAF3A
+- name: Ethernet5
+  peer: DC1-LEAF3A
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF3A_Ethernet5
@@ -605,8 +606,8 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
-  name: Ethernet5
-- peer: DC1-LEAF3A
+- name: Ethernet6
+  peer: DC1-LEAF3A
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF3A_Ethernet6
@@ -615,7 +616,6 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
-  name: Ethernet6
 - name: Ethernet1
   peer: DC1-SPINE5
   peer_interface: Ethernet2

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF4A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF4A.yml
@@ -335,16 +335,16 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4093
+  tenant: system
   name: LEAF_PEER_L3
   trunk_groups:
   - LEAF_PEER_L3
-  id: 4093
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 130
   name: Tenant_A_APP_Zone_1
   tenant: Tenant_A
@@ -596,7 +596,8 @@ port_channel_interfaces:
   - LEAF_PEER_L3
   - MLAG
 ethernet_interfaces:
-- peer: DC1-LEAF4B
+- name: Ethernet5
+  peer: DC1-LEAF4B
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF4B_Ethernet5
@@ -605,8 +606,8 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
-  name: Ethernet5
-- peer: DC1-LEAF4B
+- name: Ethernet6
+  peer: DC1-LEAF4B
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF4B_Ethernet6
@@ -615,7 +616,6 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
-  name: Ethernet6
 - name: Ethernet1
   peer: DC1-SPINE6
   peer_interface: Ethernet1

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF4B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF4B.yml
@@ -335,16 +335,16 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4093
+  tenant: system
   name: LEAF_PEER_L3
   trunk_groups:
   - LEAF_PEER_L3
-  id: 4093
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 130
   name: Tenant_A_APP_Zone_1
   tenant: Tenant_A
@@ -596,7 +596,8 @@ port_channel_interfaces:
   - LEAF_PEER_L3
   - MLAG
 ethernet_interfaces:
-- peer: DC1-LEAF4A
+- name: Ethernet5
+  peer: DC1-LEAF4A
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF4A_Ethernet5
@@ -605,8 +606,8 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
-  name: Ethernet5
-- peer: DC1-LEAF4A
+- name: Ethernet6
+  peer: DC1-LEAF4A
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-LEAF4A_Ethernet6
@@ -615,7 +616,6 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
-  name: Ethernet6
 - name: Ethernet1
   peer: DC1-SPINE6
   peer_interface: Ethernet2

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -443,16 +443,16 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4093
+  tenant: system
   name: LEAF_PEER_L3
   trunk_groups:
   - LEAF_PEER_L3
-  id: 4093
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 130
   name: Tenant_A_APP_Zone_1
   tenant: Tenant_A
@@ -839,7 +839,8 @@ port_channel_interfaces:
       unit: percent
   mlag: 15
 ethernet_interfaces:
-- peer: DC1-SVC3B
+- name: Ethernet5
+  peer: DC1-SVC3B
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-SVC3B_Ethernet5
@@ -848,8 +849,8 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
-  name: Ethernet5
-- peer: DC1-SVC3B
+- name: Ethernet6
+  peer: DC1-SVC3B
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-SVC3B_Ethernet6
@@ -858,7 +859,6 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
-  name: Ethernet6
 - name: Ethernet1
   peer: DC1-SPINE1
   peer_interface: Ethernet4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -443,16 +443,16 @@ management_api_http:
   - name: MGMT
   enable_https: true
 vlans:
-- tenant: system
+- id: 4093
+  tenant: system
   name: LEAF_PEER_L3
   trunk_groups:
   - LEAF_PEER_L3
-  id: 4093
-- tenant: system
+- id: 4094
+  tenant: system
   name: MLAG_PEER
   trunk_groups:
   - MLAG
-  id: 4094
 - id: 130
   name: Tenant_A_APP_Zone_1
   tenant: Tenant_A
@@ -829,7 +829,8 @@ port_channel_interfaces:
       unit: percent
   mlag: 15
 ethernet_interfaces:
-- peer: DC1-SVC3A
+- name: Ethernet5
+  peer: DC1-SVC3A
   peer_interface: Ethernet5
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-SVC3A_Ethernet5
@@ -838,8 +839,8 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
-  name: Ethernet5
-- peer: DC1-SVC3A
+- name: Ethernet6
+  peer: DC1-SVC3A
   peer_interface: Ethernet6
   peer_type: mlag_peer
   description: MLAG_PEER_DC1-SVC3A_Ethernet6
@@ -848,7 +849,6 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
-  name: Ethernet6
 - name: Ethernet1
   peer: DC1-SPINE1
   peer_interface: Ethernet5

--- a/ansible_collections/arista/avd/plugins/filter/convert_dicts.py
+++ b/ansible_collections/arista/avd/plugins/filter/convert_dicts.py
@@ -61,9 +61,7 @@ def convert_dicts(dictionary, primary_key="name", secondary_key=None):
         output = []
         for element in dictionary:
             if not isinstance(element, dict):
-                item = {}
-                item.update({primary_key: element})
-                output.append(item)
+                output.append({primary_key: element})
             elif primary_key not in element and secondary_key is not None:
                 # if element of nested dictionary is a dictionary but primary key is missing, insert primary and secondary keys.
                 for key in element:
@@ -81,19 +79,24 @@ def convert_dicts(dictionary, primary_key="name", secondary_key=None):
         for key in dictionary:
             if secondary_key is not None:
                 # Add secondary key for the values if secondary key is provided
-                item = {}
-                item.update({primary_key: key})
-                item.update({secondary_key: dictionary[key]})
-                output.append(item)
+                output.append(
+                    {
+                        primary_key: key,
+                        secondary_key: dictionary[key],
+                    }
+                )
             else:
                 if not isinstance(dictionary[key], dict):
                     # Not a nested dictionary
                     output.append({primary_key: key})
                 else:
                     # Nested dictionary
-                    item = dictionary[key].copy()
-                    item.update({primary_key: key})
-                    output.append(item)
+                    output.append(
+                        {
+                            primary_key: key,
+                            **dictionary[key],
+                        }
+                    )
         return output
 
 


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Optimize convert_dicts

## Component(s) name

`convert_dicts` code leveraged by `arista.avd.convert_dicts` filter as well as python modules.

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

- Avoid setting "item" variables
- Insert primary key as first key when converting from dict-of-dict to list-of-dict

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Reran all molecule. The reordering is because of the change of primary_key placement after conversion.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
