### PR TITLE
Feat(eos_designs): Add schema for queue_monitor_length

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/queue_monitor_length.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/queue_monitor_length.yml
@@ -1,5 +1,4 @@
 queue_monitor_length:
-  # "enabled: true" will be required in AVD4.0. In AVD3.x default is true as long as queue_monitor_length is defined and not None
   enabled: true
   default_thresholds:
     low: 10

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/AVD_LAB.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/AVD_LAB.yml
@@ -43,7 +43,8 @@ ntp:
       vrf: "{{ mgmt_interface_vrf | arista.avd.default('MGMT') }}"
 
 queue_monitor_length:
-  log: 5
+  enabled: true
   notifying: true
+  log: 5
   # Note "notifying" should only be rendered on 7280R since default
   # platform_settings for default has queue_monitor_length_notify_support: false

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/platform.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/platform.py
@@ -162,3 +162,7 @@ class PlatformMixin:
     @cached_property
     def platform_settings_feature_support_interface_storm_control(self) -> bool:
         return get(self.platform_settings, "feature_support.interface_storm_control", default=True) is True
+
+    @cached_property
+    def platform_settings_feature_support_queue_monitor_length_notify(self) -> bool:
+        return get(self.platform_settings, "feature_support.queue_monitor_length_notify", default=True) is True

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/Input Variables.md
@@ -5044,6 +5044,40 @@ Keys are the same used under endpoints adapters. Keys defined under endpoints ad
         transport: <str>
     ```
 
+## Queue Monitor Length
+
+=== "Table"
+
+    | Variable | Type | Required | Default | Value Restrictions | Description |
+    | -------- | ---- | -------- | ------- | ------------------ | ----------- |
+    | [<samp>queue_monitor_length</samp>](## "queue_monitor_length") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;enabled</samp>](## "queue_monitor_length.enabled") | Boolean | Required |  |  |  |
+    | [<samp>&nbsp;&nbsp;notifying</samp>](## "queue_monitor_length.notifying") | Boolean |  |  |  | If True, `eos_designs` will configure `queue-monitor length notifying` according to the<br>`platform_settings.[].feature_support.queue_monitor_length_notify` setting. |
+    | [<samp>&nbsp;&nbsp;default_thresholds</samp>](## "queue_monitor_length.default_thresholds") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;high</samp>](## "queue_monitor_length.default_thresholds.high") | Integer | Required |  |  | Default high threshold for Ethernet Interfaces.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;low</samp>](## "queue_monitor_length.default_thresholds.low") | Integer |  |  |  | Default low threshold for Ethernet Interfaces.<br>Low threshold support is platform dependent.<br> |
+    | [<samp>&nbsp;&nbsp;log</samp>](## "queue_monitor_length.log") | Integer |  |  |  | Logging interval in seconds |
+    | [<samp>&nbsp;&nbsp;cpu</samp>](## "queue_monitor_length.cpu") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;thresholds</samp>](## "queue_monitor_length.cpu.thresholds") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;high</samp>](## "queue_monitor_length.cpu.thresholds.high") | Integer | Required |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;low</samp>](## "queue_monitor_length.cpu.thresholds.low") | Integer |  |  |  |  |
+
+=== "YAML"
+
+    ```yaml
+    queue_monitor_length:
+      enabled: <bool>
+      notifying: <bool>
+      default_thresholds:
+        high: <int>
+        low: <int>
+      log: <int>
+      cpu:
+        thresholds:
+          high: <int>
+          low: <int>
+    ```
+
 ## Redundancy
 
 Redundancy for chassis platforms with dual supervisors | Optional

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/base/avdstructuredconfig.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/base/avdstructuredconfig.py
@@ -317,16 +317,11 @@ class AvdStructuredConfigBase(AvdFacts):
         if (queue_monitor_length := get(self._hostvars, "queue_monitor_length")) is None:
             return None
 
-        queue_monitor_length_dict = {"enabled": True}
-        queue_monitor_length_notifying = get(queue_monitor_length, "notifying")
-        notify_supported = get(self.shared_utils.platform_settings, "feature_support.queue_monitor_length_notify")
-        if queue_monitor_length_notifying is not None and notify_supported is not False:
-            queue_monitor_length_dict["notifying"] = queue_monitor_length_notifying
+        # Enforce platform feature support for notifying.
+        if get(queue_monitor_length, "notifying") is True and not self.shared_utils.platform_settings_feature_support_queue_monitor_length_notify:
+            queue_monitor_length.pop("notifying", None)
 
-        if get(queue_monitor_length, "log") is not None:
-            queue_monitor_length_dict["log"] = queue_monitor_length.get("log")
-
-        return queue_monitor_length_dict
+        return queue_monitor_length
 
     @cached_property
     def ip_name_servers(self) -> list | None:

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/base/avdstructuredconfig.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/base/avdstructuredconfig.py
@@ -317,8 +317,8 @@ class AvdStructuredConfigBase(AvdFacts):
         if (queue_monitor_length := get(self._hostvars, "queue_monitor_length")) is None:
             return None
 
-        # Enforce platform feature support for notifying.
-        if get(queue_monitor_length, "notifying") is True and not self.shared_utils.platform_settings_feature_support_queue_monitor_length_notify:
+        # Remove notifying key if not supported by the platform settings.
+        if not self.shared_utils.platform_settings_feature_support_queue_monitor_length_notify:
             queue_monitor_length.pop("notifying", None)
 
         return queue_monitor_length

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -4541,6 +4541,87 @@
       },
       "title": "PTP Profiles"
     },
+    "queue_monitor_length": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "title": "Enabled"
+        },
+        "notifying": {
+          "type": "boolean",
+          "description": "If True, `eos_designs` will configure `queue-monitor length notifying` according to the\n`platform_settings.[].feature_support.queue_monitor_length_notify` setting.",
+          "title": "Notifying"
+        },
+        "default_thresholds": {
+          "type": "object",
+          "properties": {
+            "high": {
+              "type": "integer",
+              "description": "Default high threshold for Ethernet Interfaces.\n",
+              "title": "High"
+            },
+            "low": {
+              "type": "integer",
+              "description": "Default low threshold for Ethernet Interfaces.\nLow threshold support is platform dependent.\n",
+              "title": "Low"
+            }
+          },
+          "required": [
+            "high"
+          ],
+          "additionalProperties": false,
+          "patternProperties": {
+            "^_.+$": {}
+          },
+          "title": "Default Thresholds"
+        },
+        "log": {
+          "type": "integer",
+          "description": "Logging interval in seconds",
+          "title": "Log"
+        },
+        "cpu": {
+          "type": "object",
+          "properties": {
+            "thresholds": {
+              "type": "object",
+              "properties": {
+                "high": {
+                  "type": "integer",
+                  "title": "High"
+                },
+                "low": {
+                  "type": "integer",
+                  "title": "Low"
+                }
+              },
+              "required": [
+                "high"
+              ],
+              "additionalProperties": false,
+              "patternProperties": {
+                "^_.+$": {}
+              },
+              "title": "Thresholds"
+            }
+          },
+          "additionalProperties": false,
+          "patternProperties": {
+            "^_.+$": {}
+          },
+          "title": "CPU"
+        }
+      },
+      "required": [
+        "enabled"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^_.+$": {}
+      },
+      "title": "Queue Monitor Length"
+    },
     "redundancy": {
       "type": "object",
       "description": "Redundancy for chassis platforms with dual supervisors | Optional",

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
@@ -1534,6 +1534,18 @@ keys:
           type: str
           valid_values:
           - ipv4
+  queue_monitor_length:
+    $ref: eos_cli_config_gen#/keys/queue_monitor_length
+    type: dict
+    keys:
+      enabled:
+        type: bool
+      notifying:
+        type: bool
+        description: 'If True, `eos_designs` will configure `queue-monitor length
+          notifying` according to the
+
+          `platform_settings.[].feature_support.queue_monitor_length_notify` setting.'
   redundancy:
     type: dict
     description: Redundancy for chassis platforms with dual supervisors | Optional

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/queue_monitor_length.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/queue_monitor_length.schema.yml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  queue_monitor_length:
+    $ref: "eos_cli_config_gen#/keys/queue_monitor_length"
+    type: dict
+    keys:
+      enabled:
+        # Specifically setting this key to keep it at the top of the documentation. Everything else is inherited by the $ref above.
+        type: bool
+      notifying:
+        # Specifically overriding the description for this key. Everything else is inherited by the $ref above.
+        type: bool
+        description: |
+          If True, `eos_designs` will configure `queue-monitor length notifying` according to the
+          `platform_settings.[].feature_support.queue_monitor_length_notify` setting.


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Add schema for queue_monitor_length

## Related Issue(s)

Fixes #2852 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

- Add schema for queue monitor length
- Enhance support through eos_designs by not parsing the inputs, but just relaying it (after filtering out `notifying` where needed)

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Covered by existing molecule scenario `evpn_underlay_ebgp_overlay_ebgp`

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
