### PR TITLE
Feat(eos_designs,eos_cli_config_gen)!: bgp graceful-restart

### DIFF
--- a/ansible_collections/arista/avd/docs/getting-started/intro-to-ansible-and-avd.md
+++ b/ansible_collections/arista/avd/docs/getting-started/intro-to-ansible-and-avd.md
@@ -218,8 +218,6 @@ spine:
       # - update wait-for-convergence
       # - update wait-install
       - distance bgp 20 200 200
-      - graceful-restart restart-time 300
-      - graceful-restart
 
   # Definition of nodes contained in this group.
   # Specific configuration of device must take place under the node definition. Each node inherites all values defined under 'defaults'

--- a/ansible_collections/arista/avd/docs/how-to/first-project.md
+++ b/ansible_collections/arista/avd/docs/how-to/first-project.md
@@ -191,8 +191,6 @@ spine:
     # Recommended for vEOS
     bgp_defaults:
       - 'distance bgp 20 200 200'
-      - 'graceful-restart restart-time 300'
-      - 'graceful-restart'
   nodes:
     AVD-SPINE1:
       id: 1

--- a/ansible_collections/arista/avd/docs/porting-guides/4.x.x.md
+++ b/ansible_collections/arista/avd/docs/porting-guides/4.x.x.md
@@ -39,6 +39,28 @@ l3leaf:
 !!! note
     This will now explicitly activate or deactivate bgp_default_ipv4_unicast in the EOS configuration.
 
+A new key, `bgp_graceful_restart` was introduced to implement the best practice of enabling bgp graceful restart with a graceful restart time of 300 seconds.
+
+To change the default behavior update the following variables
+
+```yaml
+    bgp_graceful_restart:
+      enabled: <bool> -> default true
+      restart_time: <int> -> default 300
+```
+
+Configuration under the `<node_type_key>.defaults.bgp_defaults` should also be removed to avoid duplicate entries in the configuration.
+
+Example:
+
+```yaml
+l3leaf:
+  defaults:
+    bgp_defaults:
+      # - graceful-restart restart-time 300 <--- remove this item to avoid duplicates
+      # - graceful-restart <--- remove this item to avoid duplicates
+```
+
 The following keys under `bgp_peer_groups` have been replaced to avoid upper-case variables.
 
 Removed keys:

--- a/ansible_collections/arista/avd/docs/porting-guides/4.x.x.md
+++ b/ansible_collections/arista/avd/docs/porting-guides/4.x.x.md
@@ -44,9 +44,9 @@ A new key, `bgp_graceful_restart` was introduced to implement the best practice 
 To change the default behavior update the following variables
 
 ```yaml
-    bgp_graceful_restart:
-      enabled: <bool> -> default true
-      restart_time: <int> -> default 300
+bgp_graceful_restart:
+  enabled: <bool> -> default true
+  restart_time: <int> -> default 300
 ```
 
 Configuration under the `<node_type_key>.defaults.bgp_defaults` should also be removed to avoid duplicate entries in the configuration.

