### PR TITLE
Fix(eos_designs): Sort internal objects for consistent output

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l2leaf1a.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l2leaf1a.yml
@@ -27,25 +27,25 @@ vlans:
   name: svi100_with_trunk_groups
   tenant: TRUNK_GROUP_TESTS
   trunk_groups:
+  - MLAG
   - TG_100
   - TG_NOT_MATCHING_ANY_SERVERS
-  - MLAG
   - UPLINK
 - id: 200
   name: svi200_with_trunk_groups
   tenant: TRUNK_GROUP_TESTS
   trunk_groups:
+  - MLAG
   - TG_200
   - TG_NOT_MATCHING_ANY_SERVERS
-  - MLAG
   - UPLINK
 - id: 300
   name: svi300_with_trunk_groups
   tenant: TRUNK_GROUP_TESTS
   trunk_groups:
+  - MLAG
   - TG_300
   - TG_NOT_MATCHING_ANY_SERVERS
-  - MLAG
   - UPLINK
 - id: 398
   name: svi398_without_trunk_groups
@@ -57,25 +57,25 @@ vlans:
   name: l2vlan110_with_trunk_groups
   tenant: TRUNK_GROUP_TESTS
   trunk_groups:
+  - MLAG
   - TG_100
   - TG_NOT_MATCHING_ANY_SERVERS
-  - MLAG
   - UPLINK
 - id: 210
   name: l2vlan210_with_trunk_groups
   tenant: TRUNK_GROUP_TESTS
   trunk_groups:
+  - MLAG
   - TG_200
   - TG_NOT_MATCHING_ANY_SERVERS
-  - MLAG
   - UPLINK
 - id: 310
   name: l2vlan310_with_trunk_groups
   tenant: TRUNK_GROUP_TESTS
   trunk_groups:
+  - MLAG
   - TG_300
   - TG_NOT_MATCHING_ANY_SERVERS
-  - MLAG
   - UPLINK
 - id: 399
   name: l2vlan399_without_trunk_groups

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l2leaf1b.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l2leaf1b.yml
@@ -33,16 +33,16 @@ vlans:
   name: svi200_with_trunk_groups
   tenant: TRUNK_GROUP_TESTS
   trunk_groups:
-  - TG_200
   - CUSTOM_MLAG_TG_NAME
   - CUSTOM_UPLINK_TG_NAME
+  - TG_200
 - id: 300
   name: svi300_with_trunk_groups
   tenant: TRUNK_GROUP_TESTS
   trunk_groups:
-  - TG_300
   - CUSTOM_MLAG_TG_NAME
   - CUSTOM_UPLINK_TG_NAME
+  - TG_300
 - id: 398
   name: svi398_without_trunk_groups
   tenant: TRUNK_GROUP_TESTS
@@ -59,16 +59,16 @@ vlans:
   name: l2vlan210_with_trunk_groups
   tenant: TRUNK_GROUP_TESTS
   trunk_groups:
-  - TG_200
   - CUSTOM_MLAG_TG_NAME
   - CUSTOM_UPLINK_TG_NAME
+  - TG_200
 - id: 310
   name: l2vlan310_with_trunk_groups
   tenant: TRUNK_GROUP_TESTS
   trunk_groups:
-  - TG_300
   - CUSTOM_MLAG_TG_NAME
   - CUSTOM_UPLINK_TG_NAME
+  - TG_300
 - id: 399
   name: l2vlan399_without_trunk_groups
   tenant: TRUNK_GROUP_TESTS

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf1a.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf1a.yml
@@ -230,51 +230,51 @@ vlans:
 - id: 100
   trunk_groups:
   - TRUNK_GROUP_TESTS_L2LEAF1
+  - MLAG
   - TG_100
   - TG_NOT_MATCHING_ANY_SERVERS
-  - MLAG
   name: svi100_with_trunk_groups
   tenant: TRUNK_GROUP_TESTS
 - id: 110
   trunk_groups:
   - TRUNK_GROUP_TESTS_L2LEAF1
+  - MLAG
   - TG_100
   - TG_NOT_MATCHING_ANY_SERVERS
-  - MLAG
   name: l2vlan110_with_trunk_groups
   tenant: TRUNK_GROUP_TESTS
 - id: 200
   trunk_groups:
   - trunk-group-tests-l2leaf3
   - TRUNK_GROUP_TESTS_L2LEAF1
