### PR TITLE
Fix(eos_designs,eos_cli_config_gen): Update schema keys for VRFs to accept numeric VRF names

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF1A.cfg
@@ -62,6 +62,8 @@ vlan 451
 vlan 452
    name Tenant_D_v6_WAN_Zone_3
 !
+vrf instance 12345678
+!
 vrf instance MGMT
 !
 vrf instance Tenant_A_APP_Zone
@@ -70,8 +72,6 @@ vrf instance Tenant_A_OP_Zone
    description Tenant_A_OP_Zone
 !
 vrf instance Tenant_A_WEB_Zone
-!
-vrf instance Tenant_D_WAN_Zone
 !
 interface Ethernet6
    description server02_SINGLE_NODE_TRUNK_Eth1
@@ -193,7 +193,7 @@ interface Vlan132
 interface Vlan450
    description Tenant_D_v6_WAN_Zone_1
    no shutdown
-   vrf Tenant_D_WAN_Zone
+   vrf 12345678
    ipv6 enable
    ipv6 address virtual 2001:db8:355::1/64
 !
@@ -201,7 +201,7 @@ interface Vlan451
    description Tenant_D_v6_WAN_Zone_2
    no shutdown
    mtu 1560
-   vrf Tenant_D_WAN_Zone
+   vrf 12345678
    ipv6 enable
    ipv6 address virtual 2001:db8:451::1/64
 !
@@ -209,7 +209,7 @@ interface Vlan452
    description Tenant_D_v6_WAN_Zone_3
    no shutdown
    mtu 1560
-   vrf Tenant_D_WAN_Zone
+   vrf 12345678
    ipv6 address virtual 2001:db8:412::1/64
    ip address virtual 10.4.12.254/24
 !
@@ -226,22 +226,23 @@ interface Vxlan1
    vxlan vlan 450 vni 40450
    vxlan vlan 451 vni 40451
    vxlan vlan 452 vni 40452
+   vxlan vrf 12345678 vni 41
    vxlan vrf Tenant_A_APP_Zone vni 12
    vxlan vrf Tenant_A_OP_Zone vni 10
    vxlan vrf Tenant_A_WEB_Zone vni 11
-   vxlan vrf Tenant_D_WAN_Zone vni 41
 !
 ip virtual-router mac-address 00:dc:00:00:00:0a
 !
 ip address virtual source-nat vrf Tenant_A_OP_Zone address 10.255.1.9
 !
 ip routing
+ip routing vrf 12345678
 no ip routing vrf MGMT
 ip routing vrf Tenant_A_APP_Zone
 ip routing vrf Tenant_A_OP_Zone
 ip routing vrf Tenant_A_WEB_Zone
-ip routing vrf Tenant_D_WAN_Zone
-ipv6 unicast-routing vrf Tenant_D_WAN_Zone
+!
+ipv6 unicast-routing vrf 12345678
 !
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.168.255.0/24 eq 32
@@ -301,6 +302,12 @@ router bgp 65101
    neighbor 192.168.255.4 description DC1-SPINE4
    redistribute connected route-map RM-CONN-2-BGP
    !
+   vlan-aware-bundle 12345678
+      rd 1.1.1.1:41
+      route-target both 1234:41
+      redistribute learned
+      vlan 450-452
+   !
    vlan-aware-bundle Tenant_A_APP_Zone
       rd 1.1.1.1:12
       route-target both 1234:12
@@ -319,12 +326,6 @@ router bgp 65101
       redistribute learned
       vlan 120-121
    !
-   vlan-aware-bundle Tenant_D_WAN_Zone
-      rd 1.1.1.1:41
-      route-target both 1234:41
-      redistribute learned
-      vlan 450-452
-   !
    address-family evpn
       host-flap detection window 180 threshold 5 expiry timeout 10 seconds
       neighbor EVPN-OVERLAY-PEERS activate
@@ -332,6 +333,13 @@ router bgp 65101
    address-family ipv4
       no neighbor EVPN-OVERLAY-PEERS activate
       neighbor UNDERLAY-PEERS activate
+   !
+   vrf 12345678
+      rd 1.1.1.1:41
+      route-target import evpn 1234:41
+      route-target export evpn 1234:41
+      router-id 192.168.255.9
+      redistribute connected
    !
    vrf Tenant_A_APP_Zone
       rd 1.1.1.1:12
@@ -352,13 +360,6 @@ router bgp 65101
       rd 1.1.1.1:11
       route-target import evpn 1234:11
       route-target export evpn 1234:11
-      router-id 192.168.255.9
-      redistribute connected
-   !
-   vrf Tenant_D_WAN_Zone
-      rd 1.1.1.1:41
-      route-target import evpn 1234:41
-      route-target export evpn 1234:41
       router-id 192.168.255.9
       redistribute connected
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2A.cfg
@@ -108,6 +108,8 @@ vlan 451
 vlan 452
    name Tenant_D_v6_WAN_Zone_3
 !
+vrf instance 12345678
+!
 vrf instance MGMT
 !
 vrf instance Tenant_A_APP_Zone
@@ -126,8 +128,6 @@ vrf instance Tenant_B_OP_Zone
 vrf instance Tenant_C_OP_Zone
 !
 vrf instance Tenant_D_OP_Zone
-!
-vrf instance Tenant_D_WAN_Zone
 !
 interface Port-Channel7
    description DC1_L2LEAF1_Po1
@@ -520,7 +520,7 @@ interface Vlan413
 interface Vlan450
    description Tenant_D_v6_WAN_Zone_1
    no shutdown
-   vrf Tenant_D_WAN_Zone
+   vrf 12345678
    ipv6 enable
    ipv6 address virtual 2001:db8:355::1/64
 !
@@ -528,7 +528,7 @@ interface Vlan451
    description Tenant_D_v6_WAN_Zone_2
    no shutdown
    mtu 1560
-   vrf Tenant_D_WAN_Zone
+   vrf 12345678
    ipv6 enable
    ipv6 address virtual 2001:db8:451::1/64
 !
@@ -536,7 +536,7 @@ interface Vlan452
    description Tenant_D_v6_WAN_Zone_3
    no shutdown
    mtu 1560
-   vrf Tenant_D_WAN_Zone
+   vrf 12345678
    ipv6 address virtual 2001:db8:412::1/64
    ip address virtual 10.4.12.254/24
 !
@@ -566,6 +566,7 @@ interface Vxlan1
    vxlan vlan 450 vni 40450
    vxlan vlan 451 vni 40451
    vxlan vlan 452 vni 40452
+   vxlan vrf 12345678 vni 41
    vxlan vrf Tenant_A_APP_Zone vni 12
    vxlan vrf Tenant_A_DB_Zone vni 13
    vxlan vrf Tenant_A_OP_Zone vni 10
@@ -574,7 +575,6 @@ interface Vxlan1
    vxlan vrf Tenant_B_OP_Zone vni 20
    vxlan vrf Tenant_C_OP_Zone vni 30
    vxlan vrf Tenant_D_OP_Zone vni 40
-   vxlan vrf Tenant_D_WAN_Zone vni 41
 !
 hardware tcam
    system profile vxlan-routing
@@ -584,6 +584,7 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 ip address virtual source-nat vrf Tenant_A_OP_Zone address 10.255.1.10
 !
 ip routing
+ip routing vrf 12345678
 no ip routing vrf MGMT
 ip routing vrf Tenant_A_APP_Zone
 ip routing vrf Tenant_A_DB_Zone
@@ -593,9 +594,9 @@ ip routing vrf Tenant_A_WEB_Zone
 ip routing vrf Tenant_B_OP_Zone
 ip routing vrf Tenant_C_OP_Zone
 ip routing vrf Tenant_D_OP_Zone
-ip routing vrf Tenant_D_WAN_Zone
+!
+ipv6 unicast-routing vrf 12345678
 ipv6 unicast-routing vrf Tenant_D_OP_Zone
-ipv6 unicast-routing vrf Tenant_D_WAN_Zone
 !
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.168.255.0/24 eq 32
@@ -671,6 +672,12 @@ router bgp 65102
    neighbor 192.168.255.4 description DC1-SPINE4
    redistribute connected route-map RM-CONN-2-BGP
    !
+   vlan-aware-bundle 12345678
+      rd 65001:41
+      route-target both 100000:41
+      redistribute learned
+      vlan 450-452
+   !
    vlan-aware-bundle Tenant_A_APP_Zone
       rd 65001:12
       route-target both 100000:12
@@ -725,12 +732,6 @@ router bgp 65102
       redistribute learned
       vlan 410-413
    !
-   vlan-aware-bundle Tenant_D_WAN_Zone
-      rd 65001:41
-      route-target both 100000:41
-      redistribute learned
-      vlan 450-452
-   !
    address-family evpn
       host-flap detection window 180 threshold 5 expiry timeout 10 seconds
       neighbor EVPN-OVERLAY-PEERS activate
@@ -738,6 +739,13 @@ router bgp 65102
    address-family ipv4
       no neighbor EVPN-OVERLAY-PEERS activate
       neighbor UNDERLAY-PEERS activate
+   !
+   vrf 12345678
+      rd 65001:41
+      route-target import evpn 100000:41
+      route-target export evpn 100000:41
+      router-id 192.168.255.10
+      redistribute connected
    !
    vrf Tenant_A_APP_Zone
       rd 65001:12
@@ -796,13 +804,6 @@ router bgp 65102
       router-id 192.168.255.10
       redistribute connected
       redistribute static
-   !
-   vrf Tenant_D_WAN_Zone
-      rd 65001:41
-      route-target import evpn 100000:41
-      route-target export evpn 100000:41
-      router-id 192.168.255.10
-      redistribute connected
 !
 router ospf 16 vrf Tenant_A_OSPF
    router-id 192.168.255.10

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2B.cfg
@@ -108,6 +108,8 @@ vlan 451
 vlan 452
    name Tenant_D_v6_WAN_Zone_3
 !
+vrf instance 12345678
+!
 vrf instance MGMT
 !
 vrf instance Tenant_A_APP_Zone
@@ -126,8 +128,6 @@ vrf instance Tenant_B_OP_Zone
 vrf instance Tenant_C_OP_Zone
 !
 vrf instance Tenant_D_OP_Zone
-!
-vrf instance Tenant_D_WAN_Zone
 !
 interface Port-Channel7
    description DC1_L2LEAF1_Po1
@@ -484,7 +484,7 @@ interface Vlan413
 interface Vlan450
    description Tenant_D_v6_WAN_Zone_1
    no shutdown
-   vrf Tenant_D_WAN_Zone
+   vrf 12345678
    ipv6 enable
    ipv6 address virtual 2001:db8:355::1/64
 !
@@ -492,7 +492,7 @@ interface Vlan451
    description Tenant_D_v6_WAN_Zone_2
    no shutdown
    mtu 1560
-   vrf Tenant_D_WAN_Zone
+   vrf 12345678
    ipv6 enable
    ipv6 address virtual 2001:db8:451::1/64
 !
@@ -500,7 +500,7 @@ interface Vlan452
    description Tenant_D_v6_WAN_Zone_3
    no shutdown
    mtu 1560
-   vrf Tenant_D_WAN_Zone
+   vrf 12345678
    ipv6 address virtual 2001:db8:412::1/64
    ip address virtual 10.4.12.254/24
 !
@@ -530,6 +530,7 @@ interface Vxlan1
    vxlan vlan 450 vni 40450
    vxlan vlan 451 vni 40451
    vxlan vlan 452 vni 40452
+   vxlan vrf 12345678 vni 41
    vxlan vrf Tenant_A_APP_Zone vni 12
    vxlan vrf Tenant_A_DB_Zone vni 13
    vxlan vrf Tenant_A_OP_Zone vni 10
@@ -538,7 +539,6 @@ interface Vxlan1
    vxlan vrf Tenant_B_OP_Zone vni 20
    vxlan vrf Tenant_C_OP_Zone vni 30
    vxlan vrf Tenant_D_OP_Zone vni 40
-   vxlan vrf Tenant_D_WAN_Zone vni 41
 !
 hardware tcam
    system profile vxlan-routing
@@ -548,6 +548,7 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 ip address virtual source-nat vrf Tenant_A_OP_Zone address 10.255.1.11
 !
 ip routing
+ip routing vrf 12345678
 no ip routing vrf MGMT
 ip routing vrf Tenant_A_APP_Zone
 ip routing vrf Tenant_A_DB_Zone
@@ -557,9 +558,9 @@ ip routing vrf Tenant_A_WEB_Zone
 ip routing vrf Tenant_B_OP_Zone
 ip routing vrf Tenant_C_OP_Zone
 ip routing vrf Tenant_D_OP_Zone
-ip routing vrf Tenant_D_WAN_Zone
+!
+ipv6 unicast-routing vrf 12345678
 ipv6 unicast-routing vrf Tenant_D_OP_Zone
-ipv6 unicast-routing vrf Tenant_D_WAN_Zone
 !
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.168.255.0/24 eq 32
@@ -634,6 +635,12 @@ router bgp 65102
    neighbor 192.168.255.4 description DC1-SPINE4
    redistribute connected route-map RM-CONN-2-BGP
    !
+   vlan-aware-bundle 12345678
+      rd 65001:41
+      route-target both 100000:41
+      redistribute learned
+      vlan 450-452
+   !
    vlan-aware-bundle Tenant_A_APP_Zone
       rd 65001:12
       route-target both 100000:12
@@ -688,12 +695,6 @@ router bgp 65102
       redistribute learned
       vlan 410-413
    !
-   vlan-aware-bundle Tenant_D_WAN_Zone
-      rd 65001:41
-      route-target both 100000:41
-      redistribute learned
-      vlan 450-452
-   !
    address-family evpn
       host-flap detection window 180 threshold 5 expiry timeout 10 seconds
       neighbor EVPN-OVERLAY-PEERS activate
@@ -701,6 +702,13 @@ router bgp 65102
    address-family ipv4
       no neighbor EVPN-OVERLAY-PEERS activate
       neighbor UNDERLAY-PEERS activate
+   !
+   vrf 12345678
+      rd 65001:41
+      route-target import evpn 100000:41
+      route-target export evpn 100000:41
+      router-id 192.168.255.11
+      redistribute connected
    !
    vrf Tenant_A_APP_Zone
       rd 65001:12
@@ -759,13 +767,6 @@ router bgp 65102
       router-id 192.168.255.11
       redistribute connected
       redistribute static
-   !
-   vrf Tenant_D_WAN_Zone
-      rd 65001:41
-      route-target import evpn 100000:41
-      route-target export evpn 100000:41
-      router-id 192.168.255.11
-      redistribute connected
 !
 router ospf 16 vrf Tenant_A_OSPF
    router-id 192.168.255.11

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_false.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_false.cfg
@@ -127,6 +127,8 @@ vlan 451
 vlan 452
    name Tenant_D_v6_WAN_Zone_3
 !
+vrf instance 12345678
+!
 vrf instance MGMT
 !
 vrf instance Tenant_A_APP_Zone
@@ -149,8 +151,6 @@ vrf instance Tenant_C_OP_Zone
 vrf instance Tenant_C_WAN_Zone
 !
 vrf instance Tenant_D_OP_Zone
-!
-vrf instance Tenant_D_WAN_Zone
 !
 interface Loopback0
    description EVPN_Overlay_Peering
