### PR TITLE
Feat(eos_cli_config_gen): BGP RR preserve-attributes

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
@@ -147,7 +147,6 @@ router bgp 65101
    update wait-install
    no bgp default ipv4-unicast
    no bgp default ipv4-unicast transport ipv6
-
    bgp bestpath d-path
    bgp listen range 10.10.10.0/24 peer-group my-peer-group1 peer-filter my-peer-filter
    bgp listen range 12.10.10.0/24 peer-id include router-id peer-group my-peer-group3 remote-as 65444

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
@@ -58,6 +58,7 @@ interface Management1
 | no bgp default ipv4-unicast transport ipv6 |
 | distance bgp 20 200 200 |
 | maximum-paths 32 ecmp 32 |
+| bgp route-reflector preserve-attributes always |
 
 #### Router BGP Listen Ranges
 
@@ -145,6 +146,7 @@ router bgp 65101
    update wait-install
    no bgp default ipv4-unicast
    no bgp default ipv4-unicast transport ipv6
+   bgp route-reflector preserve-attributes always
    bgp bestpath d-path
    bgp listen range 10.10.10.0/24 peer-group my-peer-group1 peer-filter my-peer-filter
    bgp listen range 12.10.10.0/24 peer-id include router-id peer-group my-peer-group3 remote-as 65444

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
@@ -141,12 +141,13 @@ router bgp 65101
    graceful-restart stalepath-time 666
    graceful-restart
    graceful-restart-helper restart-time 888
+   bgp route-reflector preserve-attributes always
    maximum-paths 32 ecmp 32
    update wait-for-convergence
    update wait-install
    no bgp default ipv4-unicast
    no bgp default ipv4-unicast transport ipv6
-   bgp route-reflector preserve-attributes always
+
    bgp bestpath d-path
    bgp listen range 10.10.10.0/24 peer-group my-peer-group1 peer-filter my-peer-filter
    bgp listen range 12.10.10.0/24 peer-id include router-id peer-group my-peer-group3 remote-as 65444

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-base.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-base.cfg
@@ -24,6 +24,7 @@ router bgp 65101
    update wait-install
    no bgp default ipv4-unicast
    no bgp default ipv4-unicast transport ipv6
+   bgp route-reflector preserve-attributes always
    bgp bestpath d-path
    bgp listen range 10.10.10.0/24 peer-group my-peer-group1 peer-filter my-peer-filter
    bgp listen range 12.10.10.0/24 peer-id include router-id peer-group my-peer-group3 remote-as 65444

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-base.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-base.cfg
@@ -19,12 +19,13 @@ router bgp 65101
    graceful-restart stalepath-time 666
    graceful-restart
    graceful-restart-helper restart-time 888
+   bgp route-reflector preserve-attributes always
    maximum-paths 32 ecmp 32
    update wait-for-convergence
    update wait-install
    no bgp default ipv4-unicast
    no bgp default ipv4-unicast transport ipv6
-   bgp route-reflector preserve-attributes always
+
    bgp bestpath d-path
    bgp listen range 10.10.10.0/24 peer-group my-peer-group1 peer-filter my-peer-filter
    bgp listen range 12.10.10.0/24 peer-id include router-id peer-group my-peer-group3 remote-as 65444

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-base.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-base.cfg
@@ -25,7 +25,6 @@ router bgp 65101
    update wait-install
    no bgp default ipv4-unicast
    no bgp default ipv4-unicast transport ipv6
-
    bgp bestpath d-path
    bgp listen range 10.10.10.0/24 peer-group my-peer-group1 peer-filter my-peer-filter
    bgp listen range 12.10.10.0/24 peer-id include router-id peer-group my-peer-group3 remote-as 65444

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-base.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-base.yml
@@ -23,6 +23,9 @@ router_bgp:
     default:
       ipv4_unicast: false
       ipv4_unicast_transport_ipv6: false
+    route_reflector_preserve_attributes:
+      enabled: true
+      always: true
     bestpath:
       d_path: true
   listen_ranges:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -4738,6 +4738,9 @@ Set Link Aggregation Control Protocol (LACP) parameters.
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;default</samp>](## "router_bgp.bgp.default") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_unicast</samp>](## "router_bgp.bgp.default.ipv4_unicast") | Boolean |  |  |  | Default activation of IPv4 unicast address-family on all IPv4 neighbors (EOS default = True). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_unicast_transport_ipv6</samp>](## "router_bgp.bgp.default.ipv4_unicast_transport_ipv6") | Boolean |  |  |  | Default activation of IPv4 unicast address-family on all IPv6 neighbors (EOS default == False). |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;route_reflector_preserve_attributes</samp>](## "router_bgp.bgp.route_reflector_preserve_attributes") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "router_bgp.bgp.route_reflector_preserve_attributes.enabled") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;always</samp>](## "router_bgp.bgp.route_reflector_preserve_attributes.always") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;bestpath</samp>](## "router_bgp.bgp.bestpath") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;d_path</samp>](## "router_bgp.bgp.bestpath.d_path") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;listen_ranges</samp>](## "router_bgp.listen_ranges") | List, items: Dictionary |  |  |  | Improved "listen_ranges" data model to support multiple listen ranges and additional filter capabilities<br> |
@@ -5302,6 +5305,9 @@ Set Link Aggregation Control Protocol (LACP) parameters.
         default:
           ipv4_unicast: <bool>
           ipv4_unicast_transport_ipv6: <bool>
+        route_reflector_preserve_attributes:
+          enabled: <bool>
+          always: <bool>
         bestpath:
           d_path: <bool>
       listen_ranges:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -11611,6 +11611,24 @@
               },
               "title": "Default"
             },
