### PR TITLE
Feat(eos_designs): use proper structured config knobs for bgp maximum paths

### DIFF
--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-leaf1a.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-leaf1a.md
@@ -608,10 +608,10 @@ ip route vrf MGMT 0.0.0.0/0 172.16.1.1
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -690,9 +690,9 @@ router bgp 65101
    router-id 10.255.0.3
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-leaf1b.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-leaf1b.md
@@ -608,10 +608,10 @@ ip route vrf MGMT 0.0.0.0/0 172.16.1.1
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -690,9 +690,9 @@ router bgp 65101
    router-id 10.255.0.4
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-leaf2a.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-leaf2a.md
@@ -616,10 +616,10 @@ ip route vrf MGMT 0.0.0.0/0 172.16.1.1
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -720,9 +720,9 @@ router bgp 65102
    router-id 10.255.0.5
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-CORE peer group
    neighbor EVPN-OVERLAY-CORE update-source Loopback0
    neighbor EVPN-OVERLAY-CORE bfd

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-leaf2b.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-leaf2b.md
@@ -616,10 +616,10 @@ ip route vrf MGMT 0.0.0.0/0 172.16.1.1
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -720,9 +720,9 @@ router bgp 65102
    router-id 10.255.0.6
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-CORE peer group
    neighbor EVPN-OVERLAY-CORE update-source Loopback0
    neighbor EVPN-OVERLAY-CORE bfd

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-spine1.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-spine1.md
@@ -278,10 +278,10 @@ ip route vrf MGMT 0.0.0.0/0 172.16.1.1
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -334,9 +334,9 @@ router bgp 65100
    router-id 10.255.0.1
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-spine2.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-spine2.md
@@ -278,10 +278,10 @@ ip route vrf MGMT 0.0.0.0/0 172.16.1.1
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -334,9 +334,9 @@ router bgp 65100
    router-id 10.255.0.2
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-leaf1a.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-leaf1a.md
@@ -608,10 +608,10 @@ ip route vrf MGMT 0.0.0.0/0 172.16.2.1
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -690,9 +690,9 @@ router bgp 65201
    router-id 10.255.128.13
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-leaf1b.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-leaf1b.md
@@ -608,10 +608,10 @@ ip route vrf MGMT 0.0.0.0/0 172.16.2.1
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -690,9 +690,9 @@ router bgp 65201
    router-id 10.255.128.14
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-leaf2a.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-leaf2a.md
@@ -616,10 +616,10 @@ ip route vrf MGMT 0.0.0.0/0 172.16.2.1
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -720,9 +720,9 @@ router bgp 65202
    router-id 10.255.128.15
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-CORE peer group
    neighbor EVPN-OVERLAY-CORE update-source Loopback0
    neighbor EVPN-OVERLAY-CORE bfd

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-leaf2b.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-leaf2b.md
@@ -616,10 +616,10 @@ ip route vrf MGMT 0.0.0.0/0 172.16.2.1
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -720,9 +720,9 @@ router bgp 65202
    router-id 10.255.128.16
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-CORE peer group
    neighbor EVPN-OVERLAY-CORE update-source Loopback0
    neighbor EVPN-OVERLAY-CORE bfd

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-spine1.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-spine1.md
@@ -278,10 +278,10 @@ ip route vrf MGMT 0.0.0.0/0 172.16.2.1
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -334,9 +334,9 @@ router bgp 65200
    router-id 10.255.128.11
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-spine2.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-spine2.md
@@ -278,10 +278,10 @@ ip route vrf MGMT 0.0.0.0/0 172.16.2.1
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -334,9 +334,9 @@ router bgp 65200
    router-id 10.255.128.12
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-leaf1a.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-leaf1a.cfg
@@ -249,9 +249,9 @@ router bgp 65101
    router-id 10.255.0.3
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-leaf1b.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-leaf1b.cfg
@@ -249,9 +249,9 @@ router bgp 65101
    router-id 10.255.0.4
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-leaf2a.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-leaf2a.cfg
@@ -256,9 +256,9 @@ router bgp 65102
    router-id 10.255.0.5
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-CORE peer group
    neighbor EVPN-OVERLAY-CORE update-source Loopback0
    neighbor EVPN-OVERLAY-CORE bfd

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-leaf2b.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-leaf2b.cfg
@@ -256,9 +256,9 @@ router bgp 65102
    router-id 10.255.0.6
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-CORE peer group
    neighbor EVPN-OVERLAY-CORE update-source Loopback0
    neighbor EVPN-OVERLAY-CORE bfd

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-spine1.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-spine1.cfg
@@ -75,9 +75,9 @@ router bgp 65100
    router-id 10.255.0.1
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-spine2.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-spine2.cfg
@@ -75,9 +75,9 @@ router bgp 65100
    router-id 10.255.0.2
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-leaf1a.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-leaf1a.cfg
@@ -249,9 +249,9 @@ router bgp 65201
    router-id 10.255.128.13
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-leaf1b.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-leaf1b.cfg
@@ -249,9 +249,9 @@ router bgp 65201
    router-id 10.255.128.14
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-leaf2a.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-leaf2a.cfg
@@ -256,9 +256,9 @@ router bgp 65202
    router-id 10.255.128.15
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-CORE peer group
    neighbor EVPN-OVERLAY-CORE update-source Loopback0
    neighbor EVPN-OVERLAY-CORE bfd

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-leaf2b.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-leaf2b.cfg
@@ -256,9 +256,9 @@ router bgp 65202
    router-id 10.255.128.16
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-CORE peer group
    neighbor EVPN-OVERLAY-CORE update-source Loopback0
    neighbor EVPN-OVERLAY-CORE bfd

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-spine1.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-spine1.cfg
@@ -75,9 +75,9 @@ router bgp 65200
    router-id 10.255.128.11
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-spine2.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-spine2.cfg
@@ -75,9 +75,9 @@ router bgp 65200
    router-id 10.255.128.12
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf1a.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf1a.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 10.255.0.3
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf1b.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf1b.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 10.255.0.4
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf2a.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf2a.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 10.255.0.5
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf2b.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf2b.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 10.255.0.6
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-spine1.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-spine1.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 10.255.0.1
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-spine2.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-spine2.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 10.255.0.2
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf1a.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf1a.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 10.255.128.13
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf1b.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf1b.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 10.255.128.14
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf2a.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf2a.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 10.255.128.15
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf2b.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf2b.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 10.255.128.16
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-spine1.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-spine1.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 10.255.128.11
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-spine2.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-spine2.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 10.255.128.12
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf1a.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf1a.md
@@ -608,10 +608,10 @@ ip route vrf MGMT 0.0.0.0/0 172.16.1.1
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -690,9 +690,9 @@ router bgp 65101
    router-id 10.255.0.3
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf1b.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf1b.md
@@ -608,10 +608,10 @@ ip route vrf MGMT 0.0.0.0/0 172.16.1.1
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -690,9 +690,9 @@ router bgp 65101
    router-id 10.255.0.4
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf2a.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf2a.md
@@ -608,10 +608,10 @@ ip route vrf MGMT 0.0.0.0/0 172.16.1.1
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -690,9 +690,9 @@ router bgp 65102
    router-id 10.255.0.5
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf2b.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf2b.md
@@ -608,10 +608,10 @@ ip route vrf MGMT 0.0.0.0/0 172.16.1.1
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -690,9 +690,9 @@ router bgp 65102
    router-id 10.255.0.6
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-spine1.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-spine1.md
@@ -278,10 +278,10 @@ ip route vrf MGMT 0.0.0.0/0 172.16.1.1
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -334,9 +334,9 @@ router bgp 65100
    router-id 10.255.0.1
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-spine2.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-spine2.md
@@ -278,10 +278,10 @@ ip route vrf MGMT 0.0.0.0/0 172.16.1.1
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -334,9 +334,9 @@ router bgp 65100
    router-id 10.255.0.2
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/configs/dc1-leaf1a.cfg
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/configs/dc1-leaf1a.cfg
@@ -249,9 +249,9 @@ router bgp 65101
    router-id 10.255.0.3
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/configs/dc1-leaf1b.cfg
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/configs/dc1-leaf1b.cfg
@@ -249,9 +249,9 @@ router bgp 65101
    router-id 10.255.0.4
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/configs/dc1-leaf2a.cfg
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/configs/dc1-leaf2a.cfg
@@ -249,9 +249,9 @@ router bgp 65102
    router-id 10.255.0.5
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/configs/dc1-leaf2b.cfg
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/configs/dc1-leaf2b.cfg
@@ -249,9 +249,9 @@ router bgp 65102
    router-id 10.255.0.6
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/configs/dc1-spine1.cfg
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/configs/dc1-spine1.cfg
@@ -75,9 +75,9 @@ router bgp 65100
    router-id 10.255.0.1
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/configs/dc1-spine2.cfg
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/configs/dc1-spine2.cfg
@@ -75,9 +75,9 @@ router bgp 65100
    router-id 10.255.0.2
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf1a.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf1a.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 10.255.0.3
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf1b.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf1b.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 10.255.0.4
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf2a.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf2a.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 10.255.0.5
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf2b.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf2b.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 10.255.0.6
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-spine1.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-spine1.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 10.255.0.1
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-spine2.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-spine2.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 10.255.0.2
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-BL1A.md
@@ -629,10 +629,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -714,9 +714,9 @@ router bgp 65104
    router-id 192.168.255.10
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-BL1B.md
@@ -629,10 +629,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -714,9 +714,9 @@ router bgp 65104
    router-id 192.168.255.11
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF1A.md
@@ -518,10 +518,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -587,9 +587,9 @@ router bgp 65101
    router-id 192.168.255.5
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF2A.md
@@ -856,10 +856,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -950,9 +950,9 @@ router bgp 65102
    router-id 192.168.255.6
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF2B.md
@@ -856,10 +856,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -950,9 +950,9 @@ router bgp 65102
    router-id 192.168.255.7
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE1.md
@@ -365,10 +365,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -427,9 +427,9 @@ router bgp 65001
    router-id 192.168.255.1
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE2.md
@@ -365,10 +365,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -427,9 +427,9 @@ router bgp 65001
    router-id 192.168.255.2
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE3.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE3.md
@@ -365,10 +365,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -427,9 +427,9 @@ router bgp 65001
    router-id 192.168.255.3
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE4.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE4.md
@@ -365,10 +365,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -427,9 +427,9 @@ router bgp 65001
    router-id 192.168.255.4
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SVC3A.md
@@ -972,10 +972,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -1075,9 +1075,9 @@ router bgp 65103
    router-id 192.168.255.8
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SVC3B.md
@@ -946,10 +946,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -1049,9 +1049,9 @@ router bgp 65103
    router-id 192.168.255.9
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-BL1A.cfg
@@ -226,9 +226,9 @@ router bgp 65104
    router-id 192.168.255.10
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-BL1B.cfg
@@ -226,9 +226,9 @@ router bgp 65104
    router-id 192.168.255.11
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-LEAF1A.cfg
@@ -164,9 +164,9 @@ router bgp 65101
    router-id 192.168.255.5
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-LEAF2A.cfg
@@ -400,9 +400,9 @@ router bgp 65102
    router-id 192.168.255.6
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-LEAF2B.cfg
@@ -400,9 +400,9 @@ router bgp 65102
    router-id 192.168.255.7
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SPINE1.cfg
@@ -105,9 +105,9 @@ router bgp 65001
    router-id 192.168.255.1
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SPINE2.cfg
@@ -105,9 +105,9 @@ router bgp 65001
    router-id 192.168.255.2
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SPINE3.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SPINE3.cfg
@@ -105,9 +105,9 @@ router bgp 65001
    router-id 192.168.255.3
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SPINE4.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SPINE4.cfg
@@ -105,9 +105,9 @@ router bgp 65001
    router-id 192.168.255.4
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SVC3A.cfg
@@ -483,9 +483,9 @@ router bgp 65103
    router-id 192.168.255.8
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SVC3B.cfg
@@ -467,9 +467,9 @@ router bgp 65103
    router-id 192.168.255.9
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-BL1A.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.10
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-BL1B.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.11
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF1A.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.5
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF2A.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.6
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF2B.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.7
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SPINE1.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.1
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SPINE2.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.2
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SPINE3.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.3
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SPINE4.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.4
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SVC3A.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.8
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SVC3B.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.9
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/cvp/cv_server_configlets.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/cvp/cv_server_configlets.yml
@@ -62,8 +62,8 @@ cvp_configlets:
     less preferred on spines to ensure optimal routing\n   set origin incomplete\n!\nrouter
     bfd\n   multihop interval 1200 min-rx 1200 multiplier 3\n!\nrouter bgp 65104\n
     \  router-id 192.168.255.10\n   graceful-restart restart-time 300\n   graceful-restart\n
