### PR TITLE
Fix(eos_cli_config_gen,eos_designs): Update schemas missing `items` and remove unused keys

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-isis-new.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-isis-new.yml
@@ -12,11 +12,6 @@ router_isis:
       delay: 15000
   advertise:
     passive_only: true
-  no_passive_interfaces:
-    - Ethernet1
-    - Ethernet2
-    - Vlan4093
-    - Loopback1
   redistribute_routes:
     - source_protocol: static
       include_leaked: True

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-isis.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-isis.yml
@@ -12,11 +12,6 @@ router_isis:
       delay: 15000
   advertise:
     passive_only: true
-  no_passive_interfaces:
-    - Ethernet1
-    - Ethernet2
-    - Vlan4093
-    - Loopback1
   address_family_ipv4:
     maximum_paths: 2
   segment_routing_mpls:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-BL1A.yml
@@ -247,13 +247,6 @@ router_isis:
   address_family_ipv4:
     enabled: true
     maximum_paths: 4
-  no_passive_interfaces:
-  - Ethernet1
-  - Ethernet2
-  - Ethernet3
-  - Ethernet4
-  - Vlan4093
-  - Loopback1
 ip_extcommunity_lists:
 - name: ECL-EVPN-SOO
   entries:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-BL1B.yml
@@ -233,13 +233,6 @@ router_isis:
   address_family_ipv4:
     enabled: true
     maximum_paths: 4
-  no_passive_interfaces:
-  - Ethernet1
-  - Ethernet2
-  - Ethernet3
-  - Ethernet4
-  - Vlan4093
-  - Loopback1
 ip_extcommunity_lists:
 - name: ECL-EVPN-SOO
   entries:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF1A.yml
@@ -164,12 +164,6 @@ router_isis:
   address_family_ipv4:
     enabled: true
     maximum_paths: 4
-  no_passive_interfaces:
-  - Ethernet1
-  - Ethernet2
-  - Ethernet3
-  - Ethernet4
-  - Loopback0
 ip_extcommunity_lists:
 - name: ECL-EVPN-SOO
   entries:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -250,13 +250,6 @@ router_isis:
   address_family_ipv4:
     enabled: true
     maximum_paths: 4
-  no_passive_interfaces:
-  - Ethernet1
-  - Ethernet2
-  - Ethernet3
-  - Ethernet4
-  - Vlan4093
-  - Loopback10
 ip_extcommunity_lists:
 - name: ECL-EVPN-SOO
   entries:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -250,13 +250,6 @@ router_isis:
   address_family_ipv4:
     enabled: true
     maximum_paths: 4
-  no_passive_interfaces:
-  - Ethernet1
-  - Ethernet2
-  - Ethernet3
-  - Ethernet4
-  - Vlan4093
-  - Loopback10
 ip_extcommunity_lists:
 - name: ECL-EVPN-SOO
   entries:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SPINE1.yml
@@ -215,14 +215,6 @@ router_isis:
   address_family_ipv4:
     enabled: true
     maximum_paths: 4
-  no_passive_interfaces:
-  - Ethernet1
-  - Ethernet2
-  - Ethernet3
-  - Ethernet4
-  - Ethernet5
-  - Ethernet6
-  - Ethernet7
 router_bfd:
   multihop:
     interval: 1200

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SPINE2.yml
@@ -158,11 +158,3 @@ router_isis:
   address_family_ipv4:
     enabled: true
     maximum_paths: 4
-  no_passive_interfaces:
-  - Ethernet1
-  - Ethernet2
-  - Ethernet3
-  - Ethernet4
-  - Ethernet5
-  - Ethernet6
-  - Ethernet7

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SPINE3.yml
@@ -158,11 +158,3 @@ router_isis:
   address_family_ipv4:
     enabled: true
     maximum_paths: 4
-  no_passive_interfaces:
-  - Ethernet1
-  - Ethernet2
-  - Ethernet3
-  - Ethernet4
-  - Ethernet5
-  - Ethernet6
-  - Ethernet7

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SPINE4.yml
@@ -215,14 +215,6 @@ router_isis:
   address_family_ipv4:
     enabled: true
     maximum_paths: 4
-  no_passive_interfaces:
-  - Ethernet1
-  - Ethernet2
-  - Ethernet3
-  - Ethernet4
-  - Ethernet5
-  - Ethernet6
-  - Ethernet7
 router_bfd:
   multihop:
     interval: 1200

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SVC3A.yml
@@ -250,13 +250,6 @@ router_isis:
   address_family_ipv4:
     enabled: true
     maximum_paths: 4
-  no_passive_interfaces:
-  - Ethernet1
-  - Ethernet2
-  - Ethernet3
-  - Ethernet4
-  - Vlan4094
-  - Loopback1
 ip_extcommunity_lists:
 - name: ECL-EVPN-SOO
   entries:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SVC3B.yml