+  - MLAG
   - TG_200
   - TG_NOT_MATCHING_ANY_SERVERS
-  - MLAG
   name: svi200_with_trunk_groups
   tenant: TRUNK_GROUP_TESTS
 - id: 210
   trunk_groups:
   - trunk-group-tests-l2leaf3
   - TRUNK_GROUP_TESTS_L2LEAF1
+  - MLAG
   - TG_200
   - TG_NOT_MATCHING_ANY_SERVERS
-  - MLAG
   name: l2vlan210_with_trunk_groups
   tenant: TRUNK_GROUP_TESTS
 - id: 300
   trunk_groups:
   - TRUNK_GROUP_TESTS_L2LEAF1
+  - MLAG
   - TG_300
   - TG_NOT_MATCHING_ANY_SERVERS
-  - MLAG
   name: svi300_with_trunk_groups
   tenant: TRUNK_GROUP_TESTS
 - id: 310
   trunk_groups:
   - TRUNK_GROUP_TESTS_L2LEAF1
+  - MLAG
   - TG_300
   - TG_NOT_MATCHING_ANY_SERVERS
-  - MLAG
   name: l2vlan310_with_trunk_groups
   tenant: TRUNK_GROUP_TESTS
 - id: 398
@@ -303,9 +303,9 @@ vlans:
   name: svi301_with_trunk_groups_only_l3leaf
   tenant: TRUNK_GROUP_TESTS
   trunk_groups:
+  - MLAG
   - TG_300
   - TG_NOT_MATCHING_ANY_SERVERS
-  - MLAG
 - id: 3299
   name: MLAG_iBGP_TG_300
   trunk_groups:
@@ -315,9 +315,9 @@ vlans:
   name: l2vlan310_with_trunk_groups_only_l3leaf
   tenant: TRUNK_GROUP_TESTS
   trunk_groups:
+  - MLAG
   - TG_300
   - TG_NOT_MATCHING_ANY_SERVERS
-  - MLAG
 vlan_interfaces:
 - name: Vlan4093
   description: MLAG_PEER_L3_PEERING

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf1b.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf1b.yml
@@ -256,15 +256,15 @@ vlans:
 - id: 300
   trunk_groups:
   - TRUNK_GROUP_TESTS_L2LEAF1
-  - TG_300
   - CUSTOM_MLAG_TG_NAME
+  - TG_300
   name: svi300_with_trunk_groups
   tenant: TRUNK_GROUP_TESTS
 - id: 310
   trunk_groups:
   - TRUNK_GROUP_TESTS_L2LEAF1
-  - TG_300
   - CUSTOM_MLAG_TG_NAME
+  - TG_300
   name: l2vlan310_with_trunk_groups
   tenant: TRUNK_GROUP_TESTS
 - id: 398
@@ -293,8 +293,8 @@ vlans:
   name: svi301_with_trunk_groups_only_l3leaf
   tenant: TRUNK_GROUP_TESTS
   trunk_groups:
-  - TG_300
   - CUSTOM_MLAG_TG_NAME
+  - TG_300
 - id: 3299
   name: MLAG_iBGP_TG_300
   trunk_groups:
@@ -304,8 +304,8 @@ vlans:
   name: l2vlan310_with_trunk_groups_only_l3leaf
   tenant: TRUNK_GROUP_TESTS
   trunk_groups:
-  - TG_300
   - CUSTOM_MLAG_TG_NAME
+  - TG_300
 vlan_interfaces:
 - name: Vlan4093
   description: MLAG_PEER_L3_PEERING

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf2a.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf2a.yml
@@ -122,17 +122,17 @@ vlans:
 - id: 200
   trunk_groups:
   - trunk-group-tests-l2leaf4
+  - MLAG
   - TG_200
   - TG_NOT_MATCHING_ANY_SERVERS
-  - MLAG
   name: svi200_with_trunk_groups
   tenant: TRUNK_GROUP_TESTS
 - id: 210
   trunk_groups:
   - trunk-group-tests-l2leaf4
+  - MLAG
   - TG_200
   - TG_NOT_MATCHING_ANY_SERVERS
