### PR TITLE
Feat(eos_designs): Support multiple descriptions in connected_endpoint adapters

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/connected-endpoints-mismatched-descriptions.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/connected-endpoints-mismatched-descriptions.yml
@@ -1,0 +1,20 @@
+loopback_ipv4_pool: 192.168.0.0/24
+
+type: l2leaf
+l2leaf:
+  defaults:
+  nodes:
+    - name: connected-endpoints-mismatched-descriptions
+
+servers:
+  # port-channel provide physical and individual port-channel descriptions
+  - name: OLD_SW-1/7
+    adapters:
+      - switches: [connected-endpoints-mismatched-descriptions, connected-endpoints-mismatched-descriptions]
+        switch_ports: [Ethernet9, Ethernet10]
+        descriptions: ["PHYSICAL_PORT_DESCRIPTION_1", "PHYSICAL_PORT_DESCRIPTION_2", "NEGATIVE_TEST_DESCR"]
+        port_channel:
+          mode: "active"
+          description: "PORT_CHANNEL_DESCRIPTION"
+
+expected_error_message: "Length of lists 'switches', 'switch_ports', and 'descriptions' (if used) must match for adapter."

--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/connected-endpoints-mismatched-descriptions.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/connected-endpoints-mismatched-descriptions.yml
@@ -17,4 +17,4 @@ servers:
           mode: "active"
           description: "PORT_CHANNEL_DESCRIPTION"
 
-expected_error_message: "Length of lists 'switches', 'switch_ports', and 'descriptions' (if used) must match for adapter."
+expected_error_message: "Length of lists 'switches', 'switch_ports', and 'descriptions' (if used) must match for adapter. Check configuration for OLD_SW-1/7, adapter switch_ports ['Ethernet9', 'Ethernet10']."

--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/hosts.yml
@@ -29,6 +29,7 @@ all:
     EOS_DESIGNS_FAILURES: # Add cases that fail during 'eos_designs_structured_config' phase
       hosts:
         failure-port-channel:
+        connected-endpoints-mismatched-descriptions:
         duplicate-vlans-l2vlans:
         duplicate-vlans-svi-id:
         duplicate-vrfs-duplicate-svi-name-conflict:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/connected_endpoints.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/connected_endpoints.cfg
@@ -23,6 +23,11 @@ interface Port-Channel7
    no shutdown
    switchport
 !
+interface Port-Channel10
+   description OLD_SW-1/7_PORT_CHANNEL_DESCRIPTION
+   no shutdown
+   switchport
+!
 interface Ethernet4
    description PHYSICAL_PORT_DESCRIPTION
    no shutdown
@@ -52,6 +57,16 @@ interface Ethernet9
    description test of var set under play vars
    no shutdown
    switchport
+!
+interface Ethernet10
+   description PHYSICAL_PORT_DESCRIPTION_1
+   no shutdown
+   channel-group 10 mode active
+!
+interface Ethernet11
+   description PHYSICAL_PORT_DESCRIPTION_2
+   no shutdown
+   channel-group 10 mode active
 no ip routing vrf MGMT
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/connected_endpoints.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/connected_endpoints.yml
@@ -63,6 +63,24 @@ ethernet_interfaces:
   description: test of var set under play vars
   shutdown: false
   type: switched
+- name: Ethernet10
+  peer: OLD_SW-1/7
+  peer_type: server
+  description: PHYSICAL_PORT_DESCRIPTION_1
+  shutdown: false
+  type: port-channel-member
+  channel_group:
+    id: 10
+    mode: active
+- name: Ethernet11
+  peer: OLD_SW-1/7
+  peer_type: server
+  description: PHYSICAL_PORT_DESCRIPTION_2
+  shutdown: false
+  type: port-channel-member
+  channel_group:
+    id: 10
+    mode: active
 port_channel_interfaces:
 - name: Port-Channel5
   description: OLD_SW-1/5_PORT_CHANNEL_DESCRIPTION
@@ -70,5 +88,9 @@ port_channel_interfaces:
   shutdown: false
 - name: Port-Channel7
   description: PHYSICAL_PORT_DESCRIPTION_PORT_CHANNEL_DESCRIPTION
+  type: switched
+  shutdown: false
+- name: Port-Channel10
+  description: OLD_SW-1/7_PORT_CHANNEL_DESCRIPTION
   type: switched
   shutdown: false

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/connected_endpoints.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/connected_endpoints.yml
@@ -37,3 +37,12 @@ servers:
       - switches: [connected_endpoints]
         switch_ports: [Ethernet9]
         description: "{{ string_set_as_play_var }}"
