### PR TITLE
Fix(eos_designs): eBGP rfc5549 creates invalid configuration for MLAG scenarios

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-v4-evpn.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-v4-evpn.md
@@ -284,6 +284,9 @@ router bgp 65101
          neighbor 10.2.3.4 route-map RM-10.2.3.4-SET-NEXT-HOP-OUT out
          neighbor 10.2.3.5 activate
          neighbor 10.2.3.5 route-map RM-10.2.3.5-SET-NEXT-HOP-IN in
+         neighbor 10.2.3.6 next-hop address-family ipv6
+         neighbor 10.2.3.7 next-hop address-family ipv6 originate
+         no neighbor 10.2.3.8 next-hop address-family ipv6
          network 10.0.0.0/8
          network 100.64.0.0/10 route-map RM-10.2.3.4
    !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-v4-evpn.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-v4-evpn.cfg
@@ -122,6 +122,9 @@ router bgp 65101
          neighbor 10.2.3.4 route-map RM-10.2.3.4-SET-NEXT-HOP-OUT out
          neighbor 10.2.3.5 activate
          neighbor 10.2.3.5 route-map RM-10.2.3.5-SET-NEXT-HOP-IN in
+         neighbor 10.2.3.6 next-hop address-family ipv6
+         neighbor 10.2.3.7 next-hop address-family ipv6 originate
+         no neighbor 10.2.3.8 next-hop address-family ipv6
          network 10.0.0.0/8
          network 100.64.0.0/10 route-map RM-10.2.3.4
    !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-v4-evpn.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-v4-evpn.yml
@@ -172,6 +172,20 @@ router_bgp:
           - ip_address: 10.2.3.5
             activate: true
             route_map_in: RM-10.2.3.5-SET-NEXT-HOP-IN
+          - ip_address: 10.2.3.6
+            next_hop:
+              address_family_ipv6:
+                enabled: true
+          - ip_address: 10.2.3.7
+            next_hop:
+              address_family_ipv6:
+                enabled: true
+                originate: true
+          - ip_address: 10.2.3.8
+            next_hop:
+              address_family_ipv6:
+                enabled: false
+                originate: true # this should not get added to the configuration
         networks:
           - prefix: 10.0.0.0/8
           - prefix: 100.64.0.0/10

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LER2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LER2.yml
@@ -94,15 +94,15 @@ router_bgp:
         - '65000:20'
     redistribute_routes:
     - source_protocol: connected
+    address_family_ipv4:
+      neighbors:
+      - ip_address: 192.168.48.1
+        activate: true
     neighbors:
     - ip_address: 192.168.48.1
       description: TENANT_B_CPE_SITE3
       password: toZKiUFLVUTU4hdS5V8F4Q==
       remote_as: '65201'
-    address_family_ipv4:
-      neighbors:
-      - ip_address: 192.168.48.1
-        activate: true
     updates:
       wait_install: true
   vlans:

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE2-LER1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE2-LER1.yml
@@ -90,15 +90,15 @@ router_bgp:
     redistribute_routes:
     - source_protocol: connected
     - source_protocol: ospf
+    address_family_ipv4:
+      neighbors:
+      - ip_address: 192.168.48.3
+        activate: true
     neighbors:
     - ip_address: 192.168.48.3
       description: TENANT_B_CPE_SITE5
       password: OajzUG59/YF0NkgvOQyRnQ==
       remote_as: '65202'
-    address_family_ipv4:
-      neighbors:
-      - ip_address: 192.168.48.3
-        activate: true
     updates:
       wait_install: true
   vlans:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1A.yml
@@ -144,6 +144,12 @@ router_bgp:
     - source_protocol: connected
     - source_protocol: static
     - source_protocol: ospf
+    address_family_ipv4:
+      neighbors:
+      - ip_address: 123.1.1.10
+        activate: true
+      - ip_address: 123.1.1.11
+        activate: true
     neighbors:
     - ip_address: 123.1.1.10
       remote_as: '1234'
@@ -179,12 +185,6 @@ router_bgp:
       route_map_out: RM-Tenant_A_WAN_Zone-fd5a:fe45:8831:06c5::a-SET-NEXT-HOP-OUT
     - ip_address: fd5a:fe45:8831:06c5::b
       remote_as: '12345'
-    address_family_ipv4:
-      neighbors:
-      - ip_address: 123.1.1.10
-        activate: true
-      - ip_address: 123.1.1.11
-        activate: true
     address_family_ipv6:
       neighbors:
       - ip_address: fd5a:fe45:8831:06c5::a

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1B.yml
@@ -148,6 +148,12 @@ router_bgp:
     - source_protocol: connected
     - source_protocol: static
     - source_protocol: ospf
+    address_family_ipv4:
+      neighbors:
+      - ip_address: 123.1.1.10
+        activate: true
+      - ip_address: 123.1.1.11
+        activate: true
     neighbors:
     - ip_address: 123.1.1.10
       remote_as: '1234'
@@ -183,12 +189,6 @@ router_bgp:
       route_map_out: RM-Tenant_A_WAN_Zone-fd5a:fe45:8831:06c5::a-SET-NEXT-HOP-OUT
     - ip_address: fd5a:fe45:8831:06c5::b
       remote_as: '12345'
-    address_family_ipv4:
-      neighbors:
-      - ip_address: 123.1.1.10
-        activate: true
-      - ip_address: 123.1.1.11
-        activate: true
     address_family_ipv6:
       neighbors:
       - ip_address: fd5a:fe45:8831:06c5::a

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL2A.yml
@@ -198,6 +198,12 @@ router_bgp:
         - '31:31'
     redistribute_routes:
     - source_protocol: connected
+    address_family_ipv4:
+      neighbors:
+      - ip_address: 2.2.2.2
+        activate: true
+      - ip_address: 2.2.2.3
+        activate: true
     neighbors:
     - ip_address: 2.2.2.2
       peer_group: Tenant_C_BGP_PEER_GROUP
@@ -205,12 +211,6 @@ router_bgp:
     - ip_address: 2.2.2.3
       peer_group: Tenant_C_BGP_PEER_GROUP2
       description: test_bgp_peer_group_without_nodes_2nd_time
-    address_family_ipv4:
-      neighbors:
-      - ip_address: 2.2.2.2
-        activate: true
-      - ip_address: 2.2.2.3
-        activate: true
     updates:
       wait_install: true
   vlan_aware_bundles:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL2B.yml
@@ -194,6 +194,10 @@ router_bgp:
         - '31:31'
     redistribute_routes:
     - source_protocol: connected
+    address_family_ipv4:
+      neighbors:
+      - ip_address: 1.1.1.1
+        activate: true
     neighbors:
     - ip_address: 1.1.1.1
       peer_group: Tenant_C_WAN_Zone_BGP_PEER_GROUP
@@ -202,10 +206,6 @@ router_bgp:
     - ip_address: BEBA::C0CA:C07A
       peer_group: Tenant_C_WAN_Zone_BGP_PEER_GROUP
       description: test_ipv6
-    address_family_ipv4:
-      neighbors:
-      - ip_address: 1.1.1.1
-        activate: true
     address_family_ipv6:
       neighbors:
       - ip_address: BEBA::C0CA:C07A

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-BL1A.yml
@@ -124,6 +124,12 @@ router_bgp:
     - source_protocol: connected
     - source_protocol: static
     - source_protocol: ospf
+    address_family_ipv4:
+      neighbors:
+      - ip_address: 123.1.1.10
+        activate: true
+      - ip_address: 123.1.1.11
+        activate: true
     neighbors:
     - ip_address: 123.1.1.10
       remote_as: '1234'
@@ -159,12 +165,6 @@ router_bgp:
       route_map_out: RM-Tenant_A_WAN_Zone-fd5a:fe45:8831:06c5::a-SET-NEXT-HOP-OUT
     - ip_address: fd5a:fe45:8831:06c5::b
       remote_as: '12345'
-    address_family_ipv4:
-      neighbors:
-      - ip_address: 123.1.1.10
-        activate: true
-      - ip_address: 123.1.1.11
-        activate: true
     address_family_ipv6:
       neighbors:
       - ip_address: fd5a:fe45:8831:06c5::a

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-BL1B.yml
@@ -124,6 +124,12 @@ router_bgp:
     - source_protocol: connected
     - source_protocol: static
     - source_protocol: ospf
+    address_family_ipv4:
+      neighbors:
+      - ip_address: 123.1.1.10
+        activate: true
+      - ip_address: 123.1.1.11
+        activate: true
     neighbors:
     - ip_address: 123.1.1.10
       remote_as: '1234'
@@ -159,12 +165,6 @@ router_bgp:
       route_map_out: RM-Tenant_A_WAN_Zone-fd5a:fe45:8831:06c5::a-SET-NEXT-HOP-OUT
     - ip_address: fd5a:fe45:8831:06c5::b
       remote_as: '12345'
-    address_family_ipv4:
-      neighbors:
-      - ip_address: 123.1.1.10
-        activate: true
-      - ip_address: 123.1.1.11
-        activate: true
     address_family_ipv6:
       neighbors:
       - ip_address: fd5a:fe45:8831:06c5::a

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
@@ -102,6 +102,12 @@ router_bgp:
     redistribute_routes:
     - source_protocol: connected
     - source_protocol: static
+    address_family_ipv4:
+      neighbors:
+      - ip_address: 123.1.1.10
+        activate: true
+      - ip_address: 123.1.1.11
+        activate: true
     neighbors:
     - ip_address: 123.1.1.10
       remote_as: '1234'
@@ -136,12 +142,6 @@ router_bgp:
       route_map_out: RM-Tenant_A_WAN_Zone-fd5a:fe45:8831:06c5::a-SET-NEXT-HOP-OUT
     - ip_address: fd5a:fe45:8831:06c5::b
       remote_as: '12345'
-    address_family_ipv4:
-      neighbors:
-      - ip_address: 123.1.1.10
-        activate: true
-      - ip_address: 123.1.1.11
-        activate: true
     address_family_ipv6:
       neighbors:
       - ip_address: fd5a:fe45:8831:06c5::a

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
@@ -102,6 +102,12 @@ router_bgp:
     redistribute_routes:
     - source_protocol: connected
     - source_protocol: static
+    address_family_ipv4:
+      neighbors:
+      - ip_address: 123.1.1.10
+        activate: true
+      - ip_address: 123.1.1.11
+        activate: true
     neighbors:
     - ip_address: 123.1.1.10
       remote_as: '1234'
@@ -136,12 +142,6 @@ router_bgp:
       route_map_out: RM-Tenant_A_WAN_Zone-fd5a:fe45:8831:06c5::a-SET-NEXT-HOP-OUT
     - ip_address: fd5a:fe45:8831:06c5::b
       remote_as: '12345'
-    address_family_ipv4:
-      neighbors:
-      - ip_address: 123.1.1.10
-        activate: true
-      - ip_address: 123.1.1.11
-        activate: true
     address_family_ipv6:
       neighbors:
       - ip_address: fd5a:fe45:8831:06c5::a

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_BL1.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_BL1.yml
@@ -1,6 +1,6 @@
 ---
 my_dci_ethernet_interfaces:
-  Ethernet4000:
+  - name: Ethernet4000
     description: My test
     ip_address: 10.1.2.3/12
     shutdown: false
@@ -16,5 +16,5 @@ override_ntp: null
 # Override other custom_structured_config (above)
 # Will only take effect on DC1_BL1B since the same key is set in hostvars for DC1_BL1A.
 my_special_dci_ethernet_interfaces:
-  Ethernet4000:
+  - name: Ethernet4000
     description: My second test

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/host_vars/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/host_vars/DC1-BL1A.yml
@@ -1,6 +1,6 @@
 ---
 my_special_dci_ethernet_interfaces:
-  Ethernet4000:
+  - name: Ethernet4000
     ip_address: 10.3.2.1/21
 
 custom_structured_configuration_list_merge: append

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -1138,6 +1138,9 @@ router bgp 65102
       update wait-install
       neighbor 10.255.251.3 peer group MLAG_PEER
       redistribute connected
