### PR TITLE
Feat(eos_designs): Make BFD configurable under bgp_peer_groups

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/bgp-peer-groups-1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/bgp-peer-groups-1.cfg
@@ -6,7 +6,7 @@ transceiver qsfp default-mode 4x10G
 !
 service routing protocols model multi-agent
 !
-hostname bgp-peer-groups-structured-config-2
+hostname bgp-peer-groups-1
 !
 no spanning-tree vlan-id 4094
 !
@@ -20,7 +20,7 @@ vlan 4094
 vrf instance MGMT
 !
 interface Port-Channel3
-   description MLAG_PEER_bgp-peer-groups-structured-config-1_Po3
+   description MLAG_PEER_bgp-peer-groups-2_Po3
    no shutdown
    switchport
    switchport mode trunk
@@ -28,14 +28,14 @@ interface Port-Channel3
    switchport trunk group MLAG
 !
 interface Ethernet3
-   description MLAG_PEER_bgp-peer-groups-structured-config-1_Ethernet3
+   description MLAG_PEER_bgp-peer-groups-2_Ethernet3
    no shutdown
    channel-group 3 mode active
 !
 interface Loopback0
    description MPLS_Overlay_peering
    no shutdown
-   ip address 192.168.255.112/32
+   ip address 192.168.255.111/32
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
@@ -47,10 +47,10 @@ interface Vlan4094
    no shutdown
    mtu 9214
    no autostate
-   ip address 192.168.253.205/31
+   ip address 192.168.253.204/31
 !
 interface Vxlan1
-   description bgp-peer-groups-structured-config-2_VTEP
+   description bgp-peer-groups-1_VTEP
    vxlan source-interface Loopback1
    vxlan virtual-router encapsulation mac-address mlag-system-id
    vxlan udp-port 4789
@@ -67,7 +67,7 @@ ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
 mlag configuration
    domain-id mlag
    local-interface Vlan4094
-   peer-address 192.168.253.204
+   peer-address 192.168.253.205
    peer-link Port-Channel3
    reload-delay mlag 300
    reload-delay non-mlag 330
@@ -93,57 +93,46 @@ router bfd
    multihop interval 300 min-rx 300 multiplier 3
 !
 router bgp 65001
-   router-id 192.168.255.112
+   router-id 192.168.255.111
    maximum-paths 4 ecmp 4
    update wait-install
    no bgp default ipv4-unicast
-   bgp cluster-id 192.168.255.112
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS remote-as 65001
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS description Description for evpn_overlay_peers via structured_config
-   neighbor EVPN-OVERLAY-PEERS route-reflector-client
-   neighbor EVPN-OVERLAY-PEERS bfd
    neighbor EVPN-OVERLAY-PEERS send-community
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS description Description for ipv4_underlay_peers via structured_config
+   neighbor IPv4-UNDERLAY-PEERS bfd
    neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
    neighbor MLAG-IPv4-UNDERLAY-PEER peer group
    neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65001
    neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self
    neighbor MLAG-IPv4-UNDERLAY-PEER description Description for mlag_ipv4_underlay_peer via structured_config
+   neighbor MLAG-IPv4-UNDERLAY-PEER bfd
    neighbor MLAG-IPv4-UNDERLAY-PEER send-community
    neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000
    neighbor MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN in
-   neighbor RR-OVERLAY-PEERS peer group
-   neighbor RR-OVERLAY-PEERS remote-as 65001
-   neighbor RR-OVERLAY-PEERS update-source Loopback0
-   neighbor RR-OVERLAY-PEERS description Description for rr_overlay_peers via structured_config
-   neighbor RR-OVERLAY-PEERS bfd
-   neighbor RR-OVERLAY-PEERS send-community
-   neighbor RR-OVERLAY-PEERS maximum-routes 0
-   neighbor 192.168.253.204 peer group MLAG-IPv4-UNDERLAY-PEER
-   neighbor 192.168.253.204 description bgp-peer-groups-structured-config-1
-   neighbor 192.168.255.111 peer group EVPN-OVERLAY-PEERS
-   neighbor 192.168.255.111 description bgp-peer-groups-structured-config-1
+   neighbor 192.168.253.205 peer group MLAG-IPv4-UNDERLAY-PEER
+   neighbor 192.168.253.205 description bgp-peer-groups-2
+   neighbor 192.168.255.112 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.112 description bgp-peer-groups-2
    redistribute connected route-map RM-CONN-2-BGP
    !
    address-family evpn
       neighbor EVPN-OVERLAY-PEERS route-map RM-EVPN-SOO-IN in
       neighbor EVPN-OVERLAY-PEERS route-map RM-EVPN-SOO-OUT out
       neighbor EVPN-OVERLAY-PEERS activate
-      neighbor RR-OVERLAY-PEERS activate
    !
    address-family ipv4
       no neighbor EVPN-OVERLAY-PEERS activate
       neighbor IPv4-UNDERLAY-PEERS activate
       neighbor MLAG-IPv4-UNDERLAY-PEER activate
-      no neighbor RR-OVERLAY-PEERS activate
    !
    address-family vpn-ipv4