-    \  no bgp default ipv4-unicast\n   distance bgp 20 200 200\n   maximum-paths 4
-    ecmp 4\n   neighbor EVPN-OVERLAY-PEERS peer group\n   neighbor EVPN-OVERLAY-PEERS
+    \  maximum-paths 4 ecmp 4\n   no bgp default ipv4-unicast\n   distance bgp 20
+    200 200\n   neighbor EVPN-OVERLAY-PEERS peer group\n   neighbor EVPN-OVERLAY-PEERS
     update-source Loopback0\n   neighbor EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS
     ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n
     \  neighbor EVPN-OVERLAY-PEERS send-community\n   neighbor EVPN-OVERLAY-PEERS
@@ -174,8 +174,8 @@ cvp_configlets:
     less preferred on spines to ensure optimal routing\n   set origin incomplete\n!\nrouter
     bfd\n   multihop interval 1200 min-rx 1200 multiplier 3\n!\nrouter bgp 65104\n
     \  router-id 192.168.255.11\n   graceful-restart restart-time 300\n   graceful-restart\n
-    \  no bgp default ipv4-unicast\n   distance bgp 20 200 200\n   maximum-paths 4
-    ecmp 4\n   neighbor EVPN-OVERLAY-PEERS peer group\n   neighbor EVPN-OVERLAY-PEERS
+    \  maximum-paths 4 ecmp 4\n   no bgp default ipv4-unicast\n   distance bgp 20
+    200 200\n   neighbor EVPN-OVERLAY-PEERS peer group\n   neighbor EVPN-OVERLAY-PEERS
     update-source Loopback0\n   neighbor EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS
     ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n
     \  neighbor EVPN-OVERLAY-PEERS send-community\n   neighbor EVPN-OVERLAY-PEERS
@@ -362,19 +362,19 @@ cvp_configlets:
     route vrf MGMT 0.0.0.0/0 192.168.200.5\n!\nroute-map RM-CONN-2-BGP permit 10\n
     \  match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n!\nrouter bfd\n   multihop
     interval 1200 min-rx 1200 multiplier 3\n!\nrouter bgp 65101\n   router-id 192.168.255.5\n
-    \  graceful-restart restart-time 300\n   graceful-restart\n   no bgp default ipv4-unicast\n
-    \  distance bgp 20 200 200\n   maximum-paths 4 ecmp 4\n   neighbor EVPN-OVERLAY-PEERS
-    peer group\n   neighbor EVPN-OVERLAY-PEERS update-source Loopback0\n   neighbor
-    EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3\n   neighbor
-    EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n   neighbor EVPN-OVERLAY-PEERS
-    send-community\n   neighbor EVPN-OVERLAY-PEERS maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS
-    peer group\n   neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==\n
-    \  neighbor IPv4-UNDERLAY-PEERS send-community\n   neighbor IPv4-UNDERLAY-PEERS
-    maximum-routes 12000\n   neighbor 172.31.255.0 peer group IPv4-UNDERLAY-PEERS\n
-    \  neighbor 172.31.255.0 remote-as 65001\n   neighbor 172.31.255.0 description
-    DC1-SPINE1_Ethernet1\n   neighbor 172.31.255.2 peer group IPv4-UNDERLAY-PEERS\n
-    \  neighbor 172.31.255.2 remote-as 65001\n   neighbor 172.31.255.2 description
-    DC1-SPINE2_Ethernet1\n   neighbor 172.31.255.4 peer group IPv4-UNDERLAY-PEERS\n
+    \  graceful-restart restart-time 300\n   graceful-restart\n   maximum-paths 4
+    ecmp 4\n   no bgp default ipv4-unicast\n   distance bgp 20 200 200\n   neighbor
+    EVPN-OVERLAY-PEERS peer group\n   neighbor EVPN-OVERLAY-PEERS update-source Loopback0\n
+    \  neighbor EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS ebgp-multihop
+    3\n   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n   neighbor
+    EVPN-OVERLAY-PEERS send-community\n   neighbor EVPN-OVERLAY-PEERS maximum-routes
+    0\n   neighbor IPv4-UNDERLAY-PEERS peer group\n   neighbor IPv4-UNDERLAY-PEERS
+    password 7 AQQvKeimxJu+uGQ/yYvv9w==\n   neighbor IPv4-UNDERLAY-PEERS send-community\n
+    \  neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000\n   neighbor 172.31.255.0
+    peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.0 remote-as 65001\n   neighbor
+    172.31.255.0 description DC1-SPINE1_Ethernet1\n   neighbor 172.31.255.2 peer group
+    IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.2 remote-as 65001\n   neighbor 172.31.255.2
+    description DC1-SPINE2_Ethernet1\n   neighbor 172.31.255.4 peer group IPv4-UNDERLAY-PEERS\n
     \  neighbor 172.31.255.4 remote-as 65001\n   neighbor 172.31.255.4 description
     DC1-SPINE3_Ethernet1\n   neighbor 172.31.255.6 peer group IPv4-UNDERLAY-PEERS\n
     \  neighbor 172.31.255.6 remote-as 65001\n   neighbor 172.31.255.6 description
@@ -507,8 +507,8 @@ cvp_configlets:
     Make routes learned over MLAG Peer-link less preferred on spines to ensure optimal
     routing\n   set origin incomplete\n!\nrouter bfd\n   multihop interval 1200 min-rx
     1200 multiplier 3\n!\nrouter bgp 65102\n   router-id 192.168.255.6\n   graceful-restart
-    restart-time 300\n   graceful-restart\n   no bgp default ipv4-unicast\n   distance
-    bgp 20 200 200\n   maximum-paths 4 ecmp 4\n   neighbor EVPN-OVERLAY-PEERS peer
+    restart-time 300\n   graceful-restart\n   maximum-paths 4 ecmp 4\n   no bgp default
+    ipv4-unicast\n   distance bgp 20 200 200\n   neighbor EVPN-OVERLAY-PEERS peer
     group\n   neighbor EVPN-OVERLAY-PEERS update-source Loopback0\n   neighbor EVPN-OVERLAY-PEERS
     bfd\n   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS
     password 7 q+VNViP5i4rVjW1cxFv2wA==\n   neighbor EVPN-OVERLAY-PEERS send-community\n
@@ -679,8 +679,8 @@ cvp_configlets:
     Make routes learned over MLAG Peer-link less preferred on spines to ensure optimal
     routing\n   set origin incomplete\n!\nrouter bfd\n   multihop interval 1200 min-rx
     1200 multiplier 3\n!\nrouter bgp 65102\n   router-id 192.168.255.7\n   graceful-restart
-    restart-time 300\n   graceful-restart\n   no bgp default ipv4-unicast\n   distance
-    bgp 20 200 200\n   maximum-paths 4 ecmp 4\n   neighbor EVPN-OVERLAY-PEERS peer
+    restart-time 300\n   graceful-restart\n   maximum-paths 4 ecmp 4\n   no bgp default
+    ipv4-unicast\n   distance bgp 20 200 200\n   neighbor EVPN-OVERLAY-PEERS peer
     group\n   neighbor EVPN-OVERLAY-PEERS update-source Loopback0\n   neighbor EVPN-OVERLAY-PEERS
     bfd\n   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS
     password 7 q+VNViP5i4rVjW1cxFv2wA==\n   neighbor EVPN-OVERLAY-PEERS send-community\n
@@ -773,19 +773,20 @@ cvp_configlets:
     vrf MGMT 0.0.0.0/0 192.168.200.5\n!\nroute-map RM-CONN-2-BGP permit 10\n   match
     ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n!\nrouter bfd\n   multihop interval
     1200 min-rx 1200 multiplier 3\n!\nrouter bgp 65001\n   router-id 192.168.255.1\n
-    \  graceful-restart restart-time 300\n   graceful-restart\n   no bgp default ipv4-unicast\n
-    \  distance bgp 20 200 200\n   maximum-paths 4 ecmp 4\n   neighbor EVPN-OVERLAY-PEERS
-    peer group\n   neighbor EVPN-OVERLAY-PEERS next-hop-unchanged\n   neighbor EVPN-OVERLAY-PEERS
-    update-source Loopback0\n   neighbor EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS
-    ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n
-    \  neighbor EVPN-OVERLAY-PEERS send-community\n   neighbor EVPN-OVERLAY-PEERS
-    maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS peer group\n   neighbor IPv4-UNDERLAY-PEERS
-    password 7 AQQvKeimxJu+uGQ/yYvv9w==\n   neighbor IPv4-UNDERLAY-PEERS send-community\n
-    \  neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000\n   neighbor 172.31.255.1
-    peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.1 remote-as 65101\n   neighbor
-    172.31.255.1 description DC1-LEAF1A_Ethernet1\n   neighbor 172.31.255.9 peer group
-    IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.9 remote-as 65102\n   neighbor 172.31.255.9
-    description DC1-LEAF2A_Ethernet1\n   neighbor 172.31.255.17 peer group IPv4-UNDERLAY-PEERS\n
+    \  graceful-restart restart-time 300\n   graceful-restart\n   maximum-paths 4
+    ecmp 4\n   no bgp default ipv4-unicast\n   distance bgp 20 200 200\n   neighbor
+    EVPN-OVERLAY-PEERS peer group\n   neighbor EVPN-OVERLAY-PEERS next-hop-unchanged\n
+    \  neighbor EVPN-OVERLAY-PEERS update-source Loopback0\n   neighbor EVPN-OVERLAY-PEERS
+    bfd\n   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS
+    password 7 q+VNViP5i4rVjW1cxFv2wA==\n   neighbor EVPN-OVERLAY-PEERS send-community\n
+    \  neighbor EVPN-OVERLAY-PEERS maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS
+    peer group\n   neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==\n
+    \  neighbor IPv4-UNDERLAY-PEERS send-community\n   neighbor IPv4-UNDERLAY-PEERS
+    maximum-routes 12000\n   neighbor 172.31.255.1 peer group IPv4-UNDERLAY-PEERS\n
+    \  neighbor 172.31.255.1 remote-as 65101\n   neighbor 172.31.255.1 description
+    DC1-LEAF1A_Ethernet1\n   neighbor 172.31.255.9 peer group IPv4-UNDERLAY-PEERS\n
+    \  neighbor 172.31.255.9 remote-as 65102\n   neighbor 172.31.255.9 description
+    DC1-LEAF2A_Ethernet1\n   neighbor 172.31.255.17 peer group IPv4-UNDERLAY-PEERS\n
     \  neighbor 172.31.255.17 remote-as 65102\n   neighbor 172.31.255.17 description
     DC1-LEAF2B_Ethernet1\n   neighbor 172.31.255.25 peer group IPv4-UNDERLAY-PEERS\n
     \  neighbor 172.31.255.25 remote-as 65103\n   neighbor 172.31.255.25 description
@@ -843,29 +844,30 @@ cvp_configlets:
     vrf MGMT 0.0.0.0/0 192.168.200.5\n!\nroute-map RM-CONN-2-BGP permit 10\n   match
     ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n!\nrouter bfd\n   multihop interval
     1200 min-rx 1200 multiplier 3\n!\nrouter bgp 65001\n   router-id 192.168.255.2\n
