### PR TITLE
Fix(eos_designs): Schema validation for connected endpoints not executed

### DIFF
--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/group_vars/CONNECTED_ENDPOINTS.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/group_vars/CONNECTED_ENDPOINTS.yml
@@ -2,53 +2,53 @@
 # Definition of connected endpoints in the fabric.
 servers:
   # Name of the defined server.
-  dc1-leaf1-server1:
+  - name: dc1-leaf1-server1
     # Definition of adapters on the server.
     adapters:
-      # Name of the server interfaces that will be used in the description of each interface
-    - endpoint_ports: [ PCI1, PCI2 ]
-      # Device ports where the server ports are connected.
-      switch_ports: [ Ethernet5, Ethernet5 ]
-      # Device names where the server ports are connected.
-      switches: [ dc1-leaf1a, dc1-leaf1b ]
-      # VLANs that will be configured on these ports.
-      vlans: 11-12,21-22
-      # Native VLAN to be used on these ports.
-      native_vlan: 4092
-      # L2 mode of the port.
-      mode: trunk
-      # Spanning tree portfast configuration on this port.
-      spanning_tree_portfast: edge
-      # Definition of the pair of ports as port channel.
-      port_channel:
-        # Description of the port channel interface.
-        description: PortChannel dc1-leaf1-server1
-        # Port channel mode for LACP.
-        mode: active
+        # Name of the server interfaces that will be used in the description of each interface
+      - endpoint_ports: [ PCI1, PCI2 ]
+        # Device ports where the server ports are connected.
+        switch_ports: [ Ethernet5, Ethernet5 ]
+        # Device names where the server ports are connected.
+        switches: [ dc1-leaf1a, dc1-leaf1b ]
+        # VLANs that will be configured on these ports.
+        vlans: 11-12,21-22
+        # Native VLAN to be used on these ports.
+        native_vlan: 4092
+        # L2 mode of the port.
+        mode: trunk
+        # Spanning tree portfast configuration on this port.
+        spanning_tree_portfast: edge
+        # Definition of the pair of ports as port channel.
+        port_channel:
+          # Description of the port channel interface.
+          description: PortChannel dc1-leaf1-server1
+          # Port channel mode for LACP.
+          mode: active
 
-    - endpoint_ports: [ iLO ]
-      switch_ports: [ Ethernet5 ]
-      switches: [ dc1-leaf1c ]
-      vlans: 11
-      mode: access
-      spanning_tree_portfast: edge
+      - endpoint_ports: [ iLO ]
+        switch_ports: [ Ethernet5 ]
+        switches: [ dc1-leaf1c ]
+        vlans: 11
+        mode: access
+        spanning_tree_portfast: edge
 
-  dc1-leaf2-server1:
+  - name: dc1-leaf2-server1
     adapters:
-    - endpoint_ports: [ PCI1, PCI2 ]
-      switch_ports: [ Ethernet5, Ethernet5 ]
-      switches: [ dc1-leaf2a, dc1-leaf2b ]
-      vlans: 11-12,21-22
-      native_vlan: 4092
-      mode: trunk
-      spanning_tree_portfast: edge
-      port_channel:
-        description: PortChannel dc1-leaf2-server1
-        mode: active
+      - endpoint_ports: [ PCI1, PCI2 ]
+        switch_ports: [ Ethernet5, Ethernet5 ]
+        switches: [ dc1-leaf2a, dc1-leaf2b ]
+        vlans: 11-12,21-22
+        native_vlan: 4092
+        mode: trunk
+        spanning_tree_portfast: edge
+        port_channel:
+          description: PortChannel dc1-leaf2-server1
+          mode: active
 
-    - endpoint_ports: [ iLO ]
-      switch_ports: [ Ethernet5 ]
-      switches: [ dc1-leaf2c ]
-      vlans: 11
-      mode: access
-      spanning_tree_portfast: edge
+      - endpoint_ports: [ iLO ]
+        switch_ports: [ Ethernet5 ]
+        switches: [ dc1-leaf2c ]
+        vlans: 11
+        mode: access
+        spanning_tree_portfast: edge

--- a/ansible_collections/arista/avd/molecule/dhcp_configuration/inventory/group_vars/DC1_SERVERS.yml
+++ b/ansible_collections/arista/avd/molecule/dhcp_configuration/inventory/group_vars/DC1_SERVERS.yml
@@ -1,21 +1,21 @@
 port_profiles:
 
-  TENANT_A_B:
+  - profile: TENANT_A_B
     mode: trunk
     vlans: "110-111,210-211"
 
-  TENANT_A:
+  - profile: TENANT_A
     mode: trunk
     vlans: "110"
 
-  TENANT_B:
+  - profile: TENANT_B
     mode: trunk
     vlans: "210-211"
 
 
 servers:
 
-  server01:
+  - name: server01
     rack: RackB
     adapters:
       - endpoint_ports: [ Eth1 ]
@@ -30,7 +30,7 @@ servers:
           description: PortChanne1
           mode: active
 
-  server02:
+  - name: server02
     rack: RackB
     adapters:
       - endpoint_ports: [ Eth1 ]