+  # port-channel provide physical and individual port-channel descriptions
+  - name: OLD_SW-1/7
+    adapters:
+      - switches: [connected_endpoints, connected_endpoints]
+        switch_ports: [Ethernet10, Ethernet11]
+        descriptions: ["PHYSICAL_PORT_DESCRIPTION_1", "PHYSICAL_PORT_DESCRIPTION_2"]
+        port_channel:
+          mode: "active"
+          description: "PORT_CHANNEL_DESCRIPTION"

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/connected-endpoints.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/connected-endpoints.md
@@ -15,8 +15,9 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "&lt;connected_endpoints_keys.key&gt;.[].adapters.[].switch_ports.[].&lt;str&gt;") | String |  |  |  | Switchport interface. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;switches</samp>](## "&lt;connected_endpoints_keys.key&gt;.[].adapters.[].switches") | List, items: String | Required |  |  | List of switches.<br>The lists `endpoint_ports`, `switch_ports`, and `switches` must have the same length.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "&lt;connected_endpoints_keys.key&gt;.[].adapters.[].switches.[].&lt;str&gt;") | String |  |  |  | Device |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;endpoint_ports</samp>](## "&lt;connected_endpoints_keys.key&gt;.[].adapters.[].endpoint_ports") | List, items: String |  |  |  | Endpoint ports is used for description, required unless description is set.<br>The lists `endpoint_ports`, `switch_ports`, and `switches` must have the same length.<br>Each list item is one switchport.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;endpoint_ports</samp>](## "&lt;connected_endpoints_keys.key&gt;.[].adapters.[].endpoint_ports") | List, items: String |  |  |  | Endpoint ports is used for description, required unless `description` or `descriptions` is set.<br>The lists `endpoint_ports`, `switch_ports`, `descriptions` and `switches` must have the same length.<br>Each list item is one switchport.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "&lt;connected_endpoints_keys.key&gt;.[].adapters.[].endpoint_ports.[].&lt;str&gt;") | String |  |  |  | Interface name. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;descriptions</samp>](## "&lt;connected_endpoints_keys.key&gt;.[].adapters.[].descriptions") | List |  |  |  | Unique description per port. When set, takes priority over description.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;server_ports</samp>](## "&lt;connected_endpoints_keys.key&gt;.[].adapters.[].server_ports") <span style="color:red">removed</span> | List, items: String |  |  |  | <span style="color:red">This key was removed. Support was removed in AVD version 4.0.0. Use <samp>endpoint_ports</samp> instead.</span> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "&lt;connected_endpoints_keys.key&gt;.[].adapters.[].server_ports.[].&lt;str&gt;") | String |  |  |  | Used for documentation purposes. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;speed</samp>](## "&lt;connected_endpoints_keys.key&gt;.[].adapters.[].speed") | String |  |  |  | Set adapter speed: `< interface_speed >`, `forced < interface_speed >`, `auto < interface_speed >`.<br>If not specified will be auto.<br> |
@@ -162,6 +163,7 @@
               - <str>
             endpoint_ports:
               - <str>
+            descriptions: <list>
             speed: <str>
             description: <str>
             profile: <str>

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/connected_endpoints/ethernet_interfaces.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/connected_endpoints/ethernet_interfaces.py
@@ -94,7 +94,10 @@ class EthernetInterfacesMixin(UtilsMixin):
         # check lengths of lists
         nodes_length = len(adapter["switches"])
         if len(adapter["switch_ports"]) != nodes_length or ("descriptions" in adapter and len(adapter["descriptions"]) != nodes_length):
-            raise AristaAvdError("Length of lists 'switches', 'switch_ports', and 'descriptions' (if used) must match for adapter.")
+            raise AristaAvdError(
+                f"Length of lists 'switches', 'switch_ports', and 'descriptions' (if used) must match for adapter. Check configuration for {peer}, adapter"
+                f" switch_ports {adapter['switch_ports']}."
+            )
 
         # if 'descriptions' is set, it is preferred
         if (interface_descriptions := adapter.get("descriptions")) is not None:

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/connected_endpoints/ethernet_interfaces.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/connected_endpoints/ethernet_interfaces.py
@@ -8,6 +8,7 @@ from collections import ChainMap
 from functools import cached_property
 
 from ansible_collections.arista.avd.plugins.filter.range_expand import range_expand
+from ansible_collections.arista.avd.plugins.plugin_utils.errors import AristaAvdError
 from ansible_collections.arista.avd.plugins.plugin_utils.strip_empties import strip_null_from_data
 from ansible_collections.arista.avd.plugins.plugin_utils.utils import append_if_not_duplicate, default, get, replace_or_append_item
 
@@ -97,7 +98,7 @@ class EthernetInterfacesMixin(UtilsMixin):
             "peer_interface": peer_interface,
             "peer_type": connected_endpoint["type"],
             "port_profile": adapter.get("profile"),
-            "description": self.shared_utils.interface_descriptions.connected_endpoints_ethernet_interfaces(peer, peer_interface, adapter.get("description")),
+            "description": self.shared_utils.interface_descriptions.connected_endpoints_ethernet_interfaces(peer, peer_interface, interface_description),
             "speed": adapter.get("speed"),
             "shutdown": not adapter.get("enabled", True),
             "eos_cli": adapter.get("raw_eos_cli"),

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/connected_endpoints/ethernet_interfaces.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/connected_endpoints/ethernet_interfaces.py
@@ -91,6 +91,17 @@ class EthernetInterfacesMixin(UtilsMixin):
         channel_group_id = get(adapter, "port_channel.channel_id", default=default_channel_group_id)
         short_esi = self._get_short_esi(adapter, channel_group_id)
 
+        # check lengths of lists
+        nodes_length = len(adapter["switches"])
+        if len(adapter["switch_ports"]) != nodes_length or ("descriptions" in adapter and len(adapter["descriptions"]) != nodes_length):
+            raise AristaAvdError("Length of lists 'switches', 'switch_ports', and 'descriptions' (if used) must match for adapter.")
+
+        # if 'descriptions' is set, it is preferred
+        if (interface_descriptions := adapter.get("descriptions")) is not None:
+            interface_description = interface_descriptions[node_index]
+        else:
+            interface_description = adapter.get("description")
+
         # Common ethernet_interface settings
         ethernet_interface = {
             "name": adapter["switch_ports"][node_index],

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
@@ -3427,10 +3427,10 @@ $defs:
               endpoint_ports:
                 type: list
                 description: 'Endpoint ports is used for description, required unless
-                  description is set.
+                  `description` or `descriptions` is set.
 
-                  The lists `endpoint_ports`, `switch_ports`, and `switches` must
-                  have the same length.
+                  The lists `endpoint_ports`, `switch_ports`, `descriptions` and `switches`
+                  must have the same length.
 
                   Each list item is one switchport.
 
@@ -3438,6 +3438,12 @@ $defs:
                 items:
                   type: str
                   description: Interface name.
+              descriptions:
+                type: list
+                description: 'Unique description per port. When set, takes priority
+                  over description.
+
+                  '
               server_ports:
                 type: list
                 deprecation:

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/defs_connected_endpoints.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/defs_connected_endpoints.schema.yml
@@ -52,12 +52,16 @@ $defs:
               endpoint_ports:
                 type: list
                 description: |
-                  Endpoint ports is used for description, required unless description is set.
-                  The lists `endpoint_ports`, `switch_ports`, and `switches` must have the same length.
+                  Endpoint ports is used for description, required unless `description` or `descriptions` is set.
+                  The lists `endpoint_ports`, `switch_ports`, `descriptions` and `switches` must have the same length.
                   Each list item is one switchport.
                 items:
                   type: str
                   description: Interface name.
+              descriptions:
+                type: list
+                description: |
+                  Unique description per port. When set, takes priority over description.
               server_ports:
                 type: list
                 deprecation:


### PR DESCRIPTION
## Change Summary

support individual descriptions following the existing model for L3_interfaces

## Related Issue(s)

Fixes #2952

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

Add a new key for descriptions.

```
  - name: OLD_SW-1/7
    adapters:
      - switches: [connected_endpoints, connected_endpoints]
        switch_ports: [Ethernet9, Ethernet10]
        descriptions: ["PHYSICAL_PORT_DESCRIPTION_1", "PHYSICAL_PORT_DESCRIPTION_2"]
        port_channel:
          mode: "active"
          description: "PORT_CHANNEL_DESCRIPTION"
```

## How to test

molecule

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been rebased from devel before I start
- [X] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [X] My change requires a change to the documentation and documentation have been updated accordingly.
- [X] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