-    \  graceful-restart restart-time 300\n   graceful-restart\n   no bgp default ipv4-unicast\n
-    \  distance bgp 20 200 200\n   maximum-paths 4 ecmp 4\n   neighbor EVPN-OVERLAY-PEERS
-    peer group\n   neighbor EVPN-OVERLAY-PEERS next-hop-unchanged\n   neighbor EVPN-OVERLAY-PEERS
-    update-source Loopback0\n   neighbor EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS
-    ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n
-    \  neighbor EVPN-OVERLAY-PEERS send-community\n   neighbor EVPN-OVERLAY-PEERS
-    maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS peer group\n   neighbor IPv4-UNDERLAY-PEERS
-    password 7 AQQvKeimxJu+uGQ/yYvv9w==\n   neighbor IPv4-UNDERLAY-PEERS send-community\n
-    \  neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000\n   neighbor 172.31.255.3
-    peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.3 remote-as 65101\n   neighbor
-    172.31.255.3 description DC1-LEAF1A_Ethernet2\n   neighbor 172.31.255.11 peer
-    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.11 remote-as 65102\n   neighbor
-    172.31.255.11 description DC1-LEAF2A_Ethernet2\n   neighbor 172.31.255.19 peer
-    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.19 remote-as 65102\n   neighbor
-    172.31.255.19 description DC1-LEAF2B_Ethernet2\n   neighbor 172.31.255.27 peer
-    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.27 remote-as 65103\n   neighbor
-    172.31.255.27 description DC1-SVC3A_Ethernet2\n   neighbor 172.31.255.35 peer
-    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.35 remote-as 65103\n   neighbor
-    172.31.255.35 description DC1-SVC3B_Ethernet2\n   neighbor 172.31.255.43 peer
-    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.43 remote-as 65104\n   neighbor
-    172.31.255.43 description DC1-BL1A_Ethernet2\n   neighbor 172.31.255.51 peer group
-    IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.51 remote-as 65104\n   neighbor 172.31.255.51
-    description DC1-BL1B_Ethernet2\n   neighbor 192.168.255.5 peer group EVPN-OVERLAY-PEERS\n
+    \  graceful-restart restart-time 300\n   graceful-restart\n   maximum-paths 4
+    ecmp 4\n   no bgp default ipv4-unicast\n   distance bgp 20 200 200\n   neighbor
+    EVPN-OVERLAY-PEERS peer group\n   neighbor EVPN-OVERLAY-PEERS next-hop-unchanged\n
+    \  neighbor EVPN-OVERLAY-PEERS update-source Loopback0\n   neighbor EVPN-OVERLAY-PEERS
+    bfd\n   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS
+    password 7 q+VNViP5i4rVjW1cxFv2wA==\n   neighbor EVPN-OVERLAY-PEERS send-community\n
+    \  neighbor EVPN-OVERLAY-PEERS maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS
+    peer group\n   neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==\n
+    \  neighbor IPv4-UNDERLAY-PEERS send-community\n   neighbor IPv4-UNDERLAY-PEERS
+    maximum-routes 12000\n   neighbor 172.31.255.3 peer group IPv4-UNDERLAY-PEERS\n
+    \  neighbor 172.31.255.3 remote-as 65101\n   neighbor 172.31.255.3 description
+    DC1-LEAF1A_Ethernet2\n   neighbor 172.31.255.11 peer group IPv4-UNDERLAY-PEERS\n
+    \  neighbor 172.31.255.11 remote-as 65102\n   neighbor 172.31.255.11 description
+    DC1-LEAF2A_Ethernet2\n   neighbor 172.31.255.19 peer group IPv4-UNDERLAY-PEERS\n
+    \  neighbor 172.31.255.19 remote-as 65102\n   neighbor 172.31.255.19 description
+    DC1-LEAF2B_Ethernet2\n   neighbor 172.31.255.27 peer group IPv4-UNDERLAY-PEERS\n
+    \  neighbor 172.31.255.27 remote-as 65103\n   neighbor 172.31.255.27 description
+    DC1-SVC3A_Ethernet2\n   neighbor 172.31.255.35 peer group IPv4-UNDERLAY-PEERS\n
+    \  neighbor 172.31.255.35 remote-as 65103\n   neighbor 172.31.255.35 description
+    DC1-SVC3B_Ethernet2\n   neighbor 172.31.255.43 peer group IPv4-UNDERLAY-PEERS\n
+    \  neighbor 172.31.255.43 remote-as 65104\n   neighbor 172.31.255.43 description
+    DC1-BL1A_Ethernet2\n   neighbor 172.31.255.51 peer group IPv4-UNDERLAY-PEERS\n
+    \  neighbor 172.31.255.51 remote-as 65104\n   neighbor 172.31.255.51 description
+    DC1-BL1B_Ethernet2\n   neighbor 192.168.255.5 peer group EVPN-OVERLAY-PEERS\n
     \  neighbor 192.168.255.5 remote-as 65101\n   neighbor 192.168.255.5 description
     DC1-LEAF1A\n   neighbor 192.168.255.6 peer group EVPN-OVERLAY-PEERS\n   neighbor
     192.168.255.6 remote-as 65102\n   neighbor 192.168.255.6 description DC1-LEAF2A\n
@@ -913,29 +915,30 @@ cvp_configlets:
     vrf MGMT 0.0.0.0/0 192.168.200.5\n!\nroute-map RM-CONN-2-BGP permit 10\n   match
     ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n!\nrouter bfd\n   multihop interval
     1200 min-rx 1200 multiplier 3\n!\nrouter bgp 65001\n   router-id 192.168.255.3\n
-    \  graceful-restart restart-time 300\n   graceful-restart\n   no bgp default ipv4-unicast\n
-    \  distance bgp 20 200 200\n   maximum-paths 4 ecmp 4\n   neighbor EVPN-OVERLAY-PEERS
-    peer group\n   neighbor EVPN-OVERLAY-PEERS next-hop-unchanged\n   neighbor EVPN-OVERLAY-PEERS
-    update-source Loopback0\n   neighbor EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS
-    ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n
-    \  neighbor EVPN-OVERLAY-PEERS send-community\n   neighbor EVPN-OVERLAY-PEERS
-    maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS peer group\n   neighbor IPv4-UNDERLAY-PEERS
-    password 7 AQQvKeimxJu+uGQ/yYvv9w==\n   neighbor IPv4-UNDERLAY-PEERS send-community\n
-    \  neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000\n   neighbor 172.31.255.5
-    peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.5 remote-as 65101\n   neighbor
-    172.31.255.5 description DC1-LEAF1A_Ethernet3\n   neighbor 172.31.255.13 peer
-    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.13 remote-as 65102\n   neighbor
-    172.31.255.13 description DC1-LEAF2A_Ethernet3\n   neighbor 172.31.255.21 peer
-    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.21 remote-as 65102\n   neighbor
-    172.31.255.21 description DC1-LEAF2B_Ethernet3\n   neighbor 172.31.255.29 peer
-    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.29 remote-as 65103\n   neighbor
-    172.31.255.29 description DC1-SVC3A_Ethernet3\n   neighbor 172.31.255.37 peer
-    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.37 remote-as 65103\n   neighbor
-    172.31.255.37 description DC1-SVC3B_Ethernet3\n   neighbor 172.31.255.45 peer
-    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.45 remote-as 65104\n   neighbor
-    172.31.255.45 description DC1-BL1A_Ethernet3\n   neighbor 172.31.255.53 peer group
-    IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.53 remote-as 65104\n   neighbor 172.31.255.53
-    description DC1-BL1B_Ethernet3\n   neighbor 192.168.255.5 peer group EVPN-OVERLAY-PEERS\n
+    \  graceful-restart restart-time 300\n   graceful-restart\n   maximum-paths 4
+    ecmp 4\n   no bgp default ipv4-unicast\n   distance bgp 20 200 200\n   neighbor
+    EVPN-OVERLAY-PEERS peer group\n   neighbor EVPN-OVERLAY-PEERS next-hop-unchanged\n
+    \  neighbor EVPN-OVERLAY-PEERS update-source Loopback0\n   neighbor EVPN-OVERLAY-PEERS
+    bfd\n   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS
+    password 7 q+VNViP5i4rVjW1cxFv2wA==\n   neighbor EVPN-OVERLAY-PEERS send-community\n
+    \  neighbor EVPN-OVERLAY-PEERS maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS
+    peer group\n   neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==\n
+    \  neighbor IPv4-UNDERLAY-PEERS send-community\n   neighbor IPv4-UNDERLAY-PEERS
+    maximum-routes 12000\n   neighbor 172.31.255.5 peer group IPv4-UNDERLAY-PEERS\n
+    \  neighbor 172.31.255.5 remote-as 65101\n   neighbor 172.31.255.5 description
+    DC1-LEAF1A_Ethernet3\n   neighbor 172.31.255.13 peer group IPv4-UNDERLAY-PEERS\n
+    \  neighbor 172.31.255.13 remote-as 65102\n   neighbor 172.31.255.13 description
+    DC1-LEAF2A_Ethernet3\n   neighbor 172.31.255.21 peer group IPv4-UNDERLAY-PEERS\n
+    \  neighbor 172.31.255.21 remote-as 65102\n   neighbor 172.31.255.21 description
+    DC1-LEAF2B_Ethernet3\n   neighbor 172.31.255.29 peer group IPv4-UNDERLAY-PEERS\n
+    \  neighbor 172.31.255.29 remote-as 65103\n   neighbor 172.31.255.29 description
+    DC1-SVC3A_Ethernet3\n   neighbor 172.31.255.37 peer group IPv4-UNDERLAY-PEERS\n
+    \  neighbor 172.31.255.37 remote-as 65103\n   neighbor 172.31.255.37 description
+    DC1-SVC3B_Ethernet3\n   neighbor 172.31.255.45 peer group IPv4-UNDERLAY-PEERS\n
+    \  neighbor 172.31.255.45 remote-as 65104\n   neighbor 172.31.255.45 description
+    DC1-BL1A_Ethernet3\n   neighbor 172.31.255.53 peer group IPv4-UNDERLAY-PEERS\n
+    \  neighbor 172.31.255.53 remote-as 65104\n   neighbor 172.31.255.53 description
+    DC1-BL1B_Ethernet3\n   neighbor 192.168.255.5 peer group EVPN-OVERLAY-PEERS\n
     \  neighbor 192.168.255.5 remote-as 65101\n   neighbor 192.168.255.5 description
     DC1-LEAF1A\n   neighbor 192.168.255.6 peer group EVPN-OVERLAY-PEERS\n   neighbor
     192.168.255.6 remote-as 65102\n   neighbor 192.168.255.6 description DC1-LEAF2A\n
@@ -983,29 +986,30 @@ cvp_configlets:
     vrf MGMT 0.0.0.0/0 192.168.200.5\n!\nroute-map RM-CONN-2-BGP permit 10\n   match
     ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n!\nrouter bfd\n   multihop interval
     1200 min-rx 1200 multiplier 3\n!\nrouter bgp 65001\n   router-id 192.168.255.4\n
-    \  graceful-restart restart-time 300\n   graceful-restart\n   no bgp default ipv4-unicast\n
-    \  distance bgp 20 200 200\n   maximum-paths 4 ecmp 4\n   neighbor EVPN-OVERLAY-PEERS
-    peer group\n   neighbor EVPN-OVERLAY-PEERS next-hop-unchanged\n   neighbor EVPN-OVERLAY-PEERS
-    update-source Loopback0\n   neighbor EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS
-    ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n
-    \  neighbor EVPN-OVERLAY-PEERS send-community\n   neighbor EVPN-OVERLAY-PEERS
-    maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS peer group\n   neighbor IPv4-UNDERLAY-PEERS
-    password 7 AQQvKeimxJu+uGQ/yYvv9w==\n   neighbor IPv4-UNDERLAY-PEERS send-community\n
-    \  neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000\n   neighbor 172.31.255.7
-    peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.7 remote-as 65101\n   neighbor
-    172.31.255.7 description DC1-LEAF1A_Ethernet4\n   neighbor 172.31.255.15 peer
-    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.15 remote-as 65102\n   neighbor
-    172.31.255.15 description DC1-LEAF2A_Ethernet4\n   neighbor 172.31.255.23 peer
-    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.23 remote-as 65102\n   neighbor
-    172.31.255.23 description DC1-LEAF2B_Ethernet4\n   neighbor 172.31.255.31 peer
-    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.31 remote-as 65103\n   neighbor
-    172.31.255.31 description DC1-SVC3A_Ethernet4\n   neighbor 172.31.255.39 peer
-    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.39 remote-as 65103\n   neighbor
-    172.31.255.39 description DC1-SVC3B_Ethernet4\n   neighbor 172.31.255.47 peer
-    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.47 remote-as 65104\n   neighbor
-    172.31.255.47 description DC1-BL1A_Ethernet4\n   neighbor 172.31.255.55 peer group
-    IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.55 remote-as 65104\n   neighbor 172.31.255.55
-    description DC1-BL1B_Ethernet4\n   neighbor 192.168.255.5 peer group EVPN-OVERLAY-PEERS\n
+    \  graceful-restart restart-time 300\n   graceful-restart\n   maximum-paths 4
+    ecmp 4\n   no bgp default ipv4-unicast\n   distance bgp 20 200 200\n   neighbor
+    EVPN-OVERLAY-PEERS peer group\n   neighbor EVPN-OVERLAY-PEERS next-hop-unchanged\n
+    \  neighbor EVPN-OVERLAY-PEERS update-source Loopback0\n   neighbor EVPN-OVERLAY-PEERS
+    bfd\n   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS
+    password 7 q+VNViP5i4rVjW1cxFv2wA==\n   neighbor EVPN-OVERLAY-PEERS send-community\n
+    \  neighbor EVPN-OVERLAY-PEERS maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS
+    peer group\n   neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==\n
+    \  neighbor IPv4-UNDERLAY-PEERS send-community\n   neighbor IPv4-UNDERLAY-PEERS
+    maximum-routes 12000\n   neighbor 172.31.255.7 peer group IPv4-UNDERLAY-PEERS\n
+    \  neighbor 172.31.255.7 remote-as 65101\n   neighbor 172.31.255.7 description
+    DC1-LEAF1A_Ethernet4\n   neighbor 172.31.255.15 peer group IPv4-UNDERLAY-PEERS\n
+    \  neighbor 172.31.255.15 remote-as 65102\n   neighbor 172.31.255.15 description
+    DC1-LEAF2A_Ethernet4\n   neighbor 172.31.255.23 peer group IPv4-UNDERLAY-PEERS\n
+    \  neighbor 172.31.255.23 remote-as 65102\n   neighbor 172.31.255.23 description
+    DC1-LEAF2B_Ethernet4\n   neighbor 172.31.255.31 peer group IPv4-UNDERLAY-PEERS\n
+    \  neighbor 172.31.255.31 remote-as 65103\n   neighbor 172.31.255.31 description
+    DC1-SVC3A_Ethernet4\n   neighbor 172.31.255.39 peer group IPv4-UNDERLAY-PEERS\n
+    \  neighbor 172.31.255.39 remote-as 65103\n   neighbor 172.31.255.39 description
+    DC1-SVC3B_Ethernet4\n   neighbor 172.31.255.47 peer group IPv4-UNDERLAY-PEERS\n
+    \  neighbor 172.31.255.47 remote-as 65104\n   neighbor 172.31.255.47 description
+    DC1-BL1A_Ethernet4\n   neighbor 172.31.255.55 peer group IPv4-UNDERLAY-PEERS\n
+    \  neighbor 172.31.255.55 remote-as 65104\n   neighbor 172.31.255.55 description
+    DC1-BL1B_Ethernet4\n   neighbor 192.168.255.5 peer group EVPN-OVERLAY-PEERS\n
     \  neighbor 192.168.255.5 remote-as 65101\n   neighbor 192.168.255.5 description
     DC1-LEAF1A\n   neighbor 192.168.255.6 peer group EVPN-OVERLAY-PEERS\n   neighbor
     192.168.255.6 remote-as 65102\n   neighbor 192.168.255.6 description DC1-LEAF2A\n