+      !
+      address-family ipv4
+         no neighbor 10.255.251.3 next-hop address-family ipv6
    !
    vrf Tenant_A_DB_Zone
       rd 192.168.255.6:13
@@ -1147,6 +1150,9 @@ router bgp 65102
       update wait-install
       neighbor 10.255.251.3 peer group MLAG_PEER
       redistribute connected
+      !
+      address-family ipv4
+         no neighbor 10.255.251.3 next-hop address-family ipv6
    !
    vrf Tenant_A_OP_Zone
       rd 192.168.255.6:10
@@ -1156,6 +1162,9 @@ router bgp 65102
       update wait-install
       neighbor 10.255.251.3 peer group MLAG_PEER
       redistribute connected
+      !
+      address-family ipv4
+         no neighbor 10.255.251.3 next-hop address-family ipv6
    !
    vrf Tenant_A_WEB_Zone
       rd 192.168.255.6:11
@@ -1165,6 +1174,9 @@ router bgp 65102
       update wait-install
       neighbor 10.255.251.3 peer group MLAG_PEER
       redistribute connected
+      !
+      address-family ipv4
+         no neighbor 10.255.251.3 next-hop address-family ipv6
    !
    vrf Tenant_B_OP_Zone
       rd 192.168.255.6:20
@@ -1174,6 +1186,9 @@ router bgp 65102
       update wait-install
       neighbor 10.255.251.3 peer group MLAG_PEER
       redistribute connected
+      !
+      address-family ipv4
+         no neighbor 10.255.251.3 next-hop address-family ipv6
    !
    vrf Tenant_C_OP_Zone
       rd 192.168.255.6:30
@@ -1183,6 +1198,9 @@ router bgp 65102
       update wait-install
       neighbor 10.255.251.3 peer group MLAG_PEER
       redistribute connected
+      !
+      address-family ipv4
+         no neighbor 10.255.251.3 next-hop address-family ipv6
 ```
 
 ## BFD

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -593,7 +593,7 @@ interface Loopback100
 
 | Interface | VRF | IP Address | IP Address Virtual | IP Router Virtual Address | VRRP | ACL In | ACL Out |
 | --------- | --- | ---------- | ------------------ | ------------------------- | ---- | ------ | ------- |
-| Vlan2 |  Tenant_C_OP_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
+| Vlan2 |  Tenant_C_OP_Zone  |  10.255.251.2/31  |  -  |  -  |  -  |  -  |  -  |
 | Vlan110 |  Tenant_A_OP_Zone  |  -  |  10.1.10.1/24  |  -  |  -  |  -  |  -  |
 | Vlan111 |  Tenant_A_OP_Zone  |  -  |  10.1.11.1/24  |  -  |  -  |  -  |  -  |
 | Vlan120 |  Tenant_A_WEB_Zone  |  -  |  10.1.20.1/24  |  -  |  -  |  -  |  -  |
@@ -606,11 +606,11 @@ interface Loopback100
 | Vlan211 |  Tenant_B_OP_Zone  |  -  |  10.2.11.1/24  |  -  |  -  |  -  |  -  |
 | Vlan310 |  Tenant_C_OP_Zone  |  -  |  10.3.10.1/24  |  -  |  -  |  -  |  -  |
 | Vlan311 |  Tenant_C_OP_Zone  |  -  |  10.3.11.1/24  |  -  |  -  |  -  |  -  |
-| Vlan3009 |  Tenant_A_OP_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
-| Vlan3010 |  Tenant_A_WEB_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
-| Vlan3011 |  Tenant_A_APP_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
-| Vlan3012 |  Tenant_A_DB_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
-| Vlan3019 |  Tenant_B_OP_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
+| Vlan3009 |  Tenant_A_OP_Zone  |  10.255.251.2/31  |  -  |  -  |  -  |  -  |  -  |
+| Vlan3010 |  Tenant_A_WEB_Zone  |  10.255.251.2/31  |  -  |  -  |  -  |  -  |  -  |
+| Vlan3011 |  Tenant_A_APP_Zone  |  10.255.251.2/31  |  -  |  -  |  -  |  -  |  -  |
+| Vlan3012 |  Tenant_A_DB_Zone  |  10.255.251.2/31  |  -  |  -  |  -  |  -  |  -  |
+| Vlan3019 |  Tenant_B_OP_Zone  |  10.255.251.2/31  |  -  |  -  |  -  |  -  |  -  |
 | Vlan4093 |  default  |  -  |  -  |  -  |  -  |  -  |  -  |
 | Vlan4094 |  default  |  10.255.252.2/31  |  -  |  -  |  -  |  -  |  -  |
 
@@ -623,7 +623,7 @@ interface Vlan2
    no shutdown
    mtu 1500
    vrf Tenant_C_OP_Zone
-   ipv6 enable
+   ip address 10.255.251.2/31
 !
 interface Vlan110
    description Tenant_A_OP_Zone_1
@@ -705,35 +705,35 @@ interface Vlan3009
    no shutdown
    mtu 1500
    vrf Tenant_A_OP_Zone
-   ipv6 enable
+   ip address 10.255.251.2/31
 !
 interface Vlan3010
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_WEB_Zone
-   ipv6 enable
+   ip address 10.255.251.2/31
 !
 interface Vlan3011
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_APP_Zone
-   ipv6 enable
+   ip address 10.255.251.2/31
 !
 interface Vlan3012
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_DB_Zone
-   ipv6 enable
+   ip address 10.255.251.2/31
 !
 interface Vlan3019
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone
    no shutdown
    mtu 1500
    vrf Tenant_B_OP_Zone
-   ipv6 enable
+   ip address 10.255.251.2/31
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
@@ -852,12 +852,12 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 | --- | --------------- |
 | default | True (ipv6 interfaces) |
 | MGMT | False |
-| Tenant_A_APP_Zone | True (ipv6 interfaces) |
-| Tenant_A_DB_Zone | True (ipv6 interfaces) |
-| Tenant_A_OP_Zone | True (ipv6 interfaces) |
-| Tenant_A_WEB_Zone | True (ipv6 interfaces) |
-| Tenant_B_OP_Zone | True (ipv6 interfaces) |
-| Tenant_C_OP_Zone | True (ipv6 interfaces) |
+| Tenant_A_APP_Zone | True |
+| Tenant_A_DB_Zone | True |
+| Tenant_A_OP_Zone | True |
+| Tenant_A_WEB_Zone | True |
+| Tenant_B_OP_Zone | True |
+| Tenant_C_OP_Zone | True |
 
 #### IP Routing Device Configuration
 
@@ -865,12 +865,12 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 !
 ip routing ipv6 interfaces
 no ip routing vrf MGMT
-ip routing ipv6 interfaces vrf Tenant_A_APP_Zone
-ip routing ipv6 interfaces vrf Tenant_A_DB_Zone
-ip routing ipv6 interfaces vrf Tenant_A_OP_Zone
-ip routing ipv6 interfaces vrf Tenant_A_WEB_Zone
-ip routing ipv6 interfaces vrf Tenant_B_OP_Zone
-ip routing ipv6 interfaces vrf Tenant_C_OP_Zone
+ip routing vrf Tenant_A_APP_Zone
+ip routing vrf Tenant_A_DB_Zone
+ip routing vrf Tenant_A_OP_Zone
+ip routing vrf Tenant_A_WEB_Zone
+ip routing vrf Tenant_B_OP_Zone
+ip routing vrf Tenant_C_OP_Zone
 ```
 
 ### IPv6 Routing
@@ -966,6 +966,12 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | 192.168.255.2 | 65001 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - | - | - |
 | 192.168.255.3 | 65001 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - | - | - |
 | 192.168.255.4 | 65001 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - | - | - |
+| 10.255.251.3 | Inherited from peer group MLAG_PEER | Tenant_A_APP_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - | - | - |
+| 10.255.251.3 | Inherited from peer group MLAG_PEER | Tenant_A_DB_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - | - | - |
+| 10.255.251.3 | Inherited from peer group MLAG_PEER | Tenant_A_OP_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - | - | - |
+| 10.255.251.3 | Inherited from peer group MLAG_PEER | Tenant_A_WEB_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - | - | - |
+| 10.255.251.3 | Inherited from peer group MLAG_PEER | Tenant_B_OP_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - | - | - |
+| 10.255.251.3 | Inherited from peer group MLAG_PEER | Tenant_C_OP_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - | - | - |
 
 #### BGP Neighbor Interfaces
 
@@ -976,12 +982,6 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | Ethernet3 | default | UNDERLAY_PEERS | 65001 | - |
 | Ethernet4 | default | UNDERLAY_PEERS | 65001 | - |
 | Vlan4093 | default | MLAG_PEER | 65102 | - |
-| Vlan3011 | Tenant_A_APP_Zone | MLAG_PEER | 65102 | - |
-| Vlan3012 | Tenant_A_DB_Zone | MLAG_PEER | 65102 | - |
-| Vlan3009 | Tenant_A_OP_Zone | MLAG_PEER | 65102 | - |
-| Vlan3010 | Tenant_A_WEB_Zone | MLAG_PEER | 65102 | - |
-| Vlan3019 | Tenant_B_OP_Zone | MLAG_PEER | 65102 | - |
-| Vlan2 | Tenant_C_OP_Zone | MLAG_PEER | 65102 | - |
 
 #### Router BGP EVPN Address Family
 
@@ -1135,7 +1135,8 @@ router bgp 65102
       route-target import evpn 12:12
       route-target export evpn 12:12
       router-id 192.168.255.6
-      neighbor interface Vlan3011 peer-group MLAG_PEER remote-as 65102
+      update wait-install
+      neighbor 10.255.251.3 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1143,7 +1144,8 @@ router bgp 65102
       route-target import evpn 13:13
       route-target export evpn 13:13
       router-id 192.168.255.6
-      neighbor interface Vlan3012 peer-group MLAG_PEER remote-as 65102
+      update wait-install
+      neighbor 10.255.251.3 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1151,7 +1153,8 @@ router bgp 65102
       route-target import evpn 10:10
       route-target export evpn 10:10
       router-id 192.168.255.6
-      neighbor interface Vlan3009 peer-group MLAG_PEER remote-as 65102
+      update wait-install
+      neighbor 10.255.251.3 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -1159,7 +1162,8 @@ router bgp 65102
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.6
-      neighbor interface Vlan3010 peer-group MLAG_PEER remote-as 65102
+      update wait-install
+      neighbor 10.255.251.3 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1167,7 +1171,8 @@ router bgp 65102
       route-target import evpn 20:20
       route-target export evpn 20:20
       router-id 192.168.255.6
-      neighbor interface Vlan3019 peer-group MLAG_PEER remote-as 65102
+      update wait-install
+      neighbor 10.255.251.3 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1175,7 +1180,8 @@ router bgp 65102
       route-target import evpn 30:30
       route-target export evpn 30:30
       router-id 192.168.255.6