-      neighbor RR-OVERLAY-PEERS activate
 !
 management api http-commands
    protocol https

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/bgp-peer-groups-2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/bgp-peer-groups-2.cfg
@@ -6,7 +6,7 @@ transceiver qsfp default-mode 4x10G
 !
 service routing protocols model multi-agent
 !
-hostname bgp-peer-groups-structured-config-1
+hostname bgp-peer-groups-2
 !
 no spanning-tree vlan-id 4094
 !
@@ -20,7 +20,7 @@ vlan 4094
 vrf instance MGMT
 !
 interface Port-Channel3
-   description MLAG_PEER_bgp-peer-groups-structured-config-2_Po3
+   description MLAG_PEER_bgp-peer-groups-1_Po3
    no shutdown
    switchport
    switchport mode trunk
@@ -28,14 +28,14 @@ interface Port-Channel3
    switchport trunk group MLAG
 !
 interface Ethernet3
-   description MLAG_PEER_bgp-peer-groups-structured-config-2_Ethernet3
+   description MLAG_PEER_bgp-peer-groups-1_Ethernet3
    no shutdown
    channel-group 3 mode active
 !
 interface Loopback0
    description MPLS_Overlay_peering
    no shutdown
-   ip address 192.168.255.111/32
+   ip address 192.168.255.112/32
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
@@ -47,10 +47,10 @@ interface Vlan4094
    no shutdown
    mtu 9214
    no autostate
-   ip address 192.168.253.204/31
+   ip address 192.168.253.205/31
 !
 interface Vxlan1
-   description bgp-peer-groups-structured-config-1_VTEP
+   description bgp-peer-groups-2_VTEP
    vxlan source-interface Loopback1
    vxlan virtual-router encapsulation mac-address mlag-system-id
    vxlan udp-port 4789
@@ -67,7 +67,7 @@ ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
 mlag configuration
    domain-id mlag
    local-interface Vlan4094
-   peer-address 192.168.253.205
+   peer-address 192.168.253.204
    peer-link Port-Channel3
    reload-delay mlag 300
    reload-delay non-mlag 330
@@ -93,45 +93,57 @@ router bfd
    multihop interval 300 min-rx 300 multiplier 3
 !
 router bgp 65001
-   router-id 192.168.255.111
+   router-id 192.168.255.112
    maximum-paths 4 ecmp 4
    update wait-install
    no bgp default ipv4-unicast
+   bgp cluster-id 192.168.255.112
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS remote-as 65001
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS description Description for evpn_overlay_peers via structured_config
-   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS route-reflector-client
    neighbor EVPN-OVERLAY-PEERS send-community
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS description Description for ipv4_underlay_peers via structured_config
+   neighbor IPv4-UNDERLAY-PEERS bfd
    neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
    neighbor MLAG-IPv4-UNDERLAY-PEER peer group
    neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65001
    neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self
    neighbor MLAG-IPv4-UNDERLAY-PEER description Description for mlag_ipv4_underlay_peer via structured_config
+   neighbor MLAG-IPv4-UNDERLAY-PEER bfd
    neighbor MLAG-IPv4-UNDERLAY-PEER send-community
    neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000
    neighbor MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN in
-   neighbor 192.168.253.205 peer group MLAG-IPv4-UNDERLAY-PEER
-   neighbor 192.168.253.205 description bgp-peer-groups-structured-config-2
-   neighbor 192.168.255.112 peer group EVPN-OVERLAY-PEERS
-   neighbor 192.168.255.112 description bgp-peer-groups-structured-config-2
+   neighbor RR-OVERLAY-PEERS peer group
+   neighbor RR-OVERLAY-PEERS remote-as 65001
+   neighbor RR-OVERLAY-PEERS update-source Loopback0
+   neighbor RR-OVERLAY-PEERS description Description for rr_overlay_peers via structured_config
+   neighbor RR-OVERLAY-PEERS send-community
+   neighbor RR-OVERLAY-PEERS maximum-routes 0
+   neighbor 192.168.253.204 peer group MLAG-IPv4-UNDERLAY-PEER
+   neighbor 192.168.253.204 description bgp-peer-groups-1
+   neighbor 192.168.255.111 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.111 description bgp-peer-groups-1
    redistribute connected route-map RM-CONN-2-BGP
    !
    address-family evpn
       neighbor EVPN-OVERLAY-PEERS route-map RM-EVPN-SOO-IN in
       neighbor EVPN-OVERLAY-PEERS route-map RM-EVPN-SOO-OUT out
       neighbor EVPN-OVERLAY-PEERS activate
+      neighbor RR-OVERLAY-PEERS activate
    !
    address-family ipv4
       no neighbor EVPN-OVERLAY-PEERS activate
       neighbor IPv4-UNDERLAY-PEERS activate
       neighbor MLAG-IPv4-UNDERLAY-PEER activate
+      no neighbor RR-OVERLAY-PEERS activate
    !
    address-family vpn-ipv4
+      neighbor RR-OVERLAY-PEERS activate
 !
 management api http-commands
    protocol https

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/bgp-peer-groups-3.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/bgp-peer-groups-3.cfg
@@ -6,7 +6,7 @@ transceiver qsfp default-mode 4x10G
 !
 service routing protocols model multi-agent
 !
