### PR TITLE
Fix(eos_cli_config_gen): Fix typo in router-bgp.j2 (#2753)

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
@@ -127,12 +127,14 @@ interface Management1
 | Neighbor | Remote AS | VRF | Shutdown | Send-community | Maximum-routes | Allowas-in | BFD | RIB Pre-Policy Retain | Route-Reflector Client |
 | -------- | --------- | --- | -------- | -------------- | -------------- | ---------- | --- | --------------------- | ---------------------- |
 | 192.0.3.1 | 65432 | default | - | all | - | - | - | True | - |
-| 192.0.3.2 | 65433 | default | - | extended | 10000 | - | - | True (All) | - |
-| 192.0.3.3 | 65434 | default | - | standard | - | - | - | True | - |
+| 192.0.3.2 | 65433 | default | - | extended | 10000 | - | True | True (All) | - |
+| 192.0.3.3 | 65434 | default | - | standard | - | - | False | True | - |
 | 192.0.3.4 | 65435 | default | - | large | - | - | - | False | - |
 | 192.0.3.5 | 65436 | default | - | standard | 12000 | - | - | - | - |
 | 192.0.3.6 | 65437 | default | - | - | - | - | - | - | False |
 | 192.0.3.7 | 65438 | default | - | - | - | - | - | - | True |
+| 192.0.3.8 | 65438 | default | - | - | - | - | True | - | - |
+| 192.0.3.9 | 65438 | default | - | - | - | - | False | - | - |
 
 ### BGP Neighbor Interfaces
 
@@ -180,6 +182,7 @@ router bgp 65101
    neighbor 192.0.3.1 send-community
    neighbor 192.0.3.1 link-bandwidth default 100G
    neighbor 192.0.3.2 remote-as 65433
+   neighbor 192.0.3.2 bfd
    neighbor 192.0.3.2 rib-in pre-policy retain all
    neighbor 192.0.3.2 default-originate route-map RM-FOO-MATCH3
    neighbor 192.0.3.2 send-community extended
@@ -206,6 +209,12 @@ router bgp 65101
    neighbor 192.0.3.7 remove-private-as ingress replace-as
    neighbor 192.0.3.7 description test_remove_private_as_all
    neighbor 192.0.3.7 route-reflector-client
+   neighbor 192.0.3.8 peer group TEST
+   neighbor 192.0.3.8 remote-as 65438
+   neighbor 192.0.3.8 bfd
+   neighbor 192.0.3.9 peer group TEST
+   neighbor 192.0.3.9 remote-as 65438
+   no neighbor 192.0.3.9 bfd
    aggregate-address 1.1.1.0/24 advertise-only
    aggregate-address 1.12.1.0/24 as-set summary-only attribute-map RM-ATTRIBUTE match-map RM-MATCH advertise-only
    aggregate-address 2.2.1.0/24

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-vrf-lite.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-vrf-lite.md
@@ -159,16 +159,22 @@ ip route vrf BLUE-C1 193.1.2.0/24 Null0
 | -------- | ----- |
 | Address Family | ipv4 |
 | Remote AS | 65001 |
+| BFD | True |
 
 ### BGP Neighbors
 
 | Neighbor | Remote AS | VRF | Shutdown | Send-community | Maximum-routes | Allowas-in | BFD | RIB Pre-Policy Retain | Route-Reflector Client |
 | -------- | --------- | --- | -------- | -------------- | -------------- | ---------- | --- | --------------------- | ---------------------- |
 | 10.1.1.0 | Inherited from peer group OBS_WAN | BLUE-C1 | - | - | - | - | - | - | - |
-| 10.255.1.1 | Inherited from peer group WELCOME_ROUTERS | BLUE-C1 | - | - | - | - | - | - | - |
+| 10.255.1.1 | Inherited from peer group WELCOME_ROUTERS | BLUE-C1 | - | - | - | - | Inherited from peer group WELCOME_ROUTERS | - | - |
 | 101.0.3.1 | Inherited from peer group SEDI | BLUE-C1 | - | - | - | - | - | - | - |
 | 101.0.3.2 | Inherited from peer group SEDI | BLUE-C1 | True | - | - | Allowed, allowed 3 (default) times | - | - | - |
 | 101.0.3.3 | - | BLUE-C1 | Inherited from peer group SEDI-shut | - | - | Allowed, allowed 5 times | - | - | - |
+| 101.0.3.4 | - | BLUE-C1 | - | - | - | - | - | - | - |
+| 101.0.3.5 | Inherited from peer group WELCOME_ROUTERS | BLUE-C1 | - | - | - | - | False | - | - |
+| 101.0.3.6 | Inherited from peer group WELCOME_ROUTERS | BLUE-C1 | - | - | - | - | True | - | - |
+| 101.0.3.7 | - | BLUE-C1 | - | - | - | - | True | - | - |
+| 101.0.3.8 | - | BLUE-C1 | - | - | - | - | False | - | - |
 | 10.1.1.0 | Inherited from peer group OBS_WAN | RED-C1 | - | - | - | - | - | - | - |
 | 10.1.1.0 | Inherited from peer group OBS_WAN | YELLOW-C1 | - | - | - | - | - | - | - |
 
@@ -204,6 +210,7 @@ router bgp 65001
    neighbor WELCOME_ROUTERS peer group
    neighbor WELCOME_ROUTERS remote-as 65001
    neighbor WELCOME_ROUTERS description BGP Connection to WELCOME ROUTER 02
+   neighbor WELCOME_ROUTERS bfd
    redistribute static
    !
    address-family ipv4
@@ -226,6 +233,12 @@ router bgp 65001
       neighbor 101.0.3.2 shutdown
       neighbor 101.0.3.3 peer group SEDI-shut
       neighbor 101.0.3.3 allowas-in 5
+      neighbor 101.0.3.4 peer group TEST-PASSIVE
+      neighbor 101.0.3.5 peer group WELCOME_ROUTERS
+      no neighbor 101.0.3.5 bfd
+      neighbor 101.0.3.6 peer group WELCOME_ROUTERS
+      neighbor 101.0.3.6 bfd
+      neighbor 101.0.3.7 bfd
       aggregate-address 0.0.0.0/0 as-set summary-only attribute-map RM-BGP-AGG-APPLY-SET
       aggregate-address 193.1.0.0/16 as-set summary-only attribute-map RM-BGP-AGG-APPLY-SET
       redistribute static

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-base.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-base.cfg
@@ -39,6 +39,7 @@ router bgp 65101
    neighbor 192.0.3.1 send-community
    neighbor 192.0.3.1 link-bandwidth default 100G
    neighbor 192.0.3.2 remote-as 65433
+   neighbor 192.0.3.2 bfd
    neighbor 192.0.3.2 rib-in pre-policy retain all
    neighbor 192.0.3.2 default-originate route-map RM-FOO-MATCH3
    neighbor 192.0.3.2 send-community extended
@@ -65,6 +66,12 @@ router bgp 65101
    neighbor 192.0.3.7 remove-private-as ingress replace-as
    neighbor 192.0.3.7 description test_remove_private_as_all
    neighbor 192.0.3.7 route-reflector-client
+   neighbor 192.0.3.8 peer group TEST
+   neighbor 192.0.3.8 remote-as 65438
+   neighbor 192.0.3.8 bfd
+   neighbor 192.0.3.9 peer group TEST
+   neighbor 192.0.3.9 remote-as 65438
+   no neighbor 192.0.3.9 bfd
    aggregate-address 1.1.1.0/24 advertise-only
    aggregate-address 1.12.1.0/24 as-set summary-only attribute-map RM-ATTRIBUTE match-map RM-MATCH advertise-only
    aggregate-address 2.2.1.0/24

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-vrf-lite.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-vrf-lite.cfg
@@ -53,6 +53,7 @@ router bgp 65001
    neighbor WELCOME_ROUTERS peer group
    neighbor WELCOME_ROUTERS remote-as 65001
    neighbor WELCOME_ROUTERS description BGP Connection to WELCOME ROUTER 02
+   neighbor WELCOME_ROUTERS bfd
    redistribute static
    !
    address-family ipv4
@@ -75,6 +76,12 @@ router bgp 65001
       neighbor 101.0.3.2 shutdown
       neighbor 101.0.3.3 peer group SEDI-shut
       neighbor 101.0.3.3 allowas-in 5
+      neighbor 101.0.3.4 peer group TEST-PASSIVE
+      neighbor 101.0.3.5 peer group WELCOME_ROUTERS
+      no neighbor 101.0.3.5 bfd
+      neighbor 101.0.3.6 peer group WELCOME_ROUTERS
+      neighbor 101.0.3.6 bfd
+      neighbor 101.0.3.7 bfd
       aggregate-address 0.0.0.0/0 as-set summary-only attribute-map RM-BGP-AGG-APPLY-SET
       aggregate-address 193.1.0.0/16 as-set summary-only attribute-map RM-BGP-AGG-APPLY-SET
       redistribute static

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-base.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-base.yml
@@ -106,6 +106,8 @@ router_bgp:
       rib_in_pre_policy_retain:
         enabled: true
     192.0.3.2:
+      # Testing bfd true OUTSIDE a peer group that should render
+      bfd: true
       remote_as: 65433
       send_community: extended
       maximum_routes: 10000
@@ -119,6 +121,8 @@ router_bgp:
         enabled: true
         all: true
     192.0.3.3:
+      # Testing bfd false OUTSIDE a peer group that should NOT render
+      bfd: false
       remote_as: 65434
       send_community: standard
       rib_in_pre_policy_retain:
@@ -158,6 +162,16 @@ router_bgp:
         enabled: true
         replace_as: true
       route_reflector_client: true
+    # Testing bfd true IN a peer group that should render
+    192.0.3.8:
+      peer_group: TEST
+      bfd: true
+      remote_as: 65438
+    # Testing bfd false IN a peer group that should render
+    192.0.3.9:
+      peer_group: TEST
+      bfd: false
+      remote_as: 65438
   neighbor_interfaces:
     Ethernet2:
       peer_group: PG-FOO-v4

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-vrf-lite.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-vrf-lite.yml
@@ -43,6 +43,7 @@ router_bgp:
       description: 'BGP Connection to OBS WAN CPE'
       remote_as: 65000
     WELCOME_ROUTERS:
+      bfd: true
       type: ipv4
       description: 'BGP Connection to WELCOME ROUTER 02'
       remote_as: 65001
@@ -53,6 +54,7 @@ router_bgp:
       update_source: Loopback101
       ebgp_multihop: 10
     SEDI-shut:
+      bfd: false
       type: ipv4
       description: 'BGP Peer Shutdown'
       shutdown: true
@@ -92,6 +94,22 @@ router_bgp:
           allowas_in:
             enabled: true
             times: 5
+        101.0.3.4:
+          peer_group: TEST-PASSIVE
+        # Testing bfd false IN a peer group that should render
+        101.0.3.5:
+          peer_group: WELCOME_ROUTERS
+          bfd: false
+        # Testing bfd true IN a peer group that should render
+        101.0.3.6:
+          peer_group: WELCOME_ROUTERS
+          bfd: true
+        # Testing bfd true OUTSIDE a peer group that should render
+        101.0.3.7:
+          bfd: true
+        # Testing bfd false OUTSIDE a peer group that should NOT render
+        101.0.3.8:
+          bfd: false
       redistribute_routes:
         - static
       aggregate_addresses:

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-SPINE2.md
@@ -389,6 +389,7 @@ router bgp 65120
    neighbor 200.200.200.201 remote-as 65210
    neighbor 200.200.200.201 local-as 65112 no-prepend replace-as
    neighbor 200.200.200.201 description DC2-POD1-SPINE2
+   no neighbor 200.200.200.201 bfd
    redistribute connected route-map RM-CONN-2-BGP
    !
    address-family evpn

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-SUPER-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-SUPER-SPINE1.md
@@ -341,6 +341,7 @@ router bgp 65100
    neighbor 11.1.2.1 peer group IPv4-UNDERLAY-PEERS
    neighbor 11.1.2.1 remote-as 65200
    neighbor 11.1.2.1 description DC2-SUPER-SPINE1
+   no neighbor 11.1.2.1 bfd
    neighbor 172.16.11.1 peer group IPv4-UNDERLAY-PEERS
    neighbor 172.16.11.1 remote-as 65110.100
    neighbor 172.16.11.1 description DC1-POD1-SPINE1_Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-SPINE2.md
@@ -365,6 +365,7 @@ router bgp 65210
    neighbor 200.200.200.101 peer group IPv4-UNDERLAY-PEERS
    neighbor 200.200.200.101 remote-as 65112
    neighbor 200.200.200.101 description DC1-POD2-SPINE2
+   no neighbor 200.200.200.101 bfd
    redistribute connected route-map RM-CONN-2-BGP
    !
    address-family ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-SUPER-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-SUPER-SPINE1.md
@@ -405,6 +405,7 @@ router bgp 65200
    neighbor 11.1.2.0 peer group IPv4-UNDERLAY-PEERS
    neighbor 11.1.2.0 remote-as 65100
    neighbor 11.1.2.0 description DC1-SUPER-SPINE1
+   no neighbor 11.1.2.0 bfd
    neighbor 172.16.10.1 peer group EVPN-OVERLAY-PEERS
    neighbor 172.16.10.1 remote-as 65101
    neighbor 172.16.10.1 description DC1-RS1

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD2-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD2-SPINE2.cfg
@@ -116,6 +116,7 @@ router bgp 65120
    neighbor 200.200.200.201 remote-as 65210
    neighbor 200.200.200.201 local-as 65112 no-prepend replace-as
    neighbor 200.200.200.201 description DC2-POD1-SPINE2
+   no neighbor 200.200.200.201 bfd
    redistribute connected route-map RM-CONN-2-BGP
    !
    address-family evpn

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-SUPER-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-SUPER-SPINE1.cfg
@@ -106,6 +106,7 @@ router bgp 65100
    neighbor 11.1.2.1 peer group IPv4-UNDERLAY-PEERS
    neighbor 11.1.2.1 remote-as 65200
    neighbor 11.1.2.1 description DC2-SUPER-SPINE1
+   no neighbor 11.1.2.1 bfd
    neighbor 172.16.11.1 peer group IPv4-UNDERLAY-PEERS
    neighbor 172.16.11.1 remote-as 65110.100
    neighbor 172.16.11.1 description DC1-POD1-SPINE1_Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-SPINE2.cfg
@@ -110,6 +110,7 @@ router bgp 65210
    neighbor 200.200.200.101 peer group IPv4-UNDERLAY-PEERS
    neighbor 200.200.200.101 remote-as 65112
    neighbor 200.200.200.101 description DC1-POD2-SPINE2
+   no neighbor 200.200.200.101 bfd
    redistribute connected route-map RM-CONN-2-BGP
    !
    address-family ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-SUPER-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-SUPER-SPINE1.cfg
@@ -123,6 +123,7 @@ router bgp 65200
    neighbor 11.1.2.0 peer group IPv4-UNDERLAY-PEERS
    neighbor 11.1.2.0 remote-as 65100
    neighbor 11.1.2.0 description DC1-SUPER-SPINE1
+   no neighbor 11.1.2.0 bfd
    neighbor 172.16.10.1 peer group EVPN-OVERLAY-PEERS
    neighbor 172.16.10.1 remote-as 65101
    neighbor 172.16.10.1 description DC1-RS1

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-SPINE2.md
@@ -387,6 +387,7 @@ router bgp 65120
    neighbor 200.200.200.201 remote-as 65210
    neighbor 200.200.200.201 local-as 65112 no-prepend replace-as
    neighbor 200.200.200.201 description DC2-POD1-SPINE2
+   no neighbor 200.200.200.201 bfd
    redistribute connected route-map RM-CONN-2-BGP
    !
    address-family evpn

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-SUPER-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-SUPER-SPINE1.md
@@ -337,6 +337,7 @@ router bgp 65100
    neighbor 11.1.2.1 peer group IPv4-UNDERLAY-PEERS
    neighbor 11.1.2.1 remote-as 65200
    neighbor 11.1.2.1 description DC2-SUPER-SPINE1
+   no neighbor 11.1.2.1 bfd
    neighbor 172.16.11.1 peer group IPv4-UNDERLAY-PEERS
    neighbor 172.16.11.1 remote-as 65110
    neighbor 172.16.11.1 description DC1-POD1-SPINE1_Ethernet1

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-SPINE2.md
@@ -352,6 +352,7 @@ router bgp 65210
    neighbor 200.200.200.101 peer group IPv4-UNDERLAY-PEERS
    neighbor 200.200.200.101 remote-as 65112
    neighbor 200.200.200.101 description DC1-POD2-SPINE2
+   no neighbor 200.200.200.101 bfd
    redistribute connected route-map RM-CONN-2-BGP
    !
    address-family ipv4

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC2-SUPER-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC2-SUPER-SPINE1.md
@@ -407,6 +407,7 @@ router bgp 65200
    neighbor 11.1.2.0 peer group IPv4-UNDERLAY-PEERS
    neighbor 11.1.2.0 remote-as 65100
    neighbor 11.1.2.0 description DC1-SUPER-SPINE1
+   no neighbor 11.1.2.0 bfd
    neighbor 172.16.10.1 peer group EVPN-OVERLAY-PEERS
    neighbor 172.16.10.1 remote-as 65101
    neighbor 172.16.10.1 description DC1-RS1

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/intended/configs/DC1-POD2-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/intended/configs/DC1-POD2-SPINE2.cfg
@@ -114,6 +114,7 @@ router bgp 65120
    neighbor 200.200.200.201 remote-as 65210
    neighbor 200.200.200.201 local-as 65112 no-prepend replace-as
    neighbor 200.200.200.201 description DC2-POD1-SPINE2
+   no neighbor 200.200.200.201 bfd
    redistribute connected route-map RM-CONN-2-BGP
    !
    address-family evpn

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/intended/configs/DC1-SUPER-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/intended/configs/DC1-SUPER-SPINE1.cfg
@@ -102,6 +102,7 @@ router bgp 65100
    neighbor 11.1.2.1 peer group IPv4-UNDERLAY-PEERS
    neighbor 11.1.2.1 remote-as 65200
    neighbor 11.1.2.1 description DC2-SUPER-SPINE1
+   no neighbor 11.1.2.1 bfd
    neighbor 172.16.11.1 peer group IPv4-UNDERLAY-PEERS
    neighbor 172.16.11.1 remote-as 65110
    neighbor 172.16.11.1 description DC1-POD1-SPINE1_Ethernet1

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-SPINE2.cfg
@@ -99,6 +99,7 @@ router bgp 65210
    neighbor 200.200.200.101 peer group IPv4-UNDERLAY-PEERS
    neighbor 200.200.200.101 remote-as 65112
    neighbor 200.200.200.101 description DC1-POD2-SPINE2
+   no neighbor 200.200.200.101 bfd
    redistribute connected route-map RM-CONN-2-BGP
    !
    address-family ipv4

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/intended/configs/DC2-SUPER-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/intended/configs/DC2-SUPER-SPINE1.cfg
@@ -125,6 +125,7 @@ router bgp 65200
    neighbor 11.1.2.0 peer group IPv4-UNDERLAY-PEERS
    neighbor 11.1.2.0 remote-as 65100
    neighbor 11.1.2.0 description DC1-SUPER-SPINE1
+   no neighbor 11.1.2.0 bfd
    neighbor 172.16.10.1 peer group EVPN-OVERLAY-PEERS
    neighbor 172.16.10.1 remote-as 65101
    neighbor 172.16.10.1 description DC1-RS1

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -251,6 +251,8 @@ router bgp {{ router_bgp.as }}
 {%         endif %}
 {%         if neighbor.bfd is arista.avd.defined(true) %}
    neighbor {{ neighbor.ip_address }} bfd
+{%         elif neighbor.bfd is arista.avd.defined(false) and neighbor.peer_group is arista.avd.defined %}
+   no neighbor {{ neighbor.ip_address }} bfd
 {%         endif %}
 {%         if neighbor.allowas_in.enabled is arista.avd.defined(true) %}
 {%             set allowas_in_cli = "neighbor " ~ neighbor.ip_address ~ " allowas-in" %}
@@ -903,8 +905,8 @@ router bgp {{ router_bgp.as }}
 {%             endif %}
 {%             if neighbor.bfd is arista.avd.defined(true) %}
       neighbor {{ neighbor.ip_address }} bfd
-{%             elif neighbor.bfd is arista.avd.defined(false) %}
-      no neighbor {{ neighbo.ip_address }} bfd
+{%             elif neighbor.bfd is arista.avd.defined(false) and neighbor.peer_group is arista.avd.defined %}
+      no neighbor {{ neighbor.ip_address }} bfd
 {%             endif %}
 {%             if neighbor.allowas_in.enabled is arista.avd.defined(true) %}
 {%                 set allowas_in_cli = "neighbor " ~ neighbor.ip_address ~ " allowas-in" %}


### PR DESCRIPTION
## Change Summary

Partial cherry-pick of #2753 

- Adjusted test case input to comply with AVD 3.8 schema.
- Regenerated configs and documentation for unit tests and all config look correct.