@@ -336,7 +336,7 @@ interface Vlan413
 interface Vlan450
    description Tenant_D_v6_WAN_Zone_1
    no shutdown
-   vrf Tenant_D_WAN_Zone
+   vrf 12345678
    ipv6 enable
    ipv6 address virtual 2001:db8:355::1/64
 !
@@ -344,7 +344,7 @@ interface Vlan451
    description Tenant_D_v6_WAN_Zone_2
    no shutdown
    mtu 1560
-   vrf Tenant_D_WAN_Zone
+   vrf 12345678
    ipv6 enable
    ipv6 address virtual 2001:db8:451::1/64
 !
@@ -352,7 +352,7 @@ interface Vlan452
    description Tenant_D_v6_WAN_Zone_3
    no shutdown
    mtu 1560
-   vrf Tenant_D_WAN_Zone
+   vrf 12345678
    ipv6 address virtual 2001:db8:412::1/64
    ip address virtual 10.4.12.254/24
 !
@@ -392,6 +392,7 @@ interface Vxlan1
    vxlan vlan 450 vni 40450
    vxlan vlan 451 vni 40451
    vxlan vlan 452 vni 40452
+   vxlan vrf 12345678 vni 41
    vxlan vrf Tenant_A_APP_Zone vni 12
    vxlan vrf Tenant_A_DB_Zone vni 13
    vxlan vrf Tenant_A_OP_Zone vni 10
@@ -402,13 +403,13 @@ interface Vxlan1
    vxlan vrf Tenant_C_OP_Zone vni 30
    vxlan vrf Tenant_C_WAN_Zone vni 31
    vxlan vrf Tenant_D_OP_Zone vni 40
-   vxlan vrf Tenant_D_WAN_Zone vni 41
 !
 ip virtual-router mac-address 00:dc:00:00:00:0a
 !
 ip address virtual source-nat vrf Tenant_A_OP_Zone address 10.255.1.109
 !
 ip routing
+ip routing vrf 12345678
 no ip routing vrf MGMT
 ip routing vrf Tenant_A_APP_Zone
 ip routing vrf Tenant_A_DB_Zone
@@ -420,9 +421,9 @@ ip routing vrf Tenant_B_WAN_Zone
 ip routing vrf Tenant_C_OP_Zone
 ip routing vrf Tenant_C_WAN_Zone
 ip routing vrf Tenant_D_OP_Zone
-ip routing vrf Tenant_D_WAN_Zone
+!
+ipv6 unicast-routing vrf 12345678
 ipv6 unicast-routing vrf Tenant_D_OP_Zone
-ipv6 unicast-routing vrf Tenant_D_WAN_Zone
 !
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.168.255.0/24 eq 32
@@ -454,6 +455,12 @@ router bgp 101
    neighbor UNDERLAY-PEERS send-community
    neighbor UNDERLAY-PEERS maximum-routes 12000
    redistribute connected route-map RM-CONN-2-BGP
+   !
+   vlan-aware-bundle 12345678
+      rd 192.168.255.109:41
+      route-target both 41:41
+      redistribute learned
+      vlan 450-452
    !
    vlan-aware-bundle l2vlan_with_no_tags
       rd 192.168.255.109:20162
@@ -539,12 +546,6 @@ router bgp 101
       redistribute learned
       vlan 410-413
    !
-   vlan-aware-bundle Tenant_D_WAN_Zone
-      rd 192.168.255.109:41
-      route-target both 41:41
-      redistribute learned
-      vlan 450-452
-   !
    address-family evpn
       host-flap detection window 180 threshold 5 expiry timeout 10 seconds
       neighbor EVPN-OVERLAY-PEERS activate
@@ -552,6 +553,13 @@ router bgp 101
    address-family ipv4
       no neighbor EVPN-OVERLAY-PEERS activate
       neighbor UNDERLAY-PEERS activate
+   !
+   vrf 12345678
+      rd 192.168.255.109:41
+      route-target import evpn 41:41
+      route-target export evpn 41:41
+      router-id 192.168.255.109
+      redistribute connected
    !
    vrf Tenant_A_APP_Zone
       rd 192.168.255.109:12
@@ -622,13 +630,6 @@ router bgp 101
       rd 192.168.255.109:40
       route-target import evpn 40:40
       route-target export evpn 40:40
-      router-id 192.168.255.109
-      redistribute connected
-   !
-   vrf Tenant_D_WAN_Zone
-      rd 192.168.255.109:41
-      route-target import evpn 41:41
-      route-target export evpn 41:41
       router-id 192.168.255.109
       redistribute connected
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_true.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_true.cfg
@@ -209,6 +209,12 @@ router bgp 101
    neighbor UNDERLAY-PEERS maximum-routes 12000
    redistribute connected route-map RM-CONN-2-BGP
    !
+   vlan-aware-bundle 12345678
+      rd 192.168.255.109:41
+      route-target both 41:41
+      redistribute learned
+      vlan 450-452
+   !
    vlan-aware-bundle l2vlan_with_no_tags
       rd 192.168.255.109:20162
       route-target both 20162:20162
@@ -292,12 +298,6 @@ router bgp 101
       route-target both 40:40
       redistribute learned
       vlan 410-413
-   !
-   vlan-aware-bundle Tenant_D_WAN_Zone
-      rd 192.168.255.109:41
-      route-target both 41:41
-      redistribute learned
-      vlan 450-452
    !
    address-family evpn
       host-flap detection window 180 threshold 5 expiry timeout 10 seconds

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF1A.yml
@@ -121,7 +121,7 @@ router_bgp:
         - '1234:11'
     redistribute_routes:
     - source_protocol: connected
-  - name: Tenant_D_WAN_Zone
+  - name: '12345678'
     router_id: 192.168.255.9
     rd: 1.1.1.1:41
     route_targets:
@@ -160,7 +160,7 @@ router_bgp:
     redistribute_routes:
     - learned
     vlan: 120-121
-  - name: Tenant_D_WAN_Zone
+  - name: '12345678'
     rd: 1.1.1.1:41
     route_targets:
       both:
@@ -236,7 +236,7 @@ vrfs:
 - name: Tenant_A_WEB_Zone
   tenant: Tenant_A
   ip_routing: true
-- name: Tenant_D_WAN_Zone
+- name: '12345678'
   tenant: Tenant_D
   ip_routing: true
   ipv6_routing: true
@@ -466,7 +466,7 @@ vlan_interfaces:
   ipv6_enable: true
   ipv6_address_virtuals:
   - 2001:db8:355::1/64
-  vrf: Tenant_D_WAN_Zone
+  vrf: '12345678'
 - name: Vlan451
   tenant: Tenant_D
   tags:
@@ -477,7 +477,7 @@ vlan_interfaces:
   mtu: 1560
   ipv6_address_virtuals:
   - 2001:db8:451::1/64
-  vrf: Tenant_D_WAN_Zone
+  vrf: '12345678'
 - name: Vlan452
   tenant: Tenant_D
   tags:
@@ -489,7 +489,7 @@ vlan_interfaces:
   ip_address_virtual: 10.4.12.254/24
   ipv6_address_virtuals:
   - 2001:db8:412::1/64
-  vrf: Tenant_D_WAN_Zone
+  vrf: '12345678'
 router_ospf:
   process_ids:
   - id: 9
@@ -532,7 +532,7 @@ vxlan_interface:
         vni: 10
       - name: Tenant_A_WEB_Zone
         vni: 11
-      - name: Tenant_D_WAN_Zone
+      - name: '12345678'
         vni: 41
 virtual_source_nat_vrfs:
 - name: Tenant_A_OP_Zone

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
@@ -193,6 +193,20 @@ router_bgp:
         - '100000:30'
     redistribute_routes:
     - source_protocol: connected
+  - name: '12345678'
+    router_id: 192.168.255.10
+    rd: '65001:41'
+    route_targets:
+      import:
+      - address_family: evpn
+        route_targets:
+        - '100000:41'
+      export:
+      - address_family: evpn
+        route_targets:
+        - '100000:41'
+    redistribute_routes:
+    - source_protocol: connected
   - name: Tenant_D_OP_Zone
     router_id: 192.168.255.10
     rd: '65001:40'
@@ -208,20 +222,6 @@ router_bgp:
     redistribute_routes:
     - source_protocol: connected
     - source_protocol: static
-  - name: Tenant_D_WAN_Zone
-    router_id: 192.168.255.10
-    rd: '65001:41'
-    route_targets:
-      import:
-      - address_family: evpn
-        route_targets:
-        - '100000:41'
-      export:
-      - address_family: evpn
-        route_targets:
-        - '100000:41'
-    redistribute_routes:
-    - source_protocol: connected
   vlan_aware_bundles:
   - name: Tenant_A_APP_Zone
     rd: '65001:12'
@@ -289,6 +289,14 @@ router_bgp:
     redistribute_routes:
     - learned
     vlan: 310-311
+  - name: '12345678'
+    rd: '65001:41'
+    route_targets:
+      both:
+      - '100000:41'
+    redistribute_routes:
+    - learned
+    vlan: 450-452
   - name: Tenant_D_OP_Zone
     rd: '65001:40'
     route_targets:
@@ -297,14 +305,6 @@ router_bgp:
     redistribute_routes:
     - learned
     vlan: 410-413
-  - name: Tenant_D_WAN_Zone
-    rd: '65001:41'
-    route_targets:
-      both:
-      - '100000:41'
-    redistribute_routes:
-    - learned
-    vlan: 450-452
 static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0
@@ -399,11 +399,11 @@ vrfs:
 - name: Tenant_C_OP_Zone
   tenant: Tenant_C
   ip_routing: true
-- name: Tenant_D_OP_Zone
+- name: '12345678'
   tenant: Tenant_D
   ip_routing: true
   ipv6_routing: true
-- name: Tenant_D_WAN_Zone
+- name: Tenant_D_OP_Zone
   tenant: Tenant_D
   ip_routing: true
   ipv6_routing: true
@@ -836,6 +836,15 @@ vlans:
 - id: 311
   name: Tenant_C_OP_Zone_2
   tenant: Tenant_C
+- id: 450
+  name: Tenant_D_v6_WAN_Zone_1
+  tenant: Tenant_D
+- id: 451
+  name: Tenant_D_v6_WAN_Zone_2
+  tenant: Tenant_D
+- id: 452
+  name: Tenant_D_v6_WAN_Zone_3
+  tenant: Tenant_D
 - id: 410
   name: Tenant_D_v6_OP_Zone_1
   tenant: Tenant_D
@@ -847,15 +856,6 @@ vlans:
   tenant: Tenant_D
 - id: 413
   name: Tenant_D_v6_OP_Zone_3
-  tenant: Tenant_D
-- id: 450
-  name: Tenant_D_v6_WAN_Zone_1
-  tenant: Tenant_D
-- id: 451
-  name: Tenant_D_v6_WAN_Zone_2
-  tenant: Tenant_D
-- id: 452
-  name: Tenant_D_v6_WAN_Zone_3
   tenant: Tenant_D
 ip_igmp_snooping:
   globally_enabled: true
@@ -987,6 +987,39 @@ vlan_interfaces:
   shutdown: false
   ip_address_virtual: 10.3.11.1/24
   vrf: Tenant_C_OP_Zone
+- name: Vlan450
+  tenant: Tenant_D
+  tags:
+  - v6wan
+  description: Tenant_D_v6_WAN_Zone_1
+  shutdown: false
+  ipv6_enable: true
+  ipv6_address_virtuals:
+  - 2001:db8:355::1/64
+  vrf: '12345678'
+- name: Vlan451
+  tenant: Tenant_D
+  tags:
+  - v6wan
+  description: Tenant_D_v6_WAN_Zone_2
+  shutdown: false
+  ipv6_enable: true
+  mtu: 1560
+  ipv6_address_virtuals:
+  - 2001:db8:451::1/64
+  vrf: '12345678'
+- name: Vlan452
+  tenant: Tenant_D
+  tags:
+  - v6wan
+  description: Tenant_D_v6_WAN_Zone_3
+  shutdown: false
+  ipv6_enable: false
+  mtu: 1560
+  ip_address_virtual: 10.4.12.254/24
+  ipv6_address_virtuals:
+  - 2001:db8:412::1/64
+  vrf: '12345678'
 - name: Vlan410
   tenant: Tenant_D
   tags:
@@ -1043,39 +1076,6 @@ vlan_interfaces:
   - ip_helper: 1.1.1.1
     source_interface: lo101
     vrf: TEST
-- name: Vlan450
-  tenant: Tenant_D
-  tags:
-  - v6wan
-  description: Tenant_D_v6_WAN_Zone_1
-  shutdown: false
-  ipv6_enable: true
-  ipv6_address_virtuals:
-  - 2001:db8:355::1/64
-  vrf: Tenant_D_WAN_Zone
-- name: Vlan451
-  tenant: Tenant_D
-  tags:
-  - v6wan
-  description: Tenant_D_v6_WAN_Zone_2
-  shutdown: false
-  ipv6_enable: true
-  mtu: 1560
-  ipv6_address_virtuals:
-  - 2001:db8:451::1/64
-  vrf: Tenant_D_WAN_Zone
-- name: Vlan452
-  tenant: Tenant_D
-  tags:
-  - v6wan
-  description: Tenant_D_v6_WAN_Zone_3
-  shutdown: false
-  ipv6_enable: false
-  mtu: 1560
-  ip_address_virtual: 10.4.12.254/24
-  ipv6_address_virtuals:
-  - 2001:db8:412::1/64
-  vrf: Tenant_D_WAN_Zone
 ipv6_static_routes:
 - destination_address_prefix: ::/0
   gateway: 2001:db8:311::4
@@ -1134,6 +1134,12 @@ vxlan_interface:
         vni: 30310
       - id: 311
         vni: 30311
+      - id: 450
+        vni: 40450
+      - id: 451
+        vni: 40451
+      - id: 452
+        vni: 40452
       - id: 410
         vni: 40410
       - id: 411
@@ -1142,12 +1148,6 @@ vxlan_interface:
         vni: 40412
       - id: 413
         vni: 40413
-      - id: 450
-        vni: 40450
-      - id: 451
-        vni: 40451
-      - id: 452
-        vni: 40452
       vrfs:
       - name: Tenant_A_APP_Zone
         vni: 12
@@ -1163,10 +1163,10 @@ vxlan_interface:
         vni: 20
       - name: Tenant_C_OP_Zone
         vni: 30
+      - name: '12345678'
+        vni: 41
       - name: Tenant_D_OP_Zone
         vni: 40
-      - name: Tenant_D_WAN_Zone
-        vni: 41
 virtual_source_nat_vrfs:
 - name: Tenant_A_OP_Zone
   ip_address: 10.255.1.10

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
@@ -193,6 +193,20 @@ router_bgp:
         - '100000:30'
     redistribute_routes:
     - source_protocol: connected
+  - name: '12345678'
+    router_id: 192.168.255.11
+    rd: '65001:41'
+    route_targets:
+      import:
+      - address_family: evpn
+        route_targets:
+        - '100000:41'
+      export:
+      - address_family: evpn
+        route_targets:
+        - '100000:41'
+    redistribute_routes:
+    - source_protocol: connected
   - name: Tenant_D_OP_Zone
     router_id: 192.168.255.11
     rd: '65001:40'