-hostname bgp-peer-groups-structured-config-3
+hostname bgp-peer-groups-3
 !
 no enable password
 no aaa root
@@ -38,14 +38,12 @@ router bgp 65001
    neighbor IPVPN-GATEWAY-PEERS peer group
    neighbor IPVPN-GATEWAY-PEERS update-source Loopback0
    neighbor IPVPN-GATEWAY-PEERS description Description for ipvpn_gateway_peers via structured_config
-   neighbor IPVPN-GATEWAY-PEERS bfd
    neighbor IPVPN-GATEWAY-PEERS send-community
    neighbor IPVPN-GATEWAY-PEERS maximum-routes 0
    neighbor MPLS-OVERLAY-PEERS peer group
    neighbor MPLS-OVERLAY-PEERS remote-as 65001
    neighbor MPLS-OVERLAY-PEERS update-source Loopback0
    neighbor MPLS-OVERLAY-PEERS description Description for mpls_overlay_peers via structured_config
-   neighbor MPLS-OVERLAY-PEERS bfd
    neighbor MPLS-OVERLAY-PEERS send-community
    neighbor MPLS-OVERLAY-PEERS maximum-routes 0
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-1.yml
@@ -15,18 +15,20 @@ router_bgp:
     remote_as: '65001'
     next_hop_self: true
     description: Description for mlag_ipv4_underlay_peer via structured_config
+    bfd: true
     maximum_routes: 12000
     send_community: all
     route_map_in: RM-MLAG-PEER-IN
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4
+    bfd: true
     maximum_routes: 12000
     send_community: all
     description: Description for ipv4_underlay_peers via structured_config
   - name: EVPN-OVERLAY-PEERS
     type: evpn
     update_source: Loopback0
-    bfd: true
+    bfd: false
     send_community: all
     maximum_routes: 0
     remote_as: '65001'
@@ -42,10 +44,10 @@ router_bgp:
   neighbors:
   - ip_address: 192.168.253.205
     peer_group: MLAG-IPv4-UNDERLAY-PEER
-    description: bgp-peer-groups-structured-config-2
+    description: bgp-peer-groups-2
   - ip_address: 192.168.255.112
     peer_group: EVPN-OVERLAY-PEERS
-    description: bgp-peer-groups-structured-config-2
+    description: bgp-peer-groups-2
   redistribute_routes:
   - source_protocol: connected
     route_map: RM-CONN-2-BGP
@@ -91,7 +93,7 @@ vlan_interfaces:
   mtu: 9214
 port_channel_interfaces:
 - name: Port-Channel3
-  description: MLAG_PEER_bgp-peer-groups-structured-config-2_Po3
+  description: MLAG_PEER_bgp-peer-groups-2_Po3
   type: switched
   shutdown: false
   mode: trunk
@@ -100,10 +102,10 @@ port_channel_interfaces:
   - MLAG
 ethernet_interfaces:
 - name: Ethernet3
-  peer: bgp-peer-groups-structured-config-2
+  peer: bgp-peer-groups-2
   peer_interface: Ethernet3
   peer_type: mlag_peer
-  description: MLAG_PEER_bgp-peer-groups-structured-config-2_Ethernet3
+  description: MLAG_PEER_bgp-peer-groups-2_Ethernet3
   type: port-channel-member
   shutdown: false
   channel_group:
@@ -174,7 +176,7 @@ ip_igmp_snooping:
   globally_enabled: true
 vxlan_interface:
   Vxlan1:
-    description: bgp-peer-groups-structured-config-1_VTEP
+    description: bgp-peer-groups-1_VTEP
     vxlan:
       udp_port: 4789
       source_interface: Loopback1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-2.yml
@@ -15,18 +15,20 @@ router_bgp:
     remote_as: '65001'
     next_hop_self: true
     description: Description for mlag_ipv4_underlay_peer via structured_config
+    bfd: true
     maximum_routes: 12000
     send_community: all
     route_map_in: RM-MLAG-PEER-IN
   - name: IPv4-UNDERLAY-PEERS
     type: ipv4
+    bfd: true
     maximum_routes: 12000
     send_community: all
     description: Description for ipv4_underlay_peers via structured_config
   - name: EVPN-OVERLAY-PEERS
     type: evpn
     update_source: Loopback0
-    bfd: true
+    bfd: false
     send_community: all
     maximum_routes: 0
     remote_as: '65001'
@@ -35,7 +37,7 @@ router_bgp:
   - name: RR-OVERLAY-PEERS
     type: mpls
     update_source: Loopback0
-    bfd: true
+    bfd: false
     send_community: all
     maximum_routes: 0
     remote_as: '65001'
@@ -53,10 +55,10 @@ router_bgp:
   neighbors:
   - ip_address: 192.168.253.204
     peer_group: MLAG-IPv4-UNDERLAY-PEER
-    description: bgp-peer-groups-structured-config-1
+    description: bgp-peer-groups-1
   - ip_address: 192.168.255.111
     peer_group: EVPN-OVERLAY-PEERS
