### PR TITLE
Feat(eos_cli_config_gen): Add comments to queue

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/qos.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/qos.md
@@ -312,12 +312,12 @@ QOS Profile: **experiment**
 
 **TX Queues**
 
-| TX queue | Type | Bandwidth | Priority | Shape Rate |
-| -------- | ---- | --------- | -------- | ---------- |
-| 3 | All | 30 | no priority | - |
-| 4 | All | 10 | - | - |
-| 5 | All | 40 | - | - |
-| 7 | All | 30 | - | 40 percent |
+| TX queue | Type | Bandwidth | Priority | Shape Rate | Comment |
+| -------- | ---- | --------- | -------- | ---------- | ------- |
+| 3 | All | 30 | no priority | - | - |
+| 4 | All | 10 | - | - | - |
+| 5 | All | 40 | - | - | - |
+| 7 | All | 30 | - | 40 percent | - |
 
 QOS Profile: **no_qos_trust**
 
@@ -337,11 +337,11 @@ QOS Profile: **qprof_testwithpolicy**
 
 **TX Queues**
 
-| TX queue | Type | Bandwidth | Priority | Shape Rate |
-| -------- | ---- | --------- | -------- | ---------- |
-| 0 | All | 1 | - | - |
-| 1 | All | 80 | - | - |
-| 5 | All | 19 | no priority | - |
+| TX queue | Type | Bandwidth | Priority | Shape Rate | Comment |
+| -------- | ---- | --------- | -------- | ---------- | ------- |
+| 0 | All | 1 | - | - | - |
+| 1 | All | 80 | - | - | - |
+| 5 | All | 19 | no priority | - | Multi-line comment here.  |
 
 QOS Profile: **test**
 
@@ -353,11 +353,11 @@ QOS Profile: **test**
 
 **TX Queues**
 
-| TX queue | Type | Bandwidth | Priority | Shape Rate |
-| -------- | ---- | --------- | -------- | ---------- |
-| 1 | All | 50 | no priority | - |
-| 2 | All | 10 | priority strict | - |
-| 4 | All | 10 | - | - |
+| TX queue | Type | Bandwidth | Priority | Shape Rate | Comment |
+| -------- | ---- | --------- | -------- | ---------- | ------- |
+| 1 | All | 50 | no priority | - | - |
+| 2 | All | 10 | priority strict | - | - |
+| 4 | All | 10 | - | - | - |
 
 QOS Profile: **uc_mc_queues_test**
 
@@ -369,14 +369,14 @@ QOS Profile: **uc_mc_queues_test**
 
 **TX Queues**
 
-| TX queue | Type | Bandwidth | Priority | Shape Rate |
-| -------- | ---- | --------- | -------- | ---------- |
-| 1 | Unicast | 50 | no priority | - |
-| 2 | Unicast | 10 | priority strict | - |
-| 4 | Unicast | 10 | - | - |
-| 1 | Multicast | 50 | no priority | - |
-| 2 | Multicast | 10 | priority strict | - |
-| 4 | Multicast | 10 | - | - |
+| TX queue | Type | Bandwidth | Priority | Shape Rate | Comment |
+| -------- | ---- | --------- | -------- | ---------- | ------- |
+| 1 | Unicast | 50 | no priority | - | Test no priority |
+| 2 | Unicast | 10 | priority strict | - | - |
+| 4 | Unicast | 10 | - | - | Test guaranteed percent |
+| 1 | Multicast | 50 | no priority | - | - |
+| 2 | Multicast | 10 | priority strict | - | Test strict priority |
+| 4 | Multicast | 10 | - | - | Test guaranteed percent |
 
 #### QOS Profile Device Configuration
 
@@ -418,6 +418,8 @@ qos profile qprof_testwithpolicy
    tx-queue 5
       bandwidth percent 19
       no priority
+      !! Multi-line comment
+      !! here.
 !
 qos profile test
    qos trust dscp
@@ -440,6 +442,7 @@ qos profile uc_mc_queues_test
    uc-tx-queue 1
       bandwidth percent 50
       no priority