@@ -1155,8 +1159,8 @@ cvp_configlets:
     Make routes learned over MLAG Peer-link less preferred on spines to ensure optimal
     routing\n   set origin incomplete\n!\nrouter bfd\n   multihop interval 1200 min-rx
     1200 multiplier 3\n!\nrouter bgp 65103\n   router-id 192.168.255.8\n   graceful-restart
-    restart-time 300\n   graceful-restart\n   no bgp default ipv4-unicast\n   distance
-    bgp 20 200 200\n   maximum-paths 4 ecmp 4\n   neighbor EVPN-OVERLAY-PEERS peer
+    restart-time 300\n   graceful-restart\n   maximum-paths 4 ecmp 4\n   no bgp default
+    ipv4-unicast\n   distance bgp 20 200 200\n   neighbor EVPN-OVERLAY-PEERS peer
     group\n   neighbor EVPN-OVERLAY-PEERS update-source Loopback0\n   neighbor EVPN-OVERLAY-PEERS
     bfd\n   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS
     password 7 q+VNViP5i4rVjW1cxFv2wA==\n   neighbor EVPN-OVERLAY-PEERS send-community\n
@@ -1360,8 +1364,8 @@ cvp_configlets:
     less preferred on spines to ensure optimal routing\n   set origin incomplete\n!\nrouter
     bfd\n   multihop interval 1200 min-rx 1200 multiplier 3\n!\nrouter bgp 65103\n
     \  router-id 192.168.255.9\n   graceful-restart restart-time 300\n   graceful-restart\n
-    \  no bgp default ipv4-unicast\n   distance bgp 20 200 200\n   maximum-paths 4
-    ecmp 4\n   neighbor EVPN-OVERLAY-PEERS peer group\n   neighbor EVPN-OVERLAY-PEERS
+    \  maximum-paths 4 ecmp 4\n   no bgp default ipv4-unicast\n   distance bgp 20
+    200 200\n   neighbor EVPN-OVERLAY-PEERS peer group\n   neighbor EVPN-OVERLAY-PEERS
     update-source Loopback0\n   neighbor EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS
     ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n
     \  neighbor EVPN-OVERLAY-PEERS send-community\n   neighbor EVPN-OVERLAY-PEERS

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/BGP-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/BGP-SPINE1.md
@@ -371,10 +371,10 @@ ip route vrf MGMT 0.0.0.0/0 172.31.0.1
 
 | BGP Tuning |
 | ---------- |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -411,8 +411,8 @@ router bgp 65001
    router-id 192.168.255.1
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/BGP-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/BGP-SPINE2.md
@@ -373,10 +373,10 @@ ip route 10.0.0.0/8 10.1.100.100
 
 | BGP Tuning |
 | ---------- |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -413,8 +413,8 @@ router bgp 65001
    router-id 192.168.255.2
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/BGP-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/BGP-SPINE1.cfg
@@ -113,8 +113,8 @@ router bgp 65001
    router-id 192.168.255.1
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/BGP-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/BGP-SPINE2.cfg
@@ -114,8 +114,8 @@ router bgp 65001
    router-id 192.168.255.2
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-SPINE1.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65001'
   router_id: 192.168.255.1
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-SPINE2.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65001'
   router_id: 192.168.255.2
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER1.md
@@ -632,10 +632,10 @@ router isis CORE
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -704,9 +704,9 @@ router bgp 65000
    router-id 100.70.0.5
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor MPLS-OVERLAY-PEERS peer group
    neighbor MPLS-OVERLAY-PEERS remote-as 65000
    neighbor MPLS-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER2.md
@@ -597,10 +597,10 @@ router isis CORE
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -686,9 +686,9 @@ router bgp 65000
    router-id 100.70.0.6
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor MPLS-OVERLAY-PEERS peer group
    neighbor MPLS-OVERLAY-PEERS remote-as 65000
    neighbor MPLS-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-RR1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-RR1.md
@@ -354,10 +354,10 @@ router isis CORE
 | ---------- |
 | distance bgp 20 200 200 |
 | bgp route-reflector preserve-attributes always |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -434,11 +434,11 @@ router bgp 65000
    router-id 100.70.0.8
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    bgp cluster-id 1.1.1.1
    distance bgp 20 200 200
    bgp route-reflector preserve-attributes always
-   maximum-paths 4 ecmp 4
    neighbor MPLS-OVERLAY-PEERS peer group
    neighbor MPLS-OVERLAY-PEERS remote-as 65000
    neighbor MPLS-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-LER1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-LER1.md
@@ -634,10 +634,10 @@ router isis CORE
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -724,9 +724,9 @@ router bgp 65000
    router-id 100.70.0.7
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor MPLS-OVERLAY-PEERS peer group
    neighbor MPLS-OVERLAY-PEERS remote-as 65000
    neighbor MPLS-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-RR1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-RR1.md
@@ -354,10 +354,10 @@ router isis CORE
 | ---------- |
 | distance bgp 20 200 200 |
 | bgp route-reflector preserve-attributes always |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -434,11 +434,11 @@ router bgp 65000
    router-id 100.70.0.9
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    bgp cluster-id 1.1.1.1
    distance bgp 20 200 200
    bgp route-reflector preserve-attributes always
-   maximum-paths 4 ecmp 4
    neighbor MPLS-OVERLAY-PEERS peer group
    neighbor MPLS-OVERLAY-PEERS remote-as 65000
    neighbor MPLS-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE1-LER1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE1-LER1.cfg
@@ -205,9 +205,9 @@ router bgp 65000
    router-id 100.70.0.5
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor MPLS-OVERLAY-PEERS peer group
    neighbor MPLS-OVERLAY-PEERS remote-as 65000
    neighbor MPLS-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE1-LER2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE1-LER2.cfg
@@ -203,9 +203,9 @@ router bgp 65000
    router-id 100.70.0.6
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor MPLS-OVERLAY-PEERS peer group
    neighbor MPLS-OVERLAY-PEERS remote-as 65000
    neighbor MPLS-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE1-RR1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE1-RR1.cfg
@@ -67,11 +67,11 @@ router bgp 65000
    router-id 100.70.0.8
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    bgp cluster-id 1.1.1.1
    distance bgp 20 200 200
    bgp route-reflector preserve-attributes always
-   maximum-paths 4 ecmp 4
    neighbor MPLS-OVERLAY-PEERS peer group
    neighbor MPLS-OVERLAY-PEERS remote-as 65000
    neighbor MPLS-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE2-LER1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE2-LER1.cfg
@@ -201,9 +201,9 @@ router bgp 65000
    router-id 100.70.0.7
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor MPLS-OVERLAY-PEERS peer group
    neighbor MPLS-OVERLAY-PEERS remote-as 65000
    neighbor MPLS-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE2-RR1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE2-RR1.cfg
@@ -67,11 +67,11 @@ router bgp 65000
    router-id 100.70.0.9
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    bgp cluster-id 1.1.1.1
    distance bgp 20 200 200
    bgp route-reflector preserve-attributes always
-   maximum-paths 4 ecmp 4
    neighbor MPLS-OVERLAY-PEERS peer group
    neighbor MPLS-OVERLAY-PEERS remote-as 65000
    neighbor MPLS-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LER1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LER1.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 100.70.0.5
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LER2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LER2.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 100.70.0.6
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-RR1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-RR1.yml
@@ -4,10 +4,12 @@ router_bgp:
   bgp_defaults:
   - distance bgp 20 200 200
   - bgp route-reflector preserve-attributes always
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE2-LER1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE2-LER1.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 100.70.0.7
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE2-RR1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE2-RR1.yml
@@ -4,10 +4,12 @@ router_bgp:
   bgp_defaults:
   - distance bgp 20 200 200
   - bgp route-reflector preserve-attributes always
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF1A.md
@@ -386,10 +386,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -445,9 +445,9 @@ router bgp 65111.100
    router-id 172.16.110.3
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2B.md
@@ -783,10 +783,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -890,9 +890,9 @@ router bgp 65112.100
    router-id 172.16.110.5
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-CORE peer group
    neighbor EVPN-OVERLAY-CORE update-source Loopback0
    neighbor EVPN-OVERLAY-CORE bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-SPINE1.md
@@ -321,10 +321,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -383,9 +383,9 @@ router bgp 65110.100
    router-id 172.16.110.1
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-SPINE2.md
@@ -336,10 +336,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -371,9 +371,9 @@ router bgp 65110.100
    router-id 172.16.110.2
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS password 7 <removed>
    neighbor IPv4-UNDERLAY-PEERS send-community

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-LEAF1A.md
@@ -543,10 +543,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -616,9 +616,9 @@ router bgp 65121
    router-id 172.16.120.3
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-SPINE1.md
@@ -314,10 +314,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -368,9 +368,9 @@ router bgp 65120
    router-id 172.16.120.1
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-SPINE2.md
@@ -306,10 +306,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -359,9 +359,9 @@ router bgp 65120
    router-id 172.16.120.2
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-RS1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-RS1.md
@@ -263,10 +263,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -320,9 +320,9 @@ router bgp 65101
    router-id 172.16.10.1
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-RS2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-RS2.md
@@ -291,10 +291,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -346,9 +346,9 @@ router bgp 65102
    router-id 172.16.10.2
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-SUPER-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-SUPER-SPINE1.md
@@ -297,10 +297,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -331,9 +331,9 @@ router bgp 65100
    router-id 172.16.100.1
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS password 7 <removed>
    neighbor IPv4-UNDERLAY-PEERS send-community

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-SUPER-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-SUPER-SPINE2.md
@@ -323,10 +323,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -357,9 +357,9 @@ router bgp 65100
    router-id 172.16.100.2
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS password 7 <removed>
    neighbor IPv4-UNDERLAY-PEERS send-community

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1.POD1.LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1.POD1.LEAF2A.md
@@ -758,10 +758,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -866,9 +866,9 @@ router bgp 65112.100
    router-id 172.16.110.4
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-CORE peer group
    neighbor EVPN-OVERLAY-CORE update-source Loopback0
    neighbor EVPN-OVERLAY-CORE bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-LEAF1A.md
@@ -483,10 +483,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -549,9 +549,9 @@ router bgp 65211
    router-id 172.16.210.3
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-LEAF2A.md
@@ -409,10 +409,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -459,9 +459,9 @@ router bgp 65212
    router-id 172.16.210.4
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-SPINE1.md
@@ -312,10 +312,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -369,9 +369,9 @@ router bgp 65210
    router-id 172.16.210.1
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-SPINE2.md
@@ -311,10 +311,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -344,9 +344,9 @@ router bgp 65210
    router-id 172.16.210.2
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-RS1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-RS1.md
@@ -282,10 +282,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -336,9 +336,9 @@ router bgp 65201
    router-id 172.16.20.1
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-RS2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-RS2.md
@@ -280,10 +280,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -310,9 +310,9 @@ router bgp 65201
    router-id 172.16.20.2
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-SUPER-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-SUPER-SPINE1.md
@@ -330,10 +330,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -389,9 +389,9 @@ router bgp 65200
    router-id 172.16.200.1
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-SUPER-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-SUPER-SPINE2.md
@@ -290,10 +290,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -321,9 +321,9 @@ router bgp 65200
    router-id 172.16.200.2
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF1A.cfg
@@ -120,9 +120,9 @@ router bgp 65111.100
    router-id 172.16.110.3
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2B.cfg
@@ -388,9 +388,9 @@ router bgp 65112.100
    router-id 172.16.110.5
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-CORE peer group
    neighbor EVPN-OVERLAY-CORE update-source Loopback0
    neighbor EVPN-OVERLAY-CORE bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-SPINE1.cfg
