### PR TITLE
Fix(eos_designs): Ignore "overlay_routing_protocol_address_family: ipv6" on l2leaf

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/DC1-L2LEAF1A.yml
@@ -2,3 +2,7 @@
 # Test that having underlay_ipv6 will not require
 # loopback_ipv6_pool for devices that are not underlay_router
 underlay_ipv6: true
+
+# Test that having "overlay_routing_protocol_address_family: ipv6"
+# will not raise an error for devices that are not underlay_router (issue/2954)
+overlay_routing_protocol_address_family: ipv6

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_facts/overlay.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_facts/overlay.py
@@ -56,14 +56,16 @@ class OverlayMixin:
         return None
 
     @cached_property
-    def overlay(self: EosDesignsFacts) -> dict:
+    def overlay(self: EosDesignsFacts) -> dict | None:
         """
         Exposed in avd_switch_facts
         """
-        return {
-            "peering_address": self.shared_utils.overlay_peering_address,
-            "evpn_mpls": self.shared_utils.overlay_evpn_mpls,
-        }
+        if self.shared_utils.underlay_router is True:
+            return {
+                "peering_address": self.shared_utils.overlay_peering_address,
+                "evpn_mpls": self.shared_utils.overlay_evpn_mpls,
+            }
+        return None
 
     @cached_property
     def vtep_ip(self: EosDesignsFacts) -> str | None:

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/overlay.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/overlay.py
@@ -153,9 +153,13 @@ class OverlayMixin:
         )
 
     @cached_property
-    def overlay_peering_address(self: SharedUtils) -> str:
+    def overlay_peering_address(self: SharedUtils) -> str | None:
+        if not self.underlay_router:
+            return None
+
         if self.overlay_routing_protocol_address_family == "ipv6":
             return self.ipv6_router_id
+
         return self.router_id
 
     @cached_property

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/overlay/utils.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/overlay/utils.py
@@ -236,5 +236,5 @@ class UtilsMixin:
         bgp_as = peer_facts.get("bgp_as")
         peers_dict[peer_name] = {
             "bgp_as": str(bgp_as) if bgp_as is not None else None,
-            "ip_address": get(peer_facts, "overlay.peering_address", required=True),
+            "ip_address": get(peer_facts, "overlay.peering_address", required=True, org_key=f"switch.overlay.peering_address for {peer_name}"),
         }


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Fix Ignore `overlay_routing_protocol_address_family: ipv6` on l2leaf

## Related Issue(s)

Fixes #2954 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

- Add `underlay_router: true` condition for rendering overlay facts
- Add `underlay_router: true` condition for rendering overlay peering address
- Add test coverage first recreating the issue and then verifying the fix.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

- Added molecule coverage and no side effects

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
