### PR TITLE
Feat(plugins): Make setting of switch fact optional for yaml_templates_to_facts

### DIFF
--- a/ansible_collections/arista/avd/plugins/README.md
+++ b/ansible_collections/arista/avd/plugins/README.md
@@ -581,12 +581,12 @@ The module arguments are:
     # while still allowing the data to be validated.
     # During conversion, messages will be generated with information about the host(s) and key(s) which required conversion.
     #
-    # conversion_mode:disabled means that conversion will not run.
-    # conversion_mode:error will produce error messages and fail the task.
-    # conversion_mode:warning will produce warning messages.
-    # conversion_mode:info will produce regular log messages.
-    # conversion_mode:debug will produce hidden messages viewable with -v.
-    # conversion_mode:quiet will not produce any messages.
+    # "conversion_mode: disabled" means that conversion will not run.
+    # "conversion_mode: error" will produce error messages and fail the task.
+    # "conversion_mode: warning" will produce warning messages.
+    # "conversion_mode: info" will produce regular log messages.
+    # "conversion_mode: debug" will produce hidden messages viewable with -v.
+    # "conversion_mode: quiet" will not produce any messages.
     conversion_mode: < error | warning | info | debug (default) | quiet | disabled >
 
     # Export cProfile data to a file ex. "eos_designs_structured_config-{{inventory_hostname}}"
@@ -632,7 +632,7 @@ The module arguments are:
           # Merge strategy for lists for Ansible Combine filter. See Ansible Combine filter for details.
           list_merge: < append (default) | replace | keep | prepend | append_rp | prepend_rp >
 
-          # Filter out keys from the generated output if value is null/none/undefined
+          # Filter out keys from the generated output if the value is null/none/undefined
           strip_empty_keys: < true (default) | false >
 
     # If true the output data will be run through another jinja2 rendering before returning.
@@ -644,11 +644,11 @@ The module arguments are:
     # During validation, messages will be generated with information
     # about the host(s) and key(s) which failed validation.
     #
-    # validation_mode:disabled means that validation will not run.
-    # validation_mode:error will produce error messages and fail the task.
-    # validation_mode:warning will produce warning messages.
-    # validation_mode:info will produce regular log messages.
-    # validation_mode:debug will produce hidden messages viewable with -v.
+    # "validation_mode: disabled" means that validation will not run.
+    # "validation_mode: error" will produce error messages and fail the task.
+    # "validation_mode: warning" will produce warning messages.
+    # "validation_mode: info" will produce regular log messages.
+    # "validation_mode: debug" will produce hidden messages viewable with -v.
     validation_mode: < error | warning (default) | info | debug | disabled >
 ```
 

--- a/ansible_collections/arista/avd/plugins/README.md
+++ b/ansible_collections/arista/avd/plugins/README.md
@@ -603,7 +603,7 @@ The module arguments are:
     mode: < string >
 
     # AVD Schema for output data. Used for automatic merge of data.
-    output_schem: < schema as dict>
+    output_schema: < schema as dict >
 
     # ID of AVD Schema for output data. Used for automatic merge of data.
     output_schema_id: < eos_cli_config_gen | eos_designs >

--- a/ansible_collections/arista/avd/plugins/action/yaml_templates_to_facts.py
+++ b/ansible_collections/arista/avd/plugins/action/yaml_templates_to_facts.py
@@ -64,13 +64,15 @@ class ActionModule(ActionBase):
             validation_mode = self._task.args.get("validation_mode")
             output_schema = self._task.args.get("output_schema")
             output_schema_id = self._task.args.get("output_schema_id")
+            set_switch_fact = self._task.args.get("set_switch_fact", True)
 
         else:
             raise AnsibleActionFail("The argument 'templates' must be set")
 
         hostname = task_vars["inventory_hostname"]
 
-        task_vars["switch"] = get(task_vars, f"avd_switch_facts..{hostname}..switch", separator="..", default={})
+        if set_switch_fact:
+            task_vars["switch"] = get(task_vars, f"avd_switch_facts..{hostname}..switch", separator="..", default={})
 
         # Read ansible variables and perform templating to support inline jinja2
         for var in task_vars:
@@ -100,13 +102,13 @@ class ActionModule(ActionBase):
         # Initialize SharedUtils class to be passed to each python_module below.
         shared_utils = SharedUtils(hostvars=template_vars, templar=self.templar)
 
-        # Insert dynamic keys into the input data if not set.
-        # These keys are required by the schema, but the default values are set inside shared_utils.
-        task_vars.setdefault("node_type_keys", shared_utils.node_type_keys)
-        task_vars.setdefault("connected_endpoints_keys", shared_utils.connected_endpoints_keys)
-        task_vars.setdefault("network_services_keys", shared_utils.network_services_keys)
-
         if schema or schema_id:
+            # Insert dynamic keys into the input data if not set.
+            # These keys are required by the schema, but the default values are set inside shared_utils.
+            task_vars.setdefault("node_type_keys", shared_utils.node_type_keys)
+            task_vars.setdefault("connected_endpoints_keys", shared_utils.connected_endpoints_keys)
+            task_vars.setdefault("network_services_keys", shared_utils.network_services_keys)
+
             # Load schema tools and perform conversion and validation
             avdschematools = AvdSchemaTools(
                 hostname=hostname,
@@ -268,7 +270,8 @@ class ActionModule(ActionBase):
         else:
             result["ansible_facts"] = output
 
-        result["ansible_facts"]["switch"] = task_vars.get("switch")
+        if set_switch_fact:
+            result["ansible_facts"]["switch"] = task_vars.get("switch")
 
         if cprofile_file:
             profiler.disable()

--- a/ansible_collections/arista/avd/plugins/modules/yaml_templates_to_facts.py
+++ b/ansible_collections/arista/avd/plugins/modules/yaml_templates_to_facts.py
@@ -144,7 +144,6 @@ options:
 """
 
 EXAMPLES = r"""
-# tasks file for configlet_build_config
 - name: Generate device configuration in structured format
   arista.avd.yaml_templates_to_facts:
     root_key: structured_config
@@ -161,6 +160,8 @@ EXAMPLES = r"""
         options:
           list_merge: "{{ custom_structured_configuration_list_merge }}"
           strip_empty_keys: false
+    schema_id: eos_designs
+    output_schema_id: eos_cli_config_gen
   check_mode: no
   changed_when: False
 """

--- a/ansible_collections/arista/avd/plugins/modules/yaml_templates_to_facts.py
+++ b/ansible_collections/arista/avd/plugins/modules/yaml_templates_to_facts.py
@@ -135,6 +135,12 @@ options:
     required: false
     type: str
     choices: [ "eos_cli_config_gen", "eos_designs" ]
+  set_switch_fact:
+    description:
+      - Set "switch" fact from on "avd_switch_facts.<inventory_hostname>.switch"
+    required: false
+    type: bool
+    default: true
 """
 
 EXAMPLES = r"""


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Make setting of switch fact optional for yaml_templates_to_facts

## Related Issue(s)

Fixes #3020 

## Component(s) name

`arista.avd.yaml_templates_to_facts`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

New `set_switch_fact` argument on `yaml_templates_to_facts` to prevent setting the `switch` fact.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

No changes no any existing outputs.
Will be tested manually.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