@@ -134,9 +134,9 @@ router bgp 65110.100
    router-id 172.16.110.1
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-SPINE2.cfg
@@ -109,9 +109,9 @@ router bgp 65110.100
    router-id 172.16.110.2
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
    neighbor IPv4-UNDERLAY-PEERS send-community

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD2-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD2-LEAF1A.cfg
@@ -207,9 +207,9 @@ router bgp 65121
    router-id 172.16.120.3
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD2-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD2-SPINE1.cfg
@@ -93,9 +93,9 @@ router bgp 65120
    router-id 172.16.120.1
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD2-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD2-SPINE2.cfg
@@ -86,9 +86,9 @@ router bgp 65120
    router-id 172.16.120.2
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-RS1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-RS1.cfg
@@ -86,9 +86,9 @@ router bgp 65101
    router-id 172.16.10.1
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-RS2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-RS2.cfg
@@ -92,9 +92,9 @@ router bgp 65102
    router-id 172.16.10.2
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-SUPER-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-SUPER-SPINE1.cfg
@@ -96,9 +96,9 @@ router bgp 65100
    router-id 172.16.100.1
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
    neighbor IPv4-UNDERLAY-PEERS send-community

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-SUPER-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-SUPER-SPINE2.cfg
@@ -100,9 +100,9 @@ router bgp 65100
    router-id 172.16.100.2
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
    neighbor IPv4-UNDERLAY-PEERS send-community

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1.POD1.LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1.POD1.LEAF2A.cfg
@@ -384,9 +384,9 @@ router bgp 65112.100
    router-id 172.16.110.4
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-CORE peer group
    neighbor EVPN-OVERLAY-CORE update-source Loopback0
    neighbor EVPN-OVERLAY-CORE bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-LEAF1A.cfg
@@ -157,9 +157,9 @@ router bgp 65211
    router-id 172.16.210.3
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-LEAF2A.cfg
@@ -110,9 +110,9 @@ router bgp 65212
    router-id 172.16.210.4
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-SPINE1.cfg
@@ -91,9 +91,9 @@ router bgp 65210
    router-id 172.16.210.1
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-SPINE2.cfg
@@ -89,9 +89,9 @@ router bgp 65210
    router-id 172.16.210.2
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-RS1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-RS1.cfg
@@ -64,9 +64,9 @@ router bgp 65201
    router-id 172.16.20.1
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-RS2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-RS2.cfg
@@ -61,9 +61,9 @@ router bgp 65201
    router-id 172.16.20.2
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-SUPER-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-SUPER-SPINE1.cfg
@@ -107,9 +107,9 @@ router bgp 65200
    router-id 172.16.200.1
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-SUPER-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-SUPER-SPINE2.cfg
@@ -70,9 +70,9 @@ router bgp 65200
    router-id 172.16.200.2
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF1A.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 172.16.110.3
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2B.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 172.16.110.5
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-SPINE1.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 172.16.110.1
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-SPINE2.yml
@@ -4,10 +4,12 @@ router_bgp:
   router_id: 172.16.110.2
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD2-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD2-LEAF1A.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 172.16.120.3
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD2-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD2-SPINE1.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 172.16.120.1
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD2-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD2-SPINE2.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 172.16.120.2
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-RS1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-RS1.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 172.16.10.1
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-RS2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-RS2.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 172.16.10.2
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-SUPER-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-SUPER-SPINE1.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 172.16.100.1
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-SUPER-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-SUPER-SPINE2.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 172.16.100.2
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1.POD1.LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1.POD1.LEAF2A.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 172.16.110.4
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-LEAF1A.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 172.16.210.3
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-LEAF2A.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 172.16.210.4
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-SPINE1.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 172.16.210.1
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-SPINE2.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 172.16.210.2
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-RS1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-RS1.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 172.16.20.1
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-RS2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-RS2.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 172.16.20.2
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-SUPER-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-SUPER-SPINE1.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 172.16.200.1
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-SUPER-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-SUPER-SPINE2.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 172.16.200.2
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/intended/structured_configs/duplicate-ip-address-1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/intended/structured_configs/duplicate-ip-address-1.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65101'
   router_id: 10.255.0.4
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/intended/structured_configs/duplicate-ip-address-2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/intended/structured_configs/duplicate-ip-address-2.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65101'
   router_id: 10.255.0.4
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF1A.cfg
@@ -56,9 +56,9 @@ router bgp 65101
    router-id 192.168.255.3
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF1B.cfg
@@ -56,9 +56,9 @@ router bgp 65102
    router-id 192.168.255.4
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF2.cfg
@@ -56,9 +56,9 @@ router bgp 65103
    router-id 192.168.255.5
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF3A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF3A.cfg
@@ -109,9 +109,9 @@ router bgp 65105
    router-id 192.168.255.7
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF3B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF3B.cfg
@@ -109,9 +109,9 @@ router bgp 65105
    router-id 192.168.255.8
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF4A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF4A.cfg
@@ -109,9 +109,9 @@ router bgp 65222
    router-id 192.168.255.9
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF4B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF4B.cfg
@@ -109,9 +109,9 @@ router bgp 65222
    router-id 192.168.255.10
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF5A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF5A.cfg
@@ -56,9 +56,9 @@ router bgp 65333
    router-id 192.168.255.11
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF7A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF7A.cfg
@@ -109,9 +109,9 @@ router bgp 65222.0
    router-id 192.168.255.13
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF7B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF7B.cfg
@@ -109,9 +109,9 @@ router bgp 65222.0
    router-id 192.168.255.14
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF8A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF8A.cfg
@@ -56,9 +56,9 @@ router bgp 65222.12
    router-id 192.168.255.15
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF8B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF8B.cfg
@@ -56,9 +56,9 @@ router bgp 65222.13
    router-id 192.168.255.16
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_UNGROUPED_LEAF6.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_UNGROUPED_LEAF6.cfg
@@ -56,9 +56,9 @@ router bgp 65110
    router-id 192.168.255.12
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_NODE_TYPE_LEAF01.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_NODE_TYPE_LEAF01.cfg
@@ -70,9 +70,9 @@ router bgp 65101
    router-id 192.168.255.3
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_NODE_TYPE_SPINE01.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_NODE_TYPE_SPINE01.cfg
@@ -58,9 +58,9 @@ router bgp 65100
    router-id 192.168.255.1
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_NODE_TYPE_SPINE02.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_NODE_TYPE_SPINE02.cfg
@@ -58,9 +58,9 @@ router bgp 65100
    router-id 192.168.255.2
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_NODE_TYPE_UNGROUPED_LEAF02.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_NODE_TYPE_UNGROUPED_LEAF02.cfg
@@ -70,9 +70,9 @@ router bgp 65102
    router-id 192.168.255.4
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-PYTHON_MODULES-L3LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-PYTHON_MODULES-L3LEAF1A.cfg
@@ -141,8 +141,8 @@ router bgp 65101
    router-id 192.168.255.21
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-PYTHON_MODULES-L3LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-PYTHON_MODULES-L3LEAF1B.cfg
@@ -141,8 +141,8 @@ router bgp 65101
    router-id 192.168.255.22
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-PYTHON_MODULES-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-PYTHON_MODULES-SPINE1.cfg
@@ -58,8 +58,8 @@ router bgp 65001
    router-id 192.168.255.1
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-TEMPLATES-L3LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-TEMPLATES-L3LEAF1A.cfg
@@ -141,8 +141,8 @@ router bgp 65101
    router-id 192.168.255.21
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-TEMPLATES-L3LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-TEMPLATES-L3LEAF1B.cfg
@@ -141,8 +141,8 @@ router bgp 65101
    router-id 192.168.255.22
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-TEMPLATES-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-TEMPLATES-SPINE1.cfg
@@ -58,8 +58,8 @@ router bgp 65001
    router-id 192.168.255.1
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1A.cfg
@@ -250,9 +250,9 @@ router bgp 65104
    router-id 192.168.255.14
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-CORE peer group
    neighbor EVPN-OVERLAY-CORE update-source Loopback0
    neighbor EVPN-OVERLAY-CORE bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1B.cfg
@@ -228,9 +228,9 @@ router bgp 65105
    router-id 192.168.255.15
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-CORE peer group
    neighbor EVPN-OVERLAY-CORE update-source Loopback0
    neighbor EVPN-OVERLAY-CORE bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL2A.cfg
@@ -164,9 +164,9 @@ router bgp 65106
    router-id 192.168.255.16
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    bgp bestpath d-path
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL2B.cfg
@@ -162,9 +162,9 @@ router bgp 65107
    router-id 192.168.255.17
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    bgp bestpath d-path
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-CL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-CL1A.cfg
@@ -232,9 +232,9 @@ router bgp 65108
    router-id 192.168.255.18
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-CL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-CL1B.cfg
@@ -236,9 +236,9 @@ router bgp 65109
    router-id 192.168.255.19
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF1A.cfg
@@ -261,9 +261,9 @@ router bgp 65101
    router-id 192.168.255.9
    graceful-restart restart-time 500
    graceful-restart
+   maximum-paths 4 ecmp 4
    bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2A.cfg
