### PR TITLE
Fix(eos_cli_config_gen): Force domain_identifier to be a string

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-evpn-vpn-import-pruning.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-evpn-vpn-import-pruning.md
@@ -168,7 +168,7 @@ router bgp 65101
    !
    address-family evpn
       host-flap detection window 10 threshold 1
-      domain identifier 3906060
+      domain identifier 65101:0
       neighbor EVPN-OVERLAY-PEERS activate
       no neighbor MLAG-IPv4-UNDERLAY-PEER activate
       route import match-failure action discard

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-vpn-ipv4-vpn-ipv6.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-vpn-ipv4-vpn-ipv6.md
@@ -131,7 +131,7 @@ router bgp 65103
    neighbor 2001:cafe:192:168::4 send-community
    !
    address-family vpn-ipv4
-      domain identifier 3900000
+      domain identifier 65000:0
       neighbor MPLS-IBGP-PEERS activate
       neighbor MPLS-IBGP-PEERS route-map RM-IBGP-PEER-IN4 in
       neighbor MPLS-IBGP-PEERS route-map RM-IBGP-PEER-OUT4 out
@@ -142,7 +142,7 @@ router bgp 65103
       route import match-failure action discard
    !
    address-family vpn-ipv6
-      domain identifier 3900000
+      domain identifier 65000:0
       neighbor MPLS-IBGP-PEERS activate
       neighbor MPLS-IBGP-PEERS route-map RM-IBGP-PEER-IN6 in
       neighbor MPLS-IBGP-PEERS route-map RM-IBGP-PEER-OUT6 out

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-evpn-vpn-import-pruning.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-evpn-vpn-import-pruning.cfg
@@ -58,7 +58,7 @@ router bgp 65101
    !
    address-family evpn
       host-flap detection window 10 threshold 1
-      domain identifier 3906060
+      domain identifier 65101:0
       neighbor EVPN-OVERLAY-PEERS activate
       no neighbor MLAG-IPv4-UNDERLAY-PEER activate
       route import match-failure action discard

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-vpn-ipv4-vpn-ipv6.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-vpn-ipv4-vpn-ipv6.cfg
@@ -33,7 +33,7 @@ router bgp 65103
    neighbor 2001:cafe:192:168::4 send-community
    !
    address-family vpn-ipv4
-      domain identifier 3900000
+      domain identifier 65000:0
       neighbor MPLS-IBGP-PEERS activate
       neighbor MPLS-IBGP-PEERS route-map RM-IBGP-PEER-IN4 in
       neighbor MPLS-IBGP-PEERS route-map RM-IBGP-PEER-OUT4 out
@@ -44,7 +44,7 @@ router bgp 65103
       route import match-failure action discard
    !
    address-family vpn-ipv6
-      domain identifier 3900000
+      domain identifier 65000:0
       neighbor MPLS-IBGP-PEERS activate
       neighbor MPLS-IBGP-PEERS route-map RM-IBGP-PEER-IN6 in
       neighbor MPLS-IBGP-PEERS route-map RM-IBGP-PEER-OUT6 out

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-evpn-vpn-import-pruning.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-evpn-vpn-import-pruning.yml
@@ -33,7 +33,7 @@ router_bgp:
       peer_group: EVPN-OVERLAY-PEERS
   redistribute_routes:
   address_family_evpn:
-    domain_identifier: 65101:0
+    domain_identifier: "65101:0"
     peer_groups:
       - name: EVPN-OVERLAY-PEERS
         activate: true

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-vpn-ipv4-vpn-ipv6.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-vpn-ipv4-vpn-ipv6.yml
@@ -28,7 +28,7 @@ router_bgp:
       remote_as: 65004
       send_community: all
   address_family_vpn_ipv4:
-    domain_identifier: 65000:0
+    domain_identifier: "65000:0"
     route:
       import_match_failure_action: discard
     peer_groups:
@@ -44,7 +44,7 @@ router_bgp:
     neighbor_default_encapsulation_mpls_next_hop_self:
       source_interface: Loopback0
   address_family_vpn_ipv6:
-    domain_identifier: 65000:0
+    domain_identifier: "65000:0"
     route:
       import_match_failure_action: discard
     peer_groups:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -7718,8 +7718,6 @@ keys:
         keys:
           domain_identifier:
             type: str
-            convert_types:
-            - int
           neighbor_default:
             type: dict
             keys:
@@ -8217,8 +8215,6 @@ keys:
         keys:
           domain_identifier:
             type: str
-            convert_types:
-            - int
           peer_groups:
             type: list
             primary_key: name
@@ -8273,8 +8269,6 @@ keys:
         keys:
           domain_identifier:
             type: str
-            convert_types:
-            - int
           peer_groups:
             type: list
             primary_key: name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_bgp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_bgp.schema.yml
@@ -777,8 +777,6 @@ keys:
         keys:
           domain_identifier:
             type: str
-            convert_types:
-              - int
           neighbor_default:
             type: dict
             keys:
@@ -1275,8 +1273,6 @@ keys:
         keys:
           domain_identifier:
             type: str
-            convert_types:
-              - int
           peer_groups:
             type: list
             primary_key: name
@@ -1331,8 +1327,6 @@ keys:
         keys:
           domain_identifier:
             type: str
-            convert_types:
-              - int
           peer_groups:
             type: list
             primary_key: name


### PR DESCRIPTION
## Change Summary
Currently domain_identifier accepts both str and int due to it's convert_type value. When parsing the YAML, pyyaml reads `domain_identifier: 65000:0` as a sexagesimal float converting it to 3900000. We then accept that due to the convert_type making it "3900000" causing the domain_identifier output to be `domain identifier 3900000` in the config. This change forces domain_identifier to be a str in the YAML because otherwise users could run into this and be quite confused

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Remove the convert_types from relevant domain_identifiers
```
          domain_identifier:
            type: str
            convert_types:
            - int
```
to
```
          domain_identifier:
            type: str
```
## How to test
Updating the relevant molecules to reflect the correction functionality
## Checklist
### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
