### PR TITLE
Feat(eos_designs)!: Change p2p_uplinks_mtu default value from 9000 to 9214

### DIFF
--- a/ansible_collections/arista/avd/docs/porting-guides/4.x.x.md
+++ b/ansible_collections/arista/avd/docs/porting-guides/4.x.x.md
@@ -17,7 +17,7 @@ built in to `eos_designs`.
 
 The default value for `p2p_uplinks_mtu` has changed from 9000 to 9214.
 
-To retain existing behavior set `p2p_uplinks_mtu` to 9000.
+To retain AVD 3.8 behavior set `p2p_uplinks_mtu` to 9000.
 
 ```yaml
 p2p_uplinks_mtu: 9000

--- a/ansible_collections/arista/avd/docs/porting-guides/4.x.x.md
+++ b/ansible_collections/arista/avd/docs/porting-guides/4.x.x.md
@@ -13,7 +13,15 @@ built in to `eos_designs`.
 - `evpn_rd_type` has been removed and replaced with `overlay_rd_type`.
 - `evpn_rt_type` has been removed and replaced with `overlay_rt_type`.
 
-### Fabric variables
+### P2P uplink mtu
+
+The default value for `p2p_uplinks_mtu` has changed from 9000 to 9214.
+
+To retain existing behavior set `p2p_uplinks_mtu` to 9000.
+
+```yaml
+p2p_uplinks_mtu: 9000
+```
 
 #### BGP variables
 
@@ -61,7 +69,7 @@ bgp_peer_groups:
 
 TODO: Add link to data model once schema is done.
 
-**ISIS underlay variables:**
+#### ISIS underlay variables
 
 - `isis_default_circuit_type`  default changed from `level-1-2` (EOS default) to `level-2`.
 

--- a/ansible_collections/arista/avd/docs/release-notes/4.x.x.md
+++ b/ansible_collections/arista/avd/docs/release-notes/4.x.x.md
@@ -97,24 +97,33 @@ See details in the [Porting guide for AVD 4.x.x](../porting-guides/4.x.x.md#link
 
 - `evpn_rd_type` has been removed and replaced with `overlay_rd_type`.
 - `evpn_rt_type` has been removed and replaced with `overlay_rt_type`.
+
+See details in the [Porting guide for AVD 4.x.x](../porting-guides/4.x.x.md#network-services-variables).
+
 - `bgp_peer_groups.IPv4_UNDERLAY_PEERS` has been removed and replaced with `bgp_peer_groups.ipv4_underlay_peers` to avoid upper-case variables.
 - `bgp_peer_groups.MLAG_IPv4_UNDERLAY_PEER` has been removed and replaced with `bgp_peer_groups.mlag_ipv4_underlay_peer` to avoid upper-case variables.
 - `bgp_peer_groups.EVPN_OVERLAY_PEERS` has been removed and replaced with `bgp_peer_groups.evpn_overlay_peers` to avoid upper-case variables.
 - `connected_endpoints_key.[].adapters.[].server_ports` has been removed and replaced with `connected_endpoints_key.[].adapters.[].endpoint_ports`.
 
-See details in the [Porting guide for AVD 4.x.x](../porting-guides/4.x.x.md#fabric-variables).
+See details in the [Porting guide for AVD 4.x.x](../porting-guides/4.x.x.md#bgp-variables).
 
 #### Change in defaults eos_designs in underlay ISIS variables
 
 - `isis_default_circuit_type`  default changed from `level-1-2` (EOS default) to `level-2`.
 
-See details in the [Porting guide for AVD 4.x.x](../porting-guides/4.x.x.md#fabric-variables).
+See details in the [Porting guide for AVD 4.x.x](../porting-guides/4.x.x.md#isis-underlay-variables).
 
 ### change in defaults eos_designs in BGP variables
 
 A new key, `bgp_default_ipv4_unicast: <bool> -> default false` was introduced to implement the best practice of disabling the default activation of IPv4 unicast address-family.
 
-See details in the [Porting guide for AVD 4.x.x](../porting-guides/4.x.x.md#fabric-variables).
+See details in the [Porting guide for AVD 4.x.x](../porting-guides/4.x.x.md#bgp-variables).
+
+### change in default for eos_designs point-to-point ethernet interfaces
+
+The default value for `p2p_uplinks_mtu` has changed from 9000 to 9214.
+
+See details in the [Porting guide for AVD 4.x.x](../porting-guides/4.x.x.md#p2p-uplink-mtu).
 
 #### Change in eos_designs behavior in core_interfaces variables
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/BGP-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/BGP-SPINE1.md
@@ -161,7 +161,7 @@ vlan 4094
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet5 | P2P_LINK_TO_DUMMY-CORE_Ethernet1/3 | routed | - | 192.168.253.4/31 | default | 9000 | False | - | - |
+| Ethernet5 | P2P_LINK_TO_DUMMY-CORE_Ethernet1/3 | routed | - | 192.168.253.4/31 | default | 9214 | False | - | - |
 
 #### Ethernet Interfaces Device Configuration
 
@@ -190,7 +190,7 @@ interface Ethernet4
 interface Ethernet5
    description P2P_LINK_TO_DUMMY-CORE_Ethernet1/3
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 192.168.253.4/31
 ```
@@ -271,7 +271,7 @@ interface Loopback0
 | Interface | Description | VRF |  MTU | Shutdown |
 | --------- | ----------- | --- | ---- | -------- |
 | Vlan100 | SVI_100 | default | - | False |
-| Vlan4094 | MLAG_PEER | default | 9000 | False |
+| Vlan4094 | MLAG_PEER | default | 9214 | False |
 
 ##### IPv4
 
@@ -292,7 +292,7 @@ interface Vlan100
 interface Vlan4094
    description MLAG_PEER
    no shutdown
-   mtu 9000
+   mtu 9214
    no autostate
    ip address 192.168.254.0/31
 ```

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/BGP-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/BGP-SPINE2.md
@@ -161,7 +161,7 @@ vlan 4094
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet5 | P2P_LINK_TO_DUMMY-CORE_Ethernet1/4 | routed | - | 192.168.253.6/31 | default | 9000 | False | - | - |
+| Ethernet5 | P2P_LINK_TO_DUMMY-CORE_Ethernet1/4 | routed | - | 192.168.253.6/31 | default | 9214 | False | - | - |
 
 #### Ethernet Interfaces Device Configuration
 
@@ -190,7 +190,7 @@ interface Ethernet4
 interface Ethernet5
    description P2P_LINK_TO_DUMMY-CORE_Ethernet1/4
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 192.168.253.6/31
 ```
@@ -271,7 +271,7 @@ interface Loopback0
 | Interface | Description | VRF |  MTU | Shutdown |
 | --------- | ----------- | --- | ---- | -------- |
 | Vlan100 | SVI_100 | default | - | False |
-| Vlan4094 | MLAG_PEER | default | 9000 | False |
+| Vlan4094 | MLAG_PEER | default | 9214 | False |
 
 ##### IPv4
 
@@ -292,7 +292,7 @@ interface Vlan100
 interface Vlan4094
    description MLAG_PEER
    no shutdown
-   mtu 9000
+   mtu 9214
    no autostate
    ip address 192.168.254.1/31
 ```

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/L2ONLY-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/L2ONLY-SPINE1.md
@@ -224,7 +224,7 @@ interface Port-Channel3
 
 | Interface | Description | VRF |  MTU | Shutdown |
 | --------- | ----------- | --- | ---- | -------- |
-| Vlan4094 | MLAG_PEER | default | 9000 | False |
+| Vlan4094 | MLAG_PEER | default | 9214 | False |
 
 ##### IPv4
 
@@ -239,7 +239,7 @@ interface Port-Channel3
 interface Vlan4094
    description MLAG_PEER
    no shutdown
-   mtu 9000
+   mtu 9214
    no autostate
    ip address 192.168.254.0/31
 ```

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/L2ONLY-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/L2ONLY-SPINE2.md
@@ -224,7 +224,7 @@ interface Port-Channel3
 
 | Interface | Description | VRF |  MTU | Shutdown |
 | --------- | ----------- | --- | ---- | -------- |
-| Vlan4094 | MLAG_PEER | default | 9000 | False |
+| Vlan4094 | MLAG_PEER | default | 9214 | False |
 
 ##### IPv4
 
@@ -239,7 +239,7 @@ interface Port-Channel3
 interface Vlan4094
    description MLAG_PEER
    no shutdown
