### PR TITLE
Feat(eos_cli_config_gen): add support for password complexity policies

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-accounts.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-accounts.md
@@ -1,0 +1,34 @@
+# management-accounts
+
+## Table of Contents
+
+- [Management](#management)
+  - [Management Interfaces](#management-interfaces)
+
+## Management
+
+### Management Interfaces
+
+#### Management Interfaces Summary
+
+##### IPv4
+
+| Management Interface | description | Type | VRF | IP Address | Gateway |
+| -------------------- | ----------- | ---- | --- | ---------- | ------- |
+| Management1 | oob_management | oob | MGMT | 10.73.255.122/24 | 10.73.255.2 |
+
+##### IPv6
+
+| Management Interface | description | Type | VRF | IPv6 Address | IPv6 Gateway |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ |
+| Management1 | oob_management | oob | MGMT | - | - |
+
+#### Management Interfaces Device Configuration
+
+```eos
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-accounts.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-accounts.md
@@ -4,6 +4,7 @@
 
 - [Management](#management)
   - [Management Interfaces](#management-interfaces)
+  - [Management Accounts](#management-accounts)
 
 ## Management
 
@@ -31,4 +32,18 @@ interface Management1
    description oob_management
    vrf MGMT
    ip address 10.73.255.122/24
+```
+
+### Management Accounts
+
+#### Password Policy
+
+The password policy set for management accounts is: AVD_POLICY
+
+#### Management Accounts Device Configuration
+
+```eos
+!
+management accounts
+   password policy AVD_POLICY
 ```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-security.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-security.md
@@ -99,13 +99,13 @@ management security
    password encryption-key common
    password encryption reversible aes-256-gcm
    password minimum length 17
-   password policy AVD_POLICY minimum digits 3
-   password policy AVD_POLICY minimum length 10
-   password policy AVD_POLICY minimum lower 2
-   password policy AVD_POLICY minimum special 1
-   password policy AVD_POLICY minimum upper 1
-   password policy AVD_POLICY maximum repetitive 2
-   password policy AVD_POLICY maximum sequential 2
+   password policy AVD_POLICY minimum digits 1
+   password policy AVD_POLICY minimum length 2
+   password policy AVD_POLICY minimum lower 3
+   password policy AVD_POLICY minimum special 4
+   password policy AVD_POLICY minimum upper 5
+   password policy AVD_POLICY maximum repetitive 6
+   password policy AVD_POLICY maximum sequential 7
    ssl profile certificate-profile
       certificate eAPI.crt key eAPI.key
    ssl profile cipher-list-profile

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-security.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-security.md
@@ -11,6 +11,7 @@
   - [SSL profile test1-trust-cert Certificates Summary](#ssl-profile-test1-trust-cert-certificates-summary)
   - [SSL profile test2-chain-cert Certificates Summary](#ssl-profile-test2-chain-cert-certificates-summary)
   - [SSL profile test2-trust-cert Certificates Summary](#ssl-profile-test2-trust-cert-certificates-summary)
+  - [Password Policies](#password-policies)
   - [Management Security Configuration](#management-security-configuration)
 
 ## Management
@@ -90,6 +91,20 @@ interface Management1
 | ------------------ | ----------- | ------ | ------ |
 | - | Hostname must be FQDN | - | Enabled |
 
+### Password Policies
+#### Policy AVD_POLICY
+
+**Minimum requirements:**
+- Digits: 1
+- Length: 2
+- Lowercase letters: 3
+- Special characters: 4
+- Uppercase letters: 5
+
+**Maximum requirements:**
+- Repetitive characters: 6
+- Sequential characters: 7
+
 ### Management Security Configuration
 
 ```eos
@@ -99,13 +114,14 @@ management security
    password encryption-key common
    password encryption reversible aes-256-gcm
    password minimum length 17
-   password policy AVD_POLICY minimum digits 1
-   password policy AVD_POLICY minimum length 2
-   password policy AVD_POLICY minimum lower 3
-   password policy AVD_POLICY minimum special 4
-   password policy AVD_POLICY minimum upper 5
-   password policy AVD_POLICY maximum repetitive 6
-   password policy AVD_POLICY maximum sequential 7
+   password policy AVD_POLICY
+      minimum digits 1
+      minimum length 2
+      minimum lower 3
+      minimum special 4
+      minimum upper 5
+      maximum repetitive 6
+      maximum sequential 7
    ssl profile certificate-profile
       certificate eAPI.crt key eAPI.key
    ssl profile cipher-list-profile

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-security.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-security.md
@@ -92,18 +92,9 @@ interface Management1
 | - | Hostname must be FQDN | - | Enabled |
 
 ### Password Policies
-#### Policy AVD_POLICY
-
-**Minimum requirements:**
-- Digits: 1
-- Length: 2
-- Lowercase letters: 3
-- Special characters: 4
-- Uppercase letters: 5
-
-**Maximum requirements:**
-- Repetitive characters: 6
-- Sequential characters: 7
+| Policy Name | Digits | Length | Lowercase letters | Special characters | Uppercase letters | Repetitive characters | Sequential characters |
+|-------------|--------|--------|-------------------|--------------------|-------------------|-----------------------|----------------------|
+| AVD_POLICY | > 1 | > 2 | > 3 | > 4 | > 5 | < 6 | < 7 |
 
 ### Management Security Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-security.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-security.md
@@ -99,6 +99,13 @@ management security
    password encryption-key common
    password encryption reversible aes-256-gcm
    password minimum length 17
+   password policy AVD_POLICY minimum digits 3
+   password policy AVD_POLICY minimum length 10
+   password policy AVD_POLICY minimum lower 2
+   password policy AVD_POLICY minimum special 1
+   password policy AVD_POLICY minimum upper 1
+   password policy AVD_POLICY maximum repetitive 2
+   password policy AVD_POLICY maximum sequential 2
    ssl profile certificate-profile
       certificate eAPI.crt key eAPI.key
    ssl profile cipher-list-profile

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/management-accounts.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/management-accounts.cfg
@@ -1,0 +1,18 @@
+!RANCID-CONTENT-TYPE: arista
+!
+transceiver qsfp default-mode 4x10G
+!
+hostname management-accounts
+!
+no enable password
+no aaa root
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+!
+management accounts
+   password policy AVD_POLICY
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/management-security.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/management-security.cfg
@@ -17,13 +17,14 @@ management security
    password encryption-key common
    password encryption reversible aes-256-gcm
    password minimum length 17
-   password policy AVD_POLICY minimum digits 1
-   password policy AVD_POLICY minimum length 2
-   password policy AVD_POLICY minimum lower 3
-   password policy AVD_POLICY minimum special 4
-   password policy AVD_POLICY minimum upper 5
-   password policy AVD_POLICY maximum repetitive 6
-   password policy AVD_POLICY maximum sequential 7
+   password policy AVD_POLICY
+      minimum digits 1
+      minimum length 2
+      minimum lower 3
+      minimum special 4
+      minimum upper 5
+      maximum repetitive 6
+      maximum sequential 7
    ssl profile certificate-profile
       certificate eAPI.crt key eAPI.key
    ssl profile cipher-list-profile

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/management-security.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/management-security.cfg
@@ -17,13 +17,13 @@ management security
    password encryption-key common
    password encryption reversible aes-256-gcm
    password minimum length 17
-   password policy AVD_POLICY minimum digits 3
-   password policy AVD_POLICY minimum length 10
-   password policy AVD_POLICY minimum lower 2
-   password policy AVD_POLICY minimum special 1
-   password policy AVD_POLICY minimum upper 1
-   password policy AVD_POLICY maximum repetitive 2
-   password policy AVD_POLICY maximum sequential 2
+   password policy AVD_POLICY minimum digits 1
+   password policy AVD_POLICY minimum length 2
+   password policy AVD_POLICY minimum lower 3
+   password policy AVD_POLICY minimum special 4
+   password policy AVD_POLICY minimum upper 5
+   password policy AVD_POLICY maximum repetitive 6
+   password policy AVD_POLICY maximum sequential 7
    ssl profile certificate-profile
       certificate eAPI.crt key eAPI.key
    ssl profile cipher-list-profile

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/management-security.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/management-security.cfg
@@ -17,6 +17,13 @@ management security
    password encryption-key common
    password encryption reversible aes-256-gcm
    password minimum length 17
+   password policy AVD_POLICY minimum digits 3
+   password policy AVD_POLICY minimum length 10
+   password policy AVD_POLICY minimum lower 2
+   password policy AVD_POLICY minimum special 1
+   password policy AVD_POLICY minimum upper 1
+   password policy AVD_POLICY maximum repetitive 2
+   password policy AVD_POLICY maximum sequential 2
    ssl profile certificate-profile
       certificate eAPI.crt key eAPI.key
    ssl profile cipher-list-profile

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/management-accounts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/management-accounts.yml
@@ -1,0 +1,3 @@
+management_accounts:
+  password:
+    policy: "AVD_POLICY"

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/management-security.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/management-security.yml
@@ -5,7 +5,7 @@ management_security:
     minimum_length: 17
     encryption_key_common: true
     encryption_reversible: aes-256-gcm
-    policy:
+    policies:
       - name: AVD_POLICY
         minimum:
           digits: 1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/management-security.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/management-security.yml
@@ -5,6 +5,16 @@ management_security:
     minimum_length: 17
     encryption_key_common: true
     encryption_reversible: aes-256-gcm
+    policy:
+      minimum:
+        digits: 3
+        length: 10
+        lower: 2
+        special: 1
+        upper: 1
+      maximum:
+        repetitive: 2
+        sequential: 2
   ssl_profiles:
     - name: tls-versions-profile
       tls_versions: "1.0 1.1"

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/management-security.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/management-security.yml
@@ -6,15 +6,16 @@ management_security:
     encryption_key_common: true
     encryption_reversible: aes-256-gcm
     policy:
-      minimum:
-        digits: 3
-        length: 10
-        lower: 2
-        special: 1
-        upper: 1
-      maximum:
-        repetitive: 2
-        sequential: 2
+      - name: AVD_POLICY
+        minimum:
+          digits: 1
+          length: 2
+          lower: 3
+          special: 4
+          upper: 5
+        maximum:
+          repetitive: 6
+          sequential: 7
   ssl_profiles:
     - name: tls-versions-profile
       tls_versions: "1.0 1.1"

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts.ini
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts.ini
@@ -62,6 +62,7 @@ mcs-client
 loopbacks-interfaces
 mac-address-table
 maintenance
+management-accounts
 management-api-http
 management-cvx
 management-api-models

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/input-variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/input-variables.md
@@ -447,6 +447,12 @@ roles/eos_cli_config_gen/docs/tables/ip-name-servers.md
 roles/eos_cli_config_gen/docs/tables/ip-ssh-client-source-interfaces.md
 --8<--
 
+### Management Accounts
+
+--8<--
+roles/eos_cli_config_gen/docs/tables/management-accounts.md
+--8<--
+
 ### Management API HTTP
 
 --8<--

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/input-variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/input-variables.md
@@ -447,7 +447,7 @@ roles/eos_cli_config_gen/docs/tables/ip-name-servers.md
 roles/eos_cli_config_gen/docs/tables/ip-ssh-client-source-interfaces.md
 --8<--
 
-### Management Accounts
+### Management accounts
 
 --8<--
 roles/eos_cli_config_gen/docs/tables/management-accounts.md

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/management-accounts.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/management-accounts.md
@@ -1,0 +1,15 @@
+=== "Table"
+
+    | Variable | Type | Required | Default | Value Restrictions | Description |
+    | -------- | ---- | -------- | ------- | ------------------ | ----------- |
+    | [<samp>management_accounts</samp>](## "management_accounts") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;password</samp>](## "management_accounts.password") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;policy</samp>](## "management_accounts.password.policy") | String |  |  |  |  |
+
+=== "YAML"
+
+    ```yaml
+    management_accounts:
+      password:
+        policy: <str>
+    ```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/management-security.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/management-security.md
@@ -8,6 +8,16 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;minimum_length</samp>](## "management_security.password.minimum_length") | Integer |  |  | Min: 1<br>Max: 32 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;encryption_key_common</samp>](## "management_security.password.encryption_key_common") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;encryption_reversible</samp>](## "management_security.password.encryption_reversible") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;policy</samp>](## "management_security.password.policy") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;minimum</samp>](## "management_security.password.policy.minimum") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;digits</samp>](## "management_security.password.policy.minimum.digits") | Integer |  |  | Min: 0 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;length</samp>](## "management_security.password.policy.minimum.length") | Integer |  |  | Min: 0 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;lower</samp>](## "management_security.password.policy.minimum.lower") | Integer |  |  | Min: 0 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;special</samp>](## "management_security.password.policy.minimum.special") | Integer |  |  | Min: 0 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;upper</samp>](## "management_security.password.policy.minimum.upper") | Integer |  |  | Min: 0 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;maximum</samp>](## "management_security.password.policy.maximum") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;repetitive</samp>](## "management_security.password.policy.maximum.repetitive") | Integer |  |  | Min: 0 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;sequential</samp>](## "management_security.password.policy.maximum.sequential") | Integer |  |  | Min: 0 |  |
     | [<samp>&nbsp;&nbsp;ssl_profiles</samp>](## "management_security.ssl_profiles") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "management_security.ssl_profiles.[].name") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tls_versions</samp>](## "management_security.ssl_profiles.[].tls_versions") | String |  |  |  | List of allowed TLS versions as string<br>Examples:<br>  - "1.0"<br>  - "1.0 1.1"<br> |
@@ -39,6 +49,16 @@
         minimum_length: <int>
         encryption_key_common: <bool>
         encryption_reversible: <str>
+        policy:
+          minimum:
+            digits: <int>
+            length: <int>
+            lower: <int>
+            special: <int>
+            upper: <int>
+          maximum:
+            repetitive: <int>
+            sequential: <int>
       ssl_profiles:
         - name: <str>
           tls_versions: <str>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/management-security.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/management-security.md
@@ -11,14 +11,14 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;policies</samp>](## "management_security.password.policies") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "management_security.password.policies.[].name") | String | Required, Unique |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;minimum</samp>](## "management_security.password.policies.[].minimum") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;digits</samp>](## "management_security.password.policies.[].minimum.digits") | Integer |  |  | Min: 0 |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;length</samp>](## "management_security.password.policies.[].minimum.length") | Integer |  |  | Min: 0 |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;lower</samp>](## "management_security.password.policies.[].minimum.lower") | Integer |  |  | Min: 0 |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;special</samp>](## "management_security.password.policies.[].minimum.special") | Integer |  |  | Min: 0 |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;upper</samp>](## "management_security.password.policies.[].minimum.upper") | Integer |  |  | Min: 0 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;digits</samp>](## "management_security.password.policies.[].minimum.digits") | Integer |  |  | Min: 1<br>Max: 65535 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;length</samp>](## "management_security.password.policies.[].minimum.length") | Integer |  |  | Min: 1<br>Max: 65535 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;lower</samp>](## "management_security.password.policies.[].minimum.lower") | Integer |  |  | Min: 1<br>Max: 65535 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;special</samp>](## "management_security.password.policies.[].minimum.special") | Integer |  |  | Min: 1<br>Max: 65535 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;upper</samp>](## "management_security.password.policies.[].minimum.upper") | Integer |  |  | Min: 1<br>Max: 65535 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;maximum</samp>](## "management_security.password.policies.[].maximum") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;repetitive</samp>](## "management_security.password.policies.[].maximum.repetitive") | Integer |  |  | Min: 0 |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;sequential</samp>](## "management_security.password.policies.[].maximum.sequential") | Integer |  |  | Min: 0 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;repetitive</samp>](## "management_security.password.policies.[].maximum.repetitive") | Integer |  |  | Min: 1<br>Max: 65535 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;sequential</samp>](## "management_security.password.policies.[].maximum.sequential") | Integer |  |  | Min: 1<br>Max: 65535 |  |
     | [<samp>&nbsp;&nbsp;ssl_profiles</samp>](## "management_security.ssl_profiles") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "management_security.ssl_profiles.[].name") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tls_versions</samp>](## "management_security.ssl_profiles.[].tls_versions") | String |  |  |  | List of allowed TLS versions as string<br>Examples:<br>  - "1.0"<br>  - "1.0 1.1"<br> |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/management-security.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/management-security.md
@@ -8,17 +8,17 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;minimum_length</samp>](## "management_security.password.minimum_length") | Integer |  |  | Min: 1<br>Max: 32 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;encryption_key_common</samp>](## "management_security.password.encryption_key_common") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;encryption_reversible</samp>](## "management_security.password.encryption_reversible") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;policy</samp>](## "management_security.password.policy") | List, items: Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "management_security.password.policy.[].name") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;minimum</samp>](## "management_security.password.policy.[].minimum") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;digits</samp>](## "management_security.password.policy.[].minimum.digits") | Integer |  |  | Min: 0 |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;length</samp>](## "management_security.password.policy.[].minimum.length") | Integer |  |  | Min: 0 |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;lower</samp>](## "management_security.password.policy.[].minimum.lower") | Integer |  |  | Min: 0 |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;special</samp>](## "management_security.password.policy.[].minimum.special") | Integer |  |  | Min: 0 |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;upper</samp>](## "management_security.password.policy.[].minimum.upper") | Integer |  |  | Min: 0 |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;maximum</samp>](## "management_security.password.policy.[].maximum") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;repetitive</samp>](## "management_security.password.policy.[].maximum.repetitive") | Integer |  |  | Min: 0 |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;sequential</samp>](## "management_security.password.policy.[].maximum.sequential") | Integer |  |  | Min: 0 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;policies</samp>](## "management_security.password.policies") | List, items: Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "management_security.password.policies.[].name") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;minimum</samp>](## "management_security.password.policies.[].minimum") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;digits</samp>](## "management_security.password.policies.[].minimum.digits") | Integer |  |  | Min: 0 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;length</samp>](## "management_security.password.policies.[].minimum.length") | Integer |  |  | Min: 0 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;lower</samp>](## "management_security.password.policies.[].minimum.lower") | Integer |  |  | Min: 0 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;special</samp>](## "management_security.password.policies.[].minimum.special") | Integer |  |  | Min: 0 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;upper</samp>](## "management_security.password.policies.[].minimum.upper") | Integer |  |  | Min: 0 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;maximum</samp>](## "management_security.password.policies.[].maximum") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;repetitive</samp>](## "management_security.password.policies.[].maximum.repetitive") | Integer |  |  | Min: 0 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;sequential</samp>](## "management_security.password.policies.[].maximum.sequential") | Integer |  |  | Min: 0 |  |
     | [<samp>&nbsp;&nbsp;ssl_profiles</samp>](## "management_security.ssl_profiles") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "management_security.ssl_profiles.[].name") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tls_versions</samp>](## "management_security.ssl_profiles.[].tls_versions") | String |  |  |  | List of allowed TLS versions as string<br>Examples:<br>  - "1.0"<br>  - "1.0 1.1"<br> |
@@ -50,7 +50,7 @@
         minimum_length: <int>
         encryption_key_common: <bool>
         encryption_reversible: <str>
-        policy:
+        policies:
           - name: <str>
             minimum:
               digits: <int>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/management-security.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/management-security.md
@@ -8,16 +8,17 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;minimum_length</samp>](## "management_security.password.minimum_length") | Integer |  |  | Min: 1<br>Max: 32 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;encryption_key_common</samp>](## "management_security.password.encryption_key_common") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;encryption_reversible</samp>](## "management_security.password.encryption_reversible") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;policy</samp>](## "management_security.password.policy") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;minimum</samp>](## "management_security.password.policy.minimum") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;digits</samp>](## "management_security.password.policy.minimum.digits") | Integer |  |  | Min: 0 |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;length</samp>](## "management_security.password.policy.minimum.length") | Integer |  |  | Min: 0 |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;lower</samp>](## "management_security.password.policy.minimum.lower") | Integer |  |  | Min: 0 |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;special</samp>](## "management_security.password.policy.minimum.special") | Integer |  |  | Min: 0 |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;upper</samp>](## "management_security.password.policy.minimum.upper") | Integer |  |  | Min: 0 |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;maximum</samp>](## "management_security.password.policy.maximum") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;repetitive</samp>](## "management_security.password.policy.maximum.repetitive") | Integer |  |  | Min: 0 |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;sequential</samp>](## "management_security.password.policy.maximum.sequential") | Integer |  |  | Min: 0 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;policy</samp>](## "management_security.password.policy") | List, items: Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "management_security.password.policy.[].name") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;minimum</samp>](## "management_security.password.policy.[].minimum") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;digits</samp>](## "management_security.password.policy.[].minimum.digits") | Integer |  |  | Min: 0 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;length</samp>](## "management_security.password.policy.[].minimum.length") | Integer |  |  | Min: 0 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;lower</samp>](## "management_security.password.policy.[].minimum.lower") | Integer |  |  | Min: 0 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;special</samp>](## "management_security.password.policy.[].minimum.special") | Integer |  |  | Min: 0 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;upper</samp>](## "management_security.password.policy.[].minimum.upper") | Integer |  |  | Min: 0 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;maximum</samp>](## "management_security.password.policy.[].maximum") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;repetitive</samp>](## "management_security.password.policy.[].maximum.repetitive") | Integer |  |  | Min: 0 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;sequential</samp>](## "management_security.password.policy.[].maximum.sequential") | Integer |  |  | Min: 0 |  |
     | [<samp>&nbsp;&nbsp;ssl_profiles</samp>](## "management_security.ssl_profiles") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "management_security.ssl_profiles.[].name") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tls_versions</samp>](## "management_security.ssl_profiles.[].tls_versions") | String |  |  |  | List of allowed TLS versions as string<br>Examples:<br>  - "1.0"<br>  - "1.0 1.1"<br> |
@@ -50,15 +51,16 @@
         encryption_key_common: <bool>
         encryption_reversible: <str>
         policy:
-          minimum:
-            digits: <int>
-            length: <int>
-            lower: <int>
-            special: <int>
-            upper: <int>
-          maximum:
-            repetitive: <int>
-            sequential: <int>
+          - name: <str>
+            minimum:
+              digits: <int>
+              length: <int>
+              lower: <int>
+              special: <int>
+              upper: <int>
+            maximum:
+              repetitive: <int>
+              sequential: <int>
       ssl_profiles:
         - name: <str>
           tls_versions: <str>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/management-security.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/management-security.md
@@ -9,7 +9,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;encryption_key_common</samp>](## "management_security.password.encryption_key_common") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;encryption_reversible</samp>](## "management_security.password.encryption_reversible") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;policies</samp>](## "management_security.password.policies") | List, items: Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "management_security.password.policies.[].name") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "management_security.password.policies.[].name") | String | Required, Unique |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;minimum</samp>](## "management_security.password.policies.[].minimum") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;digits</samp>](## "management_security.password.policies.[].minimum.digits") | Integer |  |  | Min: 0 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;length</samp>](## "management_security.password.policies.[].minimum.length") | Integer |  |  | Min: 0 |  |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -7430,6 +7430,71 @@
             "encryption_reversible": {
               "type": "string",
               "title": "Encryption Reversible"
+            },
+            "policy": {
+              "type": "object",
+              "properties": {
+                "minimum": {
+                  "type": "object",
+                  "properties": {
+                    "digits": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "title": "Digits"
+                    },
+                    "length": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "title": "Length"
+                    },
+                    "lower": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "title": "Lower"
+                    },
+                    "special": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "title": "Special"
+                    },
+                    "upper": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "title": "Upper"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "patternProperties": {
+                    "^_.+$": {}
+                  },
+                  "title": "Minimum"
+                },
+                "maximum": {
+                  "type": "object",
+                  "properties": {
+                    "repetitive": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "title": "Repetitive"
+                    },
+                    "sequential": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "title": "Sequential"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "patternProperties": {
+                    "^_.+$": {}
+                  },
+                  "title": "Maximum"
+                }
+              },
+              "additionalProperties": false,
+              "patternProperties": {
+                "^_.+$": {}
+              },
+              "title": "Policy"
             }
           },
           "additionalProperties": false,

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -7455,7 +7455,7 @@
               "type": "string",
               "title": "Encryption Reversible"
             },
-            "policy": {
+            "policies": {
               "type": "array",
               "items": {
                 "type": "object",
@@ -7525,7 +7525,7 @@
                   "^_.+$": {}
                 }
               },
-              "title": "Policy"
+              "title": "Policies"
             }
           },
           "additionalProperties": false,

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -7469,27 +7469,32 @@
                     "properties": {
                       "digits": {
                         "type": "integer",
-                        "minimum": 0,
+                        "minimum": 1,
+                        "maximum": 65535,
                         "title": "Digits"
                       },
                       "length": {
                         "type": "integer",
-                        "minimum": 0,
+                        "minimum": 1,
+                        "maximum": 65535,
                         "title": "Length"
                       },
                       "lower": {
                         "type": "integer",
-                        "minimum": 0,
+                        "minimum": 1,
+                        "maximum": 65535,
                         "title": "Lower"
                       },
                       "special": {
                         "type": "integer",
-                        "minimum": 0,
+                        "minimum": 1,
+                        "maximum": 65535,
                         "title": "Special"
                       },
                       "upper": {
                         "type": "integer",
-                        "minimum": 0,
+                        "minimum": 1,
+                        "maximum": 65535,
                         "title": "Upper"
                       }
                     },
@@ -7504,12 +7509,14 @@
                     "properties": {
                       "repetitive": {
                         "type": "integer",
-                        "minimum": 0,
+                        "minimum": 1,
+                        "maximum": 65535,
                         "title": "Repetitive"
                       },
                       "sequential": {
                         "type": "integer",
-                        "minimum": 0,
+                        "minimum": 1,
+                        "maximum": 65535,
                         "title": "Sequential"
                       }
                     },

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -6900,6 +6900,30 @@
         "^_.+$": {}
       }
     },
+    "management_accounts": {
+      "type": "object",
+      "properties": {
+        "password": {
+          "type": "object",
+          "properties": {
+            "policy": {
+              "type": "string",
+              "title": "Policy"
+            }
+          },
+          "additionalProperties": false,
+          "patternProperties": {
+            "^_.+$": {}
+          },
+          "title": "Password"
+        }
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^_.+$": {}
+      },
+      "title": "Management Accounts"
+    },
     "management_api_gnmi": {
       "type": "object",
       "properties": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -7432,67 +7432,74 @@
               "title": "Encryption Reversible"
             },
             "policy": {
-              "type": "object",
-              "properties": {
-                "minimum": {
-                  "type": "object",
-                  "properties": {
-                    "digits": {
-                      "type": "integer",
-                      "minimum": 0,
-                      "title": "Digits"
-                    },
-                    "length": {
-                      "type": "integer",
-                      "minimum": 0,
-                      "title": "Length"
-                    },
-                    "lower": {
-                      "type": "integer",
-                      "minimum": 0,
-                      "title": "Lower"
-                    },
-                    "special": {
-                      "type": "integer",
-                      "minimum": 0,
-                      "title": "Special"
-                    },
-                    "upper": {
-                      "type": "integer",
-                      "minimum": 0,
-                      "title": "Upper"
-                    }
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "title": "Name"
                   },
-                  "additionalProperties": false,
-                  "patternProperties": {
-                    "^_.+$": {}
+                  "minimum": {
+                    "type": "object",
+                    "properties": {
+                      "digits": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "title": "Digits"
+                      },
+                      "length": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "title": "Length"
+                      },
+                      "lower": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "title": "Lower"
+                      },
+                      "special": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "title": "Special"
+                      },
+                      "upper": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "title": "Upper"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Minimum"
                   },
-                  "title": "Minimum"
+                  "maximum": {
+                    "type": "object",
+                    "properties": {
+                      "repetitive": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "title": "Repetitive"
+                      },
+                      "sequential": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "title": "Sequential"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Maximum"
+                  }
                 },
-                "maximum": {
-                  "type": "object",
-                  "properties": {
-                    "repetitive": {
-                      "type": "integer",
-                      "minimum": 0,
-                      "title": "Repetitive"
-                    },
-                    "sequential": {
-                      "type": "integer",
-                      "minimum": 0,
-                      "title": "Sequential"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "patternProperties": {
-                    "^_.+$": {}
-                  },
-                  "title": "Maximum"
+                "additionalProperties": false,
+                "patternProperties": {
+                  "^_.+$": {}
                 }
-              },
-              "additionalProperties": false,
-              "patternProperties": {
-                "^_.+$": {}
               },
               "title": "Policy"
             }

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -7523,7 +7523,10 @@
                 "additionalProperties": false,
                 "patternProperties": {
                   "^_.+$": {}
-                }
+                },
+                "required": [
+                  "name"
+                ]
               },
               "title": "Policies"
             }

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -4603,6 +4603,7 @@ keys:
             type: str
           policies:
             type: list
+            primary_key: name
             items:
               type: dict
               keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -4276,6 +4276,14 @@ keys:
                   items:
                     type: str
                     description: Name of Interface Group
+  management_accounts:
+    type: dict
+    keys:
+      password:
+        type: dict
+        keys:
+          policy:
+            type: str
   management_api_gnmi:
     type: dict
     keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -4593,6 +4593,36 @@ keys:
             type: bool
           encryption_reversible:
             type: str
+          policy:
+            type: dict
+            keys:
+              minimum:
+                type: dict
+                keys:
+                  digits:
+                    type: int
+                    min: 0
+                  length:
+                    type: int
+                    min: 0
+                  lower:
+                    type: int
+                    min: 0
+                  special:
+                    type: int
+                    min: 0
+                  upper:
+                    type: int
+                    min: 0
+              maximum:
+                type: dict
+                keys:
+                  repetitive:
+                    type: int
+                    min: 0
+                  sequential:
+                    type: int
+                    min: 0
       ssl_profiles:
         type: list
         items:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -4601,7 +4601,7 @@ keys:
             type: bool
           encryption_reversible:
             type: str
-          policy:
+          policies:
             type: list
             items:
               type: dict
@@ -4614,27 +4614,41 @@ keys:
                     digits:
                       type: int
                       min: 0
+                      convert_types:
+                      - str
                     length:
                       type: int
                       min: 0
+                      convert_types:
+                      - str
                     lower:
                       type: int
                       min: 0
+                      convert_types:
+                      - str
                     special:
                       type: int
                       min: 0
+                      convert_types:
+                      - str
                     upper:
                       type: int
                       min: 0
+                      convert_types:
+                      - str
                 maximum:
                   type: dict
                   keys:
                     repetitive:
                       type: int
                       min: 0
+                      convert_types:
+                      - str
                     sequential:
                       type: int
                       min: 0
+                      convert_types:
+                      - str
       ssl_profiles:
         type: list
         items:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -4614,27 +4614,32 @@ keys:
                   keys:
                     digits:
                       type: int
-                      min: 0
+                      min: 1
+                      max: 65535
                       convert_types:
                       - str
                     length:
                       type: int
-                      min: 0
+                      min: 1
+                      max: 65535
                       convert_types:
                       - str
                     lower:
                       type: int
-                      min: 0
+                      min: 1
+                      max: 65535
                       convert_types:
                       - str
                     special:
                       type: int
-                      min: 0
+                      min: 1
+                      max: 65535
                       convert_types:
                       - str
                     upper:
                       type: int
-                      min: 0
+                      min: 1
+                      max: 65535
                       convert_types:
                       - str
                 maximum:
@@ -4642,12 +4647,14 @@ keys:
                   keys:
                     repetitive:
                       type: int
-                      min: 0
+                      min: 1
+                      max: 65535
                       convert_types:
                       - str
                     sequential:
                       type: int
-                      min: 0
+                      min: 1
+                      max: 65535
                       convert_types:
                       - str
       ssl_profiles:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -4594,35 +4594,39 @@ keys:
           encryption_reversible:
             type: str
           policy:
-            type: dict
-            keys:
-              minimum:
-                type: dict
-                keys:
-                  digits:
-                    type: int
-                    min: 0
-                  length:
-                    type: int
-                    min: 0
-                  lower:
-                    type: int
-                    min: 0
-                  special:
-                    type: int
-                    min: 0
-                  upper:
-                    type: int
-                    min: 0
-              maximum:
-                type: dict
-                keys:
-                  repetitive:
-                    type: int
-                    min: 0
-                  sequential:
-                    type: int
-                    min: 0
+            type: list
+            items:
+              type: dict
+              keys:
+                name:
+                  type: str
+                minimum:
+                  type: dict
+                  keys:
+                    digits:
+                      type: int
+                      min: 0
+                    length:
+                      type: int
+                      min: 0
+                    lower:
+                      type: int
+                      min: 0
+                    special:
+                      type: int
+                      min: 0
+                    upper:
+                      type: int
+                      min: 0
+                maximum:
+                  type: dict
+                  keys:
+                    repetitive:
+                      type: int
+                      min: 0
+                    sequential:
+                      type: int
+                      min: 0
       ssl_profiles:
         type: list
         items:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_accounts.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_accounts.schema.yml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  management_accounts:
+    type: dict
+    keys:
+      password:
+        type: dict
+        keys:
+          policy:
+            type: str

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_security.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_security.schema.yml
@@ -22,35 +22,39 @@ keys:
           encryption_reversible:
             type: str
           policy:
-            type: dict
-            keys:
-              minimum:
-                type: dict
-                keys:
-                  digits:
-                    type: int
-                    min: 0
-                  length:
-                    type: int
-                    min: 0
-                  lower:
-                    type: int
-                    min: 0
-                  special:
-                    type: int
-                    min: 0
-                  upper:
-                    type: int
-                    min: 0
-              maximum:
-                type: dict
-                keys:
-                  repetitive:
-                    type: int
-                    min: 0
-                  sequential:
-                    type: int
-                    min: 0
+            type: list
+            items:
+              type: dict
+              keys:
+                name:
+                  type: str
+                minimum:
+                  type: dict
+                  keys:
+                    digits:
+                      type: int
+                      min: 0
+                    length:
+                      type: int
+                      min: 0
+                    lower:
+                      type: int
+                      min: 0
+                    special:
+                      type: int
+                      min: 0
+                    upper:
+                      type: int
+                      min: 0
+                maximum:
+                  type: dict
+                  keys:
+                    repetitive:
+                      type: int
+                      min: 0
+                    sequential:
+                      type: int
+                      min: 0
       ssl_profiles:
         type: list
         items:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_security.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_security.schema.yml
@@ -23,6 +23,7 @@ keys:
             type: str
           policies:
             type: list
+            primary_key: name
             items:
               type: dict
               keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_security.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_security.schema.yml
@@ -21,6 +21,36 @@ keys:
             type: bool
           encryption_reversible:
             type: str
+          policy:
+            type: dict
+            keys:
+              minimum:
+                type: dict
+                keys:
+                  digits:
+                    type: int
+                    min: 0
+                  length:
+                    type: int
+                    min: 0
+                  lower:
+                    type: int
+                    min: 0
+                  special:
+                    type: int
+                    min: 0
+                  upper:
+                    type: int
+                    min: 0
+              maximum:
+                type: dict
+                keys:
+                  repetitive:
+                    type: int
+                    min: 0
+                  sequential:
+                    type: int
+                    min: 0
       ssl_profiles:
         type: list
         items:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_security.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_security.schema.yml
@@ -21,7 +21,7 @@ keys:
             type: bool
           encryption_reversible:
             type: str
-          policy:
+          policies:
             type: list
             items:
               type: dict
@@ -34,27 +34,41 @@ keys:
                     digits:
                       type: int
                       min: 0
+                      convert_types:
+                      - str
                     length:
                       type: int
                       min: 0
+                      convert_types:
+                      - str
                     lower:
                       type: int
                       min: 0
+                      convert_types:
+                      - str
                     special:
                       type: int
                       min: 0
+                      convert_types:
+                      - str
                     upper:
                       type: int
                       min: 0
+                      convert_types:
+                      - str
                 maximum:
                   type: dict
                   keys:
                     repetitive:
                       type: int
                       min: 0
+                      convert_types:
+                      - str
                     sequential:
                       type: int
                       min: 0
+                      convert_types:
+                      - str
       ssl_profiles:
         type: list
         items:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_security.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_security.schema.yml
@@ -34,27 +34,32 @@ keys:
                   keys:
                     digits:
                       type: int
-                      min: 0
+                      min: 1
+                      max: 65535
                       convert_types:
                       - str
                     length:
                       type: int
-                      min: 0
+                      min: 1
+                      max: 65535
                       convert_types:
                       - str
                     lower:
                       type: int
-                      min: 0
+                      min: 1
+                      max: 65535
                       convert_types:
                       - str
                     special:
                       type: int
-                      min: 0
+                      min: 1
+                      max: 65535
                       convert_types:
                       - str
                     upper:
                       type: int
-                      min: 0
+                      min: 1
+                      max: 65535
                       convert_types:
                       - str
                 maximum:
@@ -62,12 +67,14 @@ keys:
                   keys:
                     repetitive:
                       type: int
-                      min: 0
+                      min: 1
+                      max: 65535
                       convert_types:
                       - str
                     sequential:
                       type: int
-                      min: 0
+                      min: 1
+                      max: 65535
                       convert_types:
                       - str
       ssl_profiles:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-accounts.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-accounts.j2
@@ -1,0 +1,19 @@
+{# doc - management accounts #}
+{% if management_accounts is arista.avd.defined %}
+
+### Management Accounts
+
+#### Password Policy
+
+{%     if management_accounts.password.policy is arista.avd.defined %}
+The password policy set for management accounts is: {{ management_accounts.password.policy }}
+{%     else %}
+No specific password policy is set for management accounts.
+{%     endif %}
+
+#### Management Accounts Device Configuration
+
+```eos
+{%     include 'eos/management-accounts.j2' %}
+```
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-security.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-security.j2
@@ -94,9 +94,9 @@
 {%             endif %}
 {%         endfor %}
 {%     endif %}
+{%     if management_security.password.policy is arista.avd.defined %}
 
 ### Password Policies
-{%     if management_security.password.policy is arista.avd.defined %}
 {%         for policy in management_security.password.policy %}
 #### Policy {{ policy.name }}
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-security.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-security.j2
@@ -95,6 +95,42 @@
 {%         endfor %}
 {%     endif %}
 
+### Password Policies
+{%     if management_security.password.policy is arista.avd.defined %}
+{%         for policy in management_security.password.policy %}
+#### Policy {{ policy.name }}
+
+{%             if policy.minimum is arista.avd.defined %}
+**Minimum requirements:**
+{%                 if policy.minimum.digits is arista.avd.defined %}
+- Digits: {{ policy.minimum.digits }}
+{%                 endif %}
+{%                 if policy.minimum.length is arista.avd.defined %}
+- Length: {{ policy.minimum.length }}
+{%                 endif %}
+{%                 if policy.minimum.lower is arista.avd.defined %}
+- Lowercase letters: {{ policy.minimum.lower }}
+{%                 endif %}
+{%                 if policy.minimum.special is arista.avd.defined %}
+- Special characters: {{ policy.minimum.special }}
+{%                 endif %}
+{%                 if policy.minimum.upper is arista.avd.defined %}
+- Uppercase letters: {{ policy.minimum.upper }}
+{%                 endif %}
+{%             endif %}
+
+{%             if policy.maximum is arista.avd.defined %}
+**Maximum requirements:**
+{%                 if policy.maximum.repetitive is arista.avd.defined %}
+- Repetitive characters: {{ policy.maximum.repetitive }}
+{%                 endif %}
+{%                 if policy.maximum.sequential is arista.avd.defined %}
+- Sequential characters: {{ policy.maximum.sequential }}
+{%                 endif %}
+{%             endif %}
+{%         endfor %}
+{%     endif %}
+
 ### Management Security Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-security.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-security.j2
@@ -94,10 +94,10 @@
 {%             endif %}
 {%         endfor %}
 {%     endif %}
-{%     if management_security.password.policy is arista.avd.defined %}
+{%     if management_security.password.policies is arista.avd.defined %}
 
 ### Password Policies
-{%         for policy in management_security.password.policy %}
+{%         for policy in management_security.password.policies %}
 #### Policy {{ policy.name }}
 
 {%             if policy.minimum is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-security.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-security.j2
@@ -97,37 +97,17 @@
 {%     if management_security.password.policies is arista.avd.defined %}
 
 ### Password Policies
-{%         for policy in management_security.password.policies %}
-#### Policy {{ policy.name }}
-
-{%             if policy.minimum is arista.avd.defined %}
-**Minimum requirements:**
-{%                 if policy.minimum.digits is arista.avd.defined %}
-- Digits: {{ policy.minimum.digits }}
-{%                 endif %}
-{%                 if policy.minimum.length is arista.avd.defined %}
-- Length: {{ policy.minimum.length }}
-{%                 endif %}
-{%                 if policy.minimum.lower is arista.avd.defined %}
-- Lowercase letters: {{ policy.minimum.lower }}
-{%                 endif %}
-{%                 if policy.minimum.special is arista.avd.defined %}
-- Special characters: {{ policy.minimum.special }}
-{%                 endif %}
-{%                 if policy.minimum.upper is arista.avd.defined %}
-- Uppercase letters: {{ policy.minimum.upper }}
-{%                 endif %}
-{%             endif %}
-
-{%             if policy.maximum is arista.avd.defined %}
-**Maximum requirements:**
-{%                 if policy.maximum.repetitive is arista.avd.defined %}
-- Repetitive characters: {{ policy.maximum.repetitive }}
-{%                 endif %}
-{%                 if policy.maximum.sequential is arista.avd.defined %}
-- Sequential characters: {{ policy.maximum.sequential }}
-{%                 endif %}
-{%             endif %}
+| Policy Name | Digits | Length | Lowercase letters | Special characters | Uppercase letters | Repetitive characters | Sequential characters |
+|-------------|--------|--------|-------------------|--------------------|-------------------|-----------------------|----------------------|
+{%         for policy in management_security.password.policies | arista.avd.natural_sort('name') %}
+{%             set min_digits = policy.minimum.digits if policy.minimum.digits is arista.avd.defined else 'N/A' %}
+{%             set min_length = policy.minimum.length if policy.minimum.length is arista.avd.defined else 'N/A' %}
+{%             set min_lower = policy.minimum.lower if policy.minimum.lower is arista.avd.defined else 'N/A' %}
+{%             set min_special = policy.minimum.special if policy.minimum.special is arista.avd.defined else 'N/A' %}
+{%             set min_upper = policy.minimum.upper if policy.minimum.upper is arista.avd.defined else 'N/A' %}
+{%             set max_repetitive = policy.maximum.repetitive if policy.maximum.repetitive is arista.avd.defined else 'N/A' %}
+{%             set max_sequential = policy.maximum.sequential if policy.maximum.sequential is arista.avd.defined else 'N/A' %}
+| {{ policy.name }} | > {{ min_digits }} | > {{ min_length }} | > {{ min_lower }} | > {{ min_special }} | > {{ min_upper }} | < {{ max_repetitive }} | < {{ max_sequential }} |
 {%         endfor %}
 {%     endif %}
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management.j2
@@ -12,6 +12,7 @@
        or management_ssh is arista.avd.defined
        or management_tech_support is arista.avd.defined
        or ip_ssh_client_source_interfaces is arista.avd.defined
+       or management_accounts is arista.avd.defined
        or management_api_gnmi is arista.avd.defined
        or management_cvx is arista.avd.defined
        or management_console is arista.avd.defined
@@ -44,6 +45,8 @@
 {%     include 'documentation/management-tech-support.j2' %}
 {## IP SSH Client Source Interfaces #}
 {%     include 'documentation/ip-ssh-client-source-interfaces.j2' %}
+{## Management Accounts #}
+{%     include 'documentation/management-accounts.j2' %}
 {## Management API gNMI #}
 {%     include 'documentation/management-api-gnmi.j2' %}
 {## Management CVX #}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-intended-config.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-intended-config.j2
@@ -272,6 +272,8 @@
 {% include 'eos/ip-http-client-source-interfaces.j2' %}
 {# ip ssh client source interfaces #}
 {% include 'eos/ip-ssh-client-source-interfaces.j2' %}
+{# management accounts #}
+{% include 'eos/management-accounts.j2' %}
 {# management api http #}
 {% include 'eos/management-api-http.j2' %}
 {# management console #}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-accounts.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-accounts.j2
@@ -1,0 +1,8 @@
+{# eos - management accounts #}
+{% if management_accounts is arista.avd.defined %}
+!
+management accounts
+{%     if management_accounts.password.policy is arista.avd.defined %}
+   password policy {{ management_accounts.password.policy }}
+{%     endif %}
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-security.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-security.j2
@@ -14,8 +14,8 @@ management security
 {%     if management_security.password.minimum_length is arista.avd.defined %}
    password minimum length {{ management_security.password.minimum_length }}
 {%     endif %}
-{%     if management_security.password.policy is arista.avd.defined %}
-{%         for policy in management_security.password.policy %}
+{%     if management_security.password.policies is arista.avd.defined %}
+{%         for policy in management_security.password.policies %}
    password policy {{ policy.name }}
 {%             if policy.minimum is arista.avd.defined %}
 {%                 if policy.minimum.digits is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-security.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-security.j2
@@ -15,31 +15,33 @@ management security
    password minimum length {{ management_security.password.minimum_length }}
 {%     endif %}
 {%     if management_security.password.policy is arista.avd.defined %}
-{%         if management_security.password.policy.minimum is arista.avd.defined %}
-{%             if management_security.password.policy.minimum.digits is arista.avd.defined %}
-   password policy AVD_POLICY minimum digits {{ management_security.password.policy.minimum.digits }}
+{%         for policy in management_security.password.policy %}
+{%             if policy.minimum is arista.avd.defined %}
+{%                 if policy.minimum.digits is arista.avd.defined %}
+   password policy {{ policy.name }} minimum digits {{ policy.minimum.digits }}
+{%                 endif %}
+{%                 if policy.minimum.length is arista.avd.defined %}
+   password policy {{ policy.name }} minimum length {{ policy.minimum.length }}
+{%                 endif %}
+{%                 if policy.minimum.lower is arista.avd.defined %}
+   password policy {{ policy.name }} minimum lower {{ policy.minimum.lower }}
+{%                 endif %}
+{%                 if policy.minimum.special is arista.avd.defined %}
+   password policy {{ policy.name }} minimum special {{ policy.minimum.special }}
+{%                 endif %}
+{%                 if policy.minimum.upper is arista.avd.defined %}
+   password policy {{ policy.name }} minimum upper {{ policy.minimum.upper }}
+{%                 endif %}
 {%             endif %}
-{%             if management_security.password.policy.minimum.length is arista.avd.defined %}
-   password policy AVD_POLICY minimum length {{ management_security.password.policy.minimum.length }}
+{%             if policy.maximum is arista.avd.defined %}
+{%                 if policy.maximum.repetitive is arista.avd.defined %}
+   password policy {{ policy.name }} maximum repetitive {{ policy.maximum.repetitive }}
+{%                 endif %}
+{%                 if policy.maximum.sequential is arista.avd.defined %}
+   password policy {{ policy.name }} maximum sequential {{ policy.maximum.sequential }}
+{%                 endif %}
 {%             endif %}
-{%             if management_security.password.policy.minimum.lower is arista.avd.defined %}
-   password policy AVD_POLICY minimum lower {{ management_security.password.policy.minimum.lower }}
-{%             endif %}
-{%             if management_security.password.policy.minimum.special is arista.avd.defined %}
-   password policy AVD_POLICY minimum special {{ management_security.password.policy.minimum.special }}
-{%             endif %}
-{%             if management_security.password.policy.minimum.upper is arista.avd.defined %}
-   password policy AVD_POLICY minimum upper {{ management_security.password.policy.minimum.upper }}
-{%             endif %}
-{%         endif %}
-{%         if management_security.password.policy.maximum is arista.avd.defined %}
-{%             if management_security.password.policy.maximum.repetitive is arista.avd.defined %}
-   password policy AVD_POLICY maximum repetitive {{ management_security.password.policy.maximum.repetitive }}
-{%             endif %}
-{%             if management_security.password.policy.maximum.sequential is arista.avd.defined %}
-   password policy AVD_POLICY maximum sequential {{ management_security.password.policy.maximum.sequential }}
-{%             endif %}
-{%         endif %}
+{%         endfor %}
 {%     endif %}
 {%     for ssl_profile in management_security.ssl_profiles | arista.avd.natural_sort %}
    ssl profile {{ ssl_profile.name }}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-security.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-security.j2
@@ -14,6 +14,33 @@ management security
 {%     if management_security.password.minimum_length is arista.avd.defined %}
    password minimum length {{ management_security.password.minimum_length }}
 {%     endif %}
+{%     if management_security.password.policy is arista.avd.defined %}
+{%         if management_security.password.policy.minimum is arista.avd.defined %}
+{%             if management_security.password.policy.minimum.digits is arista.avd.defined %}
+   password policy AVD_POLICY minimum digits {{ management_security.password.policy.minimum.digits }}
+{%             endif %}
+{%             if management_security.password.policy.minimum.length is arista.avd.defined %}
+   password policy AVD_POLICY minimum length {{ management_security.password.policy.minimum.length }}
+{%             endif %}
+{%             if management_security.password.policy.minimum.lower is arista.avd.defined %}
+   password policy AVD_POLICY minimum lower {{ management_security.password.policy.minimum.lower }}
+{%             endif %}
+{%             if management_security.password.policy.minimum.special is arista.avd.defined %}
+   password policy AVD_POLICY minimum special {{ management_security.password.policy.minimum.special }}
+{%             endif %}
+{%             if management_security.password.policy.minimum.upper is arista.avd.defined %}
+   password policy AVD_POLICY minimum upper {{ management_security.password.policy.minimum.upper }}
+{%             endif %}
+{%         endif %}
+{%         if management_security.password.policy.maximum is arista.avd.defined %}
+{%             if management_security.password.policy.maximum.repetitive is arista.avd.defined %}
+   password policy AVD_POLICY maximum repetitive {{ management_security.password.policy.maximum.repetitive }}
+{%             endif %}
+{%             if management_security.password.policy.maximum.sequential is arista.avd.defined %}
+   password policy AVD_POLICY maximum sequential {{ management_security.password.policy.maximum.sequential }}
+{%             endif %}
+{%         endif %}
+{%     endif %}
 {%     for ssl_profile in management_security.ssl_profiles | arista.avd.natural_sort %}
    ssl profile {{ ssl_profile.name }}
 {%         if ssl_profile.tls_versions is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-security.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-security.j2
@@ -16,29 +16,30 @@ management security
 {%     endif %}
 {%     if management_security.password.policy is arista.avd.defined %}
 {%         for policy in management_security.password.policy %}
+   password policy {{ policy.name }}
 {%             if policy.minimum is arista.avd.defined %}
 {%                 if policy.minimum.digits is arista.avd.defined %}
-   password policy {{ policy.name }} minimum digits {{ policy.minimum.digits }}
+      minimum digits {{ policy.minimum.digits }}
 {%                 endif %}
 {%                 if policy.minimum.length is arista.avd.defined %}
-   password policy {{ policy.name }} minimum length {{ policy.minimum.length }}
+      minimum length {{ policy.minimum.length }}
 {%                 endif %}
 {%                 if policy.minimum.lower is arista.avd.defined %}
-   password policy {{ policy.name }} minimum lower {{ policy.minimum.lower }}
+      minimum lower {{ policy.minimum.lower }}
 {%                 endif %}
 {%                 if policy.minimum.special is arista.avd.defined %}
-   password policy {{ policy.name }} minimum special {{ policy.minimum.special }}
+      minimum special {{ policy.minimum.special }}
 {%                 endif %}
 {%                 if policy.minimum.upper is arista.avd.defined %}
-   password policy {{ policy.name }} minimum upper {{ policy.minimum.upper }}
+      minimum upper {{ policy.minimum.upper }}
 {%                 endif %}
 {%             endif %}
 {%             if policy.maximum is arista.avd.defined %}
 {%                 if policy.maximum.repetitive is arista.avd.defined %}
-   password policy {{ policy.name }} maximum repetitive {{ policy.maximum.repetitive }}
+      maximum repetitive {{ policy.maximum.repetitive }}
 {%                 endif %}
 {%                 if policy.maximum.sequential is arista.avd.defined %}
-   password policy {{ policy.name }} maximum sequential {{ policy.maximum.sequential }}
+      maximum sequential {{ policy.maximum.sequential }}
 {%                 endif %}
 {%             endif %}
 {%         endfor %}


### PR DESCRIPTION
## Change Summary

Add support for the password complexity policies introduced into EOS 4.29.2F (https://www.arista.com/en/support/toi/eos-4-29-2f/17208-support-for-password-complexity-policies)

## Related Issue(s)

Fixes #2972

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Add policy list key to management_security.password with all the relevant options exposed in EOS CLI
Add ability to set policy used via management_accounts

## How to test
- run molecule test -s eos_cli_config_gen
## Checklist
### User Checklist
- [x] Implement management_security.password schema and generation
- [x] Implement management_accounts
- [x] Add/update relevant documentation templates
- [x] Review the new Documentation

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