+      !! Test no priority
    !
    uc-tx-queue 2
       bandwidth percent 10
@@ -447,6 +450,7 @@ qos profile uc_mc_queues_test
    !
    uc-tx-queue 4
       bandwidth guaranteed percent 10
+      !! Test guaranteed percent
    !
    mc-tx-queue 1
       bandwidth percent 50
@@ -455,9 +459,11 @@ qos profile uc_mc_queues_test
    mc-tx-queue 2
       bandwidth percent 10
       priority strict
+      !! Test strict priority
    !
    mc-tx-queue 4
       bandwidth guaranteed percent 10
+      !! Test guaranteed percent
 ```
 
 #### QOS Interfaces

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/qos.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/qos.md
@@ -341,7 +341,7 @@ QOS Profile: **qprof_testwithpolicy**
 | -------- | ---- | --------- | -------- | ---------- | ------- |
 | 0 | All | 1 | - | - | - |
 | 1 | All | 80 | - | - | - |
-| 5 | All | 19 | no priority | - | Multi-line comment here.  |
+| 5 | All | 19 | no priority | - | Multi-line comment<br>here. |
 
 QOS Profile: **test**
 
@@ -416,10 +416,10 @@ qos profile qprof_testwithpolicy
       bandwidth percent 80
    !
    tx-queue 5
-      bandwidth percent 19
-      no priority
       !! Multi-line comment
       !! here.
+      bandwidth percent 19
+      no priority
 !
 qos profile test
    qos trust dscp
@@ -440,30 +440,30 @@ qos profile test
 qos profile uc_mc_queues_test
    !
    uc-tx-queue 1
+      !! Test no priority
       bandwidth percent 50
       no priority
-      !! Test no priority
    !
    uc-tx-queue 2
       bandwidth percent 10
       priority strict
    !
    uc-tx-queue 4
-      bandwidth guaranteed percent 10
       !! Test guaranteed percent
+      bandwidth guaranteed percent 10
    !
    mc-tx-queue 1
       bandwidth percent 50
       no priority
    !
    mc-tx-queue 2
+      !! Test strict priority
       bandwidth percent 10
       priority strict
-      !! Test strict priority
    !
    mc-tx-queue 4
-      bandwidth guaranteed percent 10
       !! Test guaranteed percent
+      bandwidth guaranteed percent 10
 ```
 
 #### QOS Interfaces

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/qos.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/qos.cfg
@@ -40,6 +40,8 @@ qos profile qprof_testwithpolicy
    tx-queue 5
       bandwidth percent 19
       no priority
+      !! Multi-line comment
+      !! here.
 !
 qos profile test
    qos trust dscp
@@ -62,6 +64,7 @@ qos profile uc_mc_queues_test
    uc-tx-queue 1
       bandwidth percent 50
       no priority
+      !! Test no priority
    !
    uc-tx-queue 2
       bandwidth percent 10
@@ -69,6 +72,7 @@ qos profile uc_mc_queues_test
    !
    uc-tx-queue 4
       bandwidth guaranteed percent 10
+      !! Test guaranteed percent
    !
    mc-tx-queue 1
       bandwidth percent 50
@@ -77,9 +81,11 @@ qos profile uc_mc_queues_test
    mc-tx-queue 2
       bandwidth percent 10
       priority strict
+      !! Test strict priority
    !
    mc-tx-queue 4
       bandwidth guaranteed percent 10
+      !! Test guaranteed percent
 !
 no enable password
 no aaa root

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/qos.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/qos.cfg
@@ -38,10 +38,10 @@ qos profile qprof_testwithpolicy
       bandwidth percent 80
    !
    tx-queue 5
-      bandwidth percent 19
-      no priority
       !! Multi-line comment
       !! here.
+      bandwidth percent 19
+      no priority
 !
 qos profile test
    qos trust dscp
@@ -62,30 +62,30 @@ qos profile test
 qos profile uc_mc_queues_test
    !
    uc-tx-queue 1
+      !! Test no priority
       bandwidth percent 50
       no priority
