### PR TITLE
Feat(eos_designs): Add schema for ptp_profiles

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_designs/docs/Fabric Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/Fabric Variables.md
@@ -243,19 +243,17 @@ search:
 
 ## PTP Profiles
 
-PTP Profiles
-
 === "Table"
 
     | Variable | Type | Required | Default | Value Restrictions | Description |
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
     | [<samp>ptp_profiles</samp>](## "ptp_profiles") | List, items: Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;- profile</samp>](## "ptp_profiles.[].profile") | String |  |  |  | PTP Profile |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;announce</samp>](## "ptp_profiles.[].announce") | Dictionary |  |  |  | PTP Announce Interval |
+    | [<samp>&nbsp;&nbsp;- profile</samp>](## "ptp_profiles.[].profile") | String |  |  |  | PTP profile. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;announce</samp>](## "ptp_profiles.[].announce") | Dictionary |  |  |  | PTP announce interval. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interval</samp>](## "ptp_profiles.[].announce.interval") | Integer |  |  | Min: -7<br>Max: 4 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;timeout</samp>](## "ptp_profiles.[].announce.timeout") | Integer |  |  | Min: 2<br>Max: 255 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;delay_req</samp>](## "ptp_profiles.[].delay_req") | Integer |  |  | Min: -7<br>Max: 8 |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;sync_message</samp>](## "ptp_profiles.[].sync_message") | Dictionary |  |  |  | PTP Sync Message Interval |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;sync_message</samp>](## "ptp_profiles.[].sync_message") | Dictionary |  |  |  | PTP sync message interval. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interval</samp>](## "ptp_profiles.[].sync_message.interval") | Integer |  |  | Min: -7<br>Max: 3 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;transport</samp>](## "ptp_profiles.[].transport") | String |  |  | Valid Values:<br>- ipv4 |  |
 

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/Fabric Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/Fabric Variables.md
@@ -235,6 +235,20 @@ search:
     vtep_vvtep_ip: <str>
     ```
 
+## PTP Profiles
+
+=== "Table"
+
+    | Variable | Type | Required | Default | Value Restrictions | Description |
+    | -------- | ---- | -------- | ------- | ------------------ | ----------- |
+    | [<samp>ptp_profiles</samp>](## "ptp_profiles") | List |  |  |  | PTP Profiles |
+
+=== "YAML"
+
+    ```yaml
+    ptp_profiles:
+    ```
+
 ## Routing Protocol Selection
 
 === "Table"

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/Fabric Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/Fabric Variables.md
@@ -237,16 +237,34 @@ search:
 
 ## PTP Profiles
 
+PTP Profiles
+
 === "Table"
 
     | Variable | Type | Required | Default | Value Restrictions | Description |
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
-    | [<samp>ptp_profiles</samp>](## "ptp_profiles") | List |  |  |  | PTP Profiles |
+    | [<samp>ptp_profiles</samp>](## "ptp_profiles") | List, items: Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;- profile</samp>](## "ptp_profiles.[].profile") | String |  |  |  | PTP Profile |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;announce</samp>](## "ptp_profiles.[].announce") | Dictionary |  |  |  | PTP Announce Interval |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interval</samp>](## "ptp_profiles.[].announce.interval") | Integer |  |  | Min: -7<br>Max: 4 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;timeout</samp>](## "ptp_profiles.[].announce.timeout") | Integer |  |  | Min: 2<br>Max: 255 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;delay_req</samp>](## "ptp_profiles.[].delay_req") | Integer |  |  | Min: -7<br>Max: 8 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;sync_message</samp>](## "ptp_profiles.[].sync_message") | Dictionary |  |  |  | PTP Sync Message Interval |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interval</samp>](## "ptp_profiles.[].sync_message.interval") | Integer |  |  | Min: -7<br>Max: 3 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;transport</samp>](## "ptp_profiles.[].transport") | String |  |  | Valid Values:<br>- ipv4 |  |
 
 === "YAML"
 
     ```yaml
     ptp_profiles:
+      - profile: <str>
+        announce:
+          interval: <int>
+          timeout: <int>
+        delay_req: <int>
+        sync_message:
+          interval: <int>
+        transport: <str>
     ```
 
 ## Routing Protocol Selection

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -4132,18 +4132,17 @@
     },
     "ptp_profiles": {
       "type": "array",
-      "description": "PTP Profiles",
       "items": {
         "type": "object",
         "properties": {
           "profile": {
             "type": "string",
-            "description": "PTP Profile",
+            "description": "PTP profile.",
             "title": "Profile"
           },
           "announce": {
             "type": "object",
-            "description": "PTP Announce Interval",
+            "description": "PTP announce interval.",
             "properties": {
               "interval": {
                 "type": "integer",
@@ -4172,7 +4171,7 @@
           },
           "sync_message": {
             "type": "object",
-            "description": "PTP Sync Message Interval",
+            "description": "PTP sync message interval.",
             "properties": {
               "interval": {
                 "type": "integer",

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -4108,73 +4108,72 @@
     "ptp_profiles": {
       "type": "array",
       "description": "PTP Profiles",
-      "properties": {
-        "profile": {
-          "type": "object",
-          "description": "PTP Profile",
-          "properties": {
-            "announce": {
-              "type": "object",
-              "description": "PTP Announce Interval",
-              "properties": {
-                "interval": {
-                  "type": "integer",
-                  "minimum": -7,
-                  "maximum": 4,
-                  "title": "Interval"
-                },
-                "timeout": {
-                  "type": "integer",
-                  "minimum": 2,
-                  "maximum": 255,
-                  "title": "Timeout"
-                }
-              },
-              "additionalProperties": false,
-              "patternProperties": {
-                "^_.+$": {}
-              },
-              "title": "Announce"
-            },
-            "delay_req": {
-              "type": "integer",
-              "minimum": -7,
-              "maximum": 8,
-              "title": "Delay Req"
-            },
-            "sync_message": {
-              "type": "object",
-              "description": "PTP Sync Message Interval",
-              "properties": {
-                "interval": {
-                  "type": "integer",
-                  "minimum": -7,
-                  "maximum": 3,
-                  "title": "Interval"
-                }
-              },
-              "additionalProperties": false,
-              "patternProperties": {
-                "^_.+$": {}
-              },
-              "title": "Sync Message"
-            },
-            "transport": {
-              "type": "string",
-              "enum": "ipv4",
-              "title": "Transport"
-            }
+      "items": {
+        "type": "object",
+        "properties": {
+          "profile": {
+            "type": "string",
+            "description": "PTP Profile",
+            "title": "Profile"
           },
-          "additionalProperties": false,
-          "patternProperties": {
-            "^_.+$": {}
+          "announce": {
+            "type": "object",
+            "description": "PTP Announce Interval",
+            "properties": {
+              "interval": {
+                "type": "integer",
+                "minimum": -7,
+                "maximum": 4,
+                "title": "Interval"
+              },
+              "timeout": {
+                "type": "integer",
+                "minimum": 2,
+                "maximum": 255,
+                "title": "Timeout"
+              }
+            },
+            "additionalProperties": false,
+            "patternProperties": {
+              "^_.+$": {}
+            },
+            "title": "Announce"
           },
-          "title": "Profile"
+          "delay_req": {
+            "type": "integer",
+            "minimum": -7,
+            "maximum": 8,
+            "title": "Delay Req"
+          },
+          "sync_message": {
+            "type": "object",
+            "description": "PTP Sync Message Interval",
+            "properties": {
+              "interval": {
+                "type": "integer",
+                "minimum": -7,
+                "maximum": 3,
+                "title": "Interval"
+              }
+            },
+            "additionalProperties": false,
+            "patternProperties": {
+              "^_.+$": {}
+            },
+            "title": "Sync Message"
+          },
+          "transport": {
+            "type": "string",
+            "enum": [
+              "ipv4"
+            ],
+            "title": "Transport"
+          }
+        },
+        "additionalProperties": false,
+        "patternProperties": {
+          "^_.+$": {}
         }
-      },
-      "additionalProperties": false,
-      "patternProperties": {
-        "^_.+$": {}
       },
       "title": "PTP Profiles"
     },

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -4105,6 +4105,79 @@
       },
       "title": "Port Profiles"
     },
+    "ptp_profiles": {
+      "type": "array",
+      "description": "PTP Profiles",
+      "properties": {
+        "profile": {
+          "type": "object",
+          "description": "PTP Profile",
+          "properties": {
+            "announce": {
+              "type": "object",
+              "description": "PTP Announce Interval",
+              "properties": {
+                "interval": {
+                  "type": "integer",
+                  "minimum": -7,
+                  "maximum": 4,
+                  "title": "Interval"
+                },
+                "timeout": {
+                  "type": "integer",
+                  "minimum": 2,
+                  "maximum": 255,
+                  "title": "Timeout"
+                }
+              },
+              "additionalProperties": false,
+              "patternProperties": {
+                "^_.+$": {}
+              },
+              "title": "Announce"
+            },
+            "delay_req": {
+              "type": "integer",
+              "minimum": -7,
+              "maximum": 8,
+              "title": "Delay Req"
+            },
+            "sync_message": {
+              "type": "object",
+              "description": "PTP Sync Message Interval",
+              "properties": {
+                "interval": {
+                  "type": "integer",
+                  "minimum": -7,
+                  "maximum": 3,
+                  "title": "Interval"
+                }
+              },
+              "additionalProperties": false,
+              "patternProperties": {
+                "^_.+$": {}
+              },
+              "title": "Sync Message"
+            },
+            "transport": {
+              "type": "string",
+              "enum": "ipv4",
+              "title": "Transport"
+            }
+          },
+          "additionalProperties": false,
+          "patternProperties": {
+            "^_.+$": {}
+          },
+          "title": "Profile"
+        }
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^_.+$": {}
+      },
+      "title": "PTP Profiles"
+    },
     "redundancy": {
       "type": "object",
       "description": "Redundancy for chassis platforms with dual supervisors | Optional",

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
@@ -1482,6 +1482,52 @@ keys:
 
             Port_profiles can refer to another port_profile to inherit settings in
             up to two levels (adapter->profile->parent_profile).'
+  ptp_profiles:
+    documentation_options:
+      filename: Fabric Variables
+      table: PTP Profiles
+    type: list
+    description: PTP Profiles
+    keys:
+      profile:
+        type: dict
+        description: PTP Profile
+        keys:
+          announce:
+            type: dict
+            description: PTP Announce Interval
+            keys:
+              interval:
+                type: int
+                convert_types:
+                - str
+                min: -7
+                max: 4
+              timeout:
+                type: int
+                convert_types:
+                - str
+                min: 2
+                max: 255
+          delay_req:
+            type: int
+            convert_types:
+            - str
+            min: -7
+            max: 8
+          sync_message:
+            type: dict
+            description: PTP Sync Message Interval
+            keys:
+              interval:
+                type: int
+                convert_types:
+                - str
+                min: -7
+                max: 3
+          transport:
+            type: str
+            valid_values: ipv4
   redundancy:
     documentation_options:
       filename: Platform Specific Settings

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
@@ -1485,49 +1485,50 @@ keys:
   ptp_profiles:
     documentation_options:
       filename: Fabric Variables
-      table: PTP Profiles
     type: list
     description: PTP Profiles
-    keys:
-      profile:
-        type: dict
-        description: PTP Profile
-        keys:
-          announce:
-            type: dict
-            description: PTP Announce Interval
-            keys:
-              interval:
-                type: int
-                convert_types:
-                - str
-                min: -7
-                max: 4
-              timeout:
-                type: int
-                convert_types:
-                - str
-                min: 2
-                max: 255
-          delay_req:
-            type: int
-            convert_types:
-            - str
-            min: -7
-            max: 8
-          sync_message:
-            type: dict
-            description: PTP Sync Message Interval
-            keys:
-              interval:
-                type: int
-                convert_types:
-                - str
-                min: -7
-                max: 3
-          transport:
-            type: str
-            valid_values: ipv4
+    items:
+      type: dict
+      keys:
+        profile:
+          type: str
+          description: PTP Profile
+        announce:
+          type: dict
+          description: PTP Announce Interval
+          keys:
+            interval:
+              type: int
+              convert_types:
+              - str
+              min: -7
+              max: 4
+            timeout:
+              type: int
+              convert_types:
+              - str
+              min: 2
+              max: 255
+        delay_req:
+          type: int
+          convert_types:
+          - str
+          min: -7
+          max: 8
+        sync_message:
+          type: dict
+          description: PTP Sync Message Interval
+          keys:
+            interval:
+              type: int
+              convert_types:
+              - str
+              min: -7
+              max: 3
+        transport:
+          type: str
+          valid_values:
+          - ipv4
   redundancy:
     documentation_options:
       filename: Platform Specific Settings

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
@@ -1519,16 +1519,15 @@ keys:
     documentation_options:
       filename: Fabric Variables
     type: list
-    description: PTP Profiles
     items:
       type: dict
       keys:
         profile:
           type: str
-          description: PTP Profile
+          description: PTP profile.
         announce:
           type: dict
-          description: PTP Announce Interval
+          description: PTP announce interval.
           keys:
             interval:
               type: int
@@ -1550,7 +1549,7 @@ keys:
           max: 8
         sync_message:
           type: dict
-          description: PTP Sync Message Interval
+          description: PTP sync message interval.
           keys:
             interval:
               type: int

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/ptp_profiles.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/ptp_profiles.schema.yml
@@ -6,46 +6,46 @@ keys:
   ptp_profiles:
     documentation_options:
       filename: Fabric Variables
-      table: PTP Profiles
     type: list
     description: PTP Profiles
-    keys:
-      profile:
-        type: dict
-        description: PTP Profile
-        keys:
-          announce:
-            type: dict
-            description: PTP Announce Interval
-            keys:
-              interval:
-                type: int
-                convert_types:
-                - str
-                min: -7
-                max: 4
-              timeout:
-                type: int
-                convert_types:
-                - str
-                min: 2
-                max: 255
-          delay_req:
-            type: int
-            convert_types:
-            - str
-            min: -7
-            max: 8
-          sync_message:
-            type: dict
-            description: PTP Sync Message Interval
-            keys:
-              interval:
-                type: int
-                convert_types:
-                - str
-                min: -7
-                max: 3
-          transport:
-            type: str
-            valid_values: "ipv4"
+    items:
+      type: dict
+      keys:
+        profile:
+          type: str
+          description: PTP Profile
+        announce:
+          type: dict
+          description: PTP Announce Interval
+          keys:
+            interval:
+              type: int
+              convert_types:
+              - str
+              min: -7
+              max: 4
+            timeout:
+              type: int
+              convert_types:
+              - str
+              min: 2
+              max: 255
+        delay_req:
+          type: int
+          convert_types:
+          - str
+          min: -7
+          max: 8
+        sync_message:
+          type: dict
+          description: PTP Sync Message Interval
+          keys:
+            interval:
+              type: int
+              convert_types:
+              - str
+              min: -7
+              max: 3
+        transport:
+          type: str
+          valid_values: ["ipv4"]

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/ptp_profiles.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/ptp_profiles.schema.yml
@@ -7,16 +7,15 @@ keys:
     documentation_options:
       filename: Fabric Variables
     type: list
-    description: PTP Profiles
     items:
       type: dict
       keys:
         profile:
           type: str
-          description: PTP Profile
+          description: PTP profile.
         announce:
           type: dict
-          description: PTP Announce Interval
+          description: PTP announce interval.
           keys:
             interval:
               type: int
@@ -38,7 +37,7 @@ keys:
           max: 8
         sync_message:
           type: dict
-          description: PTP Sync Message Interval
+          description: PTP sync message interval.
           keys:
             interval:
               type: int

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/ptp_profiles.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/ptp_profiles.schema.yml
@@ -1,0 +1,51 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  ptp_profiles:
+    documentation_options:
+      filename: Fabric Variables
+      table: PTP Profiles
+    type: list
+    description: PTP Profiles
+    keys:
+      profile:
+        type: dict
+        description: PTP Profile
+        keys:
+          announce:
+            type: dict
+            description: PTP Announce Interval
+            keys:
+              interval:
+                type: int
+                convert_types:
+                - str
+                min: -7
+                max: 4
+              timeout:
+                type: int
+                convert_types:
+                - str
+                min: 2
+                max: 255
+          delay_req:
+            type: int
+            convert_types:
+            - str
+            min: -7
+            max: 8
+          sync_message:
+            type: dict
+            description: PTP Sync Message Interval
+            keys:
+              interval:
+                type: int
+                convert_types:
+                - str
+                min: -7
+                max: 3
+          transport:
+            type: str
+            valid_values: "ipv4"


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->

## Related Issue(s)

Fixes #2836 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
Added schema for ptp_profiles

## How to test

`pre-commit run schemas --all`
`molecule converge -s eos_designs_unit_tests`

## Checklist

### User Checklist

- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been rebased from devel before I start
- [X] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [X] My change requires a change to the documentation and documentation have been updated accordingly.
- [X] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
