### PR TITLE
Feat(eos_designs): Add `is_deployed` & `mgmt_interface_description` to schema

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
@@ -275,8 +275,11 @@ all:
                     DC1_L2LEAF1:
                       hosts:
                         DC1-L2LEAF1A:
+                          # Ensure is_deployed: true works as expected.
+                          is_deployed: true
                           ansible_host: 192.168.200.112
                         DC1-L2LEAF1B:
+                          is_deployed: true
                           ansible_host: 192.168.200.115
                     DC1_L2LEAF2:
                       hosts:

--- a/ansible_collections/arista/avd/plugins/plugin_utils/schema/key_to_display_name.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/schema/key_to_display_name.py
@@ -41,6 +41,7 @@ WORDLIST = {
     "l2": "L2",
     "mac": "MAC",
     "mcs": "MCS",
+    "mgmt": "Management",
     "mib": "MIB",
     "mka": "MKA",
     "mlag": "MLAG",

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/Fabric Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/Fabric Variables.md
@@ -223,16 +223,15 @@ Control fabric documentation generation.
 
 ## IS Deployed
 
-Is device already deployed in the fabric. If this is not defined, it is
-assumed device is deployed. When set to false, interfaces toward this
-device may be shutdown and `eos_config_deploy_cvp` does not try to
-deploy configuration for this device.
+Is device already deployed in the fabric
+When set to false, interfaces toward this device may be shutdown depending on the `shutdown_interfaces_towards_undeployed_peers` setting.
+Furthermore `eos_config_deploy_cvp` will not attempt to move or apply configurations to the device.
 
 === "Table"
 
     | Variable | Type | Required | Default | Value Restrictions | Description |
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
-    | [<samp>is_deployed</samp>](## "is_deployed") | Boolean |  |  |  |  |
+    | [<samp>is_deployed</samp>](## "is_deployed") | Boolean |  | True |  |  |
 
 === "YAML"
 

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/Fabric Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/Fabric Variables.md
@@ -225,8 +225,7 @@ Control fabric documentation generation.
 
 Is device already deployed in the fabric. If this is not defined, it is
 assumed device is deployed. When set to false, interfaces toward this
-device may be shutdown and `eos_config_deploy_cvp` or
-`eos_config_deploy_eapi` do not try to
+device may be shutdown and `eos_config_deploy_cvp` does not try to
 deploy configuration for this device.
 
 === "Table"

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/Fabric Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/Fabric Variables.md
@@ -221,6 +221,26 @@ Control fabric documentation generation.
     underlay_rfc5549: <bool>
     ```
 
+## IS Deployed
+
+Is device already deployed in the fabric. If this is not defined, it is
+assumed device is deployed. When set to false, interfaces toward this
+device may be shutdown and `eos_config_deploy_cvp` or
+`eos_config_deploy_eapi` do not try to
+deploy configuration for this device.
+
+=== "Table"
+
+    | Variable | Type | Required | Default | Value Restrictions | Description |
+    | -------- | ---- | -------- | ------- | ------------------ | ----------- |
+    | [<samp>is_deployed</samp>](## "is_deployed") | Boolean |  |  |  |  |
+
+=== "YAML"
+
+    ```yaml
+    is_deployed: <bool>
+    ```
+
 ## ISIS Settings
 
 === "Table"

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/Input Variables.md
@@ -220,14 +220,13 @@ Used as next-hop for default gateway or static routes defined under 'mgmt_destin
 
 ## Mgmt Interface Description
 
-Description on the Management interface to override
-the default `oob_management`.
+Management interface description
 
 === "Table"
 
     | Variable | Type | Required | Default | Value Restrictions | Description |
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
-    | [<samp>mgmt_interface_description</samp>](## "mgmt_interface_description") | String |  |  |  |  |
+    | [<samp>mgmt_interface_description</samp>](## "mgmt_interface_description") | String |  | oob_management |  |  |
 
 === "YAML"
 

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/Input Variables.md
@@ -159,6 +159,25 @@ customize the system behavior, and implement workarounds to problems discovered 
         shell: <str>
     ```
 
+## Management Destination Networks
+
+List of IPv4 prefixes to configure as static routes towards the OOB Management interface gateway.
+Replaces the default route.
+
+=== "Table"
+
+    | Variable | Type | Required | Default | Value Restrictions | Description |
+    | -------- | ---- | -------- | ------- | ------------------ | ----------- |
+    | [<samp>mgmt_destination_networks</samp>](## "mgmt_destination_networks") | List, items: String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;- &lt;str&gt;</samp>](## "mgmt_destination_networks.[].&lt;str&gt;") | String |  |  |  | IPv4_address/Mask |
+
+=== "YAML"
+
+    ```yaml
+    mgmt_destination_networks:
+      - <str>
+    ```
+
 ## Management Eapi
 
 Default is HTTPS management eAPI enabled.
@@ -182,26 +201,7 @@ The VRF is set to < mgmt_interface_vrf >.
       default_services: <bool>
     ```
 
-## Mgmt Destination Networks
-
-List of IPv4 prefixes to configure as static routes towards the OOB Management interface gateway.
-Replaces the default route.
-
-=== "Table"
-
-    | Variable | Type | Required | Default | Value Restrictions | Description |
-    | -------- | ---- | -------- | ------- | ------------------ | ----------- |
-    | [<samp>mgmt_destination_networks</samp>](## "mgmt_destination_networks") | List, items: String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;- &lt;str&gt;</samp>](## "mgmt_destination_networks.[].&lt;str&gt;") | String |  |  |  | IPv4_address/Mask |
-
-=== "YAML"
-
-    ```yaml
-    mgmt_destination_networks:
-      - <str>
-    ```
-
-## Mgmt Gateway
+## Management Gateway
 
 OOB Management interface gateway in IPv4 format.
 Used as next-hop for default gateway or static routes defined under 'mgmt_destination_networks'
@@ -218,7 +218,7 @@ Used as next-hop for default gateway or static routes defined under 'mgmt_destin
     mgmt_gateway: <str>
     ```
 
-## Mgmt Interface Description
+## Management Interface Description
 
 Management interface description
 
@@ -234,7 +234,7 @@ Management interface description
     mgmt_interface_description: <str>
     ```
 
-## Mgmt Interface VRF
+## Management Interface VRF
 
 OOB Management VRF.
 
@@ -250,7 +250,7 @@ OOB Management VRF.
     mgmt_interface_vrf: <str>
     ```
 
-## Mgmt Interface
+## Management Interface
 
 OOB Management interface.
 
@@ -266,7 +266,7 @@ OOB Management interface.
     mgmt_interface: <str>
     ```
 
-## Mgmt VRF Routing
+## Management VRF Routing
 
 Configure IP routing for the OOB Management VRF.
 

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/Input Variables.md
@@ -218,6 +218,23 @@ Used as next-hop for default gateway or static routes defined under 'mgmt_destin
     mgmt_gateway: <str>
     ```
 
+## Mgmt Interface Description
+
+Description on the Management interface to override
+the default `oob_management`.
+
+=== "Table"
+
+    | Variable | Type | Required | Default | Value Restrictions | Description |
+    | -------- | ---- | -------- | ------- | ------------------ | ----------- |
+    | [<samp>mgmt_interface_description</samp>](## "mgmt_interface_description") | String |  |  |  |  |
+
+=== "YAML"
+
+    ```yaml
+    mgmt_interface_description: <str>
+    ```
+
 ## Mgmt Interface VRF
 
 OOB Management VRF.

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -1336,8 +1336,9 @@
       "title": "IPv6 Mgmt Gateway"
     },
     "is_deployed": {
-      "description": "Is device already deployed in the fabric. If this is not defined, it is\nassumed device is deployed. When set to false, interfaces toward this\ndevice may be shutdown and `eos_config_deploy_cvp` does not try to\ndeploy configuration for this device.\n",
+      "description": "Is device already deployed in the fabric\nWhen set to false, interfaces toward this device may be shutdown depending on the `shutdown_interfaces_towards_undeployed_peers` setting.\nFurthermore `eos_config_deploy_cvp` will not attempt to move or apply configurations to the device.\n",
       "type": "boolean",
+      "default": true,
       "title": "IS Deployed"
     },
     "isis_advertise_passive_only": {
@@ -2018,36 +2019,36 @@
         "type": "string",
         "description": "IPv4_address/Mask"
       },
-      "title": "Mgmt Destination Networks"
+      "title": "Management Destination Networks"
     },
     "mgmt_gateway": {
       "type": "string",
       "description": "OOB Management interface gateway in IPv4 format.\nUsed as next-hop for default gateway or static routes defined under 'mgmt_destination_networks'",
-      "title": "Mgmt Gateway"
+      "title": "Management Gateway"
     },
     "mgmt_interface": {
       "type": "string",
       "default": "Management1",
       "description": "OOB Management interface.",
-      "title": "Mgmt Interface"
+      "title": "Management Interface"
     },
     "mgmt_interface_description": {
       "type": "string",
       "description": "Management interface description\n",
       "default": "oob_management",
-      "title": "Mgmt Interface Description"
+      "title": "Management Interface Description"
     },
     "mgmt_interface_vrf": {
       "type": "string",
       "default": "MGMT",
       "description": "OOB Management VRF.",
-      "title": "Mgmt Interface VRF"
+      "title": "Management Interface VRF"
     },
     "mgmt_vrf_routing": {
       "type": "boolean",
       "default": false,
       "description": "Configure IP routing for the OOB Management VRF.",
-      "title": "Mgmt VRF Routing"
+      "title": "Management VRF Routing"
     },
     "mlag_ibgp_peering_vrfs": {
       "type": "object",

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -2031,6 +2031,11 @@
       "description": "OOB Management interface.",
       "title": "Mgmt Interface"
     },
+    "mgmt_interface_description": {
+      "type": "string",
+      "description": "Description on the Management interface to override\nthe default `oob_management`.",
+      "title": "Mgmt Interface Description"
+    },
     "mgmt_interface_vrf": {
       "type": "string",
       "default": "MGMT",

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -1335,6 +1335,11 @@
       "description": "OOB Management interface gateway in IPv6 format.\nUsed as next-hop for default gateway or static routes defined under 'ipv6_mgmt_destination_networks'",
       "title": "IPv6 Mgmt Gateway"
     },
+    "is_deployed": {
+      "description": "Is device already deployed in the fabric. If this is not defined, it is\nassumed device is deployed. When set to false, interfaces toward this\ndevice may be shutdown and `eos_config_deploy_cvp` or\n`eos_config_deploy_eapi` do not try to\ndeploy configuration for this device.\n",
+      "type": "boolean",
+      "title": "IS Deployed"
+    },
     "isis_advertise_passive_only": {
       "type": "boolean",
       "default": false,

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -1336,7 +1336,7 @@
       "title": "IPv6 Mgmt Gateway"
     },
     "is_deployed": {
-      "description": "Is device already deployed in the fabric. If this is not defined, it is\nassumed device is deployed. When set to false, interfaces toward this\ndevice may be shutdown and `eos_config_deploy_cvp` or\n`eos_config_deploy_eapi` do not try to\ndeploy configuration for this device.\n",
+      "description": "Is device already deployed in the fabric. If this is not defined, it is\nassumed device is deployed. When set to false, interfaces toward this\ndevice may be shutdown and `eos_config_deploy_cvp` does not try to\ndeploy configuration for this device.\n",
       "type": "boolean",
       "title": "IS Deployed"
     },
@@ -2033,7 +2033,8 @@
     },
     "mgmt_interface_description": {
       "type": "string",
-      "description": "Description on the Management interface to override\nthe default `oob_management`.",
+      "description": "Management interface description\n",
+      "default": "oob_management",
       "title": "Mgmt Interface Description"
     },
     "mgmt_interface_vrf": {

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
@@ -806,19 +806,19 @@ keys:
 
       Used as next-hop for default gateway or static routes defined under ''ipv6_mgmt_destination_networks'''
   is_deployed:
-    description: 'Is device already deployed in the fabric. If this is not defined,
-      it is
+    description: 'Is device already deployed in the fabric
 
-      assumed device is deployed. When set to false, interfaces toward this
+      When set to false, interfaces toward this device may be shutdown depending on
+      the `shutdown_interfaces_towards_undeployed_peers` setting.
 
-      device may be shutdown and `eos_config_deploy_cvp` does not try to
-
-      deploy configuration for this device.
+      Furthermore `eos_config_deploy_cvp` will not attempt to move or apply configurations
+      to the device.
 
       '
     documentation_options:
       filename: Fabric Variables
     type: bool
+    default: true
   isis_advertise_passive_only:
     documentation_options:
       filename: Fabric Variables

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
@@ -995,6 +995,11 @@ keys:
     type: str
     default: Management1
     description: OOB Management interface.
+  mgmt_interface_description:
+    type: str
+    description: 'Description on the Management interface to override
+
+      the default `oob_management`.'
   mgmt_interface_vrf:
     type: str
     default: MGMT

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
@@ -811,9 +811,7 @@ keys:
 
       assumed device is deployed. When set to false, interfaces toward this
 
-      device may be shutdown and `eos_config_deploy_cvp` or
-
-      `eos_config_deploy_eapi` do not try to
+      device may be shutdown and `eos_config_deploy_cvp` does not try to
 
       deploy configuration for this device.
 
@@ -997,9 +995,10 @@ keys:
     description: OOB Management interface.
   mgmt_interface_description:
     type: str
-    description: 'Description on the Management interface to override
+    description: 'Management interface description
 
-      the default `oob_management`.'
+      '
+    default: oob_management
   mgmt_interface_vrf:
     type: str
     default: MGMT

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
@@ -805,6 +805,22 @@ keys:
     description: 'OOB Management interface gateway in IPv6 format.
 
       Used as next-hop for default gateway or static routes defined under ''ipv6_mgmt_destination_networks'''
+  is_deployed:
+    description: 'Is device already deployed in the fabric. If this is not defined,
+      it is
+
+      assumed device is deployed. When set to false, interfaces toward this
+
+      device may be shutdown and `eos_config_deploy_cvp` or
+
+      `eos_config_deploy_eapi` do not try to
+
+      deploy configuration for this device.
+
+      '
+    documentation_options:
+      filename: Fabric Variables
+    type: bool
   isis_advertise_passive_only:
     documentation_options:
       filename: Fabric Variables

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/is_deployed.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/is_deployed.schema.yml
@@ -7,8 +7,7 @@ keys:
     description: |
       Is device already deployed in the fabric. If this is not defined, it is
       assumed device is deployed. When set to false, interfaces toward this
-      device may be shutdown and `eos_config_deploy_cvp` or
-      `eos_config_deploy_eapi` do not try to
+      device may be shutdown and `eos_config_deploy_cvp` does not try to
       deploy configuration for this device.
     documentation_options:
       filename: Fabric Variables

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/is_deployed.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/is_deployed.schema.yml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  is_deployed:
+    description: |
+      Is device already deployed in the fabric. If this is not defined, it is
+      assumed device is deployed. When set to false, interfaces toward this
+      device may be shutdown and `eos_config_deploy_cvp` or
+      `eos_config_deploy_eapi` do not try to
+      deploy configuration for this device.
+    documentation_options:
+      filename: Fabric Variables
+    type: bool

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/is_deployed.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/is_deployed.schema.yml
@@ -5,10 +5,10 @@ type: dict
 keys:
   is_deployed:
     description: |
-      Is device already deployed in the fabric. If this is not defined, it is
-      assumed device is deployed. When set to false, interfaces toward this
-      device may be shutdown and `eos_config_deploy_cvp` does not try to
-      deploy configuration for this device.
+      Is device already deployed in the fabric
+      When set to false, interfaces toward this device may be shutdown depending on the `shutdown_interfaces_towards_undeployed_peers` setting.
+      Furthermore `eos_config_deploy_cvp` will not attempt to move or apply configurations to the device.
     documentation_options:
       filename: Fabric Variables
     type: bool
+    default: true

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/mgmt_interface_description.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/mgmt_interface_description.schema.yml
@@ -6,5 +6,5 @@ keys:
   mgmt_interface_description:
     type: str
     description: |
-      Description on the Management interface to override
+      Management interface description
       the default `oob_management`.

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/mgmt_interface_description.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/mgmt_interface_description.schema.yml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  mgmt_interface_description:
+    type: str
+    description: |
+      Description on the Management interface to override
+      the default `oob_management`.

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/mgmt_interface_description.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/mgmt_interface_description.schema.yml
@@ -7,4 +7,4 @@ keys:
     type: str
     description: |
       Management interface description
-      the default `oob_management`.
+    default: oob_management


### PR DESCRIPTION
## Change Summary

Add some of the schema keys that were missing as identified in #2834 

<!-- Enter short PR description -->

## Related Issue(s)

Related to  #2834 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

- Define `is_deployed` in the `eos_designs` schema.
- Define `mgmt_interface_management` in the `eos_designs` schema.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

- run `molecule test -s eos_designs_unit_tests`

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->

- Review whether updates to documentation are enough/correct.
- Review whether schema needs further/stricter validation.

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
