### PR TITLE
Feat(eos_cli_config_gen): Add global logging event storm-control

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/logging.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/logging.md
@@ -76,6 +76,8 @@ interface Management1
 logging buffered 1000000 warnings
 no logging trap
 logging console errors
+logging event storm-control discards global
+logging event storm-control discards interval 10
 logging synchronous level critical
 logging host 20.20.20.7
 logging host 50.50.50.7 100 200 protocol tcp

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/logging.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/logging.cfg
@@ -5,6 +5,8 @@ transceiver qsfp default-mode 4x10G
 logging buffered 1000000 warnings
 no logging trap
 logging console errors
+logging event storm-control discards global
+logging event storm-control discards interval 10
 logging synchronous level critical
 logging host 20.20.20.7
 logging host 50.50.50.7 100 200 protocol tcp

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/logging.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/logging.yml
@@ -45,5 +45,5 @@ logging:
   event:
     storm_control:
       discards:
-        enable: true
+        global: true
         interval: 10

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/logging.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/logging.yml
@@ -42,3 +42,8 @@ logging:
           ports:
             - 100
             - 200
+  event:
+    storm_control:
+      discards:
+        enable: true
+        interval: 10

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/logging.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/logging.md
@@ -30,6 +30,11 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;match_lists</samp>](## "logging.policy.match.match_lists") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "logging.policy.match.match_lists.[].name") | String | Required, Unique |  |  | Match list |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;action</samp>](## "logging.policy.match.match_lists.[].action") | String |  |  | Valid Values:<br>- discard |  |
+    | [<samp>&nbsp;&nbsp;event</samp>](## "logging.event") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;storm_control</samp>](## "logging.event.storm_control") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;discards</samp>](## "logging.event.storm_control.discards") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enable</samp>](## "logging.event.storm_control.discards.enable") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interval</samp>](## "logging.event.storm_control.discards.interval") | Integer |  |  | Min: 10<br>Max: 65535 | Logging interval in seconds |
 
 === "YAML"
 
@@ -62,4 +67,9 @@
           match_lists:
             - name: <str>
               action: <str>
+      event:
+        storm_control:
+          discards:
+            enable: <bool>
+            interval: <int>
     ```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/logging.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/logging.md
@@ -33,7 +33,7 @@
     | [<samp>&nbsp;&nbsp;event</samp>](## "logging.event") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;storm_control</samp>](## "logging.event.storm_control") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;discards</samp>](## "logging.event.storm_control.discards") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enable</samp>](## "logging.event.storm_control.discards.enable") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;global</samp>](## "logging.event.storm_control.discards.global") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interval</samp>](## "logging.event.storm_control.discards.interval") | Integer |  |  | Min: 10<br>Max: 65535 | Logging interval in seconds |
 
 === "YAML"
@@ -70,6 +70,6 @@
       event:
         storm_control:
           discards:
-            enable: <bool>
+            global: <bool>
             interval: <int>
     ```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -6272,38 +6272,45 @@
         },
         "event": {
           "type": "object",
-          "items": {
-            "type": "object",
-            "properties": {
-              "storm_control_discards": {
-                "type": "object",
-                "items": {
+          "properties": {
+            "storm_control": {
+              "type": "object",
+              "properties": {
+                "discards": {
                   "type": "object",
                   "properties": {
                     "enable": {
                       "type": "boolean",
-                      "description": "Enable logging for storm-control discards",
                       "title": "Enable"
                     },
                     "interval": {
                       "type": "integer",
-                      "description": "Interval in seconds",
                       "minimum": 10,
                       "maximum": 65535,
+                      "description": "Logging interval in seconds",
                       "title": "Interval"
-                    },
+                    }
                   },
-                },
-                "title": "Storm-Control discards"
-              }
-            },
-            "additionalProperties": false,
-            "patternProperties": {
-              "^_.+$": {}
+                  "additionalProperties": false,
+                  "patternProperties": {
+                    "^_.+$": {}
+                  },
+                  "title": "Discards"
+                }
+              },
+              "additionalProperties": false,
+              "patternProperties": {
+                "^_.+$": {}
+              },
+              "title": "Storm Control"
             }
           },
+          "additionalProperties": false,
+          "patternProperties": {
+            "^_.+$": {}
+          },
           "title": "Event"
-        },
+        }
       },
       "additionalProperties": false,
       "patternProperties": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -6279,9 +6279,9 @@
                 "discards": {
                   "type": "object",
                   "properties": {
-                    "enable": {
+                    "global": {
                       "type": "boolean",
-                      "title": "Enable"
+                      "title": "Global"
                     },
                     "interval": {
                       "type": "integer",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -6269,7 +6269,41 @@
             "^_.+$": {}
           },
           "title": "Policy"
-        }
+        },
+        "event": {
+          "type": "object",
+          "items": {
+            "type": "object",
+            "properties": {
+              "storm_control_discards": {
+                "type": "object",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "enable": {
+                      "type": "boolean",
+                      "description": "Enable logging for storm-control discards",
+                      "title": "Enable"
+                    },
+                    "interval": {
+                      "type": "integer",
+                      "description": "Interval in seconds",
+                      "minimum": 10,
+                      "maximum": 65535,
+                      "title": "Interval"
+                    },
+                  },
+                },
+                "title": "Storm-Control discards"
+              }
+            },
+            "additionalProperties": false,
+            "patternProperties": {
+              "^_.+$": {}
+            }
+          },
+          "title": "Event"
+        },
       },
       "additionalProperties": false,
       "patternProperties": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -3925,15 +3925,23 @@ keys:
                       valid_values:
                       - discard
       event:
-        storm_control_discards:
-          enable: bool
-          interval:
-            description: Interval in seconds
-            type: int
-            min: 10
-            max: 65535
-            convert_types:
-            - str
+        type: dict
+        keys:
+          storm_control:
+            type: dict
+            keys:
+              discards:
+                type: dict
+                keys:
+                  enable:
+                    type: bool
+                  interval:
+                    type: int
+                    convert_types:
+                    - str
+                    min: 10
+                    max: 65535
+                    description: Logging interval in seconds
   loopback_interfaces:
     type: list
     primary_key: name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -3933,7 +3933,7 @@ keys:
               discards:
                 type: dict
                 keys:
-                  enable:
+                  global:
                     type: bool
                   interval:
                     type: int

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -3924,6 +3924,16 @@ keys:
                       type: str
                       valid_values:
                       - discard
+      event:
+        storm_control_discards:
+          enable: bool
+          interval:
+            description: Interval in seconds
+            type: int
+            min: 10
+            max: 65535
+            convert_types:
+            - str
   loopback_interfaces:
     type: list
     primary_key: name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/logging.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/logging.schema.yml
@@ -127,3 +127,21 @@ keys:
                     action:
                       type: str
                       valid_values: ["discard"]
+      event:
+        type: dict
+        keys:
+          storm_control:
+            type: dict
+            keys:
+              discards:
+                type: dict
+                keys:
+                  enable:
+                    type: bool
+                  interval:
+                    type: int
+                    convert_types:
+                      - str
+                    min: 10
+                    max: 65535
+                    description: Logging interval in seconds

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/logging.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/logging.schema.yml
@@ -136,7 +136,7 @@ keys:
               discards:
                 type: dict
                 keys:
-                  enable:
+                  global:
                     type: bool
                   interval:
                     type: int

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/logging.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/logging.j2
@@ -28,6 +28,12 @@ no logging monitor
 {%     elif logging.monitor is arista.avd.defined %}
 logging monitor {{ logging.monitor }}
 {%     endif %}
+{%     if logging.event.storm_control_discards.enable is arista.avd.defined(true) %}
+logging event storm-control discards global
+{%     endif %}
+{%     if logging.event.storm_control_discards.interval is arista.avd.defined %}
+logging event storm-control discards interval {{ logging.event.storm_control_discards.interval }}
+{%     endif %}
 {%     if logging.synchronous.level is arista.avd.defined('disabled') %}
 no logging synchronous
 {%     elif logging.synchronous is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/logging.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/logging.j2
@@ -28,7 +28,7 @@ no logging monitor
 {%     elif logging.monitor is arista.avd.defined %}
 logging monitor {{ logging.monitor }}
 {%     endif %}
-{%     if logging.event.storm_control.discards.enable is arista.avd.defined(true) %}
+{%     if logging.event.storm_control.discards.global is arista.avd.defined(true) %}
 logging event storm-control discards global
 {%     endif %}
 {%     if logging.event.storm_control.discards.interval is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/logging.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/logging.j2
@@ -28,11 +28,11 @@ no logging monitor
 {%     elif logging.monitor is arista.avd.defined %}
 logging monitor {{ logging.monitor }}
 {%     endif %}
-{%     if logging.event.storm_control_discards.enable is arista.avd.defined(true) %}
+{%     if logging.event.storm_control.discards.enable is arista.avd.defined(true) %}
 logging event storm-control discards global
 {%     endif %}
-{%     if logging.event.storm_control_discards.interval is arista.avd.defined %}
-logging event storm-control discards interval {{ logging.event.storm_control_discards.interval }}
+{%     if logging.event.storm_control.discards.interval is arista.avd.defined %}
+logging event storm-control discards interval {{ logging.event.storm_control.discards.interval }}
 {%     endif %}
 {%     if logging.synchronous.level is arista.avd.defined('disabled') %}
 no logging synchronous


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Add global configuration to enable event logging for storm-control discards.

```
access(config)#logging event ?
  congestion-drops  Drops due to congestion
  flowcontrol       Configure syslogging for flowcontrol
  link-status       UPDOWN messages
  login             Login activities
  port-channel      Configure port-channel messages
  spanning-tree     Spanning tree messages
  storm-control     Configure storm-control

access(config)#logging event storm-control ?
  discards  Discards due to storm control

access(config)#logging event storm-control discards ?
  global    Configure global storm control discard logging
  interval  Logging interval
```


## Related Issue(s)

Fixes #2993

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

```
logging:
  event:
    storm_control_discards:
      enable: <bool>
      interval: <int>
```

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
```
logging:
  event:
    storm_control_discards:
      enable: true
      interval: 10
```

renders to:
```
logging event storm-control discards global
logging event storm-control discards interval 10
```


## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
