### PR TITLE
Fix: Description key not considered with connected endpoints (#2745)

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/connected_endpoints.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/connected_endpoints.cfg
@@ -1,0 +1,61 @@
+!RANCID-CONTENT-TYPE: arista
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname connected_endpoints
+!
+no enable password
+no aaa root
+!
+vrf instance MGMT
+!
+interface Port-Channel5
+   description OLD_SW-1/5_PORT_CHANNEL_DESCRIPTION
+   no shutdown
+   switchport
+!
+interface Port-Channel7
+   description PHYSICAL_PORT_DESCRIPTION_PORT_CHANNEL_DESCRIPTION
+   no shutdown
+   switchport
+!
+interface Ethernet4
+   description PHYSICAL_PORT_DESCRIPTION
+   no shutdown
+   switchport
+!
+interface Ethernet5
+   description OLD_SW-1/5
+   no shutdown
+   channel-group 5 mode active
+!
+interface Ethernet6
+   description OLD_SW-1/5
+   no shutdown
+   channel-group 5 mode active
+!
+interface Ethernet7
+   description PHYSICAL_PORT_DESCRIPTION
+   no shutdown
+   channel-group 7 mode active
+!
+interface Ethernet8
+   description PHYSICAL_PORT_DESCRIPTION
+   no shutdown
+   channel-group 7 mode active
+!
+ip routing
+no ip routing vrf MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/connected_endpoints.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/connected_endpoints.yml
@@ -1,0 +1,68 @@
+service_routing_protocols_model: multi-agent
+ip_routing: true
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+vrfs:
+  MGMT:
+    ip_routing: false
+management_api_http:
+  enable_vrfs:
+    MGMT: {}
+  enable_https: true
+ip_igmp_snooping:
+  globally_enabled: true
+ethernet_interfaces:
+  Ethernet4:
+    peer: OLD_SW-1/4
+    peer_type: server
+    description: PHYSICAL_PORT_DESCRIPTION
+    type: switched
+    shutdown: false
+  Ethernet5:
+    peer: OLD_SW-1/5
+    peer_type: server
+    description: OLD_SW-1/5
+    type: switched
+    shutdown: false
+    channel_group:
+      id: 5
+      mode: active
+  Ethernet6:
+    peer: OLD_SW-1/5
+    peer_type: server
+    description: OLD_SW-1/5
+    type: switched
+    shutdown: false
+    channel_group:
+      id: 5
+      mode: active
+  Ethernet7:
+    peer: OLD_SW-1/6
+    peer_type: server
+    description: PHYSICAL_PORT_DESCRIPTION
+    type: switched
+    shutdown: false
+    channel_group:
+      id: 7
+      mode: active
+  Ethernet8:
+    peer: OLD_SW-1/6
+    peer_type: server
+    description: PHYSICAL_PORT_DESCRIPTION
+    type: switched
+    shutdown: false
+    channel_group:
+      id: 7
+      mode: active
+port_channel_interfaces:
+  Port-Channel5:
+    description: OLD_SW-1/5_PORT_CHANNEL_DESCRIPTION
+    type: switched
+    shutdown: false
+  Port-Channel7:
+    description: PHYSICAL_PORT_DESCRIPTION_PORT_CHANNEL_DESCRIPTION
+    type: switched
+    shutdown: false

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/connected_endpoints.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/connected_endpoints.yml
@@ -1,0 +1,33 @@
+loopback_ipv4_pool: 192.168.0.0/24
+
+type: l2leaf
+l2leaf:
+  defaults:
+  nodes:
+    connected_endpoints:
+      id: 1
+
+servers:
+  # single port override physical port description
+  OLD_SW-1/4:
+    adapters:
+      - switches: [connected_endpoints]
+        switch_ports: [Ethernet4]
+        description: "PHYSICAL_PORT_DESCRIPTION"
+  # port-channel provide port-channel description
+  OLD_SW-1/5:
+    adapters:
+      - switches: [connected_endpoints, connected_endpoints]
+        switch_ports: [Ethernet5, Ethernet6]
+        port_channel:
+          mode: "active"
+          description: "PORT_CHANNEL_DESCRIPTION"
+  # port-channel provide physical and port-channel descriptions
+  OLD_SW-1/6:
+    adapters:
+      - switches: [connected_endpoints, connected_endpoints]
+        switch_ports: [Ethernet7, Ethernet8]
+        description: "PHYSICAL_PORT_DESCRIPTION"
+        port_channel:
+          mode: "active"
+          description: "PORT_CHANNEL_DESCRIPTION"

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
@@ -5,6 +5,7 @@ all:
       children:
         CLEAN_UNIT_TESTS: # Single Devices testing one specific case and only using hostvars
           hosts:
+            connected_endpoints:
             cvp-instance-ips-cvaas:
             device.with.dots.in.hostname:
             filter.only_vlans_in_use:

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/connected_endpoints/ethernet_interfaces.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/connected_endpoints/ethernet_interfaces.py
@@ -74,7 +74,7 @@ class EthernetInterfacesMixin(UtilsMixin):
             "peer": peer,
             "peer_interface": peer_interface,
             "peer_type": connected_endpoint["type"],
-            "description": self._avd_interface_descriptions.connected_endpoints_ethernet_interfaces(peer, peer_interface),
+            "description": self._avd_interface_descriptions.connected_endpoints_ethernet_interfaces(peer, peer_interface, adapter.get("description")),
             "speed": adapter.get("speed"),
             "mtu": adapter.get("mtu"),
             "l2_mtu": adapter.get("l2_mtu"),

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/connected_endpoints/port_channel_interfaces.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/connected_endpoints/port_channel_interfaces.py
@@ -83,6 +83,7 @@ class PortChannelInterfacesMixin(UtilsMixin):
         Return structured_config for one port_channel_interface
         """
         peer = connected_endpoint["name"]
+        adapter_description = get(adapter, "description")
         adapter_port_channel_description = get(adapter, "port_channel.description")
         port_channel_type = "routed" if get(adapter, "port_channel.subinterfaces") else "switched"
         port_channel_mode = get(adapter, "port_channel.mode")
@@ -90,7 +91,9 @@ class PortChannelInterfacesMixin(UtilsMixin):
 
         # Common port_channel_interface settings
         port_channel_interface = {
-            "description": self._avd_interface_descriptions.connected_endpoints_port_channel_interfaces(peer, adapter_port_channel_description),
+            "description": self._avd_interface_descriptions.connected_endpoints_port_channel_interfaces(
+                peer, adapter_description, adapter_port_channel_description
+            ),
             "type": port_channel_type,
             "shutdown": not get(adapter, "port_channel.enabled", default=True),
             "mtu": adapter.get("mtu"),

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/interface_descriptions/avdinterfacedescriptions.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/interface_descriptions/avdinterfacedescriptions.py
@@ -95,17 +95,30 @@ class AvdInterfaceDescriptions(AvdFacts):
 
         return f"MLAG_PEER_{self._mlag_peer}_Po{self._mlag_port_channel_id}"
 
-    def connected_endpoints_ethernet_interfaces(self, peer: str = None, peer_interface: str = None) -> str:
+    def connected_endpoints_ethernet_interfaces(self, peer: str = None, peer_interface: str = None, adapter_description: str = None) -> str:
+        """If a jinja template is configured, use it.
+        If not, use the adapter.description or default to <PEER>_<PEER_INTERFACE>"""
+
         if template_path := get(
             self._hostvars,
             "switch.interface_descriptions.connected_endpoints_ethernet_interfaces",
         ):
-            return self._template(template_path, peer=peer, peer_interface=peer_interface)
+            return self._template(template_path, peer=peer, peer_interface=peer_interface, adapter_description=adapter_description)
+
+        if adapter_description:
+            return adapter_description
 
         elements = [peer, peer_interface]
         return "_".join([str(element) for element in elements if element is not None])
 
-    def connected_endpoints_port_channel_interfaces(self, peer: str = None, adapter_port_channel_description: str = None) -> str:
+    def connected_endpoints_port_channel_interfaces(
+        self, peer: str = None, adapter_description: str = None, adapter_port_channel_description: str = None
+    ) -> str:
+        """If a jinja template is configured, use it.
+        If not, return the <adapter.description>_<port_channel_description> or
+        default to <PEER>_<adapter_port_channel_description>
+        """
+
         if template_path := get(
             self._hostvars,
             "switch.interface_descriptions.connected_endpoints_port_channel_interfaces",
@@ -114,9 +127,10 @@ class AvdInterfaceDescriptions(AvdFacts):
                 template_path,
                 peer=peer,
                 adapter_port_channel_description=adapter_port_channel_description,
+                adapter_description=adapter_description,
             )
 
-        elements = [peer, adapter_port_channel_description]
+        elements = [adapter_description or peer, adapter_port_channel_description]
         return "_".join([str(element) for element in elements if element is not None])
 
     def overlay_loopback_interface(self, overlay_loopback_description: str = None) -> str:


### PR DESCRIPTION
## Change Summary

Partial cherry-pick of #2745 

- Adjusted Python code the leverage older functions and variables.
- Added id to the device host variable
- Configuration generated for the connected_endpoint generated an extra `ip routing` added in the configuration which was expected. All other configuration was identical.
