### PR TITLE
Revert(eos_designs): Duplicate checks for VRFs

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/vlans.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/vlans.py
@@ -44,9 +44,11 @@ class VlansMixin(UtilsMixin):
                     continue
 
                 if vlan_id in vlans:
-                    self._raise_duplicate_vlan_error(
-                        vlan_id, f"MLAG Peering VLAN in vrf '{vrf['name']}' (check for duplicate VRF VNI/ID)", tenant["name"], vlans[vlan_id]
-                    )
+                    if vlans[vlan_id]["name"] != f"MLAG_iBGP_{vrf['name']}":
+                        # Only raise if the duplicate is for a different VRF.
+                        self._raise_duplicate_vlan_error(
+                            vlan_id, f"MLAG Peering VLAN in vrf '{vrf['name']}' (check for duplicate VRF VNI/ID)", tenant["name"], vlans[vlan_id]
+                        )
 
                 vlans[vlan_id] = {
                     "tenant": tenant["name"],

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/vlans.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/vlans.py
@@ -43,12 +43,11 @@ class VlansMixin(UtilsMixin):
                 if (vlan_id := self._mlag_ibgp_peering_vlan_vrf(vrf, tenant)) is None:
                     continue
 
-                if vlan_id in vlans:
-                    if vlans[vlan_id]["name"] != f"MLAG_iBGP_{vrf['name']}":
-                        # Only raise if the duplicate is for a different VRF.
-                        self._raise_duplicate_vlan_error(
-                            vlan_id, f"MLAG Peering VLAN in vrf '{vrf['name']}' (check for duplicate VRF VNI/ID)", tenant["name"], vlans[vlan_id]
-                        )
+                if vlan_id in vlans and vlans[vlan_id]["name"] != f"MLAG_iBGP_{vrf['name']}":
+                    # Only raise if the duplicate is for a different VRF.
+                    self._raise_duplicate_vlan_error(
+                        vlan_id, f"MLAG Peering VLAN in vrf '{vrf['name']}' (check for duplicate VRF VNI/ID)", tenant["name"], vlans[vlan_id]
+                    )
 
                 vlans[vlan_id] = {
                     "tenant": tenant["name"],

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/vrfs.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/vrfs.py
@@ -20,9 +20,6 @@ class VrfsMixin(UtilsMixin):
         Return structured config for vrfs.
 
         Used for creating VRFs except VRF "default".
-
-        This function also detects duplicate vrfs and raise an error in case of duplicates between
-        all Tenants deployed on this device.
         """
 
         if not self._network_services_l3:
@@ -34,9 +31,6 @@ class VrfsMixin(UtilsMixin):
                 vrf_name = vrf["name"]
                 if vrf_name == "default":
                     continue
-
-                if vrf_name in vrfs:
-                    self._raise_duplicate_vrf_error(vrf_name, tenant["name"], vrfs[vrf_name])
 
                 new_vrf = {
                     "tenant": tenant["name"],
@@ -78,10 +72,3 @@ class VrfsMixin(UtilsMixin):
                 return True
 
         return False
-
-    def _raise_duplicate_vrf_error(self, vrf_name: str, tenant_name: str, duplicate_vrf_config: dict) -> NoReturn:
-        msg = f"Duplicate VRF '{vrf_name}' found in Tenant '{tenant_name}'."
-        if (duplicate_vlan_tenant := duplicate_vrf_config["tenant"]) != tenant_name:
-            msg = f"{msg} Other VRF is in Tenant '{duplicate_vlan_tenant}'."
-
-        raise AristaAvdError(msg)

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/vrfs.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/vrfs.py
@@ -1,9 +1,6 @@
 from __future__ import annotations
 
 from functools import cached_property
-from typing import NoReturn
-
-from ansible_collections.arista.avd.plugins.plugin_utils.errors import AristaAvdError
 
 from .utils import UtilsMixin
 

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/vxlan_interface.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/vxlan_interface.py
@@ -76,8 +76,6 @@ class VxlanInterfaceMixin(UtilsMixin):
                     if vni is not None:
                         # Silently ignore if we cannot set a VNI
                         # This is legacy behavior so we will leave stricter enforcement to the schema
-                        if vni in vnis:
-                            self._raise_duplicate_vni_error(vni, f"VRF '{vrf_name}'", tenant["name"], vnis[vni])
 
                         vnis[vni] = tenant["name"]
                         vrfs[vrf_name] = {"vni": vni}


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Revert duplicate checks for VRFs

## Related Issue(s)

There are valid use cases where the same VRF name is defined across multiple "tenants".
This case should be allowed.

In 3.8 the last duplicate "wins" since we use dictionaries in the underlying data models.

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

- Remove duplicate check for VRF names
- Remove duplicate check for VRF VNI
- Ignore duplicate MLAG peer vlan as long as they are for the same VRF name

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

No changes to molecule.
Will be tested on customer repo.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
