### PR TITLE
Fix(eos_designs): Remove EVPN related config if VRF 'default' is not EVPN enabled

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn-vtep-with-default-vrf-not-evpn.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn-vtep-with-default-vrf-not-evpn.cfg
@@ -1,0 +1,92 @@
+!RANCID-CONTENT-TYPE: arista
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname evpn-vtep-with-default-vrf-not-evpn
+!
+no enable password
+no aaa root
+!
+vlan 110
+   name SVI-110
+!
+vrf instance MGMT
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 192.168.255.109/32
+!
+interface Loopback1
+   description VTEP_VXLAN_Tunnel_Source
+   no shutdown
+   ip address 192.168.254.109/32
+!
+interface Vlan110
+   description SVI-110
+   no shutdown
+   ip address virtual 10.1.10.1
+!
+interface Vxlan1
+   description evpn-vtep-with-default-vrf-not-evpn_VTEP
+   vxlan source-interface Loopback1
+   vxlan udp-port 4789
+   vxlan vlan 110 vni 10110
+!
+ip virtual-router mac-address 00:dc:00:00:00:0a
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+   seq 20 permit 192.168.254.0/24 eq 32
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+router bfd
+   multihop interval 300 min-rx 300 multiplier 3
+!
+router bgp 101
+   router-id 192.168.255.109
+   graceful-restart restart-time 300
+   graceful-restart
+   maximum-paths 4 ecmp 4
+   update wait-install
+   no bgp default ipv4-unicast
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor IPv4-UNDERLAY-PEERS peer group
+   neighbor IPv4-UNDERLAY-PEERS send-community
+   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   vlan 110
+      rd 192.168.255.109:10110
+      route-target both 10110:10110
+      redistribute learned
+   !
+   address-family evpn
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor IPv4-UNDERLAY-PEERS activate
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn-vtep-with-default-vrf-not-evpn.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn-vtep-with-default-vrf-not-evpn.yml
@@ -1,0 +1,112 @@
+router_bgp:
+  as: '101'
+  router_id: 192.168.255.109
+  bgp:
+    default:
+      ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
+  updates:
+    wait_install: true
+  graceful_restart:
+    enabled: true
+    restart_time: 300
+  peer_groups:
+  - name: IPv4-UNDERLAY-PEERS
+    type: ipv4
+    maximum_routes: 12000
+    send_community: all
+  - name: EVPN-OVERLAY-PEERS
+    type: evpn
+    update_source: Loopback0
+    bfd: true
+    send_community: all
+    maximum_routes: 0
+    ebgp_multihop: 3
+  address_family_ipv4:
+    peer_groups:
+    - name: IPv4-UNDERLAY-PEERS
+      activate: true
+    - name: EVPN-OVERLAY-PEERS
+      activate: false
+  redistribute_routes:
+  - source_protocol: connected
+    route_map: RM-CONN-2-BGP
+  address_family_evpn:
+    peer_groups:
+    - name: EVPN-OVERLAY-PEERS
+      activate: true
+  vlans:
+  - id: 110
+    tenant: MY_FABRIC
+    rd: 192.168.255.109:10110
+    route_targets:
+      both:
+      - 10110:10110
+    redistribute_routes:
+    - learned
+service_routing_protocols_model: multi-agent
+ip_routing: true
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+vrfs:
+- name: MGMT
+  ip_routing: false
+management_api_http:
+  enable_vrfs:
+  - name: MGMT
+  enable_https: true
+loopback_interfaces:
+- name: Loopback0
+  description: EVPN_Overlay_Peering
+  shutdown: false
+  ip_address: 192.168.255.109/32
+- name: Loopback1
+  description: VTEP_VXLAN_Tunnel_Source
+  shutdown: false
+  ip_address: 192.168.254.109/32
+prefix_lists:
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
+route_maps:
+- name: RM-CONN-2-BGP
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    match:
+    - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+router_bfd:
+  multihop:
+    interval: 300
+    min_rx: 300
+    multiplier: 3
+vlans:
+- id: 110
+  name: SVI-110
+  tenant: MY_FABRIC
+ip_igmp_snooping:
+  globally_enabled: true
+ip_virtual_router_mac_address: 00:dc:00:00:00:0a
+vlan_interfaces:
+- name: Vlan110
+  tenant: MY_FABRIC
+  description: SVI-110
+  shutdown: false
+  ip_address_virtual: 10.1.10.1
+vxlan_interface:
+  Vxlan1:
+    description: evpn-vtep-with-default-vrf-not-evpn_VTEP
+    vxlan:
+      udp_port: 4789
+      source_interface: Loopback1
+      vlans:
+      - id: 110
+        vni: 10110

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/evpn-vtep-with-default-vrf-not-evpn.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/evpn-vtep-with-default-vrf-not-evpn.yml
@@ -1,4 +1,4 @@
-# Testing an EVPN VTEP where thed default VRF is _not_ EVPN enabled.
+# Testing an EVPN VTEP where the default VRF is _not_ EVPN enabled.
 # Make sure there is no route-map added to the underlay peer group filtering the evpn prefixes.
 # Also make sure the VRF is not configured under interface Vxlan 1
 # Minimum config to only test the specific feature.

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/evpn-vtep-with-default-vrf-not-evpn.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/evpn-vtep-with-default-vrf-not-evpn.yml
@@ -1,0 +1,28 @@
+# Testing an EVPN VTEP where thed default VRF is _not_ EVPN enabled.
+# Make sure there is no route-map added to the underlay peer group filtering the evpn prefixes.
+# Also make sure the VRF is not configured under interface Vxlan 1
+# Minimum config to only test the specific feature.
+type: l3leaf
+l3leaf:
+  defaults:
+    loopback_ipv4_pool: 192.168.255.0/24
+    loopback_ipv4_offset: 8
+    vtep_loopback_ipv4_pool: 192.168.254.0/24
+    virtual_router_mac_address: 00:dc:00:00:00:0a
+  nodes:
+    evpn-vtep-with-default-vrf-not-evpn:
+      id: 101
+      bgp_as: 101
+
+tenants:
+  MY_FABRIC:
+    mac_vrf_vni_base: 10000
+    vrfs:
+      default:
+        address_families: []
+        vrf_id: 1
+        svis:
+          110:
+            name: SVI-110
+            enabled: true
+            ip_address_virtual: 10.1.10.1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
@@ -11,6 +11,7 @@ all:
             cvp-instance-ips-cvaas:
             cvp-instance-ips-onprem-token:
             device.with.dots.in.hostname:
+            evpn-vtep-with-default-vrf-not-evpn:
             filter.only_vlans_in_use:
             ignore-custom-keys-in-data-models:
             no_mgmt_interface:

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/prefix_lists.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/prefix_lists.py
@@ -18,7 +18,7 @@ class PrefixListsMixin(UtilsMixin):
 
         Only used for EVPN services in VRF "default"
         """
-        if not (self.shared_utils.network_services_l3 and self.shared_utils.overlay_vtep and self.shared_utils.overlay_evpn):
+        if not self._vrf_default_evpn:
             return None
 
         subnets = self._vrf_default_ipv4_subnets

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/route_maps.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/route_maps.py
@@ -72,7 +72,7 @@ class RouteMapsMixin(UtilsMixin):
 
         Called from main route_maps function
         """
-        if not (self.shared_utils.overlay_vtep and self.shared_utils.overlay_evpn):
+        if not self._vrf_default_evpn:
             return None
 
         subnets = self._vrf_default_ipv4_subnets

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/router_bgp.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/router_bgp.py
@@ -95,11 +95,7 @@ class RouterBgpMixin(UtilsMixin):
                 bgp_peer_groups.append(peer_group)
 
         # router bgp default vrf configuration for evpn
-        if (
-            (self._vrf_default_ipv4_subnets or self._vrf_default_ipv4_static_routes["static_routes"])
-            and self.shared_utils.overlay_vtep
-            and self.shared_utils.overlay_evpn
-        ):
+        if self._vrf_default_evpn and (self._vrf_default_ipv4_subnets or self._vrf_default_ipv4_static_routes["static_routes"]):
             bgp_peer_groups.append(
                 {
                     "name": self.shared_utils.bgp_peer_groups["ipv4_underlay_peers"]["name"],
@@ -160,7 +156,7 @@ class RouterBgpMixin(UtilsMixin):
                     else:
                         target["route_targets"].append(rt["route_target"])
 
-                if vrf_name == "default" and self.shared_utils.overlay_evpn and self._vrf_default_ipv4_subnets:
+                if vrf_name == "default" and self._vrf_default_evpn and self._vrf_default_ipv4_subnets:
                     # Special handling of vrf default.
 
                     if (target := get_item(route_targets["export"], "address_family", "evpn")) is None:

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/utils.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/utils.py
@@ -49,6 +49,23 @@ class UtilsMixin(UtilsFilteredTenantsMixin):
         return [int(id) for id in range_expand(endpoint_vlans)]
 
     @cached_property
+    def _vrf_default_evpn(self) -> bool:
+        """
+        Return boolean telling if VRF "default" is running EVPN or not.
+        """
+        if not (self.shared_utils.network_services_l3 and self.shared_utils.overlay_vtep and self.shared_utils.overlay_evpn):
+            return False
+
+        for tenant in self._filtered_tenants:
+            if (vrf_default := get_item(tenant["vrfs"], "name", "default")) is None:
+                continue
+
+            if "evpn" in vrf_default.get("address_families", ["evpn"]):
+                return True
+
+        return False
+
+    @cached_property
     def _vrf_default_ipv4_subnets(self) -> list[str]:
         """
         Return list of ipv4 subnets in VRF "default"

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/vxlan_interface.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/vxlan_interface.py
@@ -67,8 +67,13 @@ class VxlanInterfaceMixin(UtilsMixin):
                         vnis[vni] = tenant["name"]
                         vlans.append({"id": vlan_id, **vlan})
 
-                if self.shared_utils.network_services_l3 and self.shared_utils.overlay_evpn:
+                if self.shared_utils.network_services_l3 and self.shared_utils.overlay_evpn_vxlan:
                     vrf_name = vrf["name"]
+
+                    # Only configure VNI for VRF if the VRF is EVPN enabled
+                    if "evpn" not in vrf.get("address_families", ["evpn"]):
+                        continue
+
                     vni = default(
                         vrf.get("vrf_vni"),
                         vrf.get("vrf_id"),


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Remove EVPN related config if VRF 'default' is not EVPN enabled

## Related Issue(s)

For EVPN networks carrying VRF 'default' the best practice is to use the overlay (EVPN l3vni) for services, but keep loopbacks in the underlay. To avoid the services from being routed in the underlay, AVD implements route-maps and prefix-lists when VRF 'default' is defined on an EVPN VTEP.
It is possible to disable EVPN under the VRF configuration by setting `address_families:[]` in which case the VRF should _not_ be added to EVPN configuration, and the route-maps and prefix-lists should not be created at all.
Before this fix, the route-maps and prefix-lists were still configured even if the VRF was not configured for EVPN. The VRF was also configured with a VNI under the VXLAN interface.

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

- Detect if VRF 'default' has `evpn` address-family enabled (true by default)
- Only configure the underlay filtering route-map/prefix-lists if EVPN is enabled for VRF 'default'
- Only configure VNI for VRFs where EVPN is enabled _and_ the overlay is EVPN-VXLAN (changed from pure EVPN check - which would also be true with EVPN-MPLS)

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Added a molecule test case for this corner case.
No other changes to molecule outputs.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