-   mtu 9000
+   mtu 9214
    no autostate
    ip address 192.168.254.1/31
 ```

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/OSPF-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/OSPF-SPINE1.md
@@ -159,7 +159,7 @@ vlan 4094
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet5 | P2P_LINK_TO_DUMMY-CORE_Ethernet1/1 | routed | - | 192.168.253.0/31 | default | 9000 | False | - | - |
+| Ethernet5 | P2P_LINK_TO_DUMMY-CORE_Ethernet1/1 | routed | - | 192.168.253.0/31 | default | 9214 | False | - | - |
 
 #### Ethernet Interfaces Device Configuration
 
@@ -188,7 +188,7 @@ interface Ethernet4
 interface Ethernet5
    description P2P_LINK_TO_DUMMY-CORE_Ethernet1/1
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 192.168.253.0/31
    ip ospf network point-to-point
@@ -272,7 +272,7 @@ interface Loopback0
 | Interface | Description | VRF |  MTU | Shutdown |
 | --------- | ----------- | --- | ---- | -------- |
 | Vlan100 | SVI_100 | default | - | False |
-| Vlan4094 | MLAG_PEER | default | 9000 | False |
+| Vlan4094 | MLAG_PEER | default | 9214 | False |
 
 ##### IPv4
 
@@ -293,7 +293,7 @@ interface Vlan100
 interface Vlan4094
    description MLAG_PEER
    no shutdown
-   mtu 9000
+   mtu 9214
    no autostate
    ip address 192.168.254.0/31
    ip ospf network point-to-point

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/OSPF-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/OSPF-SPINE2.md
@@ -159,7 +159,7 @@ vlan 4094
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet5 | P2P_LINK_TO_DUMMY-CORE_Ethernet1/2 | routed | - | 192.168.253.2/31 | default | 9000 | False | - | - |
+| Ethernet5 | P2P_LINK_TO_DUMMY-CORE_Ethernet1/2 | routed | - | 192.168.253.2/31 | default | 9214 | False | - | - |
 
 #### Ethernet Interfaces Device Configuration
 
@@ -188,7 +188,7 @@ interface Ethernet4
 interface Ethernet5
    description P2P_LINK_TO_DUMMY-CORE_Ethernet1/2
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 192.168.253.2/31
    ip ospf network point-to-point
@@ -272,7 +272,7 @@ interface Loopback0
 | Interface | Description | VRF |  MTU | Shutdown |
 | --------- | ----------- | --- | ---- | -------- |
 | Vlan100 | SVI_100 | default | - | False |
-| Vlan4094 | MLAG_PEER | default | 9000 | False |
+| Vlan4094 | MLAG_PEER | default | 9214 | False |
 
 ##### IPv4
 
@@ -293,7 +293,7 @@ interface Vlan100
 interface Vlan4094
    description MLAG_PEER
    no shutdown
-   mtu 9000
+   mtu 9214
    no autostate
    ip address 192.168.254.1/31
    ip ospf network point-to-point

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/BGP-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/BGP-SPINE1.cfg
@@ -70,7 +70,7 @@ interface Ethernet4
 interface Ethernet5
    description P2P_LINK_TO_DUMMY-CORE_Ethernet1/3
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 192.168.253.4/31
 !
@@ -87,7 +87,7 @@ interface Vlan100
 interface Vlan4094
    description MLAG_PEER
    no shutdown
-   mtu 9000
+   mtu 9214
    no autostate
    ip address 192.168.254.0/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/BGP-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/BGP-SPINE2.cfg
@@ -70,7 +70,7 @@ interface Ethernet4
 interface Ethernet5
    description P2P_LINK_TO_DUMMY-CORE_Ethernet1/4
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 192.168.253.6/31
 !
@@ -87,7 +87,7 @@ interface Vlan100
 interface Vlan4094
    description MLAG_PEER
    no shutdown
-   mtu 9000
+   mtu 9214
    no autostate
    ip address 192.168.254.1/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/L2ONLY-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/L2ONLY-SPINE1.cfg
@@ -69,7 +69,7 @@ interface Ethernet4
 interface Vlan4094
    description MLAG_PEER
    no shutdown
-   mtu 9000
+   mtu 9214
    no autostate
    ip address 192.168.254.0/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/L2ONLY-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/L2ONLY-SPINE2.cfg
@@ -69,7 +69,7 @@ interface Ethernet4
 interface Vlan4094
    description MLAG_PEER
    no shutdown
-   mtu 9000
+   mtu 9214
    no autostate
    ip address 192.168.254.1/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/OSPF-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/OSPF-SPINE1.cfg
@@ -70,7 +70,7 @@ interface Ethernet4
 interface Ethernet5
    description P2P_LINK_TO_DUMMY-CORE_Ethernet1/1
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 192.168.253.0/31
    ip ospf network point-to-point
@@ -90,7 +90,7 @@ interface Vlan100
 interface Vlan4094
    description MLAG_PEER
    no shutdown
-   mtu 9000
+   mtu 9214
    no autostate
    ip address 192.168.254.0/31
    ip ospf network point-to-point

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/OSPF-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/OSPF-SPINE2.cfg
@@ -70,7 +70,7 @@ interface Ethernet4
 interface Ethernet5
    description P2P_LINK_TO_DUMMY-CORE_Ethernet1/2
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 192.168.253.2/31
    ip ospf network point-to-point
@@ -90,7 +90,7 @@ interface Vlan100
 interface Vlan4094
    description MLAG_PEER
    no shutdown
-   mtu 9000
+   mtu 9214
    no autostate
    ip address 192.168.254.1/31
    ip ospf network point-to-point

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-SPINE1.yml
@@ -70,7 +70,7 @@ vlan_interfaces:
   shutdown: false
   ip_address: 192.168.254.0/31
   no_autostate: true
-  mtu: 9000
+  mtu: 9214
 - name: Vlan100
   tenant: L2LS_BGP
   description: SVI_100
@@ -148,7 +148,7 @@ ethernet_interfaces:
   description: P2P_LINK_TO_DUMMY-CORE_Ethernet1/3
   type: routed
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   ip_address: 192.168.253.4/31
 mlag_configuration:
   domain_id: BGP_SPINES

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-SPINE2.yml
@@ -74,7 +74,7 @@ vlan_interfaces:
   shutdown: false
   ip_address: 192.168.254.1/31
   no_autostate: true
-  mtu: 9000
+  mtu: 9214
 - name: Vlan100
   tenant: L2LS_BGP
   description: SVI_100
@@ -152,7 +152,7 @@ ethernet_interfaces:
   description: P2P_LINK_TO_DUMMY-CORE_Ethernet1/4
   type: routed
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   ip_address: 192.168.253.6/31
 mlag_configuration:
   domain_id: BGP_SPINES

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/L2ONLY-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/L2ONLY-SPINE1.yml
@@ -33,7 +33,7 @@ vlan_interfaces:
   shutdown: false
   ip_address: 192.168.254.0/31
   no_autostate: true
-  mtu: 9000
+  mtu: 9214
 port_channel_interfaces:
 - name: Port-Channel3
   description: MLAG_PEER_L2ONLY-SPINE2_Po3

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/L2ONLY-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/L2ONLY-SPINE2.yml
@@ -33,7 +33,7 @@ vlan_interfaces:
   shutdown: false
   ip_address: 192.168.254.1/31
   no_autostate: true
-  mtu: 9000
+  mtu: 9214
 port_channel_interfaces:
 - name: Port-Channel3
   description: MLAG_PEER_L2ONLY-SPINE1_Po3

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-SPINE1.yml
@@ -33,7 +33,7 @@ vlan_interfaces:
   shutdown: false
   ip_address: 192.168.254.0/31
   no_autostate: true
-  mtu: 9000
+  mtu: 9214
   ospf_network_point_to_point: true
   ospf_area: 0.0.0.0
 - name: Vlan100
@@ -113,7 +113,7 @@ ethernet_interfaces:
   description: P2P_LINK_TO_DUMMY-CORE_Ethernet1/1
   type: routed
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   ip_address: 192.168.253.0/31
   ospf_network_point_to_point: true
   ospf_area: 0.0.0.0

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-SPINE2.yml
@@ -36,7 +36,7 @@ vlan_interfaces:
   shutdown: false
   ip_address: 192.168.254.1/31
   no_autostate: true
-  mtu: 9000
+  mtu: 9214
   ospf_network_point_to_point: true
   ospf_area: 0.0.0.0
 - name: Vlan100
@@ -116,7 +116,7 @@ ethernet_interfaces:
   description: P2P_LINK_TO_DUMMY-CORE_Ethernet1/2
   type: routed
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   ip_address: 192.168.253.2/31
   ospf_network_point_to_point: true
   ospf_area: 0.0.0.0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF3A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF3A.cfg
@@ -63,13 +63,13 @@ interface Management1
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
    no shutdown
-   mtu 9000
+   mtu 9214
    ip address 10.255.251.8/31
 !
 interface Vlan4094
    description MLAG_PEER
    no shutdown
-   mtu 9000
+   mtu 9214
    no autostate
    ip address 10.255.252.8/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF3B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF3B.cfg
@@ -63,13 +63,13 @@ interface Management1
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
    no shutdown
-   mtu 9000
+   mtu 9214
    ip address 10.255.251.9/31
 !
 interface Vlan4094
    description MLAG_PEER
    no shutdown
-   mtu 9000
+   mtu 9214
    no autostate
    ip address 10.255.252.9/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF4A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF4A.cfg
@@ -63,13 +63,13 @@ interface Management1
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
    no shutdown
-   mtu 9000
+   mtu 9214
    ip address 10.255.251.12/31
 !
 interface Vlan4094
    description MLAG_PEER
    no shutdown
-   mtu 9000
+   mtu 9214
    no autostate
    ip address 10.255.252.12/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF4B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF4B.cfg
@@ -63,13 +63,13 @@ interface Management1
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
    no shutdown
-   mtu 9000
+   mtu 9214
    ip address 10.255.251.13/31
 !
 interface Vlan4094
    description MLAG_PEER
    no shutdown
-   mtu 9000
+   mtu 9214
    no autostate
    ip address 10.255.252.13/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF7A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF7A.cfg
@@ -63,13 +63,13 @@ interface Management1
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
    no shutdown
-   mtu 9000
+   mtu 9214
    ip address 10.255.251.20/31
 !
 interface Vlan4094
    description MLAG_PEER
    no shutdown
-   mtu 9000
+   mtu 9214
    no autostate
    ip address 10.255.252.20/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF7B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF7B.cfg
@@ -63,13 +63,13 @@ interface Management1
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
    no shutdown
-   mtu 9000
+   mtu 9214
    ip address 10.255.251.21/31
 !
 interface Vlan4094
    description MLAG_PEER
    no shutdown
-   mtu 9000
+   mtu 9214
    no autostate
    ip address 10.255.252.21/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_NODE_TYPE_LEAF01.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_NODE_TYPE_LEAF01.cfg
@@ -19,14 +19,14 @@ vrf instance MGMT
 interface Ethernet1
    description P2P_LINK_TO_AUTO_NODE_TYPE_SPINE01_Ethernet1
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 172.31.255.1/31
 !
 interface Ethernet2
    description P2P_LINK_TO_AUTO_NODE_TYPE_SPINE02_Ethernet1
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 172.31.255.3/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_NODE_TYPE_SPINE01.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_NODE_TYPE_SPINE01.cfg
@@ -18,14 +18,14 @@ vrf instance MGMT
 interface Ethernet1
    description P2P_LINK_TO_AUTO_NODE_TYPE_LEAF01_Ethernet1
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 172.31.255.0/31
 !
 interface Ethernet2
    description P2P_LINK_TO_AUTO_NODE_TYPE_UNGROUPED_LEAF02_Ethernet1
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 172.31.255.4/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_NODE_TYPE_SPINE02.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_NODE_TYPE_SPINE02.cfg
@@ -18,14 +18,14 @@ vrf instance MGMT
 interface Ethernet1
    description P2P_LINK_TO_AUTO_NODE_TYPE_LEAF01_Ethernet2
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 172.31.255.2/31
 !
 interface Ethernet2
    description P2P_LINK_TO_AUTO_NODE_TYPE_UNGROUPED_LEAF02_Ethernet2
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 172.31.255.6/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_NODE_TYPE_UNGROUPED_LEAF02.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_NODE_TYPE_UNGROUPED_LEAF02.cfg
@@ -19,14 +19,14 @@ vrf instance MGMT
 interface Ethernet1
    description P2P_LINK_TO_AUTO_NODE_TYPE_SPINE01_Ethernet2
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 172.31.255.5/31
 !
 interface Ethernet2
    description P2P_LINK_TO_AUTO_NODE_TYPE_SPINE02_Ethernet2
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 172.31.255.7/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-PYTHON_MODULES-L3LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-PYTHON_MODULES-L3LEAF1A.cfg
@@ -44,7 +44,7 @@ interface Port-Channel3
 interface Ethernet1
    description TEST_CUSTOM_PREFIX_P2P_LINK_TO_CUSTOM-PYTHON_MODULES-SPINE1_Ethernet1
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 172.31.255.21/31
 !
@@ -83,20 +83,20 @@ interface Vlan110
 interface Vlan3000
    description MLAG_PEER_L3_iBGP: vrf TEST_VRF
    no shutdown
-   mtu 9000
+   mtu 9214
    vrf TEST_VRF
    ip address 10.255.240.10/31
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
    no shutdown
-   mtu 9000
+   mtu 9214
    ip address 10.255.251.10/31
 !
 interface Vlan4094
    description MLAG_PEER
    no shutdown
-   mtu 9000
+   mtu 9214
    no autostate
    ip address 10.255.252.10/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-PYTHON_MODULES-L3LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-PYTHON_MODULES-L3LEAF1B.cfg
@@ -44,7 +44,7 @@ interface Port-Channel3
 interface Ethernet1
    description TEST_CUSTOM_PREFIX_P2P_LINK_TO_CUSTOM-PYTHON_MODULES-SPINE1_Ethernet2
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 172.31.255.23/31
 !
@@ -83,20 +83,20 @@ interface Vlan110
 interface Vlan3000
    description MLAG_PEER_L3_iBGP: vrf TEST_VRF
    no shutdown
-   mtu 9000
+   mtu 9214
    vrf TEST_VRF
    ip address 10.255.240.11/31
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
    no shutdown
-   mtu 9000
+   mtu 9214
    ip address 10.255.251.11/31
 !
 interface Vlan4094
    description MLAG_PEER
    no shutdown
-   mtu 9000
+   mtu 9214
    no autostate
    ip address 10.255.252.11/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-PYTHON_MODULES-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-PYTHON_MODULES-SPINE1.cfg
@@ -18,14 +18,14 @@ vrf instance MGMT
 interface Ethernet1
    description TEST_CUSTOM_PREFIX_P2P_LINK_TO_CUSTOM-PYTHON_MODULES-L3LEAF1A_Ethernet1
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 172.31.255.20/31
 !
 interface Ethernet2
    description TEST_CUSTOM_PREFIX_P2P_LINK_TO_CUSTOM-PYTHON_MODULES-L3LEAF1B_Ethernet1
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 172.31.255.22/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-TEMPLATES-L3LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-TEMPLATES-L3LEAF1A.cfg
@@ -44,7 +44,7 @@ interface Port-Channel3
 interface Ethernet1
    description TEST_CUSTOM_PREFIX_P2P_LINK_TO_CUSTOM-TEMPLATES-SPINE1_Ethernet1
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 172.31.255.21/31
 !
@@ -83,20 +83,20 @@ interface Vlan110
 interface Vlan3000
    description MLAG_PEER_L3_iBGP: vrf TEST_VRF
    no shutdown
-   mtu 9000
+   mtu 9214
    vrf TEST_VRF
    ip address 10.255.240.10/31
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
    no shutdown
-   mtu 9000
+   mtu 9214
    ip address 10.255.251.10/31
 !
 interface Vlan4094
    description MLAG_PEER
    no shutdown
-   mtu 9000
+   mtu 9214
    no autostate
    ip address 10.255.252.10/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-TEMPLATES-L3LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-TEMPLATES-L3LEAF1B.cfg
@@ -44,7 +44,7 @@ interface Port-Channel3
 interface Ethernet1
    description TEST_CUSTOM_PREFIX_P2P_LINK_TO_CUSTOM-TEMPLATES-SPINE1_Ethernet2
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 172.31.255.23/31
 !
@@ -83,20 +83,20 @@ interface Vlan110
 interface Vlan3000
    description MLAG_PEER_L3_iBGP: vrf TEST_VRF
    no shutdown
-   mtu 9000
+   mtu 9214
    vrf TEST_VRF
    ip address 10.255.240.11/31
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
    no shutdown
-   mtu 9000
+   mtu 9214
    ip address 10.255.251.11/31
 !
 interface Vlan4094
    description MLAG_PEER
    no shutdown
-   mtu 9000
+   mtu 9214
    no autostate
    ip address 10.255.252.11/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-TEMPLATES-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-TEMPLATES-SPINE1.cfg
@@ -18,14 +18,14 @@ vrf instance MGMT
 interface Ethernet1
    description TEST_CUSTOM_PREFIX_P2P_LINK_TO_CUSTOM-TEMPLATES-L3LEAF1A_Ethernet1
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 172.31.255.20/31
 !
 interface Ethernet2
    description TEST_CUSTOM_PREFIX_P2P_LINK_TO_CUSTOM-TEMPLATES-L3LEAF1B_Ethernet1
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 172.31.255.22/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF1A.cfg
@@ -270,7 +270,7 @@ interface Port-Channel6
 interface Ethernet1
    description P2P_LINK_TO_EVPN-MULTICAST-SPINE1_Ethernet1
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 172.31.255.1/31
    pim ipv4 sparse-mode
@@ -563,119 +563,119 @@ interface Vlan550
 interface Vlan3010
    description MLAG_PEER_L3_iBGP: vrf MULTICAST_ENABLED_110_111
    no shutdown
-   mtu 9000
+   mtu 9214
    vrf MULTICAST_ENABLED_110_111
    ip address 10.255.251.0/31
 !
 interface Vlan3011
    description MLAG_PEER_L3_iBGP: vrf MULTICAST_ENABLED_210_DISABLED_211
    no shutdown
-   mtu 9000
+   mtu 9214
    vrf MULTICAST_ENABLED_210_DISABLED_211
    ip address 10.255.251.0/31
 !
 interface Vlan3012
    description MLAG_PEER_L3_iBGP: vrf MULTICAST_DISABLED_310_311
    no shutdown
-   mtu 9000
+   mtu 9214
    vrf MULTICAST_DISABLED_310_311
    ip address 10.255.251.0/31
 !
 interface Vlan3020
    description MLAG_PEER_L3_iBGP: vrf MULTICAST_ENABLED_1_2
    no shutdown
-   mtu 9000
+   mtu 9214
    vrf MULTICAST_ENABLED_1_2
    ip address 10.255.251.0/31
 !
 interface Vlan3021
    description MLAG_PEER_L3_iBGP: vrf MULTICAST_ENABLED_3_DISABLED_4
    no shutdown
-   mtu 9000
+   mtu 9214
    vrf MULTICAST_ENABLED_3_DISABLED_4
    ip address 10.255.251.0/31
 !
 interface Vlan3022
    description MLAG_PEER_L3_iBGP: vrf MULTICAST_DISABLED_5_6
    no shutdown
-   mtu 9000
+   mtu 9214
    vrf MULTICAST_DISABLED_5_6
    ip address 10.255.251.0/31
 !
 interface Vlan3030
    description MLAG_PEER_L3_iBGP: vrf TEN_C_L3_MULTICAST_ENABLED_130_131
    no shutdown
-   mtu 9000
+   mtu 9214
    vrf TEN_C_L3_MULTICAST_ENABLED_130_131
    ip address 10.255.251.0/31
 !
 interface Vlan3031
    description MLAG_PEER_L3_iBGP: vrf TEN_C_L3_MULTICAST_ENABLED_230_DISABLED_231
    no shutdown
-   mtu 9000
+   mtu 9214
    vrf TEN_C_L3_MULTICAST_ENABLED_230_DISABLED_231
    ip address 10.255.251.0/31
 !
 interface Vlan3032
    description MLAG_PEER_L3_iBGP: vrf TEN_C_L3_MULTICAST_DISABLED_330_331
    no shutdown
-   mtu 9000
+   mtu 9214
    vrf TEN_C_L3_MULTICAST_DISABLED_330_331
    ip address 10.255.251.0/31
 !
 interface Vlan3040
    description MLAG_PEER_L3_iBGP: vrf TEN_D_L3_MULTICAST_ENABLED_140_DISABLED_141
    no shutdown
-   mtu 9000
+   mtu 9214
    vrf TEN_D_L3_MULTICAST_ENABLED_140_DISABLED_141
    ip address 10.255.251.0/31
 !
 interface Vlan3041
    description MLAG_PEER_L3_iBGP: vrf TEN_D_L3_MULTICAST_DISABLED_240_241
    no shutdown
-   mtu 9000
+   mtu 9214
    vrf TEN_D_L3_MULTICAST_DISABLED_240_241
    ip address 10.255.251.0/31
 !
 interface Vlan3050
    description MLAG_PEER_L3_iBGP: vrf TEN_E_PEG_L3_MULTICAST_ENABLED
    no shutdown
-   mtu 9000
+   mtu 9214
    vrf TEN_E_PEG_L3_MULTICAST_ENABLED
    ip address 10.255.251.0/31
 !
 interface Vlan3051
    description MLAG_PEER_L3_iBGP: vrf TEN_E_L3_MULTICAST_TRANSIT
    no shutdown
-   mtu 9000
+   mtu 9214
    vrf TEN_E_L3_MULTICAST_TRANSIT
    ip address 10.255.251.0/31
 !
 interface Vlan3054
    description MLAG_PEER_L3_iBGP: vrf TEN_E_L3_MULTICAST_ENABLED_PEG_OVERRIDE
    no shutdown
-   mtu 9000
+   mtu 9214
    vrf TEN_E_L3_MULTICAST_ENABLED_PEG_OVERRIDE
    ip address 10.255.251.0/31
 !
 interface Vlan3059
    description MLAG_PEER_L3_iBGP: vrf TEN_E_L3_MULTICAST_EVPN_PEG_RP_NODES
    no shutdown
-   mtu 9000
+   mtu 9214
    vrf TEN_E_L3_MULTICAST_EVPN_PEG_RP_NODES
    ip address 10.255.251.0/31
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
    no shutdown
-   mtu 9000
+   mtu 9214
    ip address 10.255.251.0/31
    pim ipv4 sparse-mode
 !
 interface Vlan4094
    description MLAG_PEER
    no shutdown
-   mtu 9000
+   mtu 9214
    no autostate
    ip address 10.255.252.0/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF1B.cfg
@@ -270,7 +270,7 @@ interface Port-Channel6
 interface Ethernet1
    description P2P_LINK_TO_EVPN-MULTICAST-SPINE1_Ethernet2
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 172.31.255.3/31
    pim ipv4 sparse-mode
@@ -563,119 +563,119 @@ interface Vlan550
 interface Vlan3010
    description MLAG_PEER_L3_iBGP: vrf MULTICAST_ENABLED_110_111
    no shutdown
-   mtu 9000
+   mtu 9214
    vrf MULTICAST_ENABLED_110_111
    ip address 10.255.251.1/31
 !
 interface Vlan3011
    description MLAG_PEER_L3_iBGP: vrf MULTICAST_ENABLED_210_DISABLED_211
    no shutdown
-   mtu 9000
+   mtu 9214
    vrf MULTICAST_ENABLED_210_DISABLED_211
    ip address 10.255.251.1/31
 !
 interface Vlan3012
    description MLAG_PEER_L3_iBGP: vrf MULTICAST_DISABLED_310_311
    no shutdown
-   mtu 9000
+   mtu 9214
    vrf MULTICAST_DISABLED_310_311
    ip address 10.255.251.1/31
 !
 interface Vlan3020
    description MLAG_PEER_L3_iBGP: vrf MULTICAST_ENABLED_1_2
    no shutdown
-   mtu 9000
+   mtu 9214
    vrf MULTICAST_ENABLED_1_2
    ip address 10.255.251.1/31
 !
 interface Vlan3021
    description MLAG_PEER_L3_iBGP: vrf MULTICAST_ENABLED_3_DISABLED_4
    no shutdown
-   mtu 9000
+   mtu 9214
    vrf MULTICAST_ENABLED_3_DISABLED_4
    ip address 10.255.251.1/31
 !
 interface Vlan3022
    description MLAG_PEER_L3_iBGP: vrf MULTICAST_DISABLED_5_6
    no shutdown
-   mtu 9000
+   mtu 9214
    vrf MULTICAST_DISABLED_5_6
    ip address 10.255.251.1/31
 !
 interface Vlan3030
    description MLAG_PEER_L3_iBGP: vrf TEN_C_L3_MULTICAST_ENABLED_130_131
    no shutdown
-   mtu 9000
+   mtu 9214
    vrf TEN_C_L3_MULTICAST_ENABLED_130_131
    ip address 10.255.251.1/31
 !
 interface Vlan3031
    description MLAG_PEER_L3_iBGP: vrf TEN_C_L3_MULTICAST_ENABLED_230_DISABLED_231
    no shutdown
-   mtu 9000
+   mtu 9214
    vrf TEN_C_L3_MULTICAST_ENABLED_230_DISABLED_231
    ip address 10.255.251.1/31
 !
 interface Vlan3032
    description MLAG_PEER_L3_iBGP: vrf TEN_C_L3_MULTICAST_DISABLED_330_331
    no shutdown
-   mtu 9000
+   mtu 9214
    vrf TEN_C_L3_MULTICAST_DISABLED_330_331
    ip address 10.255.251.1/31
 !
 interface Vlan3040
    description MLAG_PEER_L3_iBGP: vrf TEN_D_L3_MULTICAST_ENABLED_140_DISABLED_141
    no shutdown
-   mtu 9000
+   mtu 9214
    vrf TEN_D_L3_MULTICAST_ENABLED_140_DISABLED_141
    ip address 10.255.251.1/31
 !
 interface Vlan3041
    description MLAG_PEER_L3_iBGP: vrf TEN_D_L3_MULTICAST_DISABLED_240_241
    no shutdown
-   mtu 9000
+   mtu 9214
    vrf TEN_D_L3_MULTICAST_DISABLED_240_241
    ip address 10.255.251.1/31
 !
 interface Vlan3050
    description MLAG_PEER_L3_iBGP: vrf TEN_E_PEG_L3_MULTICAST_ENABLED
    no shutdown
-   mtu 9000
+   mtu 9214
    vrf TEN_E_PEG_L3_MULTICAST_ENABLED
    ip address 10.255.251.1/31
 !
 interface Vlan3051
    description MLAG_PEER_L3_iBGP: vrf TEN_E_L3_MULTICAST_TRANSIT
    no shutdown
-   mtu 9000
+   mtu 9214
    vrf TEN_E_L3_MULTICAST_TRANSIT
    ip address 10.255.251.1/31
 !
 interface Vlan3054
    description MLAG_PEER_L3_iBGP: vrf TEN_E_L3_MULTICAST_ENABLED_PEG_OVERRIDE
    no shutdown
-   mtu 9000
+   mtu 9214
    vrf TEN_E_L3_MULTICAST_ENABLED_PEG_OVERRIDE
    ip address 10.255.251.1/31
 !
 interface Vlan3059
    description MLAG_PEER_L3_iBGP: vrf TEN_E_L3_MULTICAST_EVPN_PEG_RP_NODES
    no shutdown
-   mtu 9000
+   mtu 9214
    vrf TEN_E_L3_MULTICAST_EVPN_PEG_RP_NODES
    ip address 10.255.251.1/31
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
    no shutdown
-   mtu 9000
+   mtu 9214
    ip address 10.255.251.1/31
    pim ipv4 sparse-mode
 !
 interface Vlan4094
    description MLAG_PEER
    no shutdown
-   mtu 9000
+   mtu 9214
    no autostate
    ip address 10.255.252.1/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF2A.cfg
@@ -185,7 +185,7 @@ vrf instance TEN_E_PEG_L3_MULTICAST_ENABLED
 interface Ethernet1
    description P2P_LINK_TO_EVPN-MULTICAST-SPINE1_Ethernet3
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 172.31.255.5/31
    pim ipv4 sparse-mode

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF3A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF3A.cfg
@@ -183,7 +183,7 @@ vrf instance TEN_E_PEG_L3_MULTICAST_ENABLED
 interface Ethernet1
    description P2P_LINK_TO_EVPN-MULTICAST-SPINE1_Ethernet4
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 172.31.255.7/31
    pim ipv4 sparse-mode

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF3B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF3B.cfg
@@ -183,7 +183,7 @@ vrf instance TEN_E_PEG_L3_MULTICAST_ENABLED
 interface Ethernet1
    description P2P_LINK_TO_EVPN-MULTICAST-SPINE1_Ethernet5
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 172.31.255.9/31
    pim ipv4 sparse-mode

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-SPINE1.cfg
@@ -18,7 +18,7 @@ vrf instance MGMT
 interface Ethernet1
    description P2P_LINK_TO_EVPN-MULTICAST-L3LEAF1A_Ethernet1
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 172.31.255.0/31
    pim ipv4 sparse-mode
@@ -26,7 +26,7 @@ interface Ethernet1
 interface Ethernet2
    description P2P_LINK_TO_EVPN-MULTICAST-L3LEAF1B_Ethernet1
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 172.31.255.2/31
    pim ipv4 sparse-mode
@@ -34,7 +34,7 @@ interface Ethernet2
 interface Ethernet3
    description P2P_LINK_TO_EVPN-MULTICAST-L3LEAF2A_Ethernet1
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 172.31.255.4/31
    pim ipv4 sparse-mode
@@ -42,7 +42,7 @@ interface Ethernet3
 interface Ethernet4
    description P2P_LINK_TO_EVPN-MULTICAST-L3LEAF3A_Ethernet1
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 172.31.255.6/31
    pim ipv4 sparse-mode
@@ -50,7 +50,7 @@ interface Ethernet4
 interface Ethernet5
    description P2P_LINK_TO_EVPN-MULTICAST-L3LEAF3B_Ethernet1
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 172.31.255.8/31
    pim ipv4 sparse-mode

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3A.cfg
@@ -73,7 +73,7 @@ interface Loopback1
 interface Vlan3000
    description MLAG_PEER_L3_iBGP: vrf TEST
    no shutdown
-   mtu 9000
+   mtu 9214
    vrf TEST
    ip address 192.168.253.4/31
 !
@@ -90,13 +90,13 @@ interface Vlan3903
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
    no shutdown
-   mtu 9000
+   mtu 9214
    ip address 192.168.253.4/31
 !
 interface Vlan4094
    description MLAG_PEER
    no shutdown
-   mtu 9000
+   mtu 9214
    no autostate
    ip address 192.168.254.4/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3B.cfg
@@ -73,7 +73,7 @@ interface Loopback1
 interface Vlan3000
    description MLAG_PEER_L3_iBGP: vrf TEST
    no shutdown
-   mtu 9000
+   mtu 9214
    vrf TEST
    ip address 192.168.253.5/31
 !
@@ -90,13 +90,13 @@ interface Vlan3903
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
    no shutdown
-   mtu 9000
+   mtu 9214
    ip address 192.168.253.5/31
 !
 interface Vlan4094
    description MLAG_PEER
    no shutdown
-   mtu 9000
+   mtu 9214
    no autostate
    ip address 192.168.254.5/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L3LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L3LEAF1A.cfg
@@ -43,7 +43,7 @@ interface Port-Channel6
 interface Ethernet1
    description P2P_LINK_TO_UNDERLAY-MULTICAST-SPINE1_Ethernet1
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 172.31.255.1/31
    pim ipv4 sparse-mode
@@ -51,7 +51,7 @@ interface Ethernet1
 interface Ethernet2
    description P2P_LINK_TO_UNDERLAY-MULTICAST-SPINE2_Ethernet1
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 172.31.255.3/31
 !
@@ -89,14 +89,14 @@ interface Management1
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
    no shutdown
-   mtu 9000
+   mtu 9214
    ip address 10.255.251.0/31
    pim ipv4 sparse-mode
 !
 interface Vlan4094
    description MLAG_PEER
    no shutdown
-   mtu 9000
+   mtu 9214
    no autostate
    ip address 10.255.252.0/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L3LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L3LEAF1B.cfg
@@ -35,7 +35,7 @@ interface Port-Channel3
 interface Ethernet1
    description P2P_LINK_TO_UNDERLAY-MULTICAST-SPINE1_Ethernet2
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 172.31.255.5/31
    pim ipv4 sparse-mode
@@ -43,7 +43,7 @@ interface Ethernet1
 interface Ethernet2
    description P2P_LINK_TO_UNDERLAY-MULTICAST-SPINE2_Ethernet2
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 172.31.255.7/31
 !
@@ -76,14 +76,14 @@ interface Management1
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
    no shutdown
-   mtu 9000
+   mtu 9214
    ip address 10.255.251.1/31
    pim ipv4 sparse-mode
 !
 interface Vlan4094
    description MLAG_PEER
    no shutdown
-   mtu 9000
+   mtu 9214
    no autostate
    ip address 10.255.252.1/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L3LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L3LEAF2A.cfg
@@ -31,7 +31,7 @@ interface Port-Channel3
 interface Ethernet1
    description P2P_LINK_TO_UNDERLAY-MULTICAST-SPINE1_Ethernet3
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 172.31.255.9/31
    pim ipv4 sparse-mode
@@ -39,7 +39,7 @@ interface Ethernet1
 interface Ethernet2
    description P2P_LINK_TO_UNDERLAY-MULTICAST-SPINE2_Ethernet3
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 172.31.255.11/31
 !
@@ -72,7 +72,7 @@ interface Management1
 interface Vlan4094
    description MLAG_PEER
    no shutdown
-   mtu 9000
+   mtu 9214
    no autostate
    ip address 10.255.252.4/31
    pim ipv4 sparse-mode

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L3LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L3LEAF2B.cfg
@@ -31,7 +31,7 @@ interface Port-Channel3
 interface Ethernet1
    description P2P_LINK_TO_UNDERLAY-MULTICAST-SPINE1_Ethernet4
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 172.31.255.13/31
    pim ipv4 sparse-mode
@@ -39,7 +39,7 @@ interface Ethernet1
 interface Ethernet2
    description P2P_LINK_TO_UNDERLAY-MULTICAST-SPINE2_Ethernet4
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 172.31.255.15/31
 !
@@ -72,7 +72,7 @@ interface Management1
 interface Vlan4094
    description MLAG_PEER
    no shutdown
-   mtu 9000
+   mtu 9214
    no autostate
    ip address 10.255.252.5/31
    pim ipv4 sparse-mode

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-SPINE1.cfg
@@ -18,7 +18,7 @@ vrf instance MGMT
 interface Ethernet1
    description P2P_LINK_TO_UNDERLAY-MULTICAST-L3LEAF1A_Ethernet1
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 172.31.255.0/31
    pim ipv4 sparse-mode
@@ -26,7 +26,7 @@ interface Ethernet1
 interface Ethernet2
    description P2P_LINK_TO_UNDERLAY-MULTICAST-L3LEAF1B_Ethernet1
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 172.31.255.4/31
    pim ipv4 sparse-mode
@@ -34,7 +34,7 @@ interface Ethernet2
 interface Ethernet3
    description P2P_LINK_TO_UNDERLAY-MULTICAST-L3LEAF2A_Ethernet1
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 172.31.255.8/31
    pim ipv4 sparse-mode
@@ -42,7 +42,7 @@ interface Ethernet3
 interface Ethernet4
    description P2P_LINK_TO_UNDERLAY-MULTICAST-L3LEAF2B_Ethernet1
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 172.31.255.12/31
    pim ipv4 sparse-mode

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-SPINE2.cfg
@@ -18,28 +18,28 @@ vrf instance MGMT
 interface Ethernet1
    description P2P_LINK_TO_UNDERLAY-MULTICAST-L3LEAF1A_Ethernet2
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 172.31.255.2/31
 !
 interface Ethernet2
    description P2P_LINK_TO_UNDERLAY-MULTICAST-L3LEAF1B_Ethernet2
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 172.31.255.6/31
 !
 interface Ethernet3
    description P2P_LINK_TO_UNDERLAY-MULTICAST-L3LEAF2A_Ethernet2
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 172.31.255.10/31
 !
 interface Ethernet4
    description P2P_LINK_TO_UNDERLAY-MULTICAST-L3LEAF2B_Ethernet2
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 172.31.255.14/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY_FILTER_PEER_AS_L3LEAF1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY_FILTER_PEER_AS_L3LEAF1.cfg
@@ -16,14 +16,14 @@ vrf instance MGMT
 interface Ethernet1
    description P2P_LINK_TO_UNDERLAY_FILTER_PEER_AS_SPINE1_Ethernet1
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 192.168.0.1/31
 !
 interface Ethernet2
    description P2P_LINK_TO_UNDERLAY_FILTER_PEER_AS_SPINE2_Ethernet1
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 192.168.0.3/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY_FILTER_PEER_AS_SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY_FILTER_PEER_AS_SPINE1.cfg
@@ -18,7 +18,7 @@ vrf instance MGMT
 interface Ethernet1
    description P2P_LINK_TO_UNDERLAY_FILTER_PEER_AS_L3LEAF1_Ethernet1
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 192.168.0.0/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY_FILTER_PEER_AS_SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY_FILTER_PEER_AS_SPINE2.cfg
@@ -18,7 +18,7 @@ vrf instance MGMT
 interface Ethernet1
    description P2P_LINK_TO_UNDERLAY_FILTER_PEER_AS_L3LEAF1_Ethernet2
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 192.168.0.2/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1A.cfg
@@ -72,7 +72,7 @@ interface Management1
 interface Vlan4094
    description MLAG_PEER
    no shutdown
-   mtu 9000
+   mtu 9214
    no autostate
    ip address 10.255.252.0/31
 no ip routing vrf MGMT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1B.cfg
@@ -72,7 +72,7 @@ interface Management1
 interface Vlan4094
    description MLAG_PEER
    no shutdown
-   mtu 9000
+   mtu 9214
    no autostate
    ip address 10.255.252.1/31
 no ip routing vrf MGMT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1A.cfg
@@ -48,7 +48,7 @@ interface Port-Channel5
 interface Ethernet1
    description P2P_LINK_TO_UPLINK-MLAG-STRUCTURED-CONFIG-SPINE1_Ethernet1
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 172.31.255.1/31
    pim ipv4 sparse-mode
@@ -92,14 +92,14 @@ interface Management1
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
    no shutdown
-   mtu 9000
+   mtu 9214
    ip address 10.255.251.0/31
    pim ipv4 sparse-mode
 !
 interface Vlan4094
    description mlag_peer_vlan_structured_config_override
    no shutdown
-   mtu 9000
+   mtu 9214
    no autostate
    ip address 10.255.252.0/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1B.cfg
@@ -48,7 +48,7 @@ interface Port-Channel5
 interface Ethernet1
    description P2P_LINK_TO_UPLINK-MLAG-STRUCTURED-CONFIG-SPINE1_Ethernet2
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 172.31.255.3/31
    pim ipv4 sparse-mode
@@ -92,14 +92,14 @@ interface Management1
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
    no shutdown
-   mtu 9000
+   mtu 9214
    ip address 10.255.251.1/31
    pim ipv4 sparse-mode
 !
 interface Vlan4094
    description mlag_peer_vlan_structured_config_override
    no shutdown
-   mtu 9000
+   mtu 9214
    no autostate
    ip address 10.255.252.1/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UPLINK-MLAG-STRUCTURED-CONFIG-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UPLINK-MLAG-STRUCTURED-CONFIG-SPINE1.cfg
@@ -18,7 +18,7 @@ vrf instance MGMT
 interface Ethernet1
    description P2P_LINK_TO_UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1A_Ethernet1
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 172.31.255.0/31
    pim ipv4 sparse-mode
@@ -26,7 +26,7 @@ interface Ethernet1
 interface Ethernet2
    description P2P_LINK_TO_UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1B_Ethernet1
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 172.31.255.2/31
    pim ipv4 sparse-mode

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/bgp-peer-groups-structured-config-1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/bgp-peer-groups-structured-config-1.cfg
@@ -46,7 +46,7 @@ interface Loopback1
 interface Vlan4094
    description MLAG_PEER
    no shutdown
-   mtu 9000
+   mtu 9214
    no autostate
    ip address 192.168.253.204/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/bgp-peer-groups-structured-config-2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/bgp-peer-groups-structured-config-2.cfg
@@ -46,7 +46,7 @@ interface Loopback1
 interface Vlan4094
    description MLAG_PEER
    no shutdown
-   mtu 9000
+   mtu 9214
    no autostate
    ip address 192.168.253.205/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/l3_edge_bgp.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/l3_edge_bgp.cfg
@@ -18,14 +18,14 @@ vrf instance MGMT
 interface Port-Channel5
    description P2P_LINK_TO_peer5_Port-Channel5
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 192.168.0.8/31
 !
 interface Port-Channel7
    description P2P_LINK_TO_peer6_Port-Channel7
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 192.168.0.10/31
 !
@@ -45,7 +45,7 @@ interface ethernet1
 interface ethernet2
    description P2P_LINK_TO_peer2_ethernet2
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 192.168.0.2/31
    ipv6 enable
@@ -53,14 +53,14 @@ interface ethernet2
 interface ethernet3
    description P2P_LINK_TO_peer3_ethernet3
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 192.168.0.4/31
 !
 interface ethernet4
    description Custom description on l3_edge_bgp eth4
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 192.168.0.6/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/l3_edge_isis.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/l3_edge_isis.cfg
@@ -29,7 +29,7 @@ interface ethernet1
 interface ethernet2
    description P2P_LINK_TO_peer2_ethernet2
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 192.168.0.2/31
    isis enable EVPN_UNDERLAY
@@ -43,7 +43,7 @@ interface ethernet2
 interface ethernet3
    description P2P_LINK_TO_peer3_ethernet3
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 192.168.0.4/31
    isis enable EVPN_UNDERLAY
@@ -55,7 +55,7 @@ interface ethernet3
 interface ethernet4
    description P2P_LINK_TO_peer4_ethernet4
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 192.168.0.6/31
    isis enable EVPN_UNDERLAY

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/l3_edge_ospf.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/l3_edge_ospf.cfg
@@ -29,7 +29,7 @@ interface ethernet1
 interface ethernet2
    description P2P_LINK_TO_peer2_ethernet2
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 192.168.0.2/31
    ip ospf network point-to-point
@@ -38,7 +38,7 @@ interface ethernet2
 interface ethernet3
    description P2P_LINK_TO_peer3_ethernet3
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 192.168.0.4/31
    ip ospf network point-to-point
@@ -47,7 +47,7 @@ interface ethernet3
 interface ethernet4
    description P2P_LINK_TO_peer4_ethernet4
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 192.168.0.6/31
    ip ospf network point-to-point

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/network-ports-tests-2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/network-ports-tests-2.cfg
@@ -542,7 +542,7 @@ interface Ethernet10/1
 interface Vlan4094
    description MLAG_PEER
    no shutdown
-   mtu 9000
+   mtu 9214
    no autostate
    ip address 10.255.252.1/31
 no ip routing vrf MGMT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/network-ports-tests.1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/network-ports-tests.1.cfg
@@ -539,7 +539,7 @@ interface Ethernet14
 interface Vlan4094
    description MLAG_PEER
    no shutdown
-   mtu 9000
+   mtu 9214
    no autostate
    ip address 10.255.252.0/31
 no ip routing vrf MGMT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-leaf1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-leaf1.cfg
@@ -37,7 +37,7 @@ vrf instance VRF1
 interface Ethernet1
    description P2P_LINK_TO_PTP-TESTS-SPINE1_Ethernet1
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 10.254.2.1/31
    ptp enable
@@ -50,7 +50,7 @@ interface Ethernet1
 interface Ethernet2
    description P2P_LINK_TO_PTP-TESTS-SPINE1_Ethernet2
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 10.254.2.3/31
    ptp enable

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-leaf2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-leaf2.cfg
@@ -45,7 +45,7 @@ vrf instance VRF1
 interface Ethernet1
    description P2P_LINK_TO_PTP-TESTS-SPINE1_Ethernet3
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 10.254.2.5/31
    ptp enable
@@ -58,7 +58,7 @@ interface Ethernet1
 interface Ethernet2
    description P2P_LINK_TO_PTP-TESTS-SPINE1_Ethernet4
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 10.254.2.7/31
    ptp enable

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-spine1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-spine1.cfg
@@ -31,7 +31,7 @@ vrf instance MGMT
 interface Ethernet1
    description P2P_LINK_TO_PTP-TESTS-LEAF1_Ethernet1
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 10.254.2.0/31
    ptp enable
@@ -44,7 +44,7 @@ interface Ethernet1
 interface Ethernet2
    description P2P_LINK_TO_PTP-TESTS-LEAF1_Ethernet2
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 10.254.2.2/31
    ptp enable
@@ -57,7 +57,7 @@ interface Ethernet2
 interface Ethernet3
    description P2P_LINK_TO_PTP-TESTS-LEAF2_Ethernet1
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 10.254.2.4/31
    ptp enable
@@ -70,7 +70,7 @@ interface Ethernet3
 interface Ethernet4
    description P2P_LINK_TO_PTP-TESTS-LEAF2_Ethernet2
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ip address 10.254.2.6/31
    ptp enable
@@ -83,7 +83,7 @@ interface Ethernet4
 interface Ethernet6
    description P2P_LINK_TO_ptp-tests-spine2_Ethernet6
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ptp enable
    ptp sync-message interval -3
@@ -95,7 +95,7 @@ interface Ethernet6
 interface Ethernet7
    description P2P_LINK_TO_ptp-tests-spine2_Ethernet7
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ptp enable
    ptp sync-message interval -3
@@ -107,7 +107,7 @@ interface Ethernet7
 interface Ethernet8
    description P2P_LINK_TO_ptp-tests-spine2_Ethernet8
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ptp enable
    ptp sync-message interval -3
@@ -119,7 +119,7 @@ interface Ethernet8
 interface Ethernet9
    description P2P_LINK_TO_ptp-tests-spine2_Ethernet9
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ptp enable
    ptp sync-message interval -3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-spine2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-spine2.cfg
@@ -39,7 +39,7 @@ vrf instance MGMT
 interface Ethernet6
    description P2P_LINK_TO_ptp-tests-spine1_Ethernet6
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ptp enable
    ptp sync-message interval -3
@@ -51,7 +51,7 @@ interface Ethernet6
 interface Ethernet7
    description P2P_LINK_TO_ptp-tests-spine1_Ethernet7
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ptp enable
    ptp sync-message interval -3
@@ -63,7 +63,7 @@ interface Ethernet7
 interface Ethernet8
    description P2P_LINK_TO_ptp-tests-spine1_Ethernet8
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ptp enable
    ptp sync-message interval -3
@@ -75,7 +75,7 @@ interface Ethernet8
 interface Ethernet9
    description P2P_LINK_TO_ptp-tests-spine1_Ethernet9
    no shutdown
-   mtu 9000
+   mtu 9214
    no switchport
    ptp enable
    ptp sync-message interval -3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l2leaf1a.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l2leaf1a.cfg
@@ -124,7 +124,7 @@ interface Ethernet13
 interface Vlan4094
    description MLAG_PEER
    no shutdown
-   mtu 9000
+   mtu 9214
    no autostate
    ip address 10.255.248.0/31
 no ip routing vrf MGMT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l2leaf1b.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l2leaf1b.cfg
@@ -124,7 +124,7 @@ interface Ethernet13
 interface Vlan4094
    description MLAG_PEER
    no shutdown
-   mtu 9000
+   mtu 9214
    no autostate
    ip address 10.255.248.1/31
 no ip routing vrf MGMT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l3leaf1a.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l3leaf1a.cfg
@@ -222,34 +222,34 @@ interface Vlan398
 interface Vlan3099
    description MLAG_PEER_L3_iBGP: vrf TG_100
    no shutdown
-   mtu 9000
+   mtu 9214
    vrf TG_100
    ip address 10.255.247.0/31
 !
 interface Vlan3199
    description MLAG_PEER_L3_iBGP: vrf TG_200
    no shutdown
-   mtu 9000
+   mtu 9214
    vrf TG_200
    ip address 10.255.247.0/31
 !
 interface Vlan3299
    description MLAG_PEER_L3_iBGP: vrf TG_300
    no shutdown
-   mtu 9000
+   mtu 9214
    vrf TG_300
    ip address 10.255.247.0/31
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
    no shutdown
-   mtu 9000
+   mtu 9214
    ip address 10.255.247.0/31
 !
 interface Vlan4094
    description MLAG_PEER
    no shutdown
-   mtu 9000
+   mtu 9214
    no autostate
    ip address 10.255.248.0/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l3leaf1b.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l3leaf1b.cfg
@@ -202,34 +202,34 @@ interface Vlan398
 interface Vlan3099
    description MLAG_PEER_L3_iBGP: vrf TG_100
    no shutdown
-   mtu 9000
+   mtu 9214
    vrf TG_100
    ip address 10.255.247.1/31
 !
 interface Vlan3199
    description MLAG_PEER_L3_iBGP: vrf TG_200
    no shutdown
-   mtu 9000
+   mtu 9214
    vrf TG_200
    ip address 10.255.247.1/31
 !
 interface Vlan3299
    description MLAG_PEER_L3_iBGP: vrf TG_300
    no shutdown
-   mtu 9000
+   mtu 9214
    vrf TG_300
    ip address 10.255.247.1/31
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
    no shutdown
-   mtu 9000
+   mtu 9214
    ip address 10.255.247.1/31
 !
 interface Vlan4094
    description MLAG_PEER
    no shutdown
-   mtu 9000
+   mtu 9214
    no autostate
    ip address 10.255.248.1/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l3leaf2a.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l3leaf2a.cfg
@@ -94,20 +94,20 @@ interface Vlan200
 interface Vlan3199
    description MLAG_PEER_L3_iBGP: vrf TG_200
    no shutdown
-   mtu 9000
+   mtu 9214
    vrf TG_200
    ip address 10.255.247.4/31
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
    no shutdown
-   mtu 9000
+   mtu 9214
    ip address 10.255.247.4/31
 !
 interface Vlan4094
    description MLAG_PEER
    no shutdown
-   mtu 9000
+   mtu 9214
    no autostate
    ip address 10.255.248.4/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l3leaf2b.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l3leaf2b.cfg
@@ -89,20 +89,20 @@ interface Vlan200
 interface Vlan3199
    description MLAG_PEER_L3_iBGP: vrf TG_200
    no shutdown
-   mtu 9000
+   mtu 9214
    vrf TG_200
    ip address 10.255.247.5/31
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
    no shutdown
-   mtu 9000
+   mtu 9214
    ip address 10.255.247.5/31
 !
 interface Vlan4094
    description MLAG_PEER
    no shutdown
-   mtu 9000
+   mtu 9214
    no autostate
    ip address 10.255.248.5/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF3A.yml
@@ -93,14 +93,14 @@ vlan_interfaces:
 - name: Vlan4093
   description: MLAG_PEER_L3_PEERING
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   ip_address: 10.255.251.8/31
 - name: Vlan4094
   description: MLAG_PEER
   shutdown: false
   ip_address: 10.255.252.8/31
   no_autostate: true
-  mtu: 9000
+  mtu: 9214
 port_channel_interfaces:
 - name: Port-Channel3
   description: MLAG_PEER_AUTO_BGP_ASN_LEAF3B_Po3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF3B.yml
@@ -93,14 +93,14 @@ vlan_interfaces:
 - name: Vlan4093
   description: MLAG_PEER_L3_PEERING
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   ip_address: 10.255.251.9/31
 - name: Vlan4094
   description: MLAG_PEER
   shutdown: false
   ip_address: 10.255.252.9/31
   no_autostate: true
-  mtu: 9000
+  mtu: 9214
 port_channel_interfaces:
 - name: Port-Channel3
   description: MLAG_PEER_AUTO_BGP_ASN_LEAF3A_Po3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF4A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF4A.yml
@@ -93,14 +93,14 @@ vlan_interfaces:
 - name: Vlan4093
   description: MLAG_PEER_L3_PEERING
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   ip_address: 10.255.251.12/31
 - name: Vlan4094
   description: MLAG_PEER
   shutdown: false
   ip_address: 10.255.252.12/31
   no_autostate: true
-  mtu: 9000
+  mtu: 9214
 port_channel_interfaces:
 - name: Port-Channel3
   description: MLAG_PEER_AUTO_BGP_ASN_LEAF4B_Po3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF4B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF4B.yml
@@ -93,14 +93,14 @@ vlan_interfaces:
 - name: Vlan4093
   description: MLAG_PEER_L3_PEERING
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   ip_address: 10.255.251.13/31
 - name: Vlan4094
   description: MLAG_PEER
   shutdown: false
   ip_address: 10.255.252.13/31
   no_autostate: true
-  mtu: 9000
+  mtu: 9214
 port_channel_interfaces:
 - name: Port-Channel3
   description: MLAG_PEER_AUTO_BGP_ASN_LEAF4A_Po3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF7A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF7A.yml
@@ -93,14 +93,14 @@ vlan_interfaces:
 - name: Vlan4093
   description: MLAG_PEER_L3_PEERING
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   ip_address: 10.255.251.20/31
 - name: Vlan4094
   description: MLAG_PEER
   shutdown: false
   ip_address: 10.255.252.20/31
   no_autostate: true
-  mtu: 9000
+  mtu: 9214
 port_channel_interfaces:
 - name: Port-Channel3
   description: MLAG_PEER_AUTO_BGP_ASN_LEAF7B_Po3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF7B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF7B.yml
@@ -93,14 +93,14 @@ vlan_interfaces:
 - name: Vlan4093
   description: MLAG_PEER_L3_PEERING
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   ip_address: 10.255.251.21/31
 - name: Vlan4094
   description: MLAG_PEER
   shutdown: false
   ip_address: 10.255.252.21/31
   no_autostate: true
-  mtu: 9000
+  mtu: 9214
 port_channel_interfaces:
 - name: Port-Channel3
   description: MLAG_PEER_AUTO_BGP_ASN_LEAF7A_Po3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_NODE_TYPE_LEAF01.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_NODE_TYPE_LEAF01.yml
@@ -87,7 +87,7 @@ ethernet_interfaces:
   peer_type: spine
   description: P2P_LINK_TO_AUTO_NODE_TYPE_SPINE01_Ethernet1
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   type: routed
   ip_address: 172.31.255.1/31
 - name: Ethernet2
@@ -96,7 +96,7 @@ ethernet_interfaces:
   peer_type: spine
   description: P2P_LINK_TO_AUTO_NODE_TYPE_SPINE02_Ethernet1
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   type: routed
   ip_address: 172.31.255.3/31
 loopback_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_NODE_TYPE_SPINE01.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_NODE_TYPE_SPINE01.yml
@@ -85,7 +85,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: P2P_LINK_TO_AUTO_NODE_TYPE_LEAF01_Ethernet1
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   type: routed
   ip_address: 172.31.255.0/31
 - name: Ethernet2
@@ -94,7 +94,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: P2P_LINK_TO_AUTO_NODE_TYPE_UNGROUPED_LEAF02_Ethernet1
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   type: routed
   ip_address: 172.31.255.4/31
 loopback_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_NODE_TYPE_SPINE02.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_NODE_TYPE_SPINE02.yml
@@ -85,7 +85,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: P2P_LINK_TO_AUTO_NODE_TYPE_LEAF01_Ethernet2
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   type: routed
   ip_address: 172.31.255.2/31
 - name: Ethernet2
@@ -94,7 +94,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: P2P_LINK_TO_AUTO_NODE_TYPE_UNGROUPED_LEAF02_Ethernet2
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   type: routed
   ip_address: 172.31.255.6/31
 loopback_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_NODE_TYPE_UNGROUPED_LEAF02.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_NODE_TYPE_UNGROUPED_LEAF02.yml
@@ -87,7 +87,7 @@ ethernet_interfaces:
   peer_type: spine
   description: P2P_LINK_TO_AUTO_NODE_TYPE_SPINE01_Ethernet2
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   type: routed
   ip_address: 172.31.255.5/31
 - name: Ethernet2
@@ -96,7 +96,7 @@ ethernet_interfaces:
   peer_type: spine
   description: P2P_LINK_TO_AUTO_NODE_TYPE_SPINE02_Ethernet2
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   type: routed
   ip_address: 172.31.255.7/31
 loopback_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-PYTHON_MODULES-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-PYTHON_MODULES-L3LEAF1A.yml
@@ -134,14 +134,14 @@ vlan_interfaces:
 - name: Vlan4093
   description: MLAG_PEER_L3_PEERING
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   ip_address: 10.255.251.10/31
 - name: Vlan4094
   description: MLAG_PEER
   shutdown: false
   ip_address: 10.255.252.10/31
   no_autostate: true
-  mtu: 9000
+  mtu: 9214
 - name: Vlan110
   tenant: CUSTOM_PYTHON_MODULES_TENANT
   tags:
@@ -156,7 +156,7 @@ vlan_interfaces:
   shutdown: false
   description: 'MLAG_PEER_L3_iBGP: vrf TEST_VRF'
   vrf: TEST_VRF
-  mtu: 9000
+  mtu: 9214
   ip_address: 10.255.240.10/31
 port_channel_interfaces:
 - name: Port-Channel3
@@ -195,7 +195,7 @@ ethernet_interfaces:
   peer_type: spine
   description: TEST_CUSTOM_PREFIX_P2P_LINK_TO_CUSTOM-PYTHON_MODULES-SPINE1_Ethernet1
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   type: routed
   ip_address: 172.31.255.21/31
 mlag_configuration:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-PYTHON_MODULES-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-PYTHON_MODULES-L3LEAF1B.yml
@@ -134,14 +134,14 @@ vlan_interfaces:
 - name: Vlan4093
   description: MLAG_PEER_L3_PEERING
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   ip_address: 10.255.251.11/31
 - name: Vlan4094
   description: MLAG_PEER
   shutdown: false
   ip_address: 10.255.252.11/31
   no_autostate: true
-  mtu: 9000
+  mtu: 9214
 - name: Vlan110
   tenant: CUSTOM_PYTHON_MODULES_TENANT
   tags:
@@ -156,7 +156,7 @@ vlan_interfaces:
   shutdown: false
   description: 'MLAG_PEER_L3_iBGP: vrf TEST_VRF'
   vrf: TEST_VRF
-  mtu: 9000
+  mtu: 9214
   ip_address: 10.255.240.11/31
 port_channel_interfaces:
 - name: Port-Channel3
@@ -195,7 +195,7 @@ ethernet_interfaces:
   peer_type: spine
   description: TEST_CUSTOM_PREFIX_P2P_LINK_TO_CUSTOM-PYTHON_MODULES-SPINE1_Ethernet2
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   type: routed
   ip_address: 172.31.255.23/31
 mlag_configuration:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-PYTHON_MODULES-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-PYTHON_MODULES-SPINE1.yml
@@ -84,7 +84,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: TEST_CUSTOM_PREFIX_P2P_LINK_TO_CUSTOM-PYTHON_MODULES-L3LEAF1A_Ethernet1
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   type: routed
   ip_address: 172.31.255.20/31
 - name: Ethernet2
@@ -93,7 +93,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: TEST_CUSTOM_PREFIX_P2P_LINK_TO_CUSTOM-PYTHON_MODULES-L3LEAF1B_Ethernet1
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   type: routed
   ip_address: 172.31.255.22/31
 loopback_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-TEMPLATES-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-TEMPLATES-L3LEAF1A.yml
@@ -134,14 +134,14 @@ vlan_interfaces:
 - name: Vlan4093
   description: MLAG_PEER_L3_PEERING
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   ip_address: 10.255.251.10/31
 - name: Vlan4094
   description: MLAG_PEER
   shutdown: false
   ip_address: 10.255.252.10/31
   no_autostate: true
-  mtu: 9000
+  mtu: 9214
 - name: Vlan110
   tenant: CUSTOM_TEMPLATES_TENANT
   tags:
@@ -156,7 +156,7 @@ vlan_interfaces:
   shutdown: false
   description: 'MLAG_PEER_L3_iBGP: vrf TEST_VRF'
   vrf: TEST_VRF
-  mtu: 9000
+  mtu: 9214
   ip_address: 10.255.240.10/31
 port_channel_interfaces:
 - name: Port-Channel3
@@ -195,7 +195,7 @@ ethernet_interfaces:
   peer_type: spine
   description: TEST_CUSTOM_PREFIX_P2P_LINK_TO_CUSTOM-TEMPLATES-SPINE1_Ethernet1
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   type: routed
   ip_address: 172.31.255.21/31
 mlag_configuration:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-TEMPLATES-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-TEMPLATES-L3LEAF1B.yml
@@ -134,14 +134,14 @@ vlan_interfaces:
 - name: Vlan4093
   description: MLAG_PEER_L3_PEERING
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   ip_address: 10.255.251.11/31
 - name: Vlan4094
   description: MLAG_PEER
   shutdown: false
   ip_address: 10.255.252.11/31
   no_autostate: true
-  mtu: 9000
+  mtu: 9214
 - name: Vlan110
   tenant: CUSTOM_TEMPLATES_TENANT
   tags:
@@ -156,7 +156,7 @@ vlan_interfaces:
   shutdown: false
   description: 'MLAG_PEER_L3_iBGP: vrf TEST_VRF'
   vrf: TEST_VRF
-  mtu: 9000
+  mtu: 9214
   ip_address: 10.255.240.11/31
 port_channel_interfaces:
 - name: Port-Channel3
@@ -195,7 +195,7 @@ ethernet_interfaces:
   peer_type: spine
   description: TEST_CUSTOM_PREFIX_P2P_LINK_TO_CUSTOM-TEMPLATES-SPINE1_Ethernet2
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   type: routed
   ip_address: 172.31.255.23/31
 mlag_configuration:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-TEMPLATES-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-TEMPLATES-SPINE1.yml
@@ -84,7 +84,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: TEST_CUSTOM_PREFIX_P2P_LINK_TO_CUSTOM-TEMPLATES-L3LEAF1A_Ethernet1
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   type: routed
   ip_address: 172.31.255.20/31
 - name: Ethernet2
@@ -93,7 +93,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: TEST_CUSTOM_PREFIX_P2P_LINK_TO_CUSTOM-TEMPLATES-L3LEAF1B_Ethernet1
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   type: routed
   ip_address: 172.31.255.22/31
 loopback_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF1A.yml
@@ -807,7 +807,7 @@ vlan_interfaces:
 - name: Vlan4093
   description: MLAG_PEER_L3_PEERING
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   ip_address: 10.255.251.0/31
   pim:
     ipv4:
@@ -817,7 +817,7 @@ vlan_interfaces:
   shutdown: false
   ip_address: 10.255.252.0/31
   no_autostate: true
-  mtu: 9000
+  mtu: 9214
 - name: Vlan310
   tenant: Tenant_A
   tags:
@@ -840,7 +840,7 @@ vlan_interfaces:
   shutdown: false
   description: 'MLAG_PEER_L3_iBGP: vrf MULTICAST_DISABLED_310_311'
   vrf: MULTICAST_DISABLED_310_311
-  mtu: 9000
+  mtu: 9214
   ip_address: 10.255.251.0/31
 - name: Vlan110
   tenant: Tenant_A
@@ -864,7 +864,7 @@ vlan_interfaces:
   shutdown: false
   description: 'MLAG_PEER_L3_iBGP: vrf MULTICAST_ENABLED_110_111'
   vrf: MULTICAST_ENABLED_110_111
-  mtu: 9000
+  mtu: 9214
   ip_address: 10.255.251.0/31
 - name: Vlan210
   tenant: Tenant_A
@@ -888,7 +888,7 @@ vlan_interfaces:
   shutdown: false
   description: 'MLAG_PEER_L3_iBGP: vrf MULTICAST_ENABLED_210_DISABLED_211'
   vrf: MULTICAST_ENABLED_210_DISABLED_211
-  mtu: 9000
+  mtu: 9214
   ip_address: 10.255.251.0/31
 - name: Vlan5
   tenant: Tenant_B
@@ -912,7 +912,7 @@ vlan_interfaces:
   shutdown: false
   description: 'MLAG_PEER_L3_iBGP: vrf MULTICAST_DISABLED_5_6'
   vrf: MULTICAST_DISABLED_5_6
-  mtu: 9000
+  mtu: 9214
   ip_address: 10.255.251.0/31
 - name: Vlan1
   tenant: Tenant_B
@@ -936,7 +936,7 @@ vlan_interfaces:
   shutdown: false
   description: 'MLAG_PEER_L3_iBGP: vrf MULTICAST_ENABLED_1_2'
   vrf: MULTICAST_ENABLED_1_2
-  mtu: 9000
+  mtu: 9214
   ip_address: 10.255.251.0/31
 - name: Vlan3
   tenant: Tenant_B
@@ -960,7 +960,7 @@ vlan_interfaces:
   shutdown: false
   description: 'MLAG_PEER_L3_iBGP: vrf MULTICAST_ENABLED_3_DISABLED_4'
   vrf: MULTICAST_ENABLED_3_DISABLED_4
-  mtu: 9000
+  mtu: 9214
   ip_address: 10.255.251.0/31
 - name: Vlan330
   tenant: Tenant_C
@@ -984,7 +984,7 @@ vlan_interfaces:
   shutdown: false
   description: 'MLAG_PEER_L3_iBGP: vrf TEN_C_L3_MULTICAST_DISABLED_330_331'
   vrf: TEN_C_L3_MULTICAST_DISABLED_330_331
-  mtu: 9000
+  mtu: 9214
   ip_address: 10.255.251.0/31
 - name: Vlan130
   tenant: Tenant_C
@@ -1017,7 +1017,7 @@ vlan_interfaces:
   shutdown: false
   description: 'MLAG_PEER_L3_iBGP: vrf TEN_C_L3_MULTICAST_ENABLED_130_131'
   vrf: TEN_C_L3_MULTICAST_ENABLED_130_131
-  mtu: 9000
+  mtu: 9214
   ip_address: 10.255.251.0/31
 - name: Vlan230
   tenant: Tenant_C
@@ -1045,7 +1045,7 @@ vlan_interfaces:
   shutdown: false
   description: 'MLAG_PEER_L3_iBGP: vrf TEN_C_L3_MULTICAST_ENABLED_230_DISABLED_231'
   vrf: TEN_C_L3_MULTICAST_ENABLED_230_DISABLED_231
-  mtu: 9000
+  mtu: 9214
   ip_address: 10.255.251.0/31
 - name: Vlan240
   tenant: Tenant_D
@@ -1069,7 +1069,7 @@ vlan_interfaces:
   shutdown: false
   description: 'MLAG_PEER_L3_iBGP: vrf TEN_D_L3_MULTICAST_DISABLED_240_241'
   vrf: TEN_D_L3_MULTICAST_DISABLED_240_241
-  mtu: 9000
+  mtu: 9214
   ip_address: 10.255.251.0/31
 - name: Vlan140
   tenant: Tenant_D
@@ -1097,7 +1097,7 @@ vlan_interfaces:
   shutdown: false
   description: 'MLAG_PEER_L3_iBGP: vrf TEN_D_L3_MULTICAST_ENABLED_140_DISABLED_141'
   vrf: TEN_D_L3_MULTICAST_ENABLED_140_DISABLED_141
-  mtu: 9000
+  mtu: 9214
   ip_address: 10.255.251.0/31
 - name: Vlan550
   tenant: Tenant_E
@@ -1117,7 +1117,7 @@ vlan_interfaces:
   shutdown: false
   description: 'MLAG_PEER_L3_iBGP: vrf TEN_E_L3_MULTICAST_ENABLED_PEG_OVERRIDE'
   vrf: TEN_E_L3_MULTICAST_ENABLED_PEG_OVERRIDE
-  mtu: 9000
+  mtu: 9214
   ip_address: 10.255.251.0/31
 - name: Vlan260
   tenant: Tenant_E
@@ -1137,7 +1137,7 @@ vlan_interfaces:
   shutdown: false
   description: 'MLAG_PEER_L3_iBGP: vrf TEN_E_L3_MULTICAST_EVPN_PEG_RP_NODES'
   vrf: TEN_E_L3_MULTICAST_EVPN_PEG_RP_NODES
-  mtu: 9000
+  mtu: 9214
   ip_address: 10.255.251.0/31
 - name: Vlan250
   tenant: Tenant_E
@@ -1157,7 +1157,7 @@ vlan_interfaces:
   shutdown: false
   description: 'MLAG_PEER_L3_iBGP: vrf TEN_E_L3_MULTICAST_TRANSIT'
   vrf: TEN_E_L3_MULTICAST_TRANSIT
-  mtu: 9000
+  mtu: 9214
   ip_address: 10.255.251.0/31
 - name: Vlan150
   tenant: Tenant_E
@@ -1177,7 +1177,7 @@ vlan_interfaces:
   shutdown: false
   description: 'MLAG_PEER_L3_iBGP: vrf TEN_E_PEG_L3_MULTICAST_ENABLED'
   vrf: TEN_E_PEG_L3_MULTICAST_ENABLED
-  mtu: 9000
+  mtu: 9214
   ip_address: 10.255.251.0/31
 port_channel_interfaces:
 - name: Port-Channel3
@@ -1223,7 +1223,7 @@ ethernet_interfaces:
   peer_type: spine
   description: P2P_LINK_TO_EVPN-MULTICAST-SPINE1_Ethernet1
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   type: routed
   ip_address: 172.31.255.1/31
   pim:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF1B.yml
@@ -807,7 +807,7 @@ vlan_interfaces:
 - name: Vlan4093
   description: MLAG_PEER_L3_PEERING
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   ip_address: 10.255.251.1/31
   pim:
     ipv4:
@@ -817,7 +817,7 @@ vlan_interfaces:
   shutdown: false
   ip_address: 10.255.252.1/31
   no_autostate: true
-  mtu: 9000
+  mtu: 9214
 - name: Vlan310
   tenant: Tenant_A
   tags:
@@ -840,7 +840,7 @@ vlan_interfaces:
   shutdown: false
   description: 'MLAG_PEER_L3_iBGP: vrf MULTICAST_DISABLED_310_311'
   vrf: MULTICAST_DISABLED_310_311
-  mtu: 9000
+  mtu: 9214
   ip_address: 10.255.251.1/31
 - name: Vlan110
   tenant: Tenant_A
@@ -864,7 +864,7 @@ vlan_interfaces:
   shutdown: false
   description: 'MLAG_PEER_L3_iBGP: vrf MULTICAST_ENABLED_110_111'
   vrf: MULTICAST_ENABLED_110_111
-  mtu: 9000
+  mtu: 9214
   ip_address: 10.255.251.1/31
 - name: Vlan210
   tenant: Tenant_A
@@ -888,7 +888,7 @@ vlan_interfaces:
   shutdown: false
   description: 'MLAG_PEER_L3_iBGP: vrf MULTICAST_ENABLED_210_DISABLED_211'
   vrf: MULTICAST_ENABLED_210_DISABLED_211
-  mtu: 9000
+  mtu: 9214
   ip_address: 10.255.251.1/31
 - name: Vlan5
   tenant: Tenant_B
@@ -912,7 +912,7 @@ vlan_interfaces:
   shutdown: false
   description: 'MLAG_PEER_L3_iBGP: vrf MULTICAST_DISABLED_5_6'
   vrf: MULTICAST_DISABLED_5_6
-  mtu: 9000
+  mtu: 9214
   ip_address: 10.255.251.1/31
 - name: Vlan1
   tenant: Tenant_B
@@ -936,7 +936,7 @@ vlan_interfaces:
   shutdown: false
   description: 'MLAG_PEER_L3_iBGP: vrf MULTICAST_ENABLED_1_2'
   vrf: MULTICAST_ENABLED_1_2
-  mtu: 9000
+  mtu: 9214
   ip_address: 10.255.251.1/31
 - name: Vlan3
   tenant: Tenant_B
@@ -960,7 +960,7 @@ vlan_interfaces:
   shutdown: false
   description: 'MLAG_PEER_L3_iBGP: vrf MULTICAST_ENABLED_3_DISABLED_4'
   vrf: MULTICAST_ENABLED_3_DISABLED_4
-  mtu: 9000
+  mtu: 9214
   ip_address: 10.255.251.1/31
 - name: Vlan330
   tenant: Tenant_C
@@ -984,7 +984,7 @@ vlan_interfaces:
   shutdown: false
   description: 'MLAG_PEER_L3_iBGP: vrf TEN_C_L3_MULTICAST_DISABLED_330_331'
   vrf: TEN_C_L3_MULTICAST_DISABLED_330_331
-  mtu: 9000
+  mtu: 9214
   ip_address: 10.255.251.1/31
 - name: Vlan130
   tenant: Tenant_C
@@ -1017,7 +1017,7 @@ vlan_interfaces:
   shutdown: false
   description: 'MLAG_PEER_L3_iBGP: vrf TEN_C_L3_MULTICAST_ENABLED_130_131'
   vrf: TEN_C_L3_MULTICAST_ENABLED_130_131
-  mtu: 9000
+  mtu: 9214
   ip_address: 10.255.251.1/31
 - name: Vlan230
   tenant: Tenant_C
@@ -1045,7 +1045,7 @@ vlan_interfaces:
   shutdown: false
   description: 'MLAG_PEER_L3_iBGP: vrf TEN_C_L3_MULTICAST_ENABLED_230_DISABLED_231'
   vrf: TEN_C_L3_MULTICAST_ENABLED_230_DISABLED_231
-  mtu: 9000
+  mtu: 9214
   ip_address: 10.255.251.1/31
 - name: Vlan240
   tenant: Tenant_D
@@ -1069,7 +1069,7 @@ vlan_interfaces:
   shutdown: false
   description: 'MLAG_PEER_L3_iBGP: vrf TEN_D_L3_MULTICAST_DISABLED_240_241'
   vrf: TEN_D_L3_MULTICAST_DISABLED_240_241
-  mtu: 9000
+  mtu: 9214
   ip_address: 10.255.251.1/31
 - name: Vlan140
   tenant: Tenant_D
@@ -1097,7 +1097,7 @@ vlan_interfaces:
   shutdown: false
   description: 'MLAG_PEER_L3_iBGP: vrf TEN_D_L3_MULTICAST_ENABLED_140_DISABLED_141'
   vrf: TEN_D_L3_MULTICAST_ENABLED_140_DISABLED_141
-  mtu: 9000
+  mtu: 9214
   ip_address: 10.255.251.1/31
 - name: Vlan550
   tenant: Tenant_E
@@ -1117,7 +1117,7 @@ vlan_interfaces:
   shutdown: false
   description: 'MLAG_PEER_L3_iBGP: vrf TEN_E_L3_MULTICAST_ENABLED_PEG_OVERRIDE'
   vrf: TEN_E_L3_MULTICAST_ENABLED_PEG_OVERRIDE
-  mtu: 9000
+  mtu: 9214
   ip_address: 10.255.251.1/31
 - name: Vlan260
   tenant: Tenant_E
@@ -1137,7 +1137,7 @@ vlan_interfaces:
   shutdown: false
   description: 'MLAG_PEER_L3_iBGP: vrf TEN_E_L3_MULTICAST_EVPN_PEG_RP_NODES'
   vrf: TEN_E_L3_MULTICAST_EVPN_PEG_RP_NODES
-  mtu: 9000
+  mtu: 9214
   ip_address: 10.255.251.1/31
 - name: Vlan250
   tenant: Tenant_E
@@ -1157,7 +1157,7 @@ vlan_interfaces:
   shutdown: false
   description: 'MLAG_PEER_L3_iBGP: vrf TEN_E_L3_MULTICAST_TRANSIT'
   vrf: TEN_E_L3_MULTICAST_TRANSIT
-  mtu: 9000
+  mtu: 9214
   ip_address: 10.255.251.1/31
 - name: Vlan150
   tenant: Tenant_E
@@ -1177,7 +1177,7 @@ vlan_interfaces:
   shutdown: false
   description: 'MLAG_PEER_L3_iBGP: vrf TEN_E_PEG_L3_MULTICAST_ENABLED'
   vrf: TEN_E_PEG_L3_MULTICAST_ENABLED
-  mtu: 9000
+  mtu: 9214
   ip_address: 10.255.251.1/31
 port_channel_interfaces:
 - name: Port-Channel3
@@ -1223,7 +1223,7 @@ ethernet_interfaces:
   peer_type: spine
   description: P2P_LINK_TO_EVPN-MULTICAST-SPINE1_Ethernet2
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   type: routed
   ip_address: 172.31.255.3/31
   pim:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF2A.yml
@@ -649,7 +649,7 @@ ethernet_interfaces:
   peer_type: spine
   description: P2P_LINK_TO_EVPN-MULTICAST-SPINE1_Ethernet3
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   type: routed
   ip_address: 172.31.255.5/31
   pim:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF3A.yml
@@ -652,7 +652,7 @@ ethernet_interfaces:
   peer_type: spine
   description: P2P_LINK_TO_EVPN-MULTICAST-SPINE1_Ethernet4
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   type: routed
   ip_address: 172.31.255.7/31
   pim:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF3B.yml
@@ -652,7 +652,7 @@ ethernet_interfaces:
   peer_type: spine
   description: P2P_LINK_TO_EVPN-MULTICAST-SPINE1_Ethernet5
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   type: routed
   ip_address: 172.31.255.9/31
   pim:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-SPINE1.yml
@@ -111,7 +111,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: P2P_LINK_TO_EVPN-MULTICAST-L3LEAF1A_Ethernet1
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   type: routed
   ip_address: 172.31.255.0/31
   pim:
@@ -123,7 +123,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: P2P_LINK_TO_EVPN-MULTICAST-L3LEAF1B_Ethernet1
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   type: routed
   ip_address: 172.31.255.2/31
   pim:
@@ -135,7 +135,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: P2P_LINK_TO_EVPN-MULTICAST-L3LEAF2A_Ethernet1
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   type: routed
   ip_address: 172.31.255.4/31
   pim:
@@ -147,7 +147,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: P2P_LINK_TO_EVPN-MULTICAST-L3LEAF3A_Ethernet1
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   type: routed
   ip_address: 172.31.255.6/31
   pim:
@@ -159,7 +159,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: P2P_LINK_TO_EVPN-MULTICAST-L3LEAF3B_Ethernet1
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   type: routed
   ip_address: 172.31.255.8/31
   pim:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3A.yml
@@ -83,14 +83,14 @@ vlan_interfaces:
 - name: Vlan4093
   description: MLAG_PEER_L3_PEERING
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   ip_address: 192.168.253.4/31
 - name: Vlan4094
   description: MLAG_PEER
   shutdown: false
   ip_address: 192.168.254.4/31
   no_autostate: true
-  mtu: 9000
+  mtu: 9214
 - name: Vlan3900
   tenant: TEST
   tags:
@@ -114,7 +114,7 @@ vlan_interfaces:
   shutdown: false
   description: 'MLAG_PEER_L3_iBGP: vrf TEST'
   vrf: TEST
-  mtu: 9000
+  mtu: 9214
   ip_address: 192.168.253.4/31
 port_channel_interfaces:
 - name: Port-Channel1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3B.yml
@@ -83,14 +83,14 @@ vlan_interfaces:
 - name: Vlan4093
   description: MLAG_PEER_L3_PEERING
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   ip_address: 192.168.253.5/31
 - name: Vlan4094
   description: MLAG_PEER
   shutdown: false
   ip_address: 192.168.254.5/31
   no_autostate: true
-  mtu: 9000
+  mtu: 9214
 - name: Vlan3900
   tenant: TEST
   tags:
@@ -114,7 +114,7 @@ vlan_interfaces:
   shutdown: false
   description: 'MLAG_PEER_L3_iBGP: vrf TEST'
   vrf: TEST
-  mtu: 9000
+  mtu: 9214
   ip_address: 192.168.253.5/31
 port_channel_interfaces:
 - name: Port-Channel1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF1A.yml
@@ -107,7 +107,7 @@ vlan_interfaces:
 - name: Vlan4093
   description: MLAG_PEER_L3_PEERING
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   ip_address: 10.255.251.0/31
   pim:
     ipv4:
@@ -117,7 +117,7 @@ vlan_interfaces:
   shutdown: false
   ip_address: 10.255.252.0/31
   no_autostate: true
-  mtu: 9000
+  mtu: 9214
 port_channel_interfaces:
 - name: Port-Channel3
   description: MLAG_PEER_UNDERLAY-MULTICAST-L3LEAF1B_Po3
@@ -162,7 +162,7 @@ ethernet_interfaces:
   peer_type: spine
   description: P2P_LINK_TO_UNDERLAY-MULTICAST-SPINE1_Ethernet1
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   type: routed
   ip_address: 172.31.255.1/31
   pim:
@@ -174,7 +174,7 @@ ethernet_interfaces:
   peer_type: spine
   description: P2P_LINK_TO_UNDERLAY-MULTICAST-SPINE2_Ethernet1
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   type: routed
   ip_address: 172.31.255.3/31
 - name: Ethernet6

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF1B.yml
@@ -107,7 +107,7 @@ vlan_interfaces:
 - name: Vlan4093
   description: MLAG_PEER_L3_PEERING
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   ip_address: 10.255.251.1/31
   pim:
     ipv4:
@@ -117,7 +117,7 @@ vlan_interfaces:
   shutdown: false
   ip_address: 10.255.252.1/31
   no_autostate: true
-  mtu: 9000
+  mtu: 9214
 port_channel_interfaces:
 - name: Port-Channel3
   description: MLAG_PEER_UNDERLAY-MULTICAST-L3LEAF1A_Po3
@@ -155,7 +155,7 @@ ethernet_interfaces:
   peer_type: spine
   description: P2P_LINK_TO_UNDERLAY-MULTICAST-SPINE1_Ethernet2
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   type: routed
   ip_address: 172.31.255.5/31
   pim:
@@ -167,7 +167,7 @@ ethernet_interfaces:
   peer_type: spine
   description: P2P_LINK_TO_UNDERLAY-MULTICAST-SPINE2_Ethernet2
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   type: routed
   ip_address: 172.31.255.7/31
 mlag_configuration:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF2A.yml
@@ -104,7 +104,7 @@ vlan_interfaces:
   shutdown: false
   ip_address: 10.255.252.4/31
   no_autostate: true
-  mtu: 9000
+  mtu: 9214
   pim:
     ipv4:
       sparse_mode: true
@@ -145,7 +145,7 @@ ethernet_interfaces:
   peer_type: spine
   description: P2P_LINK_TO_UNDERLAY-MULTICAST-SPINE1_Ethernet3
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   type: routed
   ip_address: 172.31.255.9/31
   pim:
@@ -157,7 +157,7 @@ ethernet_interfaces:
   peer_type: spine
   description: P2P_LINK_TO_UNDERLAY-MULTICAST-SPINE2_Ethernet3
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   type: routed
   ip_address: 172.31.255.11/31
 mlag_configuration:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF2B.yml
@@ -104,7 +104,7 @@ vlan_interfaces:
   shutdown: false
   ip_address: 10.255.252.5/31
   no_autostate: true
-  mtu: 9000
+  mtu: 9214
   pim:
     ipv4:
       sparse_mode: true
@@ -145,7 +145,7 @@ ethernet_interfaces:
   peer_type: spine
   description: P2P_LINK_TO_UNDERLAY-MULTICAST-SPINE1_Ethernet4
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   type: routed
   ip_address: 172.31.255.13/31
   pim:
@@ -157,7 +157,7 @@ ethernet_interfaces:
   peer_type: spine
   description: P2P_LINK_TO_UNDERLAY-MULTICAST-SPINE2_Ethernet4
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   type: routed
   ip_address: 172.31.255.15/31
 mlag_configuration:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-SPINE1.yml
@@ -103,7 +103,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: P2P_LINK_TO_UNDERLAY-MULTICAST-L3LEAF1A_Ethernet1
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   type: routed
   ip_address: 172.31.255.0/31
   pim:
@@ -115,7 +115,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: P2P_LINK_TO_UNDERLAY-MULTICAST-L3LEAF1B_Ethernet1
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   type: routed
   ip_address: 172.31.255.4/31
   pim:
@@ -127,7 +127,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: P2P_LINK_TO_UNDERLAY-MULTICAST-L3LEAF2A_Ethernet1
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   type: routed
   ip_address: 172.31.255.8/31
   pim:
@@ -139,7 +139,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: P2P_LINK_TO_UNDERLAY-MULTICAST-L3LEAF2B_Ethernet1
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   type: routed
   ip_address: 172.31.255.12/31
   pim:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-SPINE2.yml
@@ -100,7 +100,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: P2P_LINK_TO_UNDERLAY-MULTICAST-L3LEAF1A_Ethernet2
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   type: routed
   ip_address: 172.31.255.2/31
 - name: Ethernet2
@@ -109,7 +109,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: P2P_LINK_TO_UNDERLAY-MULTICAST-L3LEAF1B_Ethernet2
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   type: routed
   ip_address: 172.31.255.6/31
 - name: Ethernet3
@@ -118,7 +118,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: P2P_LINK_TO_UNDERLAY-MULTICAST-L3LEAF2A_Ethernet2
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   type: routed
   ip_address: 172.31.255.10/31
 - name: Ethernet4
@@ -127,7 +127,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: P2P_LINK_TO_UNDERLAY-MULTICAST-L3LEAF2B_Ethernet2
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   type: routed
   ip_address: 172.31.255.14/31
 loopback_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY_FILTER_PEER_AS_L3LEAF1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY_FILTER_PEER_AS_L3LEAF1.yml
@@ -49,7 +49,7 @@ ethernet_interfaces:
   peer_type: spine
   description: P2P_LINK_TO_UNDERLAY_FILTER_PEER_AS_SPINE1_Ethernet1
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   type: routed
   ip_address: 192.168.0.1/31
 - name: Ethernet2
@@ -58,7 +58,7 @@ ethernet_interfaces:
   peer_type: spine
   description: P2P_LINK_TO_UNDERLAY_FILTER_PEER_AS_SPINE2_Ethernet1
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   type: routed
   ip_address: 192.168.0.3/31
 loopback_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY_FILTER_PEER_AS_SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY_FILTER_PEER_AS_SPINE1.yml
@@ -47,7 +47,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: P2P_LINK_TO_UNDERLAY_FILTER_PEER_AS_L3LEAF1_Ethernet1
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   type: routed
   ip_address: 192.168.0.0/31
 loopback_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY_FILTER_PEER_AS_SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY_FILTER_PEER_AS_SPINE2.yml
@@ -47,7 +47,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: P2P_LINK_TO_UNDERLAY_FILTER_PEER_AS_L3LEAF1_Ethernet2
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   type: routed
   ip_address: 192.168.0.2/31
 loopback_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1A.yml
@@ -41,7 +41,7 @@ vlan_interfaces:
   shutdown: false
   ip_address: 10.255.252.0/31
   no_autostate: true
-  mtu: 9000
+  mtu: 9214
 port_channel_interfaces:
 - name: Port-Channel3
   description: MLAG_PEER_UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1B_Po3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1B.yml
@@ -41,7 +41,7 @@ vlan_interfaces:
   shutdown: false
   ip_address: 10.255.252.1/31
   no_autostate: true
-  mtu: 9000
+  mtu: 9214
 port_channel_interfaces:
 - name: Port-Channel3
   description: MLAG_PEER_UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1A_Po3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1A.yml
@@ -100,7 +100,7 @@ vlan_interfaces:
 - name: Vlan4093
   description: MLAG_PEER_L3_PEERING
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   ip_address: 10.255.251.0/31
   pim:
     ipv4:
@@ -110,7 +110,7 @@ vlan_interfaces:
   shutdown: false
   ip_address: 10.255.252.0/31
   no_autostate: true
-  mtu: 9000
+  mtu: 9214
 port_channel_interfaces:
 - name: Port-Channel3
   description: MLAG_PEER_UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1B_Po3
@@ -161,7 +161,7 @@ ethernet_interfaces:
   peer_type: spine
   description: P2P_LINK_TO_UPLINK-MLAG-STRUCTURED-CONFIG-SPINE1_Ethernet1
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   type: routed
   ip_address: 172.31.255.1/31
   pim:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1B.yml
@@ -100,7 +100,7 @@ vlan_interfaces:
 - name: Vlan4093
   description: MLAG_PEER_L3_PEERING
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   ip_address: 10.255.251.1/31
   pim:
     ipv4:
@@ -110,7 +110,7 @@ vlan_interfaces:
   shutdown: false
   ip_address: 10.255.252.1/31
   no_autostate: true
-  mtu: 9000
+  mtu: 9214
 port_channel_interfaces:
 - name: Port-Channel3
   description: MLAG_PEER_UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1A_Po3
@@ -161,7 +161,7 @@ ethernet_interfaces:
   peer_type: spine
   description: P2P_LINK_TO_UPLINK-MLAG-STRUCTURED-CONFIG-SPINE1_Ethernet2
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   type: routed
   ip_address: 172.31.255.3/31
   pim:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-SPINE1.yml
@@ -84,7 +84,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: P2P_LINK_TO_UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1A_Ethernet1
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   type: routed
   ip_address: 172.31.255.0/31
   pim:
@@ -96,7 +96,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: P2P_LINK_TO_UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1B_Ethernet1
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   type: routed
   ip_address: 172.31.255.2/31
   pim:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-structured-config-1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-structured-config-1.yml
@@ -85,7 +85,7 @@ vlan_interfaces:
   shutdown: false
   ip_address: 192.168.253.204/31
   no_autostate: true
-  mtu: 9000
+  mtu: 9214
 port_channel_interfaces:
 - name: Port-Channel3
   description: MLAG_PEER_bgp-peer-groups-structured-config-2_Po3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-structured-config-2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-structured-config-2.yml
@@ -102,7 +102,7 @@ vlan_interfaces:
   shutdown: false
   ip_address: 192.168.253.205/31
   no_autostate: true
-  mtu: 9000
+  mtu: 9214
 port_channel_interfaces:
 - name: Port-Channel3
   description: MLAG_PEER_bgp-peer-groups-structured-config-1_Po3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/l3_edge_bgp.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/l3_edge_bgp.yml
@@ -98,7 +98,7 @@ ethernet_interfaces:
   description: P2P_LINK_TO_peer2_ethernet2
   type: routed
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   ip_address: 192.168.0.2/31
   ipv6_enable: true
 - name: ethernet3
@@ -108,7 +108,7 @@ ethernet_interfaces:
   description: P2P_LINK_TO_peer3_ethernet3
   type: routed
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   ip_address: 192.168.0.4/31
 - name: ethernet4
   peer: peer4
@@ -117,7 +117,7 @@ ethernet_interfaces:
   description: Custom description on l3_edge_bgp eth4
   type: routed
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   ip_address: 192.168.0.6/31
 - name: Ethernet5
   type: port-channel-member
@@ -167,7 +167,7 @@ port_channel_interfaces:
   description: P2P_LINK_TO_peer5_Port-Channel5
   type: routed
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   ip_address: 192.168.0.8/31
 - name: Port-Channel7
   peer: peer6
@@ -176,5 +176,5 @@ port_channel_interfaces:
   description: P2P_LINK_TO_peer6_Port-Channel7
   type: routed
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   ip_address: 192.168.0.10/31

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/l3_edge_isis.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/l3_edge_isis.yml
@@ -53,7 +53,7 @@ ethernet_interfaces:
   description: P2P_LINK_TO_peer2_ethernet2
   type: routed
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   ip_address: 192.168.0.2/31
   isis_enable: EVPN_UNDERLAY
   isis_metric: 60
@@ -69,7 +69,7 @@ ethernet_interfaces:
   description: P2P_LINK_TO_peer3_ethernet3
   type: routed
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   ip_address: 192.168.0.4/31
   isis_enable: EVPN_UNDERLAY
   isis_metric: 50
@@ -83,7 +83,7 @@ ethernet_interfaces:
   description: P2P_LINK_TO_peer4_ethernet4
   type: routed
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   ip_address: 192.168.0.6/31
   isis_enable: EVPN_UNDERLAY
   isis_metric: 50

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/l3_edge_ospf.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/l3_edge_ospf.yml
@@ -54,7 +54,7 @@ ethernet_interfaces:
   description: P2P_LINK_TO_peer2_ethernet2
   type: routed
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   ip_address: 192.168.0.2/31
   ospf_network_point_to_point: true
   ospf_area: 0.0.0.0
@@ -65,7 +65,7 @@ ethernet_interfaces:
   description: P2P_LINK_TO_peer3_ethernet3
   type: routed
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   ip_address: 192.168.0.4/31
   ospf_network_point_to_point: true
   ospf_area: 0.0.0.0
@@ -76,7 +76,7 @@ ethernet_interfaces:
   description: P2P_LINK_TO_peer4_ethernet4
   type: routed
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   ip_address: 192.168.0.6/31
   ospf_network_point_to_point: true
   ospf_area: 0.0.0.0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/network-ports-tests-2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/network-ports-tests-2.yml
@@ -32,7 +32,7 @@ vlan_interfaces:
   shutdown: false
   ip_address: 10.255.252.1/31
   no_autostate: true
-  mtu: 9000
+  mtu: 9214
 port_channel_interfaces:
 - name: Port-Channel101
   description: MLAG_PEER_network-ports-tests.1_Po101

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/network-ports-tests.1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/network-ports-tests.1.yml
@@ -35,7 +35,7 @@ vlan_interfaces:
   shutdown: false
   ip_address: 10.255.252.0/31
   no_autostate: true
-  mtu: 9000
+  mtu: 9214
 port_channel_interfaces:
 - name: Port-Channel101
   description: MLAG_PEER_network-ports-tests-2_Po101

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-leaf1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-leaf1.yml
@@ -127,7 +127,7 @@ ethernet_interfaces:
   peer_type: spine
   description: P2P_LINK_TO_PTP-TESTS-SPINE1_Ethernet1
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   type: routed
   ptp:
     announce:
@@ -145,7 +145,7 @@ ethernet_interfaces:
   peer_type: spine
   description: P2P_LINK_TO_PTP-TESTS-SPINE1_Ethernet2
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   type: routed
   ptp:
     announce:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-leaf2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-leaf2.yml
@@ -140,7 +140,7 @@ ethernet_interfaces:
   peer_type: spine
   description: P2P_LINK_TO_PTP-TESTS-SPINE1_Ethernet3
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   type: routed
   ptp:
     announce:
@@ -158,7 +158,7 @@ ethernet_interfaces:
   peer_type: spine
   description: P2P_LINK_TO_PTP-TESTS-SPINE1_Ethernet4
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   type: routed
   ptp:
     announce:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-spine1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-spine1.yml
@@ -110,7 +110,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: P2P_LINK_TO_PTP-TESTS-LEAF1_Ethernet1
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   type: routed
   ptp:
     announce:
@@ -128,7 +128,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: P2P_LINK_TO_PTP-TESTS-LEAF1_Ethernet2
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   type: routed
   ptp:
     announce:
@@ -146,7 +146,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: P2P_LINK_TO_PTP-TESTS-LEAF2_Ethernet1
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   type: routed
   ptp:
     announce:
@@ -164,7 +164,7 @@ ethernet_interfaces:
   peer_type: l3leaf
   description: P2P_LINK_TO_PTP-TESTS-LEAF2_Ethernet2
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   type: routed
   ptp:
     announce:
@@ -183,7 +183,7 @@ ethernet_interfaces:
   description: P2P_LINK_TO_ptp-tests-spine2_Ethernet6
   type: routed
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   ptp:
     announce:
       interval: 0
@@ -200,7 +200,7 @@ ethernet_interfaces:
   description: P2P_LINK_TO_ptp-tests-spine2_Ethernet7
   type: routed
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   ptp:
     announce:
       interval: 0
@@ -217,7 +217,7 @@ ethernet_interfaces:
   description: P2P_LINK_TO_ptp-tests-spine2_Ethernet8
   type: routed
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   ptp:
     announce:
       interval: 0
@@ -234,7 +234,7 @@ ethernet_interfaces:
   description: P2P_LINK_TO_ptp-tests-spine2_Ethernet9
   type: routed
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   ptp:
     announce:
       interval: 0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-spine2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-spine2.yml
@@ -121,7 +121,7 @@ ethernet_interfaces:
   description: P2P_LINK_TO_ptp-tests-spine1_Ethernet6
   type: routed
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   ptp:
     announce:
       interval: 0
@@ -138,7 +138,7 @@ ethernet_interfaces:
   description: P2P_LINK_TO_ptp-tests-spine1_Ethernet7
   type: routed
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   ptp:
     announce:
       interval: 0
@@ -155,7 +155,7 @@ ethernet_interfaces:
   description: P2P_LINK_TO_ptp-tests-spine1_Ethernet8
   type: routed
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   ptp:
     announce:
       interval: 0
@@ -172,7 +172,7 @@ ethernet_interfaces:
   description: P2P_LINK_TO_ptp-tests-spine1_Ethernet9
   type: routed
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   ptp:
     announce:
       interval: 0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l2leaf1a.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l2leaf1a.yml
@@ -89,7 +89,7 @@ vlan_interfaces:
   shutdown: false
   ip_address: 10.255.248.0/31
   no_autostate: true
-  mtu: 9000
+  mtu: 9214
 port_channel_interfaces:
 - name: Port-Channel3
   description: MLAG_PEER_trunk-group-tests-l2leaf1b_Po3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l2leaf1b.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l2leaf1b.yml
@@ -81,7 +81,7 @@ vlan_interfaces:
   shutdown: false
   ip_address: 10.255.248.1/31
   no_autostate: true
-  mtu: 9000
+  mtu: 9214
 port_channel_interfaces:
 - name: Port-Channel3
   description: MLAG_PEER_trunk-group-tests-l2leaf1a_Po3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf1a.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf1a.yml
@@ -313,14 +313,14 @@ vlan_interfaces:
 - name: Vlan4093
   description: MLAG_PEER_L3_PEERING
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   ip_address: 10.255.247.0/31
 - name: Vlan4094
   description: MLAG_PEER
   shutdown: false
   ip_address: 10.255.248.0/31
   no_autostate: true
-  mtu: 9000
+  mtu: 9214
 - name: Vlan100
   tenant: TRUNK_GROUP_TESTS
   tags:
@@ -336,7 +336,7 @@ vlan_interfaces:
   shutdown: false
   description: 'MLAG_PEER_L3_iBGP: vrf TG_100'
   vrf: TG_100
-  mtu: 9000
+  mtu: 9214
   ip_address: 10.255.247.0/31
 - name: Vlan200
   tenant: TRUNK_GROUP_TESTS
@@ -353,7 +353,7 @@ vlan_interfaces:
   shutdown: false
   description: 'MLAG_PEER_L3_iBGP: vrf TG_200'
   vrf: TG_200
-  mtu: 9000
+  mtu: 9214
   ip_address: 10.255.247.0/31
 - name: Vlan300
   tenant: TRUNK_GROUP_TESTS
@@ -387,7 +387,7 @@ vlan_interfaces:
   shutdown: false
   description: 'MLAG_PEER_L3_iBGP: vrf TG_300'
   vrf: TG_300
-  mtu: 9000
+  mtu: 9214
   ip_address: 10.255.247.0/31
 port_channel_interfaces:
 - name: Port-Channel3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf1b.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf1b.yml
@@ -301,14 +301,14 @@ vlan_interfaces:
 - name: Vlan4093
   description: MLAG_PEER_L3_PEERING
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   ip_address: 10.255.247.1/31
 - name: Vlan4094
   description: MLAG_PEER
   shutdown: false
   ip_address: 10.255.248.1/31
   no_autostate: true
-  mtu: 9000
+  mtu: 9214
 - name: Vlan100
   tenant: TRUNK_GROUP_TESTS
   tags:
@@ -324,7 +324,7 @@ vlan_interfaces:
   shutdown: false
   description: 'MLAG_PEER_L3_iBGP: vrf TG_100'
   vrf: TG_100
-  mtu: 9000
+  mtu: 9214
   ip_address: 10.255.247.1/31
 - name: Vlan200
   tenant: TRUNK_GROUP_TESTS
@@ -341,7 +341,7 @@ vlan_interfaces:
   shutdown: false
   description: 'MLAG_PEER_L3_iBGP: vrf TG_200'
   vrf: TG_200
-  mtu: 9000
+  mtu: 9214
   ip_address: 10.255.247.1/31
 - name: Vlan300
   tenant: TRUNK_GROUP_TESTS
@@ -375,7 +375,7 @@ vlan_interfaces:
   shutdown: false
   description: 'MLAG_PEER_L3_iBGP: vrf TG_300'
   vrf: TG_300
-  mtu: 9000
+  mtu: 9214
   ip_address: 10.255.247.1/31
 port_channel_interfaces:
 - name: Port-Channel3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf2a.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf2a.yml
@@ -139,14 +139,14 @@ vlan_interfaces:
 - name: Vlan4093
   description: MLAG_PEER_L3_PEERING
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   ip_address: 10.255.247.4/31
 - name: Vlan4094
   description: MLAG_PEER
   shutdown: false
   ip_address: 10.255.248.4/31
   no_autostate: true
-  mtu: 9000
+  mtu: 9214
 - name: Vlan200
   tenant: TRUNK_GROUP_TESTS
   tags:
@@ -162,7 +162,7 @@ vlan_interfaces:
   shutdown: false
   description: 'MLAG_PEER_L3_iBGP: vrf TG_200'
   vrf: TG_200
-  mtu: 9000
+  mtu: 9214
   ip_address: 10.255.247.4/31
 port_channel_interfaces:
 - name: Port-Channel3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf2b.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf2b.yml
@@ -135,14 +135,14 @@ vlan_interfaces:
 - name: Vlan4093
   description: MLAG_PEER_L3_PEERING
   shutdown: false
-  mtu: 9000
+  mtu: 9214
   ip_address: 10.255.247.5/31
 - name: Vlan4094
   description: MLAG_PEER
   shutdown: false
   ip_address: 10.255.248.5/31
   no_autostate: true
-  mtu: 9000
+  mtu: 9214
 - name: Vlan200
   tenant: TRUNK_GROUP_TESTS
   tags:
@@ -158,7 +158,7 @@ vlan_interfaces:
   shutdown: false
   description: 'MLAG_PEER_L3_iBGP: vrf TG_200'
   vrf: TG_200
-  mtu: 9000
+  mtu: 9214
   ip_address: 10.255.247.5/31
 port_channel_interfaces:
 - name: Port-Channel3

--- a/ansible_collections/arista/avd/roles/eos_designs/defaults/main/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/defaults/main/main.yml
@@ -43,7 +43,7 @@ terminattr_ingestgrpcurl_port: 9910
 terminattr_smashexcludes: "ale,flexCounter,hardware,kni,pulse,strata"
 terminattr_ingestexclude: "/Sysdb/cell/1/agent,/Sysdb/cell/2/agent"
 
-p2p_uplinks_mtu: 9000
+p2p_uplinks_mtu: 9214
 
 underlay_ipv6: false
 

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-variables-v4.0.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-variables-v4.0.md
@@ -53,7 +53,7 @@ isis_ti_lfa:
 bgp_as: < AS number >
 
 # Point to Point Links MTU | Required.
-p2p_uplinks_mtu: < 0-9216 | default -> 9000 >
+p2p_uplinks_mtu: < 0-9216 | default -> 9214>
 
 # IP Address used as Virtual VTEP. Will be configured as secondary IP on loopback1 | Optional
 # This is only needed for centralized routing designs

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-variables.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-variables.md
@@ -89,7 +89,7 @@ isis_ti_lfa:
 bgp_as: < AS number >
 
 # Point to Point Links MTU | Required.
-p2p_uplinks_mtu: < 0-9216 | default -> 9000 >
+p2p_uplinks_mtu: < 0-9216 | default -> 9214>
 
 # IP Address used as Virtual VTEP. Will be configured as secondary IP on loopback1 | Optional
 # This is only needed for centralized routing designs

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/Fabric Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/Fabric Variables.md
@@ -275,7 +275,7 @@ search:
 
     | Variable | Type | Required | Default | Value Restrictions | Description |
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
-    | [<samp>p2p_uplinks_mtu</samp>](## "p2p_uplinks_mtu") | Integer |  | 9000 | Min: 68<br>Max: 65535 | Point to Point Links MTU |
+    | [<samp>p2p_uplinks_mtu</samp>](## "p2p_uplinks_mtu") | Integer |  | 9214 | Min: 68<br>Max: 65535 | Point to Point Links MTU |
     | [<samp>p2p_uplinks_qos_profile</samp>](## "p2p_uplinks_qos_profile") | String |  |  |  | QOS Profile assigned on all infrastructure links |
     | [<samp>uplink_ptp</samp>](## "uplink_ptp") | Dictionary |  |  |  | Enable PTP on all infrastructure links |
     | [<samp>&nbsp;&nbsp;enable</samp>](## "uplink_ptp.enable") | Boolean |  | False |  |  |

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -3112,7 +3112,7 @@
       "type": "integer",
       "minimum": 68,
       "maximum": 65535,
-      "default": 9000,
+      "default": 9214,
       "title": "P2P Uplinks MTU"
     },
     "p2p_uplinks_qos_profile": {

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
@@ -1355,7 +1355,7 @@ keys:
     - str
     min: 68
     max: 65535
-    default: 9000
+    default: 9214
   p2p_uplinks_qos_profile:
     documentation_options:
       filename: Fabric Variables

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/p2p_uplinks_mtu.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/p2p_uplinks_mtu.schema.yml
@@ -13,4 +13,4 @@ keys:
       - str
     min: 68
     max: 65535
-    default: 9000
+    default: 9214


### PR DESCRIPTION
## Change Summary

Change `p2p_uplinks_mtu` default value from 9000 to 9214

## Related Issue(s)

Fixes #aristanetworks/avd-internal#101

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

Change p2p_uplinks_mtu default value from 9000 to 9214
updated release notes and porting guide
update molecule scenarios

## How to test

Verify CI passes and molecule scenarios updated.