-    description: bgp-peer-groups-structured-config-1
+    description: bgp-peer-groups-1
   redistribute_routes:
   - source_protocol: connected
     route_map: RM-CONN-2-BGP
@@ -108,7 +110,7 @@ vlan_interfaces:
   mtu: 9214
 port_channel_interfaces:
 - name: Port-Channel3
-  description: MLAG_PEER_bgp-peer-groups-structured-config-1_Po3
+  description: MLAG_PEER_bgp-peer-groups-1_Po3
   type: switched
   shutdown: false
   mode: trunk
@@ -117,10 +119,10 @@ port_channel_interfaces:
   - MLAG
 ethernet_interfaces:
 - name: Ethernet3
-  peer: bgp-peer-groups-structured-config-1
+  peer: bgp-peer-groups-1
   peer_interface: Ethernet3
   peer_type: mlag_peer
-  description: MLAG_PEER_bgp-peer-groups-structured-config-1_Ethernet3
+  description: MLAG_PEER_bgp-peer-groups-1_Ethernet3
   type: port-channel-member
   shutdown: false
   channel_group:
@@ -191,7 +193,7 @@ ip_igmp_snooping:
   globally_enabled: true
 vxlan_interface:
   Vxlan1:
-    description: bgp-peer-groups-structured-config-2_VTEP
+    description: bgp-peer-groups-2_VTEP
     vxlan:
       udp_port: 4789
       source_interface: Loopback1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-3.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-3.yml
@@ -15,7 +15,7 @@ router_bgp:
   - name: MPLS-OVERLAY-PEERS
     type: mpls
     update_source: Loopback0
-    bfd: true
+    bfd: false
     send_community: all
     maximum_routes: 0
     remote_as: '65001'
@@ -23,7 +23,7 @@ router_bgp:
   - name: IPVPN-GATEWAY-PEERS
     type: mpls
     update_source: Loopback0
-    bfd: true
+    bfd: false
     send_community: all
     maximum_routes: 0
     description: Description for ipvpn_gateway_peers via structured_config

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/BGP_PEER_GROUPS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/BGP_PEER_GROUPS.yml
@@ -30,30 +30,37 @@ node_type_keys:
 
 bgp_peer_groups:
   ipv4_underlay_peers:
+    bfd: true
     # Custom structured config added under router_bgp.peer_groups.<name> for eos_cli_config_gen
     structured_config:
       description: Description for ipv4_underlay_peers via structured_config
   mlag_ipv4_underlay_peer:
+    bfd: true
     # Custom structured config added under router_bgp.peer_groups.<name> for eos_cli_config_gen
     structured_config:
       description: Description for mlag_ipv4_underlay_peer via structured_config
   evpn_overlay_peers:
+    bfd: false
     # Custom structured config added under router_bgp.peer_groups.<name> for eos_cli_config_gen
     structured_config:
       description: Description for evpn_overlay_peers via structured_config
   evpn_overlay_core:
+    bfd: false
     # Custom structured config added under router_bgp.peer_groups.<name> for eos_cli_config_gen
     structured_config:
       description: Description for evpn_overlay_core via structured_config
   mpls_overlay_peers:
+    bfd: false
     # Custom structured config added under router_bgp.peer_groups.<name> for eos_cli_config_gen
     structured_config:
       description: Description for mpls_overlay_peers via structured_config
   rr_overlay_peers:
+    bfd: false
     # Custom structured config added under router_bgp.peer_groups.<name> for eos_cli_config_gen
     structured_config:
       description: Description for rr_overlay_peers via structured_config
   ipvpn_gateway_peers:
+    bfd: false
     # Custom structured config added under router_bgp.peer_groups.<name> for eos_cli_config_gen
     structured_config:
       description: Description for ipvpn_gateway_peers via structured_config
@@ -74,16 +81,16 @@ l3leaf:
   node_groups:
     - group: mlag
       nodes:
-        - name: bgp-peer-groups-structured-config-1
+        - name: bgp-peer-groups-1
           id: 103
           bgp_as: 103
-          evpn_route_servers: [ bgp-peer-groups-structured-config-2 ]
-          mpls_route_reflectors: [ bgp-peer-groups-structured-config-2 ]
+          evpn_route_servers: [ bgp-peer-groups-2 ]
+          mpls_route_reflectors: [ bgp-peer-groups-2 ]
           mpls_overlay_role: client
           evpn_gateway:
             evpn_l3:
               enabled: true
-        - name: bgp-peer-groups-structured-config-2
+        - name: bgp-peer-groups-2
           id: 104
           bgp_as: 104
           evpn_role: server
@@ -98,9 +105,9 @@ pe:
     node_sid_base: 100
     isis_system_id_prefix: '0000.0002'
   node_groups:
-    - group: bgp-peer-groups-structured-config-3
+    - group: bgp-peer-groups-3
       nodes:
-        - name: bgp-peer-groups-structured-config-3
+        - name: bgp-peer-groups-3
           id: 106
           bgp_as: 106
           evpn_role: client
@@ -113,5 +120,5 @@ rr:
   node_groups:
     - group: dummy
       nodes:
-        - name: bgp-peer-groups-structured-config-1
-        - name: bgp-peer-groups-structured-config-2
+        - name: bgp-peer-groups-1
+        - name: bgp-peer-groups-2

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
@@ -82,11 +82,11 @@ all:
             IGMP_QUERIER_L2LEAFS:
               hosts:
                 IGMP-QUERIER-L2LEAF1A:
-        BGP_PEER_GROUPS_STRUCTURED_CONFIG:
+        BGP_PEER_GROUPS:
           hosts:
-            bgp-peer-groups-structured-config-1:
-            bgp-peer-groups-structured-config-2:
-            bgp-peer-groups-structured-config-3:
+            bgp-peer-groups-1:
+            bgp-peer-groups-2:
+            bgp-peer-groups-3:
               type: pe
         EVPN_MULTICAST_TESTS:
           children:

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/bgp_peer_groups.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/bgp_peer_groups.py
@@ -27,21 +27,23 @@ class BgpPeerGroupsMixin:
             return None
 
         BGP_PEER_GROUPS = [
-            # (key, default_name)
-            ("ipv4_underlay_peers", "IPv4-UNDERLAY-PEERS"),
-            ("mlag_ipv4_underlay_peer", "MLAG-IPv4-UNDERLAY-PEER"),
-            ("evpn_overlay_peers", "EVPN-OVERLAY-PEERS"),
-            ("evpn_overlay_core", "EVPN-OVERLAY-CORE"),
-            ("mpls_overlay_peers", "MPLS-OVERLAY-PEERS"),
-            ("rr_overlay_peers", "RR-OVERLAY-PEERS"),
-            ("ipvpn_gateway_peers", "IPVPN-GATEWAY-PEERS"),
+            # (key, default_name, default_bfd)
+            # Default BFD is set to None when not True, to avoid generating config for disabling BFD
+            ("ipv4_underlay_peers", "IPv4-UNDERLAY-PEERS", None),
+            ("mlag_ipv4_underlay_peer", "MLAG-IPv4-UNDERLAY-PEER", None),
+            ("evpn_overlay_peers", "EVPN-OVERLAY-PEERS", True),
+            ("evpn_overlay_core", "EVPN-OVERLAY-CORE", True),
+            ("mpls_overlay_peers", "MPLS-OVERLAY-PEERS", True),
+            ("rr_overlay_peers", "RR-OVERLAY-PEERS", True),
+            ("ipvpn_gateway_peers", "IPVPN-GATEWAY-PEERS", True),
         ]
 
         bgp_peer_groups = {}