@@ -250,13 +250,6 @@ router_isis:
   address_family_ipv4:
     enabled: true
     maximum_paths: 4
-  no_passive_interfaces:
-  - Ethernet1
-  - Ethernet2
-  - Ethernet3
-  - Ethernet4
-  - Vlan4094
-  - Loopback1
 ip_extcommunity_lists:
 - name: ECL-EVPN-SOO
   entries:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -38,7 +38,6 @@ search:
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;type</samp>](## "aaa_accounting.commands.default.[].type") | String |  |  | Valid Values:<br>- none<br>- start-stop<br>- stop-only |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;group</samp>](## "aaa_accounting.commands.default.[].group") | String |  |  |  | Group Name |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;logging</samp>](## "aaa_accounting.commands.default.[].logging") | Boolean |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;commands_default</samp>](## "aaa_accounting.commands.commands_default") | List |  |  |  | Deprecated and removed key from AVD 2.x |
 
 === "YAML"
 
@@ -70,7 +69,6 @@ search:
             type: <str>
             group: <str>
             logging: <bool>
-        commands_default: <list>
     ```
 
 ## AAA Authentication
@@ -5945,7 +5943,6 @@ Set Link Aggregation Control Protocol (LACP) parameters.
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;prefix_segments</samp>](## "router_isis.segment_routing_mpls.prefix_segments") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- prefix</samp>](## "router_isis.segment_routing_mpls.prefix_segments.[].prefix") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;index</samp>](## "router_isis.segment_routing_mpls.prefix_segments.[].index") | Integer |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;no_passive_interfaces</samp>](## "router_isis.no_passive_interfaces") | List |  |  |  | Unused key - to be removed from eos_designs. |
 
 === "YAML"
 
@@ -5999,7 +5996,6 @@ Set Link Aggregation Control Protocol (LACP) parameters.
         prefix_segments:
           - prefix: <str>
             index: <int>
-      no_passive_interfaces: <list>
     ```
 
 ## Router L2 VPN

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -203,11 +203,6 @@
                 }
               },
               "title": "Default"
-            },
-            "commands_default": {
-              "type": "array",
-              "description": "Deprecated and removed key from AVD 2.x",
-              "title": "Commands Default"
             }
           },
           "additionalProperties": false,
@@ -15696,11 +15691,6 @@
             "^_.+$": {}
           },
           "title": "Segment Routing MPLS"
-        },
-        "no_passive_interfaces": {
-          "type": "array",
-          "description": "Unused key - to be removed from eos_designs.",
-          "title": "No Passive Interfaces"
         }
       },
       "additionalProperties": false,

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -106,9 +106,6 @@ keys:
                   type: str
                 logging:
                   type: bool
-          commands_default:
-            type: list
-            description: Deprecated and removed key from AVD 2.x
   aaa_authentication:
     type: dict
     keys:
@@ -9144,9 +9141,6 @@ keys:
                   type: int
                   convert_types:
                   - str
-      no_passive_interfaces:
-        type: list
-        description: Unused key - to be removed from eos_designs.
   router_l2_vpn:
     type: dict
     keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/aaa_accounting.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/aaa_accounting.schema.yml
@@ -90,6 +90,3 @@ keys:
                   type: str
                 logging:
                   type: bool
-          commands_default:
-            type: list
-            description: "Deprecated and removed key from AVD 2.x"

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_isis.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_isis.schema.yml
@@ -189,6 +189,3 @@ keys:
                   type: int
                   convert_types:
                     - str
