### PR TITLE
Test(plugins): Remove modern annotations and walrus operators from plugins to pass galaxy-importer tests

### DIFF
--- a/ansible_collections/arista/avd/plugins/action/batch_template.py
+++ b/ansible_collections/arista/avd/plugins/action/batch_template.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, annotations, division, print_function
+from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 

--- a/ansible_collections/arista/avd/plugins/action/inventory_to_container.py
+++ b/ansible_collections/arista/avd/plugins/action/inventory_to_container.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, annotations, division, print_function
+from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
@@ -29,7 +29,8 @@ class ActionModule(ActionBase):
             result["cvp_topology"] = self.build_cvp_topology_from_inventory(task_vars, module_args)
 
         # Write vars to file if set by user
-        if (destination := module_args.get("destination")) is not None:
+        destination = module_args.get("destination")
+        if destination is not None:
             # file should only contain subset of result data, so we build a smaller dict
             file_data_keys = ["cvp_configlets", "cvp_topology"]
             file_data = {key: result[key] for key in file_data_keys if key in result}
@@ -77,11 +78,11 @@ class ActionModule(ActionBase):
 
         return cvp_topology
 
-    def get_group_data(self, group: Group, device_filter: list[str], all_groups_from_root: set[Group] = None, parent_container: str = None) -> dict:
+    def get_group_data(self, group: Group, device_filter: list, all_groups_from_root: set = None, parent_container: str = None) -> dict:
         # Find parent container if not set
         if parent_container is None:
             # Only evaluate parent_groups which are part of all_groups_from_root. A group can have multiple parents.