@@ -208,20 +222,6 @@ router_bgp:
     redistribute_routes:
     - source_protocol: connected
     - source_protocol: static
-  - name: Tenant_D_WAN_Zone
-    router_id: 192.168.255.11
-    rd: '65001:41'
-    route_targets:
-      import:
-      - address_family: evpn
-        route_targets:
-        - '100000:41'
-      export:
-      - address_family: evpn
-        route_targets:
-        - '100000:41'
-    redistribute_routes:
-    - source_protocol: connected
   vlan_aware_bundles:
   - name: Tenant_A_APP_Zone
     rd: '65001:12'
@@ -289,6 +289,14 @@ router_bgp:
     redistribute_routes:
     - learned
     vlan: 310-311
+  - name: '12345678'
+    rd: '65001:41'
+    route_targets:
+      both:
+      - '100000:41'
+    redistribute_routes:
+    - learned
+    vlan: 450-452
   - name: Tenant_D_OP_Zone
     rd: '65001:40'
     route_targets:
@@ -297,14 +305,6 @@ router_bgp:
     redistribute_routes:
     - learned
     vlan: 410-413
-  - name: Tenant_D_WAN_Zone
-    rd: '65001:41'
-    route_targets:
-      both:
-      - '100000:41'
-    redistribute_routes:
-    - learned
-    vlan: 450-452
 static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0
@@ -399,11 +399,11 @@ vrfs:
 - name: Tenant_C_OP_Zone
   tenant: Tenant_C
   ip_routing: true
-- name: Tenant_D_OP_Zone
+- name: '12345678'
   tenant: Tenant_D
   ip_routing: true
   ipv6_routing: true
-- name: Tenant_D_WAN_Zone
+- name: Tenant_D_OP_Zone
   tenant: Tenant_D
   ip_routing: true
   ipv6_routing: true
@@ -780,6 +780,15 @@ vlans:
 - id: 311
   name: Tenant_C_OP_Zone_2
   tenant: Tenant_C
+- id: 450
+  name: Tenant_D_v6_WAN_Zone_1
+  tenant: Tenant_D
+- id: 451
+  name: Tenant_D_v6_WAN_Zone_2
+  tenant: Tenant_D
+- id: 452
+  name: Tenant_D_v6_WAN_Zone_3
+  tenant: Tenant_D
 - id: 410
   name: Tenant_D_v6_OP_Zone_1
   tenant: Tenant_D
@@ -791,15 +800,6 @@ vlans:
   tenant: Tenant_D
 - id: 413
   name: Tenant_D_v6_OP_Zone_3
-  tenant: Tenant_D
-- id: 450
-  name: Tenant_D_v6_WAN_Zone_1
-  tenant: Tenant_D
-- id: 451
-  name: Tenant_D_v6_WAN_Zone_2
-  tenant: Tenant_D
-- id: 452
-  name: Tenant_D_v6_WAN_Zone_3
   tenant: Tenant_D
 ip_igmp_snooping:
   globally_enabled: true
@@ -931,6 +931,39 @@ vlan_interfaces:
   shutdown: false
   ip_address_virtual: 10.3.11.1/24
   vrf: Tenant_C_OP_Zone
+- name: Vlan450
+  tenant: Tenant_D
+  tags:
+  - v6wan
+  description: Tenant_D_v6_WAN_Zone_1
+  shutdown: false
+  ipv6_enable: true
+  ipv6_address_virtuals:
+  - 2001:db8:355::1/64
+  vrf: '12345678'
+- name: Vlan451
+  tenant: Tenant_D
+  tags:
+  - v6wan
+  description: Tenant_D_v6_WAN_Zone_2
+  shutdown: false
+  ipv6_enable: true
+  mtu: 1560
+  ipv6_address_virtuals:
+  - 2001:db8:451::1/64
+  vrf: '12345678'
+- name: Vlan452
+  tenant: Tenant_D
+  tags:
+  - v6wan
+  description: Tenant_D_v6_WAN_Zone_3
+  shutdown: false
+  ipv6_enable: false
+  mtu: 1560
+  ip_address_virtual: 10.4.12.254/24
+  ipv6_address_virtuals:
+  - 2001:db8:412::1/64
+  vrf: '12345678'
 - name: Vlan410
   tenant: Tenant_D
   tags:
@@ -987,39 +1020,6 @@ vlan_interfaces:
   - ip_helper: 1.1.1.1
     source_interface: lo101
     vrf: TEST
-- name: Vlan450
-  tenant: Tenant_D
-  tags:
-  - v6wan
-  description: Tenant_D_v6_WAN_Zone_1
-  shutdown: false
-  ipv6_enable: true
-  ipv6_address_virtuals:
-  - 2001:db8:355::1/64
-  vrf: Tenant_D_WAN_Zone
-- name: Vlan451
-  tenant: Tenant_D
-  tags:
-  - v6wan
-  description: Tenant_D_v6_WAN_Zone_2
-  shutdown: false
-  ipv6_enable: true
-  mtu: 1560
-  ipv6_address_virtuals:
-  - 2001:db8:451::1/64
-  vrf: Tenant_D_WAN_Zone
-- name: Vlan452
-  tenant: Tenant_D
-  tags:
-  - v6wan
-  description: Tenant_D_v6_WAN_Zone_3
-  shutdown: false
-  ipv6_enable: false
-  mtu: 1560
-  ip_address_virtual: 10.4.12.254/24
-  ipv6_address_virtuals:
-  - 2001:db8:412::1/64
-  vrf: Tenant_D_WAN_Zone
 ipv6_static_routes:
 - destination_address_prefix: ::/0
   gateway: 2001:db8:311::4
@@ -1072,6 +1072,12 @@ vxlan_interface:
         vni: 30310
       - id: 311
         vni: 30311
+      - id: 450
+        vni: 40450
+      - id: 451
+        vni: 40451
+      - id: 452
+        vni: 40452
       - id: 410
         vni: 40410
       - id: 411
@@ -1080,12 +1086,6 @@ vxlan_interface:
         vni: 40412
       - id: 413
         vni: 40413
-      - id: 450
-        vni: 40450
-      - id: 451
-        vni: 40451
-      - id: 452
-        vni: 40452
       vrfs:
       - name: Tenant_A_APP_Zone
         vni: 12
@@ -1101,10 +1101,10 @@ vxlan_interface:
         vni: 20
       - name: Tenant_C_OP_Zone
         vni: 30
+      - name: '12345678'
+        vni: 41
       - name: Tenant_D_OP_Zone
         vni: 40
-      - name: Tenant_D_WAN_Zone
-        vni: 41
 virtual_source_nat_vrfs:
 - name: Tenant_A_OP_Zone
   ip_address: 10.255.1.11

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_false.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_false.yml
@@ -170,6 +170,20 @@ router_bgp:
         - '31:31'
     redistribute_routes:
     - source_protocol: connected
+  - name: '12345678'
+    router_id: 192.168.255.109
+    rd: 192.168.255.109:41
+    route_targets:
+      import:
+      - address_family: evpn
+        route_targets:
+        - '41:41'
+      export:
+      - address_family: evpn
+        route_targets:
+        - '41:41'
+    redistribute_routes:
+    - source_protocol: connected
   - name: Tenant_D_OP_Zone
     router_id: 192.168.255.109
     rd: 192.168.255.109:40
@@ -182,20 +196,6 @@ router_bgp:
       - address_family: evpn
         route_targets:
         - '40:40'
-    redistribute_routes:
-    - source_protocol: connected
-  - name: Tenant_D_WAN_Zone
-    router_id: 192.168.255.109
-    rd: 192.168.255.109:41
-    route_targets:
-      import:
-      - address_family: evpn
-        route_targets:
-        - '41:41'
-      export:
-      - address_family: evpn
-        route_targets:
-        - '41:41'
     redistribute_routes:
     - source_protocol: connected
   vlan_aware_bundles:
@@ -307,6 +307,14 @@ router_bgp:
     redistribute_routes:
     - learned
     vlan: '350'
+  - name: '12345678'
+    rd: 192.168.255.109:41
+    route_targets:
+      both:
+      - '41:41'
+    redistribute_routes:
+    - learned
+    vlan: 450-452
   - name: Tenant_D_OP_Zone
     rd: 192.168.255.109:40
     route_targets:
@@ -315,14 +323,6 @@ router_bgp:
     redistribute_routes:
     - learned
     vlan: 410-413
-  - name: Tenant_D_WAN_Zone
-    rd: 192.168.255.109:41
-    route_targets:
-      both:
-      - '41:41'
-    redistribute_routes:
-    - learned
-    vlan: 450-452
 static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0
@@ -399,11 +399,11 @@ vrfs:
 - name: Tenant_C_WAN_Zone
   tenant: Tenant_C
   ip_routing: true
-- name: Tenant_D_OP_Zone
+- name: '12345678'
   tenant: Tenant_D
   ip_routing: true
   ipv6_routing: true
-- name: Tenant_D_WAN_Zone
+- name: Tenant_D_OP_Zone
   tenant: Tenant_D
   ip_routing: true
   ipv6_routing: true
@@ -521,6 +521,15 @@ vlans:
 - id: 350
   name: Tenant_C_WAN_Zone_1
   tenant: Tenant_C
+- id: 450
+  name: Tenant_D_v6_WAN_Zone_1
+  tenant: Tenant_D
+- id: 451
+  name: Tenant_D_v6_WAN_Zone_2
+  tenant: Tenant_D
+- id: 452
+  name: Tenant_D_v6_WAN_Zone_3
+  tenant: Tenant_D
 - id: 410
   name: Tenant_D_v6_OP_Zone_1
   tenant: Tenant_D
@@ -532,15 +541,6 @@ vlans:
   tenant: Tenant_D
 - id: 413
   name: Tenant_D_v6_OP_Zone_3
-  tenant: Tenant_D
-- id: 450
-  name: Tenant_D_v6_WAN_Zone_1
-  tenant: Tenant_D
-- id: 451
-  name: Tenant_D_v6_WAN_Zone_2
-  tenant: Tenant_D
-- id: 452
-  name: Tenant_D_v6_WAN_Zone_3
   tenant: Tenant_D
 ip_igmp_snooping:
   globally_enabled: true
@@ -731,6 +731,39 @@ vlan_interfaces:
   shutdown: false
   ip_address_virtual: 10.3.50.1/24
   vrf: Tenant_C_WAN_Zone
+- name: Vlan450
+  tenant: Tenant_D
+  tags:
+  - v6wan
+  description: Tenant_D_v6_WAN_Zone_1
+  shutdown: false
+  ipv6_enable: true
+  ipv6_address_virtuals:
+  - 2001:db8:355::1/64
+  vrf: '12345678'
+- name: Vlan451
+  tenant: Tenant_D
+  tags:
+  - v6wan
+  description: Tenant_D_v6_WAN_Zone_2
+  shutdown: false
+  ipv6_enable: true
+  mtu: 1560
+  ipv6_address_virtuals:
+  - 2001:db8:451::1/64
+  vrf: '12345678'
+- name: Vlan452
+  tenant: Tenant_D
+  tags:
+  - v6wan
+  description: Tenant_D_v6_WAN_Zone_3
+  shutdown: false
+  ipv6_enable: false
+  mtu: 1560
+  ip_address_virtual: 10.4.12.254/24
+  ipv6_address_virtuals:
+  - 2001:db8:412::1/64
+  vrf: '12345678'
 - name: Vlan410
   tenant: Tenant_D
   tags:
@@ -787,39 +820,6 @@ vlan_interfaces:
   - ip_helper: 1.1.1.2
     source_interface: lo102
     vrf: TEST
-- name: Vlan450
-  tenant: Tenant_D
-  tags:
-  - v6wan
-  description: Tenant_D_v6_WAN_Zone_1
-  shutdown: false
-  ipv6_enable: true
-  ipv6_address_virtuals:
-  - 2001:db8:355::1/64
-  vrf: Tenant_D_WAN_Zone
-- name: Vlan451
-  tenant: Tenant_D
-  tags:
-  - v6wan
-  description: Tenant_D_v6_WAN_Zone_2
-  shutdown: false
-  ipv6_enable: true
-  mtu: 1560
-  ipv6_address_virtuals:
-  - 2001:db8:451::1/64
-  vrf: Tenant_D_WAN_Zone
-- name: Vlan452
-  tenant: Tenant_D
-  tags:
-  - v6wan
-  description: Tenant_D_v6_WAN_Zone_3
-  shutdown: false
-  ipv6_enable: false
-  mtu: 1560
-  ip_address_virtual: 10.4.12.254/24
-  ipv6_address_virtuals:
-  - 2001:db8:412::1/64
-  vrf: Tenant_D_WAN_Zone
 vxlan_interface:
   Vxlan1:
     description: evpn_services_l2_only_false_VTEP
@@ -877,6 +877,12 @@ vxlan_interface:
         vni: 30311
       - id: 350
         vni: 30350
+      - id: 450
+        vni: 40450
+      - id: 451
+        vni: 40451
+      - id: 452
+        vni: 40452
       - id: 410
         vni: 40410
       - id: 411
@@ -885,12 +891,6 @@ vxlan_interface:
         vni: 40412
       - id: 413
         vni: 40413
-      - id: 450
-        vni: 40450
-      - id: 451
-        vni: 40451
-      - id: 452
-        vni: 40452
       vrfs:
       - name: Tenant_A_APP_Zone
         vni: 12
@@ -910,10 +910,10 @@ vxlan_interface:
         vni: 30
       - name: Tenant_C_WAN_Zone
         vni: 31
+      - name: '12345678'
+        vni: 41
       - name: Tenant_D_OP_Zone
         vni: 40
-      - name: Tenant_D_WAN_Zone
-        vni: 41
 virtual_source_nat_vrfs:
 - name: Tenant_A_OP_Zone
   ip_address: 10.255.1.109

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_true.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_true.yml
@@ -150,6 +150,14 @@ router_bgp:
     redistribute_routes:
     - learned
     vlan: '350'
+  - name: '12345678'
+    rd: 192.168.255.109:41
+    route_targets:
+      both:
+      - '41:41'
+    redistribute_routes:
+    - learned
+    vlan: 450-452
   - name: Tenant_D_OP_Zone
     rd: 192.168.255.109:40
     route_targets:
@@ -158,14 +166,6 @@ router_bgp:
     redistribute_routes:
     - learned
     vlan: 410-413
-  - name: Tenant_D_WAN_Zone
-    rd: 192.168.255.109:41
-    route_targets:
-      both:
-      - '41:41'
-    redistribute_routes:
-    - learned
-    vlan: 450-452
 static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0
@@ -319,6 +319,15 @@ vlans:
 - id: 350
   name: Tenant_C_WAN_Zone_1
   tenant: Tenant_C
+- id: 450
+  name: Tenant_D_v6_WAN_Zone_1
+  tenant: Tenant_D
+- id: 451
+  name: Tenant_D_v6_WAN_Zone_2
+  tenant: Tenant_D
+- id: 452
+  name: Tenant_D_v6_WAN_Zone_3
+  tenant: Tenant_D
 - id: 410
   name: Tenant_D_v6_OP_Zone_1
   tenant: Tenant_D
@@ -330,15 +339,6 @@ vlans:
   tenant: Tenant_D
 - id: 413
   name: Tenant_D_v6_OP_Zone_3
