### PR TITLE
Feat(eos_cli_config_gen): Add OSPF default_information_originate options

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-ospf.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-ospf.md
@@ -275,7 +275,7 @@ router ospf 200 vrf ospf_zone
    area 3 filter prefix-list PL-OSPF-FILTERING
    max-lsa 5
    timers lsa rx min interval 100
-   default-information originate always
+   default-information originate always metric 100 metric-type 1
    redistribute static include leaked route-map rm-ospf-static
    redistribute connected include leaked route-map rm-ospf-connected
    redistribute bgp include leaked route-map rm-ospf-bgp

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-ospf.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-ospf.cfg
@@ -82,7 +82,7 @@ router ospf 200 vrf ospf_zone
    area 3 filter prefix-list PL-OSPF-FILTERING
    max-lsa 5
    timers lsa rx min interval 100
-   default-information originate always
+   default-information originate always metric 100 metric-type 1
    redistribute static include leaked route-map rm-ospf-static
    redistribute connected include leaked route-map rm-ospf-connected
    redistribute bgp include leaked route-map rm-ospf-bgp

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-ospf.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-ospf.yml
@@ -67,6 +67,8 @@ router_ospf:
       max_lsa: 5
       default_information_originate:
         always: true
+        metric_type: 1
+        metric: 100
       redistribute:
         static:
           route_map: rm-ospf-static

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-ospf.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-ospf.md
@@ -36,6 +36,8 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;max</samp>](## "router_ospf.process_ids.[].timers.spf_delay.max") | Integer |  |  | Min: 0<br>Max: 65535000 | Max wait time between two SPFs in msecs |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;default_information_originate</samp>](## "router_ospf.process_ids.[].default_information_originate") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;always</samp>](## "router_ospf.process_ids.[].default_information_originate.always") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;metric</samp>](## "router_ospf.process_ids.[].default_information_originate.metric") | Integer |  |  | Min: 1<br>Max: 65535 | Metric for default route |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;metric_type</samp>](## "router_ospf.process_ids.[].default_information_originate.metric_type") | Integer |  |  | Valid Values:<br>- 1<br>- 2 | OSPF metric type for default route |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;summary_addresses</samp>](## "router_ospf.process_ids.[].summary_addresses") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- prefix</samp>](## "router_ospf.process_ids.[].summary_addresses.[].prefix") | String | Required, Unique |  |  | Summary Prefix Address |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tag</samp>](## "router_ospf.process_ids.[].summary_addresses.[].tag") | Integer |  |  |  |  |
@@ -112,6 +114,8 @@
               max: <int>
           default_information_originate:
             always: <bool>
+            metric: <int>
+            metric_type: <int>
           summary_addresses:
             - prefix: <str>
               tag: <int>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -16809,6 +16809,22 @@
                   "always": {
                     "type": "boolean",
                     "title": "Always"
+                  },
+                  "metric": {
+                    "type": "integer",
+                    "description": "Metric for default route",
+                    "minimum": 1,
+                    "maximum": 65535,
+                    "title": "Metric"
+                  },
+                  "metric_type": {
+                    "type": "integer",
+                    "enum": [
+                      1,
+                      2
+                    ],
+                    "description": "OSPF metric type for default route",
+                    "title": "Metric Type"
                   }
                 },
                 "additionalProperties": false,

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -9810,6 +9810,21 @@ keys:
               keys:
                 always:
                   type: bool
+                metric:
+                  type: int
+                  convert_types:
+                  - str
+                  description: Metric for default route
+                  min: 1
+                  max: 65535
+                metric_type:
+                  type: int
+                  convert_types:
+                  - str
+                  valid_values:
+                  - 1
+                  - 2
+                  description: OSPF metric type for default route
             summary_addresses:
               type: list
               primary_key: prefix

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_ospf.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_ospf.schema.yml
@@ -149,6 +149,19 @@ keys:
               keys:
                 always:
                   type: bool
+                metric:
+                  type: int
+                  convert_types:
+                    - str
+                  description: Metric for default route
+                  min: 1
+                  max: 65535
+                metric_type:
+                  type: int
+                  convert_types:
+                    - str
+                  valid_values: [1, 2]
+                  description: OSPF metric type for default route
             summary_addresses:
               type: list
               primary_key: prefix

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-ospf.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-ospf.j2
@@ -116,6 +116,12 @@ router ospf {{ process_id.id }}
 {%         if process_id.default_information_originate.always is arista.avd.defined(true) %}
 {%             set default_information_originate_cli = default_information_originate_cli ~ " always" %}
 {%         endif %}
+{%         if process_id.default_information_originate.metric is arista.avd.defined %}
+{%             set default_information_originate_cli = default_information_originate_cli ~ " metric " ~ process_id.default_information_originate.metric %}
+{%         endif %}
+{%         if process_id.default_information_originate.metric_type is arista.avd.defined %}
+{%             set default_information_originate_cli = default_information_originate_cli ~ " metric-type " ~ process_id.default_information_originate.metric_type %}
+{%         endif %}
    {{ default_information_originate_cli }}
 {%     endif %}
 {%     if process_id.redistribute.static is defined %}


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Add the following missing options under `default_information_originate` at OSPF process level:

- metric-type
- metric

These are previously supported under OSPF areas but not under OSPF process

## Related Issue(s)

Fixes #2895 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->
See change summary

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Included molecule test covering these 2 options

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