-            parent_groups: set[Group] = set(group.parent_groups).intersection(all_groups_from_root)
+            parent_groups: set = set(group.parent_groups).intersection(all_groups_from_root)
             # Ensure that we have only one parent group. Otherwise we cannot build a tree.
             if len(parent_groups) > 1:
                 raise AnsibleActionFail(

--- a/ansible_collections/arista/avd/plugins/action/verify_requirements.py
+++ b/ansible_collections/arista/avd/plugins/action/verify_requirements.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 __metaclass__ = type
 
 import json
@@ -54,7 +52,7 @@ def _validate_python_version(result: dict) -> bool:
     return True
 
 
-def _validate_python_requirements(requirements: list[str], result: dict) -> bool:
+def _validate_python_requirements(requirements: list, result: dict) -> bool:
     """
     Validate python lib versions
 

--- a/ansible_collections/arista/avd/plugins/filter/hide_passwords.py
+++ b/ansible_collections/arista/avd/plugins/filter/hide_passwords.py
@@ -1,8 +1,6 @@
 #
 # arista.avd.hide_passwords filter
 #
-from __future__ import annotations
-
 __metaclass__ = type
 
 from ansible_collections.arista.avd.plugins.plugin_utils.errors import AristaAvdError

--- a/ansible_collections/arista/avd/plugins/filter/password.py
+++ b/ansible_collections/arista/avd/plugins/filter/password.py
@@ -1,8 +1,6 @@
 """
 Encrypt / Decrypt filters
 """
-from __future__ import annotations
-
 from ansible_collections.arista.avd.plugins.plugin_utils.errors import AristaAvdError, AristaAvdMissingVariableError
 from ansible_collections.arista.avd.plugins.plugin_utils.password_utils import cbc_decrypt, cbc_encrypt
 

--- a/ansible_collections/arista/avd/plugins/filter/password.py
+++ b/ansible_collections/arista/avd/plugins/filter/password.py
@@ -71,7 +71,7 @@ def ospf_simple_decrypt(password: str, key: str) -> str:
 OSPF_MESSAGE_DIGEST_HASH_ALGORITHMS = ["md5", "sha1", "sha256", "sha384", "sha512"]
 
 
-def ospf_message_digest_encrypt(password: str, key: str, hash_algorithm: str | None = None, key_id: str | None = None) -> str:
+def ospf_message_digest_encrypt(password: str, key: str, hash_algorithm: str = None, key_id: str = None) -> str:
     """
     Encrypt a password for Message Digest Keys
 
@@ -95,7 +95,7 @@ def ospf_message_digest_encrypt(password: str, key: str, hash_algorithm: str | N
     return cbc_encrypt(key_b, data).decode()
 
 
-def ospf_message_digest_decrypt(password: str, key: str, hash_algorithm: str | None = None, key_id: str | None = None) -> str:
+def ospf_message_digest_decrypt(password: str, key: str, hash_algorithm: str = None, key_id: str = None) -> str:
     """
     Decrypt a password for Message Digest Keys
 

--- a/ansible_collections/arista/avd/plugins/vars/global_vars.py
+++ b/ansible_collections/arista/avd/plugins/vars/global_vars.py
@@ -92,7 +92,7 @@ from ansible.module_utils._text import to_bytes, to_native, to_text
 from ansible.plugins.vars import BaseVarsPlugin
 from ansible.utils.vars import combine_vars
 
-FOUND: list[str] = []
+FOUND: list = []
 
 
 class VarsModule(BaseVarsPlugin):
@@ -150,7 +150,8 @@ class VarsModule(BaseVarsPlugin):
             print(entity.name, path)
 
             for path in FOUND:
-                if new_data := loader.load_from_file(path, cache=True, unsafe=True):
+                new_data = loader.load_from_file(path, cache=True, unsafe=True)
+                if new_data:
                     variables = combine_vars(variables, new_data)
 
         return variables


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->

## Related Issue(s)

Fixes #2875

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

Since the galaxy-importer runs Python 3.6 (!) we have to stick to older styles in the ansible well-known directories:

- Removed import of `annotations` 
- Removed new type annotations with pipe, `list[]` or `set[]`
- Removed walrus

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Tested import to `galaxy-dev.ansible.com`:
```log
Starting import: task_id=116257, artifact_id=116257 
Importing with galaxy-importer 0.4.0-1 
Getting doc strings via ansible-doc 
Finding content inside collection 
Loading role eos_config_deploy_eapi 
Linting role eos_config_deploy_eapi via ansible-lint... 
Loading role dhcp_provisioner 
Linting role dhcp_provisioner via ansible-lint... 
Loading role eos_cli_config_gen 
Linting role eos_cli_config_gen via ansible-lint... 
Loading role build_output_folders 
Linting role build_output_folders via ansible-lint... 
Loading role eos_config_deploy_cvp 
Linting role eos_config_deploy_cvp via ansible-lint... 
Loading role eos_validate_state 
Linting role eos_validate_state via ansible-lint... 
Loading role eos_snapshot 
Linting role eos_snapshot via ansible-lint... 
Loading role cvp_configlet_upload 
Linting role cvp_configlet_upload via ansible-lint... 
Loading role eos_designs 
Linting role eos_designs via ansible-lint... 
Loading module verify_requirements 
Linting module verify_requirements via flake8... 
Loading module yaml_templates_to_facts 
Linting module yaml_templates_to_facts via flake8... 
Loading module eos_designs_structured_config 
Linting module eos_designs_structured_config via flake8... 
Loading module batch_template 
Linting module batch_template via flake8... 
Loading module set_vars 
Linting module set_vars via flake8... 
Loading module inventory_to_container 
Linting module inventory_to_container via flake8... 
Loading module configlet_build_config 
Linting module configlet_build_config via flake8... 
Loading module validate_and_template 
Linting module validate_and_template via flake8... 
Loading module eos_designs_facts 
Linting module eos_designs_facts via flake8... 
Loading action verify_requirements 
Linting action verify_requirements via flake8... 
Loading action yaml_templates_to_facts 
Linting action yaml_templates_to_facts via flake8... 
Loading action eos_designs_structured_config 
Linting action eos_designs_structured_config via flake8... 
Loading action batch_template 
Linting action batch_template via flake8... 
Loading action set_vars 
Linting action set_vars via flake8... 
Loading action inventory_to_container 
Linting action inventory_to_container via flake8... 
Loading action validate_and_template 
Linting action validate_and_template via flake8... 
Loading action eos_designs_facts 
Linting action eos_designs_facts via flake8... 
Loading filter convert_schema 
Linting filter convert_schema via flake8... 
Loading filter add_md_toc 
Linting filter add_md_toc via flake8... 
Loading filter esi_management 
Linting filter esi_management via flake8... 
Loading filter natural_sort 
Linting filter natural_sort via flake8... 
Loading filter snmp_hash 
Linting filter snmp_hash via flake8... 
Loading filter convert_dicts 
Linting filter convert_dicts via flake8... 
Loading filter default 
Linting filter default via flake8... 
Loading filter hide_passwords 
Linting filter hide_passwords via flake8... 
Loading filter markdown_rendering 
Linting filter markdown_rendering via flake8... 
Loading filter list_compress 
Linting filter list_compress via flake8... 
Loading filter password 
Linting filter password via flake8... 
Loading filter range_expand 
Linting filter range_expand via flake8... 
Loading filter is_in_filter 
Linting filter is_in_filter via flake8... 
Loading test contains 
Linting test contains via flake8... 
Loading test defined 
Linting test defined via flake8... 
Loading vars global_vars 
Linting vars global_vars via flake8... 
Ignore files skip ansible-test sanity tests, found ignore-2.13.txt with 10 statement(s) 
Ignore files skip ansible-test sanity tests, found ignore-2.12.txt with 10 statement(s) 
Ignore files skip ansible-test sanity tests, found ignore-2.14.txt with 10 statement(s) 
Collection loading complete 
Processing via galaxy-importer complete 
Checking dependencies in importer data 
Publishing collection 
Collection published 
Import completed with 3 warnings and 0 errors 
```
## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