-      neighbor interface Vlan2 peer-group MLAG_PEER remote-as 65102
+      update wait-install
+      neighbor 10.255.251.3 peer group MLAG_PEER
       redistribute connected
 ```
 
@@ -1277,12 +1283,12 @@ route-map RM-MLAG-PEER-IN permit 10
 | VRF Name | IP Routing |
 | -------- | ---------- |
 | MGMT | disabled |
-| Tenant_A_APP_Zone | enabled (ipv6 interface) |
-| Tenant_A_DB_Zone | enabled (ipv6 interface) |
-| Tenant_A_OP_Zone | enabled (ipv6 interface) |
-| Tenant_A_WEB_Zone | enabled (ipv6 interface) |
-| Tenant_B_OP_Zone | enabled (ipv6 interface) |
-| Tenant_C_OP_Zone | enabled (ipv6 interface) |
+| Tenant_A_APP_Zone | enabled |
+| Tenant_A_DB_Zone | enabled |
+| Tenant_A_OP_Zone | enabled |
+| Tenant_A_WEB_Zone | enabled |
+| Tenant_B_OP_Zone | enabled |
+| Tenant_C_OP_Zone | enabled |
 
 ### VRF Instances Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -593,7 +593,7 @@ interface Loopback100
 
 | Interface | VRF | IP Address | IP Address Virtual | IP Router Virtual Address | VRRP | ACL In | ACL Out |
 | --------- | --- | ---------- | ------------------ | ------------------------- | ---- | ------ | ------- |
-| Vlan2 |  Tenant_C_OP_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
+| Vlan2 |  Tenant_C_OP_Zone  |  10.255.251.3/31  |  -  |  -  |  -  |  -  |  -  |
 | Vlan110 |  Tenant_A_OP_Zone  |  -  |  10.1.10.1/24  |  -  |  -  |  -  |  -  |
 | Vlan111 |  Tenant_A_OP_Zone  |  -  |  10.1.11.1/24  |  -  |  -  |  -  |  -  |
 | Vlan120 |  Tenant_A_WEB_Zone  |  -  |  10.1.20.1/24  |  -  |  -  |  -  |  -  |
@@ -606,11 +606,11 @@ interface Loopback100
 | Vlan211 |  Tenant_B_OP_Zone  |  -  |  10.2.11.1/24  |  -  |  -  |  -  |  -  |
 | Vlan310 |  Tenant_C_OP_Zone  |  -  |  10.3.10.1/24  |  -  |  -  |  -  |  -  |
 | Vlan311 |  Tenant_C_OP_Zone  |  -  |  10.3.11.1/24  |  -  |  -  |  -  |  -  |
-| Vlan3009 |  Tenant_A_OP_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
-| Vlan3010 |  Tenant_A_WEB_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
-| Vlan3011 |  Tenant_A_APP_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
-| Vlan3012 |  Tenant_A_DB_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
-| Vlan3019 |  Tenant_B_OP_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
+| Vlan3009 |  Tenant_A_OP_Zone  |  10.255.251.3/31  |  -  |  -  |  -  |  -  |  -  |
+| Vlan3010 |  Tenant_A_WEB_Zone  |  10.255.251.3/31  |  -  |  -  |  -  |  -  |  -  |
+| Vlan3011 |  Tenant_A_APP_Zone  |  10.255.251.3/31  |  -  |  -  |  -  |  -  |  -  |
+| Vlan3012 |  Tenant_A_DB_Zone  |  10.255.251.3/31  |  -  |  -  |  -  |  -  |  -  |
+| Vlan3019 |  Tenant_B_OP_Zone  |  10.255.251.3/31  |  -  |  -  |  -  |  -  |  -  |
 | Vlan4093 |  default  |  -  |  -  |  -  |  -  |  -  |  -  |
 | Vlan4094 |  default  |  10.255.252.3/31  |  -  |  -  |  -  |  -  |  -  |
 
@@ -623,7 +623,7 @@ interface Vlan2
    no shutdown
    mtu 1500
    vrf Tenant_C_OP_Zone
-   ipv6 enable
+   ip address 10.255.251.3/31
 !
 interface Vlan110
    description Tenant_A_OP_Zone_1
@@ -705,35 +705,35 @@ interface Vlan3009
    no shutdown
    mtu 1500
    vrf Tenant_A_OP_Zone
-   ipv6 enable
+   ip address 10.255.251.3/31
 !
 interface Vlan3010
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_WEB_Zone
-   ipv6 enable
+   ip address 10.255.251.3/31
 !
 interface Vlan3011
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_APP_Zone
-   ipv6 enable
+   ip address 10.255.251.3/31
 !
 interface Vlan3012
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_DB_Zone
-   ipv6 enable
+   ip address 10.255.251.3/31
 !
 interface Vlan3019
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone
    no shutdown
    mtu 1500
    vrf Tenant_B_OP_Zone
-   ipv6 enable
+   ip address 10.255.251.3/31
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
@@ -852,12 +852,12 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 | --- | --------------- |
 | default | True (ipv6 interfaces) |
 | MGMT | False |
-| Tenant_A_APP_Zone | True (ipv6 interfaces) |
-| Tenant_A_DB_Zone | True (ipv6 interfaces) |
-| Tenant_A_OP_Zone | True (ipv6 interfaces) |
-| Tenant_A_WEB_Zone | True (ipv6 interfaces) |
-| Tenant_B_OP_Zone | True (ipv6 interfaces) |
-| Tenant_C_OP_Zone | True (ipv6 interfaces) |
+| Tenant_A_APP_Zone | True |
+| Tenant_A_DB_Zone | True |
+| Tenant_A_OP_Zone | True |
+| Tenant_A_WEB_Zone | True |
+| Tenant_B_OP_Zone | True |
+| Tenant_C_OP_Zone | True |
 
 #### IP Routing Device Configuration
 
@@ -865,12 +865,12 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 !
 ip routing ipv6 interfaces
 no ip routing vrf MGMT
-ip routing ipv6 interfaces vrf Tenant_A_APP_Zone
-ip routing ipv6 interfaces vrf Tenant_A_DB_Zone
-ip routing ipv6 interfaces vrf Tenant_A_OP_Zone
-ip routing ipv6 interfaces vrf Tenant_A_WEB_Zone
-ip routing ipv6 interfaces vrf Tenant_B_OP_Zone
-ip routing ipv6 interfaces vrf Tenant_C_OP_Zone
+ip routing vrf Tenant_A_APP_Zone
+ip routing vrf Tenant_A_DB_Zone
+ip routing vrf Tenant_A_OP_Zone
+ip routing vrf Tenant_A_WEB_Zone
+ip routing vrf Tenant_B_OP_Zone
+ip routing vrf Tenant_C_OP_Zone
 ```
 
 ### IPv6 Routing
@@ -966,6 +966,12 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | 192.168.255.2 | 65001 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - | - | - |
 | 192.168.255.3 | 65001 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - | - | - |
 | 192.168.255.4 | 65001 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - | - | - |
+| 10.255.251.2 | Inherited from peer group MLAG_PEER | Tenant_A_APP_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - | - | - |
+| 10.255.251.2 | Inherited from peer group MLAG_PEER | Tenant_A_DB_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - | - | - |
+| 10.255.251.2 | Inherited from peer group MLAG_PEER | Tenant_A_OP_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - | - | - |
+| 10.255.251.2 | Inherited from peer group MLAG_PEER | Tenant_A_WEB_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - | - | - |
+| 10.255.251.2 | Inherited from peer group MLAG_PEER | Tenant_B_OP_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - | - | - |
+| 10.255.251.2 | Inherited from peer group MLAG_PEER | Tenant_C_OP_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - | - | - |
 
 #### BGP Neighbor Interfaces
 
@@ -976,12 +982,6 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | Ethernet3 | default | UNDERLAY_PEERS | 65001 | - |
 | Ethernet4 | default | UNDERLAY_PEERS | 65001 | - |
 | Vlan4093 | default | MLAG_PEER | 65102 | - |
-| Vlan3011 | Tenant_A_APP_Zone | MLAG_PEER | 65102 | - |
-| Vlan3012 | Tenant_A_DB_Zone | MLAG_PEER | 65102 | - |
-| Vlan3009 | Tenant_A_OP_Zone | MLAG_PEER | 65102 | - |
-| Vlan3010 | Tenant_A_WEB_Zone | MLAG_PEER | 65102 | - |
-| Vlan3019 | Tenant_B_OP_Zone | MLAG_PEER | 65102 | - |
-| Vlan2 | Tenant_C_OP_Zone | MLAG_PEER | 65102 | - |
 
 #### Router BGP EVPN Address Family
 
@@ -1135,7 +1135,8 @@ router bgp 65102
       route-target import evpn 12:12
       route-target export evpn 12:12
       router-id 192.168.255.7
-      neighbor interface Vlan3011 peer-group MLAG_PEER remote-as 65102
+      update wait-install
+      neighbor 10.255.251.2 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1143,7 +1144,8 @@ router bgp 65102
       route-target import evpn 13:13
       route-target export evpn 13:13
       router-id 192.168.255.7
-      neighbor interface Vlan3012 peer-group MLAG_PEER remote-as 65102
+      update wait-install
+      neighbor 10.255.251.2 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1151,7 +1153,8 @@ router bgp 65102
       route-target import evpn 10:10
       route-target export evpn 10:10
       router-id 192.168.255.7
-      neighbor interface Vlan3009 peer-group MLAG_PEER remote-as 65102
+      update wait-install
+      neighbor 10.255.251.2 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -1159,7 +1162,8 @@ router bgp 65102
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.7
-      neighbor interface Vlan3010 peer-group MLAG_PEER remote-as 65102
+      update wait-install
+      neighbor 10.255.251.2 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1167,7 +1171,8 @@ router bgp 65102
       route-target import evpn 20:20
       route-target export evpn 20:20
       router-id 192.168.255.7
-      neighbor interface Vlan3019 peer-group MLAG_PEER remote-as 65102
+      update wait-install
+      neighbor 10.255.251.2 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1175,7 +1180,8 @@ router bgp 65102
       route-target import evpn 30:30
       route-target export evpn 30:30
       router-id 192.168.255.7
-      neighbor interface Vlan2 peer-group MLAG_PEER remote-as 65102
+      update wait-install
+      neighbor 10.255.251.2 peer group MLAG_PEER
       redistribute connected
 ```
 
@@ -1277,12 +1283,12 @@ route-map RM-MLAG-PEER-IN permit 10
 | VRF Name | IP Routing |
 | -------- | ---------- |
 | MGMT | disabled |
-| Tenant_A_APP_Zone | enabled (ipv6 interface) |
-| Tenant_A_DB_Zone | enabled (ipv6 interface) |
-| Tenant_A_OP_Zone | enabled (ipv6 interface) |
-| Tenant_A_WEB_Zone | enabled (ipv6 interface) |
-| Tenant_B_OP_Zone | enabled (ipv6 interface) |
-| Tenant_C_OP_Zone | enabled (ipv6 interface) |
+| Tenant_A_APP_Zone | enabled |
+| Tenant_A_DB_Zone | enabled |
+| Tenant_A_OP_Zone | enabled |
+| Tenant_A_WEB_Zone | enabled |
+| Tenant_B_OP_Zone | enabled |
+| Tenant_C_OP_Zone | enabled |
 
 ### VRF Instances Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -1138,6 +1138,9 @@ router bgp 65102
       update wait-install
       neighbor 10.255.251.2 peer group MLAG_PEER
       redistribute connected
+      !
+      address-family ipv4
+         no neighbor 10.255.251.2 next-hop address-family ipv6
    !
    vrf Tenant_A_DB_Zone
       rd 192.168.255.7:13
@@ -1147,6 +1150,9 @@ router bgp 65102
       update wait-install
       neighbor 10.255.251.2 peer group MLAG_PEER
       redistribute connected
+      !
+      address-family ipv4
+         no neighbor 10.255.251.2 next-hop address-family ipv6
    !
    vrf Tenant_A_OP_Zone
       rd 192.168.255.7:10
@@ -1156,6 +1162,9 @@ router bgp 65102
       update wait-install
       neighbor 10.255.251.2 peer group MLAG_PEER
       redistribute connected
+      !
+      address-family ipv4
+         no neighbor 10.255.251.2 next-hop address-family ipv6
    !
    vrf Tenant_A_WEB_Zone
       rd 192.168.255.7:11
@@ -1165,6 +1174,9 @@ router bgp 65102
       update wait-install
       neighbor 10.255.251.2 peer group MLAG_PEER
       redistribute connected
+      !
+      address-family ipv4
+         no neighbor 10.255.251.2 next-hop address-family ipv6
    !
    vrf Tenant_B_OP_Zone
       rd 192.168.255.7:20
@@ -1174,6 +1186,9 @@ router bgp 65102
       update wait-install
       neighbor 10.255.251.2 peer group MLAG_PEER
       redistribute connected
+      !
+      address-family ipv4
+         no neighbor 10.255.251.2 next-hop address-family ipv6
    !
    vrf Tenant_C_OP_Zone
       rd 192.168.255.7:30
@@ -1183,6 +1198,9 @@ router bgp 65102
       update wait-install
       neighbor 10.255.251.2 peer group MLAG_PEER
       redistribute connected
+      !
+      address-family ipv4
+         no neighbor 10.255.251.2 next-hop address-family ipv6
 ```
 
 ## BFD

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF3A.md
@@ -800,18 +800,24 @@ ip routing ipv6 interfaces vrf Tenant_C_OP_Zone
 | --- | --------------- |
 | default | True |
 | MGMT | false |