@@ -617,9 +617,9 @@ router bfd
 !
 router bgp 65102
    router-id 192.168.255.10
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2B.cfg
@@ -580,9 +580,9 @@ router bfd
 !
 router bgp 65102
    router-id 192.168.255.11
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SPINE1.cfg
@@ -217,9 +217,9 @@ router bgp 65001
    router-id 192.168.255.1
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SPINE2.cfg
@@ -187,9 +187,9 @@ router bgp 65001
    router-id 192.168.255.2
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SPINE3.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SPINE3.cfg
@@ -182,9 +182,9 @@ router bgp 65001
    router-id 192.168.255.3
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SPINE4.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SPINE4.cfg
@@ -182,9 +182,9 @@ router bgp 65001
    router-id 192.168.255.4
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3A.cfg
@@ -876,9 +876,9 @@ router bgp 65103
    router-id 192.168.255.12
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3B.cfg
@@ -841,9 +841,9 @@ router bgp 65103
    router-id 192.168.255.13
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1_UNDEPLOYED_LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1_UNDEPLOYED_LEAF1A.cfg
@@ -499,9 +499,9 @@ router bgp 65110
    router-id 192.168.255.21
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1_UNDEPLOYED_LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1_UNDEPLOYED_LEAF1B.cfg
@@ -499,9 +499,9 @@ router bgp 65111
    router-id 192.168.255.22
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF1A.cfg
@@ -807,8 +807,8 @@ router bgp 65101
    router-id 192.168.255.3
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF1B.cfg
@@ -807,8 +807,8 @@ router bgp 65101
    router-id 192.168.255.4
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF2A.cfg
@@ -547,8 +547,8 @@ router bgp 65103
    router-id 192.168.255.5
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF3A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF3A.cfg
@@ -569,8 +569,8 @@ router bgp 65104
    router-id 192.168.255.6
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF3B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF3B.cfg
@@ -569,8 +569,8 @@ router bgp 65105
    router-id 192.168.255.7
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-SPINE1.cfg
@@ -84,8 +84,8 @@ router bgp 65001
    router-id 192.168.255.1
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/IGMP-QUERIER-L3LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/IGMP-QUERIER-L3LEAF1A.cfg
@@ -243,8 +243,8 @@ router bgp 65101
    router-id 192.168.255.1
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MH-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MH-LEAF1A.cfg
@@ -346,8 +346,8 @@ router bgp 65151
    router-id 192.168.255.33
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MH-LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MH-LEAF1B.cfg
@@ -346,8 +346,8 @@ router bgp 65152
    router-id 192.168.255.34
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MH-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MH-LEAF2A.cfg
@@ -162,8 +162,8 @@ router bgp 65153
    router-id 192.168.255.35
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MLAG-OSPF-L3LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MLAG-OSPF-L3LEAF1A.cfg
@@ -117,8 +117,8 @@ router bgp 65161
    router-id 192.168.255.36
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MLAG-OSPF-L3LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MLAG-OSPF-L3LEAF1B.cfg
@@ -117,8 +117,8 @@ router bgp 65161
    router-id 192.168.255.37
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_CVX_L3LEAF1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_CVX_L3LEAF1.cfg
@@ -63,8 +63,8 @@ router bgp 65001
    router-id 192.168.254.1
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_CVX_L3LEAF2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_CVX_L3LEAF2.cfg
@@ -63,8 +63,8 @@ router bgp 65002
    router-id 192.168.254.2
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF1.cfg
@@ -90,8 +90,8 @@ router bgp 65001
    router-id 192.168.254.1
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF2.cfg
@@ -90,8 +90,8 @@ router bgp 65002
    router-id 192.168.254.2
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3A.cfg
@@ -139,8 +139,8 @@ router bgp 65003
    router-id 192.168.254.3
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3B.cfg
@@ -139,8 +139,8 @@ router bgp 65003
    router-id 192.168.254.4
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF1.cfg
@@ -80,8 +80,8 @@ router bgp 65001
    router-id 192.168.255.1
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF2.cfg
@@ -80,8 +80,8 @@ router bgp 65002
    router-id 192.168.255.2
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF3.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF3.cfg
@@ -80,8 +80,8 @@ router bgp 65003
    router-id 192.168.255.3
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF4.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF4.cfg
@@ -80,8 +80,8 @@ router bgp 65004
    router-id 192.168.255.4
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF5.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF5.cfg
@@ -80,8 +80,8 @@ router bgp 65005
    router-id 192.168.255.5
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF6.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF6.cfg
@@ -80,8 +80,8 @@ router bgp 65006
    router-id 192.168.255.6
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF7.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF7.cfg
@@ -80,8 +80,8 @@ router bgp 65007
    router-id 192.168.255.7
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SVI_PROFILE_NODE_1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SVI_PROFILE_NODE_1.cfg
@@ -243,8 +243,8 @@ router bgp 65001
    router-id 192.168.255.1
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SVI_PROFILE_NODE_2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SVI_PROFILE_NODE_2.cfg
@@ -243,8 +243,8 @@ router bgp 65002
    router-id 192.168.255.1
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L3LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L3LEAF1A.cfg
@@ -136,8 +136,8 @@ router bgp 65101
    router-id 192.168.255.3
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L3LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L3LEAF1B.cfg
@@ -123,8 +123,8 @@ router bgp 65101
    router-id 192.168.255.4
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L3LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L3LEAF2A.cfg
@@ -113,8 +113,8 @@ router bgp 65102
    router-id 192.168.255.5
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L3LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L3LEAF2B.cfg
@@ -113,8 +113,8 @@ router bgp 65102
    router-id 192.168.255.6
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-SPINE1.cfg
@@ -76,8 +76,8 @@ router bgp 65001
    router-id 192.168.255.1
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-SPINE2.cfg
@@ -72,8 +72,8 @@ router bgp 65001
    router-id 192.168.255.2
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY_FILTER_PEER_AS_L3LEAF1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY_FILTER_PEER_AS_L3LEAF1.cfg
@@ -56,8 +56,8 @@ router bgp 65001
    router-id 192.168.255.3
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY_FILTER_PEER_AS_SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY_FILTER_PEER_AS_SPINE1.cfg
@@ -45,8 +45,8 @@ router bgp 65000
    router-id 192.168.255.1
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY_FILTER_PEER_AS_SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY_FILTER_PEER_AS_SPINE2.cfg
@@ -45,8 +45,8 @@ router bgp 65000
    router-id 192.168.255.2
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1A.cfg
@@ -139,8 +139,8 @@ router bgp 65101
    router-id 192.168.255.3
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1B.cfg
@@ -139,8 +139,8 @@ router bgp 65101
    router-id 192.168.255.4
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UPLINK-MLAG-STRUCTURED-CONFIG-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UPLINK-MLAG-STRUCTURED-CONFIG-SPINE1.cfg
@@ -60,8 +60,8 @@ router bgp 65001
    router-id 192.168.255.1
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/bgp-peer-groups-structured-config-1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/bgp-peer-groups-structured-config-1.cfg
@@ -96,8 +96,8 @@ router bgp 65001
    router-id 192.168.255.111
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS remote-as 65001
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/bgp-peer-groups-structured-config-2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/bgp-peer-groups-structured-config-2.cfg
@@ -96,9 +96,9 @@ router bgp 65001
    router-id 192.168.255.112
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    bgp cluster-id 192.168.255.112
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS remote-as 65001
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/bgp-peer-groups-structured-config-3.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/bgp-peer-groups-structured-config-3.cfg
@@ -33,8 +33,8 @@ router bgp 65001
    router-id 192.168.255.114
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    bgp bestpath d-path
    neighbor IPVPN-GATEWAY-PEERS peer group
    neighbor IPVPN-GATEWAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cvp-instance-ips-cvaas.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cvp-instance-ips-cvaas.cfg
@@ -42,8 +42,8 @@ router bgp 1234
    router-id 1.2.3.1
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/default_overlay_protocol_cvx.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/default_overlay_protocol_cvx.cfg
@@ -33,8 +33,8 @@ router bgp 65000
    router-id 192.168.0.42
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/default_overlay_protocol_her.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/default_overlay_protocol_her.cfg
@@ -33,8 +33,8 @@ router bgp 65000
    router-id 192.168.0.42
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/device.with.dots.in.hostname.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/device.with.dots.in.hostname.cfg
@@ -38,8 +38,8 @@ router bgp 1234
    router-id 1.2.3.1
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_false.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_false.cfg
@@ -441,8 +441,8 @@ router bgp 101
    router-id 192.168.255.109
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_true.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_true.cfg
@@ -195,8 +195,8 @@ router bgp 101
    router-id 192.168.255.109
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-parent-vrf.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-parent-vrf.cfg
@@ -120,8 +120,8 @@ router bgp 65001
    router-id 10.0.255.2
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-parent.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-parent.cfg
@@ -125,8 +125,8 @@ router bgp 65000
    router-id 10.0.255.1
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/l3_edge_bgp.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/l3_edge_bgp.cfg
@@ -102,8 +102,8 @@ router bgp 65000
    router-id 1.2.3.1
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-leaf1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-leaf1.cfg
@@ -151,8 +151,8 @@ router bgp 65101
    router-id 10.254.1.1
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-leaf2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-leaf2.cfg
@@ -132,8 +132,8 @@ router bgp 65102
    router-id 10.254.1.2
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-spine1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-spine1.cfg
@@ -157,8 +157,8 @@ router bgp 65200
    router-id 10.255.0.1
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-spine2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-spine2.cfg
@@ -113,8 +113,8 @@ router bgp 65200
    router-id 10.255.0.2
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-spine3.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-spine3.cfg
@@ -56,8 +56,8 @@ router bgp 65200
    router-id 10.255.0.3
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l3leaf1a.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l3leaf1a.cfg
@@ -307,8 +307,8 @@ router bgp 65001
    router-id 192.168.250.9
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l3leaf1b.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l3leaf1b.cfg
@@ -287,8 +287,8 @@ router bgp 65001
    router-id 192.168.250.10
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l3leaf2a.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l3leaf2a.cfg
@@ -153,8 +153,8 @@ router bgp 65002
    router-id 192.168.250.11
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l3leaf2b.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l3leaf2b.cfg
@@ -148,8 +148,8 @@ router bgp 65002
    router-id 192.168.250.12
    graceful-restart restart-time 300
    graceful-restart
-   no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
+   no bgp default ipv4-unicast
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF1A.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.3
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF1B.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.4
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF2.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.5
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF3A.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.7
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF3B.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.8
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF4A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF4A.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.9
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF4B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF4B.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.10
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF5A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF5A.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.11
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF7A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF7A.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.13
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF7B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF7B.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.14
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF8A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF8A.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.15
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF8B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF8B.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.16
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_UNGROUPED_LEAF6.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_UNGROUPED_LEAF6.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.12
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_NODE_TYPE_LEAF01.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_NODE_TYPE_LEAF01.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.3
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_NODE_TYPE_SPINE01.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_NODE_TYPE_SPINE01.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.1
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_NODE_TYPE_SPINE02.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_NODE_TYPE_SPINE02.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.2
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_NODE_TYPE_UNGROUPED_LEAF02.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_NODE_TYPE_UNGROUPED_LEAF02.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.4
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-PYTHON_MODULES-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-PYTHON_MODULES-L3LEAF1A.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65101'
   router_id: 192.168.255.21
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-PYTHON_MODULES-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-PYTHON_MODULES-L3LEAF1B.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65101'
   router_id: 192.168.255.22
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-PYTHON_MODULES-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-PYTHON_MODULES-SPINE1.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65001'
   router_id: 192.168.255.1
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-TEMPLATES-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-TEMPLATES-L3LEAF1A.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65101'
   router_id: 192.168.255.21
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-TEMPLATES-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-TEMPLATES-L3LEAF1B.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65101'
   router_id: 192.168.255.22
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-TEMPLATES-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-TEMPLATES-SPINE1.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65001'
   router_id: 192.168.255.1
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1A.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.14
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1B.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.15
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL2A.yml
@@ -3,12 +3,14 @@ router_bgp:
   router_id: 192.168.255.16
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
     bestpath:
       d_path: true
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL2B.yml
@@ -3,12 +3,14 @@ router_bgp:
   router_id: 192.168.255.17
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
     bestpath:
       d_path: true
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-CL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-CL1A.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.18
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-CL1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-CL1B.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.19
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF1A.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.9
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: true
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 500

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.10
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.11
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   peer_groups:
   - name: UNDERLAY-PEERS
     type: ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SPINE1.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.1
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SPINE2.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.2
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SPINE3.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.3
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SPINE4.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.4
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3A.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.12
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3B.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.13
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1_UNDEPLOYED_LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1_UNDEPLOYED_LEAF1A.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.21
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1_UNDEPLOYED_LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1_UNDEPLOYED_LEAF1B.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.22
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF1A.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65101'
   router_id: 192.168.255.3
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF1B.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65101'
   router_id: 192.168.255.4
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF2A.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65103'
   router_id: 192.168.255.5
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF3A.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65104'
   router_id: 192.168.255.6
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF3B.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65105'
   router_id: 192.168.255.7
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-SPINE1.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65001'
   router_id: 192.168.255.1
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/IGMP-QUERIER-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/IGMP-QUERIER-L3LEAF1A.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65101'
   router_id: 192.168.255.1
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF1A.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65151'
   router_id: 192.168.255.33
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF1B.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65152'
   router_id: 192.168.255.34
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF2A.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65153'
   router_id: 192.168.255.35
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG-OSPF-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG-OSPF-L3LEAF1A.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65161'
   router_id: 192.168.255.36
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG-OSPF-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG-OSPF-L3LEAF1B.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65161'
   router_id: 192.168.255.37
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_CVX_L3LEAF1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_CVX_L3LEAF1.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65001'
   router_id: 192.168.254.1
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_CVX_L3LEAF2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_CVX_L3LEAF2.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65002'
   router_id: 192.168.254.2
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF1.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65001'
   router_id: 192.168.254.1
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF2.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65002'
   router_id: 192.168.254.2
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3A.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65003'
   router_id: 192.168.254.3
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3B.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65003'
   router_id: 192.168.254.4
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF1.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65001'
   router_id: 192.168.255.1
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF2.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65002'
   router_id: 192.168.255.2
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF3.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF3.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65003'
   router_id: 192.168.255.3
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF4.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF4.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65004'
   router_id: 192.168.255.4
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF5.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF5.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65005'
   router_id: 192.168.255.5
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF6.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF6.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65006'
   router_id: 192.168.255.6
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF7.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF7.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65007'
   router_id: 192.168.255.7
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/SVI_PROFILE_NODE_1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/SVI_PROFILE_NODE_1.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65001'
   router_id: 192.168.255.1
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/SVI_PROFILE_NODE_2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/SVI_PROFILE_NODE_2.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65002'
   router_id: 192.168.255.1
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF1A.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65101'
   router_id: 192.168.255.3
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF1B.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65101'
   router_id: 192.168.255.4
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF2A.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65102'
   router_id: 192.168.255.5
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF2B.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65102'
   router_id: 192.168.255.6
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-SPINE1.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65001'
   router_id: 192.168.255.1
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-SPINE2.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65001'
   router_id: 192.168.255.2
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY_FILTER_PEER_AS_L3LEAF1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY_FILTER_PEER_AS_L3LEAF1.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65001'
   router_id: 192.168.255.3
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY_FILTER_PEER_AS_SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY_FILTER_PEER_AS_SPINE1.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65000'
   router_id: 192.168.255.1
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY_FILTER_PEER_AS_SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY_FILTER_PEER_AS_SPINE2.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65000'
   router_id: 192.168.255.2
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1A.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65101'
   router_id: 192.168.255.3
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1B.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65101'
   router_id: 192.168.255.4
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-SPINE1.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65001'
   router_id: 192.168.255.1
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-structured-config-1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-structured-config-1.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65001'
   router_id: 192.168.255.111
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-structured-config-2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-structured-config-2.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65001'
   router_id: 192.168.255.112
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-structured-config-3.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-structured-config-3.yml
@@ -1,13 +1,15 @@
 router_bgp:
   as: '65001'
   router_id: 192.168.255.114
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
     bestpath:
       d_path: true
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cvp-instance-ips-cvaas.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cvp-instance-ips-cvaas.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '1234'
   router_id: 1.2.3.1
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/default_overlay_protocol_cvx.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/default_overlay_protocol_cvx.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65000'
   router_id: 192.168.0.42
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/default_overlay_protocol_her.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/default_overlay_protocol_her.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65000'
   router_id: 192.168.0.42
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/device.with.dots.in.hostname.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/device.with.dots.in.hostname.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '1234'
   router_id: 1.2.3.1
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_false.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_false.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '101'
   router_id: 192.168.255.109
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_true.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_true.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '101'
   router_id: 192.168.255.109
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-parent-vrf.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-parent-vrf.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65001'
   router_id: 10.0.255.2
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-parent.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-parent.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65000'
   router_id: 10.0.255.1
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/l3_edge_bgp.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/l3_edge_bgp.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65000'
   router_id: 1.2.3.1
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-leaf1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-leaf1.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65101'
   router_id: 10.254.1.1
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-leaf2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-leaf2.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65102'
   router_id: 10.254.1.2
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-spine1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-spine1.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65200'
   router_id: 10.255.0.1
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-spine2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-spine2.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65200'
   router_id: 10.255.0.2
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-spine3.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-spine3.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65200'
   router_id: 10.255.0.3
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf1a.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf1a.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65001'
   router_id: 192.168.250.9
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf1b.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf1b.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65001'
   router_id: 192.168.250.10
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf2a.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf2a.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65002'
   router_id: 192.168.250.11
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf2b.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf2b.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65002'
   router_id: 192.168.250.12
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-BL1A.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.14
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-BL1B.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.15
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-BL2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-BL2A.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.16
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-BL2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-BL2B.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.17
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-CL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-CL1A.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.18
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-CL1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-CL1B.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.19
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-LEAF1A.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.9
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-LEAF2A.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.10
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-LEAF2B.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.11
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SPINE1.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.1
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SPINE2.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.2
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SPINE3.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.3
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SPINE4.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.4
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SVC3A.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.12
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SVC3B.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.13
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/MH-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/MH-LEAF1A.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65151'
   router_id: 192.168.255.33
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/MH-LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/MH-LEAF1B.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65152'
   router_id: 192.168.255.34
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/MH-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/MH-LEAF2A.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '65153'
   router_id: 192.168.255.35
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/cvp-instance-ips-cvaas.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/cvp-instance-ips-cvaas.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '1234'
   router_id: 1.2.3.1
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/evpn_services_l2_only_false.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/evpn_services_l2_only_false.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '101'
   router_id: 192.168.255.109
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/evpn_services_l2_only_true.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/evpn_services_l2_only_true.yml
@@ -1,11 +1,13 @@
 router_bgp:
   as: '101'
   router_id: 192.168.255.109