-  - MLAG
   name: l2vlan210_with_trunk_groups
   tenant: TRUNK_GROUP_TESTS
 - id: 3199

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/connected_endpoints/utils.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/connected_endpoints/utils.py
@@ -24,7 +24,7 @@ class UtilsMixin:
     @cached_property
     def _filtered_connected_endpoints(self) -> list:
         """
-        Return list of endpoints defined under one of the keys in "connected_endpoint_keys"
+        Return list of endpoints defined under one of the keys in "connected_endpoints_keys"
         which are connected to this switch.
 
         Adapters are filtered to contain only the ones connected to this switch.

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/inband_management/avdstructuredconfig.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/inband_management/avdstructuredconfig.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from functools import cached_property
 from ipaddress import ip_network
 
+from ansible_collections.arista.avd.plugins.filter.natural_sort import natural_sort
 from ansible_collections.arista.avd.plugins.plugin_utils.avdfacts import AvdFacts
 from ansible_collections.arista.avd.plugins.plugin_utils.errors.errors import AristaAvdMissingVariableError
 from ansible_collections.arista.avd.plugins.plugin_utils.strip_empties import strip_empties_from_dict
@@ -152,7 +153,7 @@ class AvdStructuredConfigInbandManagement(AvdFacts):
 
         svis = {}
         subnets = []
-        peers = get(self._hostvars, f"avd_topology_peers..{self.shared_utils.hostname}", separator="..", default=[])
+        peers = natural_sort(get(self._hostvars, f"avd_topology_peers..{self.shared_utils.hostname}", separator="..", default=[]))
         for peer in peers:
             peer_facts = self.shared_utils.get_peer_facts(peer, required=True)
             if (vlan := peer_facts.get("inband_mgmt_vlan")) is None:

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/vlans.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/vlans.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from functools import cached_property
 
+from ansible_collections.arista.avd.plugins.filter.natural_sort import natural_sort
 from ansible_collections.arista.avd.plugins.plugin_utils.utils import append_if_not_duplicate
 
 from .utils import UtilsMixin
@@ -92,6 +93,6 @@ class VlansMixin(UtilsMixin):
                 trunk_groups.append(self._trunk_groups_mlag_name)
             if self.shared_utils.uplink_type == "port-channel":
                 trunk_groups.append(self._trunk_groups_uplink_name)
-            vlans_vlan["trunk_groups"] = trunk_groups
+            vlans_vlan["trunk_groups"] = natural_sort(trunk_groups)
 
         return vlans_vlan

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/utils.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/utils.py
@@ -26,7 +26,7 @@ class UtilsMixin:
         This cannot be loaded in shared_utils since it will not be calculated until EosDesignsFacts has been rendered
         and shared_utils are shared between EosDesignsFacts and AvdStructuredConfig classes like this one.
         """
-        return get(self._hostvars, f"avd_topology_peers..{self.shared_utils.hostname}", separator="..", default=[])
+        return natural_sort(get(self._hostvars, f"avd_topology_peers..{self.shared_utils.hostname}", separator="..", default=[]))
 
     @cached_property
     def _underlay_filter_peer_as_route_maps_asns(self) -> list:

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/vlans.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/vlans.py
@@ -46,8 +46,8 @@ class VlansMixin(UtilsMixin):
 
         # Add configuration for uplink or peer's uplink_native_vlan if it is not defined as part of network services
         switch_vlans = range_expand(get(self._hostvars, "switch.vlans"))
-        uplink_native_vlans = set(
-            link["native_vlan"] for link in self._underlay_links if "native_vlan" in link and str(link["native_vlan"]) not in switch_vlans
+        uplink_native_vlans = natural_sort(
+            set(link["native_vlan"] for link in self._underlay_links if "native_vlan" in link and str(link["native_vlan"]) not in switch_vlans)
         )
         for peer_uplink_native_vlan in uplink_native_vlans:
             vlans.append(


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Sort internal objects for consistent output

Depending on the inventory ordering, the areas where we pass neighbor information might change.
This reveals itself with dynamic inventories, where the order may change from play to play.

## Component(s) name

`arista.avd.eos_designs>`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

- Sort inband management "parents"
- Sort uplink peers
- Sort trunk groups on vlans
- Sort auto-created native-vlans

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Seen in customer project using dynamic inventories.
Also seen with pyavd where the input inventory is sorted differently.

After applying these fixes, the output is consistent even when the inventory order changes.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