-| Tenant_A_APP_Zone | false |
-| Tenant_A_DB_Zone | false |
-| Tenant_A_OP_Zone | false |
-| Tenant_A_WEB_Zone | false |
-| Tenant_B_OP_Zone | false |
-| Tenant_C_OP_Zone | false |
+| Tenant_A_APP_Zone | true |
+| Tenant_A_DB_Zone | true |
+| Tenant_A_OP_Zone | true |
+| Tenant_A_WEB_Zone | true |
+| Tenant_B_OP_Zone | true |
+| Tenant_C_OP_Zone | true |
 
 #### IPv6 Routing Device Configuration
 
 ```eos
 !
 ipv6 unicast-routing
+ipv6 unicast-routing vrf Tenant_A_APP_Zone
+ipv6 unicast-routing vrf Tenant_A_DB_Zone
+ipv6 unicast-routing vrf Tenant_A_OP_Zone
+ipv6 unicast-routing vrf Tenant_A_WEB_Zone
+ipv6 unicast-routing vrf Tenant_B_OP_Zone
+ipv6 unicast-routing vrf Tenant_C_OP_Zone
 ```
 
 ### Static Routes

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF3B.md
@@ -800,18 +800,24 @@ ip routing ipv6 interfaces vrf Tenant_C_OP_Zone
 | --- | --------------- |
 | default | True |
 | MGMT | false |
-| Tenant_A_APP_Zone | false |
-| Tenant_A_DB_Zone | false |
-| Tenant_A_OP_Zone | false |
-| Tenant_A_WEB_Zone | false |
-| Tenant_B_OP_Zone | false |
-| Tenant_C_OP_Zone | false |
+| Tenant_A_APP_Zone | true |
+| Tenant_A_DB_Zone | true |
+| Tenant_A_OP_Zone | true |
+| Tenant_A_WEB_Zone | true |
+| Tenant_B_OP_Zone | true |
+| Tenant_C_OP_Zone | true |
 
 #### IPv6 Routing Device Configuration
 
 ```eos
 !
 ipv6 unicast-routing
+ipv6 unicast-routing vrf Tenant_A_APP_Zone
+ipv6 unicast-routing vrf Tenant_A_DB_Zone
+ipv6 unicast-routing vrf Tenant_A_OP_Zone
+ipv6 unicast-routing vrf Tenant_A_WEB_Zone
+ipv6 unicast-routing vrf Tenant_B_OP_Zone
+ipv6 unicast-routing vrf Tenant_C_OP_Zone
 ```
 
 ### Static Routes

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF4A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF4A.md
@@ -800,18 +800,24 @@ ip routing ipv6 interfaces vrf Tenant_C_OP_Zone
 | --- | --------------- |
 | default | True |
 | MGMT | false |
-| Tenant_A_APP_Zone | false |
-| Tenant_A_DB_Zone | false |
-| Tenant_A_OP_Zone | false |
-| Tenant_A_WEB_Zone | false |
-| Tenant_B_OP_Zone | false |
-| Tenant_C_OP_Zone | false |
+| Tenant_A_APP_Zone | true |
+| Tenant_A_DB_Zone | true |
+| Tenant_A_OP_Zone | true |
+| Tenant_A_WEB_Zone | true |
+| Tenant_B_OP_Zone | true |
+| Tenant_C_OP_Zone | true |
 
 #### IPv6 Routing Device Configuration
 
 ```eos
 !
 ipv6 unicast-routing
+ipv6 unicast-routing vrf Tenant_A_APP_Zone
+ipv6 unicast-routing vrf Tenant_A_DB_Zone
+ipv6 unicast-routing vrf Tenant_A_OP_Zone
+ipv6 unicast-routing vrf Tenant_A_WEB_Zone
+ipv6 unicast-routing vrf Tenant_B_OP_Zone
+ipv6 unicast-routing vrf Tenant_C_OP_Zone
 ```
 
 ### Static Routes

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF4B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF4B.md
@@ -800,18 +800,24 @@ ip routing ipv6 interfaces vrf Tenant_C_OP_Zone
 | --- | --------------- |
 | default | True |
 | MGMT | false |
-| Tenant_A_APP_Zone | false |
-| Tenant_A_DB_Zone | false |
-| Tenant_A_OP_Zone | false |
-| Tenant_A_WEB_Zone | false |
-| Tenant_B_OP_Zone | false |
-| Tenant_C_OP_Zone | false |
+| Tenant_A_APP_Zone | true |
+| Tenant_A_DB_Zone | true |
+| Tenant_A_OP_Zone | true |
+| Tenant_A_WEB_Zone | true |
+| Tenant_B_OP_Zone | true |
+| Tenant_C_OP_Zone | true |
 
 #### IPv6 Routing Device Configuration
 
 ```eos
 !
 ipv6 unicast-routing
+ipv6 unicast-routing vrf Tenant_A_APP_Zone
+ipv6 unicast-routing vrf Tenant_A_DB_Zone
+ipv6 unicast-routing vrf Tenant_A_OP_Zone
+ipv6 unicast-routing vrf Tenant_A_WEB_Zone
+ipv6 unicast-routing vrf Tenant_B_OP_Zone
+ipv6 unicast-routing vrf Tenant_C_OP_Zone
 ```
 
 ### Static Routes

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -1063,21 +1063,30 @@ ip routing ipv6 interfaces vrf Tenant_C_WAN_Zone
 | --- | --------------- |
 | default | True |
 | MGMT | false |
-| Tenant_A_APP_Zone | false |
-| Tenant_A_DB_Zone | false |
-| Tenant_A_OP_Zone | false |
-| Tenant_A_WAN_Zone | false |
-| Tenant_A_WEB_Zone | false |
-| Tenant_B_OP_Zone | false |
-| Tenant_B_WAN_Zone | false |
-| Tenant_C_OP_Zone | false |
-| Tenant_C_WAN_Zone | false |
+| Tenant_A_APP_Zone | true |
+| Tenant_A_DB_Zone | true |
+| Tenant_A_OP_Zone | true |
+| Tenant_A_WAN_Zone | true |
+| Tenant_A_WEB_Zone | true |
+| Tenant_B_OP_Zone | true |
+| Tenant_B_WAN_Zone | true |
+| Tenant_C_OP_Zone | true |
+| Tenant_C_WAN_Zone | true |
 
 #### IPv6 Routing Device Configuration
 
 ```eos
 !
 ipv6 unicast-routing
+ipv6 unicast-routing vrf Tenant_A_APP_Zone
+ipv6 unicast-routing vrf Tenant_A_DB_Zone
+ipv6 unicast-routing vrf Tenant_A_OP_Zone
+ipv6 unicast-routing vrf Tenant_A_WAN_Zone
+ipv6 unicast-routing vrf Tenant_A_WEB_Zone
+ipv6 unicast-routing vrf Tenant_B_OP_Zone
+ipv6 unicast-routing vrf Tenant_B_WAN_Zone
+ipv6 unicast-routing vrf Tenant_C_OP_Zone
+ipv6 unicast-routing vrf Tenant_C_WAN_Zone
 ```
 
 ### Static Routes

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -1037,21 +1037,30 @@ ip routing ipv6 interfaces vrf Tenant_C_WAN_Zone
 | --- | --------------- |
 | default | True |
 | MGMT | false |
-| Tenant_A_APP_Zone | false |
-| Tenant_A_DB_Zone | false |
-| Tenant_A_OP_Zone | false |
-| Tenant_A_WAN_Zone | false |
-| Tenant_A_WEB_Zone | false |
-| Tenant_B_OP_Zone | false |
-| Tenant_B_WAN_Zone | false |
-| Tenant_C_OP_Zone | false |
-| Tenant_C_WAN_Zone | false |
+| Tenant_A_APP_Zone | true |
+| Tenant_A_DB_Zone | true |
+| Tenant_A_OP_Zone | true |
+| Tenant_A_WAN_Zone | true |
+| Tenant_A_WEB_Zone | true |
+| Tenant_B_OP_Zone | true |
+| Tenant_B_WAN_Zone | true |
+| Tenant_C_OP_Zone | true |
+| Tenant_C_WAN_Zone | true |
 
 #### IPv6 Routing Device Configuration
 
 ```eos
 !
 ipv6 unicast-routing
+ipv6 unicast-routing vrf Tenant_A_APP_Zone
+ipv6 unicast-routing vrf Tenant_A_DB_Zone
+ipv6 unicast-routing vrf Tenant_A_OP_Zone
+ipv6 unicast-routing vrf Tenant_A_WAN_Zone
+ipv6 unicast-routing vrf Tenant_A_WEB_Zone
+ipv6 unicast-routing vrf Tenant_B_OP_Zone
+ipv6 unicast-routing vrf Tenant_B_WAN_Zone
+ipv6 unicast-routing vrf Tenant_C_OP_Zone
+ipv6 unicast-routing vrf Tenant_C_WAN_Zone
 ```
 
 ### Static Routes

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/fabric/DC1_FABRIC-documentation.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/fabric/DC1_FABRIC-documentation.md
@@ -29,12 +29,12 @@
 | DC1_FABRIC | l3leaf | DC1-LEAF3B | 192.168.200.107/24 | 7280R | Provisioned | - |
 | DC1_FABRIC | l3leaf | DC1-LEAF4A | 192.168.200.106/24 | 7280R | Provisioned | - |
 | DC1_FABRIC | l3leaf | DC1-LEAF4B | 192.168.200.107/24 | 7280R | Provisioned | - |
-| DC1_FABRIC | spine | DC1-SPINE1 | 192.168.200.101/24 | vEOS-LAB | Provisioned | - |
-| DC1_FABRIC | spine | DC1-SPINE2 | 192.168.200.102/24 | vEOS-LAB | Provisioned | - |
-| DC1_FABRIC | spine | DC1-SPINE3 | 192.168.200.103/24 | vEOS-LAB | Provisioned | - |
-| DC1_FABRIC | spine | DC1-SPINE4 | 192.168.200.104/24 | vEOS-LAB | Provisioned | - |
-| DC1_FABRIC | spine | DC1-SPINE5 | 192.168.200.105/24 | vEOS-LAB | Provisioned | - |
-| DC1_FABRIC | spine | DC1-SPINE6 | 192.168.200.105/24 | vEOS-LAB | Provisioned | - |
+| DC1_FABRIC | spine | DC1-SPINE1 | 192.168.200.101/24 | 7050X3 | Provisioned | - |
+| DC1_FABRIC | spine | DC1-SPINE2 | 192.168.200.102/24 | 7050X3 | Provisioned | - |
+| DC1_FABRIC | spine | DC1-SPINE3 | 192.168.200.103/24 | 7050X3 | Provisioned | - |
+| DC1_FABRIC | spine | DC1-SPINE4 | 192.168.200.104/24 | 7050X3 | Provisioned | - |
+| DC1_FABRIC | spine | DC1-SPINE5 | 192.168.200.105/24 | 7050X3 | Provisioned | - |
+| DC1_FABRIC | spine | DC1-SPINE6 | 192.168.200.105/24 | 7050X3 | Provisioned | - |
 | DC1_FABRIC | l3leaf | DC1-SVC3A | 192.168.200.108/24 | 7280R | Provisioned | - |
 | DC1_FABRIC | l3leaf | DC1-SVC3B | 192.168.200.109/24 | 7280R | Provisioned | - |
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
@@ -549,6 +549,9 @@ router bgp 65102
       update wait-install
       neighbor 10.255.251.3 peer group MLAG_PEER
       redistribute connected
+      !
+      address-family ipv4
+         no neighbor 10.255.251.3 next-hop address-family ipv6
    !
    vrf Tenant_A_DB_Zone
       rd 192.168.255.6:13
@@ -558,6 +561,9 @@ router bgp 65102
       update wait-install
       neighbor 10.255.251.3 peer group MLAG_PEER
       redistribute connected