-  tenant: Tenant_D
-- id: 450
-  name: Tenant_D_v6_WAN_Zone_1
-  tenant: Tenant_D
-- id: 451
-  name: Tenant_D_v6_WAN_Zone_2
-  tenant: Tenant_D
-- id: 452
-  name: Tenant_D_v6_WAN_Zone_3
   tenant: Tenant_D
 ip_igmp_snooping:
   globally_enabled: true
@@ -402,6 +402,12 @@ vxlan_interface:
         vni: 30311
       - id: 350
         vni: 30350
+      - id: 450
+        vni: 40450
+      - id: 451
+        vni: 40451
+      - id: 452
+        vni: 40452
       - id: 410
         vni: 40410
       - id: 411
@@ -410,9 +416,3 @@ vxlan_interface:
         vni: 40412
       - id: 413
         vni: 40413
-      - id: 450
-        vni: 40450
-      - id: 451
-        vni: 40451
-      - id: 452
-        vni: 40452

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_default.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_default.yml
@@ -130,6 +130,15 @@ vlans:
 - id: 350
   name: Tenant_C_WAN_Zone_1
   tenant: Tenant_C
+- id: 450
+  name: Tenant_D_v6_WAN_Zone_1
+  tenant: Tenant_D
+- id: 451
+  name: Tenant_D_v6_WAN_Zone_2
+  tenant: Tenant_D
+- id: 452
+  name: Tenant_D_v6_WAN_Zone_3
+  tenant: Tenant_D
 - id: 410
   name: Tenant_D_v6_OP_Zone_1
   tenant: Tenant_D
@@ -141,15 +150,6 @@ vlans:
   tenant: Tenant_D
 - id: 413
   name: Tenant_D_v6_OP_Zone_3
-  tenant: Tenant_D
-- id: 450
-  name: Tenant_D_v6_WAN_Zone_1
-  tenant: Tenant_D
-- id: 451
-  name: Tenant_D_v6_WAN_Zone_2
-  tenant: Tenant_D
-- id: 452
-  name: Tenant_D_v6_WAN_Zone_3
   tenant: Tenant_D
 ip_igmp_snooping:
   globally_enabled: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_fabric.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_fabric.yml
@@ -130,6 +130,15 @@ vlans:
 - id: 350
   name: Tenant_C_WAN_Zone_1
   tenant: Tenant_C
+- id: 450
+  name: Tenant_D_v6_WAN_Zone_1
+  tenant: Tenant_D
+- id: 451
+  name: Tenant_D_v6_WAN_Zone_2
+  tenant: Tenant_D
+- id: 452
+  name: Tenant_D_v6_WAN_Zone_3
+  tenant: Tenant_D
 - id: 410
   name: Tenant_D_v6_OP_Zone_1
   tenant: Tenant_D
@@ -141,15 +150,6 @@ vlans:
   tenant: Tenant_D
 - id: 413
   name: Tenant_D_v6_OP_Zone_3
-  tenant: Tenant_D
-- id: 450
-  name: Tenant_D_v6_WAN_Zone_1
-  tenant: Tenant_D
-- id: 451
-  name: Tenant_D_v6_WAN_Zone_2
-  tenant: Tenant_D
-- id: 452
-  name: Tenant_D_v6_WAN_Zone_3
   tenant: Tenant_D
 ip_igmp_snooping:
   globally_enabled: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_host.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_host.yml
@@ -136,6 +136,15 @@ vlans:
 - id: 350
   name: Tenant_C_WAN_Zone_1
   tenant: Tenant_C
+- id: 450
+  name: Tenant_D_v6_WAN_Zone_1
+  tenant: Tenant_D
+- id: 451
+  name: Tenant_D_v6_WAN_Zone_2
+  tenant: Tenant_D
+- id: 452
+  name: Tenant_D_v6_WAN_Zone_3
+  tenant: Tenant_D
 - id: 410
   name: Tenant_D_v6_OP_Zone_1
   tenant: Tenant_D
@@ -147,15 +156,6 @@ vlans:
   tenant: Tenant_D
 - id: 413
   name: Tenant_D_v6_OP_Zone_3
-  tenant: Tenant_D
-- id: 450
-  name: Tenant_D_v6_WAN_Zone_1
-  tenant: Tenant_D
-- id: 451
-  name: Tenant_D_v6_WAN_Zone_2
-  tenant: Tenant_D
-- id: 452
-  name: Tenant_D_v6_WAN_Zone_3
   tenant: Tenant_D
 ip_igmp_snooping:
   globally_enabled: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_platform.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_platform.yml
@@ -136,6 +136,15 @@ vlans:
 - id: 350
   name: Tenant_C_WAN_Zone_1
   tenant: Tenant_C
+- id: 450
+  name: Tenant_D_v6_WAN_Zone_1
+  tenant: Tenant_D
+- id: 451
+  name: Tenant_D_v6_WAN_Zone_2
+  tenant: Tenant_D
+- id: 452
+  name: Tenant_D_v6_WAN_Zone_3
+  tenant: Tenant_D
 - id: 410
   name: Tenant_D_v6_OP_Zone_1
   tenant: Tenant_D
@@ -147,15 +156,6 @@ vlans:
   tenant: Tenant_D
 - id: 413
   name: Tenant_D_v6_OP_Zone_3
-  tenant: Tenant_D
-- id: 450
-  name: Tenant_D_v6_WAN_Zone_1
-  tenant: Tenant_D
-- id: 451
-  name: Tenant_D_v6_WAN_Zone_2
-  tenant: Tenant_D
-- id: 452
-  name: Tenant_D_v6_WAN_Zone_3
   tenant: Tenant_D
 ip_igmp_snooping:
   globally_enabled: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_D.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_D.yml
@@ -91,7 +91,7 @@ tenant_d:
             name: Track-bfd-network-services
             track_bfd: true
             nodes: [ DC1-LEAF2A ]
-      - name: Tenant_D_WAN_Zone
+      - name: 12345678 # Testing all numeric VRF name (will require auto-conversion in schema)
         vrf_vni: 41
         svis:
           - id: 450

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -307,6 +307,8 @@ keys:
               vrf:
                 type: str
                 description: VRF name
+                convert_types:
+                - int
   access_lists:
     type: list
     primary_key: name
@@ -475,6 +477,8 @@ keys:
           description: Group Name
         vrf:
           type: str
+          convert_types:
+          - int
         neighbors:
           type: list
           items:
@@ -781,6 +785,8 @@ keys:
               description: 'The VRF to use to connect to CloudVision
 
                 '
+              convert_types:
+              - int
       cvauth:
         type: dict
         description: 'Authentication scheme used to connect to CloudVision
@@ -853,6 +859,8 @@ keys:
         description: 'The VRF to use to connect to CloudVision
 
           '
+        convert_types:
+        - int
       cvgnmi:
         type: bool
         description: 'Stream states from EOS gNMI servers (Openconfig) to CloudVision.
@@ -1264,6 +1272,8 @@ keys:
         vrf:
           type: str
           description: VRF name
+          convert_types:
+          - int
         flow_tracker:
           type: dict
           keys:
@@ -1435,6 +1445,8 @@ keys:
               vrf:
                 type: str
                 description: VRF name
+                convert_types:
+                - int
         ip_nat:
           $ref: '#/$defs/interface_ip_nat'
         ipv6_enable:
@@ -1483,6 +1495,8 @@ keys:
                 required: true
               vrf:
                 type: str
+                convert_types:
+                - int
               local_interface:
                 type: str
                 description: Local interface to communicate with DHCP server - mutually
@@ -2532,6 +2546,8 @@ keys:
                 This validation IS NOT made by the schemas.
 
                 '
+              convert_types:
+              - int
             prefix:
               type: str
               description: 'Supported only for the ''route'' feature.
@@ -2894,6 +2910,8 @@ keys:
                 '
             vrf:
               type: str
+              convert_types:
+              - int
   ip_extcommunity_lists:
     type: list
     primary_key: name
@@ -2983,6 +3001,8 @@ keys:
           type: str
         vrf:
           type: str
+          convert_types:
+          - int
   ip_icmp_redirect:
     type: bool
   ip_igmp_snooping:
@@ -3116,6 +3136,8 @@ keys:
         vrf:
           description: VRF Name
           type: str
+          convert_types:
+          - int
         priority:
           description: Priority value (lower is first)
           type: int
@@ -3308,6 +3330,8 @@ keys:
         vrf:
           type: str
           description: VRF Name
+          convert_types:
+          - int
   ip_routing:
     type: bool
   ip_routing_ipv6_interfaces:
@@ -3323,6 +3347,8 @@ keys:
         vrf:
           type: str
           default: default
+          convert_types:
+          - int
   ip_tacacs_source_interfaces:
     type: list
     display_name: IP Tacacs Source Interfaces
@@ -3335,6 +3361,8 @@ keys:
         vrf:
           type: str
           display_name: VRF
+          convert_types:
+          - int
   ip_virtual_router_mac_address:
     type: str
     description: MAC address (hh:hh:hh:hh:hh:hh)
@@ -3467,6 +3495,8 @@ keys:
       keys:
         vrf:
           type: str
+          convert_types:
+          - int
         destination_address_prefix:
           type: str
           description: IPv6 Network/Mask
@@ -3598,6 +3628,8 @@ keys:
         type: str
       vrf:
         type: str
+        convert_types:
+        - int
       receive_packet_tagged_drop:
         type: str
       tlvs:
@@ -3852,6 +3884,8 @@ keys:
           keys:
             name:
               type: str
+              convert_types:
+              - int
               required: true
               description: VRF name
             source_interface:
@@ -3922,6 +3956,8 @@ keys:
         vrf:
           type: str
           description: VRF name
+          convert_types:
+          - int
         ip_address:
           type: str
           description: IPv4_address/Mask
@@ -4276,6 +4312,8 @@ keys:
                 vrf:
                   type: str
                   description: VRF name is optional
+                  convert_types:
+                  - int
                 notification_timestamp:
                   type: str
                   valid_values:
@@ -4318,6 +4356,8 @@ keys:
                 vrf:
                   type: str
                   description: VRF name
+                  convert_types:
+                  - int
                 destination:
                   type: dict
                   keys:
@@ -4379,6 +4419,8 @@ keys:
             name:
               type: str
               description: VRF name
+              convert_types:
+              - int
             access_group:
               type: str
               description: Standard IPv4 ACL name
@@ -4417,6 +4459,8 @@ keys:
               description: VRF Name
               type: str
               required: true
+              convert_types:
+              - int
             access_group:
               description: Standard IPv4 ACL name
               type: str
@@ -4480,6 +4524,8 @@ keys:
       vrf:
         type: str
         description: VRF Name
+        convert_types:
+        - int
   management_defaults:
     type: dict
     keys:
@@ -4512,6 +4558,8 @@ keys:
         vrf:
           type: str
           description: VRF Name
+          convert_types:
+          - int
         ip_address:
           type: str
           description: IPv4_address/Mask
@@ -4600,6 +4648,8 @@ keys:
             vrf:
               type: str
               description: VRF Name
+              convert_types:
+              - int
       ipv6_access_groups:
         type: list
         items:
@@ -4611,6 +4661,8 @@ keys:
             vrf:
               type: str
               description: VRF Name
+              convert_types:
+              - int
       idle_timeout:
         type: int
         convert_types:
@@ -4673,6 +4725,8 @@ keys:
               type: str
               required: true
               description: VRF Name
+              convert_types:
+              - int
             enable:
               description: Enable SSH in VRF
               type: bool
@@ -4786,6 +4840,8 @@ keys:
           vrf:
             description: VRF Name
             type: str
+            convert_types:
+            - int
       dual_primary_detection_delay:
         type: int
         description: Delay in seconds
@@ -4871,6 +4927,8 @@ keys:
             name:
               description: VRF Name
               type: str
+              convert_types:
+              - int
             description:
               type: str
             interface_sets:
@@ -5017,6 +5075,8 @@ keys:
           vrf:
             description: VRF Name
             type: str
+            convert_types:
+            - int
       nodes:
         type: list
         items:
@@ -5033,6 +5093,8 @@ keys:
           vrf:
             type: str
             description: VRF name
+            convert_types:
+            - int
       servers:
         type: list
         items:
@@ -5079,6 +5141,8 @@ keys:
             vrf:
               type: str
               description: VRF name
+              convert_types:
+              - int
       authenticate:
         type: bool
       authenticate_servers_only:
@@ -5438,6 +5502,8 @@ keys:
         vrf:
           type: str
           description: VRF name
+          convert_types:
+          - int
         encapsulation_vlan:
           type: dict
           keys:
@@ -6558,6 +6624,8 @@ keys:
         max: 100
       vrf:
         type: str
+        convert_types:
+        - int
   radius_server:
     type: dict
     keys:
@@ -6594,6 +6662,8 @@ keys:
               description: Host IP address or name
             vrf:
               type: str
+              convert_types:
+              - int
             timeout:
               type: int
               min: 1
@@ -6623,6 +6693,8 @@ keys:
           description: Host IP address or name
         vrf:
           type: str
+          convert_types:
+          - int
         key:
           type: str
           description: Encrypted key
@@ -8221,6 +8293,8 @@ keys:
             name:
               type: str
               description: VRF name
+              convert_types:
+              - int
             rd:
               type: str
               description: Route distinguisher
@@ -9040,6 +9114,8 @@ keys:
               type: str
               required: true
               description: Destination-VRF
+              convert_types:
+              - int
             leak_routes:
               type: list
               items:
@@ -9047,6 +9123,8 @@ keys:
                 keys:
                   source_vrf:
                     type: str
+                    convert_types:
+                    - int
                   subscribe_policy:
                     type: str
                     description: Route-Map Policy
@@ -9401,6 +9479,8 @@ keys:
               type: str
               required: true
               description: VRF name
+              convert_types:
+              - int
             originator_id_local_interface:
               type: str
               description: Interface to use for originator ID
@@ -9573,6 +9653,8 @@ keys:
           keys:
             name:
               type: str
+              convert_types:
+              - int
             ipv4:
               type: dict
               keys:
@@ -9598,6 +9680,8 @@ keys:
             vrf:
               type: str
               description: VRF Name for OSPF Process
+              convert_types:
+              - int
             passive_interface_default:
               type: bool
             router_id:
@@ -9950,6 +10034,8 @@ keys:
               type: str
               description: VRF Name
               required: true
+              convert_types:
+              - int
             ipv4:
               type: dict
               keys:
@@ -10110,6 +10196,8 @@ keys:
           keys:
             name:
               type: str
+              convert_types:
+              - int
             destinations:
               type: list
               primary_key: destination
@@ -10288,6 +10376,8 @@ keys:
               description: IPv4 access list name
             vrf:
               type: str
+              convert_types:
+              - int
       ipv6_acls:
         type: list
         items:
@@ -10298,6 +10388,8 @@ keys:
               description: IPv6 access list name
             vrf:
               type: str
+              convert_types:
+              - int
       local_interfaces:
         type: list
         primary_key: name
@@ -10312,6 +10404,8 @@ keys:
               description: Interface name
             vrf:
               type: str
+              convert_types:
+              - int
       views:
         type: list
         items:
@@ -10429,6 +10523,8 @@ keys:
               description: Host IP address or name
             vrf:
               type: str
