### PR TITLE
Fix(eos_designs): Support 4.0 data models in Connected Endpoints docs

### DIFF
--- a/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/fabric/DC1_FABRIC-documentation.md
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/fabric/DC1_FABRIC-documentation.md
@@ -118,7 +118,7 @@
 | Profile Name | Parent Profile |
 | ------------ | -------------- |
 | PP-DEFAULTS | - |
-| PP-BLUE | - |
-| PP-GREEN | - |
-| PP-ORANGE | - |
+| PP-BLUE | PP-DEFAULTS |
+| PP-GREEN | PP-DEFAULTS |
+| PP-ORANGE | PP-DEFAULTS |
 | PP-FIREWALL | - |

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/fabric/TWODC_5STAGE_CLOS-documentation.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/fabric/TWODC_5STAGE_CLOS-documentation.md
@@ -275,5 +275,5 @@
 
 | Profile Name | Parent Profile |
 | ------------ | -------------- |
-| NESTED_TENANT_A | - |
+| NESTED_TENANT_A | TENANT_A |
 | TENANT_A | - |

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/documentation/connected-endpoints.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/documentation/connected-endpoints.j2
@@ -15,14 +15,14 @@
     {"key": "generic_devices", "type": "generic_device", "description": "Generic Device"}] %}
 {% set all_connected_endpoints_keys = [] %}
 {% set all_connected_endpoints = {} %}
-{% set all_profiles = {} %}
+{% set all_profiles = [] %}
 {# This is a repeat of the loop in the main file so should probably do all at once.. or somewhere else? #}
 {% for node in groups[fabric_name] | arista.avd.natural_sort %}
 {%     set node_hostvars = hostvars[node] %}
 {%     set node_facts = avd_switch_facts[node] %}
 {%     do all_connected_endpoints_keys.extend(node_hostvars.connected_endpoints_keys | arista.avd.convert_dicts("key") | arista.avd.default(default_connected_endpoints_keys)) %}
 {# Populate profiles #}
-{%     do all_profiles.update(node_hostvars.port_profiles | arista.avd.default({})) %}
+{%     do all_profiles.extend(node_hostvars.port_profiles | arista.avd.convert_dicts("profile") | arista.avd.default([])) %}
 {# Populate endpoints #}
 {%     for ethernet_interface in node_hostvars.ethernet_interfaces | arista.avd.convert_dicts("name") | arista.avd.natural_sort("name") %}
 {%         set peer_type = ethernet_interface.peer_type | arista.avd.default('undefined') %}
@@ -92,8 +92,8 @@ No connected endpoint configured!
 
 | Profile Name | Parent Profile |
 | ------------ | -------------- |
-{%     for profile in all_profiles %}
+{%     for profile in all_profiles | unique %}
 {%         set parent = profile.parent_profile | arista.avd.default("-") %}
-| {{ profile }} | {{ parent }} |
+| {{ profile.profile }} | {{ parent }} |
 {%     endfor %}
 {% endif %}


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Support 4.0 data models in Connected Endpoints docs

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

Accept `port_profiles` as a list incl. handle conversion from dict if necessary.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Tested on #2908 

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