@@ -45,7 +45,7 @@ servers:
           description: PortChanne1
           mode: active
 
-  server03:
+  - name: server03
     rack: RackC
     adapters:
       - endpoint_ports: [ Eth1, Eth2 ]
@@ -56,7 +56,7 @@ servers:
           description: PortChanne1
           mode: active
 
-  server04:
+  - name: server04
     rack: RackC
     adapters:
       - endpoint_ports: [ Eth1, Eth2 ]

--- a/ansible_collections/arista/avd/molecule/dhcp_provisioning/inventory/group_vars/DC1_SERVERS.yml
+++ b/ansible_collections/arista/avd/molecule/dhcp_provisioning/inventory/group_vars/DC1_SERVERS.yml
@@ -1,21 +1,21 @@
 port_profiles:
 
-  TENANT_A_B:
+  - profile: TENANT_A_B
     mode: trunk
     vlans: "110-111,210-211"
 
-  TENANT_A:
+  - profile: TENANT_A
     mode: access
     vlans: "110"
 
-  TENANT_B:
+  - profile: TENANT_B
     mode: trunk
     vlans: "210-211"
 
 
 servers:
 
-  server01_MLAG:
+  - name: server01_MLAG
     rack: RackB
     adapters:
       - endpoint_ports: [ Eth2, Eth3 ]
@@ -26,7 +26,7 @@ servers:
           description: PortChanne1
           mode: active
 
-  server02_SINGLE_NODE_TRUNK:
+  - name: server02_SINGLE_NODE_TRUNK
     rack: RackB
     adapters:
       - endpoint_ports: [ Eth1 ]
@@ -34,7 +34,7 @@ servers:
         switches: [ DC1-LEAF1A ]
         profile: TENANT_A_B
 
-  server02_SINGLE_NODE:
+  - name: server02_SINGLE_NODE
     rack: RackB
     adapters:
       - endpoint_ports: [ Eth1 ]
@@ -42,7 +42,7 @@ servers:
         switches: [ DC1-LEAF1A ]
         profile: TENANT_A
 
-  server03_ESI:
+  - name: server03_ESI
     rack: RackC
     adapters:
       - endpoint_ports: [ Eth1, Eth2 ]

--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/converge.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/converge.yml
@@ -32,6 +32,38 @@
               - ansible_failed_result is defined
               - ansible_failed_result.msg == expected_error_message
 
+- name: Converge Negative tests for 'eos_designs_facts'
+  hosts: invalid-schema-connected-endpoints
+  connection: local
+  tasks:
+    - name: Run failure scenario Test
+      block:
+        - name: Trigger Error
+          ansible.builtin.import_role:
+            name: arista.avd.eos_designs
+      rescue:
+        - name: Assert eos_designs failed with the expected error message
+          ansible.builtin.assert:
+            that:
+              - ansible_failed_result is defined
+              - ansible_failed_result.msg == expected_error_message
+
+- name: Converge Negative tests for 'eos_designs_facts'
+  hosts: removed-schema-connected-endpoints
+  connection: local
+  tasks:
+    - name: Run failure scenario Test
+      block:
+        - name: Trigger Error
+          ansible.builtin.import_role:
+            name: arista.avd.eos_designs
+      rescue:
+        - name: Assert eos_designs failed with the expected error message
+          ansible.builtin.assert:
+            that:
+              - ansible_failed_result is defined
+              - ansible_failed_result.msg == expected_error_message
+
 - name: Converge Negative tests for 'eos_designs_structured_config'
   hosts: EOS_DESIGNS_FAILURES
   gather_facts: false

--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/invalid-schema-connected-endpoints.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/invalid-schema-connected-endpoints.yml
@@ -1,0 +1,16 @@
+fabric_name: fabric_invalid_schema_connected_endpoints
+
+type: l2leaf
+l2leaf:
+  nodes:
+    - name: invalid-schema-connected-endpoints
+
+servers:
+  - name: host1
+    adapters:
+      - endpoint_ports: [Eth1]
+        swtch_ports: [Ethernet1]
+        switches: [invalid-schema-connected-endpoints]
+
+expected_error_message: >-
+  2 errors found during schema validation of input vars.

--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/removed-schema-connected-endpoints.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/removed-schema-connected-endpoints.yml
@@ -1,0 +1,16 @@
+fabric_name: fabric_removed_schema_connected_endpoints
+
+type: l2leaf
+l2leaf:
+  nodes:
+    - name: removed-schema-connected-endpoints
+
+servers:
+  - name: host1
+    adapters:
+      - server_ports: [Eth1]
+        switch_ports: [Ethernet1]
+        switches: [removed-schema-connected-endpoints]
+
+expected_error_message: >-
+  [DEPRECATED]: [removed-schema-connected-endpoints]: The input data model 'servers.[0].adapters.[0].server_ports' was removed. Use 'endpoint_ports' instead. This feature was removed from arista.avd.eos_designs in version 4.0.0. Please update your playbooks.

--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/hosts.yml
@@ -11,6 +11,12 @@ all:
         fabric_invalid_schema:
           hosts:
             invalid-schema:
+        fabric_invalid_schema_connected_endpoints:
+          hosts:
+            invalid-schema-connected-endpoints:
+        fabric_removed_schema_connected_endpoints:
+          hosts:
+            removed-schema-connected-endpoints:
 
     EOS_DESIGNS_FAILURES: # Add cases that fail during 'eos_designs_structured_config' phase
       hosts:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/TRUNK_GROUP_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/TRUNK_GROUP_TESTS.yml
@@ -88,7 +88,7 @@ tenants:
         trunk_groups: [ TG_NOT_MATCHING_ANY_SERVERS ]
 
 servers:
-  server_with_tg_100:
+  - name: server_with_tg_100
     adapters:
       - endpoint_ports: [ Nic1 ]
         switch_ports: [ Ethernet11 ]
@@ -96,7 +96,7 @@ servers:
         trunk_groups: [ TG_NOT_MATCHING_ANY_VLANS, TG_100 ]
         mode: trunk
         enabled: true
-  server_with_tg_200:
+  - name: server_with_tg_200
     adapters:
       - endpoint_ports: [ Nic1, Nic2, Nic3 ]
         switch_ports: [ Ethernet12, Ethernet12, Ethernet12 ]
@@ -104,7 +104,7 @@ servers:
         trunk_groups: [ TG_NOT_MATCHING_ANY_VLANS, TG_200 ]
         mode: trunk
         enabled: true
-  server_with_tg_300:
+  - name: server_with_tg_300
     adapters:
       - endpoint_ports: [ Nic1, Nic2, Nic3, Nic4 ]
         switch_ports: [ Ethernet13, Ethernet13, Ethernet13, Ethernet13 ]

--- a/ansible_collections/arista/avd/plugins/action/eos_designs_facts.py
+++ b/ansible_collections/arista/avd/plugins/action/eos_designs_facts.py
@@ -137,7 +137,7 @@ class ActionModule(ActionBase):
             # Insert dynamic keys into the input data if not set.
             # These keys are required by the schema, but the default values are set inside shared_utils.
             host_hostvars.setdefault("node_type_keys", shared_utils.node_type_keys)
-            host_hostvars.setdefault("connected_endpoint_keys", shared_utils.connected_endpoints_keys)
+            host_hostvars.setdefault("connected_endpoints_keys", shared_utils.connected_endpoints_keys)
             host_hostvars.setdefault("network_services_keys", shared_utils.network_services_keys)
 
             # Set correct hostname in schema tools and perform conversion and validation

--- a/ansible_collections/arista/avd/plugins/action/yaml_templates_to_facts.py
+++ b/ansible_collections/arista/avd/plugins/action/yaml_templates_to_facts.py
@@ -103,7 +103,7 @@ class ActionModule(ActionBase):
         # Insert dynamic keys into the input data if not set.
         # These keys are required by the schema, but the default values are set inside shared_utils.
         task_vars.setdefault("node_type_keys", shared_utils.node_type_keys)
-        task_vars.setdefault("connected_endpoint_keys", shared_utils.connected_endpoints_keys)
+        task_vars.setdefault("connected_endpoints_keys", shared_utils.connected_endpoints_keys)
         task_vars.setdefault("network_services_keys", shared_utils.network_services_keys)
 
         if schema or schema_id:

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/get_structured_config/get_structured_config.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/get_structured_config/get_structured_config.py
@@ -56,7 +56,7 @@ def get_structured_config(
     # Insert dynamic keys into the input data if not set.
     # These keys are required by the schema, but the default values are set inside shared_utils.
     vars.setdefault("node_type_keys", shared_utils.node_type_keys)
-    vars.setdefault("connected_endpoint_keys", shared_utils.connected_endpoints_keys)
+    vars.setdefault("connected_endpoints_keys", shared_utils.connected_endpoints_keys)
     vars.setdefault("network_services_keys", shared_utils.network_services_keys)
 
     # Validate input data

--- a/ansible_collections/arista/avd/tests/inventory/group_vars/DC1_SERVERS.yml
+++ b/ansible_collections/arista/avd/tests/inventory/group_vars/DC1_SERVERS.yml
@@ -1,17 +1,17 @@
 ---
 port_profiles:
-  TENANT_A_B:
+  - profile: TENANT_A_B
     mode: trunk
     vlans: "110-111,210-211"
-  TENANT_A:
+  - profile: TENANT_A
     mode: access
     vlans: "110"
-  TENANT_B:
+  - profile: TENANT_B
     mode: trunk
     vlans: "210-211"
 
 servers:
-  server01:
+  - name: server01
     rack: RackA
     adapters:
       - type: nic
@@ -19,7 +19,7 @@ servers:
         switch_ports: [Ethernet5]
         switches: [DC1-L2LEAF1A]
         profile: TENANT_A
-  server02:
+  - name: server02
     rack: RackA
     adapters:
       - type: nic


### PR DESCRIPTION
## Change Summary

Schema validation for connected endpoints not executed
 - no errors for invalided values.
 - no errors for removed variables.

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

- Correct misspelled key name
- Added test coverage in eos_designs_negative_unit_tests

## How to test

See molecule scenarios.