+      !
+      address-family ipv4
+         no neighbor 10.255.251.3 next-hop address-family ipv6
    !
    vrf Tenant_A_OP_Zone
       rd 192.168.255.6:10
@@ -567,6 +573,9 @@ router bgp 65102
       update wait-install
       neighbor 10.255.251.3 peer group MLAG_PEER
       redistribute connected
+      !
+      address-family ipv4
+         no neighbor 10.255.251.3 next-hop address-family ipv6
    !
    vrf Tenant_A_WEB_Zone
       rd 192.168.255.6:11
@@ -576,6 +585,9 @@ router bgp 65102
       update wait-install
       neighbor 10.255.251.3 peer group MLAG_PEER
       redistribute connected
+      !
+      address-family ipv4
+         no neighbor 10.255.251.3 next-hop address-family ipv6
    !
    vrf Tenant_B_OP_Zone
       rd 192.168.255.6:20
@@ -585,6 +597,9 @@ router bgp 65102
       update wait-install
       neighbor 10.255.251.3 peer group MLAG_PEER
       redistribute connected
+      !
+      address-family ipv4
+         no neighbor 10.255.251.3 next-hop address-family ipv6
    !
    vrf Tenant_C_OP_Zone
       rd 192.168.255.6:30
@@ -594,6 +609,9 @@ router bgp 65102
       update wait-install
       neighbor 10.255.251.3 peer group MLAG_PEER
       redistribute connected
+      !
+      address-family ipv4
+         no neighbor 10.255.251.3 next-hop address-family ipv6
 !
 management api http-commands
    protocol https

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
@@ -243,7 +243,7 @@ interface Vlan2
    no shutdown
    mtu 1500
    vrf Tenant_C_OP_Zone
-   ipv6 enable
+   ip address 10.255.251.2/31
 !
 interface Vlan110
    description Tenant_A_OP_Zone_1
@@ -325,35 +325,35 @@ interface Vlan3009
    no shutdown
    mtu 1500
    vrf Tenant_A_OP_Zone
-   ipv6 enable
+   ip address 10.255.251.2/31
 !
 interface Vlan3010
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_WEB_Zone
-   ipv6 enable
+   ip address 10.255.251.2/31
 !
 interface Vlan3011
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_APP_Zone
-   ipv6 enable
+   ip address 10.255.251.2/31
 !
 interface Vlan3012
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_DB_Zone
-   ipv6 enable
+   ip address 10.255.251.2/31
 !
 interface Vlan3019
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone
    no shutdown
    mtu 1500
    vrf Tenant_B_OP_Zone
-   ipv6 enable
+   ip address 10.255.251.2/31
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
@@ -403,12 +403,12 @@ ip address virtual source-nat vrf Tenant_A_OP_Zone address 10.255.1.6
 !
 ip routing ipv6 interfaces
 no ip routing vrf MGMT
-ip routing ipv6 interfaces vrf Tenant_A_APP_Zone
-ip routing ipv6 interfaces vrf Tenant_A_DB_Zone
-ip routing ipv6 interfaces vrf Tenant_A_OP_Zone
-ip routing ipv6 interfaces vrf Tenant_A_WEB_Zone
-ip routing ipv6 interfaces vrf Tenant_B_OP_Zone
-ip routing ipv6 interfaces vrf Tenant_C_OP_Zone
+ip routing vrf Tenant_A_APP_Zone
+ip routing vrf Tenant_A_DB_Zone
+ip routing vrf Tenant_A_OP_Zone
+ip routing vrf Tenant_A_WEB_Zone
+ip routing vrf Tenant_B_OP_Zone
+ip routing vrf Tenant_C_OP_Zone
 !
 ipv6 unicast-routing
 !
@@ -546,7 +546,8 @@ router bgp 65102
       route-target import evpn 12:12
       route-target export evpn 12:12
       router-id 192.168.255.6
-      neighbor interface Vlan3011 peer-group MLAG_PEER remote-as 65102
+      update wait-install
+      neighbor 10.255.251.3 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -554,7 +555,8 @@ router bgp 65102
       route-target import evpn 13:13
       route-target export evpn 13:13
       router-id 192.168.255.6
-      neighbor interface Vlan3012 peer-group MLAG_PEER remote-as 65102
+      update wait-install
+      neighbor 10.255.251.3 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -562,7 +564,8 @@ router bgp 65102
       route-target import evpn 10:10
       route-target export evpn 10:10
       router-id 192.168.255.6
-      neighbor interface Vlan3009 peer-group MLAG_PEER remote-as 65102
+      update wait-install
+      neighbor 10.255.251.3 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -570,7 +573,8 @@ router bgp 65102
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.6
-      neighbor interface Vlan3010 peer-group MLAG_PEER remote-as 65102
+      update wait-install
+      neighbor 10.255.251.3 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -578,7 +582,8 @@ router bgp 65102
       route-target import evpn 20:20
       route-target export evpn 20:20
       router-id 192.168.255.6
-      neighbor interface Vlan3019 peer-group MLAG_PEER remote-as 65102
+      update wait-install
+      neighbor 10.255.251.3 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -586,7 +591,8 @@ router bgp 65102
       route-target import evpn 30:30
       route-target export evpn 30:30
       router-id 192.168.255.6
-      neighbor interface Vlan2 peer-group MLAG_PEER remote-as 65102
+      update wait-install
+      neighbor 10.255.251.3 peer group MLAG_PEER
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
@@ -243,7 +243,7 @@ interface Vlan2
    no shutdown
    mtu 1500
    vrf Tenant_C_OP_Zone
-   ipv6 enable
+   ip address 10.255.251.3/31
 !
 interface Vlan110
    description Tenant_A_OP_Zone_1
@@ -325,35 +325,35 @@ interface Vlan3009
    no shutdown
    mtu 1500
    vrf Tenant_A_OP_Zone
-   ipv6 enable
+   ip address 10.255.251.3/31
 !
 interface Vlan3010
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_WEB_Zone
-   ipv6 enable
+   ip address 10.255.251.3/31
 !
 interface Vlan3011
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_APP_Zone
-   ipv6 enable
+   ip address 10.255.251.3/31
 !
 interface Vlan3012
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_DB_Zone
-   ipv6 enable
+   ip address 10.255.251.3/31
 !
 interface Vlan3019
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone
    no shutdown
    mtu 1500
    vrf Tenant_B_OP_Zone
-   ipv6 enable
+   ip address 10.255.251.3/31
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
@@ -403,12 +403,12 @@ ip address virtual source-nat vrf Tenant_A_OP_Zone address 10.255.1.7
 !
 ip routing ipv6 interfaces
 no ip routing vrf MGMT
-ip routing ipv6 interfaces vrf Tenant_A_APP_Zone
-ip routing ipv6 interfaces vrf Tenant_A_DB_Zone
-ip routing ipv6 interfaces vrf Tenant_A_OP_Zone
-ip routing ipv6 interfaces vrf Tenant_A_WEB_Zone
-ip routing ipv6 interfaces vrf Tenant_B_OP_Zone
-ip routing ipv6 interfaces vrf Tenant_C_OP_Zone
+ip routing vrf Tenant_A_APP_Zone
+ip routing vrf Tenant_A_DB_Zone
+ip routing vrf Tenant_A_OP_Zone
+ip routing vrf Tenant_A_WEB_Zone
+ip routing vrf Tenant_B_OP_Zone
+ip routing vrf Tenant_C_OP_Zone
 !
 ipv6 unicast-routing
 !
@@ -546,7 +546,8 @@ router bgp 65102
       route-target import evpn 12:12
       route-target export evpn 12:12
       router-id 192.168.255.7
-      neighbor interface Vlan3011 peer-group MLAG_PEER remote-as 65102
+      update wait-install
+      neighbor 10.255.251.2 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -554,7 +555,8 @@ router bgp 65102
       route-target import evpn 13:13
       route-target export evpn 13:13
       router-id 192.168.255.7
-      neighbor interface Vlan3012 peer-group MLAG_PEER remote-as 65102
+      update wait-install
+      neighbor 10.255.251.2 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -562,7 +564,8 @@ router bgp 65102
       route-target import evpn 10:10
       route-target export evpn 10:10
       router-id 192.168.255.7
-      neighbor interface Vlan3009 peer-group MLAG_PEER remote-as 65102
+      update wait-install
+      neighbor 10.255.251.2 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -570,7 +573,8 @@ router bgp 65102
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.7
-      neighbor interface Vlan3010 peer-group MLAG_PEER remote-as 65102
+      update wait-install
+      neighbor 10.255.251.2 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -578,7 +582,8 @@ router bgp 65102
       route-target import evpn 20:20
       route-target export evpn 20:20
       router-id 192.168.255.7
-      neighbor interface Vlan3019 peer-group MLAG_PEER remote-as 65102
+      update wait-install
+      neighbor 10.255.251.2 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -586,7 +591,8 @@ router bgp 65102
       route-target import evpn 30:30
       route-target export evpn 30:30
       router-id 192.168.255.7
-      neighbor interface Vlan2 peer-group MLAG_PEER remote-as 65102
+      update wait-install
+      neighbor 10.255.251.2 peer group MLAG_PEER
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
@@ -549,6 +549,9 @@ router bgp 65102
       update wait-install
       neighbor 10.255.251.2 peer group MLAG_PEER
       redistribute connected
+      !
+      address-family ipv4
+         no neighbor 10.255.251.2 next-hop address-family ipv6
    !
    vrf Tenant_A_DB_Zone
       rd 192.168.255.7:13
@@ -558,6 +561,9 @@ router bgp 65102
       update wait-install
       neighbor 10.255.251.2 peer group MLAG_PEER
       redistribute connected
+      !
+      address-family ipv4
+         no neighbor 10.255.251.2 next-hop address-family ipv6
    !
    vrf Tenant_A_OP_Zone
       rd 192.168.255.7:10
@@ -567,6 +573,9 @@ router bgp 65102
       update wait-install
       neighbor 10.255.251.2 peer group MLAG_PEER
       redistribute connected
+      !
+      address-family ipv4
+         no neighbor 10.255.251.2 next-hop address-family ipv6
    !
    vrf Tenant_A_WEB_Zone
       rd 192.168.255.7:11
@@ -576,6 +585,9 @@ router bgp 65102
       update wait-install
       neighbor 10.255.251.2 peer group MLAG_PEER
       redistribute connected
+      !
+      address-family ipv4
+         no neighbor 10.255.251.2 next-hop address-family ipv6
    !
    vrf Tenant_B_OP_Zone
       rd 192.168.255.7:20
@@ -585,6 +597,9 @@ router bgp 65102
       update wait-install
       neighbor 10.255.251.2 peer group MLAG_PEER
       redistribute connected
+      !
+      address-family ipv4
+         no neighbor 10.255.251.2 next-hop address-family ipv6
    !
    vrf Tenant_C_OP_Zone
       rd 192.168.255.7:30
@@ -594,6 +609,9 @@ router bgp 65102
       update wait-install
       neighbor 10.255.251.2 peer group MLAG_PEER
       redistribute connected
+      !
+      address-family ipv4
+         no neighbor 10.255.251.2 next-hop address-family ipv6
 !
 management api http-commands
    protocol https

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF3A.cfg
@@ -340,6 +340,12 @@ ip routing ipv6 interfaces vrf Tenant_B_OP_Zone
 ip routing ipv6 interfaces vrf Tenant_C_OP_Zone
 !
 ipv6 unicast-routing
+ipv6 unicast-routing vrf Tenant_A_APP_Zone
+ipv6 unicast-routing vrf Tenant_A_DB_Zone
+ipv6 unicast-routing vrf Tenant_A_OP_Zone
+ipv6 unicast-routing vrf Tenant_A_WEB_Zone
+ipv6 unicast-routing vrf Tenant_B_OP_Zone
+ipv6 unicast-routing vrf Tenant_C_OP_Zone
 !
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.168.255.0/24 eq 32

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF3B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF3B.cfg
@@ -340,6 +340,12 @@ ip routing ipv6 interfaces vrf Tenant_B_OP_Zone
 ip routing ipv6 interfaces vrf Tenant_C_OP_Zone
 !
 ipv6 unicast-routing