-  bgp_defaults:
-  - maximum-paths 4 ecmp 4
+  bgp_defaults: []
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -589,10 +589,10 @@ ip route vrf Tenant_A_WAN_Zone 10.3.5.0/24 Null0
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -671,9 +671,9 @@ router bgp 65104
    router-id 192.168.255.14
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -587,10 +587,10 @@ ip route vrf Tenant_A_WAN_Zone 10.3.5.0/24 Null0
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -669,9 +669,9 @@ router bgp 65105
    router-id 192.168.255.15
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
@@ -585,10 +585,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -660,9 +660,9 @@ router bgp 65101
    router-id 192.168.255.9
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -884,10 +884,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -970,9 +970,9 @@ router bgp 65102
    router-id 192.168.255.10
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -884,10 +884,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -970,9 +970,9 @@ router bgp 65102
    router-id 192.168.255.11
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE1.md
@@ -389,10 +389,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -451,9 +451,9 @@ router bgp 65001
    router-id 192.168.255.1
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE2.md
@@ -389,10 +389,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -451,9 +451,9 @@ router bgp 65001
    router-id 192.168.255.2
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE3.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE3.md
@@ -389,10 +389,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -451,9 +451,9 @@ router bgp 65001
    router-id 192.168.255.3
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE4.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE4.md
@@ -389,10 +389,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -451,9 +451,9 @@ router bgp 65001
    router-id 192.168.255.4
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -1248,10 +1248,10 @@ ip route vrf Tenant_A_WAN_Zone 10.3.5.0/24 Null0
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -1359,9 +1359,9 @@ router bgp 65103
    router-id 192.168.255.12
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -1248,10 +1248,10 @@ ip route vrf Tenant_A_WAN_Zone 10.3.5.0/24 Null0
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -1359,9 +1359,9 @@ router bgp 65103
    router-id 192.168.255.13
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1A.cfg
@@ -228,9 +228,9 @@ router bgp 65104
    router-id 192.168.255.14
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1B.cfg
@@ -227,9 +227,9 @@ router bgp 65105
    router-id 192.168.255.15
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF1A.cfg
@@ -208,9 +208,9 @@ router bgp 65101
    router-id 192.168.255.9
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
@@ -420,9 +420,9 @@ router bgp 65102
    router-id 192.168.255.10
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
@@ -420,9 +420,9 @@ router bgp 65102
    router-id 192.168.255.11
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE1.cfg
@@ -118,9 +118,9 @@ router bgp 65001
    router-id 192.168.255.1
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE2.cfg
@@ -118,9 +118,9 @@ router bgp 65001
    router-id 192.168.255.2
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE3.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE3.cfg
@@ -118,9 +118,9 @@ router bgp 65001
    router-id 192.168.255.3
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE4.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE4.cfg
@@ -118,9 +118,9 @@ router bgp 65001
    router-id 192.168.255.4
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
@@ -716,9 +716,9 @@ router bgp 65103
    router-id 192.168.255.12
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
@@ -716,9 +716,9 @@ router bgp 65103
    router-id 192.168.255.13
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.14
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.15
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.9
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.10
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.11
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE1.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.1
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE2.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.2
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE3.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.3
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE4.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.4
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.12
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.13
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1A.md
@@ -626,10 +626,10 @@ router isis EVPN_UNDERLAY
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -667,9 +667,9 @@ router bgp 65000
    router-id 192.168.255.10
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor OVERLAY-PEERS peer group
    neighbor OVERLAY-PEERS remote-as 65000
    neighbor OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1B.md
@@ -611,10 +611,10 @@ router isis EVPN_UNDERLAY
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -652,9 +652,9 @@ router bgp 65000
    router-id 192.168.255.11
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor OVERLAY-PEERS peer group
    neighbor OVERLAY-PEERS remote-as 65000
    neighbor OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF1A.md
@@ -461,10 +461,10 @@ router isis EVPN_UNDERLAY
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -502,9 +502,9 @@ router bgp 65000
    router-id 192.168.255.5
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor OVERLAY-PEERS peer group
    neighbor OVERLAY-PEERS remote-as 65000
    neighbor OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2A.md
@@ -626,10 +626,10 @@ router isis EVPN_UNDERLAY
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -667,9 +667,9 @@ router bgp 65000
    router-id 192.168.255.6
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor OVERLAY-PEERS peer group
    neighbor OVERLAY-PEERS remote-as 65000
    neighbor OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2B.md
@@ -626,10 +626,10 @@ router isis EVPN_UNDERLAY
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -667,9 +667,9 @@ router bgp 65000
    router-id 192.168.255.7
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor OVERLAY-PEERS peer group
    neighbor OVERLAY-PEERS remote-as 65000
    neighbor OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE1.md
@@ -461,10 +461,10 @@ router isis EVPN_UNDERLAY
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -508,10 +508,10 @@ router bgp 65000
    router-id 192.168.255.1
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    bgp cluster-id 192.168.255.1
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor OVERLAY-PEERS peer group
    neighbor OVERLAY-PEERS remote-as 65000
    neighbor OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE4.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE4.md
@@ -461,10 +461,10 @@ router isis EVPN_UNDERLAY
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -508,10 +508,10 @@ router bgp 65000
    router-id 192.168.255.4
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    bgp cluster-id 192.168.255.4
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor OVERLAY-PEERS peer group
    neighbor OVERLAY-PEERS remote-as 65000
    neighbor OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3A.md
@@ -619,10 +619,10 @@ router isis EVPN_UNDERLAY
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -660,9 +660,9 @@ router bgp 65000
    router-id 192.168.255.8
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor OVERLAY-PEERS peer group
    neighbor OVERLAY-PEERS remote-as 65000
    neighbor OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3B.md
@@ -619,10 +619,10 @@ router isis EVPN_UNDERLAY
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -660,9 +660,9 @@ router bgp 65000
    router-id 192.168.255.9
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor OVERLAY-PEERS peer group
    neighbor OVERLAY-PEERS remote-as 65000
    neighbor OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-BL1A.cfg
@@ -185,9 +185,9 @@ router bgp 65000
    router-id 192.168.255.10
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor OVERLAY-PEERS peer group
    neighbor OVERLAY-PEERS remote-as 65000
    neighbor OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-BL1B.cfg
@@ -173,9 +173,9 @@ router bgp 65000
    router-id 192.168.255.11
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor OVERLAY-PEERS peer group
    neighbor OVERLAY-PEERS remote-as 65000
    neighbor OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-LEAF1A.cfg
@@ -114,9 +114,9 @@ router bgp 65000
    router-id 192.168.255.5
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor OVERLAY-PEERS peer group
    neighbor OVERLAY-PEERS remote-as 65000
    neighbor OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-LEAF2A.cfg
@@ -186,9 +186,9 @@ router bgp 65000
    router-id 192.168.255.6
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor OVERLAY-PEERS peer group
    neighbor OVERLAY-PEERS remote-as 65000
    neighbor OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-LEAF2B.cfg
@@ -186,9 +186,9 @@ router bgp 65000
    router-id 192.168.255.7
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor OVERLAY-PEERS peer group
    neighbor OVERLAY-PEERS remote-as 65000
    neighbor OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SPINE1.cfg
@@ -129,10 +129,10 @@ router bgp 65000
    router-id 192.168.255.1
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    bgp cluster-id 192.168.255.1
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor OVERLAY-PEERS peer group
    neighbor OVERLAY-PEERS remote-as 65000
    neighbor OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SPINE4.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SPINE4.cfg
@@ -129,10 +129,10 @@ router bgp 65000
    router-id 192.168.255.4
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    bgp cluster-id 192.168.255.4
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor OVERLAY-PEERS peer group
    neighbor OVERLAY-PEERS remote-as 65000
    neighbor OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SVC3A.cfg
@@ -181,9 +181,9 @@ router bgp 65000
    router-id 192.168.255.8
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor OVERLAY-PEERS peer group
    neighbor OVERLAY-PEERS remote-as 65000
    neighbor OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SVC3B.cfg
@@ -181,9 +181,9 @@ router bgp 65000
    router-id 192.168.255.9
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor OVERLAY-PEERS peer group
    neighbor OVERLAY-PEERS remote-as 65000
    neighbor OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-BL1A.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.10
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-BL1B.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.11
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF1A.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.5
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.6
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.7
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SPINE1.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.1
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SPINE4.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.4
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SVC3A.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.8
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SVC3B.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.9
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -566,10 +566,10 @@ router ospf 101
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 10 ecmp 10 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 10 ecmp 10 |
 
 #### Router BGP Peer Groups
 
@@ -615,9 +615,9 @@ router bgp 65104
    router-id 192.168.255.10
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 10 ecmp 10
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 10 ecmp 10
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -566,10 +566,10 @@ router ospf 101
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 10 ecmp 10 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 10 ecmp 10 |
 
 #### Router BGP Peer Groups
 
@@ -615,9 +615,9 @@ router bgp 65104
    router-id 192.168.255.11
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 10 ecmp 10
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 10 ecmp 10
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
@@ -433,10 +433,10 @@ router ospf 101
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 10 ecmp 10 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 10 ecmp 10 |
 
 #### Router BGP Peer Groups
 
@@ -482,9 +482,9 @@ router bgp 65101
    router-id 192.168.255.5
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 10 ecmp 10
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 10 ecmp 10
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -626,10 +626,10 @@ router ospf 101
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 10 ecmp 10 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 10 ecmp 10 |
 
 #### Router BGP Peer Groups
 
@@ -698,9 +698,9 @@ router bgp 65102
    router-id 192.168.255.6
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 10 ecmp 10
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 10 ecmp 10
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -626,10 +626,10 @@ router ospf 101
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 10 ecmp 10 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 10 ecmp 10 |
 
 #### Router BGP Peer Groups
 
@@ -698,9 +698,9 @@ router bgp 65102
    router-id 192.168.255.7
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 10 ecmp 10
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 10 ecmp 10
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE1.md
@@ -417,10 +417,10 @@ router ospf 101
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 10 ecmp 10 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 10 ecmp 10 |
 
 #### Router BGP Peer Groups
 