--- a/ansible_collections/arista/avd/docs/release-notes/4.x.x.md
+++ b/ansible_collections/arista/avd/docs/release-notes/4.x.x.md
@@ -112,7 +112,8 @@ See details in the [Porting guide for AVD 4.x.x](../porting-guides/4.x.x.md#fabr
 
 ### change in defaults eos_designs in BGP variables
 
-A new key, `bgp_default_ipv4_unicast: <bool> -> default false` was introduced to implement the best practice of disabling the default activation of IPv4 unicast address-family.
+- `bgp_default_ipv4_unicast: <bool> -> default false` was introduced to implement the best practice of disabling the default activation of IPv4 unicast address-family.
+- `bgp_graceful_restart` was introduced to implement the best practice of enabling bgp graceful restart.
 
 See details in the [Porting guide for AVD 4.x.x](../porting-guides/4.x.x.md#fabric-variables).
 

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/README.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/README.md
@@ -261,8 +261,6 @@ spine:
     bgp_as: 65200 # (4)!
     bgp_defaults: # (5)!
       - distance bgp 20 200 200
-      - graceful-restart restart-time 300
-      - graceful-restart
 
   nodes: # (6)!
     dc2-spine1:
@@ -300,8 +298,6 @@ l3leaf:
     mlag_peer_l3_ipv4_pool: 10.255.129.96/27 # (10)!
     bgp_defaults:
       - distance bgp 20 200 200
-      - graceful-restart restart-time 300
-      - graceful-restart
     virtual_router_mac_address: 00:1c:73:00:00:99 # (11)!
     spanning_tree_priority: 4096 # (12)!
     spanning_tree_mode: mstp # (13)!

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-leaf1a.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-leaf1a.md
@@ -609,9 +609,9 @@ ip route vrf MGMT 0.0.0.0/0 172.16.1.1
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
+| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
-| maximum-paths 4 ecmp 4 |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -689,10 +689,10 @@ ip route vrf MGMT 0.0.0.0/0 172.16.1.1
 !
 router bgp 65101
    router-id 10.255.0.3
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-leaf1b.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-leaf1b.md
@@ -609,9 +609,9 @@ ip route vrf MGMT 0.0.0.0/0 172.16.1.1
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
+| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
-| maximum-paths 4 ecmp 4 |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -689,10 +689,10 @@ ip route vrf MGMT 0.0.0.0/0 172.16.1.1
 !
 router bgp 65101
    router-id 10.255.0.4
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-leaf2a.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-leaf2a.md
@@ -617,9 +617,9 @@ ip route vrf MGMT 0.0.0.0/0 172.16.1.1
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
+| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
-| maximum-paths 4 ecmp 4 |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -719,10 +719,10 @@ ip route vrf MGMT 0.0.0.0/0 172.16.1.1
 !
 router bgp 65102
    router-id 10.255.0.5
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-CORE peer group
    neighbor EVPN-OVERLAY-CORE update-source Loopback0

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-leaf2b.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-leaf2b.md
@@ -617,9 +617,9 @@ ip route vrf MGMT 0.0.0.0/0 172.16.1.1
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
+| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
-| maximum-paths 4 ecmp 4 |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -719,10 +719,10 @@ ip route vrf MGMT 0.0.0.0/0 172.16.1.1
 !
 router bgp 65102
    router-id 10.255.0.6
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-CORE peer group
    neighbor EVPN-OVERLAY-CORE update-source Loopback0

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-spine1.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-spine1.md
@@ -278,9 +278,9 @@ ip route vrf MGMT 0.0.0.0/0 172.16.1.1
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
+| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
-| maximum-paths 4 ecmp 4 |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -332,10 +332,10 @@ ip route vrf MGMT 0.0.0.0/0 172.16.1.1
 !
 router bgp 65100
    router-id 10.255.0.1
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-spine2.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-spine2.md
@@ -278,9 +278,9 @@ ip route vrf MGMT 0.0.0.0/0 172.16.1.1
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
+| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
-| maximum-paths 4 ecmp 4 |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -332,10 +332,10 @@ ip route vrf MGMT 0.0.0.0/0 172.16.1.1
 !
 router bgp 65100
    router-id 10.255.0.2
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-leaf1a.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-leaf1a.md
@@ -609,9 +609,9 @@ ip route vrf MGMT 0.0.0.0/0 172.16.2.1
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
+| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
-| maximum-paths 4 ecmp 4 |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -689,10 +689,10 @@ ip route vrf MGMT 0.0.0.0/0 172.16.2.1
 !
 router bgp 65201
    router-id 10.255.128.13
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-leaf1b.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-leaf1b.md
@@ -609,9 +609,9 @@ ip route vrf MGMT 0.0.0.0/0 172.16.2.1
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
+| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
-| maximum-paths 4 ecmp 4 |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -689,10 +689,10 @@ ip route vrf MGMT 0.0.0.0/0 172.16.2.1
 !
 router bgp 65201
    router-id 10.255.128.14
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-leaf2a.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-leaf2a.md
@@ -617,9 +617,9 @@ ip route vrf MGMT 0.0.0.0/0 172.16.2.1
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
+| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
-| maximum-paths 4 ecmp 4 |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -719,10 +719,10 @@ ip route vrf MGMT 0.0.0.0/0 172.16.2.1
 !
 router bgp 65202
    router-id 10.255.128.15
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-CORE peer group
    neighbor EVPN-OVERLAY-CORE update-source Loopback0

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-leaf2b.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-leaf2b.md
@@ -617,9 +617,9 @@ ip route vrf MGMT 0.0.0.0/0 172.16.2.1
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
+| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
-| maximum-paths 4 ecmp 4 |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -719,10 +719,10 @@ ip route vrf MGMT 0.0.0.0/0 172.16.2.1
 !
 router bgp 65202
    router-id 10.255.128.16
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-CORE peer group
    neighbor EVPN-OVERLAY-CORE update-source Loopback0

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-spine1.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-spine1.md
@@ -278,9 +278,9 @@ ip route vrf MGMT 0.0.0.0/0 172.16.2.1
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
+| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
-| maximum-paths 4 ecmp 4 |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -332,10 +332,10 @@ ip route vrf MGMT 0.0.0.0/0 172.16.2.1
 !
 router bgp 65200
    router-id 10.255.128.11
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-spine2.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-spine2.md
@@ -278,9 +278,9 @@ ip route vrf MGMT 0.0.0.0/0 172.16.2.1
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
+| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
-| maximum-paths 4 ecmp 4 |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -332,10 +332,10 @@ ip route vrf MGMT 0.0.0.0/0 172.16.2.1
 !
 router bgp 65200
    router-id 10.255.128.12
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/group_vars/DC1.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/group_vars/DC1.yml
@@ -20,8 +20,6 @@ spine:
       # - update wait-for-convergence
       # - update wait-install
       - distance bgp 20 200 200
-      - graceful-restart restart-time 300
-      - graceful-restart
 
   # Definition of nodes contained in this group.
   # Specific configuration of device must take place under the node definition. Each node inherites all values defined under 'defaults'
@@ -66,8 +64,6 @@ l3leaf:
       # The following command must not be enabled when using vEOS-lab
       # - update wait-install
       - distance bgp 20 200 200
-      - graceful-restart restart-time 300
-      - graceful-restart
     # Virtual router mac for VNIs assigned to Leaf switches in format xx:xx:xx:xx:xx:xx
     virtual_router_mac_address: 00:1c:73:00:00:99
     spanning_tree_priority: 4096

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/group_vars/DC2.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/group_vars/DC2.yml
@@ -20,8 +20,6 @@ spine:
       # - update wait-for-convergence
       # - update wait-install
       - distance bgp 20 200 200
-      - graceful-restart restart-time 300
-      - graceful-restart
 
   # Definition of nodes contained in this group.
   # Specific configuration of device must take place under the node definition. Each node inherites all values defined under 'defaults'
@@ -66,8 +64,6 @@ l3leaf:
       # The following command must not be enabled when using vEOS-lab
       # - update wait-install
       - distance bgp 20 200 200
-      - graceful-restart restart-time 300
-      - graceful-restart
     # Virtual router mac for VNIs assigned to Leaf switches in format xx:xx:xx:xx:xx:xx
     virtual_router_mac_address: 00:1c:73:00:00:99
     spanning_tree_priority: 4096

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-leaf1a.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-leaf1a.cfg
@@ -248,10 +248,10 @@ router bfd
 !
 router bgp 65101
    router-id 10.255.0.3
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-leaf1b.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-leaf1b.cfg
@@ -248,10 +248,10 @@ router bfd
 !
 router bgp 65101
    router-id 10.255.0.4
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-leaf2a.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-leaf2a.cfg
@@ -255,10 +255,10 @@ router bfd
 !
 router bgp 65102
    router-id 10.255.0.5
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-CORE peer group
    neighbor EVPN-OVERLAY-CORE update-source Loopback0

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-leaf2b.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-leaf2b.cfg
@@ -255,10 +255,10 @@ router bfd
 !
 router bgp 65102
    router-id 10.255.0.6
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-CORE peer group
    neighbor EVPN-OVERLAY-CORE update-source Loopback0

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-spine1.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-spine1.cfg
@@ -73,10 +73,10 @@ router bfd
 !
 router bgp 65100
    router-id 10.255.0.1
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-spine2.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-spine2.cfg
@@ -73,10 +73,10 @@ router bfd
 !
 router bgp 65100
    router-id 10.255.0.2
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-leaf1a.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-leaf1a.cfg
@@ -248,10 +248,10 @@ router bfd
 !
 router bgp 65201
    router-id 10.255.128.13
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-leaf1b.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-leaf1b.cfg
@@ -248,10 +248,10 @@ router bfd
 !
 router bgp 65201
    router-id 10.255.128.14
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-leaf2a.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-leaf2a.cfg
@@ -255,10 +255,10 @@ router bfd
 !
 router bgp 65202
    router-id 10.255.128.15
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-CORE peer group
    neighbor EVPN-OVERLAY-CORE update-source Loopback0

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-leaf2b.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-leaf2b.cfg
@@ -255,10 +255,10 @@ router bfd
 !
 router bgp 65202
    router-id 10.255.128.16
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-CORE peer group
    neighbor EVPN-OVERLAY-CORE update-source Loopback0

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-spine1.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-spine1.cfg
@@ -73,10 +73,10 @@ router bfd
 !
 router bgp 65200
    router-id 10.255.128.11
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-spine2.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-spine2.cfg
@@ -73,10 +73,10 @@ router bfd
 !
 router bgp 65200
    router-id 10.255.128.12
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf1a.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf1a.yml
@@ -3,12 +3,13 @@ router_bgp:
   router_id: 10.255.0.3
   bgp_defaults:
   - distance bgp 20 200 200
-  - graceful-restart restart-time 300
-  - graceful-restart
   - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf1b.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf1b.yml
@@ -3,12 +3,13 @@ router_bgp:
   router_id: 10.255.0.4
   bgp_defaults:
   - distance bgp 20 200 200
-  - graceful-restart restart-time 300
-  - graceful-restart
   - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf2a.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf2a.yml
@@ -3,12 +3,13 @@ router_bgp:
   router_id: 10.255.0.5
   bgp_defaults:
   - distance bgp 20 200 200
-  - graceful-restart restart-time 300
-  - graceful-restart
   - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf2b.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf2b.yml
@@ -3,12 +3,13 @@ router_bgp:
   router_id: 10.255.0.6
   bgp_defaults:
   - distance bgp 20 200 200
-  - graceful-restart restart-time 300
-  - graceful-restart
   - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-spine1.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-spine1.yml
@@ -3,12 +3,13 @@ router_bgp:
   router_id: 10.255.0.1
   bgp_defaults:
   - distance bgp 20 200 200
-  - graceful-restart restart-time 300
-  - graceful-restart
   - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-spine2.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-spine2.yml
@@ -3,12 +3,13 @@ router_bgp:
   router_id: 10.255.0.2
   bgp_defaults:
   - distance bgp 20 200 200
-  - graceful-restart restart-time 300
-  - graceful-restart
   - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf1a.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf1a.yml
@@ -3,12 +3,13 @@ router_bgp:
   router_id: 10.255.128.13
   bgp_defaults:
   - distance bgp 20 200 200
-  - graceful-restart restart-time 300
-  - graceful-restart
   - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf1b.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf1b.yml
@@ -3,12 +3,13 @@ router_bgp:
   router_id: 10.255.128.14
   bgp_defaults:
   - distance bgp 20 200 200
-  - graceful-restart restart-time 300
-  - graceful-restart
   - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf2a.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf2a.yml
@@ -3,12 +3,13 @@ router_bgp:
   router_id: 10.255.128.15
   bgp_defaults:
   - distance bgp 20 200 200
-  - graceful-restart restart-time 300
-  - graceful-restart
   - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf2b.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf2b.yml
@@ -3,12 +3,13 @@ router_bgp:
   router_id: 10.255.128.16
   bgp_defaults:
   - distance bgp 20 200 200
-  - graceful-restart restart-time 300
-  - graceful-restart
   - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-spine1.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-spine1.yml
@@ -3,12 +3,13 @@ router_bgp:
   router_id: 10.255.128.11
   bgp_defaults:
   - distance bgp 20 200 200
-  - graceful-restart restart-time 300
-  - graceful-restart
   - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-spine2.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-spine2.yml
@@ -3,12 +3,13 @@ router_bgp:
   router_id: 10.255.128.12
   bgp_defaults:
   - distance bgp 20 200 200
-  - graceful-restart restart-time 300
-  - graceful-restart
   - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/README.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/README.md
@@ -353,8 +353,6 @@ spine:
     bgp_as: 65100 # (4)!
     bgp_defaults: # (5)!
       - distance bgp 20 200 200
-      - graceful-restart restart-time 300
-      - graceful-restart
 
   nodes: # (6)!
     dc1-spine1:
@@ -392,8 +390,6 @@ l3leaf:
     mlag_peer_l3_ipv4_pool: 10.255.1.96/27 # (10)!
     bgp_defaults:
       - distance bgp 20 200 200
-      - graceful-restart restart-time 300
-      - graceful-restart
     virtual_router_mac_address: 00:1c:73:00:00:99 # (11)!
     spanning_tree_priority: 4096 # (12)!
     spanning_tree_mode: mstp # (13)!

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf1a.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf1a.md
@@ -609,9 +609,9 @@ ip route vrf MGMT 0.0.0.0/0 172.16.1.1
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
+| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
-| maximum-paths 4 ecmp 4 |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -689,10 +689,10 @@ ip route vrf MGMT 0.0.0.0/0 172.16.1.1
 !
 router bgp 65101
    router-id 10.255.0.3
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf1b.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf1b.md
@@ -609,9 +609,9 @@ ip route vrf MGMT 0.0.0.0/0 172.16.1.1
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
+| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
-| maximum-paths 4 ecmp 4 |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -689,10 +689,10 @@ ip route vrf MGMT 0.0.0.0/0 172.16.1.1
 !
 router bgp 65101
    router-id 10.255.0.4
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf2a.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf2a.md
@@ -609,9 +609,9 @@ ip route vrf MGMT 0.0.0.0/0 172.16.1.1
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
+| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
-| maximum-paths 4 ecmp 4 |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -689,10 +689,10 @@ ip route vrf MGMT 0.0.0.0/0 172.16.1.1
 !
 router bgp 65102
    router-id 10.255.0.5
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf2b.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf2b.md
@@ -609,9 +609,9 @@ ip route vrf MGMT 0.0.0.0/0 172.16.1.1
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
+| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
-| maximum-paths 4 ecmp 4 |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -689,10 +689,10 @@ ip route vrf MGMT 0.0.0.0/0 172.16.1.1
 !
 router bgp 65102
    router-id 10.255.0.6
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-spine1.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-spine1.md
@@ -278,9 +278,9 @@ ip route vrf MGMT 0.0.0.0/0 172.16.1.1
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
+| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
-| maximum-paths 4 ecmp 4 |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -332,10 +332,10 @@ ip route vrf MGMT 0.0.0.0/0 172.16.1.1
 !
 router bgp 65100
    router-id 10.255.0.1
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-spine2.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-spine2.md
@@ -278,9 +278,9 @@ ip route vrf MGMT 0.0.0.0/0 172.16.1.1
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
+| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
-| maximum-paths 4 ecmp 4 |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -332,10 +332,10 @@ ip route vrf MGMT 0.0.0.0/0 172.16.1.1
 !
 router bgp 65100
    router-id 10.255.0.2
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/group_vars/DC1.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/group_vars/DC1.yml
@@ -18,8 +18,6 @@ spine:
       # - update wait-for-convergence
       # - update wait-install
       - distance bgp 20 200 200
-      - graceful-restart restart-time 300
-      - graceful-restart
 
   # Definition of nodes contained in this group.
   # Specific configuration of device must take place under the node definition. Each node inherites all values defined under 'defaults'
@@ -64,8 +62,6 @@ l3leaf:
       # The following command must not be enabled when using vEOS-lab
       # - update wait-install
       - distance bgp 20 200 200
-      - graceful-restart restart-time 300
-      - graceful-restart
     # Virtual router mac for VNIs assigned to Leaf switches in format xx:xx:xx:xx:xx:xx
     virtual_router_mac_address: 00:1c:73:00:00:99
     spanning_tree_priority: 4096

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/configs/dc1-leaf1a.cfg
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/configs/dc1-leaf1a.cfg
@@ -248,10 +248,10 @@ router bfd
 !
 router bgp 65101
    router-id 10.255.0.3
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/configs/dc1-leaf1b.cfg
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/configs/dc1-leaf1b.cfg
@@ -248,10 +248,10 @@ router bfd
 !
 router bgp 65101
    router-id 10.255.0.4
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/configs/dc1-leaf2a.cfg
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/configs/dc1-leaf2a.cfg
@@ -248,10 +248,10 @@ router bfd
 !
 router bgp 65102
    router-id 10.255.0.5
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/configs/dc1-leaf2b.cfg
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/configs/dc1-leaf2b.cfg
@@ -248,10 +248,10 @@ router bfd
 !
 router bgp 65102
    router-id 10.255.0.6
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/configs/dc1-spine1.cfg
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/configs/dc1-spine1.cfg
@@ -73,10 +73,10 @@ router bfd
 !
 router bgp 65100
    router-id 10.255.0.1
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/configs/dc1-spine2.cfg
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/configs/dc1-spine2.cfg
@@ -73,10 +73,10 @@ router bfd
 !
 router bgp 65100
    router-id 10.255.0.2
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf1a.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf1a.yml
@@ -3,12 +3,13 @@ router_bgp:
   router_id: 10.255.0.3
   bgp_defaults:
   - distance bgp 20 200 200
-  - graceful-restart restart-time 300
-  - graceful-restart
   - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf1b.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf1b.yml
@@ -3,12 +3,13 @@ router_bgp:
   router_id: 10.255.0.4
   bgp_defaults:
   - distance bgp 20 200 200
-  - graceful-restart restart-time 300
-  - graceful-restart
   - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf2a.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf2a.yml
@@ -3,12 +3,13 @@ router_bgp:
   router_id: 10.255.0.5
   bgp_defaults:
   - distance bgp 20 200 200
-  - graceful-restart restart-time 300
-  - graceful-restart
   - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf2b.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf2b.yml
@@ -3,12 +3,13 @@ router_bgp:
   router_id: 10.255.0.6
   bgp_defaults:
   - distance bgp 20 200 200
-  - graceful-restart restart-time 300
-  - graceful-restart
   - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-spine1.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-spine1.yml
@@ -3,12 +3,13 @@ router_bgp:
   router_id: 10.255.0.1
   bgp_defaults:
   - distance bgp 20 200 200
-  - graceful-restart restart-time 300
-  - graceful-restart
   - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-spine2.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-spine2.yml
@@ -3,12 +3,13 @@ router_bgp:
   router_id: 10.255.0.2
   bgp_defaults:
   - distance bgp 20 200 200
-  - graceful-restart restart-time 300
-  - graceful-restart
   - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
@@ -47,6 +47,10 @@ interface Management1
 
 | BGP Tuning |
 | ---------- |
+| graceful-restart restart-time 555 |
+| graceful-restart stalepath-time 666 |
+| graceful-restart |
+| graceful-restart-helper restart-time 888 |
 | bgp bestpath d-path |
 | update wait-for-convergence |
 | update wait-install |

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-BL1A.md
@@ -631,6 +631,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | ---------- |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -711,6 +713,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 !
 router bgp 65104
    router-id 192.168.255.10
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-BL1B.md
@@ -631,6 +631,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | ---------- |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -711,6 +713,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 !
 router bgp 65104
    router-id 192.168.255.11
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF1A.md
@@ -519,6 +519,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | ---------- |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -583,6 +585,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 !
 router bgp 65101
    router-id 192.168.255.5
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF2A.md
@@ -858,6 +858,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | ---------- |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -947,6 +949,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 !
 router bgp 65102
    router-id 192.168.255.6
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF2B.md
@@ -858,6 +858,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | ---------- |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -947,6 +949,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 !
 router bgp 65102
    router-id 192.168.255.7
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE1.md
@@ -366,6 +366,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | ---------- |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -423,6 +425,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 !
 router bgp 65001
    router-id 192.168.255.1
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE2.md
@@ -366,6 +366,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | ---------- |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -423,6 +425,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 !
 router bgp 65001
    router-id 192.168.255.2
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE3.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE3.md
@@ -366,6 +366,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | ---------- |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -423,6 +425,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 !
 router bgp 65001
    router-id 192.168.255.3
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE4.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE4.md
@@ -366,6 +366,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | ---------- |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -423,6 +425,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 !
 router bgp 65001
    router-id 192.168.255.4
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SVC3A.md
@@ -974,6 +974,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | ---------- |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -1072,6 +1074,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 !
 router bgp 65103
    router-id 192.168.255.8
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SVC3B.md
@@ -948,6 +948,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | ---------- |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -1046,6 +1048,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 !
 router bgp 65103
    router-id 192.168.255.9
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-BL1A.cfg
@@ -225,6 +225,8 @@ router bfd
 !
 router bgp 65104
    router-id 192.168.255.10
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-BL1B.cfg
@@ -225,6 +225,8 @@ router bfd
 !
 router bgp 65104
    router-id 192.168.255.11
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-LEAF1A.cfg
@@ -162,6 +162,8 @@ router bfd
 !
 router bgp 65101
    router-id 192.168.255.5
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-LEAF2A.cfg
@@ -399,6 +399,8 @@ router bfd
 !
 router bgp 65102
    router-id 192.168.255.6
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-LEAF2B.cfg
@@ -399,6 +399,8 @@ router bfd
 !
 router bgp 65102
    router-id 192.168.255.7
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SPINE1.cfg
@@ -103,6 +103,8 @@ router bfd
 !
 router bgp 65001
    router-id 192.168.255.1
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SPINE2.cfg
@@ -103,6 +103,8 @@ router bfd
 !
 router bgp 65001
    router-id 192.168.255.2
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SPINE3.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SPINE3.cfg
@@ -103,6 +103,8 @@ router bfd
 !
 router bgp 65001
    router-id 192.168.255.3
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SPINE4.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SPINE4.cfg
@@ -103,6 +103,8 @@ router bfd
 !
 router bgp 65001
    router-id 192.168.255.4
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SVC3A.cfg
@@ -482,6 +482,8 @@ router bfd
 !
 router bgp 65103
    router-id 192.168.255.8
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SVC3B.cfg
@@ -466,6 +466,8 @@ router bfd
 !
 router bgp 65103
    router-id 192.168.255.9
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-BL1A.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-BL1B.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF1A.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF2A.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF2B.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SPINE1.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SPINE2.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SPINE3.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SPINE4.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SVC3A.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SVC3B.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/cvp/cv_server_configlets.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/cvp/cv_server_configlets.yml
@@ -62,50 +62,50 @@ cvp_configlets:
     RM-MLAG-PEER-IN permit 10\n   description Make routes learned over MLAG Peer-link
     less preferred on spines to ensure optimal routing\n   set origin incomplete\n!\nrouter
     bfd\n   multihop interval 1200 min-rx 1200 multiplier 3\n!\nrouter bgp 65104\n
-    \  router-id 192.168.255.10\n   no bgp default ipv4-unicast\n   distance bgp 20
-    200 200\n   maximum-paths 4 ecmp 4\n   neighbor EVPN-OVERLAY-PEERS peer group\n
-    \  neighbor EVPN-OVERLAY-PEERS update-source Loopback0\n   neighbor EVPN-OVERLAY-PEERS
-    bfd\n   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS
-    password 7 q+VNViP5i4rVjW1cxFv2wA==\n   neighbor EVPN-OVERLAY-PEERS send-community\n
-    \  neighbor EVPN-OVERLAY-PEERS maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS
-    peer group\n   neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==\n
-    \  neighbor IPv4-UNDERLAY-PEERS send-community\n   neighbor IPv4-UNDERLAY-PEERS
-    maximum-routes 12000\n   neighbor MLAG-IPv4-UNDERLAY-PEER peer group\n   neighbor
-    MLAG-IPv4-UNDERLAY-PEER remote-as 65104\n   neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self\n
-    \  neighbor MLAG-IPv4-UNDERLAY-PEER description DC1-BL1B\n   neighbor MLAG-IPv4-UNDERLAY-PEER
-    password 7 vnEaG8gMeQf3d3cN6PktXQ==\n   neighbor MLAG-IPv4-UNDERLAY-PEER send-community\n
-    \  neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000\n   neighbor MLAG-IPv4-UNDERLAY-PEER
-    route-map RM-MLAG-PEER-IN in\n   neighbor 10.255.251.11 peer group MLAG-IPv4-UNDERLAY-PEER\n
-    \  neighbor 10.255.251.11 description DC1-BL1B\n   neighbor 172.31.255.40 peer
-    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.40 remote-as 65001\n   neighbor
-    172.31.255.40 description DC1-SPINE1_Ethernet6\n   neighbor 172.31.255.42 peer
-    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.42 remote-as 65001\n   neighbor
-    172.31.255.42 description DC1-SPINE2_Ethernet6\n   neighbor 172.31.255.44 peer
-    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.44 remote-as 65001\n   neighbor
-    172.31.255.44 description DC1-SPINE3_Ethernet6\n   neighbor 172.31.255.46 peer
-    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.46 remote-as 65001\n   neighbor
-    172.31.255.46 description DC1-SPINE4_Ethernet6\n   neighbor 192.168.255.1 peer
-    group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.1 remote-as 65001\n   neighbor
-    192.168.255.1 description DC1-SPINE1\n   neighbor 192.168.255.2 peer group EVPN-OVERLAY-PEERS\n
-    \  neighbor 192.168.255.2 remote-as 65001\n   neighbor 192.168.255.2 description
-    DC1-SPINE2\n   neighbor 192.168.255.3 peer group EVPN-OVERLAY-PEERS\n   neighbor
-    192.168.255.3 remote-as 65001\n   neighbor 192.168.255.3 description DC1-SPINE3\n
-    \  neighbor 192.168.255.4 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.4
-    remote-as 65001\n   neighbor 192.168.255.4 description DC1-SPINE4\n   redistribute
-    connected route-map RM-CONN-2-BGP\n   !\n   vlan-aware-bundle Tenant_A_WAN_Zone\n
-    \     rd 192.168.255.10:14\n      route-target both 14:14\n      redistribute
-    learned\n      vlan 150\n   !\n   vlan-aware-bundle Tenant_B_WAN_Zone\n      rd
-    192.168.255.10:21\n      route-target both 21:21\n      redistribute learned\n
-    \     vlan 250\n   !\n   vlan-aware-bundle Tenant_C_WAN_Zone\n      rd 192.168.255.10:31\n
-    \     route-target both 31:31\n      redistribute learned\n      vlan 350\n   !\n
-    \  address-family evpn\n      neighbor EVPN-OVERLAY-PEERS activate\n   !\n   address-family
-    ipv4\n      no neighbor EVPN-OVERLAY-PEERS activate\n      neighbor IPv4-UNDERLAY-PEERS
-    activate\n      neighbor MLAG-IPv4-UNDERLAY-PEER activate\n   !\n   vrf Tenant_A_WAN_Zone\n
-    \     rd 192.168.255.10:14\n      route-target import evpn 14:14\n      route-target
-    export evpn 14:14\n      router-id 192.168.255.10\n      neighbor 10.255.251.11
-    peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute connected\n   !\n   vrf
-    Tenant_B_WAN_Zone\n      rd 192.168.255.10:21\n      route-target import evpn
-    21:21\n      route-target export evpn 21:21\n      router-id 192.168.255.10\n
+    \  router-id 192.168.255.10\n   graceful-restart restart-time 300\n   graceful-restart\n
+    \  no bgp default ipv4-unicast\n   distance bgp 20 200 200\n   maximum-paths 4
+    ecmp 4\n   neighbor EVPN-OVERLAY-PEERS peer group\n   neighbor EVPN-OVERLAY-PEERS
+    update-source Loopback0\n   neighbor EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS
+    ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n
+    \  neighbor EVPN-OVERLAY-PEERS send-community\n   neighbor EVPN-OVERLAY-PEERS
+    maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS peer group\n   neighbor IPv4-UNDERLAY-PEERS
+    password 7 AQQvKeimxJu+uGQ/yYvv9w==\n   neighbor IPv4-UNDERLAY-PEERS send-community\n
+    \  neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000\n   neighbor MLAG-IPv4-UNDERLAY-PEER
+    peer group\n   neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65104\n   neighbor MLAG-IPv4-UNDERLAY-PEER
+    next-hop-self\n   neighbor MLAG-IPv4-UNDERLAY-PEER description DC1-BL1B\n   neighbor
+    MLAG-IPv4-UNDERLAY-PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==\n   neighbor MLAG-IPv4-UNDERLAY-PEER
+    send-community\n   neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000\n   neighbor
+    MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN in\n   neighbor 10.255.251.11
+    peer group MLAG-IPv4-UNDERLAY-PEER\n   neighbor 10.255.251.11 description DC1-BL1B\n
+    \  neighbor 172.31.255.40 peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.40
+    remote-as 65001\n   neighbor 172.31.255.40 description DC1-SPINE1_Ethernet6\n
+    \  neighbor 172.31.255.42 peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.42
+    remote-as 65001\n   neighbor 172.31.255.42 description DC1-SPINE2_Ethernet6\n
+    \  neighbor 172.31.255.44 peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.44
+    remote-as 65001\n   neighbor 172.31.255.44 description DC1-SPINE3_Ethernet6\n
+    \  neighbor 172.31.255.46 peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.46
+    remote-as 65001\n   neighbor 172.31.255.46 description DC1-SPINE4_Ethernet6\n
+    \  neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.1
+    remote-as 65001\n   neighbor 192.168.255.1 description DC1-SPINE1\n   neighbor
+    192.168.255.2 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.2 remote-as
+    65001\n   neighbor 192.168.255.2 description DC1-SPINE2\n   neighbor 192.168.255.3
+    peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.3 remote-as 65001\n   neighbor
+    192.168.255.3 description DC1-SPINE3\n   neighbor 192.168.255.4 peer group EVPN-OVERLAY-PEERS\n
+    \  neighbor 192.168.255.4 remote-as 65001\n   neighbor 192.168.255.4 description
+    DC1-SPINE4\n   redistribute connected route-map RM-CONN-2-BGP\n   !\n   vlan-aware-bundle
+    Tenant_A_WAN_Zone\n      rd 192.168.255.10:14\n      route-target both 14:14\n
+    \     redistribute learned\n      vlan 150\n   !\n   vlan-aware-bundle Tenant_B_WAN_Zone\n
+    \     rd 192.168.255.10:21\n      route-target both 21:21\n      redistribute
+    learned\n      vlan 250\n   !\n   vlan-aware-bundle Tenant_C_WAN_Zone\n      rd
+    192.168.255.10:31\n      route-target both 31:31\n      redistribute learned\n
+    \     vlan 350\n   !\n   address-family evpn\n      neighbor EVPN-OVERLAY-PEERS
+    activate\n   !\n   address-family ipv4\n      no neighbor EVPN-OVERLAY-PEERS activate\n
+    \     neighbor IPv4-UNDERLAY-PEERS activate\n      neighbor MLAG-IPv4-UNDERLAY-PEER
+    activate\n   !\n   vrf Tenant_A_WAN_Zone\n      rd 192.168.255.10:14\n      route-target
+    import evpn 14:14\n      route-target export evpn 14:14\n      router-id 192.168.255.10\n
+    \     neighbor 10.255.251.11 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n   !\n   vrf Tenant_B_WAN_Zone\n      rd 192.168.255.10:21\n      route-target
+    import evpn 21:21\n      route-target export evpn 21:21\n      router-id 192.168.255.10\n
     \     neighbor 10.255.251.11 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
     connected\n   !\n   vrf Tenant_C_WAN_Zone\n      rd 192.168.255.10:31\n      route-target
     import evpn 31:31\n      route-target export evpn 31:31\n      router-id 192.168.255.10\n
@@ -175,50 +175,50 @@ cvp_configlets:
     RM-MLAG-PEER-IN permit 10\n   description Make routes learned over MLAG Peer-link
     less preferred on spines to ensure optimal routing\n   set origin incomplete\n!\nrouter
     bfd\n   multihop interval 1200 min-rx 1200 multiplier 3\n!\nrouter bgp 65104\n
-    \  router-id 192.168.255.11\n   no bgp default ipv4-unicast\n   distance bgp 20
-    200 200\n   maximum-paths 4 ecmp 4\n   neighbor EVPN-OVERLAY-PEERS peer group\n
-    \  neighbor EVPN-OVERLAY-PEERS update-source Loopback0\n   neighbor EVPN-OVERLAY-PEERS
-    bfd\n   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS
-    password 7 q+VNViP5i4rVjW1cxFv2wA==\n   neighbor EVPN-OVERLAY-PEERS send-community\n
-    \  neighbor EVPN-OVERLAY-PEERS maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS
-    peer group\n   neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==\n
-    \  neighbor IPv4-UNDERLAY-PEERS send-community\n   neighbor IPv4-UNDERLAY-PEERS
-    maximum-routes 12000\n   neighbor MLAG-IPv4-UNDERLAY-PEER peer group\n   neighbor
-    MLAG-IPv4-UNDERLAY-PEER remote-as 65104\n   neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self\n
-    \  neighbor MLAG-IPv4-UNDERLAY-PEER description DC1-BL1A\n   neighbor MLAG-IPv4-UNDERLAY-PEER
-    password 7 vnEaG8gMeQf3d3cN6PktXQ==\n   neighbor MLAG-IPv4-UNDERLAY-PEER send-community\n
-    \  neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000\n   neighbor MLAG-IPv4-UNDERLAY-PEER
-    route-map RM-MLAG-PEER-IN in\n   neighbor 10.255.251.10 peer group MLAG-IPv4-UNDERLAY-PEER\n
-    \  neighbor 10.255.251.10 description DC1-BL1A\n   neighbor 172.31.255.48 peer
-    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.48 remote-as 65001\n   neighbor
-    172.31.255.48 description DC1-SPINE1_Ethernet7\n   neighbor 172.31.255.50 peer
-    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.50 remote-as 65001\n   neighbor
-    172.31.255.50 description DC1-SPINE2_Ethernet7\n   neighbor 172.31.255.52 peer
-    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.52 remote-as 65001\n   neighbor
-    172.31.255.52 description DC1-SPINE3_Ethernet7\n   neighbor 172.31.255.54 peer
-    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.54 remote-as 65001\n   neighbor
-    172.31.255.54 description DC1-SPINE4_Ethernet7\n   neighbor 192.168.255.1 peer
-    group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.1 remote-as 65001\n   neighbor
-    192.168.255.1 description DC1-SPINE1\n   neighbor 192.168.255.2 peer group EVPN-OVERLAY-PEERS\n
-    \  neighbor 192.168.255.2 remote-as 65001\n   neighbor 192.168.255.2 description
-    DC1-SPINE2\n   neighbor 192.168.255.3 peer group EVPN-OVERLAY-PEERS\n   neighbor
-    192.168.255.3 remote-as 65001\n   neighbor 192.168.255.3 description DC1-SPINE3\n
-    \  neighbor 192.168.255.4 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.4
-    remote-as 65001\n   neighbor 192.168.255.4 description DC1-SPINE4\n   redistribute
-    connected route-map RM-CONN-2-BGP\n   !\n   vlan-aware-bundle Tenant_A_WAN_Zone\n
-    \     rd 192.168.255.11:14\n      route-target both 14:14\n      redistribute
-    learned\n      vlan 150\n   !\n   vlan-aware-bundle Tenant_B_WAN_Zone\n      rd
-    192.168.255.11:21\n      route-target both 21:21\n      redistribute learned\n
-    \     vlan 250\n   !\n   vlan-aware-bundle Tenant_C_WAN_Zone\n      rd 192.168.255.11:31\n
-    \     route-target both 31:31\n      redistribute learned\n      vlan 350\n   !\n
-    \  address-family evpn\n      neighbor EVPN-OVERLAY-PEERS activate\n   !\n   address-family
-    ipv4\n      no neighbor EVPN-OVERLAY-PEERS activate\n      neighbor IPv4-UNDERLAY-PEERS
-    activate\n      neighbor MLAG-IPv4-UNDERLAY-PEER activate\n   !\n   vrf Tenant_A_WAN_Zone\n
-    \     rd 192.168.255.11:14\n      route-target import evpn 14:14\n      route-target
-    export evpn 14:14\n      router-id 192.168.255.11\n      neighbor 10.255.251.10
-    peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute connected\n   !\n   vrf
-    Tenant_B_WAN_Zone\n      rd 192.168.255.11:21\n      route-target import evpn
-    21:21\n      route-target export evpn 21:21\n      router-id 192.168.255.11\n
+    \  router-id 192.168.255.11\n   graceful-restart restart-time 300\n   graceful-restart\n
+    \  no bgp default ipv4-unicast\n   distance bgp 20 200 200\n   maximum-paths 4
+    ecmp 4\n   neighbor EVPN-OVERLAY-PEERS peer group\n   neighbor EVPN-OVERLAY-PEERS
+    update-source Loopback0\n   neighbor EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS
+    ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n
+    \  neighbor EVPN-OVERLAY-PEERS send-community\n   neighbor EVPN-OVERLAY-PEERS
+    maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS peer group\n   neighbor IPv4-UNDERLAY-PEERS
+    password 7 AQQvKeimxJu+uGQ/yYvv9w==\n   neighbor IPv4-UNDERLAY-PEERS send-community\n
+    \  neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000\n   neighbor MLAG-IPv4-UNDERLAY-PEER
+    peer group\n   neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65104\n   neighbor MLAG-IPv4-UNDERLAY-PEER
+    next-hop-self\n   neighbor MLAG-IPv4-UNDERLAY-PEER description DC1-BL1A\n   neighbor
+    MLAG-IPv4-UNDERLAY-PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==\n   neighbor MLAG-IPv4-UNDERLAY-PEER
+    send-community\n   neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000\n   neighbor
+    MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN in\n   neighbor 10.255.251.10
+    peer group MLAG-IPv4-UNDERLAY-PEER\n   neighbor 10.255.251.10 description DC1-BL1A\n
+    \  neighbor 172.31.255.48 peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.48
+    remote-as 65001\n   neighbor 172.31.255.48 description DC1-SPINE1_Ethernet7\n
+    \  neighbor 172.31.255.50 peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.50
+    remote-as 65001\n   neighbor 172.31.255.50 description DC1-SPINE2_Ethernet7\n
+    \  neighbor 172.31.255.52 peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.52
+    remote-as 65001\n   neighbor 172.31.255.52 description DC1-SPINE3_Ethernet7\n
+    \  neighbor 172.31.255.54 peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.54
+    remote-as 65001\n   neighbor 172.31.255.54 description DC1-SPINE4_Ethernet7\n
+    \  neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.1
+    remote-as 65001\n   neighbor 192.168.255.1 description DC1-SPINE1\n   neighbor
+    192.168.255.2 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.2 remote-as
+    65001\n   neighbor 192.168.255.2 description DC1-SPINE2\n   neighbor 192.168.255.3
+    peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.3 remote-as 65001\n   neighbor
+    192.168.255.3 description DC1-SPINE3\n   neighbor 192.168.255.4 peer group EVPN-OVERLAY-PEERS\n
+    \  neighbor 192.168.255.4 remote-as 65001\n   neighbor 192.168.255.4 description
+    DC1-SPINE4\n   redistribute connected route-map RM-CONN-2-BGP\n   !\n   vlan-aware-bundle
+    Tenant_A_WAN_Zone\n      rd 192.168.255.11:14\n      route-target both 14:14\n
+    \     redistribute learned\n      vlan 150\n   !\n   vlan-aware-bundle Tenant_B_WAN_Zone\n
+    \     rd 192.168.255.11:21\n      route-target both 21:21\n      redistribute
+    learned\n      vlan 250\n   !\n   vlan-aware-bundle Tenant_C_WAN_Zone\n      rd
+    192.168.255.11:31\n      route-target both 31:31\n      redistribute learned\n
+    \     vlan 350\n   !\n   address-family evpn\n      neighbor EVPN-OVERLAY-PEERS
+    activate\n   !\n   address-family ipv4\n      no neighbor EVPN-OVERLAY-PEERS activate\n
+    \     neighbor IPv4-UNDERLAY-PEERS activate\n      neighbor MLAG-IPv4-UNDERLAY-PEER
+    activate\n   !\n   vrf Tenant_A_WAN_Zone\n      rd 192.168.255.11:14\n      route-target
+    import evpn 14:14\n      route-target export evpn 14:14\n      router-id 192.168.255.11\n
+    \     neighbor 10.255.251.10 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n   !\n   vrf Tenant_B_WAN_Zone\n      rd 192.168.255.11:21\n      route-target
+    import evpn 21:21\n      route-target export evpn 21:21\n      router-id 192.168.255.11\n
     \     neighbor 10.255.251.10 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
     connected\n   !\n   vrf Tenant_C_WAN_Zone\n      rd 192.168.255.11:31\n      route-target
     import evpn 31:31\n      route-target export evpn 31:31\n      router-id 192.168.255.11\n
@@ -364,18 +364,19 @@ cvp_configlets:
     route vrf MGMT 0.0.0.0/0 192.168.200.5\n!\nroute-map RM-CONN-2-BGP permit 10\n
     \  match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n!\nrouter bfd\n   multihop
     interval 1200 min-rx 1200 multiplier 3\n!\nrouter bgp 65101\n   router-id 192.168.255.5\n
-    \  no bgp default ipv4-unicast\n   distance bgp 20 200 200\n   maximum-paths 4
-    ecmp 4\n   neighbor EVPN-OVERLAY-PEERS peer group\n   neighbor EVPN-OVERLAY-PEERS
-    update-source Loopback0\n   neighbor EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS
-    ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n
-    \  neighbor EVPN-OVERLAY-PEERS send-community\n   neighbor EVPN-OVERLAY-PEERS
-    maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS peer group\n   neighbor IPv4-UNDERLAY-PEERS
-    password 7 AQQvKeimxJu+uGQ/yYvv9w==\n   neighbor IPv4-UNDERLAY-PEERS send-community\n
-    \  neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000\n   neighbor 172.31.255.0
-    peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.0 remote-as 65001\n   neighbor
-    172.31.255.0 description DC1-SPINE1_Ethernet1\n   neighbor 172.31.255.2 peer group
-    IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.2 remote-as 65001\n   neighbor 172.31.255.2
-    description DC1-SPINE2_Ethernet1\n   neighbor 172.31.255.4 peer group IPv4-UNDERLAY-PEERS\n
+    \  graceful-restart restart-time 300\n   graceful-restart\n   no bgp default ipv4-unicast\n
+    \  distance bgp 20 200 200\n   maximum-paths 4 ecmp 4\n   neighbor EVPN-OVERLAY-PEERS
+    peer group\n   neighbor EVPN-OVERLAY-PEERS update-source Loopback0\n   neighbor
+    EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3\n   neighbor
+    EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n   neighbor EVPN-OVERLAY-PEERS
+    send-community\n   neighbor EVPN-OVERLAY-PEERS maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS
+    peer group\n   neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==\n
+    \  neighbor IPv4-UNDERLAY-PEERS send-community\n   neighbor IPv4-UNDERLAY-PEERS
+    maximum-routes 12000\n   neighbor 172.31.255.0 peer group IPv4-UNDERLAY-PEERS\n
+    \  neighbor 172.31.255.0 remote-as 65001\n   neighbor 172.31.255.0 description
+    DC1-SPINE1_Ethernet1\n   neighbor 172.31.255.2 peer group IPv4-UNDERLAY-PEERS\n
+    \  neighbor 172.31.255.2 remote-as 65001\n   neighbor 172.31.255.2 description
+    DC1-SPINE2_Ethernet1\n   neighbor 172.31.255.4 peer group IPv4-UNDERLAY-PEERS\n
     \  neighbor 172.31.255.4 remote-as 65001\n   neighbor 172.31.255.4 description
     DC1-SPINE3_Ethernet1\n   neighbor 172.31.255.6 peer group IPv4-UNDERLAY-PEERS\n
     \  neighbor 172.31.255.6 remote-as 65001\n   neighbor 172.31.255.6 description
@@ -508,51 +509,51 @@ cvp_configlets:
     RM-MLAG-PEER-IN permit 10\n   description Make routes learned over MLAG Peer-link
     less preferred on spines to ensure optimal routing\n   set origin incomplete\n!\nrouter
     bfd\n   multihop interval 1200 min-rx 1200 multiplier 3\n!\nrouter bgp 65102\n
-    \  router-id 192.168.255.6\n   no bgp default ipv4-unicast\n   distance bgp 20
-    200 200\n   maximum-paths 4 ecmp 4\n   neighbor EVPN-OVERLAY-PEERS peer group\n
-    \  neighbor EVPN-OVERLAY-PEERS update-source Loopback0\n   neighbor EVPN-OVERLAY-PEERS
-    bfd\n   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS
-    password 7 q+VNViP5i4rVjW1cxFv2wA==\n   neighbor EVPN-OVERLAY-PEERS send-community\n
-    \  neighbor EVPN-OVERLAY-PEERS maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS
-    peer group\n   neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==\n
-    \  neighbor IPv4-UNDERLAY-PEERS send-community\n   neighbor IPv4-UNDERLAY-PEERS
-    maximum-routes 12000\n   neighbor MLAG-IPv4-UNDERLAY-PEER peer group\n   neighbor
-    MLAG-IPv4-UNDERLAY-PEER remote-as 65102\n   neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self\n
-    \  neighbor MLAG-IPv4-UNDERLAY-PEER description DC1-LEAF2B\n   neighbor MLAG-IPv4-UNDERLAY-PEER
-    password 7 vnEaG8gMeQf3d3cN6PktXQ==\n   neighbor MLAG-IPv4-UNDERLAY-PEER send-community\n
-    \  neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000\n   neighbor MLAG-IPv4-UNDERLAY-PEER
-    route-map RM-MLAG-PEER-IN in\n   neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER\n
-    \  neighbor 10.255.251.3 description DC1-LEAF2B\n   neighbor 172.31.255.8 peer
-    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.8 remote-as 65001\n   neighbor
-    172.31.255.8 description DC1-SPINE1_Ethernet2\n   neighbor 172.31.255.10 peer
-    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.10 remote-as 65001\n   neighbor
-    172.31.255.10 description DC1-SPINE2_Ethernet2\n   neighbor 172.31.255.12 peer
-    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.12 remote-as 65001\n   neighbor
-    172.31.255.12 description DC1-SPINE3_Ethernet2\n   neighbor 172.31.255.14 peer
-    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.14 remote-as 65001\n   neighbor
-    172.31.255.14 description DC1-SPINE4_Ethernet2\n   neighbor 192.168.255.1 peer
-    group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.1 remote-as 65001\n   neighbor
-    192.168.255.1 description DC1-SPINE1\n   neighbor 192.168.255.2 peer group EVPN-OVERLAY-PEERS\n
-    \  neighbor 192.168.255.2 remote-as 65001\n   neighbor 192.168.255.2 description
-    DC1-SPINE2\n   neighbor 192.168.255.3 peer group EVPN-OVERLAY-PEERS\n   neighbor
-    192.168.255.3 remote-as 65001\n   neighbor 192.168.255.3 description DC1-SPINE3\n
-    \  neighbor 192.168.255.4 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.4
-    remote-as 65001\n   neighbor 192.168.255.4 description DC1-SPINE4\n   redistribute
-    connected route-map RM-CONN-2-BGP\n   !\n   vlan-aware-bundle Tenant_A_APP_Zone\n
-    \     rd 192.168.255.6:12\n      route-target both 12:12\n      redistribute learned\n
-    \     vlan 130-131\n   !\n   vlan-aware-bundle Tenant_A_DB_Zone\n      rd 192.168.255.6:13\n
-    \     route-target both 13:13\n      redistribute learned\n      vlan 140-141\n
-    \  !\n   vlan-aware-bundle Tenant_A_OP_Zone\n      rd 192.168.255.6:10\n      route-target
-    both 10:10\n      redistribute learned\n      vlan 110-111\n   !\n   vlan-aware-bundle
-    Tenant_A_WEB_Zone\n      rd 192.168.255.6:11\n      route-target both 11:11\n
-    \     redistribute learned\n      vlan 120-121\n   !\n   vlan-aware-bundle Tenant_B_OP_Zone\n
-    \     rd 192.168.255.6:20\n      route-target both 20:20\n      redistribute learned\n
-    \     vlan 210-211\n   !\n   vlan-aware-bundle Tenant_C_OP_Zone\n      rd 192.168.255.6:30\n
-    \     route-target both 30:30\n      redistribute learned\n      vlan 310-311\n
-    \  !\n   address-family evpn\n      neighbor EVPN-OVERLAY-PEERS activate\n   !\n
-    \  address-family ipv4\n      no neighbor EVPN-OVERLAY-PEERS activate\n      neighbor
-    IPv4-UNDERLAY-PEERS activate\n      neighbor MLAG-IPv4-UNDERLAY-PEER activate\n
-    \  !\n   vrf Tenant_A_APP_Zone\n      rd 192.168.255.6:12\n      route-target
+    \  router-id 192.168.255.6\n   graceful-restart restart-time 300\n   graceful-restart\n
+    \  no bgp default ipv4-unicast\n   distance bgp 20 200 200\n   maximum-paths 4
+    ecmp 4\n   neighbor EVPN-OVERLAY-PEERS peer group\n   neighbor EVPN-OVERLAY-PEERS
+    update-source Loopback0\n   neighbor EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS
+    ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n
+    \  neighbor EVPN-OVERLAY-PEERS send-community\n   neighbor EVPN-OVERLAY-PEERS
+    maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS peer group\n   neighbor IPv4-UNDERLAY-PEERS
+    password 7 AQQvKeimxJu+uGQ/yYvv9w==\n   neighbor IPv4-UNDERLAY-PEERS send-community\n
+    \  neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000\n   neighbor MLAG-IPv4-UNDERLAY-PEER
+    peer group\n   neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65102\n   neighbor MLAG-IPv4-UNDERLAY-PEER
+    next-hop-self\n   neighbor MLAG-IPv4-UNDERLAY-PEER description DC1-LEAF2B\n   neighbor
+    MLAG-IPv4-UNDERLAY-PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==\n   neighbor MLAG-IPv4-UNDERLAY-PEER
+    send-community\n   neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000\n   neighbor
+    MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN in\n   neighbor 10.255.251.3
+    peer group MLAG-IPv4-UNDERLAY-PEER\n   neighbor 10.255.251.3 description DC1-LEAF2B\n
+    \  neighbor 172.31.255.8 peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.8
+    remote-as 65001\n   neighbor 172.31.255.8 description DC1-SPINE1_Ethernet2\n   neighbor
+    172.31.255.10 peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.10 remote-as
+    65001\n   neighbor 172.31.255.10 description DC1-SPINE2_Ethernet2\n   neighbor
+    172.31.255.12 peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.12 remote-as
+    65001\n   neighbor 172.31.255.12 description DC1-SPINE3_Ethernet2\n   neighbor
+    172.31.255.14 peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.14 remote-as
+    65001\n   neighbor 172.31.255.14 description DC1-SPINE4_Ethernet2\n   neighbor
+    192.168.255.1 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.1 remote-as
+    65001\n   neighbor 192.168.255.1 description DC1-SPINE1\n   neighbor 192.168.255.2
+    peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.2 remote-as 65001\n   neighbor
+    192.168.255.2 description DC1-SPINE2\n   neighbor 192.168.255.3 peer group EVPN-OVERLAY-PEERS\n
+    \  neighbor 192.168.255.3 remote-as 65001\n   neighbor 192.168.255.3 description
+    DC1-SPINE3\n   neighbor 192.168.255.4 peer group EVPN-OVERLAY-PEERS\n   neighbor
+    192.168.255.4 remote-as 65001\n   neighbor 192.168.255.4 description DC1-SPINE4\n
+    \  redistribute connected route-map RM-CONN-2-BGP\n   !\n   vlan-aware-bundle
+    Tenant_A_APP_Zone\n      rd 192.168.255.6:12\n      route-target both 12:12\n
+    \     redistribute learned\n      vlan 130-131\n   !\n   vlan-aware-bundle Tenant_A_DB_Zone\n
+    \     rd 192.168.255.6:13\n      route-target both 13:13\n      redistribute learned\n
+    \     vlan 140-141\n   !\n   vlan-aware-bundle Tenant_A_OP_Zone\n      rd 192.168.255.6:10\n
+    \     route-target both 10:10\n      redistribute learned\n      vlan 110-111\n
+    \  !\n   vlan-aware-bundle Tenant_A_WEB_Zone\n      rd 192.168.255.6:11\n      route-target
+    both 11:11\n      redistribute learned\n      vlan 120-121\n   !\n   vlan-aware-bundle
+    Tenant_B_OP_Zone\n      rd 192.168.255.6:20\n      route-target both 20:20\n      redistribute
+    learned\n      vlan 210-211\n   !\n   vlan-aware-bundle Tenant_C_OP_Zone\n      rd
+    192.168.255.6:30\n      route-target both 30:30\n      redistribute learned\n
+    \     vlan 310-311\n   !\n   address-family evpn\n      neighbor EVPN-OVERLAY-PEERS
+    activate\n   !\n   address-family ipv4\n      no neighbor EVPN-OVERLAY-PEERS activate\n
+    \     neighbor IPv4-UNDERLAY-PEERS activate\n      neighbor MLAG-IPv4-UNDERLAY-PEER
+    activate\n   !\n   vrf Tenant_A_APP_Zone\n      rd 192.168.255.6:12\n      route-target
     import evpn 12:12\n      route-target export evpn 12:12\n      router-id 192.168.255.6\n
     \     neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
     connected\n   !\n   vrf Tenant_A_DB_Zone\n      rd 192.168.255.6:13\n      route-target
@@ -680,51 +681,51 @@ cvp_configlets:
     RM-MLAG-PEER-IN permit 10\n   description Make routes learned over MLAG Peer-link
     less preferred on spines to ensure optimal routing\n   set origin incomplete\n!\nrouter
     bfd\n   multihop interval 1200 min-rx 1200 multiplier 3\n!\nrouter bgp 65102\n
-    \  router-id 192.168.255.7\n   no bgp default ipv4-unicast\n   distance bgp 20
-    200 200\n   maximum-paths 4 ecmp 4\n   neighbor EVPN-OVERLAY-PEERS peer group\n
-    \  neighbor EVPN-OVERLAY-PEERS update-source Loopback0\n   neighbor EVPN-OVERLAY-PEERS
-    bfd\n   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS
-    password 7 q+VNViP5i4rVjW1cxFv2wA==\n   neighbor EVPN-OVERLAY-PEERS send-community\n
-    \  neighbor EVPN-OVERLAY-PEERS maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS
-    peer group\n   neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==\n
-    \  neighbor IPv4-UNDERLAY-PEERS send-community\n   neighbor IPv4-UNDERLAY-PEERS
-    maximum-routes 12000\n   neighbor MLAG-IPv4-UNDERLAY-PEER peer group\n   neighbor
-    MLAG-IPv4-UNDERLAY-PEER remote-as 65102\n   neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self\n
-    \  neighbor MLAG-IPv4-UNDERLAY-PEER description DC1-LEAF2A\n   neighbor MLAG-IPv4-UNDERLAY-PEER
-    password 7 vnEaG8gMeQf3d3cN6PktXQ==\n   neighbor MLAG-IPv4-UNDERLAY-PEER send-community\n
-    \  neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000\n   neighbor MLAG-IPv4-UNDERLAY-PEER
-    route-map RM-MLAG-PEER-IN in\n   neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER\n
-    \  neighbor 10.255.251.2 description DC1-LEAF2A\n   neighbor 172.31.255.16 peer
-    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.16 remote-as 65001\n   neighbor
-    172.31.255.16 description DC1-SPINE1_Ethernet3\n   neighbor 172.31.255.18 peer
-    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.18 remote-as 65001\n   neighbor
-    172.31.255.18 description DC1-SPINE2_Ethernet3\n   neighbor 172.31.255.20 peer
-    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.20 remote-as 65001\n   neighbor
-    172.31.255.20 description DC1-SPINE3_Ethernet3\n   neighbor 172.31.255.22 peer
-    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.22 remote-as 65001\n   neighbor
-    172.31.255.22 description DC1-SPINE4_Ethernet3\n   neighbor 192.168.255.1 peer
-    group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.1 remote-as 65001\n   neighbor
-    192.168.255.1 description DC1-SPINE1\n   neighbor 192.168.255.2 peer group EVPN-OVERLAY-PEERS\n
-    \  neighbor 192.168.255.2 remote-as 65001\n   neighbor 192.168.255.2 description
-    DC1-SPINE2\n   neighbor 192.168.255.3 peer group EVPN-OVERLAY-PEERS\n   neighbor
-    192.168.255.3 remote-as 65001\n   neighbor 192.168.255.3 description DC1-SPINE3\n
-    \  neighbor 192.168.255.4 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.4
-    remote-as 65001\n   neighbor 192.168.255.4 description DC1-SPINE4\n   redistribute
-    connected route-map RM-CONN-2-BGP\n   !\n   vlan-aware-bundle Tenant_A_APP_Zone\n
-    \     rd 192.168.255.7:12\n      route-target both 12:12\n      redistribute learned\n
-    \     vlan 130-131\n   !\n   vlan-aware-bundle Tenant_A_DB_Zone\n      rd 192.168.255.7:13\n
-    \     route-target both 13:13\n      redistribute learned\n      vlan 140-141\n
-    \  !\n   vlan-aware-bundle Tenant_A_OP_Zone\n      rd 192.168.255.7:10\n      route-target
-    both 10:10\n      redistribute learned\n      vlan 110-111\n   !\n   vlan-aware-bundle
-    Tenant_A_WEB_Zone\n      rd 192.168.255.7:11\n      route-target both 11:11\n
-    \     redistribute learned\n      vlan 120-121\n   !\n   vlan-aware-bundle Tenant_B_OP_Zone\n
-    \     rd 192.168.255.7:20\n      route-target both 20:20\n      redistribute learned\n
-    \     vlan 210-211\n   !\n   vlan-aware-bundle Tenant_C_OP_Zone\n      rd 192.168.255.7:30\n
-    \     route-target both 30:30\n      redistribute learned\n      vlan 310-311\n
-    \  !\n   address-family evpn\n      neighbor EVPN-OVERLAY-PEERS activate\n   !\n
-    \  address-family ipv4\n      no neighbor EVPN-OVERLAY-PEERS activate\n      neighbor
-    IPv4-UNDERLAY-PEERS activate\n      neighbor MLAG-IPv4-UNDERLAY-PEER activate\n
-    \  !\n   vrf Tenant_A_APP_Zone\n      rd 192.168.255.7:12\n      route-target
+    \  router-id 192.168.255.7\n   graceful-restart restart-time 300\n   graceful-restart\n
+    \  no bgp default ipv4-unicast\n   distance bgp 20 200 200\n   maximum-paths 4
+    ecmp 4\n   neighbor EVPN-OVERLAY-PEERS peer group\n   neighbor EVPN-OVERLAY-PEERS
+    update-source Loopback0\n   neighbor EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS
+    ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n
+    \  neighbor EVPN-OVERLAY-PEERS send-community\n   neighbor EVPN-OVERLAY-PEERS
+    maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS peer group\n   neighbor IPv4-UNDERLAY-PEERS
+    password 7 AQQvKeimxJu+uGQ/yYvv9w==\n   neighbor IPv4-UNDERLAY-PEERS send-community\n
+    \  neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000\n   neighbor MLAG-IPv4-UNDERLAY-PEER
+    peer group\n   neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65102\n   neighbor MLAG-IPv4-UNDERLAY-PEER
+    next-hop-self\n   neighbor MLAG-IPv4-UNDERLAY-PEER description DC1-LEAF2A\n   neighbor
+    MLAG-IPv4-UNDERLAY-PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==\n   neighbor MLAG-IPv4-UNDERLAY-PEER
+    send-community\n   neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000\n   neighbor
+    MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN in\n   neighbor 10.255.251.2
+    peer group MLAG-IPv4-UNDERLAY-PEER\n   neighbor 10.255.251.2 description DC1-LEAF2A\n
+    \  neighbor 172.31.255.16 peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.16
+    remote-as 65001\n   neighbor 172.31.255.16 description DC1-SPINE1_Ethernet3\n
+    \  neighbor 172.31.255.18 peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.18
+    remote-as 65001\n   neighbor 172.31.255.18 description DC1-SPINE2_Ethernet3\n
+    \  neighbor 172.31.255.20 peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.20
+    remote-as 65001\n   neighbor 172.31.255.20 description DC1-SPINE3_Ethernet3\n
+    \  neighbor 172.31.255.22 peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.22
+    remote-as 65001\n   neighbor 172.31.255.22 description DC1-SPINE4_Ethernet3\n
+    \  neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.1
+    remote-as 65001\n   neighbor 192.168.255.1 description DC1-SPINE1\n   neighbor
+    192.168.255.2 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.2 remote-as
+    65001\n   neighbor 192.168.255.2 description DC1-SPINE2\n   neighbor 192.168.255.3
+    peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.3 remote-as 65001\n   neighbor
+    192.168.255.3 description DC1-SPINE3\n   neighbor 192.168.255.4 peer group EVPN-OVERLAY-PEERS\n
+    \  neighbor 192.168.255.4 remote-as 65001\n   neighbor 192.168.255.4 description
+    DC1-SPINE4\n   redistribute connected route-map RM-CONN-2-BGP\n   !\n   vlan-aware-bundle
+    Tenant_A_APP_Zone\n      rd 192.168.255.7:12\n      route-target both 12:12\n
+    \     redistribute learned\n      vlan 130-131\n   !\n   vlan-aware-bundle Tenant_A_DB_Zone\n
+    \     rd 192.168.255.7:13\n      route-target both 13:13\n      redistribute learned\n
+    \     vlan 140-141\n   !\n   vlan-aware-bundle Tenant_A_OP_Zone\n      rd 192.168.255.7:10\n
+    \     route-target both 10:10\n      redistribute learned\n      vlan 110-111\n
+    \  !\n   vlan-aware-bundle Tenant_A_WEB_Zone\n      rd 192.168.255.7:11\n      route-target
+    both 11:11\n      redistribute learned\n      vlan 120-121\n   !\n   vlan-aware-bundle
+    Tenant_B_OP_Zone\n      rd 192.168.255.7:20\n      route-target both 20:20\n      redistribute
+    learned\n      vlan 210-211\n   !\n   vlan-aware-bundle Tenant_C_OP_Zone\n      rd
+    192.168.255.7:30\n      route-target both 30:30\n      redistribute learned\n
+    \     vlan 310-311\n   !\n   address-family evpn\n      neighbor EVPN-OVERLAY-PEERS
+    activate\n   !\n   address-family ipv4\n      no neighbor EVPN-OVERLAY-PEERS activate\n
+    \     neighbor IPv4-UNDERLAY-PEERS activate\n      neighbor MLAG-IPv4-UNDERLAY-PEER
+    activate\n   !\n   vrf Tenant_A_APP_Zone\n      rd 192.168.255.7:12\n      route-target
     import evpn 12:12\n      route-target export evpn 12:12\n      router-id 192.168.255.7\n
     \     neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
     connected\n   !\n   vrf Tenant_A_DB_Zone\n      rd 192.168.255.7:13\n      route-target
@@ -774,19 +775,19 @@ cvp_configlets:
     vrf MGMT 0.0.0.0/0 192.168.200.5\n!\nroute-map RM-CONN-2-BGP permit 10\n   match
     ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n!\nrouter bfd\n   multihop interval
     1200 min-rx 1200 multiplier 3\n!\nrouter bgp 65001\n   router-id 192.168.255.1\n
-    \  no bgp default ipv4-unicast\n   distance bgp 20 200 200\n   maximum-paths 4
-    ecmp 4\n   neighbor EVPN-OVERLAY-PEERS peer group\n   neighbor EVPN-OVERLAY-PEERS
-    next-hop-unchanged\n   neighbor EVPN-OVERLAY-PEERS update-source Loopback0\n   neighbor
-    EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3\n   neighbor
-    EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n   neighbor EVPN-OVERLAY-PEERS
-    send-community\n   neighbor EVPN-OVERLAY-PEERS maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS
-    peer group\n   neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==\n
-    \  neighbor IPv4-UNDERLAY-PEERS send-community\n   neighbor IPv4-UNDERLAY-PEERS
-    maximum-routes 12000\n   neighbor 172.31.255.1 peer group IPv4-UNDERLAY-PEERS\n
-    \  neighbor 172.31.255.1 remote-as 65101\n   neighbor 172.31.255.1 description
-    DC1-LEAF1A_Ethernet1\n   neighbor 172.31.255.9 peer group IPv4-UNDERLAY-PEERS\n
-    \  neighbor 172.31.255.9 remote-as 65102\n   neighbor 172.31.255.9 description
-    DC1-LEAF2A_Ethernet1\n   neighbor 172.31.255.17 peer group IPv4-UNDERLAY-PEERS\n
+    \  graceful-restart restart-time 300\n   graceful-restart\n   no bgp default ipv4-unicast\n
+    \  distance bgp 20 200 200\n   maximum-paths 4 ecmp 4\n   neighbor EVPN-OVERLAY-PEERS
+    peer group\n   neighbor EVPN-OVERLAY-PEERS next-hop-unchanged\n   neighbor EVPN-OVERLAY-PEERS
+    update-source Loopback0\n   neighbor EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS
+    ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n
+    \  neighbor EVPN-OVERLAY-PEERS send-community\n   neighbor EVPN-OVERLAY-PEERS
+    maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS peer group\n   neighbor IPv4-UNDERLAY-PEERS
+    password 7 AQQvKeimxJu+uGQ/yYvv9w==\n   neighbor IPv4-UNDERLAY-PEERS send-community\n
+    \  neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000\n   neighbor 172.31.255.1
+    peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.1 remote-as 65101\n   neighbor
+    172.31.255.1 description DC1-LEAF1A_Ethernet1\n   neighbor 172.31.255.9 peer group
+    IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.9 remote-as 65102\n   neighbor 172.31.255.9
+    description DC1-LEAF2A_Ethernet1\n   neighbor 172.31.255.17 peer group IPv4-UNDERLAY-PEERS\n
     \  neighbor 172.31.255.17 remote-as 65102\n   neighbor 172.31.255.17 description
     DC1-LEAF2B_Ethernet1\n   neighbor 172.31.255.25 peer group IPv4-UNDERLAY-PEERS\n
     \  neighbor 172.31.255.25 remote-as 65103\n   neighbor 172.31.255.25 description
@@ -844,29 +845,29 @@ cvp_configlets:
     vrf MGMT 0.0.0.0/0 192.168.200.5\n!\nroute-map RM-CONN-2-BGP permit 10\n   match
     ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n!\nrouter bfd\n   multihop interval
     1200 min-rx 1200 multiplier 3\n!\nrouter bgp 65001\n   router-id 192.168.255.2\n
-    \  no bgp default ipv4-unicast\n   distance bgp 20 200 200\n   maximum-paths 4
-    ecmp 4\n   neighbor EVPN-OVERLAY-PEERS peer group\n   neighbor EVPN-OVERLAY-PEERS
-    next-hop-unchanged\n   neighbor EVPN-OVERLAY-PEERS update-source Loopback0\n   neighbor
-    EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3\n   neighbor
-    EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n   neighbor EVPN-OVERLAY-PEERS
-    send-community\n   neighbor EVPN-OVERLAY-PEERS maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS
-    peer group\n   neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==\n
-    \  neighbor IPv4-UNDERLAY-PEERS send-community\n   neighbor IPv4-UNDERLAY-PEERS
-    maximum-routes 12000\n   neighbor 172.31.255.3 peer group IPv4-UNDERLAY-PEERS\n
-    \  neighbor 172.31.255.3 remote-as 65101\n   neighbor 172.31.255.3 description
-    DC1-LEAF1A_Ethernet2\n   neighbor 172.31.255.11 peer group IPv4-UNDERLAY-PEERS\n
-    \  neighbor 172.31.255.11 remote-as 65102\n   neighbor 172.31.255.11 description
-    DC1-LEAF2A_Ethernet2\n   neighbor 172.31.255.19 peer group IPv4-UNDERLAY-PEERS\n
-    \  neighbor 172.31.255.19 remote-as 65102\n   neighbor 172.31.255.19 description
-    DC1-LEAF2B_Ethernet2\n   neighbor 172.31.255.27 peer group IPv4-UNDERLAY-PEERS\n
-    \  neighbor 172.31.255.27 remote-as 65103\n   neighbor 172.31.255.27 description
-    DC1-SVC3A_Ethernet2\n   neighbor 172.31.255.35 peer group IPv4-UNDERLAY-PEERS\n
-    \  neighbor 172.31.255.35 remote-as 65103\n   neighbor 172.31.255.35 description
-    DC1-SVC3B_Ethernet2\n   neighbor 172.31.255.43 peer group IPv4-UNDERLAY-PEERS\n
-    \  neighbor 172.31.255.43 remote-as 65104\n   neighbor 172.31.255.43 description
-    DC1-BL1A_Ethernet2\n   neighbor 172.31.255.51 peer group IPv4-UNDERLAY-PEERS\n
-    \  neighbor 172.31.255.51 remote-as 65104\n   neighbor 172.31.255.51 description
-    DC1-BL1B_Ethernet2\n   neighbor 192.168.255.5 peer group EVPN-OVERLAY-PEERS\n
+    \  graceful-restart restart-time 300\n   graceful-restart\n   no bgp default ipv4-unicast\n
+    \  distance bgp 20 200 200\n   maximum-paths 4 ecmp 4\n   neighbor EVPN-OVERLAY-PEERS
+    peer group\n   neighbor EVPN-OVERLAY-PEERS next-hop-unchanged\n   neighbor EVPN-OVERLAY-PEERS
+    update-source Loopback0\n   neighbor EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS
+    ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n
+    \  neighbor EVPN-OVERLAY-PEERS send-community\n   neighbor EVPN-OVERLAY-PEERS
+    maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS peer group\n   neighbor IPv4-UNDERLAY-PEERS
+    password 7 AQQvKeimxJu+uGQ/yYvv9w==\n   neighbor IPv4-UNDERLAY-PEERS send-community\n
+    \  neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000\n   neighbor 172.31.255.3
+    peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.3 remote-as 65101\n   neighbor
+    172.31.255.3 description DC1-LEAF1A_Ethernet2\n   neighbor 172.31.255.11 peer
+    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.11 remote-as 65102\n   neighbor
+    172.31.255.11 description DC1-LEAF2A_Ethernet2\n   neighbor 172.31.255.19 peer
+    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.19 remote-as 65102\n   neighbor
+    172.31.255.19 description DC1-LEAF2B_Ethernet2\n   neighbor 172.31.255.27 peer
+    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.27 remote-as 65103\n   neighbor
+    172.31.255.27 description DC1-SVC3A_Ethernet2\n   neighbor 172.31.255.35 peer
+    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.35 remote-as 65103\n   neighbor
+    172.31.255.35 description DC1-SVC3B_Ethernet2\n   neighbor 172.31.255.43 peer
+    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.43 remote-as 65104\n   neighbor
+    172.31.255.43 description DC1-BL1A_Ethernet2\n   neighbor 172.31.255.51 peer group
+    IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.51 remote-as 65104\n   neighbor 172.31.255.51
+    description DC1-BL1B_Ethernet2\n   neighbor 192.168.255.5 peer group EVPN-OVERLAY-PEERS\n
     \  neighbor 192.168.255.5 remote-as 65101\n   neighbor 192.168.255.5 description
     DC1-LEAF1A\n   neighbor 192.168.255.6 peer group EVPN-OVERLAY-PEERS\n   neighbor
     192.168.255.6 remote-as 65102\n   neighbor 192.168.255.6 description DC1-LEAF2A\n
@@ -914,29 +915,29 @@ cvp_configlets:
     vrf MGMT 0.0.0.0/0 192.168.200.5\n!\nroute-map RM-CONN-2-BGP permit 10\n   match
     ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n!\nrouter bfd\n   multihop interval
     1200 min-rx 1200 multiplier 3\n!\nrouter bgp 65001\n   router-id 192.168.255.3\n
-    \  no bgp default ipv4-unicast\n   distance bgp 20 200 200\n   maximum-paths 4
-    ecmp 4\n   neighbor EVPN-OVERLAY-PEERS peer group\n   neighbor EVPN-OVERLAY-PEERS
-    next-hop-unchanged\n   neighbor EVPN-OVERLAY-PEERS update-source Loopback0\n   neighbor
-    EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3\n   neighbor
-    EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n   neighbor EVPN-OVERLAY-PEERS
-    send-community\n   neighbor EVPN-OVERLAY-PEERS maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS
-    peer group\n   neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==\n
-    \  neighbor IPv4-UNDERLAY-PEERS send-community\n   neighbor IPv4-UNDERLAY-PEERS
-    maximum-routes 12000\n   neighbor 172.31.255.5 peer group IPv4-UNDERLAY-PEERS\n
-    \  neighbor 172.31.255.5 remote-as 65101\n   neighbor 172.31.255.5 description
-    DC1-LEAF1A_Ethernet3\n   neighbor 172.31.255.13 peer group IPv4-UNDERLAY-PEERS\n
-    \  neighbor 172.31.255.13 remote-as 65102\n   neighbor 172.31.255.13 description
-    DC1-LEAF2A_Ethernet3\n   neighbor 172.31.255.21 peer group IPv4-UNDERLAY-PEERS\n
-    \  neighbor 172.31.255.21 remote-as 65102\n   neighbor 172.31.255.21 description
-    DC1-LEAF2B_Ethernet3\n   neighbor 172.31.255.29 peer group IPv4-UNDERLAY-PEERS\n
-    \  neighbor 172.31.255.29 remote-as 65103\n   neighbor 172.31.255.29 description
-    DC1-SVC3A_Ethernet3\n   neighbor 172.31.255.37 peer group IPv4-UNDERLAY-PEERS\n
-    \  neighbor 172.31.255.37 remote-as 65103\n   neighbor 172.31.255.37 description
-    DC1-SVC3B_Ethernet3\n   neighbor 172.31.255.45 peer group IPv4-UNDERLAY-PEERS\n
-    \  neighbor 172.31.255.45 remote-as 65104\n   neighbor 172.31.255.45 description
-    DC1-BL1A_Ethernet3\n   neighbor 172.31.255.53 peer group IPv4-UNDERLAY-PEERS\n
-    \  neighbor 172.31.255.53 remote-as 65104\n   neighbor 172.31.255.53 description
-    DC1-BL1B_Ethernet3\n   neighbor 192.168.255.5 peer group EVPN-OVERLAY-PEERS\n
+    \  graceful-restart restart-time 300\n   graceful-restart\n   no bgp default ipv4-unicast\n
+    \  distance bgp 20 200 200\n   maximum-paths 4 ecmp 4\n   neighbor EVPN-OVERLAY-PEERS
+    peer group\n   neighbor EVPN-OVERLAY-PEERS next-hop-unchanged\n   neighbor EVPN-OVERLAY-PEERS
+    update-source Loopback0\n   neighbor EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS
+    ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n
+    \  neighbor EVPN-OVERLAY-PEERS send-community\n   neighbor EVPN-OVERLAY-PEERS
+    maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS peer group\n   neighbor IPv4-UNDERLAY-PEERS
+    password 7 AQQvKeimxJu+uGQ/yYvv9w==\n   neighbor IPv4-UNDERLAY-PEERS send-community\n
+    \  neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000\n   neighbor 172.31.255.5
+    peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.5 remote-as 65101\n   neighbor
+    172.31.255.5 description DC1-LEAF1A_Ethernet3\n   neighbor 172.31.255.13 peer
+    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.13 remote-as 65102\n   neighbor
+    172.31.255.13 description DC1-LEAF2A_Ethernet3\n   neighbor 172.31.255.21 peer
+    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.21 remote-as 65102\n   neighbor
+    172.31.255.21 description DC1-LEAF2B_Ethernet3\n   neighbor 172.31.255.29 peer
+    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.29 remote-as 65103\n   neighbor
+    172.31.255.29 description DC1-SVC3A_Ethernet3\n   neighbor 172.31.255.37 peer
+    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.37 remote-as 65103\n   neighbor
+    172.31.255.37 description DC1-SVC3B_Ethernet3\n   neighbor 172.31.255.45 peer
+    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.45 remote-as 65104\n   neighbor
+    172.31.255.45 description DC1-BL1A_Ethernet3\n   neighbor 172.31.255.53 peer group
+    IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.53 remote-as 65104\n   neighbor 172.31.255.53
+    description DC1-BL1B_Ethernet3\n   neighbor 192.168.255.5 peer group EVPN-OVERLAY-PEERS\n
     \  neighbor 192.168.255.5 remote-as 65101\n   neighbor 192.168.255.5 description
     DC1-LEAF1A\n   neighbor 192.168.255.6 peer group EVPN-OVERLAY-PEERS\n   neighbor
     192.168.255.6 remote-as 65102\n   neighbor 192.168.255.6 description DC1-LEAF2A\n
@@ -984,29 +985,29 @@ cvp_configlets:
     vrf MGMT 0.0.0.0/0 192.168.200.5\n!\nroute-map RM-CONN-2-BGP permit 10\n   match
     ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n!\nrouter bfd\n   multihop interval
     1200 min-rx 1200 multiplier 3\n!\nrouter bgp 65001\n   router-id 192.168.255.4\n
-    \  no bgp default ipv4-unicast\n   distance bgp 20 200 200\n   maximum-paths 4
-    ecmp 4\n   neighbor EVPN-OVERLAY-PEERS peer group\n   neighbor EVPN-OVERLAY-PEERS
-    next-hop-unchanged\n   neighbor EVPN-OVERLAY-PEERS update-source Loopback0\n   neighbor
-    EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3\n   neighbor
-    EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n   neighbor EVPN-OVERLAY-PEERS
-    send-community\n   neighbor EVPN-OVERLAY-PEERS maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS
-    peer group\n   neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==\n
-    \  neighbor IPv4-UNDERLAY-PEERS send-community\n   neighbor IPv4-UNDERLAY-PEERS
-    maximum-routes 12000\n   neighbor 172.31.255.7 peer group IPv4-UNDERLAY-PEERS\n
-    \  neighbor 172.31.255.7 remote-as 65101\n   neighbor 172.31.255.7 description
-    DC1-LEAF1A_Ethernet4\n   neighbor 172.31.255.15 peer group IPv4-UNDERLAY-PEERS\n
-    \  neighbor 172.31.255.15 remote-as 65102\n   neighbor 172.31.255.15 description
-    DC1-LEAF2A_Ethernet4\n   neighbor 172.31.255.23 peer group IPv4-UNDERLAY-PEERS\n
-    \  neighbor 172.31.255.23 remote-as 65102\n   neighbor 172.31.255.23 description
-    DC1-LEAF2B_Ethernet4\n   neighbor 172.31.255.31 peer group IPv4-UNDERLAY-PEERS\n
-    \  neighbor 172.31.255.31 remote-as 65103\n   neighbor 172.31.255.31 description
-    DC1-SVC3A_Ethernet4\n   neighbor 172.31.255.39 peer group IPv4-UNDERLAY-PEERS\n
-    \  neighbor 172.31.255.39 remote-as 65103\n   neighbor 172.31.255.39 description
-    DC1-SVC3B_Ethernet4\n   neighbor 172.31.255.47 peer group IPv4-UNDERLAY-PEERS\n
-    \  neighbor 172.31.255.47 remote-as 65104\n   neighbor 172.31.255.47 description
-    DC1-BL1A_Ethernet4\n   neighbor 172.31.255.55 peer group IPv4-UNDERLAY-PEERS\n
-    \  neighbor 172.31.255.55 remote-as 65104\n   neighbor 172.31.255.55 description
-    DC1-BL1B_Ethernet4\n   neighbor 192.168.255.5 peer group EVPN-OVERLAY-PEERS\n
+    \  graceful-restart restart-time 300\n   graceful-restart\n   no bgp default ipv4-unicast\n
+    \  distance bgp 20 200 200\n   maximum-paths 4 ecmp 4\n   neighbor EVPN-OVERLAY-PEERS
+    peer group\n   neighbor EVPN-OVERLAY-PEERS next-hop-unchanged\n   neighbor EVPN-OVERLAY-PEERS
+    update-source Loopback0\n   neighbor EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS
+    ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n
+    \  neighbor EVPN-OVERLAY-PEERS send-community\n   neighbor EVPN-OVERLAY-PEERS
+    maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS peer group\n   neighbor IPv4-UNDERLAY-PEERS
+    password 7 AQQvKeimxJu+uGQ/yYvv9w==\n   neighbor IPv4-UNDERLAY-PEERS send-community\n
+    \  neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000\n   neighbor 172.31.255.7
+    peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.7 remote-as 65101\n   neighbor
+    172.31.255.7 description DC1-LEAF1A_Ethernet4\n   neighbor 172.31.255.15 peer
+    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.15 remote-as 65102\n   neighbor
+    172.31.255.15 description DC1-LEAF2A_Ethernet4\n   neighbor 172.31.255.23 peer
+    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.23 remote-as 65102\n   neighbor
+    172.31.255.23 description DC1-LEAF2B_Ethernet4\n   neighbor 172.31.255.31 peer
+    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.31 remote-as 65103\n   neighbor
+    172.31.255.31 description DC1-SVC3A_Ethernet4\n   neighbor 172.31.255.39 peer
+    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.39 remote-as 65103\n   neighbor
+    172.31.255.39 description DC1-SVC3B_Ethernet4\n   neighbor 172.31.255.47 peer
+    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.47 remote-as 65104\n   neighbor
+    172.31.255.47 description DC1-BL1A_Ethernet4\n   neighbor 172.31.255.55 peer group
+    IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.55 remote-as 65104\n   neighbor 172.31.255.55
+    description DC1-BL1B_Ethernet4\n   neighbor 192.168.255.5 peer group EVPN-OVERLAY-PEERS\n
     \  neighbor 192.168.255.5 remote-as 65101\n   neighbor 192.168.255.5 description
     DC1-LEAF1A\n   neighbor 192.168.255.6 peer group EVPN-OVERLAY-PEERS\n   neighbor
     192.168.255.6 remote-as 65102\n   neighbor 192.168.255.6 description DC1-LEAF2A\n
@@ -1156,55 +1157,55 @@ cvp_configlets:
     RM-MLAG-PEER-IN permit 10\n   description Make routes learned over MLAG Peer-link
     less preferred on spines to ensure optimal routing\n   set origin incomplete\n!\nrouter
     bfd\n   multihop interval 1200 min-rx 1200 multiplier 3\n!\nrouter bgp 65103\n
-    \  router-id 192.168.255.8\n   no bgp default ipv4-unicast\n   distance bgp 20
-    200 200\n   maximum-paths 4 ecmp 4\n   neighbor EVPN-OVERLAY-PEERS peer group\n
-    \  neighbor EVPN-OVERLAY-PEERS update-source Loopback0\n   neighbor EVPN-OVERLAY-PEERS
-    bfd\n   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS
-    password 7 q+VNViP5i4rVjW1cxFv2wA==\n   neighbor EVPN-OVERLAY-PEERS send-community\n
-    \  neighbor EVPN-OVERLAY-PEERS maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS
-    peer group\n   neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==\n
-    \  neighbor IPv4-UNDERLAY-PEERS send-community\n   neighbor IPv4-UNDERLAY-PEERS
-    maximum-routes 12000\n   neighbor MLAG-IPv4-UNDERLAY-PEER peer group\n   neighbor
-    MLAG-IPv4-UNDERLAY-PEER remote-as 65103\n   neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self\n
-    \  neighbor MLAG-IPv4-UNDERLAY-PEER description DC1-SVC3B\n   neighbor MLAG-IPv4-UNDERLAY-PEER
-    password 7 vnEaG8gMeQf3d3cN6PktXQ==\n   neighbor MLAG-IPv4-UNDERLAY-PEER send-community\n
-    \  neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000\n   neighbor MLAG-IPv4-UNDERLAY-PEER
-    route-map RM-MLAG-PEER-IN in\n   neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n
-    \  neighbor 10.255.251.7 description DC1-SVC3B\n   neighbor 172.31.255.24 peer
-    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.24 remote-as 65001\n   neighbor
-    172.31.255.24 description DC1-SPINE1_Ethernet4\n   neighbor 172.31.255.26 peer
-    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.26 remote-as 65001\n   neighbor
-    172.31.255.26 description DC1-SPINE2_Ethernet4\n   neighbor 172.31.255.28 peer
-    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.28 remote-as 65001\n   neighbor
-    172.31.255.28 description DC1-SPINE3_Ethernet4\n   neighbor 172.31.255.30 peer
-    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.30 remote-as 65001\n   neighbor
-    172.31.255.30 description DC1-SPINE4_Ethernet4\n   neighbor 192.168.255.1 peer
-    group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.1 remote-as 65001\n   neighbor
-    192.168.255.1 description DC1-SPINE1\n   neighbor 192.168.255.2 peer group EVPN-OVERLAY-PEERS\n
-    \  neighbor 192.168.255.2 remote-as 65001\n   neighbor 192.168.255.2 description
-    DC1-SPINE2\n   neighbor 192.168.255.3 peer group EVPN-OVERLAY-PEERS\n   neighbor
-    192.168.255.3 remote-as 65001\n   neighbor 192.168.255.3 description DC1-SPINE3\n
-    \  neighbor 192.168.255.4 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.4
-    remote-as 65001\n   neighbor 192.168.255.4 description DC1-SPINE4\n   redistribute
-    connected route-map RM-CONN-2-BGP\n   !\n   vlan-aware-bundle Tenant_A_APP_Zone\n
-    \     rd 192.168.255.8:12\n      route-target both 12:12\n      redistribute learned\n
-    \     vlan 130-131\n   !\n   vlan-aware-bundle Tenant_A_DB_Zone\n      rd 192.168.255.8:13\n
-    \     route-target both 13:13\n      redistribute learned\n      vlan 140-141\n
-    \  !\n   vlan-aware-bundle Tenant_A_OP_Zone\n      rd 192.168.255.8:10\n      route-target
-    both 10:10\n      redistribute learned\n      vlan 110-111\n   !\n   vlan-aware-bundle
-    Tenant_A_WAN_Zone\n      rd 192.168.255.8:14\n      route-target both 14:14\n
-    \     redistribute learned\n      vlan 150\n   !\n   vlan-aware-bundle Tenant_A_WEB_Zone\n
-    \     rd 192.168.255.8:11\n      route-target both 11:11\n      redistribute learned\n
-    \     vlan 120-121\n   !\n   vlan-aware-bundle Tenant_B_OP_Zone\n      rd 192.168.255.8:20\n
-    \     route-target both 20:20\n      redistribute learned\n      vlan 210-211\n
-    \  !\n   vlan-aware-bundle Tenant_B_WAN_Zone\n      rd 192.168.255.8:21\n      route-target
-    both 21:21\n      redistribute learned\n      vlan 250\n   !\n   vlan-aware-bundle
-    Tenant_C_OP_Zone\n      rd 192.168.255.8:30\n      route-target both 30:30\n      redistribute
-    learned\n      vlan 310-311\n   !\n   vlan-aware-bundle Tenant_C_WAN_Zone\n      rd
-    192.168.255.8:31\n      route-target both 31:31\n      redistribute learned\n
-    \     vlan 350\n   !\n   address-family evpn\n      neighbor EVPN-OVERLAY-PEERS
-    activate\n   !\n   address-family ipv4\n      no neighbor EVPN-OVERLAY-PEERS activate\n
-    \     neighbor IPv4-UNDERLAY-PEERS activate\n      neighbor MLAG-IPv4-UNDERLAY-PEER
+    \  router-id 192.168.255.8\n   graceful-restart restart-time 300\n   graceful-restart\n
+    \  no bgp default ipv4-unicast\n   distance bgp 20 200 200\n   maximum-paths 4
+    ecmp 4\n   neighbor EVPN-OVERLAY-PEERS peer group\n   neighbor EVPN-OVERLAY-PEERS
+    update-source Loopback0\n   neighbor EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS
+    ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n
+    \  neighbor EVPN-OVERLAY-PEERS send-community\n   neighbor EVPN-OVERLAY-PEERS
+    maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS peer group\n   neighbor IPv4-UNDERLAY-PEERS
+    password 7 AQQvKeimxJu+uGQ/yYvv9w==\n   neighbor IPv4-UNDERLAY-PEERS send-community\n
+    \  neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000\n   neighbor MLAG-IPv4-UNDERLAY-PEER
+    peer group\n   neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65103\n   neighbor MLAG-IPv4-UNDERLAY-PEER
+    next-hop-self\n   neighbor MLAG-IPv4-UNDERLAY-PEER description DC1-SVC3B\n   neighbor
+    MLAG-IPv4-UNDERLAY-PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==\n   neighbor MLAG-IPv4-UNDERLAY-PEER
+    send-community\n   neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000\n   neighbor
+    MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN in\n   neighbor 10.255.251.7
+    peer group MLAG-IPv4-UNDERLAY-PEER\n   neighbor 10.255.251.7 description DC1-SVC3B\n
+    \  neighbor 172.31.255.24 peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.24
+    remote-as 65001\n   neighbor 172.31.255.24 description DC1-SPINE1_Ethernet4\n
+    \  neighbor 172.31.255.26 peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.26
+    remote-as 65001\n   neighbor 172.31.255.26 description DC1-SPINE2_Ethernet4\n
+    \  neighbor 172.31.255.28 peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.28
+    remote-as 65001\n   neighbor 172.31.255.28 description DC1-SPINE3_Ethernet4\n
+    \  neighbor 172.31.255.30 peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.30
+    remote-as 65001\n   neighbor 172.31.255.30 description DC1-SPINE4_Ethernet4\n
+    \  neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.1
+    remote-as 65001\n   neighbor 192.168.255.1 description DC1-SPINE1\n   neighbor
+    192.168.255.2 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.2 remote-as
+    65001\n   neighbor 192.168.255.2 description DC1-SPINE2\n   neighbor 192.168.255.3
+    peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.3 remote-as 65001\n   neighbor
+    192.168.255.3 description DC1-SPINE3\n   neighbor 192.168.255.4 peer group EVPN-OVERLAY-PEERS\n
+    \  neighbor 192.168.255.4 remote-as 65001\n   neighbor 192.168.255.4 description
+    DC1-SPINE4\n   redistribute connected route-map RM-CONN-2-BGP\n   !\n   vlan-aware-bundle
+    Tenant_A_APP_Zone\n      rd 192.168.255.8:12\n      route-target both 12:12\n
+    \     redistribute learned\n      vlan 130-131\n   !\n   vlan-aware-bundle Tenant_A_DB_Zone\n
+    \     rd 192.168.255.8:13\n      route-target both 13:13\n      redistribute learned\n
+    \     vlan 140-141\n   !\n   vlan-aware-bundle Tenant_A_OP_Zone\n      rd 192.168.255.8:10\n
+    \     route-target both 10:10\n      redistribute learned\n      vlan 110-111\n
+    \  !\n   vlan-aware-bundle Tenant_A_WAN_Zone\n      rd 192.168.255.8:14\n      route-target
+    both 14:14\n      redistribute learned\n      vlan 150\n   !\n   vlan-aware-bundle
+    Tenant_A_WEB_Zone\n      rd 192.168.255.8:11\n      route-target both 11:11\n
+    \     redistribute learned\n      vlan 120-121\n   !\n   vlan-aware-bundle Tenant_B_OP_Zone\n
+    \     rd 192.168.255.8:20\n      route-target both 20:20\n      redistribute learned\n
+    \     vlan 210-211\n   !\n   vlan-aware-bundle Tenant_B_WAN_Zone\n      rd 192.168.255.8:21\n
+    \     route-target both 21:21\n      redistribute learned\n      vlan 250\n   !\n
+    \  vlan-aware-bundle Tenant_C_OP_Zone\n      rd 192.168.255.8:30\n      route-target
+    both 30:30\n      redistribute learned\n      vlan 310-311\n   !\n   vlan-aware-bundle
+    Tenant_C_WAN_Zone\n      rd 192.168.255.8:31\n      route-target both 31:31\n
+    \     redistribute learned\n      vlan 350\n   !\n   address-family evpn\n      neighbor
+    EVPN-OVERLAY-PEERS activate\n   !\n   address-family ipv4\n      no neighbor EVPN-OVERLAY-PEERS
+    activate\n      neighbor IPv4-UNDERLAY-PEERS activate\n      neighbor MLAG-IPv4-UNDERLAY-PEER
     activate\n   !\n   vrf Tenant_A_APP_Zone\n      rd 192.168.255.8:12\n      route-target
     import evpn 12:12\n      route-target export evpn 12:12\n      router-id 192.168.255.8\n
     \     neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
@@ -1361,55 +1362,55 @@ cvp_configlets:
     RM-MLAG-PEER-IN permit 10\n   description Make routes learned over MLAG Peer-link
     less preferred on spines to ensure optimal routing\n   set origin incomplete\n!\nrouter
     bfd\n   multihop interval 1200 min-rx 1200 multiplier 3\n!\nrouter bgp 65103\n
-    \  router-id 192.168.255.9\n   no bgp default ipv4-unicast\n   distance bgp 20
-    200 200\n   maximum-paths 4 ecmp 4\n   neighbor EVPN-OVERLAY-PEERS peer group\n
-    \  neighbor EVPN-OVERLAY-PEERS update-source Loopback0\n   neighbor EVPN-OVERLAY-PEERS
-    bfd\n   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS
-    password 7 q+VNViP5i4rVjW1cxFv2wA==\n   neighbor EVPN-OVERLAY-PEERS send-community\n
-    \  neighbor EVPN-OVERLAY-PEERS maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS
-    peer group\n   neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==\n
-    \  neighbor IPv4-UNDERLAY-PEERS send-community\n   neighbor IPv4-UNDERLAY-PEERS
-    maximum-routes 12000\n   neighbor MLAG-IPv4-UNDERLAY-PEER peer group\n   neighbor
-    MLAG-IPv4-UNDERLAY-PEER remote-as 65103\n   neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self\n
-    \  neighbor MLAG-IPv4-UNDERLAY-PEER description DC1-SVC3A\n   neighbor MLAG-IPv4-UNDERLAY-PEER
-    password 7 vnEaG8gMeQf3d3cN6PktXQ==\n   neighbor MLAG-IPv4-UNDERLAY-PEER send-community\n
-    \  neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000\n   neighbor MLAG-IPv4-UNDERLAY-PEER
-    route-map RM-MLAG-PEER-IN in\n   neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n
-    \  neighbor 10.255.251.6 description DC1-SVC3A\n   neighbor 172.31.255.32 peer
-    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.32 remote-as 65001\n   neighbor
-    172.31.255.32 description DC1-SPINE1_Ethernet5\n   neighbor 172.31.255.34 peer
-    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.34 remote-as 65001\n   neighbor
-    172.31.255.34 description DC1-SPINE2_Ethernet5\n   neighbor 172.31.255.36 peer
-    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.36 remote-as 65001\n   neighbor
-    172.31.255.36 description DC1-SPINE3_Ethernet5\n   neighbor 172.31.255.38 peer
-    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.38 remote-as 65001\n   neighbor
-    172.31.255.38 description DC1-SPINE4_Ethernet5\n   neighbor 192.168.255.1 peer
-    group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.1 remote-as 65001\n   neighbor
-    192.168.255.1 description DC1-SPINE1\n   neighbor 192.168.255.2 peer group EVPN-OVERLAY-PEERS\n
-    \  neighbor 192.168.255.2 remote-as 65001\n   neighbor 192.168.255.2 description
-    DC1-SPINE2\n   neighbor 192.168.255.3 peer group EVPN-OVERLAY-PEERS\n   neighbor
-    192.168.255.3 remote-as 65001\n   neighbor 192.168.255.3 description DC1-SPINE3\n
-    \  neighbor 192.168.255.4 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.4
-    remote-as 65001\n   neighbor 192.168.255.4 description DC1-SPINE4\n   redistribute
-    connected route-map RM-CONN-2-BGP\n   !\n   vlan-aware-bundle Tenant_A_APP_Zone\n
-    \     rd 192.168.255.9:12\n      route-target both 12:12\n      redistribute learned\n
-    \     vlan 130-131\n   !\n   vlan-aware-bundle Tenant_A_DB_Zone\n      rd 192.168.255.9:13\n
-    \     route-target both 13:13\n      redistribute learned\n      vlan 140-141\n
-    \  !\n   vlan-aware-bundle Tenant_A_OP_Zone\n      rd 192.168.255.9:10\n      route-target
-    both 10:10\n      redistribute learned\n      vlan 110-111\n   !\n   vlan-aware-bundle
-    Tenant_A_WAN_Zone\n      rd 192.168.255.9:14\n      route-target both 14:14\n
-    \     redistribute learned\n      vlan 150\n   !\n   vlan-aware-bundle Tenant_A_WEB_Zone\n
-    \     rd 192.168.255.9:11\n      route-target both 11:11\n      redistribute learned\n
-    \     vlan 120-121\n   !\n   vlan-aware-bundle Tenant_B_OP_Zone\n      rd 192.168.255.9:20\n
-    \     route-target both 20:20\n      redistribute learned\n      vlan 210-211\n
-    \  !\n   vlan-aware-bundle Tenant_B_WAN_Zone\n      rd 192.168.255.9:21\n      route-target
-    both 21:21\n      redistribute learned\n      vlan 250\n   !\n   vlan-aware-bundle
-    Tenant_C_OP_Zone\n      rd 192.168.255.9:30\n      route-target both 30:30\n      redistribute
-    learned\n      vlan 310-311\n   !\n   vlan-aware-bundle Tenant_C_WAN_Zone\n      rd
-    192.168.255.9:31\n      route-target both 31:31\n      redistribute learned\n
-    \     vlan 350\n   !\n   address-family evpn\n      neighbor EVPN-OVERLAY-PEERS
-    activate\n   !\n   address-family ipv4\n      no neighbor EVPN-OVERLAY-PEERS activate\n
-    \     neighbor IPv4-UNDERLAY-PEERS activate\n      neighbor MLAG-IPv4-UNDERLAY-PEER
+    \  router-id 192.168.255.9\n   graceful-restart restart-time 300\n   graceful-restart\n
+    \  no bgp default ipv4-unicast\n   distance bgp 20 200 200\n   maximum-paths 4
+    ecmp 4\n   neighbor EVPN-OVERLAY-PEERS peer group\n   neighbor EVPN-OVERLAY-PEERS
+    update-source Loopback0\n   neighbor EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS
+    ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n
+    \  neighbor EVPN-OVERLAY-PEERS send-community\n   neighbor EVPN-OVERLAY-PEERS
+    maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS peer group\n   neighbor IPv4-UNDERLAY-PEERS
+    password 7 AQQvKeimxJu+uGQ/yYvv9w==\n   neighbor IPv4-UNDERLAY-PEERS send-community\n
+    \  neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000\n   neighbor MLAG-IPv4-UNDERLAY-PEER
+    peer group\n   neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65103\n   neighbor MLAG-IPv4-UNDERLAY-PEER
+    next-hop-self\n   neighbor MLAG-IPv4-UNDERLAY-PEER description DC1-SVC3A\n   neighbor
+    MLAG-IPv4-UNDERLAY-PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==\n   neighbor MLAG-IPv4-UNDERLAY-PEER
+    send-community\n   neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000\n   neighbor
+    MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN in\n   neighbor 10.255.251.6
+    peer group MLAG-IPv4-UNDERLAY-PEER\n   neighbor 10.255.251.6 description DC1-SVC3A\n
+    \  neighbor 172.31.255.32 peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.32
+    remote-as 65001\n   neighbor 172.31.255.32 description DC1-SPINE1_Ethernet5\n
+    \  neighbor 172.31.255.34 peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.34
+    remote-as 65001\n   neighbor 172.31.255.34 description DC1-SPINE2_Ethernet5\n
+    \  neighbor 172.31.255.36 peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.36
+    remote-as 65001\n   neighbor 172.31.255.36 description DC1-SPINE3_Ethernet5\n
+    \  neighbor 172.31.255.38 peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.38
+    remote-as 65001\n   neighbor 172.31.255.38 description DC1-SPINE4_Ethernet5\n
+    \  neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.1
+    remote-as 65001\n   neighbor 192.168.255.1 description DC1-SPINE1\n   neighbor
+    192.168.255.2 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.2 remote-as
+    65001\n   neighbor 192.168.255.2 description DC1-SPINE2\n   neighbor 192.168.255.3
+    peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.3 remote-as 65001\n   neighbor
+    192.168.255.3 description DC1-SPINE3\n   neighbor 192.168.255.4 peer group EVPN-OVERLAY-PEERS\n
+    \  neighbor 192.168.255.4 remote-as 65001\n   neighbor 192.168.255.4 description
+    DC1-SPINE4\n   redistribute connected route-map RM-CONN-2-BGP\n   !\n   vlan-aware-bundle
+    Tenant_A_APP_Zone\n      rd 192.168.255.9:12\n      route-target both 12:12\n
+    \     redistribute learned\n      vlan 130-131\n   !\n   vlan-aware-bundle Tenant_A_DB_Zone\n
+    \     rd 192.168.255.9:13\n      route-target both 13:13\n      redistribute learned\n
+    \     vlan 140-141\n   !\n   vlan-aware-bundle Tenant_A_OP_Zone\n      rd 192.168.255.9:10\n
+    \     route-target both 10:10\n      redistribute learned\n      vlan 110-111\n
+    \  !\n   vlan-aware-bundle Tenant_A_WAN_Zone\n      rd 192.168.255.9:14\n      route-target
+    both 14:14\n      redistribute learned\n      vlan 150\n   !\n   vlan-aware-bundle
+    Tenant_A_WEB_Zone\n      rd 192.168.255.9:11\n      route-target both 11:11\n
+    \     redistribute learned\n      vlan 120-121\n   !\n   vlan-aware-bundle Tenant_B_OP_Zone\n
+    \     rd 192.168.255.9:20\n      route-target both 20:20\n      redistribute learned\n
+    \     vlan 210-211\n   !\n   vlan-aware-bundle Tenant_B_WAN_Zone\n      rd 192.168.255.9:21\n
+    \     route-target both 21:21\n      redistribute learned\n      vlan 250\n   !\n
+    \  vlan-aware-bundle Tenant_C_OP_Zone\n      rd 192.168.255.9:30\n      route-target
+    both 30:30\n      redistribute learned\n      vlan 310-311\n   !\n   vlan-aware-bundle
+    Tenant_C_WAN_Zone\n      rd 192.168.255.9:31\n      route-target both 31:31\n
+    \     redistribute learned\n      vlan 350\n   !\n   address-family evpn\n      neighbor
+    EVPN-OVERLAY-PEERS activate\n   !\n   address-family ipv4\n      no neighbor EVPN-OVERLAY-PEERS
+    activate\n      neighbor IPv4-UNDERLAY-PEERS activate\n      neighbor MLAG-IPv4-UNDERLAY-PEER
     activate\n   !\n   vrf Tenant_A_APP_Zone\n      rd 192.168.255.9:12\n      route-target
     import evpn 12:12\n      route-target export evpn 12:12\n      router-id 192.168.255.9\n
     \     neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/BGP-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/BGP-SPINE1.md
@@ -373,6 +373,8 @@ ip route vrf MGMT 0.0.0.0/0 172.31.0.1
 | BGP Tuning |
 | ---------- |
 | maximum-paths 4 ecmp 4 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -408,6 +410,8 @@ ip route vrf MGMT 0.0.0.0/0 172.31.0.1
 !
 router bgp 65001
    router-id 192.168.255.1
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor IPv4-UNDERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/BGP-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/BGP-SPINE2.md
@@ -375,6 +375,8 @@ ip route 10.0.0.0/8 10.1.100.100
 | BGP Tuning |
 | ---------- |
 | maximum-paths 4 ecmp 4 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -410,6 +412,8 @@ ip route 10.0.0.0/8 10.1.100.100
 !
 router bgp 65001
    router-id 192.168.255.2
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor IPv4-UNDERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/BGP-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/BGP-SPINE1.cfg
@@ -112,6 +112,8 @@ route-map RM-MLAG-PEER-IN permit 10
 !
 router bgp 65001
    router-id 192.168.255.1
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor IPv4-UNDERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/BGP-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/BGP-SPINE2.cfg
@@ -113,6 +113,8 @@ route-map RM-MLAG-PEER-IN permit 10
 !
 router bgp 65001
    router-id 192.168.255.2
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor IPv4-UNDERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-SPINE1.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-SPINE2.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER1.md
@@ -632,9 +632,9 @@ router isis CORE
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
+| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
-| maximum-paths 4 ecmp 4 |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -702,10 +702,10 @@ router isis CORE
 !
 router bgp 65000
    router-id 100.70.0.5
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor MPLS-OVERLAY-PEERS peer group
    neighbor MPLS-OVERLAY-PEERS remote-as 65000

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER2.md
@@ -597,9 +597,9 @@ router isis CORE
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
+| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
-| maximum-paths 4 ecmp 4 |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -684,10 +684,10 @@ router isis CORE
 !
 router bgp 65000
    router-id 100.70.0.6
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor MPLS-OVERLAY-PEERS peer group
    neighbor MPLS-OVERLAY-PEERS remote-as 65000

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-RR1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-RR1.md
@@ -353,10 +353,10 @@ router isis CORE
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| graceful-restart restart-time 300 |
-| graceful-restart |
 | bgp route-reflector preserve-attributes always |
 | maximum-paths 4 ecmp 4 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -432,11 +432,11 @@ router isis CORE
 !
 router bgp 65000
    router-id 100.70.0.8
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    bgp cluster-id 1.1.1.1
    distance bgp 20 200 200
-   graceful-restart restart-time 300
-   graceful-restart
    bgp route-reflector preserve-attributes always
    maximum-paths 4 ecmp 4
    neighbor MPLS-OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-LER1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-LER1.md
@@ -634,9 +634,9 @@ router isis CORE
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
+| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
-| maximum-paths 4 ecmp 4 |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -722,10 +722,10 @@ router isis CORE
 !
 router bgp 65000
    router-id 100.70.0.7
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor MPLS-OVERLAY-PEERS peer group
    neighbor MPLS-OVERLAY-PEERS remote-as 65000

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-RR1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-RR1.md
@@ -353,10 +353,10 @@ router isis CORE
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| graceful-restart restart-time 300 |
-| graceful-restart |
 | bgp route-reflector preserve-attributes always |
 | maximum-paths 4 ecmp 4 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -432,11 +432,11 @@ router isis CORE
 !
 router bgp 65000
    router-id 100.70.0.9
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    bgp cluster-id 1.1.1.1
    distance bgp 20 200 200
-   graceful-restart restart-time 300
-   graceful-restart
    bgp route-reflector preserve-attributes always
    maximum-paths 4 ecmp 4
    neighbor MPLS-OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE1-LER1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE1-LER1.cfg
@@ -203,10 +203,10 @@ router bfd
 !
 router bgp 65000
    router-id 100.70.0.5
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor MPLS-OVERLAY-PEERS peer group
    neighbor MPLS-OVERLAY-PEERS remote-as 65000

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE1-LER2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE1-LER2.cfg
@@ -201,10 +201,10 @@ router bfd
 !
 router bgp 65000
    router-id 100.70.0.6
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor MPLS-OVERLAY-PEERS peer group
    neighbor MPLS-OVERLAY-PEERS remote-as 65000

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE1-RR1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE1-RR1.cfg
@@ -65,11 +65,11 @@ router bfd
 !
 router bgp 65000
    router-id 100.70.0.8
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    bgp cluster-id 1.1.1.1
    distance bgp 20 200 200
-   graceful-restart restart-time 300
-   graceful-restart
    bgp route-reflector preserve-attributes always
    maximum-paths 4 ecmp 4
    neighbor MPLS-OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE2-LER1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE2-LER1.cfg
@@ -199,10 +199,10 @@ router bfd
 !
 router bgp 65000
    router-id 100.70.0.7
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor MPLS-OVERLAY-PEERS peer group
    neighbor MPLS-OVERLAY-PEERS remote-as 65000

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE2-RR1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE2-RR1.cfg
@@ -65,11 +65,11 @@ router bfd
 !
 router bgp 65000
    router-id 100.70.0.9
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    bgp cluster-id 1.1.1.1
    distance bgp 20 200 200
-   graceful-restart restart-time 300
-   graceful-restart
    bgp route-reflector preserve-attributes always
    maximum-paths 4 ecmp 4
    neighbor MPLS-OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LER1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LER1.yml
@@ -3,12 +3,13 @@ router_bgp:
   router_id: 100.70.0.5
   bgp_defaults:
   - distance bgp 20 200 200
-  - graceful-restart restart-time 300
-  - graceful-restart
   - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MPLS-OVERLAY-PEERS
     type: mpls

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LER2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LER2.yml
@@ -3,12 +3,13 @@ router_bgp:
   router_id: 100.70.0.6
   bgp_defaults:
   - distance bgp 20 200 200
-  - graceful-restart restart-time 300
-  - graceful-restart
   - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MPLS-OVERLAY-PEERS
     type: mpls

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-RR1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-RR1.yml
@@ -3,13 +3,14 @@ router_bgp:
   router_id: 100.70.0.8
   bgp_defaults:
   - distance bgp 20 200 200
-  - graceful-restart restart-time 300
-  - graceful-restart
   - bgp route-reflector preserve-attributes always
   - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   bgp_cluster_id: 1.1.1.1
   peer_groups:
   - name: MPLS-OVERLAY-PEERS

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE2-LER1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE2-LER1.yml
@@ -3,12 +3,13 @@ router_bgp:
   router_id: 100.70.0.7
   bgp_defaults:
   - distance bgp 20 200 200
-  - graceful-restart restart-time 300
-  - graceful-restart
   - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MPLS-OVERLAY-PEERS
     type: mpls

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE2-RR1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE2-RR1.yml
@@ -3,13 +3,14 @@ router_bgp:
   router_id: 100.70.0.9
   bgp_defaults:
   - distance bgp 20 200 200
-  - graceful-restart restart-time 300
-  - graceful-restart
   - bgp route-reflector preserve-attributes always
   - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   bgp_cluster_id: 1.1.1.1
   peer_groups:
   - name: MPLS-OVERLAY-PEERS

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/inventory/group_vars/MPLS_CORE.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/inventory/group_vars/MPLS_CORE.yml
@@ -84,9 +84,7 @@ pe:
     spanning_tree_mode: mstp
     overlay_address_families: [ evpn, vpn-ipv4, vpn-ipv6 ]
     bgp_defaults:
-      - 'distance bgp 20 200 200'
-      - 'graceful-restart restart-time 300'
-      - 'graceful-restart'
+      - distance bgp 20 200 200
     mpls_route_reflectors: [ SITE1-RR1, SITE2-RR1 ]
     raw_eos_cli: |
       management security
@@ -137,10 +135,8 @@ rr:
     overlay_address_families: [ evpn, vpn-ipv4, vpn-ipv6 ]
     mpls_route_reflectors: [ SITE1-RR1, SITE2-RR1 ]
     bgp_defaults:
-      - 'distance bgp 20 200 200'
-      - 'graceful-restart restart-time 300'
-      - 'graceful-restart'
-      - 'bgp route-reflector preserve-attributes always'
+      - distance bgp 20 200 200
+      - bgp route-reflector preserve-attributes always
     raw_eos_cli: |
       management security
          password encryption-key common

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF1A.md
@@ -386,9 +386,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
+| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
-| maximum-paths 4 ecmp 4 |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -443,10 +443,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 !
 router bgp 65111.100
    router-id 172.16.110.3
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2B.md
@@ -784,9 +784,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
+| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
-| maximum-paths 4 ecmp 4 |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -889,10 +889,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 !
 router bgp 65112.100
    router-id 172.16.110.5
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-CORE peer group
    neighbor EVPN-OVERLAY-CORE update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-SPINE1.md
@@ -321,9 +321,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
+| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
-| maximum-paths 4 ecmp 4 |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -381,10 +381,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 !
 router bgp 65110.100
    router-id 172.16.110.1
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-SPINE2.md
@@ -336,9 +336,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
+| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
-| maximum-paths 4 ecmp 4 |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -369,10 +369,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 !
 router bgp 65110.100
    router-id 172.16.110.2
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS password 7 <removed>

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-LEAF1A.md
@@ -543,9 +543,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
+| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
-| maximum-paths 4 ecmp 4 |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -614,10 +614,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 !
 router bgp 65121
    router-id 172.16.120.3
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-SPINE1.md
@@ -314,9 +314,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
+| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
-| maximum-paths 4 ecmp 4 |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -366,10 +366,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 !
 router bgp 65120
    router-id 172.16.120.1
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-SPINE2.md
@@ -306,9 +306,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
+| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
-| maximum-paths 4 ecmp 4 |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -357,10 +357,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 !
 router bgp 65120
    router-id 172.16.120.2
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-RS1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-RS1.md
@@ -263,9 +263,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
+| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
-| maximum-paths 4 ecmp 4 |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -318,10 +318,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 !
 router bgp 65101
    router-id 172.16.10.1
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-RS2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-RS2.md
@@ -291,9 +291,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
+| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
-| maximum-paths 4 ecmp 4 |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -344,10 +344,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 !
 router bgp 65102
    router-id 172.16.10.2
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-SUPER-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-SUPER-SPINE1.md
@@ -297,9 +297,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
+| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
-| maximum-paths 4 ecmp 4 |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -329,10 +329,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 !
 router bgp 65100
    router-id 172.16.100.1
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS password 7 <removed>

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-SUPER-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-SUPER-SPINE2.md
@@ -323,9 +323,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
+| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
-| maximum-paths 4 ecmp 4 |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -355,10 +355,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 !
 router bgp 65100
    router-id 172.16.100.2
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS password 7 <removed>

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1.POD1.LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1.POD1.LEAF2A.md
@@ -759,9 +759,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
+| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
-| maximum-paths 4 ecmp 4 |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -865,10 +865,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 !
 router bgp 65112.100
    router-id 172.16.110.4
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-CORE peer group
    neighbor EVPN-OVERLAY-CORE update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-LEAF1A.md
@@ -483,9 +483,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
+| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
-| maximum-paths 4 ecmp 4 |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -547,10 +547,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 !
 router bgp 65211
    router-id 172.16.210.3
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-LEAF2A.md
@@ -409,9 +409,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
+| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
-| maximum-paths 4 ecmp 4 |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -457,10 +457,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 !
 router bgp 65212
    router-id 172.16.210.4
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-SPINE1.md
@@ -312,9 +312,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
+| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
-| maximum-paths 4 ecmp 4 |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -367,10 +367,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 !
 router bgp 65210
    router-id 172.16.210.1
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-SPINE2.md
@@ -311,9 +311,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
+| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
-| maximum-paths 4 ecmp 4 |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -342,10 +342,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 !
 router bgp 65210
    router-id 172.16.210.2
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS send-community

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-RS1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-RS1.md
@@ -282,9 +282,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
+| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
-| maximum-paths 4 ecmp 4 |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -334,10 +334,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 !
 router bgp 65201
    router-id 172.16.20.1
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-RS2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-RS2.md
@@ -280,9 +280,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
+| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
-| maximum-paths 4 ecmp 4 |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -308,10 +308,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 !
 router bgp 65201
    router-id 172.16.20.2
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS send-community

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-SUPER-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-SUPER-SPINE1.md
@@ -330,9 +330,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
+| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
-| maximum-paths 4 ecmp 4 |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -387,10 +387,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 !
 router bgp 65200
    router-id 172.16.200.1
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-SUPER-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-SUPER-SPINE2.md
@@ -290,9 +290,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
+| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
-| maximum-paths 4 ecmp 4 |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -319,10 +319,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 !
 router bgp 65200
    router-id 172.16.200.2
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS send-community

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF1A.cfg
@@ -118,10 +118,10 @@ router bfd
 !
 router bgp 65111.100
    router-id 172.16.110.3
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2B.cfg
@@ -387,10 +387,10 @@ router bfd
 !
 router bgp 65112.100
    router-id 172.16.110.5
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-CORE peer group
    neighbor EVPN-OVERLAY-CORE update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-SPINE1.cfg
@@ -132,10 +132,10 @@ router bfd
 !
 router bgp 65110.100
    router-id 172.16.110.1
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-SPINE2.cfg
@@ -107,10 +107,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 !
 router bgp 65110.100
    router-id 172.16.110.2
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD2-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD2-LEAF1A.cfg
@@ -205,10 +205,10 @@ router bfd
 !
 router bgp 65121
    router-id 172.16.120.3
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD2-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD2-SPINE1.cfg
@@ -91,10 +91,10 @@ router bfd
 !
 router bgp 65120
    router-id 172.16.120.1
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD2-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD2-SPINE2.cfg
@@ -84,10 +84,10 @@ router bfd
 !
 router bgp 65120
    router-id 172.16.120.2
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-RS1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-RS1.cfg
@@ -84,10 +84,10 @@ router bfd
 !
 router bgp 65101
    router-id 172.16.10.1
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-RS2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-RS2.cfg
@@ -90,10 +90,10 @@ router bfd
 !
 router bgp 65102
    router-id 172.16.10.2
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-SUPER-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-SUPER-SPINE1.cfg
@@ -94,10 +94,10 @@ route-map RM-CONN-2-BGP permit 10
 !
 router bgp 65100
    router-id 172.16.100.1
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-SUPER-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-SUPER-SPINE2.cfg
@@ -98,10 +98,10 @@ route-map RM-CONN-2-BGP permit 10
 !
 router bgp 65100
    router-id 172.16.100.2
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1.POD1.LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1.POD1.LEAF2A.cfg
@@ -383,10 +383,10 @@ router bfd
 !
 router bgp 65112.100
    router-id 172.16.110.4
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-CORE peer group
    neighbor EVPN-OVERLAY-CORE update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-LEAF1A.cfg
@@ -155,10 +155,10 @@ router bfd
 !
 router bgp 65211
    router-id 172.16.210.3
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-LEAF2A.cfg
@@ -108,10 +108,10 @@ router bfd
 !
 router bgp 65212
    router-id 172.16.210.4
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-SPINE1.cfg
@@ -89,10 +89,10 @@ router bfd
 !
 router bgp 65210
    router-id 172.16.210.1
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-SPINE2.cfg
@@ -87,10 +87,10 @@ route-map RM-CONN-2-BGP permit 10
 !
 router bgp 65210
    router-id 172.16.210.2
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS send-community

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-RS1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-RS1.cfg
@@ -62,10 +62,10 @@ router bfd
 !
 router bgp 65201
    router-id 172.16.20.1
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-RS2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-RS2.cfg
@@ -59,10 +59,10 @@ route-map RM-CONN-2-BGP permit 10
 !
 router bgp 65201
    router-id 172.16.20.2
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS send-community

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-SUPER-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-SUPER-SPINE1.cfg
@@ -105,10 +105,10 @@ router bfd
 !
 router bgp 65200
    router-id 172.16.200.1
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-SUPER-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-SUPER-SPINE2.cfg
@@ -68,10 +68,10 @@ route-map RM-CONN-2-BGP permit 10
 !
 router bgp 65200
    router-id 172.16.200.2
-   no bgp default ipv4-unicast
-   distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS send-community

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF1A.yml
@@ -3,12 +3,13 @@ router_bgp:
   router_id: 172.16.110.3
   bgp_defaults:
   - distance bgp 20 200 200
-  - graceful-restart restart-time 300
-  - graceful-restart
   - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2B.yml
@@ -3,12 +3,13 @@ router_bgp:
   router_id: 172.16.110.5
   bgp_defaults:
   - distance bgp 20 200 200
-  - graceful-restart restart-time 300
-  - graceful-restart
   - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-SPINE1.yml
@@ -3,12 +3,13 @@ router_bgp:
   router_id: 172.16.110.1
   bgp_defaults:
   - distance bgp 20 200 200
-  - graceful-restart restart-time 300
-  - graceful-restart
   - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-SPINE2.yml
@@ -4,12 +4,13 @@ router_bgp:
   router_id: 172.16.110.2
   bgp_defaults:
   - distance bgp 20 200 200
-  - graceful-restart restart-time 300
-  - graceful-restart
   - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD2-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD2-LEAF1A.yml
@@ -3,12 +3,13 @@ router_bgp:
   router_id: 172.16.120.3
   bgp_defaults:
   - distance bgp 20 200 200
-  - graceful-restart restart-time 300
-  - graceful-restart
   - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD2-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD2-SPINE1.yml
@@ -3,12 +3,13 @@ router_bgp:
   router_id: 172.16.120.1
   bgp_defaults:
   - distance bgp 20 200 200
-  - graceful-restart restart-time 300
-  - graceful-restart
   - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD2-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD2-SPINE2.yml
@@ -3,12 +3,13 @@ router_bgp:
   router_id: 172.16.120.2
   bgp_defaults:
   - distance bgp 20 200 200
-  - graceful-restart restart-time 300
-  - graceful-restart
   - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-RS1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-RS1.yml
@@ -3,12 +3,13 @@ router_bgp:
   router_id: 172.16.10.1
   bgp_defaults:
   - distance bgp 20 200 200
-  - graceful-restart restart-time 300
-  - graceful-restart
   - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-RS2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-RS2.yml
@@ -3,12 +3,13 @@ router_bgp:
   router_id: 172.16.10.2
   bgp_defaults:
   - distance bgp 20 200 200
-  - graceful-restart restart-time 300
-  - graceful-restart
   - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-SUPER-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-SUPER-SPINE1.yml
@@ -3,12 +3,13 @@ router_bgp:
   router_id: 172.16.100.1
   bgp_defaults:
   - distance bgp 20 200 200
-  - graceful-restart restart-time 300
-  - graceful-restart
   - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-SUPER-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-SUPER-SPINE2.yml
@@ -3,12 +3,13 @@ router_bgp:
   router_id: 172.16.100.2
   bgp_defaults:
   - distance bgp 20 200 200
-  - graceful-restart restart-time 300
-  - graceful-restart
   - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1.POD1.LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1.POD1.LEAF2A.yml
@@ -3,12 +3,13 @@ router_bgp:
   router_id: 172.16.110.4
   bgp_defaults:
   - distance bgp 20 200 200
-  - graceful-restart restart-time 300
-  - graceful-restart
   - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-LEAF1A.yml
@@ -3,12 +3,13 @@ router_bgp:
   router_id: 172.16.210.3
   bgp_defaults:
   - distance bgp 20 200 200
-  - graceful-restart restart-time 300
-  - graceful-restart
   - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-LEAF2A.yml
@@ -3,12 +3,13 @@ router_bgp:
   router_id: 172.16.210.4
   bgp_defaults:
   - distance bgp 20 200 200
-  - graceful-restart restart-time 300
-  - graceful-restart
   - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-SPINE1.yml
@@ -3,12 +3,13 @@ router_bgp:
   router_id: 172.16.210.1
   bgp_defaults:
   - distance bgp 20 200 200
-  - graceful-restart restart-time 300
-  - graceful-restart
   - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-SPINE2.yml
@@ -3,12 +3,13 @@ router_bgp:
   router_id: 172.16.210.2
   bgp_defaults:
   - distance bgp 20 200 200
-  - graceful-restart restart-time 300
-  - graceful-restart
   - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-RS1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-RS1.yml
@@ -3,12 +3,13 @@ router_bgp:
   router_id: 172.16.20.1
   bgp_defaults:
   - distance bgp 20 200 200
-  - graceful-restart restart-time 300
-  - graceful-restart
   - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-RS2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-RS2.yml
@@ -3,12 +3,13 @@ router_bgp:
   router_id: 172.16.20.2
   bgp_defaults:
   - distance bgp 20 200 200
-  - graceful-restart restart-time 300
-  - graceful-restart
   - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-SUPER-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-SUPER-SPINE1.yml
@@ -3,12 +3,13 @@ router_bgp:
   router_id: 172.16.200.1
   bgp_defaults:
   - distance bgp 20 200 200
-  - graceful-restart restart-time 300
-  - graceful-restart
   - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-SUPER-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-SUPER-SPINE2.yml
@@ -3,12 +3,13 @@ router_bgp:
   router_id: 172.16.200.2
   bgp_defaults:
   - distance bgp 20 200 200
-  - graceful-restart restart-time 300
-  - graceful-restart
   - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/inventory/group_vars/DC1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/inventory/group_vars/DC1.yml
@@ -15,9 +15,7 @@ super_spine:
     bgp_as: 65100
     loopback_ipv4_pool: 172.16.100.0/24
     bgp_defaults:
-      - 'distance bgp 20 200 200'
-      - 'graceful-restart restart-time 300'
-      - 'graceful-restart'
+      - distance bgp 20 200 200
   nodes:
     DC1-SUPER-SPINE1:
       id: 1
@@ -39,9 +37,7 @@ overlay_controller:
     max_uplink_switches: 4
     uplink_ipv4_pool: 172.17.10.0/24
     bgp_defaults:
-      - 'distance bgp 20 200 200'
-      - 'graceful-restart restart-time 300'
-      - 'graceful-restart'
+      - distance bgp 20 200 200
   nodes:
     DC1-RS1:
       id: 1

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/inventory/group_vars/DC1_POD1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/inventory/group_vars/DC1_POD1.yml
@@ -21,8 +21,6 @@ spine:
       profile: MACSEC_PROFILE
     bgp_defaults:
       - "distance bgp 20 200 200"
-      - "graceful-restart restart-time 300"
-      - "graceful-restart"
   nodes:
     # Spine also working as EVPN RS
     DC1-POD1-SPINE1:
@@ -54,8 +52,6 @@ l3leaf:
       profile: MACSEC_PROFILE
     bgp_defaults:
       - "distance bgp 20 200 200"
-      - "graceful-restart restart-time 300"
-      - "graceful-restart"
     mlag_peer_l3_ipv4_pool: 172.19.110.0/24
     mlag_peer_ipv4_pool: 172.20.110.0/24
     inband_mgmt_description: L2LEAF_INBAND_MGMT

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/inventory/group_vars/DC1_POD2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/inventory/group_vars/DC1_POD2.yml
@@ -16,8 +16,6 @@ spine:
       profile: MACSEC_PROFILE
     bgp_defaults:
       - "distance bgp 20 200 200"
-      - "graceful-restart restart-time 300"
-      - "graceful-restart"
   nodes:
     # Spine also working as EVPN RS
     DC1-POD2-SPINE1:
@@ -46,8 +44,6 @@ l3leaf:
       profile: MACSEC_PROFILE
     bgp_defaults:
       - "distance bgp 20 200 200"
-      - "graceful-restart restart-time 300"
-      - "graceful-restart"
     mlag_peer_l3_ipv4_pool: 172.19.120.0/24
     mlag_peer_ipv4_pool: 172.20.120.0/24
   node_groups:

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/inventory/group_vars/DC2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/inventory/group_vars/DC2.yml
@@ -7,7 +7,7 @@ super_spine:
     platform: vEOS-LAB
     bgp_as: 65200
     loopback_ipv4_pool: 172.16.200.0/24
-    bgp_defaults: ['distance bgp 20 200 200', 'graceful-restart restart-time 300', 'graceful-restart']
+    bgp_defaults: ['distance bgp 20 200 200']
   nodes:
     DC2-SUPER-SPINE1:
       id: 1
@@ -29,9 +29,7 @@ overlay_controller:
     max_uplink_switches: 4
     uplink_ipv4_pool: 172.17.20.0/24
     bgp_defaults:
-      - 'distance bgp 20 200 200'
-      - 'graceful-restart restart-time 300'
-      - 'graceful-restart'
+      - distance bgp 20 200 200
     evpn_route_servers: [ DC1-RS1, DC1-SUPER-SPINE1, DC1-POD1-SPINE1, DC1-POD1-LEAF1A ]
     bgp_as: 65201
   nodes:

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/inventory/group_vars/DC2_POD1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/inventory/group_vars/DC2_POD1.yml
@@ -13,9 +13,7 @@ spine:
     uplink_ptp:
       enable: True
     bgp_defaults:
-      - 'distance bgp 20 200 200'
-      - 'graceful-restart restart-time 300'
-      - 'graceful-restart'
+      - distance bgp 20 200 200
     raw_eos_cli: |
       interface Loopback1009
         description Loopback created from raw_eos_cli under spine defaults in DC2 POD1
@@ -44,9 +42,7 @@ l3leaf:
     uplink_ipv4_pool: 172.17.210.0/24
     uplink_ptp: {'enable': True}
     bgp_defaults:
-      - 'distance bgp 20 200 200'
-      - 'graceful-restart restart-time 300'
-      - 'graceful-restart'
+      - distance bgp 20 200 200
     bgp_as: 65555
     platform: vEOS-LAB
     evpn_role: server

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF1A.cfg
@@ -54,6 +54,8 @@ router bfd
 !
 router bgp 65101
    router-id 192.168.255.3
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF1B.cfg
@@ -54,6 +54,8 @@ router bfd
 !
 router bgp 65102
    router-id 192.168.255.4
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF2.cfg
@@ -54,6 +54,8 @@ router bfd
 !
 router bgp 65103
    router-id 192.168.255.5
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF3A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF3A.cfg
@@ -108,6 +108,8 @@ router bfd
 !
 router bgp 65105
    router-id 192.168.255.7
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF3B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF3B.cfg
@@ -108,6 +108,8 @@ router bfd
 !
 router bgp 65105
    router-id 192.168.255.8
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF4A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF4A.cfg
@@ -108,6 +108,8 @@ router bfd
 !
 router bgp 65222
    router-id 192.168.255.9
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF4B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF4B.cfg
@@ -108,6 +108,8 @@ router bfd
 !
 router bgp 65222
    router-id 192.168.255.10
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF5A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF5A.cfg
@@ -54,6 +54,8 @@ router bfd
 !
 router bgp 65333
    router-id 192.168.255.11
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF7A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF7A.cfg
@@ -108,6 +108,8 @@ router bfd
 !
 router bgp 65222.0
    router-id 192.168.255.13
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF7B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF7B.cfg
@@ -108,6 +108,8 @@ router bfd
 !
 router bgp 65222.0
    router-id 192.168.255.14
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF8A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF8A.cfg
@@ -54,6 +54,8 @@ router bfd
 !
 router bgp 65222.12
    router-id 192.168.255.15
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF8B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF8B.cfg
@@ -54,6 +54,8 @@ router bfd
 !
 router bgp 65222.13
    router-id 192.168.255.16
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_UNGROUPED_LEAF6.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_UNGROUPED_LEAF6.cfg
@@ -54,6 +54,8 @@ router bfd
 !
 router bgp 65110
    router-id 192.168.255.12
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_NODE_TYPE_LEAF01.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_NODE_TYPE_LEAF01.cfg
@@ -68,6 +68,8 @@ router bfd
 !
 router bgp 65101
    router-id 192.168.255.3
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_NODE_TYPE_SPINE01.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_NODE_TYPE_SPINE01.cfg
@@ -56,6 +56,8 @@ router bfd
 !
 router bgp 65100
    router-id 192.168.255.1
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_NODE_TYPE_SPINE02.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_NODE_TYPE_SPINE02.cfg
@@ -56,6 +56,8 @@ router bfd
 !
 router bgp 65100
    router-id 192.168.255.2
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_NODE_TYPE_UNGROUPED_LEAF02.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_NODE_TYPE_UNGROUPED_LEAF02.cfg
@@ -68,6 +68,8 @@ router bfd
 !
 router bgp 65102
    router-id 192.168.255.4
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-PYTHON_MODULES-L3LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-PYTHON_MODULES-L3LEAF1A.cfg
@@ -140,6 +140,8 @@ router bfd
 !
 router bgp 65101
    router-id 192.168.255.21
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-PYTHON_MODULES-L3LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-PYTHON_MODULES-L3LEAF1B.cfg
@@ -140,6 +140,8 @@ router bfd
 !
 router bgp 65101
    router-id 192.168.255.22
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-PYTHON_MODULES-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-PYTHON_MODULES-SPINE1.cfg
@@ -56,6 +56,8 @@ router bfd
 !
 router bgp 65001
    router-id 192.168.255.1
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-TEMPLATES-L3LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-TEMPLATES-L3LEAF1A.cfg
@@ -140,6 +140,8 @@ router bfd
 !
 router bgp 65101
    router-id 192.168.255.21
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-TEMPLATES-L3LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-TEMPLATES-L3LEAF1B.cfg
@@ -140,6 +140,8 @@ router bfd
 !
 router bgp 65101
    router-id 192.168.255.22
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-TEMPLATES-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-TEMPLATES-SPINE1.cfg
@@ -56,6 +56,8 @@ router bfd
 !
 router bgp 65001
    router-id 192.168.255.1
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1A.cfg
@@ -248,6 +248,8 @@ router bfd
 !
 router bgp 65104
    router-id 192.168.255.14
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1B.cfg
@@ -226,6 +226,8 @@ router bfd
 !
 router bgp 65105
    router-id 192.168.255.15
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL2A.cfg
@@ -162,6 +162,8 @@ router bfd
 !
 router bgp 65106
    router-id 192.168.255.16
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL2B.cfg
@@ -160,6 +160,8 @@ router bfd
 !
 router bgp 65107
    router-id 192.168.255.17
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-CL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-CL1A.cfg
@@ -230,6 +230,8 @@ router bfd
 !
 router bgp 65108
    router-id 192.168.255.18
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-CL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-CL1B.cfg
@@ -234,6 +234,8 @@ router bfd
 !
 router bgp 65109
    router-id 192.168.255.19
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF1A.cfg
@@ -259,6 +259,8 @@ router bfd
 !
 router bgp 65101
    router-id 192.168.255.9
+   graceful-restart restart-time 500
+   graceful-restart
    bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SPINE1.cfg
@@ -215,6 +215,8 @@ router bfd
 !
 router bgp 65001
    router-id 192.168.255.1
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SPINE2.cfg
@@ -185,6 +185,8 @@ router bfd
 !
 router bgp 65001
    router-id 192.168.255.2
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SPINE3.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SPINE3.cfg
@@ -180,6 +180,8 @@ router bfd
 !
 router bgp 65001
    router-id 192.168.255.3
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SPINE4.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SPINE4.cfg
@@ -180,6 +180,8 @@ router bfd
 !
 router bgp 65001
    router-id 192.168.255.4
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3A.cfg
@@ -874,6 +874,8 @@ router bfd
 !
 router bgp 65103
    router-id 192.168.255.12
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3B.cfg
@@ -839,6 +839,8 @@ router bfd
 !
 router bgp 65103
    router-id 192.168.255.13
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1_UNDEPLOYED_LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1_UNDEPLOYED_LEAF1A.cfg
@@ -497,6 +497,8 @@ router bfd
 !
 router bgp 65110
    router-id 192.168.255.21
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1_UNDEPLOYED_LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1_UNDEPLOYED_LEAF1B.cfg
@@ -497,6 +497,8 @@ router bfd
 !
 router bgp 65111
    router-id 192.168.255.22
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF1A.cfg
@@ -806,6 +806,8 @@ router bfd
 !
 router bgp 65101
    router-id 192.168.255.3
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF1B.cfg
@@ -806,6 +806,8 @@ router bfd
 !
 router bgp 65101
    router-id 192.168.255.4
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF2A.cfg
@@ -545,6 +545,8 @@ router bfd
 !
 router bgp 65103
    router-id 192.168.255.5
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF3A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF3A.cfg
@@ -567,6 +567,8 @@ router bfd
 !
 router bgp 65104
    router-id 192.168.255.6
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF3B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF3B.cfg
@@ -567,6 +567,8 @@ router bfd
 !
 router bgp 65105
    router-id 192.168.255.7
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-SPINE1.cfg
@@ -82,6 +82,8 @@ router bfd
 !
 router bgp 65001
    router-id 192.168.255.1
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/IGMP-QUERIER-L3LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/IGMP-QUERIER-L3LEAF1A.cfg
@@ -241,6 +241,8 @@ router bfd
 !
 router bgp 65101
    router-id 192.168.255.1
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MH-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MH-LEAF1A.cfg
@@ -344,6 +344,8 @@ router bfd
 !
 router bgp 65151
    router-id 192.168.255.33
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MH-LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MH-LEAF1B.cfg
@@ -344,6 +344,8 @@ router bfd
 !
 router bgp 65152
    router-id 192.168.255.34
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MH-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MH-LEAF2A.cfg
@@ -160,6 +160,8 @@ router bfd
 !
 router bgp 65153
    router-id 192.168.255.35
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MLAG-OSPF-L3LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MLAG-OSPF-L3LEAF1A.cfg
@@ -116,6 +116,8 @@ router bfd
 !
 router bgp 65161
    router-id 192.168.255.36
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MLAG-OSPF-L3LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MLAG-OSPF-L3LEAF1B.cfg
@@ -116,6 +116,8 @@ router bfd
 !
 router bgp 65161
    router-id 192.168.255.37
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_CVX_L3LEAF1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_CVX_L3LEAF1.cfg
@@ -61,6 +61,8 @@ route-map RM-CONN-2-BGP permit 10
 !
 router bgp 65001
    router-id 192.168.254.1
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor IPv4-UNDERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_CVX_L3LEAF2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_CVX_L3LEAF2.cfg
@@ -61,6 +61,8 @@ route-map RM-CONN-2-BGP permit 10
 !
 router bgp 65002
    router-id 192.168.254.2
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor IPv4-UNDERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF1.cfg
@@ -88,6 +88,8 @@ route-map RM-CONN-2-BGP permit 10
 !
 router bgp 65001
    router-id 192.168.254.1
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor IPv4-UNDERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF2.cfg
@@ -88,6 +88,8 @@ route-map RM-CONN-2-BGP permit 10
 !
 router bgp 65002
    router-id 192.168.254.2
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor IPv4-UNDERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3A.cfg
@@ -138,6 +138,8 @@ route-map RM-MLAG-PEER-IN permit 10
 !
 router bgp 65003
    router-id 192.168.254.3
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor IPv4-UNDERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3B.cfg
@@ -138,6 +138,8 @@ route-map RM-MLAG-PEER-IN permit 10
 !
 router bgp 65003
    router-id 192.168.254.4
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor IPv4-UNDERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF1.cfg
@@ -78,6 +78,8 @@ router bfd
 !
 router bgp 65001
    router-id 192.168.255.1
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF2.cfg
@@ -78,6 +78,8 @@ router bfd
 !
 router bgp 65002
    router-id 192.168.255.2
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF3.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF3.cfg
@@ -78,6 +78,8 @@ router bfd
 !
 router bgp 65003
    router-id 192.168.255.3
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF4.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF4.cfg
@@ -78,6 +78,8 @@ router bfd
 !
 router bgp 65004
    router-id 192.168.255.4
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF5.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF5.cfg
@@ -78,6 +78,8 @@ router bfd
 !
 router bgp 65005
    router-id 192.168.255.5
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF6.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF6.cfg
@@ -78,6 +78,8 @@ router bfd
 !
 router bgp 65006
    router-id 192.168.255.6
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF7.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF7.cfg
@@ -78,6 +78,8 @@ router bfd
 !
 router bgp 65007
    router-id 192.168.255.7
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SVI_PROFILE_NODE_1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SVI_PROFILE_NODE_1.cfg
@@ -241,6 +241,8 @@ router bfd
 !
 router bgp 65001
    router-id 192.168.255.1
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SVI_PROFILE_NODE_2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SVI_PROFILE_NODE_2.cfg
@@ -241,6 +241,8 @@ router bfd
 !
 router bgp 65002
    router-id 192.168.255.1
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L3LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L3LEAF1A.cfg
@@ -135,6 +135,8 @@ router bfd
 !
 router bgp 65101
    router-id 192.168.255.3
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L3LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L3LEAF1B.cfg
@@ -122,6 +122,8 @@ router bfd
 !
 router bgp 65101
    router-id 192.168.255.4
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L3LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L3LEAF2A.cfg
@@ -112,6 +112,8 @@ router bfd
 !
 router bgp 65102
    router-id 192.168.255.5
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L3LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L3LEAF2B.cfg
@@ -112,6 +112,8 @@ router bfd
 !
 router bgp 65102
    router-id 192.168.255.6
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-SPINE1.cfg
@@ -74,6 +74,8 @@ router bfd
 !
 router bgp 65001
    router-id 192.168.255.1
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-SPINE2.cfg
@@ -70,6 +70,8 @@ router bfd
 !
 router bgp 65001
    router-id 192.168.255.2
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY_FILTER_PEER_AS_L3LEAF1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY_FILTER_PEER_AS_L3LEAF1.cfg
@@ -54,6 +54,8 @@ route-map RM-BGP-AS65000-OUT permit 20
 !
 router bgp 65001
    router-id 192.168.255.3
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor IPv4-UNDERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY_FILTER_PEER_AS_SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY_FILTER_PEER_AS_SPINE1.cfg
@@ -43,6 +43,8 @@ route-map RM-CONN-2-BGP permit 10
 !
 router bgp 65000
    router-id 192.168.255.1
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor IPv4-UNDERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY_FILTER_PEER_AS_SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY_FILTER_PEER_AS_SPINE2.cfg
@@ -43,6 +43,8 @@ route-map RM-CONN-2-BGP permit 10
 !
 router bgp 65000
    router-id 192.168.255.2
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor IPv4-UNDERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1A.cfg
@@ -138,6 +138,8 @@ router bfd
 !
 router bgp 65101
    router-id 192.168.255.3
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1B.cfg
@@ -138,6 +138,8 @@ router bfd
 !
 router bgp 65101
    router-id 192.168.255.4
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UPLINK-MLAG-STRUCTURED-CONFIG-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UPLINK-MLAG-STRUCTURED-CONFIG-SPINE1.cfg
@@ -58,6 +58,8 @@ router bfd
 !
 router bgp 65001
    router-id 192.168.255.1
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/bgp-peer-groups-structured-config-1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/bgp-peer-groups-structured-config-1.cfg
@@ -95,6 +95,8 @@ router bfd
 !
 router bgp 65001
    router-id 192.168.255.111
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/bgp-peer-groups-structured-config-2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/bgp-peer-groups-structured-config-2.cfg
@@ -95,6 +95,8 @@ router bfd
 !
 router bgp 65001
    router-id 192.168.255.112
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    bgp cluster-id 192.168.255.112
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/bgp-peer-groups-structured-config-3.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/bgp-peer-groups-structured-config-3.cfg
@@ -31,6 +31,8 @@ router bfd
 !
 router bgp 65001
    router-id 192.168.255.114
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    bgp bestpath d-path

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cvp-instance-ips-cvaas.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cvp-instance-ips-cvaas.cfg
@@ -40,6 +40,8 @@ router bfd
 !
 router bgp 1234
    router-id 1.2.3.1
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/default_overlay_protocol_cvx.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/default_overlay_protocol_cvx.cfg
@@ -31,6 +31,8 @@ route-map RM-CONN-2-BGP permit 10
 !
 router bgp 65000
    router-id 192.168.0.42
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor IPv4-UNDERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/default_overlay_protocol_her.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/default_overlay_protocol_her.cfg
@@ -31,6 +31,8 @@ route-map RM-CONN-2-BGP permit 10
 !
 router bgp 65000
    router-id 192.168.0.42
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor IPv4-UNDERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/device.with.dots.in.hostname.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/device.with.dots.in.hostname.cfg
@@ -36,6 +36,8 @@ router bfd
 !
 router bgp 1234
    router-id 1.2.3.1
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_false.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_false.cfg
@@ -439,6 +439,8 @@ router bfd
 !
 router bgp 101
    router-id 192.168.255.109
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_true.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_true.cfg
@@ -193,6 +193,8 @@ router bfd
 !
 router bgp 101
    router-id 192.168.255.109
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-parent-vrf.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-parent-vrf.cfg
@@ -118,6 +118,8 @@ router bfd
 !
 router bgp 65001
    router-id 10.0.255.2
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-parent.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-parent.cfg
@@ -123,6 +123,8 @@ router bfd
 !
 router bgp 65000
    router-id 10.0.255.1
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/l3_edge_bgp.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/l3_edge_bgp.cfg
@@ -100,6 +100,8 @@ route-map RM-CONN-2-BGP permit 10
 !
 router bgp 65000
    router-id 1.2.3.1
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor IPv4-UNDERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-leaf1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-leaf1.cfg
@@ -149,6 +149,8 @@ router bfd
 !
 router bgp 65101
    router-id 10.254.1.1
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-leaf2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-leaf2.cfg
@@ -130,6 +130,8 @@ router bfd
 !
 router bgp 65102
    router-id 10.254.1.2
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-spine1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-spine1.cfg
@@ -155,6 +155,8 @@ router bfd
 !
 router bgp 65200
    router-id 10.255.0.1
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-spine2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-spine2.cfg
@@ -111,6 +111,8 @@ router bfd
 !
 router bgp 65200
    router-id 10.255.0.2
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-spine3.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-spine3.cfg
@@ -54,6 +54,8 @@ router bfd
 !
 router bgp 65200
    router-id 10.255.0.3
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l3leaf1a.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l3leaf1a.cfg
@@ -306,6 +306,8 @@ router bfd
 !
 router bgp 65001
    router-id 192.168.250.9
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l3leaf1b.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l3leaf1b.cfg
@@ -286,6 +286,8 @@ router bfd
 !
 router bgp 65001
    router-id 192.168.250.10
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l3leaf2a.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l3leaf2a.cfg
@@ -152,6 +152,8 @@ router bfd
 !
 router bgp 65002
    router-id 192.168.250.11
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l3leaf2b.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l3leaf2b.cfg
@@ -147,6 +147,8 @@ router bfd
 !
 router bgp 65002
    router-id 192.168.250.12
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF1A.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF1B.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF2.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF3A.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF3B.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF4A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF4A.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF4B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF4B.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF5A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF5A.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF7A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF7A.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF7B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF7B.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF8A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF8A.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF8B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF8B.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_UNGROUPED_LEAF6.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_UNGROUPED_LEAF6.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_NODE_TYPE_LEAF01.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_NODE_TYPE_LEAF01.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_NODE_TYPE_SPINE01.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_NODE_TYPE_SPINE01.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_NODE_TYPE_SPINE02.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_NODE_TYPE_SPINE02.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_NODE_TYPE_UNGROUPED_LEAF02.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_NODE_TYPE_UNGROUPED_LEAF02.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-PYTHON_MODULES-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-PYTHON_MODULES-L3LEAF1A.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-PYTHON_MODULES-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-PYTHON_MODULES-L3LEAF1B.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-PYTHON_MODULES-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-PYTHON_MODULES-SPINE1.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-TEMPLATES-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-TEMPLATES-L3LEAF1A.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-TEMPLATES-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-TEMPLATES-L3LEAF1B.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-TEMPLATES-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-TEMPLATES-SPINE1.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1A.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1B.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL2A.yml
@@ -9,6 +9,9 @@ router_bgp:
       ipv4_unicast: false
     bestpath:
       d_path: true
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL2B.yml
@@ -9,6 +9,9 @@ router_bgp:
       ipv4_unicast: false
     bestpath:
       d_path: true
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-CL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-CL1A.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-CL1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-CL1B.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF1A.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: true
+  graceful_restart:
+    enabled: true
+    restart_time: 500
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
@@ -7,6 +7,8 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: false
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
@@ -7,8 +7,6 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
-  graceful_restart:
-    enabled: false
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
@@ -7,6 +7,8 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: false
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
@@ -7,8 +7,6 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
-  graceful_restart:
-    enabled: false
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SPINE1.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SPINE2.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SPINE3.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SPINE4.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3A.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3B.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1_UNDEPLOYED_LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1_UNDEPLOYED_LEAF1A.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1_UNDEPLOYED_LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1_UNDEPLOYED_LEAF1B.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF1A.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF1B.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF2A.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF3A.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF3B.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-SPINE1.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/IGMP-QUERIER-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/IGMP-QUERIER-L3LEAF1A.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF1A.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF1B.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF2A.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG-OSPF-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG-OSPF-L3LEAF1A.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: EVPN-OVERLAY-PEERS
     type: evpn

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG-OSPF-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG-OSPF-L3LEAF1B.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: EVPN-OVERLAY-PEERS
     type: evpn

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_CVX_L3LEAF1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_CVX_L3LEAF1.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_CVX_L3LEAF2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_CVX_L3LEAF2.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF1.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF2.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3A.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3B.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF1.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF2.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF3.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF3.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF4.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF4.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF5.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF5.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF6.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF6.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF7.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF7.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/SVI_PROFILE_NODE_1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/SVI_PROFILE_NODE_1.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/SVI_PROFILE_NODE_2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/SVI_PROFILE_NODE_2.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF1A.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF1B.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF2A.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF2B.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-SPINE1.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-SPINE2.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY_FILTER_PEER_AS_L3LEAF1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY_FILTER_PEER_AS_L3LEAF1.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY_FILTER_PEER_AS_SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY_FILTER_PEER_AS_SPINE1.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY_FILTER_PEER_AS_SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY_FILTER_PEER_AS_SPINE2.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1A.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1B.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-SPINE1.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-structured-config-1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-structured-config-1.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-structured-config-2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-structured-config-2.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-structured-config-3.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-structured-config-3.yml
@@ -8,6 +8,9 @@ router_bgp:
       ipv4_unicast: false
     bestpath:
       d_path: true
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MPLS-OVERLAY-PEERS
     type: mpls

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cvp-instance-ips-cvaas.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cvp-instance-ips-cvaas.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/default_overlay_protocol_cvx.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/default_overlay_protocol_cvx.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/default_overlay_protocol_her.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/default_overlay_protocol_her.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/device.with.dots.in.hostname.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/device.with.dots.in.hostname.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_false.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_false.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_true.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_true.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-parent-vrf.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-parent-vrf.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-parent.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-parent.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/l3_edge_bgp.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/l3_edge_bgp.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-leaf1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-leaf1.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-leaf2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-leaf2.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-spine1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-spine1.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-spine2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-spine2.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-spine3.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-spine3.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf1a.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf1a.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf1b.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf1b.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf2a.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf2a.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf2b.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf2b.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG-IPv4-UNDERLAY-PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_LEAF1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_LEAF1.yml
@@ -1,6 +1,11 @@
 ---
 bgp_default_ipv4_unicast: true
 
+# test updating graceful restart timers
+bgp_graceful_restart:
+  enabled: true
+  restart_time: 500
+
 overlay_rd_type:
 #   # admin_subfield: < "overlay_loopback" | "vtep_loopback" | "leaf_asn" | "spine_asn" | < IPv4 Address > | <0-65535> | <0-4294967295> | default -> "overlay_loopback" >
   admin_subfield: 1.1.1.1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_LEAF2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_LEAF2.yml
@@ -1,4 +1,9 @@
 ---
+
+bgp_graceful_restart:
+  enabled: false
+  restart_time: 500 # this value should not get since since enable == false.
+
 overlay_rd_type:
 #   # admin_subfield: < "overlay_loopback" | "vtep_loopback" | "leaf_asn" | "spine_asn" | < IPv4 Address > | <0-65535> | <0-4294967295> | default -> "overlay_loopback" >
   admin_subfield: 65001

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-BL1A.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-BL1B.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-BL2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-BL2A.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-BL2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-BL2B.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-CL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-CL1A.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-CL1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-CL1B.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-LEAF1A.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-LEAF2A.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-LEAF2B.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SPINE1.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SPINE2.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SPINE3.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SPINE4.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SVC3A.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SVC3B.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/MH-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/MH-LEAF1A.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/MH-LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/MH-LEAF1B.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/MH-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/MH-LEAF2A.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/cvp-instance-ips-cvaas.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/cvp-instance-ips-cvaas.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/evpn_services_l2_only_false.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/evpn_services_l2_only_false.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/evpn_services_l2_only_true.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/evpn_services_l2_only_true.yml
@@ -6,6 +6,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -590,6 +590,8 @@ ip route vrf Tenant_A_WAN_Zone 10.3.5.0/24 Null0
 | ---------- |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -667,6 +669,8 @@ ip route vrf Tenant_A_WAN_Zone 10.3.5.0/24 Null0
 !
 router bgp 65104
    router-id 192.168.255.14
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -588,6 +588,8 @@ ip route vrf Tenant_A_WAN_Zone 10.3.5.0/24 Null0
 | ---------- |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -665,6 +667,8 @@ ip route vrf Tenant_A_WAN_Zone 10.3.5.0/24 Null0
 !
 router bgp 65105
    router-id 192.168.255.15
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
@@ -586,6 +586,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | ---------- |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -656,6 +658,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 !
 router bgp 65101
    router-id 192.168.255.9
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -885,6 +885,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | ---------- |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -966,6 +968,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 !
 router bgp 65102
    router-id 192.168.255.10
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -885,6 +885,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | ---------- |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -966,6 +968,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 !
 router bgp 65102
    router-id 192.168.255.11
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE1.md
@@ -390,6 +390,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | ---------- |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -447,6 +449,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 !
 router bgp 65001
    router-id 192.168.255.1
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE2.md
@@ -390,6 +390,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | ---------- |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -447,6 +449,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 !
 router bgp 65001
    router-id 192.168.255.2
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE3.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE3.md
@@ -390,6 +390,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | ---------- |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -447,6 +449,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 !
 router bgp 65001
    router-id 192.168.255.3
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE4.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE4.md
@@ -390,6 +390,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | ---------- |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -447,6 +449,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 !
 router bgp 65001
    router-id 192.168.255.4
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -1250,6 +1250,8 @@ ip route vrf Tenant_A_WAN_Zone 10.3.5.0/24 Null0
 | ---------- |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -1356,6 +1358,8 @@ ip route vrf Tenant_A_WAN_Zone 10.3.5.0/24 Null0
 !
 router bgp 65103
    router-id 192.168.255.12
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -1250,6 +1250,8 @@ ip route vrf Tenant_A_WAN_Zone 10.3.5.0/24 Null0
 | ---------- |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -1356,6 +1358,8 @@ ip route vrf Tenant_A_WAN_Zone 10.3.5.0/24 Null0
 !
 router bgp 65103
    router-id 192.168.255.13
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1A.cfg
@@ -226,6 +226,8 @@ router bfd
 !
 router bgp 65104
    router-id 192.168.255.14
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1B.cfg
@@ -225,6 +225,8 @@ router bfd
 !
 router bgp 65105
    router-id 192.168.255.15
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF1A.cfg
@@ -206,6 +206,8 @@ router bfd
 !
 router bgp 65101
    router-id 192.168.255.9
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
@@ -418,6 +418,8 @@ router bfd
 !
 router bgp 65102
    router-id 192.168.255.10
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
@@ -418,6 +418,8 @@ router bfd
 !
 router bgp 65102
    router-id 192.168.255.11
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE1.cfg
@@ -116,6 +116,8 @@ router bfd
 !
 router bgp 65001
    router-id 192.168.255.1
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE2.cfg
@@ -116,6 +116,8 @@ router bfd
 !
 router bgp 65001
    router-id 192.168.255.2
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE3.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE3.cfg
@@ -116,6 +116,8 @@ router bfd
 !
 router bgp 65001
    router-id 192.168.255.3
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE4.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE4.cfg
@@ -116,6 +116,8 @@ router bfd
 !
 router bgp 65001
    router-id 192.168.255.4
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
@@ -715,6 +715,8 @@ router bfd
 !
 router bgp 65103
    router-id 192.168.255.12
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
@@ -715,6 +715,8 @@ router bfd
 !
 router bgp 65103
    router-id 192.168.255.13
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE1.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE2.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE3.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE4.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1A.md
@@ -628,6 +628,8 @@ router isis EVPN_UNDERLAY
 | ---------- |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -664,6 +666,8 @@ router isis EVPN_UNDERLAY
 !
 router bgp 65000
    router-id 192.168.255.10
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1B.md
@@ -613,6 +613,8 @@ router isis EVPN_UNDERLAY
 | ---------- |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -649,6 +651,8 @@ router isis EVPN_UNDERLAY
 !
 router bgp 65000
    router-id 192.168.255.11
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF1A.md
@@ -462,6 +462,8 @@ router isis EVPN_UNDERLAY
 | ---------- |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -498,6 +500,8 @@ router isis EVPN_UNDERLAY
 !
 router bgp 65000
    router-id 192.168.255.5
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2A.md
@@ -628,6 +628,8 @@ router isis EVPN_UNDERLAY
 | ---------- |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -664,6 +666,8 @@ router isis EVPN_UNDERLAY
 !
 router bgp 65000
    router-id 192.168.255.6
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2B.md
@@ -628,6 +628,8 @@ router isis EVPN_UNDERLAY
 | ---------- |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -664,6 +666,8 @@ router isis EVPN_UNDERLAY
 !
 router bgp 65000
    router-id 192.168.255.7
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE1.md
@@ -462,6 +462,8 @@ router isis EVPN_UNDERLAY
 | ---------- |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -504,6 +506,8 @@ router isis EVPN_UNDERLAY
 !
 router bgp 65000
    router-id 192.168.255.1
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    bgp cluster-id 192.168.255.1
    distance bgp 20 200 200

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE4.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE4.md
@@ -462,6 +462,8 @@ router isis EVPN_UNDERLAY
 | ---------- |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -504,6 +506,8 @@ router isis EVPN_UNDERLAY
 !
 router bgp 65000
    router-id 192.168.255.4
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    bgp cluster-id 192.168.255.4
    distance bgp 20 200 200

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3A.md
@@ -621,6 +621,8 @@ router isis EVPN_UNDERLAY
 | ---------- |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -657,6 +659,8 @@ router isis EVPN_UNDERLAY
 !
 router bgp 65000
    router-id 192.168.255.8
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3B.md
@@ -621,6 +621,8 @@ router isis EVPN_UNDERLAY
 | ---------- |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -657,6 +659,8 @@ router isis EVPN_UNDERLAY
 !
 router bgp 65000
    router-id 192.168.255.9
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-BL1A.cfg
@@ -184,6 +184,8 @@ router bfd
 !
 router bgp 65000
    router-id 192.168.255.10
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-BL1B.cfg
@@ -172,6 +172,8 @@ router bfd
 !
 router bgp 65000
    router-id 192.168.255.11
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-LEAF1A.cfg
@@ -112,6 +112,8 @@ router bfd
 !
 router bgp 65000
    router-id 192.168.255.5
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-LEAF2A.cfg
@@ -185,6 +185,8 @@ router bfd
 !
 router bgp 65000
    router-id 192.168.255.6
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-LEAF2B.cfg
@@ -185,6 +185,8 @@ router bfd
 !
 router bgp 65000
    router-id 192.168.255.7
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SPINE1.cfg
@@ -127,6 +127,8 @@ router bfd
 !
 router bgp 65000
    router-id 192.168.255.1
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    bgp cluster-id 192.168.255.1
    distance bgp 20 200 200

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SPINE4.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SPINE4.cfg
@@ -127,6 +127,8 @@ router bfd
 !
 router bgp 65000
    router-id 192.168.255.4
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    bgp cluster-id 192.168.255.4
    distance bgp 20 200 200

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SVC3A.cfg
@@ -180,6 +180,8 @@ router bfd
 !
 router bgp 65000
    router-id 192.168.255.8
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SVC3B.cfg
@@ -180,6 +180,8 @@ router bfd
 !
 router bgp 65000
    router-id 192.168.255.9
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-BL1A.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: OVERLAY-PEERS
     type: evpn

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-BL1B.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: OVERLAY-PEERS
     type: evpn

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF1A.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: OVERLAY-PEERS
     type: evpn

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: OVERLAY-PEERS
     type: evpn

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: OVERLAY-PEERS
     type: evpn

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SPINE1.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   bgp_cluster_id: 192.168.255.1
   peer_groups:
   - name: OVERLAY-PEERS

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SPINE4.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   bgp_cluster_id: 192.168.255.4
   peer_groups:
   - name: OVERLAY-PEERS

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SVC3A.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: OVERLAY-PEERS
     type: evpn

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SVC3B.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: OVERLAY-PEERS
     type: evpn

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -568,6 +568,8 @@ router ospf 101
 | ---------- |
 | distance bgp 20 200 200 |
 | maximum-paths 10 ecmp 10 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -612,6 +614,8 @@ router ospf 101
 !
 router bgp 65104
    router-id 192.168.255.10
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 10 ecmp 10

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -568,6 +568,8 @@ router ospf 101
 | ---------- |
 | distance bgp 20 200 200 |
 | maximum-paths 10 ecmp 10 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -612,6 +614,8 @@ router ospf 101
 !
 router bgp 65104
    router-id 192.168.255.11
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 10 ecmp 10

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
@@ -434,6 +434,8 @@ router ospf 101
 | ---------- |
 | distance bgp 20 200 200 |
 | maximum-paths 10 ecmp 10 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -478,6 +480,8 @@ router ospf 101
 !
 router bgp 65101
    router-id 192.168.255.5
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 10 ecmp 10

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -628,6 +628,8 @@ router ospf 101
 | ---------- |
 | distance bgp 20 200 200 |
 | maximum-paths 10 ecmp 10 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -695,6 +697,8 @@ router ospf 101
 !
 router bgp 65102
    router-id 192.168.255.6
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 10 ecmp 10

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -628,6 +628,8 @@ router ospf 101
 | ---------- |
 | distance bgp 20 200 200 |
 | maximum-paths 10 ecmp 10 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -695,6 +697,8 @@ router ospf 101
 !
 router bgp 65102
    router-id 192.168.255.7
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 10 ecmp 10

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE1.md
@@ -418,6 +418,8 @@ router ospf 101
 | ---------- |
 | distance bgp 20 200 200 |
 | maximum-paths 10 ecmp 10 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -460,6 +462,8 @@ router ospf 101
 !
 router bgp 65001
    router-id 192.168.255.1
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 10 ecmp 10

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE2.md
@@ -418,6 +418,8 @@ router ospf 101
 | ---------- |
 | distance bgp 20 200 200 |
 | maximum-paths 10 ecmp 10 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -460,6 +462,8 @@ router ospf 101
 !
 router bgp 65001
    router-id 192.168.255.2
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 10 ecmp 10

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE3.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE3.md
@@ -418,6 +418,8 @@ router ospf 101
 | ---------- |
 | distance bgp 20 200 200 |
 | maximum-paths 10 ecmp 10 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -460,6 +462,8 @@ router ospf 101
 !
 router bgp 65001
    router-id 192.168.255.3
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 10 ecmp 10

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE4.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE4.md
@@ -418,6 +418,8 @@ router ospf 101
 | ---------- |
 | distance bgp 20 200 200 |
 | maximum-paths 10 ecmp 10 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -460,6 +462,8 @@ router ospf 101
 !
 router bgp 65001
    router-id 192.168.255.4
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 10 ecmp 10

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -621,6 +621,8 @@ router ospf 101
 | ---------- |
 | distance bgp 20 200 200 |
 | maximum-paths 10 ecmp 10 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -688,6 +690,8 @@ router ospf 101
 !
 router bgp 65103
    router-id 192.168.255.8
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 10 ecmp 10

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -621,6 +621,8 @@ router ospf 101
 | ---------- |
 | distance bgp 20 200 200 |
 | maximum-paths 10 ecmp 10 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -688,6 +690,8 @@ router ospf 101
 !
 router bgp 65103
    router-id 192.168.255.9
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 10 ecmp 10

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-BL1A.cfg
@@ -151,6 +151,8 @@ router bfd
 !
 router bgp 65104
    router-id 192.168.255.10
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 10 ecmp 10

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-BL1B.cfg
@@ -151,6 +151,8 @@ router bfd
 !
 router bgp 65104
    router-id 192.168.255.11
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 10 ecmp 10

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-LEAF1A.cfg
@@ -99,6 +99,8 @@ router bfd
 !
 router bgp 65101
    router-id 192.168.255.5
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 10 ecmp 10

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
@@ -193,6 +193,8 @@ router bfd
 !
 router bgp 65102
    router-id 192.168.255.6
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 10 ecmp 10

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
@@ -193,6 +193,8 @@ router bfd
 !
 router bgp 65102
    router-id 192.168.255.7
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 10 ecmp 10

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SPINE1.cfg
@@ -112,6 +112,8 @@ router bfd
 !
 router bgp 65001
    router-id 192.168.255.1
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 10 ecmp 10

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SPINE2.cfg
@@ -112,6 +112,8 @@ router bfd
 !
 router bgp 65001
    router-id 192.168.255.2
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 10 ecmp 10

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SPINE3.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SPINE3.cfg
@@ -112,6 +112,8 @@ router bfd
 !
 router bgp 65001
    router-id 192.168.255.3
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 10 ecmp 10

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SPINE4.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SPINE4.cfg
@@ -112,6 +112,8 @@ router bfd
 !
 router bgp 65001
    router-id 192.168.255.4
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 10 ecmp 10

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
@@ -188,6 +188,8 @@ router bfd
 !
 router bgp 65103
    router-id 192.168.255.8
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 10 ecmp 10

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
@@ -188,6 +188,8 @@ router bfd
 !
 router bgp 65103
    router-id 192.168.255.9
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 10 ecmp 10

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: EVPN-OVERLAY-PEERS
     type: evpn

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: EVPN-OVERLAY-PEERS
     type: evpn

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: EVPN-OVERLAY-PEERS
     type: evpn

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: EVPN-OVERLAY-PEERS
     type: evpn

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: EVPN-OVERLAY-PEERS
     type: evpn

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SPINE1.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: EVPN-OVERLAY-PEERS
     type: evpn

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SPINE2.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: EVPN-OVERLAY-PEERS
     type: evpn

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SPINE3.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: EVPN-OVERLAY-PEERS
     type: evpn

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SPINE4.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: EVPN-OVERLAY-PEERS
     type: evpn

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: EVPN-OVERLAY-PEERS
     type: evpn

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: EVPN-OVERLAY-PEERS
     type: evpn

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -570,6 +570,8 @@ router general
 | ---------- |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -652,6 +654,8 @@ router general
 !
 router bgp 65104
    router-id 192.168.255.10
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -547,6 +547,8 @@ ip route vrf Tenant_A_WAN_Zone 10.3.4.0/24 1.2.3.4
 | ---------- |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -629,6 +631,8 @@ ip route vrf Tenant_A_WAN_Zone 10.3.4.0/24 1.2.3.4
 !
 router bgp 65105
    router-id 192.168.255.11
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
@@ -549,6 +549,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | ---------- |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -624,6 +626,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 !
 router bgp 65101
    router-id 192.168.255.5
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -923,6 +923,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | ---------- |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -1025,6 +1027,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 !
 router bgp 65102
    router-id 192.168.255.6
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -923,6 +923,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | ---------- |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -1025,6 +1027,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 !
 router bgp 65102
    router-id 192.168.255.7
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF3A.md
@@ -842,6 +842,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | ---------- |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -938,6 +940,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 !
 router bgp 65106
    router-id 192.168.255.12
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF3B.md
@@ -842,6 +842,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | ---------- |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -938,6 +940,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 !
 router bgp 65106
    router-id 192.168.255.13
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF4A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF4A.md
@@ -842,6 +842,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | ---------- |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -938,6 +940,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 !
 router bgp 65107
    router-id 192.168.255.14
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF4B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF4B.md
@@ -842,6 +842,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | ---------- |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -938,6 +940,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 !
 router bgp 65107
    router-id 192.168.255.15
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE1.md
@@ -373,6 +373,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | ---------- |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -435,6 +437,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 !
 router bgp 65001
    router-id 192.168.255.1
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE2.md
@@ -373,6 +373,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | ---------- |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -435,6 +437,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 !
 router bgp 65001
    router-id 192.168.255.2
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE3.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE3.md
@@ -373,6 +373,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | ---------- |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -435,6 +437,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 !
 router bgp 65001
    router-id 192.168.255.3
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE4.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE4.md
@@ -373,6 +373,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | ---------- |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -435,6 +437,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 !
 router bgp 65001
    router-id 192.168.255.4
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE5.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE5.md
@@ -335,6 +335,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | ---------- |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -387,6 +389,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 !
 router bgp 65001
    router-id 192.168.255.5
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE6.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE6.md
@@ -335,6 +335,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | ---------- |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -387,6 +389,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 !
 router bgp 65001
    router-id 192.168.255.6
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -1108,6 +1108,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | ---------- |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -1219,6 +1221,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 !
 router bgp 65103
    router-id 192.168.255.8
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -1082,6 +1082,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | ---------- |
 | distance bgp 20 200 200 |
 | maximum-paths 4 ecmp 4 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
 | no bgp default ipv4-unicast |
 
 #### Router BGP Peer Groups
@@ -1193,6 +1195,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 !
 router bgp 65103
    router-id 192.168.255.9
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-BL1A.cfg
@@ -173,6 +173,8 @@ router bfd
 !
 router bgp 65104
    router-id 192.168.255.10
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-BL1B.cfg
@@ -173,6 +173,8 @@ router bfd
 !
 router bgp 65105
    router-id 192.168.255.11
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF1A.cfg
@@ -175,6 +175,8 @@ router bfd
 !
 router bgp 65101
    router-id 192.168.255.5
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
@@ -439,6 +439,8 @@ router bfd
 !
 router bgp 65102
    router-id 192.168.255.6
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
@@ -439,6 +439,8 @@ router bfd
 !
 router bgp 65102
    router-id 192.168.255.7
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF3A.cfg
@@ -374,6 +374,8 @@ router bfd
 !
 router bgp 65106
    router-id 192.168.255.12
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF3B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF3B.cfg
@@ -374,6 +374,8 @@ router bfd
 !
 router bgp 65106
    router-id 192.168.255.13
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF4A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF4A.cfg
@@ -374,6 +374,8 @@ router bfd
 !
 router bgp 65107
    router-id 192.168.255.14
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF4B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF4B.cfg
@@ -374,6 +374,8 @@ router bfd
 !
 router bgp 65107
    router-id 192.168.255.15
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE1.cfg
@@ -105,6 +105,8 @@ router bfd
 !
 router bgp 65001
    router-id 192.168.255.1
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE2.cfg
@@ -105,6 +105,8 @@ router bfd
 !
 router bgp 65001
    router-id 192.168.255.2
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE3.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE3.cfg
@@ -105,6 +105,8 @@ router bfd
 !
 router bgp 65001
    router-id 192.168.255.3
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE4.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE4.cfg
@@ -105,6 +105,8 @@ router bfd
 !
 router bgp 65001
    router-id 192.168.255.4
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE5.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE5.cfg
@@ -77,6 +77,8 @@ router bfd
 !
 router bgp 65001
    router-id 192.168.255.5
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE6.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE6.cfg
@@ -77,6 +77,8 @@ router bfd
 !
 router bgp 65001
    router-id 192.168.255.6
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
@@ -587,6 +587,8 @@ router bfd
 !
 router bgp 65103
    router-id 192.168.255.8
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
@@ -571,6 +571,8 @@ router bfd
 !
 router bgp 65103
    router-id 192.168.255.9
+   graceful-restart restart-time 300
+   graceful-restart
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: UNDERLAY_PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: UNDERLAY_PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: UNDERLAY_PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG_PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG_PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF3A.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG_PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF3B.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG_PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF4A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF4A.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG_PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF4B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF4B.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG_PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE1.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: UNDERLAY_PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE2.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: UNDERLAY_PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE3.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: UNDERLAY_PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE4.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: UNDERLAY_PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE5.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE5.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: UNDERLAY_PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE6.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE6.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: UNDERLAY_PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG_PEER
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -7,6 +7,9 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  graceful_restart:
+    enabled: true
+    restart_time: 300
   peer_groups:
   - name: MLAG_PEER
     type: ipv4

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
@@ -21,6 +21,24 @@
 {%         for bgp_default in router_bgp.bgp_defaults | arista.avd.default([]) %}
 | {{ bgp_default }} |
 {%         endfor %}
+{%         if router_bgp.graceful_restart.enabled is arista.avd.defined(true) and router_bgp.graceful_restart.restart_time is arista.avd.defined %}
+| graceful-restart restart-time {{ router_bgp.graceful_restart.restart_time }} |
+{%         endif %}
+{%         if router_bgp.graceful_restart.stalepath_time is arista.avd.defined %}
+| graceful-restart stalepath-time {{ router_bgp.graceful_restart.stalepath_time }} |
+{%         endif %}
+{%         if router_bgp.graceful_restart.enabled is arista.avd.defined(true) %}
+| graceful-restart |
+{%         endif %}
+{%         if router_bgp.graceful_restart_helper.enabled is arista.avd.defined(false) %}
+| no graceful-restart-helper |
+{%         elif router_bgp.graceful_restart_helper.enabled is arista.avd.defined(true) %}
+{%             if router_bgp.graceful_restart_helper.restart_time is arista.avd.defined %}
+| graceful-restart-helper restart-time {{ router_bgp.graceful_restart_helper.restart_time }} |
+{%             elif router_bgp.graceful_restart_helper.long_lived is arista.avd.defined(true) %}
+| graceful-restart-helper long-lived |
+{%             endif %}
+{%         endif %}
 {%         if router_bgp.bgp.bestpath.d_path is arista.avd.defined(true) %}
 | bgp bestpath d-path |
 {%         endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
@@ -21,13 +21,13 @@
 {%         for bgp_default in router_bgp.bgp_defaults | arista.avd.default([]) %}
 | {{ bgp_default }} |
 {%         endfor %}
-{%         if router_bgp.graceful_restart.enabled is arista.avd.defined(true) and router_bgp.graceful_restart.restart_time is arista.avd.defined %}
-| graceful-restart restart-time {{ router_bgp.graceful_restart.restart_time }} |
-{%         endif %}
-{%         if router_bgp.graceful_restart.stalepath_time is arista.avd.defined %}
-| graceful-restart stalepath-time {{ router_bgp.graceful_restart.stalepath_time }} |
-{%         endif %}
 {%         if router_bgp.graceful_restart.enabled is arista.avd.defined(true) %}
+{%             if router_bgp.graceful_restart.restart_time is arista.avd.defined %}
+| graceful-restart restart-time {{ router_bgp.graceful_restart.restart_time }} |
+{%             endif %}
+{%             if router_bgp.graceful_restart.stalepath_time is arista.avd.defined %}
+| graceful-restart stalepath-time {{ router_bgp.graceful_restart.stalepath_time }} |
+{%             endif %}
 | graceful-restart |
 {%         endif %}
 {%         if router_bgp.graceful_restart_helper.enabled is arista.avd.defined(false) %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -12,13 +12,13 @@ router bgp {{ router_bgp.as }}
 {%         endif %}
    {{ distance_cli }}
 {%     endif %}
-{%     if router_bgp.graceful_restart.enabled is arista.avd.defined(true) and router_bgp.graceful_restart.restart_time is arista.avd.defined %}
-   graceful-restart restart-time {{ router_bgp.graceful_restart.restart_time }}
-{%     endif %}
-{%     if router_bgp.graceful_restart.stalepath_time is arista.avd.defined %}
-   graceful-restart stalepath-time {{ router_bgp.graceful_restart.stalepath_time }}
-{%     endif %}
 {%     if router_bgp.graceful_restart.enabled is arista.avd.defined(true) %}
+{%         if router_bgp.graceful_restart.restart_time is arista.avd.defined %}
+   graceful-restart restart-time {{ router_bgp.graceful_restart.restart_time }}
+{%         endif %}
+{%         if router_bgp.graceful_restart.stalepath_time is arista.avd.defined %}
+   graceful-restart stalepath-time {{ router_bgp.graceful_restart.stalepath_time }}
+{%         endif %}
    graceful-restart
 {%     endif %}
 {%     if router_bgp.graceful_restart_helper.enabled is arista.avd.defined(false) %}

--- a/ansible_collections/arista/avd/roles/eos_designs/README.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/README.md
@@ -138,14 +138,10 @@ spine_bgp_defaults:
 #  - update wait-for-convergence
 #  - update wait-install
   - distance bgp 20 200 200
-  - graceful-restart restart-time 300
-  - graceful-restart
 
 leaf_bgp_defaults:
 #  - update wait-install
   - distance bgp 20 200 200
-  - graceful-restart restart-time 300
-  - graceful-restart
 
 # Update p2p mtu 9000 -> 1500, MTU 9000 not supported in vEOS-LAB.
 p2p_uplinks_mtu: 1500

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/Fabric Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/Fabric Variables.md
@@ -57,6 +57,9 @@ search:
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
     | [<samp>bgp_as</samp>](## "bgp_as") | String |  |  |  | AS number to use to configure overlay when "overlay_routing_protocol" == ibgp |
     | [<samp>bgp_default_ipv4_unicast</samp>](## "bgp_default_ipv4_unicast") | Boolean |  | False |  | Default activation of IPv4 unicast address-family on all IPv4 neighbors.<br>It is best practice to disable activation.<br> |
+    | [<samp>bgp_graceful_restart</samp>](## "bgp_graceful_restart") | Dictionary |  |  |  | Graceful BGP restart allows a BGP speaker with separate control plane and data plane processing to continue forwarding traffic during a BGP restart.<br>Its neighbors (receiving speakers) may retain routing information from the restarting speaker while a BGP session with it is being re-established, reducing route flapping.<br> |
+    | [<samp>&nbsp;&nbsp;enabled</samp>](## "bgp_graceful_restart.enabled") | Boolean |  | True |  | Enable or disable graceful restart helper mode for all BGP peers. |
+    | [<samp>&nbsp;&nbsp;restart_time</samp>](## "bgp_graceful_restart.restart_time") | Integer |  | 300 | Min: 1<br>Max: 3600 | Restart time in seconds. |
     | [<samp>bgp_mesh_pes</samp>](## "bgp_mesh_pes") | Boolean |  | False |  | Whether to configure an iBGP full mesh between PEs, either because there is no RR used or other reasons. |
     | [<samp>underlay_filter_peer_as</samp>](## "underlay_filter_peer_as") | Boolean |  | False |  | Configure route-map on eBGP sessions towards underlay peers, where prefixes with the peer's ASN in the AS Path are filtered away.<br>This is very useful in very large scale networks not using EVPN overlays, where convergence will be quicker by not having to return<br>all updates received from Spine-1 to Spine-2 just for Spine-2 to throw them away because of AS Path loop detection.<br>Note this key is ignored when EVPN is configured.<br> |
 
@@ -65,6 +68,9 @@ search:
     ```yaml
     bgp_as: <str>
     bgp_default_ipv4_unicast: <bool>
+    bgp_graceful_restart:
+      enabled: <bool>
+      restart_time: <int>
     bgp_mesh_pes: <bool>
     underlay_filter_peer_as: <bool>
     ```

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/base/avdstructuredconfig.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/base/avdstructuredconfig.py
@@ -29,44 +29,30 @@ class AvdStructuredConfig(AvdFacts):
         if self.shared_utils.bgp_as is None:
             return None
 
-        router_bgp = {}
-
         bgp_defaults = get(self.shared_utils.switch_data_combined, "bgp_defaults", default=[])
-
-        bgp_default_ipv4_unicast = get(self._hostvars, "bgp_default_ipv4_unicast", default=False)
-
-        bgp_graceful_restart_enabled = get(self._hostvars, "bgp_graceful_restart.enabled", default=True)
-
         if (bgp_maximum_paths := get(self._hostvars, "bgp_maximum_paths")) is not None:
             max_paths_str = f"maximum-paths {bgp_maximum_paths}"
             if (bgp_ecmp := get(self._hostvars, "bgp_ecmp")) is not None:
                 max_paths_str += f" ecmp {bgp_ecmp}"
             bgp_defaults.append(max_paths_str)
 
-        router_bgp.update(
-            {
-                "as": self.shared_utils.bgp_as,
-                "router_id": self.shared_utils.router_id,
-                "bgp_defaults": bgp_defaults,
-                "bgp": {
-                    "default": {
-                        "ipv4_unicast": bgp_default_ipv4_unicast,
-                    },
+        router_bgp = {
+            "as": self.shared_utils.bgp_as,
+            "router_id": self.shared_utils.router_id,
+            "bgp_defaults": bgp_defaults,
+            "bgp": {
+                "default": {
+                    "ipv4_unicast": get(self._hostvars, "bgp_default_ipv4_unicast", default=False),
                 },
-                "graceful_restart": {
-                    "enabled": bgp_graceful_restart_enabled,
-                },
-            }
-        )
+            },
+        }
 
-        if bgp_graceful_restart_enabled is True:
-            bgp_graceful_restart_time = get(self._hostvars, "bgp_graceful_restart.restart_time", default=300)
-
+        if get(self._hostvars, "bgp_graceful_restart.enabled", default=True) is True:
             router_bgp.update(
                 {
                     "graceful_restart": {
-                        "enabled": bgp_graceful_restart_enabled,
-                        "restart_time": bgp_graceful_restart_time,
+                        "enabled": True,
+                        "restart_time": get(self._hostvars, "bgp_graceful_restart.restart_time", default=300),
                     },
                 },
             )

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -50,6 +50,31 @@
       "default": 4,
       "title": "BGP Ecmp"
     },
+    "bgp_graceful_restart": {
+      "description": "Graceful BGP restart allows a BGP speaker with separate control plane and data plane processing to continue forwarding traffic during a BGP restart.\nIts neighbors (receiving speakers) may retain routing information from the restarting speaker while a BGP session with it is being re-established, reducing route flapping.\n",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable or disable graceful restart helper mode for all BGP peers.",
+          "title": "Enabled"
+        },
+        "restart_time": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 3600,
+          "default": 300,
+          "description": "Restart time in seconds.",
+          "title": "Restart Time"
+        }
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^_.+$": {}
+      },
+      "title": "BGP Graceful Restart"
+    },
     "bgp_maximum_paths": {
       "description": "Maximum Paths for BGP multi-path",
       "type": "integer",

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
@@ -59,6 +59,39 @@ keys:
     convert_types:
     - str
     default: 4
+  bgp_graceful_restart:
+    documentation_options:
+      filename: Fabric Variables
+      table: BGP Settings
+    description: 'Graceful BGP restart allows a BGP speaker with separate control
+      plane and data plane processing to continue forwarding traffic during a BGP
+      restart.
+
+      Its neighbors (receiving speakers) may retain routing information from the restarting
+      speaker while a BGP session with it is being re-established, reducing route
+      flapping.
+
+      '
+    type: dict
+    keys:
+      enabled:
+        documentation_options:
+          filename: Fabric Variables
+          table: BGP Settings
+        type: bool
+        default: true
+        description: Enable or disable graceful restart helper mode for all BGP peers.
+      restart_time:
+        documentation_options:
+          filename: Fabric Variables
+          table: BGP Settings
+        type: int
+        convert_types:
+        - str
+        min: 1
+        max: 3600
+        default: 300
+        description: Restart time in seconds.
   bgp_maximum_paths:
     documentation_options:
       filename: Fabric Variables

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/bgp_graceful_restart.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/bgp_graceful_restart.schema.yml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  bgp_graceful_restart:
+    documentation_options:
+      filename: Fabric Variables
+      table: BGP Settings
+    description: |
+      Graceful BGP restart allows a BGP speaker with separate control plane and data plane processing to continue forwarding traffic during a BGP restart.
+      Its neighbors (receiving speakers) may retain routing information from the restarting speaker while a BGP session with it is being re-established, reducing route flapping.
+    type: dict
+    keys:
+      enabled:
+        documentation_options:
+          filename: Fabric Variables
+          table: BGP Settings
+        type: bool
+        default: true
+        description: Enable or disable graceful restart helper mode for all BGP peers.
+      restart_time:
+        documentation_options:
+          filename: Fabric Variables
+          table: BGP Settings
+        type: int
+        convert_types:
+          - str
+        min: 1
+        max: 3600
+        default: 300
+        description: Restart time in seconds.

--- a/ansible_collections/arista/avd/tests/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/tests/inventory/group_vars/DC1_FABRIC.yml
@@ -24,8 +24,6 @@ spine:
     loopback_ipv4_pool: 192.168.255.0/24
     bgp_defaults:
       - 'distance bgp 20 200 200'
-      - 'graceful-restart restart-time 300'
-      - 'graceful-restart'
     mlag_peer_ipv4_pool: 10.255.252.0/24
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
   nodes:
@@ -55,8 +53,6 @@ l3leaf:
     virtual_router_mac_address: 00:1c:73:00:dc:01
     bgp_defaults:
       - 'distance bgp 20 200 200'
-      - 'graceful-restart restart-time 300'
-      - 'graceful-restart'
     spanning_tree_mode: mstp
     spanning_tree_priority: 16384
   node_groups:


### PR DESCRIPTION
## Change Summary

Fabric variable to adjust bgp graceful-restart and implement best practices.

## Related Issue(s)

Fixes #2802

## Component(s) name

`arista.avd.eos_designs`
`arista.avd.eos_cli_config_gen`

## Proposed changes

- [x] Added fabric variable:

    ```yaml
    bgp_graceful_restart:
      enabled: < bool > -> default true
      restart_time: < int > -> default -> 300
    ```

- [x] update eoc_cli_config_gen documentation output
- [x] update documentation to remove commands from bgp_defaults
- [x] updated release notes and porting guide
- [x] update molecule scenarios
   - added test in eos_designs unit test (DC1-LEAF1A, DC1-LEAF2A, DC1-LEAF2B)
   - remove graceful-restart configuration from `bgp_defaults:`


## How to test

See molecule scenario