-        for key, default_name in BGP_PEER_GROUPS:
+        for key, default_name, default_bfd in BGP_PEER_GROUPS:
             bgp_peer_groups[key] = {
                 "name": get(self.hostvars, f"bgp_peer_groups.{key}.name", default=default_name),
                 "password": get(self.hostvars, f"bgp_peer_groups.{key}.password"),
+                "bfd": get(self.hostvars, f"bgp_peer_groups.{key}.bfd", default=default_bfd),
                 "structured_config": get(self.hostvars, f"bgp_peer_groups.{key}.structured_config"),
             }
 

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/bgp-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/bgp-settings.md
@@ -17,30 +17,37 @@
     | [<samp>&nbsp;&nbsp;ipv4_underlay_peers</samp>](## "bgp_peer_groups.ipv4_underlay_peers") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "bgp_peer_groups.ipv4_underlay_peers.name") | String |  | `IPv4-UNDERLAY-PEERS` |  | Name of peer group. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;password</samp>](## "bgp_peer_groups.ipv4_underlay_peers.password") | String |  |  |  | Type 7 encrypted password. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;bfd</samp>](## "bgp_peer_groups.ipv4_underlay_peers.bfd") | Boolean |  | `False` |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;structured_config</samp>](## "bgp_peer_groups.ipv4_underlay_peers.structured_config") | Dictionary |  |  |  | Custom structured config added under router_bgp.peer_groups.<name> for eos_cli_config_gen. |
     | [<samp>&nbsp;&nbsp;mlag_ipv4_underlay_peer</samp>](## "bgp_peer_groups.mlag_ipv4_underlay_peer") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "bgp_peer_groups.mlag_ipv4_underlay_peer.name") | String |  | `MLAG-IPv4-UNDERLAY-PEER` |  | Name of peer group. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;password</samp>](## "bgp_peer_groups.mlag_ipv4_underlay_peer.password") | String |  |  |  | Type 7 encrypted password. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;bfd</samp>](## "bgp_peer_groups.mlag_ipv4_underlay_peer.bfd") | Boolean |  | `False` |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;structured_config</samp>](## "bgp_peer_groups.mlag_ipv4_underlay_peer.structured_config") | Dictionary |  |  |  | Custom structured config added under router_bgp.peer_groups.<name> for eos_cli_config_gen. |
     | [<samp>&nbsp;&nbsp;evpn_overlay_peers</samp>](## "bgp_peer_groups.evpn_overlay_peers") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "bgp_peer_groups.evpn_overlay_peers.name") | String |  | `EVPN-OVERLAY-PEERS` |  | Name of peer group. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;password</samp>](## "bgp_peer_groups.evpn_overlay_peers.password") | String |  |  |  | Type 7 encrypted password. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;bfd</samp>](## "bgp_peer_groups.evpn_overlay_peers.bfd") | Boolean |  | `True` |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;structured_config</samp>](## "bgp_peer_groups.evpn_overlay_peers.structured_config") | Dictionary |  |  |  | Custom structured config added under router_bgp.peer_groups.<name> for eos_cli_config_gen. |
     | [<samp>&nbsp;&nbsp;evpn_overlay_core</samp>](## "bgp_peer_groups.evpn_overlay_core") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "bgp_peer_groups.evpn_overlay_core.name") | String |  | `EVPN-OVERLAY-CORE` |  | Name of peer group. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;password</samp>](## "bgp_peer_groups.evpn_overlay_core.password") | String |  |  |  | Type 7 encrypted password. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;bfd</samp>](## "bgp_peer_groups.evpn_overlay_core.bfd") | Boolean |  | `True` |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;structured_config</samp>](## "bgp_peer_groups.evpn_overlay_core.structured_config") | Dictionary |  |  |  | Custom structured config added under router_bgp.peer_groups.<name> for eos_cli_config_gen. |
     | [<samp>&nbsp;&nbsp;mpls_overlay_peers</samp>](## "bgp_peer_groups.mpls_overlay_peers") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "bgp_peer_groups.mpls_overlay_peers.name") | String |  | `MPLS-OVERLAY-PEERS` |  | Name of peer group. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;password</samp>](## "bgp_peer_groups.mpls_overlay_peers.password") | String |  |  |  | Type 7 encrypted password. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;bfd</samp>](## "bgp_peer_groups.mpls_overlay_peers.bfd") | Boolean |  | `True` |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;structured_config</samp>](## "bgp_peer_groups.mpls_overlay_peers.structured_config") | Dictionary |  |  |  | Custom structured config added under router_bgp.peer_groups.<name> for eos_cli_config_gen. |
     | [<samp>&nbsp;&nbsp;rr_overlay_peers</samp>](## "bgp_peer_groups.rr_overlay_peers") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "bgp_peer_groups.rr_overlay_peers.name") | String |  | `RR-OVERLAY-PEERS` |  | Name of peer group. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;password</samp>](## "bgp_peer_groups.rr_overlay_peers.password") | String |  |  |  | Type 7 encrypted password. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;bfd</samp>](## "bgp_peer_groups.rr_overlay_peers.bfd") | Boolean |  | `True` |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;structured_config</samp>](## "bgp_peer_groups.rr_overlay_peers.structured_config") | Dictionary |  |  |  | Custom structured config added under router_bgp.peer_groups.<name> for eos_cli_config_gen. |
     | [<samp>&nbsp;&nbsp;ipvpn_gateway_peers</samp>](## "bgp_peer_groups.ipvpn_gateway_peers") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "bgp_peer_groups.ipvpn_gateway_peers.name") | String |  | `IPVPN-GATEWAY-PEERS` |  | Name of peer group. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;password</samp>](## "bgp_peer_groups.ipvpn_gateway_peers.password") | String |  |  |  | Type 7 encrypted password. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;bfd</samp>](## "bgp_peer_groups.ipvpn_gateway_peers.bfd") | Boolean |  | `True` |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;structured_config</samp>](## "bgp_peer_groups.ipvpn_gateway_peers.structured_config") | Dictionary |  |  |  | Custom structured config added under router_bgp.peer_groups.<name> for eos_cli_config_gen. |
     | [<samp>&nbsp;&nbsp;IPv4_UNDERLAY_PEERS</samp>](## "bgp_peer_groups.IPv4_UNDERLAY_PEERS") <span style="color:red">removed</span> | Dictionary |  |  |  | <span style="color:red">This key was removed. Support was removed in AVD version 4.0.0. Use <samp>bgp_peer_groups.ipv4_underlay_peers</samp> instead.</span> |
     | [<samp>&nbsp;&nbsp;MLAG_IPv4_UNDERLAY_PEER</samp>](## "bgp_peer_groups.MLAG_IPv4_UNDERLAY_PEER") <span style="color:red">removed</span> | Dictionary |  |  |  | <span style="color:red">This key was removed. Support was removed in AVD version 4.0.0. Use <samp>bgp_peer_groups.mlag_ipv4_underlay_peer</samp> instead.</span> |
@@ -66,30 +73,37 @@
       ipv4_underlay_peers:
         name: <str>
         password: <str>
+        bfd: <bool>
         structured_config: <dict>
       mlag_ipv4_underlay_peer:
         name: <str>
         password: <str>
+        bfd: <bool>
         structured_config: <dict>
       evpn_overlay_peers:
         name: <str>
         password: <str>
+        bfd: <bool>
         structured_config: <dict>
       evpn_overlay_core:
         name: <str>
         password: <str>
+        bfd: <bool>
         structured_config: <dict>
       mpls_overlay_peers:
         name: <str>
         password: <str>
+        bfd: <bool>
         structured_config: <dict>
       rr_overlay_peers:
         name: <str>
         password: <str>
+        bfd: <bool>
         structured_config: <dict>
       ipvpn_gateway_peers:
         name: <str>
         password: <str>
+        bfd: <bool>
         structured_config: <dict>
     bgp_update_wait_install: <bool>
     bgp_update_wait_for_convergence: <bool>

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/mlag/avdstructuredconfig.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/mlag/avdstructuredconfig.py
@@ -307,6 +307,7 @@ class AvdStructuredConfigMlag(AvdFacts):
             "next_hop_self": True,
             "description": self.shared_utils.mlag_peer,
             "password": self.shared_utils.bgp_peer_groups["mlag_ipv4_underlay_peer"]["password"],
+            "bfd": self.shared_utils.bgp_peer_groups["ipv4_underlay_peers"]["bfd"],
             "maximum_routes": 12000,
             "send_community": "all",
             "struct_cfg": self.shared_utils.bgp_peer_groups["mlag_ipv4_underlay_peer"]["structured_config"],
@@ -314,7 +315,7 @@ class AvdStructuredConfigMlag(AvdFacts):
         if self.shared_utils.mlag_ibgp_origin_incomplete is True:
             peer_group["route_map_in"] = "RM-MLAG-PEER-IN"
 
-        router_bgp["peer_groups"] = [peer_group]
+        router_bgp["peer_groups"] = [strip_empties_from_dict(peer_group)]
 
         if self.shared_utils.underlay_ipv6:
             router_bgp["address_family_ipv6"] = {

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/overlay/router_bgp.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/overlay/router_bgp.py
@@ -53,7 +53,7 @@ class RouterBgpMixin(UtilsMixin):
             "name": self.shared_utils.bgp_peer_groups[pg_name]["name"],
             "type": pg_type,
             "update_source": "Loopback0",
-            "bfd": True,
+            "bfd": self.shared_utils.bgp_peer_groups[pg_name]["bfd"],
             "password": self.shared_utils.bgp_peer_groups[pg_name]["password"],
             "send_community": "all",
             "maximum_routes": 0,

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/router_bgp.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/router_bgp.py
@@ -28,12 +28,13 @@ class RouterBgpMixin(UtilsMixin):
             "name": self.shared_utils.bgp_peer_groups["ipv4_underlay_peers"]["name"],
             "type": "ipv4",
             "password": self.shared_utils.bgp_peer_groups["ipv4_underlay_peers"]["password"],
+            "bfd": self.shared_utils.bgp_peer_groups["ipv4_underlay_peers"]["bfd"],
             "maximum_routes": 12000,
             "send_community": "all",
             "struct_cfg": self.shared_utils.bgp_peer_groups["ipv4_underlay_peers"]["structured_config"],
         }
 
-        router_bgp["peer_groups"] = [peer_group]
+        router_bgp["peer_groups"] = [strip_empties_from_dict(peer_group)]
 
         # Address Families
         # TODO - see if it makes sense to extract logic in method

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -177,6 +177,11 @@
               "description": "Type 7 encrypted password.",
               "title": "Password"
             },
+            "bfd": {
+              "type": "boolean",
+              "default": false,
+              "title": "BFD"
+            },
             "structured_config": {
               "type": "object",
               "description": "Custom structured config added under router_bgp.peer_groups.<name> for eos_cli_config_gen.",
@@ -202,6 +207,11 @@
               "type": "string",
               "description": "Type 7 encrypted password.",
               "title": "Password"
+            },
+            "bfd": {
+              "type": "boolean",
+              "default": false,
+              "title": "BFD"
             },
             "structured_config": {
               "type": "object",
@@ -229,6 +239,11 @@
               "description": "Type 7 encrypted password.",
               "title": "Password"
             },
+            "bfd": {
+              "type": "boolean",
+              "default": true,
+              "title": "BFD"
+            },
             "structured_config": {
               "type": "object",
               "description": "Custom structured config added under router_bgp.peer_groups.<name> for eos_cli_config_gen.",
@@ -254,6 +269,11 @@
               "type": "string",
               "description": "Type 7 encrypted password.",
               "title": "Password"
+            },
+            "bfd": {
+              "type": "boolean",
+              "default": true,
+              "title": "BFD"
             },
             "structured_config": {
               "type": "object",
@@ -281,6 +301,11 @@
               "description": "Type 7 encrypted password.",
               "title": "Password"
             },
+            "bfd": {
+              "type": "boolean",
+              "default": true,
+              "title": "BFD"
+            },
             "structured_config": {
               "type": "object",
               "description": "Custom structured config added under router_bgp.peer_groups.<name> for eos_cli_config_gen.",
@@ -307,6 +332,11 @@
               "description": "Type 7 encrypted password.",
               "title": "Password"
             },
+            "bfd": {
+              "type": "boolean",
+              "default": true,
+              "title": "BFD"
+            },
             "structured_config": {
               "type": "object",
               "description": "Custom structured config added under router_bgp.peer_groups.<name> for eos_cli_config_gen.",
@@ -332,6 +362,11 @@
               "type": "string",
               "description": "Type 7 encrypted password.",
               "title": "Password"
+            },
+            "bfd": {
+              "type": "boolean",
+              "default": true,
+              "title": "BFD"
             },
             "structured_config": {
               "type": "object",

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
@@ -193,6 +193,9 @@ keys:
           password:
             type: str
             description: Type 7 encrypted password.
+          bfd:
+            type: bool
+            default: false
           structured_config:
             type: dict
             description: Custom structured config added under router_bgp.peer_groups.<name>
@@ -207,6 +210,9 @@ keys:
           password:
             type: str
             description: Type 7 encrypted password.
+          bfd:
+            type: bool
+            default: false
           structured_config:
             type: dict
             description: Custom structured config added under router_bgp.peer_groups.<name>
@@ -221,6 +227,9 @@ keys:
           password:
             type: str
             description: Type 7 encrypted password.
+          bfd:
+            type: bool
+            default: true
           structured_config:
             type: dict
             description: Custom structured config added under router_bgp.peer_groups.<name>
@@ -235,6 +244,9 @@ keys:
           password:
             type: str
             description: Type 7 encrypted password.
+          bfd:
+            type: bool
+            default: true
           structured_config:
             type: dict
             description: Custom structured config added under router_bgp.peer_groups.<name>
@@ -249,6 +261,9 @@ keys:
           password:
             type: str
             description: Type 7 encrypted password.
+          bfd:
+            type: bool
+            default: true
           structured_config:
             type: dict
             description: Custom structured config added under router_bgp.peer_groups.<name>
@@ -263,6 +278,9 @@ keys:
           password:
             type: str
             description: Type 7 encrypted password.
+          bfd:
+            type: bool
+            default: true
           structured_config:
             type: dict
             description: Custom structured config added under router_bgp.peer_groups.<name>
@@ -277,6 +295,9 @@ keys:
           password:
             type: str
             description: Type 7 encrypted password.
+          bfd:
+            type: bool
+            default: true
           structured_config:
             type: dict
             description: Custom structured config added under router_bgp.peer_groups.<name>

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/bgp_peer_groups.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/bgp_peer_groups.schema.yml
@@ -21,6 +21,9 @@ keys:
           password:
             type: str
             description: Type 7 encrypted password.
+          bfd:
+            type: bool
+            default: False
           structured_config:
             type: dict
             description: Custom structured config added under router_bgp.peer_groups.<name> for eos_cli_config_gen.
@@ -34,6 +37,9 @@ keys:
           password:
             type: str
             description: Type 7 encrypted password.
+          bfd:
+            type: bool
+            default: False
           structured_config:
             type: dict
             description: Custom structured config added under router_bgp.peer_groups.<name> for eos_cli_config_gen.
@@ -47,6 +53,9 @@ keys:
           password:
             type: str
             description: Type 7 encrypted password.
+          bfd:
+            type: bool
+            default: True
           structured_config:
             type: dict
             description: Custom structured config added under router_bgp.peer_groups.<name> for eos_cli_config_gen.
@@ -60,6 +69,9 @@ keys:
           password:
             type: str
             description: Type 7 encrypted password.
+          bfd:
+            type: bool
+            default: True
           structured_config:
             type: dict
             description: Custom structured config added under router_bgp.peer_groups.<name> for eos_cli_config_gen.
@@ -73,6 +85,9 @@ keys:
           password:
             type: str
             description: Type 7 encrypted password.
+          bfd:
+            type: bool
+            default: True
           structured_config:
             type: dict
             description: Custom structured config added under router_bgp.peer_groups.<name> for eos_cli_config_gen.
@@ -86,6 +101,9 @@ keys:
           password:
             type: str
             description: Type 7 encrypted password.
+          bfd:
+            type: bool
+            default: True
           structured_config:
             type: dict
             description: Custom structured config added under router_bgp.peer_groups.<name> for eos_cli_config_gen.
@@ -99,6 +117,9 @@ keys:
           password:
             type: str
             description: Type 7 encrypted password.
+          bfd:
+            type: bool
+            default: True
           structured_config:
             type: dict
             description: Custom structured config added under router_bgp.peer_groups.<name> for eos_cli_config_gen.


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Make BFD configurable under bgp_peer_groups

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

```yaml
    bgp_peer_groups:
      ipv4_underlay_peers:
        name: <str>
        password: <str>
        bfd: <bool>
        structured_config: <dict>
      mlag_ipv4_underlay_peer:
        name: <str>
        password: <str>
        bfd: <bool>
        structured_config: <dict>
      evpn_overlay_peers:
        name: <str>
        password: <str>
        bfd: <bool>
        structured_config: <dict>
      evpn_overlay_core:
        name: <str>
        password: <str>
        bfd: <bool>
        structured_config: <dict>
      mpls_overlay_peers:
        name: <str>
        password: <str>
        bfd: <bool>
        structured_config: <dict>
      rr_overlay_peers:
        name: <str>
        password: <str>
        bfd: <bool>
        structured_config: <dict>
      ipvpn_gateway_peers:
        name: <str>
        password: <str>
        bfd: <bool>
        structured_config: <dict>
```

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

- Renamed existing molecule tests for `BGP_PEER_GROUPS_STRUCTURED_CONFIG` to `BGP_PEER_GROUPS` and added the `bfd` key with the opposite of the default value for all peer-groups.
- Verified updated outputs
- No unexpected changes.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