+ipv6 unicast-routing vrf Tenant_A_APP_Zone
+ipv6 unicast-routing vrf Tenant_A_DB_Zone
+ipv6 unicast-routing vrf Tenant_A_OP_Zone
+ipv6 unicast-routing vrf Tenant_A_WEB_Zone
+ipv6 unicast-routing vrf Tenant_B_OP_Zone
+ipv6 unicast-routing vrf Tenant_C_OP_Zone
 !
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.168.255.0/24 eq 32

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF4A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF4A.cfg
@@ -340,6 +340,12 @@ ip routing ipv6 interfaces vrf Tenant_B_OP_Zone
 ip routing ipv6 interfaces vrf Tenant_C_OP_Zone
 !
 ipv6 unicast-routing
+ipv6 unicast-routing vrf Tenant_A_APP_Zone
+ipv6 unicast-routing vrf Tenant_A_DB_Zone
+ipv6 unicast-routing vrf Tenant_A_OP_Zone
+ipv6 unicast-routing vrf Tenant_A_WEB_Zone
+ipv6 unicast-routing vrf Tenant_B_OP_Zone
+ipv6 unicast-routing vrf Tenant_C_OP_Zone
 !
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.168.255.0/24 eq 32

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF4B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF4B.cfg
@@ -340,6 +340,12 @@ ip routing ipv6 interfaces vrf Tenant_B_OP_Zone
 ip routing ipv6 interfaces vrf Tenant_C_OP_Zone
 !
 ipv6 unicast-routing
+ipv6 unicast-routing vrf Tenant_A_APP_Zone
+ipv6 unicast-routing vrf Tenant_A_DB_Zone
+ipv6 unicast-routing vrf Tenant_A_OP_Zone
+ipv6 unicast-routing vrf Tenant_A_WEB_Zone
+ipv6 unicast-routing vrf Tenant_B_OP_Zone
+ipv6 unicast-routing vrf Tenant_C_OP_Zone
 !
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.168.255.0/24 eq 32

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
@@ -559,6 +559,15 @@ ip routing ipv6 interfaces vrf Tenant_C_OP_Zone
 ip routing ipv6 interfaces vrf Tenant_C_WAN_Zone
 !
 ipv6 unicast-routing
+ipv6 unicast-routing vrf Tenant_A_APP_Zone
+ipv6 unicast-routing vrf Tenant_A_DB_Zone
+ipv6 unicast-routing vrf Tenant_A_OP_Zone
+ipv6 unicast-routing vrf Tenant_A_WAN_Zone
+ipv6 unicast-routing vrf Tenant_A_WEB_Zone
+ipv6 unicast-routing vrf Tenant_B_OP_Zone
+ipv6 unicast-routing vrf Tenant_B_WAN_Zone
+ipv6 unicast-routing vrf Tenant_C_OP_Zone
+ipv6 unicast-routing vrf Tenant_C_WAN_Zone
 !
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.168.255.0/24 eq 32

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
@@ -543,6 +543,15 @@ ip routing ipv6 interfaces vrf Tenant_C_OP_Zone
 ip routing ipv6 interfaces vrf Tenant_C_WAN_Zone
 !
 ipv6 unicast-routing
+ipv6 unicast-routing vrf Tenant_A_APP_Zone
+ipv6 unicast-routing vrf Tenant_A_DB_Zone
+ipv6 unicast-routing vrf Tenant_A_OP_Zone
+ipv6 unicast-routing vrf Tenant_A_WAN_Zone
+ipv6 unicast-routing vrf Tenant_A_WEB_Zone
+ipv6 unicast-routing vrf Tenant_B_OP_Zone
+ipv6 unicast-routing vrf Tenant_B_WAN_Zone
+ipv6 unicast-routing vrf Tenant_C_OP_Zone
+ipv6 unicast-routing vrf Tenant_C_WAN_Zone
 !
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.168.255.0/24 eq 32

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
@@ -105,6 +105,10 @@ router_bgp:
     redistribute_routes:
     - source_protocol: connected
     - source_protocol: static
+    address_family_ipv4:
+      neighbors:
+      - ip_address: 123.1.1.10
+        activate: true
     neighbors:
     - ip_address: 123.1.1.10
       remote_as: '1234'
@@ -124,10 +128,6 @@ router_bgp:
       route_map_out: RM-Tenant_A_WAN_Zone-fd5a:fe45:8831:06c5::a-SET-NEXT-HOP-OUT
     - ip_address: fd5a:fe45:8831:06c5::b
       remote_as: '12345'
-    address_family_ipv4:
-      neighbors:
-      - ip_address: 123.1.1.10
-        activate: true
     address_family_ipv6:
       neighbors:
       - ip_address: fd5a:fe45:8831:06c5::a

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
@@ -105,6 +105,10 @@ router_bgp:
     redistribute_routes:
     - source_protocol: connected
     - source_protocol: static
+    address_family_ipv4:
+      neighbors:
+      - ip_address: 123.1.1.10
+        activate: true
     neighbors:
     - ip_address: 123.1.1.10
       remote_as: '1234'
@@ -124,10 +128,6 @@ router_bgp:
       route_map_out: RM-Tenant_A_WAN_Zone-fd5a:fe45:8831:06c5::a-SET-NEXT-HOP-OUT
     - ip_address: fd5a:fe45:8831:06c5::b
       remote_as: '12345'
-    address_family_ipv4:
-      neighbors:
-      - ip_address: 123.1.1.10
-        activate: true
     address_family_ipv6:
       neighbors:
       - ip_address: fd5a:fe45:8831:06c5::a

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -116,6 +116,12 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.3
       peer_group: MLAG_PEER
+    address_family_ipv4:
+      neighbors:
+      - ip_address: 10.255.251.3
+        next_hop:
+          address_family_ipv6:
+            enabled: false
     updates:
       wait_install: true
   - name: Tenant_A_DB_Zone
@@ -135,6 +141,12 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.3
       peer_group: MLAG_PEER
+    address_family_ipv4:
+      neighbors:
+      - ip_address: 10.255.251.3
+        next_hop:
+          address_family_ipv6:
+            enabled: false
     updates:
       wait_install: true
   - name: Tenant_A_OP_Zone
@@ -154,6 +166,12 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.3
       peer_group: MLAG_PEER
+    address_family_ipv4:
+      neighbors:
+      - ip_address: 10.255.251.3
+        next_hop:
+          address_family_ipv6:
+            enabled: false
     updates:
       wait_install: true
   - name: Tenant_A_WEB_Zone
@@ -173,6 +191,12 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.3
       peer_group: MLAG_PEER
+    address_family_ipv4:
+      neighbors:
+      - ip_address: 10.255.251.3
+        next_hop:
+          address_family_ipv6:
+            enabled: false
     updates:
       wait_install: true
   - name: Tenant_B_OP_Zone
@@ -192,6 +216,12 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.3
       peer_group: MLAG_PEER
+    address_family_ipv4:
+      neighbors:
+      - ip_address: 10.255.251.3
+        next_hop:
+          address_family_ipv6:
+            enabled: false
     updates:
       wait_install: true
   - name: Tenant_C_OP_Zone
@@ -211,6 +241,12 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.3
       peer_group: MLAG_PEER
+    address_family_ipv4:
+      neighbors:
+      - ip_address: 10.255.251.3
+        next_hop:
+          address_family_ipv6:
+            enabled: false
     updates:
       wait_install: true
   vlan_aware_bundles:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -113,11 +113,11 @@ router_bgp:
         - '12:12'
     redistribute_routes:
     - source_protocol: connected
-    neighbor_interfaces:
-    - name: Vlan3011
+    neighbors:
+    - ip_address: 10.255.251.3
       peer_group: MLAG_PEER
-      remote_as: '65102'
-      description: DC1-LEAF2B
+    updates:
+      wait_install: true
   - name: Tenant_A_DB_Zone
     router_id: 192.168.255.6
     rd: 192.168.255.6:13
@@ -132,11 +132,11 @@ router_bgp:
         - '13:13'
     redistribute_routes:
     - source_protocol: connected
-    neighbor_interfaces:
-    - name: Vlan3012
+    neighbors:
+    - ip_address: 10.255.251.3
       peer_group: MLAG_PEER
-      remote_as: '65102'
-      description: DC1-LEAF2B
+    updates:
+      wait_install: true
   - name: Tenant_A_OP_Zone
     router_id: 192.168.255.6
     rd: 192.168.255.6:10
@@ -151,11 +151,11 @@ router_bgp:
         - '10:10'
     redistribute_routes:
     - source_protocol: connected
-    neighbor_interfaces:
-    - name: Vlan3009
+    neighbors:
+    - ip_address: 10.255.251.3
       peer_group: MLAG_PEER
-      remote_as: '65102'
-      description: DC1-LEAF2B
+    updates:
+      wait_install: true
   - name: Tenant_A_WEB_Zone
     router_id: 192.168.255.6
     rd: 192.168.255.6:11
@@ -170,11 +170,11 @@ router_bgp:
         - '11:11'
     redistribute_routes:
     - source_protocol: connected
-    neighbor_interfaces:
-    - name: Vlan3010
+    neighbors:
+    - ip_address: 10.255.251.3
       peer_group: MLAG_PEER
-      remote_as: '65102'
-      description: DC1-LEAF2B
+    updates:
+      wait_install: true
   - name: Tenant_B_OP_Zone
     router_id: 192.168.255.6
     rd: 192.168.255.6:20
@@ -189,11 +189,11 @@ router_bgp:
         - '20:20'
     redistribute_routes:
     - source_protocol: connected
-    neighbor_interfaces:
-    - name: Vlan3019
+    neighbors:
+    - ip_address: 10.255.251.3
       peer_group: MLAG_PEER
-      remote_as: '65102'
-      description: DC1-LEAF2B
+    updates:
+      wait_install: true
   - name: Tenant_C_OP_Zone
     router_id: 192.168.255.6
     rd: 192.168.255.6:30
@@ -208,11 +208,11 @@ router_bgp:
         - '30:30'
     redistribute_routes:
     - source_protocol: connected
-    neighbor_interfaces:
-    - name: Vlan2
+    neighbors:
+    - ip_address: 10.255.251.3
       peer_group: MLAG_PEER
-      remote_as: '65102'
-      description: DC1-LEAF2B
+    updates:
+      wait_install: true
   vlan_aware_bundles:
   - name: Tenant_A_APP_Zone
     rd: 192.168.255.6:12
@@ -327,22 +327,22 @@ vrfs:
   ip_routing: false
 - name: Tenant_A_APP_Zone
   tenant: Tenant_A
-  ip_routing_ipv6_interfaces: true
+  ip_routing: true
 - name: Tenant_A_DB_Zone
   tenant: Tenant_A
-  ip_routing_ipv6_interfaces: true
+  ip_routing: true
 - name: Tenant_A_OP_Zone
   tenant: Tenant_A
-  ip_routing_ipv6_interfaces: true
+  ip_routing: true
 - name: Tenant_A_WEB_Zone
   tenant: Tenant_A
-  ip_routing_ipv6_interfaces: true
+  ip_routing: true
 - name: Tenant_B_OP_Zone
   tenant: Tenant_B
-  ip_routing_ipv6_interfaces: true
+  ip_routing: true
 - name: Tenant_C_OP_Zone
   tenant: Tenant_C
-  ip_routing_ipv6_interfaces: true
+  ip_routing: true
 management_interfaces:
 - name: Management1
   description: oob_management
@@ -480,7 +480,7 @@ vlan_interfaces:
   description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone'
   vrf: Tenant_A_APP_Zone
   mtu: 1500
-  ipv6_enable: true
+  ip_address: 10.255.251.2/31
 - name: Vlan140
   tenant: Tenant_A
   tags:
@@ -505,7 +505,7 @@ vlan_interfaces:
   description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone'
   vrf: Tenant_A_DB_Zone
   mtu: 1500
-  ipv6_enable: true
+  ip_address: 10.255.251.2/31
 - name: Vlan110
   tenant: Tenant_A
   tags:
@@ -533,7 +533,7 @@ vlan_interfaces:
   description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone'
   vrf: Tenant_A_OP_Zone
   mtu: 1500
-  ipv6_enable: true
+  ip_address: 10.255.251.2/31
 - name: Vlan120
   tenant: Tenant_A
   tags:
@@ -563,7 +563,7 @@ vlan_interfaces:
   description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone'
   vrf: Tenant_A_WEB_Zone
   mtu: 1500
-  ipv6_enable: true
+  ip_address: 10.255.251.2/31
 - name: Vlan210
   tenant: Tenant_B
   tags:
@@ -587,7 +587,7 @@ vlan_interfaces:
   description: 'MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone'
   vrf: Tenant_B_OP_Zone
   mtu: 1500
-  ipv6_enable: true
+  ip_address: 10.255.251.2/31
 - name: Vlan310
   tenant: Tenant_C
   tags:
@@ -611,7 +611,7 @@ vlan_interfaces:
   description: 'MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone'
   vrf: Tenant_C_OP_Zone
   mtu: 1500
-  ipv6_enable: true
+  ip_address: 10.255.251.2/31
 port_channel_interfaces:
 - name: Port-Channel5
   description: MLAG_PEER_DC1-LEAF2B_Po5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -113,11 +113,11 @@ router_bgp:
         - '12:12'
     redistribute_routes:
     - source_protocol: connected
-    neighbor_interfaces:
-    - name: Vlan3011
+    neighbors:
+    - ip_address: 10.255.251.2
       peer_group: MLAG_PEER
-      remote_as: '65102'
-      description: DC1-LEAF2A
+    updates:
+      wait_install: true
   - name: Tenant_A_DB_Zone
     router_id: 192.168.255.7
     rd: 192.168.255.7:13
@@ -132,11 +132,11 @@ router_bgp:
         - '13:13'
     redistribute_routes:
     - source_protocol: connected
-    neighbor_interfaces:
-    - name: Vlan3012
+    neighbors:
+    - ip_address: 10.255.251.2
       peer_group: MLAG_PEER
-      remote_as: '65102'
-      description: DC1-LEAF2A
+    updates:
+      wait_install: true
   - name: Tenant_A_OP_Zone
     router_id: 192.168.255.7
     rd: 192.168.255.7:10
@@ -151,11 +151,11 @@ router_bgp:
         - '10:10'
     redistribute_routes:
     - source_protocol: connected
-    neighbor_interfaces:
-    - name: Vlan3009
+    neighbors:
+    - ip_address: 10.255.251.2
       peer_group: MLAG_PEER
-      remote_as: '65102'
-      description: DC1-LEAF2A
+    updates:
+      wait_install: true
   - name: Tenant_A_WEB_Zone
     router_id: 192.168.255.7
     rd: 192.168.255.7:11
@@ -170,11 +170,11 @@ router_bgp:
         - '11:11'
     redistribute_routes:
     - source_protocol: connected
-    neighbor_interfaces:
-    - name: Vlan3010
+    neighbors:
+    - ip_address: 10.255.251.2
       peer_group: MLAG_PEER
-      remote_as: '65102'
-      description: DC1-LEAF2A
+    updates:
+      wait_install: true
   - name: Tenant_B_OP_Zone
     router_id: 192.168.255.7
     rd: 192.168.255.7:20
@@ -189,11 +189,11 @@ router_bgp:
         - '20:20'
     redistribute_routes:
     - source_protocol: connected
-    neighbor_interfaces:
-    - name: Vlan3019
+    neighbors:
+    - ip_address: 10.255.251.2
       peer_group: MLAG_PEER
-      remote_as: '65102'
-      description: DC1-LEAF2A
+    updates:
+      wait_install: true
   - name: Tenant_C_OP_Zone
     router_id: 192.168.255.7
     rd: 192.168.255.7:30
@@ -208,11 +208,11 @@ router_bgp:
         - '30:30'
     redistribute_routes:
     - source_protocol: connected
-    neighbor_interfaces:
-    - name: Vlan2
+    neighbors:
+    - ip_address: 10.255.251.2
       peer_group: MLAG_PEER
-      remote_as: '65102'
-      description: DC1-LEAF2A
+    updates:
+      wait_install: true
   vlan_aware_bundles:
   - name: Tenant_A_APP_Zone
     rd: 192.168.255.7:12
@@ -327,22 +327,22 @@ vrfs:
   ip_routing: false
 - name: Tenant_A_APP_Zone
   tenant: Tenant_A
-  ip_routing_ipv6_interfaces: true
+  ip_routing: true
 - name: Tenant_A_DB_Zone
   tenant: Tenant_A
-  ip_routing_ipv6_interfaces: true
+  ip_routing: true
 - name: Tenant_A_OP_Zone
   tenant: Tenant_A
-  ip_routing_ipv6_interfaces: true
+  ip_routing: true
 - name: Tenant_A_WEB_Zone
   tenant: Tenant_A
-  ip_routing_ipv6_interfaces: true
+  ip_routing: true
 - name: Tenant_B_OP_Zone
   tenant: Tenant_B
-  ip_routing_ipv6_interfaces: true
+  ip_routing: true
 - name: Tenant_C_OP_Zone
   tenant: Tenant_C
-  ip_routing_ipv6_interfaces: true
+  ip_routing: true
 management_interfaces:
 - name: Management1
   description: oob_management
@@ -480,7 +480,7 @@ vlan_interfaces:
   description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone'
   vrf: Tenant_A_APP_Zone
   mtu: 1500
-  ipv6_enable: true
+  ip_address: 10.255.251.3/31
 - name: Vlan140
   tenant: Tenant_A
   tags:
@@ -505,7 +505,7 @@ vlan_interfaces:
   description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone'
   vrf: Tenant_A_DB_Zone
   mtu: 1500
-  ipv6_enable: true
+  ip_address: 10.255.251.3/31
 - name: Vlan110
   tenant: Tenant_A
   tags:
@@ -533,7 +533,7 @@ vlan_interfaces:
   description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone'
   vrf: Tenant_A_OP_Zone
   mtu: 1500
-  ipv6_enable: true
+  ip_address: 10.255.251.3/31
 - name: Vlan120
   tenant: Tenant_A
   tags:
@@ -563,7 +563,7 @@ vlan_interfaces:
   description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone'
   vrf: Tenant_A_WEB_Zone
   mtu: 1500
-  ipv6_enable: true
+  ip_address: 10.255.251.3/31
 - name: Vlan210
   tenant: Tenant_B
   tags:
@@ -587,7 +587,7 @@ vlan_interfaces:
   description: 'MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone'
   vrf: Tenant_B_OP_Zone
   mtu: 1500
-  ipv6_enable: true
+  ip_address: 10.255.251.3/31
 - name: Vlan310
   tenant: Tenant_C
   tags:
@@ -611,7 +611,7 @@ vlan_interfaces:
   description: 'MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone'
   vrf: Tenant_C_OP_Zone
   mtu: 1500
-  ipv6_enable: true
+  ip_address: 10.255.251.3/31
 port_channel_interfaces:
 - name: Port-Channel5
   description: MLAG_PEER_DC1-LEAF2A_Po5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -116,6 +116,12 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.2
       peer_group: MLAG_PEER
+    address_family_ipv4:
+      neighbors:
+      - ip_address: 10.255.251.2
+        next_hop:
+          address_family_ipv6:
+            enabled: false
     updates:
       wait_install: true
   - name: Tenant_A_DB_Zone
@@ -135,6 +141,12 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.2
       peer_group: MLAG_PEER
+    address_family_ipv4:
+      neighbors:
+      - ip_address: 10.255.251.2
+        next_hop:
+          address_family_ipv6:
+            enabled: false
     updates:
       wait_install: true
   - name: Tenant_A_OP_Zone
@@ -154,6 +166,12 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.2
       peer_group: MLAG_PEER
+    address_family_ipv4:
+      neighbors:
+      - ip_address: 10.255.251.2
+        next_hop:
+          address_family_ipv6:
+            enabled: false
     updates:
       wait_install: true
   - name: Tenant_A_WEB_Zone
@@ -173,6 +191,12 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.2
       peer_group: MLAG_PEER
+    address_family_ipv4:
+      neighbors:
+      - ip_address: 10.255.251.2
+        next_hop:
+          address_family_ipv6:
+            enabled: false
     updates:
       wait_install: true
   - name: Tenant_B_OP_Zone
@@ -192,6 +216,12 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.2
       peer_group: MLAG_PEER
+    address_family_ipv4:
+      neighbors:
+      - ip_address: 10.255.251.2
+        next_hop:
+          address_family_ipv6:
+            enabled: false
     updates:
       wait_install: true
   - name: Tenant_C_OP_Zone
@@ -211,6 +241,12 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.2
       peer_group: MLAG_PEER
+    address_family_ipv4:
+      neighbors:
+      - ip_address: 10.255.251.2
+        next_hop:
+          address_family_ipv6:
+            enabled: false
     updates:
       wait_install: true
   vlan_aware_bundles:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF3A.yml
@@ -310,21 +310,27 @@ vrfs:
 - name: Tenant_A_APP_Zone
   tenant: Tenant_A
   ip_routing_ipv6_interfaces: true
+  ipv6_routing: true
 - name: Tenant_A_DB_Zone
   tenant: Tenant_A
   ip_routing_ipv6_interfaces: true
+  ipv6_routing: true
 - name: Tenant_A_OP_Zone
   tenant: Tenant_A
   ip_routing_ipv6_interfaces: true
+  ipv6_routing: true
 - name: Tenant_A_WEB_Zone
   tenant: Tenant_A
   ip_routing_ipv6_interfaces: true
+  ipv6_routing: true
 - name: Tenant_B_OP_Zone
   tenant: Tenant_B
   ip_routing_ipv6_interfaces: true
+  ipv6_routing: true
 - name: Tenant_C_OP_Zone
   tenant: Tenant_C
   ip_routing_ipv6_interfaces: true
+  ipv6_routing: true
 management_interfaces:
 - name: Management1
   description: oob_management

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF3B.yml
@@ -310,21 +310,27 @@ vrfs:
 - name: Tenant_A_APP_Zone
   tenant: Tenant_A
   ip_routing_ipv6_interfaces: true
+  ipv6_routing: true
 - name: Tenant_A_DB_Zone
   tenant: Tenant_A
   ip_routing_ipv6_interfaces: true
+  ipv6_routing: true
 - name: Tenant_A_OP_Zone
   tenant: Tenant_A
   ip_routing_ipv6_interfaces: true
+  ipv6_routing: true
 - name: Tenant_A_WEB_Zone
   tenant: Tenant_A
   ip_routing_ipv6_interfaces: true
+  ipv6_routing: true
 - name: Tenant_B_OP_Zone
   tenant: Tenant_B
   ip_routing_ipv6_interfaces: true
+  ipv6_routing: true
 - name: Tenant_C_OP_Zone
   tenant: Tenant_C
   ip_routing_ipv6_interfaces: true
+  ipv6_routing: true
 management_interfaces:
 - name: Management1
   description: oob_management

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF4A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF4A.yml
@@ -310,21 +310,27 @@ vrfs:
 - name: Tenant_A_APP_Zone
   tenant: Tenant_A
   ip_routing_ipv6_interfaces: true
+  ipv6_routing: true
 - name: Tenant_A_DB_Zone
   tenant: Tenant_A
   ip_routing_ipv6_interfaces: true
+  ipv6_routing: true
 - name: Tenant_A_OP_Zone
   tenant: Tenant_A
   ip_routing_ipv6_interfaces: true
+  ipv6_routing: true
 - name: Tenant_A_WEB_Zone
   tenant: Tenant_A
   ip_routing_ipv6_interfaces: true
+  ipv6_routing: true
 - name: Tenant_B_OP_Zone
   tenant: Tenant_B
   ip_routing_ipv6_interfaces: true
+  ipv6_routing: true
 - name: Tenant_C_OP_Zone
   tenant: Tenant_C
   ip_routing_ipv6_interfaces: true
