### PR TITLE
Fix(eos_designs): Invalid defaults for ipvpn_gateway domain IDs (#2739)

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/bgp-peer-groups-structured-config-3.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/bgp-peer-groups-structured-config-3.cfg
@@ -50,7 +50,7 @@ router bgp 65001
    neighbor MPLS-OVERLAY-PEERS maximum-routes 0
    !
    address-family evpn
-      domain identifier 0:1
+      domain identifier 65535:1
       neighbor default encapsulation mpls next-hop-self source-interface Loopback0
       neighbor MPLS-OVERLAY-PEERS activate
    !
@@ -59,7 +59,7 @@ router bgp 65001
       no neighbor MPLS-OVERLAY-PEERS activate
    !
    address-family vpn-ipv4
-      domain identifier 0:2
+      domain identifier 65535:2
       neighbor IPVPN-GATEWAY-PEERS activate
       neighbor MPLS-OVERLAY-PEERS activate
       neighbor default encapsulation mpls next-hop-self source-interface Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-structured-config-3.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-structured-config-3.yml
@@ -32,7 +32,7 @@ router_bgp:
     peer_groups:
       MPLS-OVERLAY-PEERS:
         activate: true
-    domain_identifier: 0:1
+    domain_identifier: '65535:1'
   bgp:
     bestpath:
       d_path: true
@@ -44,7 +44,7 @@ router_bgp:
         activate: true
       MPLS-OVERLAY-PEERS:
         activate: true
-    domain_identifier: 0:2
+    domain_identifier: '65535:2'
 static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_facts.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_facts.py
@@ -1976,8 +1976,8 @@ class EosDesignsFacts(AvdFacts):
         """
         if get(self.overlay, "ipvpn_gateway"):
             return {
-                "evpn_domain_id": get(self._switch_data_combined, "ipvpn_gateway.evpn_domain_id", default="0:1"),
-                "ipvpn_domain_id": get(self._switch_data_combined, "ipvpn_gateway.ipvpn_domain_id", default="0:2"),
+                "evpn_domain_id": get(self._switch_data_combined, "ipvpn_gateway.evpn_domain_id", default="65535:1"),
+                "ipvpn_domain_id": get(self._switch_data_combined, "ipvpn_gateway.ipvpn_domain_id", default="65535:2"),
                 "max_routes": get(self._switch_data_combined, "ipvpn_gateway.maximum_routes", default=0),
                 "local_as": get(self._switch_data_combined, "ipvpn_gateway.local_as"),
                 "remote_peers": get(self._switch_data_combined, "ipvpn_gateway.remote_peers", default=[]),

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-topology.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-topology.md
@@ -466,8 +466,8 @@ default_interfaces:
         enabled: < true | false | default -> False >
 
         # Domain IDs are required to perform D-Path lookups for loop prevention. If omitted, the defaults are used.
-        evpn_domain_id: < "nn:nn" | default -> "0:1" >
-        ipvpn_domain_id: < "nn:nn" | default -> "0:2" >
+        evpn_domain_id: < "nn:nn" | default -> "65535:1" >
+        ipvpn_domain_id: < "nn:nn" | default -> "65535:2" >
 
         # D-path can be turned off for the inter-vpn export if desired.
         enable_d_path: < true | false | default -> true >


### PR DESCRIPTION
## Change Summary

Partial cherry-pick of #2739 

- remove eos_designs schema changes, not applicable to v3.8.x
- regenerated structured configuration.

No changes were seen in the eos configuration, and molecule unit tests were generated as expected.