### PR TITLE
Test(plugins): Add integration test for eos_designs_structured_config

### DIFF
--- a/ansible_collections/arista/avd/plugins/action/eos_designs_structured_config.py
+++ b/ansible_collections/arista/avd/plugins/action/eos_designs_structured_config.py
@@ -79,7 +79,7 @@ class ActionModule(ActionBase):
         # Get Structured Config from builtin eos_designs python_modules
         try:
             output = get_structured_config(
-                vars=task_vars,
+                vars=dict(task_vars),
                 input_schema_tools=input_schema_tools,
                 output_schema_tools=output_schema_tools,
                 result=result,
@@ -121,7 +121,10 @@ class ActionModule(ActionBase):
                 if not isinstance(template_result_data, list):
                     template_result_data = [template_result_data]
 
-                merge(output, *template_result_data, list_merge=list_merge, schema=output_schema_tools.avdschema)
+                try:
+                    merge(output, *template_result_data, list_merge=list_merge, schema=output_schema_tools.avdschema)
+                except Exception as error:
+                    raise AnsibleActionFail(message=str(error)) from error
 
         # If the argument 'template_output' is set, run the output data through another jinja2 rendering.
         # This is to resolve any input values with inline jinja using variables/facts set by the input templates.

--- a/ansible_collections/arista/avd/tests/integration/targets/eos_designs_structured_config/defaults/main.yaml
+++ b/ansible_collections/arista/avd/tests/integration/targets/eos_designs_structured_config/defaults/main.yaml
@@ -1,0 +1,20 @@
+---
+testcase: '*'
+collection_path: "{{ lookup('env', 'ANSIBLE_COLLECTIONS_PATH') }}/ansible_collections/arista/avd/tests"
+expected_output_dir: "{{ collection_path }}/inventory/eos_designs_structured_config/expected_output"
+actual_output_dir: "{{ collection_path }}/output"
+
+avd_data_validation_mode: error
+avd_data_conversion_mode: error
+fabric_name: integration_tests
+type: l2leaf
+l2leaf:
+  nodes:
+    - name: testhost
+      id: 1
+avd_switch_facts:
+  testhost:
+    switch:
+      id: 1
+      vlans: ""
+      uplinks: []

--- a/ansible_collections/arista/avd/tests/integration/targets/eos_designs_structured_config/tasks/main.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/eos_designs_structured_config/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+- name: Include test.yml
+  ansible.builtin.include_tasks: test.yml

--- a/ansible_collections/arista/avd/tests/integration/targets/eos_designs_structured_config/tasks/test.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/eos_designs_structured_config/tasks/test.yml
@@ -1,0 +1,16 @@
+- name: Collect all test cases
+  ansible.builtin.find:
+    paths: '{{ role_path }}/tests/'
+    patterns: '{{ testcase }}.yml'
+  register: test_cases
+  delegate_to: localhost
+
+- name: Set test_items
+  ansible.builtin.set_fact:
+    test_items: "{{ test_cases.files | map(attribute='path') | list }}"
+
+- name: Run test cases
+  ansible.builtin.include_tasks: '{{ test_case_to_run }}'
+  with_items: '{{ test_items }}'
+  loop_control:
+    loop_var: test_case_to_run

--- a/ansible_collections/arista/avd/tests/integration/targets/eos_designs_structured_config/templates/base.yml.j2
+++ b/ansible_collections/arista/avd/tests/integration/targets/eos_designs_structured_config/templates/base.yml.j2
@@ -1,0 +1,3 @@
+---
+custom_template1_list: ["base_item"]
+custom_template2_list: ["base_item"]

--- a/ansible_collections/arista/avd/tests/integration/targets/eos_designs_structured_config/templates/custom_template1.yml.j2
+++ b/ansible_collections/arista/avd/tests/integration/targets/eos_designs_structured_config/templates/custom_template1.yml.j2
@@ -1,0 +1,5 @@
+{# Custom template generating extra yaml data which will be merged onto the eos_designs generated vars #}
+custom_template1_var: {{ switch.id }}
+custom_template1_list:
+  - custom_template1_item
+custom_template1_none_var: {# Nothing here on purpose. Means "null" #}

--- a/ansible_collections/arista/avd/tests/integration/targets/eos_designs_structured_config/templates/custom_template2.yml.j2
+++ b/ansible_collections/arista/avd/tests/integration/targets/eos_designs_structured_config/templates/custom_template2.yml.j2
@@ -1,0 +1,4 @@
+{# Custom template generating extra yaml data which will be merged onto the eos_designs generated vars #}
+custom_template2_list:
+  - custom_template2_item
+custom_template2_none_var: {# Nothing here on purpose. Means "null" #}

--- a/ansible_collections/arista/avd/tests/integration/targets/eos_designs_structured_config/tests/test_with_dest_changed.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/eos_designs_structured_config/tests/test_with_dest_changed.yml
@@ -1,0 +1,29 @@
+- name: Test with dest (changing) - Remove test file to force change in template action
+  ansible.builtin.file:
+    path: "{{ actual_output_dir }}/eos_designs_structured_config_test_with_dest.yml"
+    state: absent
+
+- name: Test with dest (changing)
+  ignore_errors: no
+  register: result
+  arista.avd.eos_designs_structured_config:
+    dest: "{{ actual_output_dir }}/eos_designs_structured_config_test_with_dest.yml"
+
+- name: Compare actual output with expected output
+  ansible.builtin.shell: diff "{{ expected_output_dir }}/eos_designs_structured_config_test_with_dest.yml" "{{ actual_output_dir }}/eos_designs_structured_config_test_with_dest.yml"
+  failed_when: diff_output.rc
+  register: diff_output
+  delegate_to: localhost
+
+- name: Set expected_ansible_facts variable
+  ansible.builtin.include_vars:
+    name: expected_ansible_facts
+    file: "{{ expected_output_dir }}/eos_designs_structured_config_ansible_facts.yml"
+
+- name: Validate result
+  ansible.builtin.assert:
+    that:
+      - result is success
+      - result.changed == true
+      - result.ansible_facts is defined
+      - result.ansible_facts == expected_ansible_facts

--- a/ansible_collections/arista/avd/tests/integration/targets/eos_designs_structured_config/tests/test_with_dest_json.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/eos_designs_structured_config/tests/test_with_dest_json.yml
@@ -1,0 +1,23 @@
+- name: Test with dest and changed
+  ignore_errors: no
+  register: result
+  arista.avd.eos_designs_structured_config:
+    dest: "{{ actual_output_dir }}/eos_designs_structured_config_test_with_dest.json"
+
+- name: Compare actual output with expected output
+  ansible.builtin.shell: diff "{{ expected_output_dir }}/eos_designs_structured_config_test_with_dest.json" "{{ actual_output_dir }}/eos_designs_structured_config_test_with_dest.json"
+  failed_when: diff_output.rc
+  register: diff_output
+  delegate_to: localhost
+
+- name: Set expected_ansible_facts variable
+  ansible.builtin.include_vars:
+    name: expected_ansible_facts
+    file: "{{ expected_output_dir }}/eos_designs_structured_config_ansible_facts.yml"
+
+- name: Validate result
+  ansible.builtin.assert:
+    that:
+      - result is success
+      - result.ansible_facts is defined
+      - result.ansible_facts == expected_ansible_facts

--- a/ansible_collections/arista/avd/tests/integration/targets/eos_designs_structured_config/tests/test_with_dest_no_change.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/eos_designs_structured_config/tests/test_with_dest_no_change.yml
@@ -1,0 +1,29 @@
+- name: Test with dest (no change) - first run to ensure no change
+  ignore_errors: no
+  arista.avd.eos_designs_structured_config:
+    dest: "{{ actual_output_dir }}/eos_designs_structured_config_test_with_dest.yml"
+
+- name: Test with dest (no change)
+  ignore_errors: no
+  register: result
+  arista.avd.eos_designs_structured_config:
+    dest: "{{ actual_output_dir }}/eos_designs_structured_config_test_with_dest.yml"
+
+- name: Compare actual output with expected output
+  ansible.builtin.shell: diff "{{ expected_output_dir }}/eos_designs_structured_config_test_with_dest.yml" "{{ actual_output_dir }}/eos_designs_structured_config_test_with_dest.yml"
+  failed_when: diff_output.rc
+  register: diff_output
+  delegate_to: localhost
+
+- name: Set expected_ansible_facts variable
+  ansible.builtin.include_vars:
+    name: expected_ansible_facts
+    file: "{{ expected_output_dir }}/eos_designs_structured_config_ansible_facts.yml"
+
+- name: Validate result
+  ansible.builtin.assert:
+    that:
+      - result is success
+      - result.changed == false
+      - result.ansible_facts is defined
+      - result.ansible_facts == expected_ansible_facts

--- a/ansible_collections/arista/avd/tests/integration/targets/eos_designs_structured_config/tests/test_with_eos_designs_custom_templates.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/eos_designs_structured_config/tests/test_with_eos_designs_custom_templates.yml
@@ -1,0 +1,28 @@
+- name: Test with eos_designs_custom_templates
+  ignore_errors: no
+  register: result
+  arista.avd.eos_designs_structured_config:
+    eos_designs_custom_templates:
+      # Base template to initialixe various lists to test the list merge features
+      - template: base.yml.j2
+
+      # use defaults with list_merge: append and strip_empty_keys: true
+      - template: custom_template1.yml.j2
+
+      # use list_merge: prepend and strip_empty_keys: false
+      - template: custom_template2.yml.j2
+        options:
+          list_merge: prepend
+          strip_empty_keys: false
+
+- name: Validate result
+  ansible.builtin.assert:
+    that:
+      - result is success
+      - result.ansible_facts is defined
+      - result.ansible_facts.custom_template1_var == 1
+      - result.ansible_facts.custom_template1_list == ["base_item", "custom_template1_item"]
+      - result.ansible_facts.custom_template1_none_var is not defined
+      - result.ansible_facts.custom_template2_list == ["custom_template2_item", "base_item"]
+      - result.ansible_facts.custom_template2_none_var is defined
+      - result.ansible_facts.custom_template2_none_var is none

--- a/ansible_collections/arista/avd/tests/integration/targets/eos_designs_structured_config/tests/test_with_invalid_inputs.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/eos_designs_structured_config/tests/test_with_invalid_inputs.yml
@@ -1,0 +1,15 @@
+- name: Test with invalid inputs
+  ignore_errors: yes
+  register: result
+  vars:
+    underlay_routing_protocol: ABC
+  arista.avd.eos_designs_structured_config:
+    validation_mode: error
+
+- vars:
+    error_msg: >-
+      1 errors found during schema validation of input vars. Run with -v to see details
+  assert:
+    that:
+      - result.failed == True
+      - result.msg == error_msg

--- a/ansible_collections/arista/avd/tests/integration/targets/eos_designs_structured_config/tests/test_with_list_merge_invalid.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/eos_designs_structured_config/tests/test_with_list_merge_invalid.yml
@@ -1,0 +1,19 @@
+- name: Test with list_merge invalid option
+  ignore_errors: yes
+  register: result
+  vars:
+    timezone: "test"
+    hours: 84
+  arista.avd.eos_designs_structured_config:
+    eos_designs_custom_templates:
+      - template: base.yml.j2
+        options:
+          list_merge: "append12"
+
+- vars:
+    error_msg: >-
+      merge: 'list_merge' argument can only be equal to one of ['replace', 'keep', 'append', 'prepend', 'append_rp', 'prepend_rp']
+  assert:
+    that:
+      - result.failed == True
+      - result.msg == error_msg

--- a/ansible_collections/arista/avd/tests/integration/targets/eos_designs_structured_config/tests/test_with_list_merge_invalid.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/eos_designs_structured_config/tests/test_with_list_merge_invalid.yml
@@ -1,9 +1,6 @@
 - name: Test with list_merge invalid option
   ignore_errors: yes
   register: result
-  vars:
-    timezone: "test"
-    hours: 84
   arista.avd.eos_designs_structured_config:
     eos_designs_custom_templates:
       - template: base.yml.j2

--- a/ansible_collections/arista/avd/tests/integration/targets/eos_designs_structured_config/tests/test_with_template_output_false.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/eos_designs_structured_config/tests/test_with_template_output_false.yml
@@ -1,0 +1,17 @@
+- name: Test with template_output false
+  ignore_errors: no
+  register: result
+  vars:
+    custom_structured_configuration_inline_jinja_value: "test"
+    custom_structured_configuration_inline_jinja: "{{ inline_jinja_value }}"
+
+  arista.avd.eos_designs_structured_config:
+    template_output: false
+
+- assert:
+    that:
+      - result is success
+      - result.ansible_facts is defined
+      - result.ansible_facts.inline_jinja_value == "test"
+      - result.ansible_facts.inline_jinja is defined
+      - result.ansible_facts.inline_jinja[2:] == ' inline_jinja_value }}'

--- a/ansible_collections/arista/avd/tests/integration/targets/eos_designs_structured_config/tests/test_with_template_output_false.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/eos_designs_structured_config/tests/test_with_template_output_false.yml
@@ -2,8 +2,8 @@
   ignore_errors: no
   register: result
   vars:
-    custom_structured_configuration_inline_jinja_value: "test"
-    custom_structured_configuration_inline_jinja: "{{ inline_jinja_value }}"
+    custom_structured_configuration_inline_jinja_value_1: "test"
+    custom_structured_configuration_inline_jinja: "{{ inline_jinja_value_1 }}"
 
   arista.avd.eos_designs_structured_config:
     template_output: false
@@ -12,6 +12,6 @@
     that:
       - result is success
       - result.ansible_facts is defined
-      - result.ansible_facts.inline_jinja_value == "test"
+      - result.ansible_facts.inline_jinja_value_1 == "test"
       - result.ansible_facts.inline_jinja is defined
-      - result.ansible_facts.inline_jinja[2:] == ' inline_jinja_value }}'
+      - result.ansible_facts.inline_jinja[2:] == ' inline_jinja_value_1 }}'

--- a/ansible_collections/arista/avd/tests/integration/targets/eos_designs_structured_config/tests/test_with_template_output_true.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/eos_designs_structured_config/tests/test_with_template_output_true.yml
@@ -1,4 +1,4 @@
-- name: Test with template_output false
+- name: Test with template_output true
   ignore_errors: no
   register: result
   vars:

--- a/ansible_collections/arista/avd/tests/integration/targets/eos_designs_structured_config/tests/test_with_template_output_true.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/eos_designs_structured_config/tests/test_with_template_output_true.yml
@@ -1,0 +1,17 @@
+- name: Test with template_output false
+  ignore_errors: no
+  register: result
+  vars:
+    custom_structured_configuration_inline_jinja_value: "test"
+    custom_structured_configuration_inline_jinja: "{{ inline_jinja_value }}"
+
+  arista.avd.eos_designs_structured_config:
+    template_output: true
+
+- assert:
+    that:
+      - result is success
+      - result.ansible_facts is defined
+      - result.ansible_facts.inline_jinja_value == "test"
+      - result.ansible_facts.inline_jinja is defined
+      - result.ansible_facts.inline_jinja == "test"

--- a/ansible_collections/arista/avd/tests/integration/targets/eos_designs_structured_config/tests/test_without_dest.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/eos_designs_structured_config/tests/test_without_dest.yml
@@ -1,0 +1,17 @@
+- name: Test without dest
+  ignore_errors: no
+  register: result
+  arista.avd.eos_designs_structured_config:
+
+- name: Set expected_ansible_facts variable
+  ansible.builtin.include_vars:
+    name: expected_ansible_facts
+    file: "{{ expected_output_dir }}/eos_designs_structured_config_ansible_facts.yml"
+
+- name: Validate result
+  ansible.builtin.assert:
+    that:
+      - result is success
+      - result.changed == true
+      - result.ansible_facts is defined
+      - result.ansible_facts == expected_ansible_facts

--- a/ansible_collections/arista/avd/tests/inventory/eos_designs_structured_config/expected_output/eos_designs_structured_config_ansible_facts.yml
+++ b/ansible_collections/arista/avd/tests/inventory/eos_designs_structured_config/expected_output/eos_designs_structured_config_ansible_facts.yml
@@ -1,0 +1,20 @@
+service_routing_protocols_model: multi-agent
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+vrfs:
+- name: MGMT
+  ip_routing: false
+management_api_http:
+  enable_vrfs:
+  - name: MGMT
+  enable_https: true
+ip_igmp_snooping:
+  globally_enabled: true
+# Including switch.* facts here as they are outputted in ansible_facts (not in dest file)
+switch:
+  id: 1
+  uplinks: []
+  vlans: ""

--- a/ansible_collections/arista/avd/tests/inventory/eos_designs_structured_config/expected_output/eos_designs_structured_config_test_with_dest.json
+++ b/ansible_collections/arista/avd/tests/inventory/eos_designs_structured_config/expected_output/eos_designs_structured_config_test_with_dest.json
@@ -1,0 +1,1 @@
+{"service_routing_protocols_model": "multi-agent", "vlan_internal_order": {"allocation": "ascending", "range": {"beginning": 1006, "ending": 1199}}, "vrfs": [{"name": "MGMT", "ip_routing": false}], "management_api_http": {"enable_vrfs": [{"name": "MGMT"}], "enable_https": true}, "ip_igmp_snooping": {"globally_enabled": true}}

--- a/ansible_collections/arista/avd/tests/inventory/eos_designs_structured_config/expected_output/eos_designs_structured_config_test_with_dest.yml
+++ b/ansible_collections/arista/avd/tests/inventory/eos_designs_structured_config/expected_output/eos_designs_structured_config_test_with_dest.yml
@@ -1,0 +1,15 @@
+service_routing_protocols_model: multi-agent
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+vrfs:
+- name: MGMT
+  ip_routing: false
+management_api_http:
+  enable_vrfs:
+  - name: MGMT
+  enable_https: true
+ip_igmp_snooping:
+  globally_enabled: true


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Add integration test for eos_designs_structured_config

## Related Issue(s)

Fixes #2867 

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

- Add `ansible-test integration` target for `eos_designs_structured_config`

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

run `ansible-test integration --docker eos_designs_structured_config`

Also covered in CI pipeline.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