-      no_passive_interfaces:
-        type: list
-        description: Unused key - to be removed from eos_designs.

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/Input Variables.md
@@ -393,7 +393,8 @@ The default keys are `servers`, `firewalls`, `routers`, `load_balancers`, and `s
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;evpn_l3_multicast</samp>](## "&lt;network_services_keys.name&gt;.[].vrfs.[].evpn_l3_multicast") | Dictionary |  |  |  | Explicitly enable or disable evpn_l3_multicast to override setting of `<network_services_key>.[].evpn_l3_multicast.enabled`.<br>Allow override of `<network_services_key>.[].evpn_l3_multicast` node_settings.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "&lt;network_services_keys.name&gt;.[].vrfs.[].evpn_l3_multicast.enabled") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;evpn_peg</samp>](## "&lt;network_services_keys.name&gt;.[].vrfs.[].evpn_l3_multicast.evpn_peg") | List, items: Dictionary |  |  |  | For each group of nodes, allow configuration of EVPN PEG features. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- nodes</samp>](## "&lt;network_services_keys.name&gt;.[].vrfs.[].evpn_l3_multicast.evpn_peg.[].nodes") | List |  |  |  | Restrict configuration to specific nodes.<br>Will apply to all nodes with RP addresses configured if not set.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- nodes</samp>](## "&lt;network_services_keys.name&gt;.[].vrfs.[].evpn_l3_multicast.evpn_peg.[].nodes") | List, items: String |  |  |  | Restrict configuration to specific nodes.<br>Will apply to all nodes with RP addresses configured if not set.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "&lt;network_services_keys.name&gt;.[].vrfs.[].evpn_l3_multicast.evpn_peg.[].nodes.[].&lt;str&gt;") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;transit</samp>](## "&lt;network_services_keys.name&gt;.[].vrfs.[].evpn_l3_multicast.evpn_peg.[].transit") | Boolean |  | False |  | Enable EVPN PEG transit mode. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;pim_rp_addresses</samp>](## "&lt;network_services_keys.name&gt;.[].vrfs.[].pim_rp_addresses") | List, items: Dictionary |  |  |  | For each group of nodes, allow configuration of RP Addresses & associated groups.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- rps</samp>](## "&lt;network_services_keys.name&gt;.[].vrfs.[].pim_rp_addresses.[].rps") | List, items: String |  |  |  | A minimum of one RP must be specified. |
@@ -813,7 +814,8 @@ The default keys are `servers`, `firewalls`, `routers`, `load_balancers`, and `s
             evpn_l3_multicast:
               enabled: <bool>
               evpn_peg:
-                - nodes: <list>
+                - nodes:
+                    - <str>
                   transit: <bool>
             pim_rp_addresses:
               - rps:

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/router_isis.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/router_isis.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from functools import cached_property
 
 from ansible_collections.arista.avd.plugins.plugin_utils.errors import AristaAvdMissingVariableError
-from ansible_collections.arista.avd.plugins.plugin_utils.utils import default, get
+from ansible_collections.arista.avd.plugins.plugin_utils.utils import get
 
 from .utils import UtilsMixin
 
@@ -30,19 +30,6 @@ class RouterIsisMixin(UtilsMixin):
             "is_type": self._is_type,
             "address_family_ipv4": {"enabled": True, "maximum_paths": get(self._hostvars, "isis_maximum_paths", default=4)},
         }
-
-        # no passive interfaces
-        no_passive_interfaces = [link["interface"] for link in self._underlay_links if link["type"] == "underlay_p2p"]
-
-        if self.shared_utils.mlag_l3:
-            mlag_l3_vlan = default(self.shared_utils.mlag_peer_l3_vlan, self.shared_utils.mlag_peer_vlan)
-            no_passive_interfaces.append(f"Vlan{mlag_l3_vlan}")
-
-        if self.shared_utils.overlay_vtep is True:
-            no_passive_interfaces.append(self.shared_utils.vtep_loopback)
-
-        if no_passive_interfaces:
-            router_isis["no_passive_interfaces"] = no_passive_interfaces
 
         if self.shared_utils.underlay_ldp is True:
             router_isis["mpls_ldp_sync_default"] = True

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
@@ -3132,6 +3132,8 @@ $defs:
                             not set.
 
                             '
+                          items:
+                            type: str
                         transit:
                           type: bool
                           default: false

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/defs_network_services.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/defs_network_services.schema.yml
@@ -394,6 +394,8 @@ $defs:
                           description: |
                             Restrict configuration to specific nodes.
                             Will apply to all nodes with RP addresses configured if not set.
+                          items:
+                            type: str
                         transit:
                           type: bool
                           default: false


### PR DESCRIPTION
## Change Summary

The schemas for `eos_designs` and `eos_cli_config_gen` had some `list` keys that were missing the `items` key. 
Refer to the proposed changes for a description of how each was resolved.

## Related Issue(s)

Fixes #2871 

## Component(s) name

`arista.avd.eos_designs`
`arista.avd.eos_cli_config_gen`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

## eos_cli_config_gen

- [x] `aaa_accounting.commands.commands_default: <list>` : _This key was removed, as it was not used in any templates_
- [x] `router_isis.no_passive_interfaces: <list>` _This key was removed, as it was not used in any templates_

For both of the above keys, note that the changes in the molecule test inventory did not cause any change in the config being generated.

## eos_designs

- [x] `<network_services_keys.name>.vrfs.evpn_l3_multicast.evpn_peg.nodes: <list>` _Added the `str` type for the items, just like the `evpn_peg` definition at the tenant level._

- Remove the generation of `no_passive_interface` list for `router_isis`.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

- run `molecule test -s eos_cli_config_gen`
- run `molecule test -s eos_designs_unit_tests`

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- Review whether best way forward is to remove the unused keys `router_isis.no_passive_interfaces: <list>` and `router_isis.no_passive_interfaces: <list>`

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