+            "route_reflector_preserve_attributes": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "title": "Enabled"
+                },
+                "always": {
+                  "type": "boolean",
+                  "title": "Always"
+                }
+              },
+              "additionalProperties": false,
+              "patternProperties": {
+                "^_.+$": {}
+              },
+              "title": "Route Reflector Preserve Attributes"
+            },
             "bestpath": {
               "type": "object",
               "properties": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -6951,6 +6951,13 @@ keys:
                 type: bool
                 description: Default activation of IPv4 unicast address-family on
                   all IPv6 neighbors (EOS default == False).
+          route_reflector_preserve_attributes:
+            type: dict
+            keys:
+              enabled:
+                type: bool
+              always:
+                type: bool
           bestpath:
             type: dict
             keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_bgp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_bgp.schema.yml
@@ -126,6 +126,13 @@ keys:
               ipv4_unicast_transport_ipv6:
                 type: bool
                 description: Default activation of IPv4 unicast address-family on all IPv6 neighbors (EOS default == False).
+          route_reflector_preserve_attributes:
+            type: dict
+            keys:
+              enabled:
+                type: bool
+              always:
+                type: bool
           bestpath:
             type: dict
             keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
@@ -72,6 +72,13 @@
 {%             endif %}
 | {{ paths_cli }} |
 {%         endif %}
+{%         if router_bgp.bgp.route_reflector_preserve_attributes.enabled is arista.avd.defined(true) %}
+{%             set rr_preserve_attributes_cli = 'bgp route-reflector preserve-attributes' %}
+{%             if router_bgp.bgp.route_reflector_preserve_attributes.always is arista.avd.defined(true) %}
+{%                 set rr_preserve_attributes_cli = rr_preserve_attributes_cli ~ ' always' %}
+{%             endif %}
+| {{ rr_preserve_attributes_cli }} |
+{%         endif %}
 {%     endif %}
 {# Check if listen_ranges exist under router_bgp.vrfs #}
 {%     set temp = namespace() %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -53,6 +53,13 @@ router bgp {{ router_bgp.as }}
 {%     elif router_bgp.bgp.default.ipv4_unicast_transport_ipv6 is arista.avd.defined(false) %}
    no bgp default ipv4-unicast transport ipv6
 {%     endif %}
+{%     if router_bgp.bgp.route_reflector_preserve_attributes.enabled is arista.avd.defined(true) %}
+{%         set rr_preserve_attributes_cli = 'bgp route-reflector preserve-attributes' %}
+{%         if router_bgp.bgp.route_reflector_preserve_attributes.always is arista.avd.defined(true) %}
+{%             set rr_preserve_attributes_cli = rr_preserve_attributes_cli ~ ' always' %}
+{%         endif %}
+   {{ rr_preserve_attributes_cli }}
+{%     endif %}
 {%     if router_bgp.bgp_cluster_id is arista.avd.defined %}
    bgp cluster-id {{ router_bgp.bgp_cluster_id }}
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -60,7 +60,6 @@ router bgp {{ router_bgp.as }}
 {%     elif router_bgp.bgp.default.ipv4_unicast_transport_ipv6 is arista.avd.defined(false) %}
    no bgp default ipv4-unicast transport ipv6
 {%     endif %}
-
 {%     if router_bgp.bgp_cluster_id is arista.avd.defined %}
    bgp cluster-id {{ router_bgp.bgp_cluster_id }}
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -30,6 +30,13 @@ router bgp {{ router_bgp.as }}
    graceful-restart-helper long-lived
 {%         endif %}
 {%     endif %}
+{%     if router_bgp.bgp.route_reflector_preserve_attributes.enabled is arista.avd.defined(true) %}
+{%         set rr_preserve_attributes_cli = 'bgp route-reflector preserve-attributes' %}
+{%         if router_bgp.bgp.route_reflector_preserve_attributes.always is arista.avd.defined(true) %}
+{%             set rr_preserve_attributes_cli = rr_preserve_attributes_cli ~ ' always' %}
+{%         endif %}
+   {{ rr_preserve_attributes_cli }}
+{%     endif %}
 {%     if router_bgp.maximum_paths.paths is arista.avd.defined %}
 {%         set paths_cli = "maximum-paths " ~ router_bgp.maximum_paths.paths %}
 {%         if router_bgp.maximum_paths.ecmp is arista.avd.defined %}
@@ -53,13 +60,7 @@ router bgp {{ router_bgp.as }}
 {%     elif router_bgp.bgp.default.ipv4_unicast_transport_ipv6 is arista.avd.defined(false) %}
    no bgp default ipv4-unicast transport ipv6
 {%     endif %}
-{%     if router_bgp.bgp.route_reflector_preserve_attributes.enabled is arista.avd.defined(true) %}
-{%         set rr_preserve_attributes_cli = 'bgp route-reflector preserve-attributes' %}
-{%         if router_bgp.bgp.route_reflector_preserve_attributes.always is arista.avd.defined(true) %}
-{%             set rr_preserve_attributes_cli = rr_preserve_attributes_cli ~ ' always' %}
-{%         endif %}
-   {{ rr_preserve_attributes_cli }}
-{%     endif %}
+
 {%     if router_bgp.bgp_cluster_id is arista.avd.defined %}
    bgp cluster-id {{ router_bgp.bgp_cluster_id }}
 {%     endif %}


### PR DESCRIPTION
## Change Summary

Implements data model for bgp route-reflector preserve-attributes (always) command.

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

```yaml
router_bgp:
  bgp:
    route_reflector_preserve_attributes:
      enabled: <bool>
      always: <bool>
```

## How to test

Tested with molecule and on eos device to verify config order.

### Repository Checklist

- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