@@ -464,9 +464,9 @@ router bgp 65001
    router-id 192.168.255.1
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 10 ecmp 10
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 10 ecmp 10
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE2.md
@@ -417,10 +417,10 @@ router ospf 101
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 10 ecmp 10 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 10 ecmp 10 |
 
 #### Router BGP Peer Groups
 
@@ -464,9 +464,9 @@ router bgp 65001
    router-id 192.168.255.2
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 10 ecmp 10
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 10 ecmp 10
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE3.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE3.md
@@ -417,10 +417,10 @@ router ospf 101
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 10 ecmp 10 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 10 ecmp 10 |
 
 #### Router BGP Peer Groups
 
@@ -464,9 +464,9 @@ router bgp 65001
    router-id 192.168.255.3
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 10 ecmp 10
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 10 ecmp 10
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE4.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE4.md
@@ -417,10 +417,10 @@ router ospf 101
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 10 ecmp 10 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 10 ecmp 10 |
 
 #### Router BGP Peer Groups
 
@@ -464,9 +464,9 @@ router bgp 65001
    router-id 192.168.255.4
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 10 ecmp 10
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 10 ecmp 10
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -619,10 +619,10 @@ router ospf 101
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 10 ecmp 10 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 10 ecmp 10 |
 
 #### Router BGP Peer Groups
 
@@ -691,9 +691,9 @@ router bgp 65103
    router-id 192.168.255.8
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 10 ecmp 10
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 10 ecmp 10
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -619,10 +619,10 @@ router ospf 101
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 10 ecmp 10 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 10 ecmp 10 |
 
 #### Router BGP Peer Groups
 
@@ -691,9 +691,9 @@ router bgp 65103
    router-id 192.168.255.9
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 10 ecmp 10
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 10 ecmp 10
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-BL1A.cfg
@@ -152,9 +152,9 @@ router bgp 65104
    router-id 192.168.255.10
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 10 ecmp 10
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 10 ecmp 10
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-BL1B.cfg
@@ -152,9 +152,9 @@ router bgp 65104
    router-id 192.168.255.11
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 10 ecmp 10
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 10 ecmp 10
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-LEAF1A.cfg
@@ -101,9 +101,9 @@ router bgp 65101
    router-id 192.168.255.5
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 10 ecmp 10
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 10 ecmp 10
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
@@ -194,9 +194,9 @@ router bgp 65102
    router-id 192.168.255.6
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 10 ecmp 10
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 10 ecmp 10
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
@@ -194,9 +194,9 @@ router bgp 65102
    router-id 192.168.255.7
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 10 ecmp 10
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 10 ecmp 10
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SPINE1.cfg
@@ -114,9 +114,9 @@ router bgp 65001
    router-id 192.168.255.1
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 10 ecmp 10
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 10 ecmp 10
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SPINE2.cfg
@@ -114,9 +114,9 @@ router bgp 65001
    router-id 192.168.255.2
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 10 ecmp 10
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 10 ecmp 10
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SPINE3.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SPINE3.cfg
@@ -114,9 +114,9 @@ router bgp 65001
    router-id 192.168.255.3
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 10 ecmp 10
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 10 ecmp 10
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SPINE4.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SPINE4.cfg
@@ -114,9 +114,9 @@ router bgp 65001
    router-id 192.168.255.4
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 10 ecmp 10
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 10 ecmp 10
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
@@ -189,9 +189,9 @@ router bgp 65103
    router-id 192.168.255.8
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 10 ecmp 10
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 10 ecmp 10
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
@@ -189,9 +189,9 @@ router bgp 65103
    router-id 192.168.255.9
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 10 ecmp 10
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 10 ecmp 10
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.10
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 10 ecmp 10
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 10
+    ecmp: 10
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.11
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 10 ecmp 10
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 10
+    ecmp: 10
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.5
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 10 ecmp 10
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 10
+    ecmp: 10
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.6
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 10 ecmp 10
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 10
+    ecmp: 10
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.7
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 10 ecmp 10
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 10
+    ecmp: 10
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SPINE1.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.1
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 10 ecmp 10
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 10
+    ecmp: 10
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SPINE2.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.2
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 10 ecmp 10
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 10
+    ecmp: 10
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SPINE3.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.3
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 10 ecmp 10
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 10
+    ecmp: 10
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SPINE4.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.4
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 10 ecmp 10
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 10
+    ecmp: 10
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.8
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 10 ecmp 10
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 10
+    ecmp: 10
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.9
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 10 ecmp 10
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 10
+    ecmp: 10
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -569,10 +569,10 @@ router general
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -656,9 +656,9 @@ router bgp 65104
    router-id 192.168.255.10
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -546,10 +546,10 @@ ip route vrf Tenant_A_WAN_Zone 10.3.4.0/24 1.2.3.4
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -633,9 +633,9 @@ router bgp 65105
    router-id 192.168.255.11
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
@@ -548,10 +548,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -628,9 +628,9 @@ router bgp 65101
    router-id 192.168.255.5
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -921,10 +921,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -1028,9 +1028,9 @@ router bgp 65102
    router-id 192.168.255.6
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -921,10 +921,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -1028,9 +1028,9 @@ router bgp 65102
    router-id 192.168.255.7
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF3A.md
@@ -840,10 +840,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -941,9 +941,9 @@ router bgp 65106
    router-id 192.168.255.12
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF3B.md
@@ -840,10 +840,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -941,9 +941,9 @@ router bgp 65106
    router-id 192.168.255.13
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF4A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF4A.md
@@ -840,10 +840,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -941,9 +941,9 @@ router bgp 65107
    router-id 192.168.255.14
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF4B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF4B.md
@@ -840,10 +840,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -941,9 +941,9 @@ router bgp 65107
    router-id 192.168.255.15
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE1.md
@@ -372,10 +372,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -439,9 +439,9 @@ router bgp 65001
    router-id 192.168.255.1
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE2.md
@@ -372,10 +372,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -439,9 +439,9 @@ router bgp 65001
    router-id 192.168.255.2
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE3.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE3.md
@@ -372,10 +372,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -439,9 +439,9 @@ router bgp 65001
    router-id 192.168.255.3
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE4.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE4.md
@@ -372,10 +372,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -439,9 +439,9 @@ router bgp 65001
    router-id 192.168.255.4
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE5.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE5.md
@@ -334,10 +334,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -391,9 +391,9 @@ router bgp 65001
    router-id 192.168.255.5
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE6.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE6.md
@@ -334,10 +334,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -391,9 +391,9 @@ router bgp 65001
    router-id 192.168.255.6
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -1106,10 +1106,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -1222,9 +1222,9 @@ router bgp 65103
    router-id 192.168.255.8
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -1080,10 +1080,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | BGP Tuning |
 | ---------- |
 | distance bgp 20 200 200 |
-| maximum-paths 4 ecmp 4 |
 | graceful-restart restart-time 300 |
 | graceful-restart |
 | no bgp default ipv4-unicast |
+| maximum-paths 4 ecmp 4 |
 
 #### Router BGP Peer Groups
 
@@ -1196,9 +1196,9 @@ router bgp 65103
    router-id 192.168.255.9
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-BL1A.cfg
@@ -175,9 +175,9 @@ router bgp 65104
    router-id 192.168.255.10
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-BL1B.cfg
@@ -175,9 +175,9 @@ router bgp 65105
    router-id 192.168.255.11
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF1A.cfg
@@ -177,9 +177,9 @@ router bgp 65101
    router-id 192.168.255.5
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
@@ -440,9 +440,9 @@ router bgp 65102
    router-id 192.168.255.6
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
@@ -440,9 +440,9 @@ router bgp 65102
    router-id 192.168.255.7
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF3A.cfg
@@ -375,9 +375,9 @@ router bgp 65106
    router-id 192.168.255.12
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF3B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF3B.cfg
@@ -375,9 +375,9 @@ router bgp 65106
    router-id 192.168.255.13
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF4A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF4A.cfg
@@ -375,9 +375,9 @@ router bgp 65107
    router-id 192.168.255.14
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF4B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF4B.cfg
@@ -375,9 +375,9 @@ router bgp 65107
    router-id 192.168.255.15
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE1.cfg
@@ -107,9 +107,9 @@ router bgp 65001
    router-id 192.168.255.1
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE2.cfg
@@ -107,9 +107,9 @@ router bgp 65001
    router-id 192.168.255.2
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE3.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE3.cfg
@@ -107,9 +107,9 @@ router bgp 65001
    router-id 192.168.255.3
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE4.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE4.cfg
@@ -107,9 +107,9 @@ router bgp 65001
    router-id 192.168.255.4
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE5.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE5.cfg
@@ -79,9 +79,9 @@ router bgp 65001
    router-id 192.168.255.5
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE6.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE6.cfg
@@ -79,9 +79,9 @@ router bgp 65001
    router-id 192.168.255.6
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
@@ -588,9 +588,9 @@ router bgp 65103
    router-id 192.168.255.8
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
@@ -572,9 +572,9 @@ router bgp 65103
    router-id 192.168.255.9
    graceful-restart restart-time 300
    graceful-restart
+   maximum-paths 4 ecmp 4
    no bgp default ipv4-unicast
    distance bgp 20 200 200
-   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.10
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.11
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.5
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.6
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.7
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF3A.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.12
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF3B.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.13
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF4A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF4A.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.14
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF4B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF4B.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.15
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE1.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.1
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE2.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.2
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE3.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.3
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE4.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.4
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE5.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE5.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.5
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE6.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE6.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.6
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.8
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -3,10 +3,12 @@ router_bgp:
   router_id: 192.168.255.9
   bgp_defaults:
   - distance bgp 20 200 200
-  - maximum-paths 4 ecmp 4
   bgp:
     default:
       ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
   graceful_restart:
     enabled: true
     restart_time: 300

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/Management Settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/Management Settings.md
@@ -35,7 +35,7 @@ search:
     terminattr_smashexcludes: <str>
     ```
 
-## IPv6 Mgmt Destination Networks
+## IPv6 Management Destination Networks
 
 List of IPv6 prefixes to configure as static routes towards the OOB IPv6 Management interface gateway.
 Replaces the default route.
@@ -54,7 +54,7 @@ Replaces the default route.
       - <str>
     ```
 
-## IPv6 Mgmt Gateway
+## IPv6 Management Gateway
 
 OOB Management interface gateway in IPv6 format.
 Used as next-hop for default gateway or static routes defined under 'ipv6_mgmt_destination_networks'

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/base/avdstructuredconfig.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/base/avdstructuredconfig.py
@@ -31,11 +31,6 @@ class AvdStructuredConfig(AvdFacts):
 
         bgp_defaults = get(self.shared_utils.switch_data_combined, "bgp_defaults", default=[])
 
-        max_paths_str = f"maximum-paths {get(self._hostvars, 'bgp_maximum_paths', default=4)}"
-        if (bgp_ecmp := get(self._hostvars, "bgp_ecmp", default=4)) is not None:
-            max_paths_str += f" ecmp {bgp_ecmp}"
-        bgp_defaults.append(max_paths_str)
-
         router_bgp = {
             "as": self.shared_utils.bgp_as,
             "router_id": self.shared_utils.router_id,
@@ -44,6 +39,10 @@ class AvdStructuredConfig(AvdFacts):
                 "default": {
                     "ipv4_unicast": get(self._hostvars, "bgp_default_ipv4_unicast", default=False),
                 },
+            },
+            "maximum_paths": {
+                "paths": get(self._hostvars, "bgp_maximum_paths", default=4),
+                "ecmp": get(self._hostvars, "bgp_ecmp", default=4),
             },
         }
 

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -1327,13 +1327,13 @@
         "type": "string",
         "description": "IPv6_network/Mask"
       },
-      "title": "IPv6 Mgmt Destination Networks"
+      "title": "IPv6 Management Destination Networks"
     },
     "ipv6_mgmt_gateway": {
       "type": "string",
       "format": "ipv6",
       "description": "OOB Management interface gateway in IPv6 format.\nUsed as next-hop for default gateway or static routes defined under 'ipv6_mgmt_destination_networks'",
-      "title": "IPv6 Mgmt Gateway"
+      "title": "IPv6 Management Gateway"
     },
     "is_deployed": {
       "description": "Is device already deployed in the fabric\nWhen set to false, interfaces toward this device may be shutdown depending on the `shutdown_interfaces_towards_undeployed_peers` setting.\nFurthermore `eos_config_deploy_cvp` will not attempt to move or apply configurations to the device.\n",


### PR DESCRIPTION
## Change Summary

Leverage proper data model for bgp maximum-paths and ecmp

## Related Issue(s)

Fixes #2853 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

Update router_bgp base module to leverage proper keys in router_bgp structured config data model.
Molecule scenarios updated

## How to test

View molecule `- maximum-paths 4 ecmp 4` removed from defaults and added as proper keys in structured config