+  ipv6_routing: true
 management_interfaces:
 - name: Management1
   description: oob_management

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF4B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF4B.yml
@@ -310,21 +310,27 @@ vrfs:
 - name: Tenant_A_APP_Zone
   tenant: Tenant_A
   ip_routing_ipv6_interfaces: true
+  ipv6_routing: true
 - name: Tenant_A_DB_Zone
   tenant: Tenant_A
   ip_routing_ipv6_interfaces: true
+  ipv6_routing: true
 - name: Tenant_A_OP_Zone
   tenant: Tenant_A
   ip_routing_ipv6_interfaces: true
+  ipv6_routing: true
 - name: Tenant_A_WEB_Zone
   tenant: Tenant_A
   ip_routing_ipv6_interfaces: true
+  ipv6_routing: true
 - name: Tenant_B_OP_Zone
   tenant: Tenant_B
   ip_routing_ipv6_interfaces: true
+  ipv6_routing: true
 - name: Tenant_C_OP_Zone
   tenant: Tenant_C
   ip_routing_ipv6_interfaces: true
+  ipv6_routing: true
 management_interfaces:
 - name: Management1
   description: oob_management

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -409,30 +409,39 @@ vrfs:
 - name: Tenant_A_APP_Zone
   tenant: Tenant_A
   ip_routing_ipv6_interfaces: true
+  ipv6_routing: true
 - name: Tenant_A_DB_Zone
   tenant: Tenant_A
   ip_routing_ipv6_interfaces: true
+  ipv6_routing: true
 - name: Tenant_A_OP_Zone
   tenant: Tenant_A
   ip_routing_ipv6_interfaces: true
+  ipv6_routing: true
 - name: Tenant_A_WAN_Zone
   tenant: Tenant_A
   ip_routing_ipv6_interfaces: true
+  ipv6_routing: true
 - name: Tenant_A_WEB_Zone
   tenant: Tenant_A
   ip_routing_ipv6_interfaces: true
+  ipv6_routing: true
 - name: Tenant_B_OP_Zone
   tenant: Tenant_B
   ip_routing_ipv6_interfaces: true
+  ipv6_routing: true
 - name: Tenant_B_WAN_Zone
   tenant: Tenant_B
   ip_routing_ipv6_interfaces: true
+  ipv6_routing: true
 - name: Tenant_C_OP_Zone
   tenant: Tenant_C
   ip_routing_ipv6_interfaces: true
+  ipv6_routing: true
 - name: Tenant_C_WAN_Zone
   tenant: Tenant_C
   ip_routing_ipv6_interfaces: true
+  ipv6_routing: true
 management_interfaces:
 - name: Management1
   description: oob_management

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -409,30 +409,39 @@ vrfs:
 - name: Tenant_A_APP_Zone
   tenant: Tenant_A
   ip_routing_ipv6_interfaces: true
+  ipv6_routing: true
 - name: Tenant_A_DB_Zone
   tenant: Tenant_A
   ip_routing_ipv6_interfaces: true
+  ipv6_routing: true
 - name: Tenant_A_OP_Zone
   tenant: Tenant_A
   ip_routing_ipv6_interfaces: true
+  ipv6_routing: true
 - name: Tenant_A_WAN_Zone
   tenant: Tenant_A
   ip_routing_ipv6_interfaces: true
+  ipv6_routing: true
 - name: Tenant_A_WEB_Zone
   tenant: Tenant_A
   ip_routing_ipv6_interfaces: true
+  ipv6_routing: true
 - name: Tenant_B_OP_Zone
   tenant: Tenant_B
   ip_routing_ipv6_interfaces: true
+  ipv6_routing: true
 - name: Tenant_B_WAN_Zone
   tenant: Tenant_B
   ip_routing_ipv6_interfaces: true
+  ipv6_routing: true
 - name: Tenant_C_OP_Zone
   tenant: Tenant_C
   ip_routing_ipv6_interfaces: true
+  ipv6_routing: true
 - name: Tenant_C_WAN_Zone
   tenant: Tenant_C
   ip_routing_ipv6_interfaces: true
+  ipv6_routing: true
 management_interfaces:
 - name: Management1
   description: oob_management

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/inventory/group_vars/DC1_BL1.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/inventory/group_vars/DC1_BL1.yml
@@ -1,6 +1,6 @@
 ---
 my_dci_ethernet_interfaces:
-  Ethernet4000:
+  - name: Ethernet4000
     description: My test
     ip_address: 10.1.2.3/12
     shutdown: false

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/inventory/group_vars/DC1_FABRIC.yml
@@ -10,6 +10,10 @@ fabric_name: DC1_FABRIC
 
 # Point to Point Underlay with IPv6 Unnumbered
 underlay_rfc5549: true
+
+# Test if overlay_mlag_rfc5549 is True
+# Results to the following EOS config:
+#   ipv6 unicast-routing vrf <vrf_name>
 overlay_mlag_rfc5549: true
 
 overlay_routing_protocol_address_family: ipv4
@@ -36,7 +40,7 @@ bgp_peer_groups:
 # Spine Switches
 spine:
   defaults:
-    platform: vEOS-LAB
+    platform: 7050X3
     bgp_as: 65001
     loopback_ipv4_pool: 192.168.255.0/24
     bgp_defaults: ['distance bgp 20 200 200']

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/inventory/group_vars/DC1_LEAF2.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/inventory/group_vars/DC1_LEAF2.yml
@@ -1,0 +1,9 @@
+---
+
+# Test if underlay_rfc5549 is True and overlay_mlag_rfc5549 is False
+# Results to the following EOS config:
+#  router_bgp <asn>
+#     vrf <vrf_name>
+#        address-family ipv4
+#           no neighbor <mlag-peer-ip> next-hop address-family ipv6
+overlay_mlag_rfc5549: false

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -5158,6 +5158,10 @@ Set Link Aggregation Control Protocol (LACP) parameters.
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;activate</samp>](## "router_bgp.vrfs.[].address_family_ipv4.neighbors.[].activate") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map_in</samp>](## "router_bgp.vrfs.[].address_family_ipv4.neighbors.[].route_map_in") | String |  |  |  | Inbound route-map name |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map_out</samp>](## "router_bgp.vrfs.[].address_family_ipv4.neighbors.[].route_map_out") | String |  |  |  | Outbound route-map name |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;next_hop</samp>](## "router_bgp.vrfs.[].address_family_ipv4.neighbors.[].next_hop") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;address_family_ipv6</samp>](## "router_bgp.vrfs.[].address_family_ipv4.neighbors.[].next_hop.address_family_ipv6") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "router_bgp.vrfs.[].address_family_ipv4.neighbors.[].next_hop.address_family_ipv6.enabled") | Boolean | Required |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;originate</samp>](## "router_bgp.vrfs.[].address_family_ipv4.neighbors.[].next_hop.address_family_ipv6.originate") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;peer_groups</samp>](## "router_bgp.vrfs.[].address_family_ipv4.peer_groups") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "router_bgp.vrfs.[].address_family_ipv4.peer_groups.[].name") | String | Required, Unique |  |  | Peer-group name |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;activate</samp>](## "router_bgp.vrfs.[].address_family_ipv4.peer_groups.[].activate") | Boolean |  |  |  |  |
@@ -5725,6 +5729,10 @@ Set Link Aggregation Control Protocol (LACP) parameters.
                 activate: <bool>
                 route_map_in: <str>
                 route_map_out: <str>
+                next_hop:
+                  address_family_ipv6:
+                    enabled: <bool>
+                    originate: <bool>
             peer_groups:
               - name: <str>
                 activate: <bool>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -14316,6 +14316,37 @@
                           "type": "string",
                           "description": "Outbound route-map name",
                           "title": "Route Map Out"
+                        },
+                        "next_hop": {
+                          "type": "object",
+                          "properties": {
+                            "address_family_ipv6": {
+                              "type": "object",
+                              "properties": {
+                                "enabled": {
+                                  "type": "boolean",
+                                  "title": "Enabled"
+                                },
+                                "originate": {
+                                  "type": "boolean",
+                                  "title": "Originate"
+                                }
+                              },
+                              "required": [
+                                "enabled"
+                              ],
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Address Family IPv6"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Next Hop"
                         }
                       },
                       "additionalProperties": false,

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -8462,6 +8462,17 @@ keys:
                       route_map_out:
                         type: str
                         description: Outbound route-map name
+                      next_hop:
+                        type: dict
+                        keys:
+                          address_family_ipv6:
+                            type: dict
+                            keys:
+                              enabled:
+                                type: bool
+                                required: true
+                              originate:
+                                type: bool
                 peer_groups:
                   type: list
                   primary_key: name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_bgp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_bgp.schema.yml
@@ -1581,6 +1581,17 @@ keys:
                       route_map_out:
                         type: str
                         description: Outbound route-map name
+                      next_hop:
+                        type: dict
+                        keys:
+                          address_family_ipv6:
+                            type: dict
+                            keys:
+                              enabled:
+                                type: bool
+                                required: true
+                              originate:
+                                type: bool
                 peer_groups:
                   type: list
                   primary_key: name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -1167,6 +1167,17 @@ router bgp {{ router_bgp.as }}
 {%                 if neighbor.route_map_out is arista.avd.defined %}
          neighbor {{ neighbor.ip_address }} route-map {{ neighbor.route_map_out }} out
 {%                 endif %}
+{%                 if neighbor.next_hop.address_family_ipv6.enabled is arista.avd.defined %}
+{%                     if neighbor.next_hop.address_family_ipv6.enabled is arista.avd.defined(true) %}
+{%                         set ipv6_originate_cli = "neighbor " ~ neighbor.ip_address ~ " next-hop address-family ipv6" %}
+{%                         if neighbor.next_hop.address_family_ipv6.originate is arista.avd.defined(true) %}
+{%                             set ipv6_originate_cli = ipv6_originate_cli ~ " originate" %}
+{%                         endif %}
+{%                     elif neighbor.next_hop.address_family_ipv6.enabled is arista.avd.defined(false) %}
+{%                         set ipv6_originate_cli = "no neighbor " ~ neighbor.ip_address ~ " next-hop address-family ipv6" %}
+{%                     endif %}
+         {{ ipv6_originate_cli }}
+{%                 endif %}
 {%             endfor %}
 {%             for network in vrf.address_family_ipv4.networks | arista.avd.natural_sort('prefix') %}
 {%                 set network_cli = "network " ~ network.prefix %}

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/vrfs.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/vrfs.py
@@ -42,6 +42,7 @@ class VrfsMixin(UtilsMixin):
                 # MLAG IBGP Peering VLANs per VRF
                 if self.shared_utils.overlay_mlag_rfc5549 and self._mlag_ibgp_peering_enabled(vrf, tenant):
                     new_vrf["ip_routing_ipv6_interfaces"] = True
+                    new_vrf["ipv6_routing"] = True
                 else:
                     new_vrf["ip_routing"] = True
 


### PR DESCRIPTION
## Change Summary

Fix issues in the eBGP rfc5549 design with MLAG configuration scenario as described in #2906 

## Related Issue(s)

Fixes #2906 

## Component(s) name

`arista.avd.eos_designs`
`arista.avd.eos_cli_config_gen`

## Proposed changes

If underlay_rfc5549 is True and overlay_mlag_rfc5549 is True configure:

```eos
ipv6 unicast-routing vrf <vrf_name>
```

If underlay_rfc5549 is True and overlay_mlag_rfc5549 is False configure:

```eos
router_bgp <asn>
   vrf <vrf_name>
      address-family ipv4
         no neighbor <mlag-peer-ip> next-hop address-family ipv6
```

## How to test

Run Molecule scenario: `molecule converge -s evpn_underlay_rfc5549_overlay_ebgp`

## Checklist

### User Checklist

- [x] Update test case for evpn_underlay_rfc5549_overlay_ebgp
- [x] Fix underlay_rfc5549 is True and overlay_mlag_rfc5549 is True
- [x] Add eos_cli_config_gen knob for router_bgp.vrfs<vrf>.address_family_ipv4."no neighbor <ip_address> next-hop address-family ipv6"
- [x] Fix If underlay_rfc5549 is True and overlay_mlag_rfc5549 is False