+              convert_types:
+              - int
             version:
               type: str
               convert_types:
@@ -10490,6 +10586,8 @@ keys:
             name:
               type: str
               description: VRF name
+              convert_types:
+              - int
             enable:
               type: bool
   spanning_tree:
@@ -10652,6 +10750,8 @@ keys:
         vrf:
           type: str
           description: VRF Name
+          convert_types:
+          - int
         destination_address_prefix:
           type: str
           description: IPv4_network/Mask
@@ -10740,6 +10840,8 @@ keys:
                   type: str
                 vrf:
                   type: str
+                  convert_types:
+                  - int
           ipv6_access_groups:
             type: list
             primary_key: acl_name
@@ -10752,6 +10854,8 @@ keys:
                   type: str
                 vrf:
                   type: str
+                  convert_types:
+                  - int
   tacacs_servers:
     type: dict
     keys:
@@ -10765,6 +10869,8 @@ keys:
               description: Host IP address or name
             vrf:
               type: str
+              convert_types:
+              - int
             key:
               type: str
               description: Encrypted key
@@ -11161,6 +11267,8 @@ keys:
         vrf:
           type: str
           description: VRF Name
+          convert_types:
+          - int
         ip_address:
           type: str
           format: ipv4_cidr
@@ -11233,6 +11341,8 @@ keys:
         name:
           type: str
           description: VRF Name
+          convert_types:
+          - int
         ip_address:
           type: str
           description: IPv4 Address
@@ -11255,6 +11365,8 @@ keys:
         vrf:
           type: str
           description: VRF name
+          convert_types:
+          - int
         arp_aging_timeout:
           type: int
           convert_types:
@@ -11323,6 +11435,8 @@ keys:
               vrf:
                 type: str
                 description: VRF where DHCP server can be reached
+                convert_types:
+                - int
         ip_nat:
           $ref: '#/$defs/interface_ip_nat'
         ipv6_enable:
@@ -11408,6 +11522,8 @@ keys:
                 required: true
               vrf:
                 type: str
+                convert_types:
+                - int
               local_interface:
                 type: str
                 description: Local interface to communicate with DHCP server - mutually
@@ -11866,6 +11982,8 @@ keys:
         name:
           type: str
           description: VRF Name
+          convert_types:
+          - int
         description:
           type: str
         ip_routing:
@@ -11980,6 +12098,8 @@ keys:
                       type: str
                       required: true
                       description: VRF Name
+                      convert_types:
+                      - int
                     vni:
                       type: int
                       convert_types:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/aaa_server_groups.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/aaa_server_groups.schema.yml
@@ -25,3 +25,5 @@ keys:
               vrf:
                 type: str
                 description: VRF name
+                convert_types:
+                  - int

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/bgp_groups.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/bgp_groups.schema.yml
@@ -17,6 +17,8 @@ keys:
           description: Group Name
         vrf:
           type: str
+          convert_types:
+            - int
         neighbors:
           type: list
           items:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/daemon_terminattr.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/daemon_terminattr.schema.yml
@@ -28,7 +28,7 @@ keys:
           Multiple CloudVision clusters
         primary_key: name
         convert_types:
-        - dict
+          - dict
         items:
           type: dict
           keys:
@@ -96,6 +96,8 @@ keys:
               type: str
               description: |
                 The VRF to use to connect to CloudVision
+              convert_types:
+                - int
       cvauth:
         type: dict
         description: |
@@ -147,6 +149,8 @@ keys:
         type: str
         description: |
           The VRF to use to connect to CloudVision
+        convert_types:
+          - int
       cvgnmi:
         type: bool
         description: |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ethernet_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ethernet_interfaces.schema.yml
@@ -7,7 +7,7 @@ keys:
     type: list
     primary_key: name
     convert_types:
-    - dict
+      - dict
     items:
       type: dict
       keys:
@@ -23,7 +23,7 @@ keys:
           min: 0
           max: 600
           convert_types:
-          - str
+            - str
           description: Interval in seconds for updating interface counters"
         speed:
           type: str
@@ -31,17 +31,17 @@ keys:
         mtu:
           type: int
           convert_types:
-          - str
+            - str
         l2_mtu:
           type: int
           convert_types:
-          - str
+            - str
           description: |
             "l2_mtu" should only be defined for platforms supporting the "l2 mtu" CLI
         vlans:
           type: str
           convert_types:
-          - int
+            - int
           description: |
             List of switchport vlans as string
             For a trunk port this would be a range like "1-200,300"
@@ -49,7 +49,7 @@ keys:
         native_vlan:
           type: int
           convert_types:
-          - str
+            - str
         native_vlan_tag:
           type: bool
           description: If setting both native_vlan and native_vlan_tag, native_vlan_tag takes precedence
@@ -67,14 +67,14 @@ keys:
               min: 1
               max: 4094
               convert_types:
-              - str
+                - str
         l2_protocol:
           type: dict
           keys:
             encapsulation_dot1q_vlan:
               type: int
               convert_types:
-              - str
+                - str
               description: Vlan tag to configure on sub-interface
             forwarding_profile:
               type: str
@@ -109,6 +109,8 @@ keys:
         vrf:
           type: str
           description: VRF name
+          convert_types:
+            - int
         flow_tracker:
           type: dict
           keys:
@@ -157,7 +159,7 @@ keys:
                   min: 0
                   max: 65535
                   convert_types:
-                  - str
+                    - str
                   description: Preference_value is only used when "algorithm" is "preference"
                 dont_preempt:
                   type: bool
@@ -165,11 +167,11 @@ keys:
                 hold_time:
                   type: int
                   convert_types:
-                  - str
+                    - str
                 subsequent_hold_time:
                   type: int
                   convert_types:
-                  - str
+                    - str
                 candidate_reachability_required:
                   type: bool
             mpls:
@@ -180,18 +182,18 @@ keys:
                   min: 1
                   max: 1024
                   convert_types:
-                  - str
+                    - str
                 tunnel_flood_filter_time:
                   type: int
                   convert_types:
-                  - str
+                    - str
             route_target:
               type: str
               description: EVPN Route Target for ESI with format xx:xx:xx:xx:xx:xx
         encapsulation_dot1q_vlan:
           type: int
           convert_types:
-          - str
+            - str
           description: VLAN tag to configure on sub-interface
         encapsulation_vlan:
           type: dict
@@ -205,17 +207,17 @@ keys:
                     vlan:
                       type: int
                       convert_types:
-                      - str
+                        - str
                       description: Client VLAN ID
                     outer:
                       type: int
                       convert_types:
-                      - str
+                        - str
                       description: Client Outer VLAN ID
                     inner:
                       type: int
                       convert_types:
-                      - str
+                        - str
                       description: Client Inner VLAN ID
                 unmatched:
                   type: bool
@@ -229,17 +231,17 @@ keys:
                     vlan:
                       type: int
                       convert_types:
-                      - str
+                        - str
                       description: Network VLAN ID
                     outer:
                       type: int
                       convert_types:
-                      - str
+                        - str
                       description: Network outer VLAN ID
                     inner:
                       type: int
                       convert_types:
-                      - str
+                        - str
                       description: Network inner VLAN ID
                 client:
                   type: bool
@@ -248,7 +250,7 @@ keys:
           min: 1
           max: 4094
           convert_types:
-          - str
+            - str
         ip_address:
           type: str
           description: IPv4 address/mask
@@ -260,7 +262,7 @@ keys:
           type: list
           primary_key: ip_helper
           convert_types:
-          - dict
+            - dict
           items:
             type: dict
             keys:
@@ -273,6 +275,8 @@ keys:
               vrf:
                 type: str
                 description: VRF name
+                convert_types:
+                  - int
         ip_nat:
           $ref: "#/$defs/interface_ip_nat"
         ipv6_enable:
@@ -290,7 +294,7 @@ keys:
           type: list
           primary_key: ipv6_prefix
           convert_types:
-          - dict
+            - dict
           items:
             type: dict
             keys:
@@ -300,12 +304,12 @@ keys:
               valid_lifetime:
                 type: str
                 convert_types:
-                - int
+                  - int
                 description: Infinite or lifetime in seconds
               preferred_lifetime:
                 type: str
                 convert_types:
-                - int
+                  - int
                 description: Infinite or lifetime in seconds
               no_autoconfig_flag:
                 type: bool
@@ -321,6 +325,8 @@ keys:
                 required: true
               vrf:
                 type: str
+                convert_types:
+                  - int
               local_interface:
                 type: str
                 description: Local interface to communicate with DHCP server - mutually exclusive to source_address
@@ -385,11 +391,11 @@ keys:
         ospf_area:
           type: str
           convert_types:
-          - int
+            - int
         ospf_cost:
           type: int
           convert_types:
-          - str
+            - str
         ospf_authentication:
           type: str
           valid_values: ["none", "simple", "message-digest"]
@@ -400,14 +406,14 @@ keys:
           type: list
           primary_key: id
           convert_types:
-          - dict
+            - dict
           items:
             type: dict
             keys:
               id:
                 type: int
                 convert_types:
-                - str
+                  - str
                 required: true
               hash_algorithm:
                 type: str
@@ -424,7 +430,7 @@ keys:
                 dr_priority:
                   type: int
                   convert_types:
-                  - str
+                    - str
                   min: 0
                   max: 429467295
                 sparse_mode:
@@ -440,7 +446,7 @@ keys:
             id:
               type: int
               convert_types:
-              - str
+                - str
             mode:
               type: str
               valid_values: ["on", "active", "passive"]
@@ -452,7 +458,7 @@ keys:
         isis_metric:
           type: int
           convert_types:
-          - str
+            - str
         isis_network_point_to_point:
           type: bool
         isis_circuit_type:
@@ -498,7 +504,7 @@ keys:
                   min: 1
                   max: 86400
                   convert_types:
-                  - str
+                    - str
                   description: Number of seconds to delay shutting the power off after a link down event occurs. Default value is 5 seconds in EOS.
             shutdown:
               description: Set the PoE power behavior for a PoE port when the port is admin down
@@ -517,12 +523,12 @@ keys:
                   min: 0
                   max: 8
                   convert_types:
-                  - str
+                    - str
                 watts:
                   type: str
                   convert_types:
-                  - int
-                  - float
+                    - int
+                    - float
                 fixed:
                   type: bool
                   description: Set to ignore hardware classification
@@ -543,15 +549,15 @@ keys:
                 interval:
                   type: int
                   convert_types:
-                  - str
+                    - str
                 timeout:
                   type: int
                   convert_types:
-                  - str
+                    - str
             delay_req:
               type: int
               convert_types:
-              - str
+                - str
             delay_mechanism:
               type: str
               valid_values: ["e2e", "p2p"]
@@ -561,14 +567,14 @@ keys:
                 interval:
                   type: int
                   convert_types:
-                  - str
+                    - str
             role:
               type: str
               valid_values: ["master", "dynamic"]
             vlan:
               type: str
               convert_types:
-              - int
+                - int
               description: VLAN can be 'all' or list of vlans as string
             transport:
               type: str
@@ -585,8 +591,8 @@ keys:
                 level:
                   type: str
                   convert_types:
-                  - int
-                  - float
+                    - int
+                    - float
                   description: Configure maximum storm-control level
                 unit:
                   type: str
@@ -599,8 +605,8 @@ keys:
                 level:
                   type: str
                   convert_types:
-                  - int
-                  - float
+                    - int
+                    - float
                   description: Configure maximum storm-control level
                 unit:
                   type: str
@@ -613,8 +619,8 @@ keys:
                 level:
                   type: str
                   convert_types:
-                  - int
-                  - float
+                    - int
+                    - float
                   description: Configure maximum storm-control level
                 unit:
                   type: str
@@ -627,8 +633,8 @@ keys:
                 level:
                   type: str
                   convert_types:
-                  - int
-                  - float
+                    - int
+                    - float
                   description: Configure maximum storm-control level
                 unit:
                   type: str
@@ -659,14 +665,14 @@ keys:
             ztp_vlan:
               type: int
               convert_types:
-              - str
+                - str
               description: ZTP vlan number
         trunk_private_vlan_secondary:
           type: bool
         pvlan_mapping:
           type: str
           convert_types:
-          - int
+            - int
           description: List of vlans as string
         vlan_translations:
           type: list
@@ -676,12 +682,12 @@ keys:
               from:
                 type: str
                 convert_types:
-                - int
+                  - int
                 description: List of vlans as string (only one vlan if direction is "both")
               to:
                 type: int
                 convert_types:
-                - str
+                  - str
                 description: VLAN ID
               direction:
                 type: str
@@ -714,7 +720,7 @@ keys:
                   min: 1
                   max: 4094
                   convert_types:
-                  - str
+                    - str
             host_mode:
               type: dict
               keys:
@@ -740,17 +746,17 @@ keys:
                   min: 10
                   max: 65535
                   convert_types:
-                  - str
+                    - str
                 quiet_period:
                   type: int
                   min: 1
                   max: 65535
                   convert_types:
-                  - str
+                    - str
                 reauth_period:
                   type: str
                   convert_types:
-                  - int
+                    - int
                   description: Value can be 60-4294967295 or 'server'
                 reauth_timeout_ignore:
                   type: bool
@@ -759,13 +765,13 @@ keys:
                   min: 1
                   max: 65535
                   convert_types:
-                  - str
+                    - str
             reauthorization_request_limit:
               type: int
               min: 1
               max: 10
               convert_types:
-              - str
+                - str
             eapol:
               type: dict
               keys:
@@ -781,7 +787,7 @@ keys:
                       min: 0
                       max: 65535
                       convert_types:
-                      - str
+                        - str
         service_profile:
           type: str
           description: QOS profile
@@ -806,22 +812,22 @@ keys:
             dscp:
               type: int
               convert_types:
-              - str
+                - str
               description: DSCP value
             cos:
               type: int
               convert_types:
-              - str
+                - str
               description: COS value
         spanning_tree_bpdufilter:
           type: str
           convert_types:
-          - bool
+            - bool
           valid_values: ["enabled", "disabled", "True", "False", "true", "false"]
         spanning_tree_bpduguard:
           type: str
           convert_types:
-          - bool
+            - bool
           valid_values: ["enabled", "disabled", "True", "False", "true", "false"]
         spanning_tree_guard:
           type: str
@@ -847,7 +853,7 @@ keys:
                     min: 0
                     max: 7
                     convert_types:
-                    - str
+                      - str
                   no_drop:
                     type: bool
         bfd:
@@ -858,19 +864,19 @@ keys:
             interval:
               type: int
               convert_types:
-              - str
+                - str
               description: Interval in milliseconds
             min_rx:
               type: int
               convert_types:
-              - str
+                - str
               description: Rate in milliseconds
             multiplier:
               type: int
               min: 3
               max: 50
               convert_types:
-              - str
+                - str
         service_policy:
           type: dict
           keys:
@@ -911,13 +917,13 @@ keys:
               min: 3
               max: 3000
               convert_types:
-              - str
+                - str
         lacp_port_priority:
           type: int
           min: 0
           max: 65535
           convert_types:
-          - str
+            - str
         transceiver:
           type: dict
           keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/hardware_counters.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/hardware_counters.schema.yml
@@ -119,6 +119,8 @@ keys:
               description: |
                 Supported only for the 'route' feature.
                 This validation IS NOT made by the schemas.