-      !! Test no priority
    !
    uc-tx-queue 2
       bandwidth percent 10
       priority strict
    !
    uc-tx-queue 4
-      bandwidth guaranteed percent 10
       !! Test guaranteed percent
+      bandwidth guaranteed percent 10
    !
    mc-tx-queue 1
       bandwidth percent 50
       no priority
    !
    mc-tx-queue 2
+      !! Test strict priority
       bandwidth percent 10
       priority strict
-      !! Test strict priority
    !
    mc-tx-queue 4
-      bandwidth guaranteed percent 10
       !! Test guaranteed percent
+      bandwidth guaranteed percent 10
 !
 no enable password
 no aaa root

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/qos.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/qos.yml
@@ -59,6 +59,9 @@ qos_profiles:
       - id: 5
         priority: 'no priority'
         bandwidth_percent: 19
+        comment: |
+          Multi-line comment
+          here.
       - id: 1
         bandwidth_percent: 80
       - id: 0
@@ -68,11 +71,13 @@ qos_profiles:
       - id: 1
         bandwidth_percent: 50
         priority: 'no priority'
+        comment: "Test no priority"
       - id: 2
         bandwidth_percent: 10
         priority: 'priority strict'
       - id: 4
         bandwidth_guaranteed_percent: 10
+        comment: "Test guaranteed percent"
     mc_tx_queues:
       - id: 1
         bandwidth_percent: 50
@@ -80,8 +85,10 @@ qos_profiles:
       - id: 2
         bandwidth_percent: 10
         priority: 'priority strict'
+        comment: "Test strict priority"
       - id: 4
         bandwidth_guaranteed_percent: 10
+        comment: "Test guaranteed percent"
 
 policy_maps:
   qos:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/documentation/devices/host1.md
@@ -1722,11 +1722,11 @@ QOS Profile: **test**
 
 **TX Queues**
 
-| TX queue | Type | Bandwidth | Priority | Shape Rate |
-| -------- | ---- | --------- | -------- | ---------- |
-| 1 | All | 50 | no priority | - |
-| 2 | Unicast | 50 | no priority | - |
-| 3 | Multicast | 50 | no priority | - |
+| TX queue | Type | Bandwidth | Priority | Shape Rate | Comment |
+| -------- | ---- | --------- | -------- | ---------- | ------- |
+| 1 | All | 50 | no priority | - | - |
+| 2 | Unicast | 50 | no priority | - | - |
+| 3 | Multicast | 50 | no priority | - | - |
 
 #### QOS Profile Device Configuration
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/qos-profiles.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/qos-profiles.md
@@ -19,6 +19,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;priority</samp>](## "qos_profiles.[].tx_queues.[].priority") | String |  |  | Valid Values:<br>- priority strict<br>- no priority |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;shape</samp>](## "qos_profiles.[].tx_queues.[].shape") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rate</samp>](## "qos_profiles.[].tx_queues.[].shape.rate") | String |  |  |  | Supported options are platform dependent<br>Example: "< rate > kbps", "1-100 percent", "< rate > pps"<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;comment</samp>](## "qos_profiles.[].tx_queues.[].comment") | String |  |  |  | Text comment added to queue.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;uc_tx_queues</samp>](## "qos_profiles.[].uc_tx_queues") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- id</samp>](## "qos_profiles.[].uc_tx_queues.[].id") | Integer | Required, Unique |  |  | UC TX queue ID |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bandwidth_percent</samp>](## "qos_profiles.[].uc_tx_queues.[].bandwidth_percent") | Integer |  |  |  |  |
@@ -26,13 +27,15 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;priority</samp>](## "qos_profiles.[].uc_tx_queues.[].priority") | String |  |  | Valid Values:<br>- priority strict<br>- no priority |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;shape</samp>](## "qos_profiles.[].uc_tx_queues.[].shape") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rate</samp>](## "qos_profiles.[].uc_tx_queues.[].shape.rate") | String |  |  |  | Supported options are platform dependent<br>Example: "< rate > kbps", "1-100 percent", "< rate > pps"<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;comment</samp>](## "qos_profiles.[].uc_tx_queues.[].comment") | String |  |  |  | Text comment added to queue.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mc_tx_queues</samp>](## "qos_profiles.[].mc_tx_queues") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- id</samp>](## "qos_profiles.[].mc_tx_queues.[].id") | Integer | Required, Unique |  |  | MC TX queue ID |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bandwidth_percent</samp>](## "qos_profiles.[].mc_tx_queues.[].bandwidth_percent") | Integer |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bandwidth_guaranteed_percent</samp>](## "qos_profiles.[].mc_tx_queues.[].bandwidth_guaranteed_percent") | Integer |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;priority</samp>](## "qos_profiles.[].mc_tx_queues.[].priority") | String |  |  | Valid Values:<br>- priority strict<br>- no priority |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;shape</samp>](## "qos_profiles.[].mc_tx_queues.[].shape") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rate</samp>](## "qos_profiles.[].mc_tx_queues.[].shape.rate") | String |  |  |  | Supported options are platform dependent<br>Example: "< rate > kbps", "1-100 percent", "< rate > pps" |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rate</samp>](## "qos_profiles.[].mc_tx_queues.[].shape.rate") | String |  |  |  | Supported options are platform dependent<br>Example: "< rate > kbps", "1-100 percent", "< rate > pps"<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;comment</samp>](## "qos_profiles.[].mc_tx_queues.[].comment") | String |  |  |  | Text comment added to queue. |
 
 === "YAML"
 
@@ -54,6 +57,7 @@
             priority: <str>
             shape:
               rate: <str>
+            comment: <str>
         uc_tx_queues:
           - id: <int>
             bandwidth_percent: <int>
@@ -61,6 +65,7 @@
             priority: <str>
             shape:
               rate: <str>
+            comment: <str>
         mc_tx_queues:
           - id: <int>
             bandwidth_percent: <int>
@@ -68,4 +73,5 @@
             priority: <str>
             shape:
               rate: <str>
+            comment: <str>
     ```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -10769,6 +10769,11 @@
                     "^_.+$": {}
                   },
                   "title": "Shape"
+                },
+                "comment": {
+                  "type": "string",
+                  "description": "Text comment added to queue.\n",
+                  "title": "Comment"
                 }
               },
               "required": [
@@ -10821,6 +10826,11 @@
                     "^_.+$": {}
                   },
                   "title": "Shape"
+                },
+                "comment": {
+                  "type": "string",
+                  "description": "Text comment added to queue.\n",
+                  "title": "Comment"
                 }
               },
               "required": [
@@ -10864,7 +10874,7 @@
                   "properties": {
                     "rate": {
                       "type": "string",
-                      "description": "Supported options are platform dependent\nExample: \"< rate > kbps\", \"1-100 percent\", \"< rate > pps\"",
+                      "description": "Supported options are platform dependent\nExample: \"< rate > kbps\", \"1-100 percent\", \"< rate > pps\"\n",
                       "title": "Rate"
                     }
                   },
@@ -10873,6 +10883,11 @@
                     "^_.+$": {}
                   },
                   "title": "Shape"
+                },
+                "comment": {
+                  "type": "string",
+                  "description": "Text comment added to queue.",
+                  "title": "Comment"
                 }
               },
               "required": [

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -6468,6 +6468,11 @@ keys:
                       Example: "< rate > kbps", "1-100 percent", "< rate > pps"
 
                       '
+              comment:
+                type: str
+                description: 'Text comment added to queue.
+
+                  '
         uc_tx_queues:
           type: list
           primary_key: id
@@ -6505,6 +6510,11 @@ keys:
                       Example: "< rate > kbps", "1-100 percent", "< rate > pps"
 
                       '
+              comment:
+                type: str
+                description: 'Text comment added to queue.
+
+                  '
         mc_tx_queues:
           type: list
           primary_key: id
@@ -6539,7 +6549,12 @@ keys:
                     type: str
                     description: 'Supported options are platform dependent
 
-                      Example: "< rate > kbps", "1-100 percent", "< rate > pps"'
+                      Example: "< rate > kbps", "1-100 percent", "< rate > pps"
+
+                      '
+              comment:
+                type: str
+                description: Text comment added to queue.
   queue_monitor_length:
     type: dict
     keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/qos_profiles.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/qos_profiles.schema.yml
@@ -76,6 +76,10 @@ keys:
                     description: |
                       Supported options are platform dependent
                       Example: "< rate > kbps", "1-100 percent", "< rate > pps"
+              comment:
+                type: str
+                description: |
+                  Text comment added to queue.
         uc_tx_queues:
           type: list
           primary_key: id
@@ -109,6 +113,10 @@ keys:
                     description: |
                       Supported options are platform dependent
                       Example: "< rate > kbps", "1-100 percent", "< rate > pps"
+              comment:
+                type: str
+                description: |
+                  Text comment added to queue.
         mc_tx_queues:
           type: list
           primary_key: id
@@ -142,3 +150,7 @@ keys:
                     description: |
                       Supported options are platform dependent
                       Example: "< rate > kbps", "1-100 percent", "< rate > pps"
+              comment:
+                type: str
+                description: |
+                  Text comment added to queue.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/qos-profiles.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/qos-profiles.j2
@@ -25,8 +25,8 @@ QOS Profile: **{{ profile.name }}**
 
 **TX Queues**
 
-| TX queue | Type | Bandwidth | Priority | Shape Rate |
-| -------- | ---- | --------- | -------- | ---------- |
+| TX queue | Type | Bandwidth | Priority | Shape Rate | Comment |
+| -------- | ---- | --------- | -------- | ---------- | ------- |
 {%             if profile.tx_queues is arista.avd.defined %}
 {%                 for tx_queue in profile.tx_queues | arista.avd.natural_sort('id') %}
 {%                     set type = "All" %}
@@ -35,7 +35,8 @@ QOS Profile: **{{ profile.name }}**
                                     '-') %}
 {%                     set priority = tx_queue.priority | arista.avd.default('-') %}
 {%                     set shape_rate = tx_queue.shape.rate | arista.avd.default('-') %}
-| {{ tx_queue.id }} | {{ type }} | {{ bw_percent }} | {{ priority }} | {{ shape_rate }} |
+{%                     set comment = tx_queue.comment | arista.avd.default('-') | replace('\n', ' ') %}
+| {{ tx_queue.id }} | {{ type }} | {{ bw_percent }} | {{ priority }} | {{ shape_rate }} | {{ comment }} |
 {%                 endfor %}
 {%             endif %}
 {%             if profile.uc_tx_queues is arista.avd.defined %}
@@ -46,7 +47,8 @@ QOS Profile: **{{ profile.name }}**
                                         '-') %}
 {%                     set priority = uc_tx_queue.priority | arista.avd.default('-') %}
 {%                     set shape_rate = uc_tx_queue.shape.rate | arista.avd.default('-') %}
-| {{ uc_tx_queue.id }} | {{ type }} | {{ bw_percent }} | {{ priority }} | {{ shape_rate }} |
+{%                     set comment = uc_tx_queue.comment | arista.avd.default('-') | replace('\n', ' ') %}
+| {{ uc_tx_queue.id }} | {{ type }} | {{ bw_percent }} | {{ priority }} | {{ shape_rate }} | {{ comment }} |
 {%                 endfor %}
 {%             endif %}
 {%             if profile.mc_tx_queues is arista.avd.defined %}
@@ -57,7 +59,8 @@ QOS Profile: **{{ profile.name }}**
                                         '-') %}
 {%                     set priority = mc_tx_queue.priority | arista.avd.default('-') %}
 {%                     set shape_rate = mc_tx_queue.shape.rate | arista.avd.default('-') %}
-| {{ mc_tx_queue.id }} | {{ type }} | {{ bw_percent }} | {{ priority }} | {{ shape_rate }} |
+{%                     set comment = mc_tx_queue.comment | arista.avd.default('-') | replace('\n', ' ') %}
+| {{ mc_tx_queue.id }} | {{ type }} | {{ bw_percent }} | {{ priority }} | {{ shape_rate }} | {{ comment }} |
 {%                 endfor %}
 {%             endif %}
 {%         endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/qos-profiles.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/qos-profiles.j2
@@ -35,7 +35,7 @@ QOS Profile: **{{ profile.name }}**
                                     '-') %}
 {%                     set priority = tx_queue.priority | arista.avd.default('-') %}
 {%                     set shape_rate = tx_queue.shape.rate | arista.avd.default('-') %}
-{%                     set comment = tx_queue.comment | arista.avd.default('-') | replace('\n', ' ') %}
+{%                     set comment = tx_queue.comment | arista.avd.default('-') | trim | replace('\n', '<br>') %}
 | {{ tx_queue.id }} | {{ type }} | {{ bw_percent }} | {{ priority }} | {{ shape_rate }} | {{ comment }} |
 {%                 endfor %}
 {%             endif %}
@@ -47,7 +47,7 @@ QOS Profile: **{{ profile.name }}**
                                         '-') %}
 {%                     set priority = uc_tx_queue.priority | arista.avd.default('-') %}
 {%                     set shape_rate = uc_tx_queue.shape.rate | arista.avd.default('-') %}
-{%                     set comment = uc_tx_queue.comment | arista.avd.default('-') | replace('\n', ' ') %}
+{%                     set comment = uc_tx_queue.comment | arista.avd.default('-') | trim | replace('\n', '<br>') %}
 | {{ uc_tx_queue.id }} | {{ type }} | {{ bw_percent }} | {{ priority }} | {{ shape_rate }} | {{ comment }} |
 {%                 endfor %}
 {%             endif %}
@@ -59,7 +59,7 @@ QOS Profile: **{{ profile.name }}**
                                         '-') %}
 {%                     set priority = mc_tx_queue.priority | arista.avd.default('-') %}
 {%                     set shape_rate = mc_tx_queue.shape.rate | arista.avd.default('-') %}
-{%                     set comment = mc_tx_queue.comment | arista.avd.default('-') | replace('\n', ' ') %}
+{%                     set comment = mc_tx_queue.comment | arista.avd.default('-') | trim | replace('\n', '<br>') %}
 | {{ mc_tx_queue.id }} | {{ type }} | {{ bw_percent }} | {{ priority }} | {{ shape_rate }} | {{ comment }} |
 {%                 endfor %}
 {%             endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/qos-profiles.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/qos-profiles.j2
@@ -24,6 +24,11 @@ qos profile {{ profile.name }}
 {%     for tx_queue in profile.tx_queues | arista.avd.natural_sort('id') %}
    !
    tx-queue {{ tx_queue.id }}
+{%         if tx_queue.comment is arista.avd.defined %}
+{%             for comment_line in tx_queue.comment.splitlines() | arista.avd.default([]) %}
+      !! {{ comment_line }}
+{%             endfor %}
+{%         endif %}
 {%         if tx_queue.bandwidth_percent is arista.avd.defined %}
       bandwidth percent {{ tx_queue.bandwidth_percent }}
 {%         elif tx_queue.bandwidth_guaranteed_percent is arista.avd.defined %}
@@ -35,15 +40,15 @@ qos profile {{ profile.name }}
 {%         if tx_queue.shape.rate is arista.avd.defined %}
       shape rate {{ tx_queue.shape.rate }}
 {%         endif %}
-{%         if tx_queue.comment is arista.avd.defined %}
-{%             for comment_line in tx_queue.comment.splitlines() | arista.avd.default([]) %}
-      !! {{ comment_line }}
-{%             endfor %}
-{%         endif %}
 {%     endfor %}
 {%     for uc_tx_queue in profile.uc_tx_queues | arista.avd.natural_sort('id') %}
    !
    uc-tx-queue {{ uc_tx_queue.id }}
+{%         if uc_tx_queue.comment is arista.avd.defined %}
+{%             for comment_line in uc_tx_queue.comment.splitlines() | arista.avd.default([]) %}
+      !! {{ comment_line }}
+{%             endfor %}
+{%         endif %}
 {%         if uc_tx_queue.bandwidth_percent is arista.avd.defined %}
       bandwidth percent {{ uc_tx_queue.bandwidth_percent }}
 {%         elif uc_tx_queue.bandwidth_guaranteed_percent is arista.avd.defined %}
@@ -55,15 +60,15 @@ qos profile {{ profile.name }}
 {%         if uc_tx_queue.shape.rate is arista.avd.defined %}
       shape rate {{ uc_tx_queue.shape.rate }}
 {%         endif %}
-{%         if uc_tx_queue.comment is arista.avd.defined %}
-{%             for comment_line in uc_tx_queue.comment.splitlines() | arista.avd.default([]) %}
-      !! {{ comment_line }}
-{%             endfor %}
-{%         endif %}
 {%     endfor %}
 {%     for mc_tx_queue in profile.mc_tx_queues | arista.avd.natural_sort('id') %}
    !
    mc-tx-queue {{ mc_tx_queue.id }}
+{%         if mc_tx_queue.comment is arista.avd.defined %}
+{%             for comment_line in mc_tx_queue.comment.splitlines() | arista.avd.default([]) %}
+      !! {{ comment_line }}
+{%             endfor %}
+{%         endif %}
 {%         if mc_tx_queue.bandwidth_percent is arista.avd.defined %}
       bandwidth percent {{ mc_tx_queue.bandwidth_percent }}
 {%         elif mc_tx_queue.bandwidth_guaranteed_percent is arista.avd.defined %}
@@ -74,11 +79,6 @@ qos profile {{ profile.name }}
 {%         endif %}
 {%         if mc_tx_queue.shape.rate is arista.avd.defined %}
       shape rate {{ mc_tx_queue.shape.rate }}
-{%         endif %}
-{%         if mc_tx_queue.comment is arista.avd.defined %}
-{%             for comment_line in mc_tx_queue.comment.splitlines() | arista.avd.default([]) %}
-      !! {{ comment_line }}
-{%             endfor %}
 {%         endif %}
 {%     endfor %}
 {% endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/qos-profiles.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/qos-profiles.j2
@@ -35,6 +35,11 @@ qos profile {{ profile.name }}
 {%         if tx_queue.shape.rate is arista.avd.defined %}
       shape rate {{ tx_queue.shape.rate }}
 {%         endif %}
+{%         if tx_queue.comment is arista.avd.defined %}
+{%             for comment_line in tx_queue.comment.splitlines() | arista.avd.default([]) %}
+      !! {{ comment_line }}
+{%             endfor %}
+{%         endif %}
 {%     endfor %}
 {%     for uc_tx_queue in profile.uc_tx_queues | arista.avd.natural_sort('id') %}
    !
@@ -50,6 +55,11 @@ qos profile {{ profile.name }}
 {%         if uc_tx_queue.shape.rate is arista.avd.defined %}
       shape rate {{ uc_tx_queue.shape.rate }}
 {%         endif %}
+{%         if uc_tx_queue.comment is arista.avd.defined %}
+{%             for comment_line in uc_tx_queue.comment.splitlines() | arista.avd.default([]) %}
+      !! {{ comment_line }}
+{%             endfor %}
+{%         endif %}
 {%     endfor %}
 {%     for mc_tx_queue in profile.mc_tx_queues | arista.avd.natural_sort('id') %}
    !
@@ -64,6 +74,11 @@ qos profile {{ profile.name }}
 {%         endif %}
 {%         if mc_tx_queue.shape.rate is arista.avd.defined %}
       shape rate {{ mc_tx_queue.shape.rate }}
+{%         endif %}
+{%         if mc_tx_queue.comment is arista.avd.defined %}
+{%             for comment_line in mc_tx_queue.comment.splitlines() | arista.avd.default([]) %}
+      !! {{ comment_line }}
+{%             endfor %}
 {%         endif %}
 {%     endfor %}
 {% endfor %}


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->

Add support for comments in queues in qos_profiles.

## Related Issue(s)

Related to  #2863 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

- Update Templates, Schemas for `comment` key

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- Is the documentation generated correct and clear enough?
- Is the use of `!!` the right way of doing this?

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