+              convert_types:
+                - int
             prefix:
               type: str
               description: |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ip_domain_lookup.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ip_domain_lookup.schema.yml
@@ -10,7 +10,7 @@ keys:
         type: list
         primary_key: name
         convert_types:
-        - dict
+          - dict
         items:
           type: dict
           keys:
@@ -21,3 +21,5 @@ keys:
                 Source Interface
             vrf:
               type: str
+              convert_types:
+                - int

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ip_http_client_source_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ip_http_client_source_interfaces.schema.yml
@@ -13,3 +13,5 @@ keys:
           type: str
         vrf:
           type: str
+          convert_types:
+            - int

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ip_name_servers.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ip_name_servers.schema.yml
@@ -14,6 +14,8 @@ keys:
         vrf:
           description: VRF Name
           type: str
+          convert_types:
+            - int
         priority:
           description: Priority value (lower is first)
           type: int

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ip_radius_source_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ip_radius_source_interfaces.schema.yml
@@ -14,3 +14,5 @@ keys:
         vrf:
           type: str
           description: VRF Name
+          convert_types:
+            - int

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ip_ssh_client_source_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ip_ssh_client_source_interfaces.schema.yml
@@ -14,3 +14,5 @@ keys:
         vrf:
           type: str
           default: "default"
+          convert_types:
+            - int

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ip_tacacs_source_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ip_tacacs_source_interfaces.schema.yml
@@ -15,3 +15,5 @@ keys:
         vrf:
           type: str
           display_name: VRF
+          convert_types:
+            - int

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ipv6_static_routes.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ipv6_static_routes.schema.yml
@@ -10,6 +10,8 @@ keys:
       keys:
         vrf:
           type: str
+          convert_types:
+            - int
         destination_address_prefix:
           type: str
           description: IPv6 Network/Mask

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/lldp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/lldp.schema.yml
@@ -16,30 +16,32 @@ keys:
         type: str
       vrf:
         type: str
+        convert_types:
+          - int
       receive_packet_tagged_drop:
         type: str
       tlvs:
         type: list
         primary_key: name
         convert_types:
-        - dict
+          - dict
         items:
           type: dict
           keys:
             name:
               type: str
               valid_values:
-              - "link-aggregation"
-              - "management-address"
-              - "max-frame-size"
-              - "med"
-              - "port-description"
-              - "port-vlan"
-              - "power-via-mdi"
-              - "system-capabilities"
-              - "system-description"
-              - "system-name"
-              - "vlan-name"
+                - "link-aggregation"
+                - "management-address"
+                - "max-frame-size"
+                - "med"
+                - "port-description"
+                - "port-vlan"
+                - "power-via-mdi"
+                - "system-capabilities"
+                - "system-description"
+                - "system-name"
+                - "vlan-name"
             transmit:
               type: bool
       run:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/logging.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/logging.schema.yml
@@ -22,7 +22,7 @@ keys:
           size:
             type: int
             convert_types:
-            - str
+              - str
             min: 10
             max: 2147483647
           level:
@@ -71,12 +71,14 @@ keys:
         type: list
         primary_key: name
         convert_types:
-        - dict
+          - dict
         items:
           type: dict
           keys:
             name:
               type: str
+              convert_types:
+                - int
               required: true
               description: VRF name
             source_interface:
@@ -86,7 +88,7 @@ keys:
               type: list
               primary_key: name
               convert_types:
-              - dict
+                - dict
               items:
                 type: dict
                 keys:
@@ -103,7 +105,7 @@ keys:
                     items:
                       type: int
                       convert_types:
-                      - str
+                        - str
       policy:
         type: dict
         keys:
@@ -114,7 +116,7 @@ keys:
                 type: list
                 primary_key: name
                 convert_types:
-                - dict
+                  - dict
                 items:
                   type: dict
                   keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/loopback_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/loopback_interfaces.schema.yml
@@ -7,7 +7,7 @@ keys:
     type: list
     primary_key: name
     convert_types:
-    - dict
+      - dict
     items:
       type: dict
       keys:
@@ -22,6 +22,8 @@ keys:
         vrf:
           type: str
           description: VRF name
+          convert_types:
+            - int
         ip_address:
           type: str
           description: IPv4_address/Mask
@@ -40,7 +42,7 @@ keys:
         ospf_area:
           type: str
           convert_types:
-          - int
+            - int
         mpls:
           type: dict
           keys:
@@ -57,7 +59,7 @@ keys:
         isis_metric:
           type: int
           convert_types:
-          - str
+            - str
         isis_network_point_to_point:
           type: bool
         node_segment:
@@ -66,11 +68,11 @@ keys:
             ipv4_index:
               type: int
               convert_types:
-              - str
+                - str
             ipv6_index:
               type: int
               convert_types:
-              - str
+                - str
         eos_cli:
           type: str
           description: EOS CLI rendered directly on the loopback interface in the final EOS configuration

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_api_gnmi.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_api_gnmi.schema.yml
@@ -26,6 +26,8 @@ keys:
                 vrf:
                   type: str
                   description: VRF name is optional
+                  convert_types:
+                    - int
                 notification_timestamp:
                   type: str
                   valid_values: ["send-time", "last-change-time"]
@@ -58,6 +60,8 @@ keys:
                 vrf:
                   type: str
                   description: VRF name
+                  convert_types:
+                    - int
                 destination:
                   type: dict
                   keys:
@@ -71,7 +75,7 @@ keys:
                       max: 65535
                       required: true
                       convert_types:
-                      - str
+                        - str
                       description: TCP Port
                 local_interface:
                   type: dict
@@ -86,7 +90,7 @@ keys:
                       max: 65535
                       required: true
                       convert_types:
-                      - str
+                        - str
                       description: TCP Port
                 target:
                   type: dict
@@ -108,7 +112,7 @@ keys:
           remove_in_version: "5.0.0"
         primary_key: name
         convert_types:
-        - dict
+          - dict
         description: |
           These should not be mixed with the new keys above.
         items:
@@ -117,6 +121,8 @@ keys:
             name:
               type: str
               description: VRF name
+              convert_types:
+                - int
             access_group:
               type: str
               description: Standard IPv4 ACL name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_api_http.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_api_http.schema.yml
@@ -20,7 +20,7 @@ keys:
         type: list
         primary_key: name
         convert_types:
-        - dict
+          - dict
         items:
           type: dict
           keys:
@@ -28,6 +28,8 @@ keys:
               description: VRF Name
               type: str
               required: true
+              convert_types:
+                - int
             access_group:
               description: Standard IPv4 ACL name
               type: str

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_cvx.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_cvx.schema.yml
@@ -19,3 +19,5 @@ keys:
       vrf:
         type: str
         description: VRF Name
+        convert_types:
+          - int

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_interfaces.schema.yml
@@ -24,6 +24,8 @@ keys:
         vrf:
           type: str
           description: VRF Name
+          convert_types:
+            - int
         ip_address:
           type: str
           description: IPv4_address/Mask

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_ssh.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_ssh.schema.yml
@@ -18,6 +18,8 @@ keys:
             vrf:
               type: str
               description: VRF Name
+              convert_types:
+                - int
       ipv6_access_groups:
         type: list
         items:
@@ -29,10 +31,12 @@ keys:
             vrf:
               type: str
               description: VRF Name
+              convert_types:
+                - int
       idle_timeout:
         type: int
         convert_types:
-        - str
+          - str
         min: 0
         max: 86400
         description: Idle timeout in minutes
@@ -68,14 +72,14 @@ keys:
           limit:
             type: int
             convert_types:
-            - str
+              - str
             min: 1
             max: 100
             description: Maximum total number of SSH sessions to device
           per_host:
             type: int
             convert_types:
-            - str
+              - str
             min: 1
             max: 20
             description: Maximum number of SSH sessions to device from a single host
@@ -83,7 +87,7 @@ keys:
         type: list
         primary_key: name
         convert_types:
-        - dict
+          - dict
         items:
           type: dict
           keys:
@@ -91,6 +95,8 @@ keys:
               type: str
               required: true
               description: VRF Name
+              convert_types:
+                - int
             enable:
               description: Enable SSH in VRF
               type: bool

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/mlag_configuration.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/mlag_configuration.schema.yml
@@ -13,7 +13,7 @@ keys:
         type: int
         description: Heartbeat interval in milliseconds
         convert_types:
-        - str
+          - str
       local_interface:
         description: Local Interface Name
         type: str
@@ -29,27 +29,29 @@ keys:
           vrf:
             description: VRF Name
             type: str
+            convert_types:
+              - int
       dual_primary_detection_delay:
         type: int
         description: Delay in seconds
         min: 0
         max: 86400
         convert_types:
-        - str
+          - str
       dual_primary_recovery_delay_mlag:
         type: int
         description: Delay in seconds
         min: 0
         max: 86400
         convert_types:
-        - str
+          - str
       dual_primary_recovery_delay_non_mlag:
         type: int
         description: Delay in seconds
         min: 0
         max: 86400
         convert_types:
-        - str
+          - str
       peer_link:
         description: Port-Channel interface name
         type: str
@@ -57,9 +59,9 @@ keys:
         type: str
         description: Delay in seconds <0-86400> or 'infinity'
         convert_types:
-        - int
+          - int
       reload_delay_non_mlag:
         type: str
         description: Delay in seconds <0-86400> or 'infinity'
         convert_types:
-        - int
+          - int

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/monitor_connectivity.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/monitor_connectivity.schema.yml
@@ -11,7 +11,7 @@ keys:
       interval:
         type: int
         convert_types:
-        - str
+          - str
       interface_sets:
         type: list
         items:
@@ -51,6 +51,8 @@ keys:
             name:
               description: VRF Name
               type: str
+              convert_types:
+                - int
             description:
               type: str
             interface_sets:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/name_server.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/name_server.schema.yml
@@ -16,6 +16,8 @@ keys:
           vrf:
             description: VRF Name
             type: str
+            convert_types:
+              - int
       nodes:
         type: list
         items:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ntp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ntp.schema.yml
@@ -15,6 +15,8 @@ keys:
           vrf:
             type: str
             description: VRF name
+            convert_types:
+              - int
       servers:
         type: list
         items:
@@ -32,7 +34,7 @@ keys:
               min: 1
               max: 65535
               convert_types:
-              - str
+                - str
             local_interface:
               type: str
               description: Source interface
@@ -41,14 +43,14 @@ keys:
               min: 3
               max: 17
               convert_types:
-              - str
+                - str
               description: Value of maxpoll between 3 - 17 (Logarithmic)
             minpoll:
               type: int
               min: 3
               max: 17
               convert_types:
-              - str
+                - str
               description: Value of minpoll between 3 - 17 (Logarithmic)
             preferred:
               type: bool
@@ -57,10 +59,12 @@ keys:
               min: 1
               max: 4
               convert_types:
-              - str
+                - str
             vrf:
               type: str
               description: VRF name
+              convert_types:
+                - int
       authenticate:
         type: bool
       authenticate_servers_only:
@@ -69,7 +73,7 @@ keys:
         type: list
         primary_key: id
         convert_types:
-        - dict
+          - dict
         items:
           type: dict
           keys:
@@ -78,7 +82,7 @@ keys:
               min: 1
               max: 65534
               convert_types:
-              - str
+                - str
               description: Key identifier
             hash_algorithm:
               type: str
@@ -89,7 +93,7 @@ keys:
             key_type:
               type: str
               convert_types:
-              - int
+                - int
               valid_values: ["0", "7", "8a"]
       trusted_keys:
         type: str

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/port_channel_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/port_channel_interfaces.schema.yml
@@ -7,7 +7,7 @@ keys:
     type: list
     primary_key: name
     convert_types:
-    - dict
+      - dict
     items:
       type: dict
       keys:
@@ -29,13 +29,13 @@ keys:
         l2_mtu:
           type: int
           convert_types:
-          - str
+            - str
           description: |
             "l2_mtu" should only be defined for platforms supporting the "l2 mtu" CLI
         vlans:
           type: str
           convert_types:
-          - int
+            - int
           description: |
             List of switchport vlans as string
             For a trunk port this would be a range like "1-200,300"
@@ -45,10 +45,10 @@ keys:
         type:
           type: str
           valid_values:
-          - routed
-          - switched
-          - l3dot1q
-          - l2dot1q
+            - routed
+            - switched
+            - l3dot1q
+            - l2dot1q
           description: |
             l3dot1q and l2dot1q are used for sub-interfaces. The parent interface should be defined as routed.
             Interface will not be listed in device documentation, unless "type" is set.
@@ -56,10 +56,12 @@ keys:
           type: int
           description: VLAN tag to configure on sub-interface
           convert_types:
-          - str
+            - str
         vrf:
           type: str
           description: VRF name
+          convert_types:
+            - int
         encapsulation_vlan:
           type: dict
           keys:
@@ -72,17 +74,17 @@ keys:
                     vlan:
                       type: int
                       convert_types:
-                      - str
+                        - str
                       description: Client VLAN ID
                     outer:
                       type: int
                       convert_types:
-                      - str
+                        - str
                       description: Client Outer VLAN ID
                     inner:
                       type: int
                       convert_types:
-                      - str
+                        - str
                       description: Client Inner VLAN ID
                 unmatched:
                   type: bool
@@ -96,37 +98,37 @@ keys:
                     vlan:
                       type: int
                       convert_types:
-                      - str
+                        - str
                       description: Network VLAN ID
                     outer:
                       type: int
                       convert_types:
-                      - str
+                        - str
                       description: Network Outer VLAN ID
                     inner:
                       type: int
                       convert_types:
-                      - str
+                        - str
                       description: Network Inner VLAN ID
                 client:
                   type: bool
         vlan_id:
           type: int
           convert_types:
-          - str
+            - str
           min: 1
           max: 4094
         mode:
           type: str
           valid_values:
-          - access
-          - dot1q-tunnel
-          - trunk
-          - trunk phone
+            - access
+            - dot1q-tunnel
+            - trunk
+            - trunk phone
         native_vlan:
           type: int
           convert_types:
-          - str
+            - str
           description: If setting both native_vlan and native_vlan_tag, native_vlan_tag takes precedence
         native_vlan_tag:
           type: bool
@@ -144,20 +146,20 @@ keys:
               direction:
                 type: str
                 valid_values:
-                - upstream
-                - downstream
+                  - upstream
+                  - downstream
         phone:
           type: dict
           keys:
             trunk:
               type: str
               valid_values:
-              - tagged
-              - untagged
+                - tagged
+                - untagged
             vlan:
               type: int
               convert_types:
-              - str
+                - str
               min: 1
               max: 4094
         l2_protocol:
@@ -166,7 +168,7 @@ keys:
             encapsulation_dot1q_vlan:
               type: int
               convert_types:
-              - str
+                - str
               description: Vlan tag to configure on sub-interface
             forwarding_profile:
               type: str
@@ -174,11 +176,11 @@ keys:
         mtu:
           type: int
           convert_types:
-          - str
+            - str
         mlag:
           type: int
           convert_types:
-          - str
+            - str
           description: MLAG ID
           min: 1
           max: 2000
@@ -190,33 +192,33 @@ keys:
           type: int
           description: Timeout in seconds
           convert_types:
-          - str
+            - str
           default: 90
           min: 0
           max: 300
         lacp_fallback_mode:
           type: str
           valid_values:
-          - individual
-          - static
+            - individual
+            - static
         qos:
           type: dict
           keys:
             trust:
               type: str
               valid_values:
-              - dscp
-              - cos
-              - disabled
+                - dscp
+                - cos
+                - disabled
             dscp:
               type: int
               convert_types:
-              - str
+                - str
               description: DSCP value
             cos:
               type: int
               convert_types:
-              - str
+                - str
               description: COS value
         bfd:
           type: dict
@@ -227,16 +229,16 @@ keys:
               type: int
               description: Interval in milliseconds
               convert_types:
-              - str
+                - str
             min_rx:
               type: int
               description: Rate in milliseconds
               convert_types:
-              - str
+                - str
             multiplier:
               type: int
               convert_types:
-              - str
+                - str
               min: 3
               max: 50
         service_policy:
@@ -273,7 +275,7 @@ keys:
           type: str
           description: List of vlans as string
           convert_types:
-          - int
+            - int
         vlan_translations:
           type: list
           items:
@@ -282,19 +284,19 @@ keys:
               from:
                 type: str
                 convert_types:
-                - int
+                  - int
                 description: List of vlans as string (only one vlan if direction is "both")
               to:
                 type: int
                 convert_types:
-                - str
+                  - str
                 description: VLAN ID
               direction:
                 type: str
                 valid_values:
-                - in
-                - out
-                - both
+                  - in
+                  - out
+                  - both
                 default: both
         shape:
           type: dict
@@ -317,15 +319,15 @@ keys:
                 level:
                   type: str
                   convert_types:
-                  - int
-                  - float
+                    - int
+                    - float
                   description: Configure maximum storm-control level
                 unit:
                   type: str
                   default: percent
                   valid_values:
-                  - percent
-                  - pps
+                    - percent
+                    - pps
                   description: Optional field and is hardware dependant
             broadcast:
               type: dict
@@ -333,15 +335,15 @@ keys:
                 level:
                   type: str
                   convert_types:
-                  - int
-                  - float
+                    - int
+                    - float
                   description: Configure maximum storm-control level
                 unit:
                   type: str
                   default: percent
                   valid_values:
-                  - percent
-                  - pps
+                    - percent
+                    - pps
                   description: Optional field and is hardware dependant
             multicast:
               type: dict
@@ -349,15 +351,15 @@ keys:
                 level:
                   type: str
                   convert_types:
-                  - int
-                  - float
+                    - int
+                    - float
                   description: Configure maximum storm-control level
                 unit:
                   type: str
                   default: percent
                   valid_values:
-                  - percent
-                  - pps
+                    - percent
+                    - pps
                   description: Optional field and is hardware dependant
             unknown_unicast:
               type: dict
@@ -365,15 +367,15 @@ keys:
                 level:
                   type: str
                   convert_types:
-                  - int
-                  - float
+                    - int
+                    - float
                   description: Configure maximum storm-control level
                 unit:
                   type: str
                   default: percent
                   valid_values:
-                  - percent
-                  - pps
+                    - percent
+                    - pps
                   description: Optional field and is hardware dependant
         ip_proxy_arp:
           type: bool
@@ -385,22 +387,22 @@ keys:
         isis_metric:
           type: int
           convert_types:
-          - str
+            - str
         isis_network_point_to_point:
           type: bool
         isis_circuit_type:
           type: str
           valid_values:
-          - level-1-2
-          - level-1
-          - level-2
+            - level-1-2
+            - level-1
+            - level-2
         isis_hello_padding:
           type: bool
         isis_authentication_mode:
           type: str
           valid_values:
-          - text
-          - md5
+            - text
+            - md5
         isis_authentication_key:
           type: str
           description: Type-7 encrypted password
@@ -422,22 +424,22 @@ keys:
             redundancy:
               type: str
               valid_values:
-              - all-active
-              - single-active
+                - all-active
+                - single-active
             designated_forwarder_election:
               type: dict
               keys:
                 algorithm:
                   type: str
                   valid_values:
-                  - modulus
-                  - preference
+                    - modulus
+                    - preference
                 preference_value:
                   type: int
                   min: 0
                   max: 65535
                   convert_types:
-                  - str
+                    - str
                   description: Preference_value is only used when "algorithm" is "preference"
                 dont_preempt:
                   type: bool
@@ -446,11 +448,11 @@ keys:
                 hold_time:
                   type: int
                   convert_types:
-                  - str
+                    - str
                 subsequent_hold_time:
                   type: int
                   convert_types:
-                  - str
+                    - str
                 candidate_reachability_required:
                   type: bool
             mpls:
@@ -459,13 +461,13 @@ keys:
                 shared_index:
                   type: int
                   convert_types:
-                  - str
+                    - str
                   min: 1
                   max: 1024
                 tunnel_flood_filter_time:
                   type: int
                   convert_types:
-                  - str
+                    - str
             route_target:
               type: str
               description: EVPN Route Target for ESI with format xx:xx:xx:xx:xx:xx
@@ -493,24 +495,24 @@ keys:
         spanning_tree_bpdufilter:
           type: str
           convert_types:
-          - bool
+            - bool
           valid_values: ["enabled", "disabled", "True", "False", "true", "false"]
         spanning_tree_bpduguard:
           type: str
           convert_types:
-          - bool
+            - bool
           valid_values: ["enabled", "disabled", "True", "False", "true", "false"]
         spanning_tree_guard:
           type: str
           valid_values:
-          - loop
-          - root
-          - disabled
+            - loop
+            - root
+            - disabled
         spanning_tree_portfast:
           type: str
           valid_values:
-          - edge
-          - network
+            - edge
+            - network
         vmtracer:
           type: bool
         ptp:
@@ -524,43 +526,43 @@ keys:
                 interval:
                   type: int
                   convert_types:
-                  - str
+                    - str
                 timeout:
                   type: int
                   convert_types:
-                  - str
+                    - str
             delay_req:
               type: int
               convert_types:
-              - str
+                - str
             delay_mechanism:
               type: str
               valid_values:
-              - e2e
-              - p2p
+                - e2e
+                - p2p
             sync_message:
               type: dict
               keys:
                 interval:
                   type: int
                   convert_types:
-                  - str
+                    - str
             role:
               type: str
               valid_values:
-              - master
-              - dynamic
+                - master
+                - dynamic
             vlan:
               type: str
               convert_types:
-              - int
+                - int
               description: VLAN can be 'all' or list of vlans as string
             transport:
               type: str
               valid_values:
-              - ipv4
-              - ipv6
-              - layer2
+                - ipv4
+                - ipv6
+                - layer2
         ip_address:
           type: str
           description: IPv4 address/mask
@@ -582,7 +584,7 @@ keys:
           type: list
           primary_key: ipv6_prefix
           convert_types:
-          - dict
+            - dict
           items:
             type: dict
             keys:
@@ -592,12 +594,12 @@ keys:
               valid_lifetime:
                 type: str
                 convert_types:
-                - int
+                  - int
                 description: Infinite or lifetime in seconds
               preferred_lifetime:
                 type: str
                 convert_types:
-                - int
+                  - int
                 description: Infinite or lifetime in seconds
               no_autoconfig_flag:
                 type: bool
@@ -628,7 +630,7 @@ keys:
                 dr_priority:
                   type: int
                   convert_types:
-                  - str
+                    - str
                   min: 0
                   max: 429467295
                 sparse_mode:
@@ -641,17 +643,17 @@ keys:
         ospf_area:
           type: str
           convert_types:
-          - int
+            - int
         ospf_cost:
           type: int
           convert_types:
-          - str
+            - str
         ospf_authentication:
           type: str
           valid_values:
-          - none
-          - simple
-          - message-digest
+            - none
+            - simple
+            - message-digest
         ospf_authentication_key:
           type: str
           description: Encrypted password
@@ -659,23 +661,23 @@ keys:
           type: list
           primary_key: id
           convert_types:
-          - dict
+            - dict
           items:
             type: dict
             keys:
               id:
                 type: int
                 convert_types:
-                - str
+                  - str
                 required: true
               hash_algorithm:
                 type: str
                 valid_values:
-                - md5
-                - sha1
-                - sha256
-                - sha384
-                - sha512
+                  - md5
+                  - sha1
+                  - sha256
+                  - sha384
+                  - sha512
               key:
                 type: str
                 description: Encrypted password

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/queue_monitor_streaming.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/queue_monitor_streaming.schema.yml
@@ -22,3 +22,5 @@ keys:
         max: 100
       vrf:
         type: str
+        convert_types:
+          - int

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/radius_server.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/radius_server.schema.yml
@@ -22,7 +22,7 @@ keys:
             min: 0
             max: 65535
             convert_types:
-            - str
+              - str
             description: TCP Port
           tls_ssl_profile:
             type: str
@@ -38,18 +38,20 @@ keys:
               description: Host IP address or name
             vrf:
               type: str
+              convert_types:
+                - int
             timeout:
               type: int
               min: 1
               max: 1000
               convert_types:
-              - str
+                - str
             retransmit:
               type: int
               min: 0
               max: 100
               convert_types:
-              - str
+                - str
             key:
               type: str
               description: Encrypted key

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/radius_servers.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/radius_servers.schema.yml
@@ -17,6 +17,8 @@ keys:
           description: Host IP address or name
         vrf:
           type: str
+          convert_types:
+            - int
         key:
           type: str
           description: Encrypted key

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_bgp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_bgp.schema.yml
@@ -1393,6 +1393,8 @@ keys:
             name:
               type: str
               description: VRF name
+              convert_types:
+                - int
             rd:
               type: str
               description: Route distinguisher

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_general.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_general.schema.yml
@@ -31,6 +31,8 @@ keys:
               type: str
               required: true
               description: Destination-VRF
+              convert_types:
+                - int
             leak_routes:
               type: list
               items:
@@ -38,6 +40,8 @@ keys:
                 keys:
                   source_vrf:
                     type: str
+                    convert_types:
+                      - int
                   subscribe_policy:
                     type: str
                     description: Route-Map Policy

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_msdp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_msdp.schema.yml
@@ -12,7 +12,7 @@ keys:
       rejected_limit:
         type: int
         convert_types:
-        - str
+          - str
         description: Maximum number of rejected SA messages allowed in cache
         min: 0
         max: 40000
@@ -21,7 +21,7 @@ keys:
       connection_retry_interval:
         type: int
         convert_types:
-        - str
+          - str
         min: 1
         max: 65535
       group_limits:
@@ -37,7 +37,7 @@ keys:
             limit:
               type: int
               convert_types:
-              - str
+                - str
               description: Limit for SAs matching the source address prefix
               min: 0
               max: 40000
@@ -70,7 +70,7 @@ keys:
             sa_limit:
               type: int
               convert_types:
-              - str
+                - str
               description: Maximum number of SA messages allowed in cache
               min: 0
               max: 40000
@@ -90,14 +90,14 @@ keys:
                 keepalive_timer:
                   type: int
                   convert_types:
-                  - str
+                    - str
                   required: true
                   min: 1
                   max: 65535
                 hold_timer:
                   type: int
                   convert_types:
-                  - str
+                    - str
                   required: true
                   description: Must be greater than keepalive timer
                   min: 1
@@ -121,13 +121,15 @@ keys:
               type: str
               required: true
               description: VRF name
+              convert_types:
+                - int
             originator_id_local_interface:
               type: str
               description: Interface to use for originator ID
             rejected_limit:
               type: int
               convert_types:
-              - str
+                - str
               description: Maximum number of rejected SA messages allowed in cache
               min: 0
               max: 40000
@@ -136,7 +138,7 @@ keys:
             connection_retry_interval:
               type: int
               convert_types:
-              - str
+                - str
               min: 1
               max: 65535
             group_limits:
@@ -152,7 +154,7 @@ keys:
                   limit:
                     type: int
                     convert_types:
-                    - str
+                      - str
                     description: Limit for SAs matching the source address prefix
                     min: 0
                     max: 40000
@@ -185,7 +187,7 @@ keys:
                   sa_limit:
                     type: int
                     convert_types:
-                    - str
+                      - str
                     description: Maximum number of SA messages allowed in cache
                     min: 0
                     max: 40000
@@ -205,14 +207,14 @@ keys:
                       keepalive_timer:
                         type: int
                         convert_types:
-                        - str
+                          - str
                         required: true
                         min: 1
                         max: 65535
                       hold_timer:
                         type: int
                         convert_types:
-                        - str
+                          - str
                         required: true
                         description: Must be greater than keepalive timer
                         min: 1

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_multicast.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_multicast.schema.yml
@@ -18,7 +18,7 @@ keys:
                 min: 0
                 max: 600
                 convert_types:
-                - str
+                  - str
           routing:
             type: bool
           multipath:
@@ -55,7 +55,7 @@ keys:
                             min: 1
                             max: 255
                             convert_types:
-                            - str
+                              - str
       vrfs:
         type: list
         primary_key: name
@@ -64,6 +64,8 @@ keys:
           keys:
             name:
               type: str
+              convert_types:
+                - int
             ipv4:
               type: dict
               keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_ospf.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_ospf.schema.yml
@@ -23,6 +23,8 @@ keys:
             vrf:
               type: str
               description: VRF Name for OSPF Process
+              convert_types:
+                - int
             passive_interface_default:
               type: bool
             router_id:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_pim_sparse_mode.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_pim_sparse_mode.schema.yml
@@ -23,7 +23,7 @@ keys:
             # this primary_key should also be removed. TODO: AVD5.0
             primary_key: address
             convert_types:
-            - dict
+              - dict
             items:
               type: dict
               keys:
@@ -34,7 +34,7 @@ keys:
                 groups:
                   type: list
                   convert_types:
-                  - dict
+                    - dict
                   items:
                     type: str
                 access_lists:
@@ -55,7 +55,7 @@ keys:
             type: list
             primary_key: address
             convert_types:
-            - dict
+              - dict
             items:
               type: dict
               keys:
@@ -67,7 +67,7 @@ keys:
                   type: list
                   primary_key: address
                   convert_types:
-                  - dict
+                    - dict
                   items:
                     type: dict
                     keys:
@@ -78,7 +78,7 @@ keys:
                       register_count:
                         type: int
                         convert_types:
-                        - str
+                          - str
       vrfs:
         type: list
         primary_key: name
@@ -89,6 +89,8 @@ keys:
               type: str
               description: VRF Name
               required: true
+              convert_types:
+                - int
             ipv4:
               type: dict
               keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/sflow.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/sflow.schema.yml
@@ -10,29 +10,31 @@ keys:
       sample:
         type: int
         convert_types:
-        - str
+          - str
       dangerous:
         type: bool
       polling_interval:
         type: int
         convert_types:
-        - str
+          - str
         description: Polling interval in seconds
       vrfs:
         type: list
         primary_key: name
         convert_types:
-        - dict
+          - dict
         items:
           type: dict
           keys:
             name:
               type: str
+              convert_types:
+                - int
             destinations:
               type: list
               primary_key: destination
               convert_types:
-              - dict
+                - dict
               items:
                 type: dict
                 keys:
@@ -43,7 +45,7 @@ keys:
                     type: int
                     description: Port Number
                     convert_types:
-                    - str
+                      - str
             source:
               type: str
               description: |
@@ -56,7 +58,7 @@ keys:
         type: list
         primary_key: destination
         convert_types:
-        - dict
+          - dict
         items:
           type: dict
           keys:
@@ -67,7 +69,7 @@ keys:
               type: int
               description: Port Number
               convert_types:
-              - str
+                - str
       source:
         type: str
         description: |
@@ -107,7 +109,7 @@ keys:
           sample:
             type: int
             convert_types:
-            - str
+              - str
           modules:
             type: list
             primary_key: name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/snmp_server.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/snmp_server.schema.yml
@@ -13,7 +13,7 @@ keys:
           local:
             type: str
             convert_types:
-            - int
+              - int
             description: |
               Engine ID in hexadecimal
           remotes:
@@ -24,7 +24,7 @@ keys:
                 id:
                   type: str
                   convert_types:
-                  - int
+                    - int
                   description: |
                     Remote engine ID in hexadecimal
                 address:
@@ -34,7 +34,7 @@ keys:
                 udp_port:
                   type: int
                   convert_types:
-                  - str
+                    - str
       contact:
         type: str
         description: SNMP contact
@@ -45,7 +45,7 @@ keys:
         type: list
         primary_key: name
         convert_types:
-        - dict
+          - dict
         items:
           type: dict
           keys:
@@ -79,6 +79,8 @@ keys:
               description: IPv4 access list name
             vrf:
               type: str
+              convert_types:
+                - int
       ipv6_acls:
         type: list
         items:
@@ -89,11 +91,13 @@ keys:
               description: IPv6 access list name
             vrf:
               type: str
+              convert_types:
+                - int
       local_interfaces:
         type: list
         primary_key: name
         convert_types:
-        - dict
+          - dict
         items:
           type: dict
           keys:
@@ -103,6 +107,8 @@ keys:
               description: Interface name
             vrf:
               type: str
+              convert_types:
+                - int
       views:
         type: list
         items:
@@ -163,7 +169,7 @@ keys:
             udp_port:
               type: int
               convert_types:
-              - str
+                - str
               description: |
                 udp_port will not be used if no remote_address is configured
             version:
@@ -172,7 +178,7 @@ keys:
             localized:
               type: str
               convert_types:
-              - int
+                - int
               description: |
                 Engine ID in hexadecimal for localizing auth and/or priv
             auth:
@@ -201,10 +207,12 @@ keys:
               description: Host IP address or name
             vrf:
               type: str
+              convert_types:
+                - int
             version:
               type: str
               convert_types:
-              - int
+                - int
               valid_values: ["1", "2c", "3"]
             community:
               type: str
@@ -251,5 +259,7 @@ keys:
             name:
               type: str
               description: VRF name
+              convert_types:
+                - int
             enable:
               type: bool

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/static_routes.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/static_routes.schema.yml
@@ -11,6 +11,8 @@ keys:
         vrf:
           type: str
           description: VRF Name
+          convert_types:
+            - int
         destination_address_prefix:
           type: str
           description: IPv4_network/Mask

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/system.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/system.schema.yml
@@ -23,7 +23,7 @@ keys:
             type: list
             primary_key: acl_name
             convert_types:
-            - dict
+              - dict
             items:
               type: dict
               keys:
@@ -31,11 +31,13 @@ keys:
                   type: str
                 vrf:
                   type: str
+                  convert_types:
+                    - int
           ipv6_access_groups:
             type: list
             primary_key: acl_name
             convert_types:
-            - dict
+              - dict
             items:
               type: dict
               keys:
@@ -43,3 +45,5 @@ keys:
                   type: str
                 vrf:
                   type: str
+                  convert_types:
+                    - int

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/tacacs_servers.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/tacacs_servers.schema.yml
@@ -16,6 +16,8 @@ keys:
               description: Host IP address or name
             vrf:
               type: str
+              convert_types:
+                - int
             key:
               type: str
               description: Encrypted key

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/tunnel_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/tunnel_interfaces.schema.yml
@@ -28,6 +28,8 @@ keys:
         vrf:
           type: str
           description: VRF Name
+          convert_types:
+            - int
         ip_address:
           type: str
           format: ipv4_cidr

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/virtual_source_nat_vrfs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/virtual_source_nat_vrfs.schema.yml
@@ -14,6 +14,8 @@ keys:
         name:
           type: str
           description: VRF Name
+          convert_types:
+            - int
         ip_address:
           type: str
           description: IPv4 Address

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/vlan_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/vlan_interfaces.schema.yml
@@ -7,7 +7,7 @@ keys:
     type: list
     primary_key: name
     convert_types:
-    - dict
+      - dict
     items:
       type: dict
       keys:
@@ -22,17 +22,19 @@ keys:
         vrf:
           type: str
           description: VRF name
+          convert_types:
+            - int
         arp_aging_timeout:
           type: int
           convert_types:
-          - str
+            - str
           description: In seconds
           min: 1
           max: 65535
         arp_cache_dynamic_capacity:
           type: int
           convert_types:
-          - str
+            - str
           min: 0
           max: 4294967295
         arp_gratuitous_accept:
@@ -69,14 +71,14 @@ keys:
         ip_igmp_version:
           type: int
           convert_types:
-          - str
+            - str
           min: 1
           max: 3
         ip_helpers:
           type: list
           description: List of DHCP servers
           convert_types:
-          - dict
+            - dict
           primary_key: ip_helper
           items:
             type: dict
@@ -90,6 +92,8 @@ keys:
               vrf:
                 type: str
                 description: VRF where DHCP server can be reached
+                convert_types:
+                  - int
         ip_nat:
           $ref: "#/$defs/interface_ip_nat"
         ipv6_enable:
@@ -137,7 +141,7 @@ keys:
         ipv6_nd_prefixes:
           type: list
           convert_types:
-          - dict
+            - dict
           primary_key: ipv6_prefix
           items:
             type: dict
@@ -149,12 +153,12 @@ keys:
                 type: str
                 description: In seconds <0-4294967295> or infinite
                 convert_types:
-                - int
+                  - int
               preferred_lifetime:
                 type: str
                 description: In seconds <0-4294967295> or infinite
                 convert_types:
-                - int
+                  - int
               no_autoconfig_flag:
                 type: bool
         ipv6_dhcp_relay_destinations:
@@ -169,6 +173,8 @@ keys:
                 required: true
               vrf:
                 type: str
+                convert_types:
+                  - int
               local_interface:
                 type: str
                 description: Local interface to communicate with DHCP server - mutually exclusive to source_address
@@ -217,7 +223,7 @@ keys:
                     administrative_distance:
                       type: int
                       convert_types:
-                      - str
+                        - str
                       min: 1
                       max: 255
                 static:
@@ -244,7 +250,7 @@ keys:
                     administrative_distance:
                       type: int
                       convert_types:
-                      - str
+                        - str
                       min: 1
                       max: 255
                 static:
@@ -254,17 +260,17 @@ keys:
         ospf_area:
           type: str
           convert_types:
-          - int
+            - int
         ospf_cost:
           type: int
           convert_types:
-          - str
+            - str
         ospf_authentication:
           type: str
           valid_values:
-          - none
-          - simple
-          - message-digest
+            - none
+            - simple
+            - message-digest
         ospf_authentication_key:
           type: str
           description: Encrypted password used for simple authentication
@@ -272,7 +278,7 @@ keys:
           type: list
           description: Keys used for message-digest authentication
           convert_types:
-          - dict
+            - dict
           primary_key: id
           items:
             type: dict
@@ -280,15 +286,15 @@ keys:
               id:
                 type: int
                 convert_types:
-                - str
+                  - str
               hash_algorithm:
                 type: str
                 valid_values:
-                - md5
-                - sha1
-                - sha256
-                - sha384
-                - sha512
+                  - md5
+                  - sha1
+                  - sha256
+                  - sha384
+                  - sha512
               key:
                 type: str
                 description: Encrypted password
@@ -301,7 +307,7 @@ keys:
                 dr_priority:
                   type: int
                   convert_types:
-                  - str
+                    - str
                   min: 0
                   max: 429467295
                 sparse_mode:
@@ -316,13 +322,13 @@ keys:
         isis_metric:
           type: int
           convert_types:
-          - str
+            - str
         isis_network_point_to_point:
           type: bool
         mtu:
           type: int
           convert_types:
-          - str
+            - str
         no_autostate:
           type: bool
         vrrp_ids:
@@ -335,12 +341,12 @@ keys:
               id:
                 type: int
                 convert_types:
-                - str
+                  - str
                 description: VRID
               priority_level:
                 type: int
                 convert_types:
-                - str
+                  - str
                 description: Instance priority
               advertisement:
                 type: dict
@@ -348,7 +354,7 @@ keys:
                   interval:
                     type: int
                     convert_types:
-                    - str
+                      - str
                     description: Interval in seconds
               preempt:
                 type: dict
@@ -362,12 +368,12 @@ keys:
                       minimum:
                         type: int
                         convert_types:
-                        - str
+                          - str
                         description: Minimum preempt delay in seconds
                       reload:
                         type: int
                         convert_types:
-                        - str
+                          - str
                         description: Reload preempt delay in seconds
               timers:
                 type: dict
@@ -379,7 +385,7 @@ keys:
                         type: int
                         description: Delay after reload in seconds.
                         convert_types:
-                        - str
+                          - str
               tracked_object:
                 type: list
                 primary_key: name
@@ -392,7 +398,7 @@ keys:
                     decrement:
                       type: int
                       convert_types:
-                      - str
+                        - str
                       min: 1
                       max: 254
                       description: Decrement VRRP priority by 1-254
@@ -408,10 +414,10 @@ keys:
                   version:
                     type: int
                     convert_types:
-                    - str
+                      - str
                     valid_values:
-                    - 2
-                    - 3
+                      - 2
+                      - 3
               ipv6:
                 type: dict
                 keys:
@@ -434,16 +440,16 @@ keys:
             priority:
               type: int
               convert_types:
-              - str
+                - str
               description: Instance priority
             advertisement_interval:
               type: int
               convert_types:
-              - str
+                - str
             preempt_delay_minimum:
               type: int
               convert_types:
-              - str
+                - str
             ipv4:
               type: str
               description: Virtual IPv4 address
@@ -459,7 +465,7 @@ keys:
             distance:
               type: int
               convert_types:
-              - str
+                - str
               min: 1
               max: 255
         bfd:
@@ -470,17 +476,17 @@ keys:
             interval:
               type: int
               convert_types:
-              - str
+                - str
               description: Rate in milliseconds
             min_rx:
               type: int
               convert_types:
-              - str
+                - str
               description: Minimum RX hold time in milliseconds
             multiplier:
               type: int
               convert_types:
-              - str
+                - str
               min: 3
               max: 50
         service_policy:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/vrfs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/vrfs.schema.yml
@@ -16,6 +16,8 @@ keys:
         name:
           type: str
           description: VRF Name
+          convert_types:
+            - int
         description:
           type: str
         ip_routing:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/vxlan_interface.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/vxlan_interface.schema.yml
@@ -28,7 +28,7 @@ keys:
               udp_port:
                 type: int
                 convert_types:
-                - str
+                  - str
               virtual_router_encapsulation_mac_address:
                 type: str
                 description: |
@@ -39,15 +39,15 @@ keys:
                   interval:
                     type: int
                     convert_types:
-                    - str
+                      - str
                   min_rx:
                     type: int
                     convert_types:
-                    - str
+                      - str
                   multiplier:
                     type: int
                     convert_types:
-                    - str
+                      - str
                     min: 3
                     max: 50
                   prefix_list:
@@ -66,20 +66,20 @@ keys:
                 type: list
                 primary_key: id
                 convert_types:
-                - dict
+                  - dict
                 items:
                   type: dict
                   keys:
                     id:
                       type: int
                       convert_types:
-                      - str
+                        - str
                       required: true
                       description: VLAN ID
                     vni:
                       type: int
                       convert_types:
-                      - str
+                        - str
                     multicast_group:
                       type: str
                       description: IP Multicast Group Address
@@ -92,7 +92,7 @@ keys:
                 type: list
                 primary_key: name
                 convert_types:
-                - dict
+                  - dict
                 items:
                   type: dict
                   keys:
@@ -100,10 +100,12 @@ keys:
                       type: str
                       required: true
                       description: VRF Name
+                      convert_types:
+                        - int
                     vni:
                       type: int
                       convert_types:
-                      - str
+                        - str
                     multicast_group:
                       type: str
                       description: IP Multicast Group Address

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
@@ -1093,6 +1093,8 @@ keys:
     type: str
     default: MGMT
     description: OOB Management VRF.
+    convert_types:
+    - int
   mgmt_vrf_routing:
     documentation_options:
       filename: Input Variables
@@ -3289,6 +3291,8 @@ $defs:
             keys:
               name:
                 type: str
+                convert_types:
+                - int
               address_families:
                 type: list
                 items:
@@ -3366,6 +3370,8 @@ $defs:
                       type: str
                       description: VRF to originate DHCP relay packets to DHCP server.
                         If not set, uses current VRF
+                      convert_types:
+                      - int
               enable_mlag_ibgp_peering_vrfs:
                 type: bool
                 description: 'MLAG iBGP peering per VRF.
@@ -5099,6 +5105,8 @@ $defs:
               it must be set on each applicable node/node-group/node-type as needed.'
             type: str
             default: default
+            convert_types:
+            - int
           inband_mgmt_mtu:
             description: 'MTU configured on the Inband Management Interface.
 
@@ -5685,6 +5693,8 @@ $defs:
               type: str
               description: VRF to originate DHCP relay packets to DHCP server. If
                 not set, EOS uses the VRF on the SVI.
+              convert_types:
+              - int
       vni_override:
         type: int
         convert_types:

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/defs_network_services.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/defs_network_services.schema.yml
@@ -218,6 +218,8 @@ $defs:
             keys:
               name:
                 type: str
+                convert_types:
+                  - int
               address_families:
                 type: list
                 items:
@@ -276,6 +278,8 @@ $defs:
                     source_vrf:
                       type: str
                       description: VRF to originate DHCP relay packets to DHCP server. If not set, uses current VRF
+                      convert_types:
+                        - int
               enable_mlag_ibgp_peering_vrfs:
                 type: bool
                 description: |

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/defs_node_type.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/defs_node_type.schema.yml
@@ -630,6 +630,8 @@ $defs:
               This setting is only applied on the devices where it is set, it does not automatically affect any parent/child devices configuration, so it must be set on each applicable node/node-group/node-type as needed.
             type: str
             default: "default"
+            convert_types:
+              - int
           inband_mgmt_mtu:
             description: |-
               MTU configured on the Inband Management Interface.

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/defs_svi_settings.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/defs_svi_settings.schema.yml
@@ -95,6 +95,8 @@ $defs:
             source_vrf:
               type: str
               description: VRF to originate DHCP relay packets to DHCP server. If not set, EOS uses the VRF on the SVI.
+              convert_types:
+                - int
       vni_override:
         type: int
         convert_types:

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/mgmt_interface_vrf.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/mgmt_interface_vrf.schema.yml
@@ -10,3 +10,5 @@ keys:
     type: str
     default: MGMT
     description: OOB Management VRF.
+    convert_types:
+      - int


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Update schema keys for VRFs to accept numeric VRF names

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Added a molecule coverage for tenant VRFs. We are not testing every place we use VRFs, but we have plenty of test coverage for type conversion already.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
