### PR TITLE
Fix(eos_config_deploy_cvp): device_filter is not behaving correctly if input is a string

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/converge.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/converge.yml
@@ -31,3 +31,24 @@
         execute_tasks: false
         state: present
         cv_collection: v3
+
+- name: "Converge -- Build Cloudvision Configuration - empty filter as a string"
+  hosts: CVP
+  gather_facts: false
+  connection: local
+  vars:
+    root_dir: '{{ playbook_dir }}'
+  tasks:
+    - name: Run CVP provisioning
+      # tags: generate
+      ansible.builtin.import_role:
+        name: arista.avd.eos_config_deploy_cvp
+      vars:
+        container_root: 'DC1_FABRIC'
+        configlets_prefix: 'AVD'
+        device_filter: ''
+        execute_tasks: false
+        state: absent
+        cv_collection: v3
+        # overwriting the default structured_cvp_dir_name to get different files
+        structured_cvp_dir_name: cvp-empty-filter

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/cvp-empty-filter/cv_server.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/cvp-empty-filter/cv_server.yml
@@ -1,0 +1,59 @@
+---
+cvp_devices:
+  - fqdn: DC1-BL1A
+    configlets:
+      - AVD_DC1-BL1A
+  - fqdn: DC1-BL1B
+    configlets:
+      - AVD_DC1-BL1B
+  - fqdn: DC1-L2LEAF1A
+    configlets:
+      - AVD_DC1-L2LEAF1A
+  - fqdn: DC1-L2LEAF2A
+    configlets:
+      - AVD_DC1-L2LEAF2A
+  - fqdn: DC1-L2LEAF2B
+    configlets:
+      - AVD_DC1-L2LEAF2B
+  - fqdn: DC1-LEAF1A
+    configlets:
+      - AVD_DC1-LEAF1A
+  - fqdn: DC1-LEAF2A
+    configlets:
+      - AVD_DC1-LEAF2A
+  - fqdn: DC1-LEAF2B
+    configlets:
+      - AVD_DC1-LEAF2B
+  - fqdn: DC1-SPINE1
+    configlets:
+      - AVD_DC1-SPINE1
+  - fqdn: DC1-SPINE2
+    configlets:
+      - AVD_DC1-SPINE2
+  - fqdn: DC1-SPINE3
+    configlets:
+      - AVD_DC1-SPINE3
+  - fqdn: DC1-SPINE4
+    configlets:
+      - AVD_DC1-SPINE4
+cvp_containers:
+  DC1_BL1:
+    parentContainerName: DC1_LEAFS
+  DC1_FABRIC:
+    parentContainerName: Tenant
+  DC1_L2LEAF1:
+    parentContainerName: DC1_L2LEAFS
+  DC1_L2LEAF2:
+    parentContainerName: DC1_L2LEAFS
+  DC1_L2LEAFS:
+    parentContainerName: DC1_FABRIC
+  DC1_LEAF1:
+    parentContainerName: DC1_LEAFS
+  DC1_LEAF2:
+    parentContainerName: DC1_LEAFS
+  DC1_LEAFS:
+    parentContainerName: DC1_FABRIC
+  DC1_SPINES:
+    parentContainerName: DC1_FABRIC
+  DC1_SVC3:
+    parentContainerName: DC1_LEAFS

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/cvp-empty-filter/cv_server.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/cvp-empty-filter/cv_server.yml
@@ -1,39 +1,51 @@
 ---
 cvp_devices:
   - fqdn: DC1-BL1A
+    parentContainerName: DC1_BL1
     configlets:
       - AVD_DC1-BL1A
   - fqdn: DC1-BL1B
+    parentContainerName: DC1_BL1
     configlets:
       - AVD_DC1-BL1B
   - fqdn: DC1-L2LEAF1A
+    parentContainerName: DC1_L2LEAF1
     configlets:
       - AVD_DC1-L2LEAF1A
   - fqdn: DC1-L2LEAF2A
+    parentContainerName: DC1_L2LEAF2
     configlets:
       - AVD_DC1-L2LEAF2A
   - fqdn: DC1-L2LEAF2B
+    parentContainerName: DC1_L2LEAF2
     configlets:
       - AVD_DC1-L2LEAF2B
   - fqdn: DC1-LEAF1A
+    parentContainerName: DC1_LEAF1
     configlets:
       - AVD_DC1-LEAF1A
   - fqdn: DC1-LEAF2A
+    parentContainerName: DC1_LEAF2
     configlets:
       - AVD_DC1-LEAF2A
   - fqdn: DC1-LEAF2B
+    parentContainerName: DC1_LEAF2
     configlets:
       - AVD_DC1-LEAF2B
   - fqdn: DC1-SPINE1
+    parentContainerName: DC1_SPINES
     configlets:
       - AVD_DC1-SPINE1
   - fqdn: DC1-SPINE2
+    parentContainerName: DC1_SPINES
     configlets:
       - AVD_DC1-SPINE2
   - fqdn: DC1-SPINE3
+    parentContainerName: DC1_SPINES
     configlets:
       - AVD_DC1-SPINE3
   - fqdn: DC1-SPINE4
+    parentContainerName: DC1_SPINES
     configlets:
       - AVD_DC1-SPINE4
 cvp_containers:

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/cvp-empty-filter/cv_server_configlets.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/cvp-empty-filter/cv_server_configlets.yml
@@ -1446,31 +1446,43 @@ cvp_configlets:
     \  !\n   vrf MGMT\n      no shutdown\n!\nend\n"
 cvp_topology:
   DC1_BL1:
-    devices: []
+    devices:
+    - DC1-BL1A
+    - DC1-BL1B
     parent_container: DC1_LEAFS
   DC1_FABRIC:
     devices: []
     parent_container: Tenant
   DC1_L2LEAF1:
-    devices: []
+    devices:
+    - DC1-L2LEAF1A
     parent_container: DC1_L2LEAFS
   DC1_L2LEAF2:
-    devices: []
+    devices:
+    - DC1-L2LEAF2A
+    - DC1-L2LEAF2B
     parent_container: DC1_L2LEAFS
   DC1_L2LEAFS:
     devices: []
     parent_container: DC1_FABRIC
   DC1_LEAF1:
-    devices: []
+    devices:
+    - DC1-LEAF1A
     parent_container: DC1_LEAFS
   DC1_LEAF2:
-    devices: []
+    devices:
+    - DC1-LEAF2A
+    - DC1-LEAF2B
     parent_container: DC1_LEAFS
   DC1_LEAFS:
     devices: []
     parent_container: DC1_FABRIC
   DC1_SPINES:
-    devices: []
+    devices:
+    - DC1-SPINE1
+    - DC1-SPINE2
+    - DC1-SPINE3
+    - DC1-SPINE4
     parent_container: DC1_FABRIC
   DC1_SVC3:
     devices: []

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/cvp-empty-filter/cv_server_configlets.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/cvp-empty-filter/cv_server_configlets.yml
@@ -1,0 +1,1477 @@
+cvp_configlets:
+  AVD_DC1-BL1A: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr
+    -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
+    -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
+    internal order ascending range 1006 1199\n!\ntransceiver qsfp default-mode 4x10G\n!\nservice
+    routing protocols model multi-agent\n!\nhostname DC1-BL1A\nip name-server vrf
+    MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nntp local-interface vrf
+    MGMT Management1\nntp server vrf MGMT 192.168.200.5 prefer\n!\nspanning-tree mode
+    mstp\nno spanning-tree vlan-id 4093-4094\nspanning-tree mst 0 priority 4096\n!\nno
+    enable password\nno aaa root\n!\nusername admin privilege 15 role network-admin
+    nopassword\nusername cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\nvlan
+    150\n   name Tenant_A_WAN_Zone_1\n!\nvlan 250\n   name Tenant_B_WAN_Zone_1\n!\nvlan
+    350\n   name Tenant_C_WAN_Zone_1\n!\nvlan 3013\n   name MLAG_iBGP_Tenant_A_WAN_Zone\n
+    \  trunk group LEAF_PEER_L3\n!\nvlan 3020\n   name MLAG_iBGP_Tenant_B_WAN_Zone\n
+    \  trunk group LEAF_PEER_L3\n!\nvlan 3030\n   name MLAG_iBGP_Tenant_C_WAN_Zone\n
+    \  trunk group LEAF_PEER_L3\n!\nvlan 4093\n   name LEAF_PEER_L3\n   trunk group
+    LEAF_PEER_L3\n!\nvlan 4094\n   name MLAG_PEER\n   trunk group MLAG\n!\nvrf instance
+    MGMT\n!\nvrf instance Tenant_A_WAN_Zone\n!\nvrf instance Tenant_B_WAN_Zone\n!\nvrf
+    instance Tenant_C_WAN_Zone\n!\ninterface Port-Channel5\n   description MLAG_PEER_DC1-BL1B_Po5\n
+    \  no shutdown\n   switchport\n   switchport mode trunk\n   switchport trunk group
+    LEAF_PEER_L3\n   switchport trunk group MLAG\n!\ninterface Ethernet1\n   description
+    P2P_LINK_TO_DC1-SPINE1_Ethernet6\n   no shutdown\n   mtu 1500\n   no switchport\n
+    \  ip address 172.31.255.41/31\n!\ninterface Ethernet2\n   description P2P_LINK_TO_DC1-SPINE2_Ethernet6\n
+    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.43/31\n!\ninterface
+    Ethernet3\n   description P2P_LINK_TO_DC1-SPINE3_Ethernet6\n   no shutdown\n   mtu
+    1500\n   no switchport\n   ip address 172.31.255.45/31\n!\ninterface Ethernet4\n
+    \  description P2P_LINK_TO_DC1-SPINE4_Ethernet6\n   no shutdown\n   mtu 1500\n
+    \  no switchport\n   ip address 172.31.255.47/31\n!\ninterface Ethernet5\n   description
+    MLAG_PEER_DC1-BL1B_Ethernet5\n   no shutdown\n   channel-group 5 mode active\n!\ninterface
+    Ethernet6\n   description MLAG_PEER_DC1-BL1B_Ethernet6\n   no shutdown\n   channel-group
+    5 mode active\n!\ninterface Loopback0\n   description EVPN_Overlay_Peering\n   no
+    shutdown\n   ip address 192.168.255.10/32\n!\ninterface Loopback1\n   description
+    VTEP_VXLAN_Tunnel_Source\n   no shutdown\n   ip address 192.168.254.10/32\n!\ninterface
+    Management1\n   description oob_management\n   no shutdown\n   vrf MGMT\n   ip
+    address 192.168.200.110/24\n!\ninterface Vlan150\n   description Tenant_A_WAN_Zone_1\n
+    \  no shutdown\n   vrf Tenant_A_WAN_Zone\n   ip address virtual 10.1.40.1/24\n!\ninterface
+    Vlan250\n   description Tenant_B_WAN_Zone_1\n   no shutdown\n   vrf Tenant_B_WAN_Zone\n
+    \  ip address virtual 10.2.50.1/24\n!\ninterface Vlan350\n   description Tenant_C_WAN_Zone_1\n
+    \  no shutdown\n   vrf Tenant_C_WAN_Zone\n   ip address virtual 10.3.50.1/24\n!\ninterface
+    Vlan3013\n   description MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_A_WAN_Zone\n   ip address 10.255.251.10/31\n!\ninterface
+    Vlan3020\n   description MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_B_WAN_Zone\n   ip address 10.255.251.10/31\n!\ninterface
+    Vlan3030\n   description MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_C_WAN_Zone\n   ip address 10.255.251.10/31\n!\ninterface
+    Vlan4093\n   description MLAG_PEER_L3_PEERING\n   no shutdown\n   mtu 1500\n   ip
+    address 10.255.251.10/31\n!\ninterface Vlan4094\n   description MLAG_PEER\n   no
+    shutdown\n   mtu 1500\n   no autostate\n   ip address 10.255.252.10/31\n!\ninterface
+    Vxlan1\n   description DC1-BL1A_VTEP\n   vxlan source-interface Loopback1\n   vxlan
+    virtual-router encapsulation mac-address mlag-system-id\n   vxlan udp-port 4789\n
+    \  vxlan vlan 150 vni 10150\n   vxlan vlan 250 vni 20250\n   vxlan vlan 350 vni
+    30350\n   vxlan vrf Tenant_A_WAN_Zone vni 14\n   vxlan vrf Tenant_B_WAN_Zone vni
+    21\n   vxlan vrf Tenant_C_WAN_Zone vni 31\n!\nip virtual-router mac-address 00:dc:00:00:00:0a\n!\nip
+    routing\nno ip routing vrf MGMT\nip routing vrf Tenant_A_WAN_Zone\nip routing
+    vrf Tenant_B_WAN_Zone\nip routing vrf Tenant_C_WAN_Zone\n!\nip prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n
+    \  seq 10 permit 192.168.255.0/24 eq 32\n   seq 20 permit 192.168.254.0/24 eq
+    32\n!\nmlag configuration\n   domain-id DC1_BL1\n   local-interface Vlan4094\n
+    \  peer-address 10.255.252.11\n   peer-link Port-Channel5\n   reload-delay mlag
+    300\n   reload-delay non-mlag 330\n!\nip route vrf MGMT 0.0.0.0/0 192.168.200.5\n!\nroute-map
+    RM-CONN-2-BGP permit 10\n   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n!\nroute-map
+    RM-MLAG-PEER-IN permit 10\n   description Make routes learned over MLAG Peer-link
+    less preferred on spines to ensure optimal routing\n   set origin incomplete\n!\nrouter
+    bfd\n   multihop interval 1200 min-rx 1200 multiplier 3\n!\nrouter bgp 65104\n
+    \  router-id 192.168.255.10\n   maximum-paths 4 ecmp 4\n   update wait-install\n
+    \  no bgp default ipv4-unicast\n   distance bgp 20 200 200\n   neighbor EVPN-OVERLAY-PEERS
+    peer group\n   neighbor EVPN-OVERLAY-PEERS update-source Loopback0\n   neighbor
+    EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3\n   neighbor
+    EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n   neighbor EVPN-OVERLAY-PEERS
+    send-community\n   neighbor EVPN-OVERLAY-PEERS maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS
+    peer group\n   neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==\n
+    \  neighbor IPv4-UNDERLAY-PEERS send-community\n   neighbor IPv4-UNDERLAY-PEERS
+    maximum-routes 12000\n   neighbor MLAG-IPv4-UNDERLAY-PEER peer group\n   neighbor
+    MLAG-IPv4-UNDERLAY-PEER remote-as 65104\n   neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self\n
+    \  neighbor MLAG-IPv4-UNDERLAY-PEER description DC1-BL1B\n   neighbor MLAG-IPv4-UNDERLAY-PEER
+    password 7 vnEaG8gMeQf3d3cN6PktXQ==\n   neighbor MLAG-IPv4-UNDERLAY-PEER send-community\n
+    \  neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000\n   neighbor MLAG-IPv4-UNDERLAY-PEER
+    route-map RM-MLAG-PEER-IN in\n   neighbor 10.255.251.11 peer group MLAG-IPv4-UNDERLAY-PEER\n
+    \  neighbor 10.255.251.11 description DC1-BL1B\n   neighbor 172.31.255.40 peer
+    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.40 remote-as 65001\n   neighbor
+    172.31.255.40 description DC1-SPINE1_Ethernet6\n   neighbor 172.31.255.42 peer
+    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.42 remote-as 65001\n   neighbor
+    172.31.255.42 description DC1-SPINE2_Ethernet6\n   neighbor 172.31.255.44 peer
+    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.44 remote-as 65001\n   neighbor
+    172.31.255.44 description DC1-SPINE3_Ethernet6\n   neighbor 172.31.255.46 peer
+    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.46 remote-as 65001\n   neighbor
+    172.31.255.46 description DC1-SPINE4_Ethernet6\n   neighbor 192.168.255.1 peer
+    group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.1 remote-as 65001\n   neighbor
+    192.168.255.1 description DC1-SPINE1\n   neighbor 192.168.255.2 peer group EVPN-OVERLAY-PEERS\n
+    \  neighbor 192.168.255.2 remote-as 65001\n   neighbor 192.168.255.2 description
+    DC1-SPINE2\n   neighbor 192.168.255.3 peer group EVPN-OVERLAY-PEERS\n   neighbor
+    192.168.255.3 remote-as 65001\n   neighbor 192.168.255.3 description DC1-SPINE3\n
+    \  neighbor 192.168.255.4 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.4
+    remote-as 65001\n   neighbor 192.168.255.4 description DC1-SPINE4\n   redistribute
+    connected route-map RM-CONN-2-BGP\n   !\n   vlan-aware-bundle Tenant_A_WAN_Zone\n
+    \     rd 192.168.255.10:14\n      route-target both 14:14\n      redistribute
+    learned\n      vlan 150\n   !\n   vlan-aware-bundle Tenant_B_WAN_Zone\n      rd
+    192.168.255.10:21\n      route-target both 21:21\n      redistribute learned\n
+    \     vlan 250\n   !\n   vlan-aware-bundle Tenant_C_WAN_Zone\n      rd 192.168.255.10:31\n
+    \     route-target both 31:31\n      redistribute learned\n      vlan 350\n   !\n
+    \  address-family evpn\n      neighbor EVPN-OVERLAY-PEERS activate\n   !\n   address-family
+    ipv4\n      no neighbor EVPN-OVERLAY-PEERS activate\n      neighbor IPv4-UNDERLAY-PEERS
+    activate\n      neighbor MLAG-IPv4-UNDERLAY-PEER activate\n   !\n   vrf Tenant_A_WAN_Zone\n
+    \     rd 192.168.255.10:14\n      route-target import evpn 14:14\n      route-target
+    export evpn 14:14\n      router-id 192.168.255.10\n      update wait-install\n
+    \     neighbor 10.255.251.11 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n   !\n   vrf Tenant_B_WAN_Zone\n      rd 192.168.255.10:21\n      route-target
+    import evpn 21:21\n      route-target export evpn 21:21\n      router-id 192.168.255.10\n
+    \     update wait-install\n      neighbor 10.255.251.11 peer group MLAG-IPv4-UNDERLAY-PEER\n
+    \     redistribute connected\n   !\n   vrf Tenant_C_WAN_Zone\n      rd 192.168.255.10:31\n
+    \     route-target import evpn 31:31\n      route-target export evpn 31:31\n      router-id
+    192.168.255.10\n      update wait-install\n      neighbor 10.255.251.11 peer group
+    MLAG-IPv4-UNDERLAY-PEER\n      redistribute connected\n!\nmanagement api http-commands\n
+    \  protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no shutdown\n!\nend\n"
+  AVD_DC1-BL1B: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr
+    -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
+    -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
+    internal order ascending range 1006 1199\n!\ntransceiver qsfp default-mode 4x10G\n!\nservice
+    routing protocols model multi-agent\n!\nhostname DC1-BL1B\nip name-server vrf
+    MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nntp local-interface vrf
+    MGMT Management1\nntp server vrf MGMT 192.168.200.5 prefer\n!\nspanning-tree mode
+    mstp\nno spanning-tree vlan-id 4093-4094\nspanning-tree mst 0 priority 4096\n!\nno
+    enable password\nno aaa root\n!\nusername admin privilege 15 role network-admin
+    nopassword\nusername cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\nvlan
+    150\n   name Tenant_A_WAN_Zone_1\n!\nvlan 250\n   name Tenant_B_WAN_Zone_1\n!\nvlan
+    350\n   name Tenant_C_WAN_Zone_1\n!\nvlan 3013\n   name MLAG_iBGP_Tenant_A_WAN_Zone\n
+    \  trunk group LEAF_PEER_L3\n!\nvlan 3020\n   name MLAG_iBGP_Tenant_B_WAN_Zone\n
+    \  trunk group LEAF_PEER_L3\n!\nvlan 3030\n   name MLAG_iBGP_Tenant_C_WAN_Zone\n
+    \  trunk group LEAF_PEER_L3\n!\nvlan 4093\n   name LEAF_PEER_L3\n   trunk group
+    LEAF_PEER_L3\n!\nvlan 4094\n   name MLAG_PEER\n   trunk group MLAG\n!\nvrf instance
+    MGMT\n!\nvrf instance Tenant_A_WAN_Zone\n!\nvrf instance Tenant_B_WAN_Zone\n!\nvrf
+    instance Tenant_C_WAN_Zone\n!\ninterface Port-Channel5\n   description MLAG_PEER_DC1-BL1A_Po5\n
+    \  no shutdown\n   switchport\n   switchport mode trunk\n   switchport trunk group
+    LEAF_PEER_L3\n   switchport trunk group MLAG\n!\ninterface Ethernet1\n   description
+    P2P_LINK_TO_DC1-SPINE1_Ethernet7\n   no shutdown\n   mtu 1500\n   no switchport\n
+    \  ip address 172.31.255.49/31\n!\ninterface Ethernet2\n   description P2P_LINK_TO_DC1-SPINE2_Ethernet7\n
+    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.51/31\n!\ninterface
+    Ethernet3\n   description P2P_LINK_TO_DC1-SPINE3_Ethernet7\n   no shutdown\n   mtu
+    1500\n   no switchport\n   ip address 172.31.255.53/31\n!\ninterface Ethernet4\n
+    \  description P2P_LINK_TO_DC1-SPINE4_Ethernet7\n   no shutdown\n   mtu 1500\n
+    \  no switchport\n   ip address 172.31.255.55/31\n!\ninterface Ethernet5\n   description
+    MLAG_PEER_DC1-BL1A_Ethernet5\n   no shutdown\n   channel-group 5 mode active\n!\ninterface
+    Ethernet6\n   description MLAG_PEER_DC1-BL1A_Ethernet6\n   no shutdown\n   channel-group
+    5 mode active\n!\ninterface Loopback0\n   description EVPN_Overlay_Peering\n   no
+    shutdown\n   ip address 192.168.255.11/32\n!\ninterface Loopback1\n   description
+    VTEP_VXLAN_Tunnel_Source\n   no shutdown\n   ip address 192.168.254.10/32\n!\ninterface
+    Management1\n   description oob_management\n   no shutdown\n   vrf MGMT\n   ip
+    address 192.168.200.111/24\n!\ninterface Vlan150\n   description Tenant_A_WAN_Zone_1\n
+    \  no shutdown\n   vrf Tenant_A_WAN_Zone\n   ip address virtual 10.1.40.1/24\n!\ninterface
+    Vlan250\n   description Tenant_B_WAN_Zone_1\n   no shutdown\n   vrf Tenant_B_WAN_Zone\n
+    \  ip address virtual 10.2.50.1/24\n!\ninterface Vlan350\n   description Tenant_C_WAN_Zone_1\n
+    \  no shutdown\n   vrf Tenant_C_WAN_Zone\n   ip address virtual 10.3.50.1/24\n!\ninterface
+    Vlan3013\n   description MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_A_WAN_Zone\n   ip address 10.255.251.11/31\n!\ninterface
+    Vlan3020\n   description MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_B_WAN_Zone\n   ip address 10.255.251.11/31\n!\ninterface
+    Vlan3030\n   description MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_C_WAN_Zone\n   ip address 10.255.251.11/31\n!\ninterface
+    Vlan4093\n   description MLAG_PEER_L3_PEERING\n   no shutdown\n   mtu 1500\n   ip
+    address 10.255.251.11/31\n!\ninterface Vlan4094\n   description MLAG_PEER\n   no
+    shutdown\n   mtu 1500\n   no autostate\n   ip address 10.255.252.11/31\n!\ninterface
+    Vxlan1\n   description DC1-BL1B_VTEP\n   vxlan source-interface Loopback1\n   vxlan
+    virtual-router encapsulation mac-address mlag-system-id\n   vxlan udp-port 4789\n
+    \  vxlan vlan 150 vni 10150\n   vxlan vlan 250 vni 20250\n   vxlan vlan 350 vni
+    30350\n   vxlan vrf Tenant_A_WAN_Zone vni 14\n   vxlan vrf Tenant_B_WAN_Zone vni
+    21\n   vxlan vrf Tenant_C_WAN_Zone vni 31\n!\nip virtual-router mac-address 00:dc:00:00:00:0a\n!\nip
+    routing\nno ip routing vrf MGMT\nip routing vrf Tenant_A_WAN_Zone\nip routing
+    vrf Tenant_B_WAN_Zone\nip routing vrf Tenant_C_WAN_Zone\n!\nip prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n
+    \  seq 10 permit 192.168.255.0/24 eq 32\n   seq 20 permit 192.168.254.0/24 eq
+    32\n!\nmlag configuration\n   domain-id DC1_BL1\n   local-interface Vlan4094\n
+    \  peer-address 10.255.252.10\n   peer-link Port-Channel5\n   reload-delay mlag
+    300\n   reload-delay non-mlag 330\n!\nip route vrf MGMT 0.0.0.0/0 192.168.200.5\n!\nroute-map
+    RM-CONN-2-BGP permit 10\n   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n!\nroute-map
+    RM-MLAG-PEER-IN permit 10\n   description Make routes learned over MLAG Peer-link
+    less preferred on spines to ensure optimal routing\n   set origin incomplete\n!\nrouter
+    bfd\n   multihop interval 1200 min-rx 1200 multiplier 3\n!\nrouter bgp 65104\n
+    \  router-id 192.168.255.11\n   maximum-paths 4 ecmp 4\n   update wait-install\n
+    \  no bgp default ipv4-unicast\n   distance bgp 20 200 200\n   neighbor EVPN-OVERLAY-PEERS
+    peer group\n   neighbor EVPN-OVERLAY-PEERS update-source Loopback0\n   neighbor
+    EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3\n   neighbor
+    EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n   neighbor EVPN-OVERLAY-PEERS
+    send-community\n   neighbor EVPN-OVERLAY-PEERS maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS
+    peer group\n   neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==\n
+    \  neighbor IPv4-UNDERLAY-PEERS send-community\n   neighbor IPv4-UNDERLAY-PEERS
+    maximum-routes 12000\n   neighbor MLAG-IPv4-UNDERLAY-PEER peer group\n   neighbor
+    MLAG-IPv4-UNDERLAY-PEER remote-as 65104\n   neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self\n
+    \  neighbor MLAG-IPv4-UNDERLAY-PEER description DC1-BL1A\n   neighbor MLAG-IPv4-UNDERLAY-PEER
+    password 7 vnEaG8gMeQf3d3cN6PktXQ==\n   neighbor MLAG-IPv4-UNDERLAY-PEER send-community\n
+    \  neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000\n   neighbor MLAG-IPv4-UNDERLAY-PEER
+    route-map RM-MLAG-PEER-IN in\n   neighbor 10.255.251.10 peer group MLAG-IPv4-UNDERLAY-PEER\n
+    \  neighbor 10.255.251.10 description DC1-BL1A\n   neighbor 172.31.255.48 peer
+    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.48 remote-as 65001\n   neighbor
+    172.31.255.48 description DC1-SPINE1_Ethernet7\n   neighbor 172.31.255.50 peer
+    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.50 remote-as 65001\n   neighbor
+    172.31.255.50 description DC1-SPINE2_Ethernet7\n   neighbor 172.31.255.52 peer
+    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.52 remote-as 65001\n   neighbor
+    172.31.255.52 description DC1-SPINE3_Ethernet7\n   neighbor 172.31.255.54 peer
+    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.54 remote-as 65001\n   neighbor
+    172.31.255.54 description DC1-SPINE4_Ethernet7\n   neighbor 192.168.255.1 peer
+    group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.1 remote-as 65001\n   neighbor
+    192.168.255.1 description DC1-SPINE1\n   neighbor 192.168.255.2 peer group EVPN-OVERLAY-PEERS\n
+    \  neighbor 192.168.255.2 remote-as 65001\n   neighbor 192.168.255.2 description
+    DC1-SPINE2\n   neighbor 192.168.255.3 peer group EVPN-OVERLAY-PEERS\n   neighbor
+    192.168.255.3 remote-as 65001\n   neighbor 192.168.255.3 description DC1-SPINE3\n
+    \  neighbor 192.168.255.4 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.4
+    remote-as 65001\n   neighbor 192.168.255.4 description DC1-SPINE4\n   redistribute
+    connected route-map RM-CONN-2-BGP\n   !\n   vlan-aware-bundle Tenant_A_WAN_Zone\n
+    \     rd 192.168.255.11:14\n      route-target both 14:14\n      redistribute
+    learned\n      vlan 150\n   !\n   vlan-aware-bundle Tenant_B_WAN_Zone\n      rd
+    192.168.255.11:21\n      route-target both 21:21\n      redistribute learned\n
+    \     vlan 250\n   !\n   vlan-aware-bundle Tenant_C_WAN_Zone\n      rd 192.168.255.11:31\n
+    \     route-target both 31:31\n      redistribute learned\n      vlan 350\n   !\n
+    \  address-family evpn\n      neighbor EVPN-OVERLAY-PEERS activate\n   !\n   address-family
+    ipv4\n      no neighbor EVPN-OVERLAY-PEERS activate\n      neighbor IPv4-UNDERLAY-PEERS
+    activate\n      neighbor MLAG-IPv4-UNDERLAY-PEER activate\n   !\n   vrf Tenant_A_WAN_Zone\n
+    \     rd 192.168.255.11:14\n      route-target import evpn 14:14\n      route-target
+    export evpn 14:14\n      router-id 192.168.255.11\n      update wait-install\n
+    \     neighbor 10.255.251.10 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n   !\n   vrf Tenant_B_WAN_Zone\n      rd 192.168.255.11:21\n      route-target
+    import evpn 21:21\n      route-target export evpn 21:21\n      router-id 192.168.255.11\n
+    \     update wait-install\n      neighbor 10.255.251.10 peer group MLAG-IPv4-UNDERLAY-PEER\n
+    \     redistribute connected\n   !\n   vrf Tenant_C_WAN_Zone\n      rd 192.168.255.11:31\n
+    \     route-target import evpn 31:31\n      route-target export evpn 31:31\n      router-id
+    192.168.255.11\n      update wait-install\n      neighbor 10.255.251.10 peer group
+    MLAG-IPv4-UNDERLAY-PEER\n      redistribute connected\n!\nmanagement api http-commands\n
+    \  protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no shutdown\n!\nend\n"
+  AVD_DC1-L2LEAF1A: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr
+    -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
+    -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
+    internal order ascending range 1006 1199\n!\nno ip igmp snooping vlan 120\n!\ntransceiver
+    qsfp default-mode 4x10G\n!\nservice routing protocols model multi-agent\n!\nhostname
+    DC1-L2LEAF1A\nip name-server vrf MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nntp
+    local-interface vrf MGMT Management1\nntp server vrf MGMT 192.168.200.5 prefer\n!\nspanning-tree
+    mode mstp\nspanning-tree mst 0 priority 16384\n!\nno enable password\nno aaa root\n!\nusername
+    admin privilege 15 role network-admin nopassword\nusername cvpadmin privilege
+    15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\nvlan
+    110\n   name Tenant_A_OP_Zone_1\n!\nvlan 111\n   name Tenant_A_OP_Zone_2\n!\nvlan
+    120\n   name Tenant_A_WEB_Zone_1\n!\nvlan 121\n   name Tenant_A_WEBZone_2\n!\nvlan
+    130\n   name Tenant_A_APP_Zone_1\n!\nvlan 131\n   name Tenant_A_APP_Zone_2\n!\nvrf
+    instance MGMT\n!\ninterface Port-Channel1\n   description DC1_LEAF2_Po7\n   no
+    shutdown\n   switchport\n   switchport trunk allowed vlan 110-111,120-121,130-131\n
+    \  switchport mode trunk\n!\ninterface Ethernet1\n   description DC1-LEAF2A_Ethernet7\n
+    \  no shutdown\n   channel-group 1 mode active\n!\ninterface Ethernet2\n   description
+    DC1-LEAF2B_Ethernet7\n   no shutdown\n   channel-group 1 mode active\n!\ninterface
+    Management1\n   description oob_management\n   no shutdown\n   vrf MGMT\n   ip
+    address 192.168.200.112/24\nno ip routing vrf MGMT\n!\nip route vrf MGMT 0.0.0.0/0
+    192.168.200.5\n!\nmanagement api http-commands\n   protocol https\n   no shutdown\n
+    \  !\n   vrf MGMT\n      no shutdown\n!\nend\n"
+  AVD_DC1-L2LEAF2A: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr
+    -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
+    -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
+    internal order ascending range 1006 1199\n!\nno ip igmp snooping vlan 120\n!\ntransceiver
+    qsfp default-mode 4x10G\n!\nservice routing protocols model multi-agent\n!\nhostname
+    DC1-L2LEAF2A\nip name-server vrf MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nntp
+    local-interface vrf MGMT Management1\nntp server vrf MGMT 192.168.200.5 prefer\n!\nspanning-tree
+    mode mstp\nno spanning-tree vlan-id 4094\nspanning-tree mst 0 priority 16384\n!\nno
+    enable password\nno aaa root\n!\nusername admin privilege 15 role network-admin
+    nopassword\nusername cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\nvlan
+    110\n   name Tenant_A_OP_Zone_1\n!\nvlan 111\n   name Tenant_A_OP_Zone_2\n!\nvlan
+    120\n   name Tenant_A_WEB_Zone_1\n!\nvlan 121\n   name Tenant_A_WEBZone_2\n!\nvlan
+    130\n   name Tenant_A_APP_Zone_1\n!\nvlan 131\n   name Tenant_A_APP_Zone_2\n!\nvlan
+    140\n   name Tenant_A_DB_BZone_1\n!\nvlan 141\n   name Tenant_A_DB_Zone_2\n!\nvlan
+    150\n   name Tenant_A_WAN_Zone_1\n!\nvlan 210\n   name Tenant_B_OP_Zone_1\n!\nvlan
+    211\n   name Tenant_B_OP_Zone_2\n!\nvlan 250\n   name Tenant_B_WAN_Zone_1\n!\nvlan
+    310\n   name Tenant_C_OP_Zone_1\n!\nvlan 311\n   name Tenant_C_OP_Zone_2\n!\nvlan
+    350\n   name Tenant_C_WAN_Zone_1\n!\nvlan 4094\n   name MLAG_PEER\n   trunk group
+    MLAG\n!\nvrf instance MGMT\n!\ninterface Port-Channel1\n   description DC1_SVC3_Po7\n
+    \  no shutdown\n   switchport\n   switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350\n
+    \  switchport mode trunk\n   mlag 1\n!\ninterface Port-Channel3\n   description
+    MLAG_PEER_DC1-L2LEAF2B_Po3\n   no shutdown\n   switchport\n   switchport mode
+    trunk\n   switchport trunk group MLAG\n!\ninterface Ethernet1\n   description
+    DC1-SVC3A_Ethernet7\n   no shutdown\n   channel-group 1 mode active\n!\ninterface
+    Ethernet2\n   description DC1-SVC3B_Ethernet7\n   no shutdown\n   channel-group
+    1 mode active\n!\ninterface Ethernet3\n   description MLAG_PEER_DC1-L2LEAF2B_Ethernet3\n
+    \  no shutdown\n   channel-group 3 mode active\n!\ninterface Ethernet4\n   description
+    MLAG_PEER_DC1-L2LEAF2B_Ethernet4\n   no shutdown\n   channel-group 3 mode active\n!\ninterface
+    Management1\n   description oob_management\n   no shutdown\n   vrf MGMT\n   ip
+    address 192.168.200.113/24\n!\ninterface Vlan4094\n   description MLAG_PEER\n
+    \  no shutdown\n   mtu 1500\n   no autostate\n   ip address 10.255.252.16/31\nno
+    ip routing vrf MGMT\n!\nmlag configuration\n   domain-id DC1_L2LEAF2\n   local-interface
+    Vlan4094\n   peer-address 10.255.252.17\n   peer-link Port-Channel3\n   reload-delay
+    mlag 300\n   reload-delay non-mlag 330\n!\nip route vrf MGMT 0.0.0.0/0 192.168.200.5\n!\nmanagement
+    api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no
+    shutdown\n!\nend\n"
+  AVD_DC1-L2LEAF2B: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr
+    -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
+    -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
+    internal order ascending range 1006 1199\n!\nno ip igmp snooping vlan 120\n!\ntransceiver
+    qsfp default-mode 4x10G\n!\nservice routing protocols model multi-agent\n!\nhostname
+    DC1-L2LEAF2B\nip name-server vrf MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nntp
+    local-interface vrf MGMT Management1\nntp server vrf MGMT 192.168.200.5 prefer\n!\nspanning-tree
+    mode mstp\nno spanning-tree vlan-id 4094\nspanning-tree mst 0 priority 16384\n!\nno
+    enable password\nno aaa root\n!\nusername admin privilege 15 role network-admin
+    nopassword\nusername cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\nvlan
+    110\n   name Tenant_A_OP_Zone_1\n!\nvlan 111\n   name Tenant_A_OP_Zone_2\n!\nvlan
+    120\n   name Tenant_A_WEB_Zone_1\n!\nvlan 121\n   name Tenant_A_WEBZone_2\n!\nvlan
+    130\n   name Tenant_A_APP_Zone_1\n!\nvlan 131\n   name Tenant_A_APP_Zone_2\n!\nvlan
+    140\n   name Tenant_A_DB_BZone_1\n!\nvlan 141\n   name Tenant_A_DB_Zone_2\n!\nvlan
+    150\n   name Tenant_A_WAN_Zone_1\n!\nvlan 210\n   name Tenant_B_OP_Zone_1\n!\nvlan
+    211\n   name Tenant_B_OP_Zone_2\n!\nvlan 250\n   name Tenant_B_WAN_Zone_1\n!\nvlan
+    310\n   name Tenant_C_OP_Zone_1\n!\nvlan 311\n   name Tenant_C_OP_Zone_2\n!\nvlan
+    350\n   name Tenant_C_WAN_Zone_1\n!\nvlan 4094\n   name MLAG_PEER\n   trunk group
+    MLAG\n!\nvrf instance MGMT\n!\ninterface Port-Channel1\n   description DC1_SVC3_Po7\n
+    \  no shutdown\n   switchport\n   switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350\n
+    \  switchport mode trunk\n   mlag 1\n!\ninterface Port-Channel3\n   description
+    MLAG_PEER_DC1-L2LEAF2A_Po3\n   no shutdown\n   switchport\n   switchport mode
+    trunk\n   switchport trunk group MLAG\n!\ninterface Ethernet1\n   description
+    DC1-SVC3A_Ethernet8\n   no shutdown\n   channel-group 1 mode active\n!\ninterface
+    Ethernet2\n   description DC1-SVC3B_Ethernet8\n   no shutdown\n   channel-group
+    1 mode active\n!\ninterface Ethernet3\n   description MLAG_PEER_DC1-L2LEAF2A_Ethernet3\n
+    \  no shutdown\n   channel-group 3 mode active\n!\ninterface Ethernet4\n   description
+    MLAG_PEER_DC1-L2LEAF2A_Ethernet4\n   no shutdown\n   channel-group 3 mode active\n!\ninterface
+    Management1\n   description oob_management\n   no shutdown\n   vrf MGMT\n   ip
+    address 192.168.200.114/24\n!\ninterface Vlan4094\n   description MLAG_PEER\n
+    \  no shutdown\n   mtu 1500\n   no autostate\n   ip address 10.255.252.17/31\nno
+    ip routing vrf MGMT\n!\nmlag configuration\n   domain-id DC1_L2LEAF2\n   local-interface
+    Vlan4094\n   peer-address 10.255.252.16\n   peer-link Port-Channel3\n   reload-delay
+    mlag 300\n   reload-delay non-mlag 330\n!\nip route vrf MGMT 0.0.0.0/0 192.168.200.5\n!\nmanagement
+    api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no
+    shutdown\n!\nend\n"
+  AVD_DC1-LEAF1A: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr
+    -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
+    -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
+    internal order ascending range 1006 1199\n!\nno ip igmp snooping vlan 120\n!\ntransceiver
+    qsfp default-mode 4x10G\n!\nservice routing protocols model multi-agent\n!\nhostname
+    DC1-LEAF1A\nip name-server vrf MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nntp
+    local-interface vrf MGMT Management1\nntp server vrf MGMT 192.168.200.5 prefer\n!\nspanning-tree
+    mode mstp\nspanning-tree mst 0 priority 4096\n!\nno enable password\nno aaa root\n!\nusername
+    admin privilege 15 role network-admin nopassword\nusername cvpadmin privilege
+    15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\nvlan
+    120\n   name Tenant_A_WEB_Zone_1\n!\nvlan 121\n   name Tenant_A_WEBZone_2\n!\nvlan
+    130\n   name Tenant_A_APP_Zone_1\n!\nvlan 131\n   name Tenant_A_APP_Zone_2\n!\nvrf
+    instance MGMT\n!\nvrf instance Tenant_A_APP_Zone\n!\nvrf instance Tenant_A_WEB_Zone\n!\ninterface
+    Ethernet1\n   description P2P_LINK_TO_DC1-SPINE1_Ethernet1\n   no shutdown\n   mtu
+    1500\n   no switchport\n   ip address 172.31.255.1/31\n!\ninterface Ethernet2\n
+    \  description P2P_LINK_TO_DC1-SPINE2_Ethernet1\n   no shutdown\n   mtu 1500\n
+    \  no switchport\n   ip address 172.31.255.3/31\n!\ninterface Ethernet3\n   description
+    P2P_LINK_TO_DC1-SPINE3_Ethernet1\n   no shutdown\n   mtu 1500\n   no switchport\n
+    \  ip address 172.31.255.5/31\n!\ninterface Ethernet4\n   description P2P_LINK_TO_DC1-SPINE4_Ethernet1\n
+    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.7/31\n!\ninterface
+    Ethernet6\n   description server02_SINGLE_NODE_TRUNK_Eth1\n   no shutdown\n   switchport
+    trunk allowed vlan 110-111,210-211\n   switchport mode trunk\n   switchport\n!\ninterface
+    Ethernet7\n   description server02_SINGLE_NODE_Eth1\n   no shutdown\n   switchport
+    access vlan 110\n   switchport mode access\n   switchport\n!\ninterface Loopback0\n
+    \  description EVPN_Overlay_Peering\n   no shutdown\n   ip address 192.168.255.5/32\n!\ninterface
+    Loopback1\n   description VTEP_VXLAN_Tunnel_Source\n   no shutdown\n   ip address
+    192.168.254.5/32\n!\ninterface Management1\n   description oob_management\n   no
+    shutdown\n   vrf MGMT\n   ip address 192.168.200.105/24\n!\ninterface Vlan120\n
+    \  description Tenant_A_WEB_Zone_1\n   no shutdown\n   vrf Tenant_A_WEB_Zone\n
+    \  ip helper-address 1.1.1.1 vrf TEST source-interface lo100\n   ip address virtual
+    10.1.20.1/24\n!\ninterface Vlan121\n   description Tenant_A_WEBZone_2\n   shutdown\n
+    \  mtu 1560\n   vrf Tenant_A_WEB_Zone\n   ip address virtual 10.1.10.254/24\n!\ninterface
+    Vlan130\n   description Tenant_A_APP_Zone_1\n   no shutdown\n   vrf Tenant_A_APP_Zone\n
+    \  ip address virtual 10.1.30.1/24\n!\ninterface Vlan131\n   description Tenant_A_APP_Zone_2\n
+    \  no shutdown\n   vrf Tenant_A_APP_Zone\n   ip address virtual 10.1.31.1/24\n!\ninterface
+    Vxlan1\n   description DC1-LEAF1A_VTEP\n   vxlan source-interface Loopback1\n
+    \  vxlan udp-port 4789\n   vxlan vlan 120 vni 10120\n   vxlan vlan 121 vni 10121\n
+    \  vxlan vlan 130 vni 10130\n   vxlan vlan 131 vni 10131\n   vxlan vrf Tenant_A_APP_Zone
+    vni 12\n   vxlan vrf Tenant_A_WEB_Zone vni 11\n!\nip virtual-router mac-address
+    00:dc:00:00:00:0a\n!\nip routing\nno ip routing vrf MGMT\nip routing vrf Tenant_A_APP_Zone\nip
+    routing vrf Tenant_A_WEB_Zone\n!\nip prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n   seq
+    10 permit 192.168.255.0/24 eq 32\n   seq 20 permit 192.168.254.0/24 eq 32\n!\nip
+    route vrf MGMT 0.0.0.0/0 192.168.200.5\n!\nroute-map RM-CONN-2-BGP permit 10\n
+    \  match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n!\nrouter bfd\n   multihop
+    interval 1200 min-rx 1200 multiplier 3\n!\nrouter bgp 65101\n   router-id 192.168.255.5\n
+    \  maximum-paths 4 ecmp 4\n   update wait-install\n   no bgp default ipv4-unicast\n
+    \  distance bgp 20 200 200\n   neighbor EVPN-OVERLAY-PEERS peer group\n   neighbor
+    EVPN-OVERLAY-PEERS update-source Loopback0\n   neighbor EVPN-OVERLAY-PEERS bfd\n
+    \  neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS
+    password 7 q+VNViP5i4rVjW1cxFv2wA==\n   neighbor EVPN-OVERLAY-PEERS send-community\n
+    \  neighbor EVPN-OVERLAY-PEERS maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS
+    peer group\n   neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==\n
+    \  neighbor IPv4-UNDERLAY-PEERS send-community\n   neighbor IPv4-UNDERLAY-PEERS
+    maximum-routes 12000\n   neighbor 172.31.255.0 peer group IPv4-UNDERLAY-PEERS\n
+    \  neighbor 172.31.255.0 remote-as 65001\n   neighbor 172.31.255.0 description
+    DC1-SPINE1_Ethernet1\n   neighbor 172.31.255.2 peer group IPv4-UNDERLAY-PEERS\n
+    \  neighbor 172.31.255.2 remote-as 65001\n   neighbor 172.31.255.2 description
+    DC1-SPINE2_Ethernet1\n   neighbor 172.31.255.4 peer group IPv4-UNDERLAY-PEERS\n
+    \  neighbor 172.31.255.4 remote-as 65001\n   neighbor 172.31.255.4 description
+    DC1-SPINE3_Ethernet1\n   neighbor 172.31.255.6 peer group IPv4-UNDERLAY-PEERS\n
+    \  neighbor 172.31.255.6 remote-as 65001\n   neighbor 172.31.255.6 description
+    DC1-SPINE4_Ethernet1\n   neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS\n
+    \  neighbor 192.168.255.1 remote-as 65001\n   neighbor 192.168.255.1 description
+    DC1-SPINE1\n   neighbor 192.168.255.2 peer group EVPN-OVERLAY-PEERS\n   neighbor
+    192.168.255.2 remote-as 65001\n   neighbor 192.168.255.2 description DC1-SPINE2\n
+    \  neighbor 192.168.255.3 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.3
+    remote-as 65001\n   neighbor 192.168.255.3 description DC1-SPINE3\n   neighbor
+    192.168.255.4 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.4 remote-as
+    65001\n   neighbor 192.168.255.4 description DC1-SPINE4\n   redistribute connected
+    route-map RM-CONN-2-BGP\n   !\n   vlan-aware-bundle Tenant_A_APP_Zone\n      rd
+    192.168.255.5:12\n      route-target both 12:12\n      redistribute learned\n
+    \     vlan 130-131\n   !\n   vlan-aware-bundle Tenant_A_WEB_Zone\n      rd 192.168.255.5:11\n
+    \     route-target both 11:11\n      redistribute learned\n      vlan 120-121\n
+    \  !\n   address-family evpn\n      neighbor EVPN-OVERLAY-PEERS activate\n   !\n
+    \  address-family ipv4\n      no neighbor EVPN-OVERLAY-PEERS activate\n      neighbor
+    IPv4-UNDERLAY-PEERS activate\n   !\n   vrf Tenant_A_APP_Zone\n      rd 192.168.255.5:12\n
+    \     route-target import evpn 12:12\n      route-target export evpn 12:12\n      router-id
+    192.168.255.5\n      redistribute connected\n   !\n   vrf Tenant_A_WEB_Zone\n
+    \     rd 192.168.255.5:11\n      route-target import evpn 11:11\n      route-target
+    export evpn 11:11\n      router-id 192.168.255.5\n      redistribute connected\n!\nmanagement
+    api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no
+    shutdown\n!\nend\n"
+  AVD_DC1-LEAF2A: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr
+    -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
+    -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
+    internal order ascending range 1006 1199\n!\nno ip igmp snooping vlan 120\n!\ntransceiver
+    qsfp default-mode 4x10G\n!\nservice routing protocols model multi-agent\n!\nhostname
+    DC1-LEAF2A\nip name-server vrf MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nntp
+    local-interface vrf MGMT Management1\nntp server vrf MGMT 192.168.200.5 prefer\n!\nspanning-tree
+    mode mstp\nno spanning-tree vlan-id 4093-4094\nspanning-tree mst 0 priority 4096\n!\nno
+    enable password\nno aaa root\n!\nusername admin privilege 15 role network-admin
+    nopassword\nusername cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\nvlan
+    110\n   name Tenant_A_OP_Zone_1\n!\nvlan 111\n   name Tenant_A_OP_Zone_2\n!\nvlan
+    120\n   name Tenant_A_WEB_Zone_1\n!\nvlan 121\n   name Tenant_A_WEBZone_2\n!\nvlan
+    130\n   name Tenant_A_APP_Zone_1\n!\nvlan 131\n   name Tenant_A_APP_Zone_2\n!\nvlan
+    140\n   name Tenant_A_DB_BZone_1\n!\nvlan 141\n   name Tenant_A_DB_Zone_2\n!\nvlan
+    210\n   name Tenant_B_OP_Zone_1\n!\nvlan 211\n   name Tenant_B_OP_Zone_2\n!\nvlan
+    310\n   name Tenant_C_OP_Zone_1\n!\nvlan 311\n   name Tenant_C_OP_Zone_2\n!\nvlan
+    3009\n   name MLAG_iBGP_Tenant_A_OP_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3010\n   name MLAG_iBGP_Tenant_A_WEB_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3011\n   name MLAG_iBGP_Tenant_A_APP_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3012\n   name MLAG_iBGP_Tenant_A_DB_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3019\n   name MLAG_iBGP_Tenant_B_OP_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3029\n   name MLAG_iBGP_Tenant_C_OP_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    4093\n   name LEAF_PEER_L3\n   trunk group LEAF_PEER_L3\n!\nvlan 4094\n   name
+    MLAG_PEER\n   trunk group MLAG\n!\nvrf instance MGMT\n!\nvrf instance Tenant_A_APP_Zone\n!\nvrf
+    instance Tenant_A_DB_Zone\n!\nvrf instance Tenant_A_OP_Zone\n!\nvrf instance Tenant_A_WEB_Zone\n!\nvrf
+    instance Tenant_B_OP_Zone\n!\nvrf instance Tenant_C_OP_Zone\n!\ninterface Port-Channel5\n
+    \  description MLAG_PEER_DC1-LEAF2B_Po5\n   no shutdown\n   switchport\n   switchport
+    mode trunk\n   switchport trunk group LEAF_PEER_L3\n   switchport trunk group
+    MLAG\n!\ninterface Port-Channel7\n   description DC1-L2LEAF1A_Po1\n   no shutdown\n
+    \  switchport\n   switchport trunk allowed vlan 110-111,120-121,130-131\n   switchport
+    mode trunk\n   mlag 7\n!\ninterface Port-Channel10\n   description server01_MLAG_PortChanne1\n
+    \  no shutdown\n   switchport\n   switchport trunk allowed vlan 210-211\n   switchport
+    mode trunk\n   mlag 10\n!\ninterface Ethernet1\n   description P2P_LINK_TO_DC1-SPINE1_Ethernet2\n
+    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.9/31\n!\ninterface
+    Ethernet2\n   description P2P_LINK_TO_DC1-SPINE2_Ethernet2\n   no shutdown\n   mtu
+    1500\n   no switchport\n   ip address 172.31.255.11/31\n!\ninterface Ethernet3\n
+    \  description P2P_LINK_TO_DC1-SPINE3_Ethernet2\n   no shutdown\n   mtu 1500\n
+    \  no switchport\n   ip address 172.31.255.13/31\n!\ninterface Ethernet4\n   description
+    P2P_LINK_TO_DC1-SPINE4_Ethernet2\n   no shutdown\n   mtu 1500\n   no switchport\n
+    \  ip address 172.31.255.15/31\n!\ninterface Ethernet5\n   description MLAG_PEER_DC1-LEAF2B_Ethernet5\n
+    \  no shutdown\n   channel-group 5 mode active\n!\ninterface Ethernet6\n   description
+    MLAG_PEER_DC1-LEAF2B_Ethernet6\n   no shutdown\n   channel-group 5 mode active\n!\ninterface
+    Ethernet7\n   description DC1-L2LEAF1A_Ethernet1\n   no shutdown\n   channel-group
+    7 mode active\n!\ninterface Ethernet10\n   description server01_MLAG_Eth2\n   no
+    shutdown\n   channel-group 10 mode active\n!\ninterface Loopback0\n   description
+    EVPN_Overlay_Peering\n   no shutdown\n   ip address 192.168.255.6/32\n!\ninterface
+    Loopback1\n   description VTEP_VXLAN_Tunnel_Source\n   no shutdown\n   ip address
+    192.168.254.6/32\n!\ninterface Loopback100\n   description Tenant_A_OP_Zone_VTEP_DIAGNOSTICS\n
+    \  no shutdown\n   vrf Tenant_A_OP_Zone\n   ip address 10.255.1.6/32\n!\ninterface
+    Management1\n   description oob_management\n   no shutdown\n   vrf MGMT\n   ip
+    address 192.168.200.106/24\n!\ninterface Vlan110\n   description Tenant_A_OP_Zone_1\n
+    \  no shutdown\n   vrf Tenant_A_OP_Zone\n   ip address virtual 10.1.10.1/24\n!\ninterface
+    Vlan111\n   description Tenant_A_OP_Zone_2\n   no shutdown\n   vrf Tenant_A_OP_Zone\n
+    \  ip helper-address 1.1.1.1 vrf MGMT source-interface lo100\n   ip address virtual
+    10.1.11.1/24\n!\ninterface Vlan120\n   description Tenant_A_WEB_Zone_1\n   no
+    shutdown\n   vrf Tenant_A_WEB_Zone\n   ip helper-address 1.1.1.1 vrf TEST source-interface
+    lo100\n   ip address virtual 10.1.20.1/24\n!\ninterface Vlan121\n   description
+    Tenant_A_WEBZone_2\n   shutdown\n   mtu 1560\n   vrf Tenant_A_WEB_Zone\n   ip
+    address virtual 10.1.10.254/24\n!\ninterface Vlan130\n   description Tenant_A_APP_Zone_1\n
+    \  no shutdown\n   vrf Tenant_A_APP_Zone\n   ip address virtual 10.1.30.1/24\n!\ninterface
+    Vlan131\n   description Tenant_A_APP_Zone_2\n   no shutdown\n   vrf Tenant_A_APP_Zone\n
+    \  ip address virtual 10.1.31.1/24\n!\ninterface Vlan140\n   description Tenant_A_DB_BZone_1\n
+    \  no shutdown\n   vrf Tenant_A_DB_Zone\n   ip address virtual 10.1.40.1/24\n!\ninterface
+    Vlan141\n   description Tenant_A_DB_Zone_2\n   no shutdown\n   vrf Tenant_A_DB_Zone\n
+    \  ip address virtual 10.1.41.1/24\n!\ninterface Vlan210\n   description Tenant_B_OP_Zone_1\n
+    \  no shutdown\n   vrf Tenant_B_OP_Zone\n   ip address virtual 10.2.10.1/24\n!\ninterface
+    Vlan211\n   description Tenant_B_OP_Zone_2\n   no shutdown\n   vrf Tenant_B_OP_Zone\n
+    \  ip address virtual 10.2.11.1/24\n!\ninterface Vlan310\n   description Tenant_C_OP_Zone_1\n
+    \  no shutdown\n   vrf Tenant_C_OP_Zone\n   ip address virtual 10.3.10.1/24\n!\ninterface
+    Vlan311\n   description Tenant_C_OP_Zone_2\n   no shutdown\n   vrf Tenant_C_OP_Zone\n
+    \  ip address virtual 10.3.11.1/24\n!\ninterface Vlan3009\n   description MLAG_PEER_L3_iBGP:
+    vrf Tenant_A_OP_Zone\n   no shutdown\n   mtu 1500\n   vrf Tenant_A_OP_Zone\n   ip
+    address 10.255.251.2/31\n!\ninterface Vlan3010\n   description MLAG_PEER_L3_iBGP:
+    vrf Tenant_A_WEB_Zone\n   no shutdown\n   mtu 1500\n   vrf Tenant_A_WEB_Zone\n
+    \  ip address 10.255.251.2/31\n!\ninterface Vlan3011\n   description MLAG_PEER_L3_iBGP:
+    vrf Tenant_A_APP_Zone\n   no shutdown\n   mtu 1500\n   vrf Tenant_A_APP_Zone\n
+    \  ip address 10.255.251.2/31\n!\ninterface Vlan3012\n   description MLAG_PEER_L3_iBGP:
+    vrf Tenant_A_DB_Zone\n   no shutdown\n   mtu 1500\n   vrf Tenant_A_DB_Zone\n   ip
+    address 10.255.251.2/31\n!\ninterface Vlan3019\n   description MLAG_PEER_L3_iBGP:
+    vrf Tenant_B_OP_Zone\n   no shutdown\n   mtu 1500\n   vrf Tenant_B_OP_Zone\n   ip
+    address 10.255.251.2/31\n!\ninterface Vlan3029\n   description MLAG_PEER_L3_iBGP:
+    vrf Tenant_C_OP_Zone\n   no shutdown\n   mtu 1500\n   vrf Tenant_C_OP_Zone\n   ip
+    address 10.255.251.2/31\n!\ninterface Vlan4093\n   description MLAG_PEER_L3_PEERING\n
+    \  no shutdown\n   mtu 1500\n   ip address 10.255.251.2/31\n!\ninterface Vlan4094\n
+    \  description MLAG_PEER\n   no shutdown\n   mtu 1500\n   no autostate\n   ip
+    address 10.255.252.2/31\n!\ninterface Vxlan1\n   description DC1-LEAF2A_VTEP\n
+    \  vxlan source-interface Loopback1\n   vxlan virtual-router encapsulation mac-address
+    mlag-system-id\n   vxlan udp-port 4789\n   vxlan vlan 110 vni 10110\n   vxlan
+    vlan 111 vni 50111\n   vxlan vlan 120 vni 10120\n   vxlan vlan 121 vni 10121\n
+    \  vxlan vlan 130 vni 10130\n   vxlan vlan 131 vni 10131\n   vxlan vlan 140 vni
+    10140\n   vxlan vlan 141 vni 10141\n   vxlan vlan 210 vni 20210\n   vxlan vlan
+    211 vni 20211\n   vxlan vlan 310 vni 30310\n   vxlan vlan 311 vni 30311\n   vxlan
+    vrf Tenant_A_APP_Zone vni 12\n   vxlan vrf Tenant_A_DB_Zone vni 13\n   vxlan vrf
+    Tenant_A_OP_Zone vni 10\n   vxlan vrf Tenant_A_WEB_Zone vni 11\n   vxlan vrf Tenant_B_OP_Zone
+    vni 20\n   vxlan vrf Tenant_C_OP_Zone vni 30\n!\nip virtual-router mac-address
+    00:dc:00:00:00:0a\n!\nip address virtual source-nat vrf Tenant_A_OP_Zone address
+    10.255.1.6\n!\nip routing\nno ip routing vrf MGMT\nip routing vrf Tenant_A_APP_Zone\nip
+    routing vrf Tenant_A_DB_Zone\nip routing vrf Tenant_A_OP_Zone\nip routing vrf
+    Tenant_A_WEB_Zone\nip routing vrf Tenant_B_OP_Zone\nip routing vrf Tenant_C_OP_Zone\n!\nip
+    prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n   seq 10 permit 192.168.255.0/24 eq 32\n
+    \  seq 20 permit 192.168.254.0/24 eq 32\n!\nmlag configuration\n   domain-id DC1_LEAF2\n
+    \  local-interface Vlan4094\n   peer-address 10.255.252.3\n   peer-link Port-Channel5\n
+    \  reload-delay mlag 300\n   reload-delay non-mlag 330\n!\nip route vrf MGMT 0.0.0.0/0
+    192.168.200.5\n!\nroute-map RM-CONN-2-BGP permit 10\n   match ip address prefix-list
+    PL-LOOPBACKS-EVPN-OVERLAY\n!\nroute-map RM-MLAG-PEER-IN permit 10\n   description
+    Make routes learned over MLAG Peer-link less preferred on spines to ensure optimal
+    routing\n   set origin incomplete\n!\nrouter bfd\n   multihop interval 1200 min-rx
+    1200 multiplier 3\n!\nrouter bgp 65102\n   router-id 192.168.255.6\n   maximum-paths
+    4 ecmp 4\n   update wait-install\n   no bgp default ipv4-unicast\n   distance
+    bgp 20 200 200\n   neighbor EVPN-OVERLAY-PEERS peer group\n   neighbor EVPN-OVERLAY-PEERS
+    update-source Loopback0\n   neighbor EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS
+    ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n
+    \  neighbor EVPN-OVERLAY-PEERS send-community\n   neighbor EVPN-OVERLAY-PEERS
+    maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS peer group\n   neighbor IPv4-UNDERLAY-PEERS
+    password 7 AQQvKeimxJu+uGQ/yYvv9w==\n   neighbor IPv4-UNDERLAY-PEERS send-community\n
+    \  neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000\n   neighbor MLAG-IPv4-UNDERLAY-PEER
+    peer group\n   neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65102\n   neighbor MLAG-IPv4-UNDERLAY-PEER
+    next-hop-self\n   neighbor MLAG-IPv4-UNDERLAY-PEER description DC1-LEAF2B\n   neighbor
+    MLAG-IPv4-UNDERLAY-PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==\n   neighbor MLAG-IPv4-UNDERLAY-PEER
+    send-community\n   neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000\n   neighbor
+    MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN in\n   neighbor 10.255.251.3
+    peer group MLAG-IPv4-UNDERLAY-PEER\n   neighbor 10.255.251.3 description DC1-LEAF2B\n
+    \  neighbor 172.31.255.8 peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.8
+    remote-as 65001\n   neighbor 172.31.255.8 description DC1-SPINE1_Ethernet2\n   neighbor
+    172.31.255.10 peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.10 remote-as
+    65001\n   neighbor 172.31.255.10 description DC1-SPINE2_Ethernet2\n   neighbor
+    172.31.255.12 peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.12 remote-as
+    65001\n   neighbor 172.31.255.12 description DC1-SPINE3_Ethernet2\n   neighbor
+    172.31.255.14 peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.14 remote-as
+    65001\n   neighbor 172.31.255.14 description DC1-SPINE4_Ethernet2\n   neighbor
+    192.168.255.1 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.1 remote-as
+    65001\n   neighbor 192.168.255.1 description DC1-SPINE1\n   neighbor 192.168.255.2
+    peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.2 remote-as 65001\n   neighbor
+    192.168.255.2 description DC1-SPINE2\n   neighbor 192.168.255.3 peer group EVPN-OVERLAY-PEERS\n
+    \  neighbor 192.168.255.3 remote-as 65001\n   neighbor 192.168.255.3 description
+    DC1-SPINE3\n   neighbor 192.168.255.4 peer group EVPN-OVERLAY-PEERS\n   neighbor
+    192.168.255.4 remote-as 65001\n   neighbor 192.168.255.4 description DC1-SPINE4\n
+    \  redistribute connected route-map RM-CONN-2-BGP\n   !\n   vlan-aware-bundle
+    Tenant_A_APP_Zone\n      rd 192.168.255.6:12\n      route-target both 12:12\n
+    \     redistribute learned\n      vlan 130-131\n   !\n   vlan-aware-bundle Tenant_A_DB_Zone\n
+    \     rd 192.168.255.6:13\n      route-target both 13:13\n      redistribute learned\n
+    \     vlan 140-141\n   !\n   vlan-aware-bundle Tenant_A_OP_Zone\n      rd 192.168.255.6:10\n
+    \     route-target both 10:10\n      redistribute learned\n      vlan 110-111\n
+    \  !\n   vlan-aware-bundle Tenant_A_WEB_Zone\n      rd 192.168.255.6:11\n      route-target
+    both 11:11\n      redistribute learned\n      vlan 120-121\n   !\n   vlan-aware-bundle
+    Tenant_B_OP_Zone\n      rd 192.168.255.6:20\n      route-target both 20:20\n      redistribute
+    learned\n      vlan 210-211\n   !\n   vlan-aware-bundle Tenant_C_OP_Zone\n      rd
+    192.168.255.6:30\n      route-target both 30:30\n      redistribute learned\n
+    \     vlan 310-311\n   !\n   address-family evpn\n      neighbor EVPN-OVERLAY-PEERS
+    activate\n   !\n   address-family ipv4\n      no neighbor EVPN-OVERLAY-PEERS activate\n
+    \     neighbor IPv4-UNDERLAY-PEERS activate\n      neighbor MLAG-IPv4-UNDERLAY-PEER
+    activate\n   !\n   vrf Tenant_A_APP_Zone\n      rd 192.168.255.6:12\n      route-target
+    import evpn 12:12\n      route-target export evpn 12:12\n      router-id 192.168.255.6\n
+    \     update wait-install\n      neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER\n
+    \     redistribute connected\n   !\n   vrf Tenant_A_DB_Zone\n      rd 192.168.255.6:13\n
+    \     route-target import evpn 13:13\n      route-target export evpn 13:13\n      router-id
+    192.168.255.6\n      update wait-install\n      neighbor 10.255.251.3 peer group
+    MLAG-IPv4-UNDERLAY-PEER\n      redistribute connected\n   !\n   vrf Tenant_A_OP_Zone\n
+    \     rd 192.168.255.6:10\n      route-target import evpn 10:10\n      route-target
+    export evpn 10:10\n      router-id 192.168.255.6\n      update wait-install\n
+    \     neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n   !\n   vrf Tenant_A_WEB_Zone\n      rd 192.168.255.6:11\n      route-target
+    import evpn 11:11\n      route-target export evpn 11:11\n      router-id 192.168.255.6\n
+    \     update wait-install\n      neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER\n
+    \     redistribute connected\n   !\n   vrf Tenant_B_OP_Zone\n      rd 192.168.255.6:20\n
+    \     route-target import evpn 20:20\n      route-target export evpn 20:20\n      router-id
+    192.168.255.6\n      update wait-install\n      neighbor 10.255.251.3 peer group
+    MLAG-IPv4-UNDERLAY-PEER\n      redistribute connected\n   !\n   vrf Tenant_C_OP_Zone\n
+    \     rd 192.168.255.6:30\n      route-target import evpn 30:30\n      route-target
+    export evpn 30:30\n      router-id 192.168.255.6\n      update wait-install\n
+    \     neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n!\nmanagement api http-commands\n   protocol https\n   no shutdown\n
+    \  !\n   vrf MGMT\n      no shutdown\n!\nend\n"
+  AVD_DC1-LEAF2B: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr
+    -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
+    -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
+    internal order ascending range 1006 1199\n!\nno ip igmp snooping vlan 120\n!\ntransceiver
+    qsfp default-mode 4x10G\n!\nservice routing protocols model multi-agent\n!\nhostname
+    DC1-LEAF2B\nip name-server vrf MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nntp
+    local-interface vrf MGMT Management1\nntp server vrf MGMT 192.168.200.5 prefer\n!\nspanning-tree
+    mode mstp\nno spanning-tree vlan-id 4093-4094\nspanning-tree mst 0 priority 4096\n!\nno
+    enable password\nno aaa root\n!\nusername admin privilege 15 role network-admin
+    nopassword\nusername cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\nvlan
+    110\n   name Tenant_A_OP_Zone_1\n!\nvlan 111\n   name Tenant_A_OP_Zone_2\n!\nvlan
+    120\n   name Tenant_A_WEB_Zone_1\n!\nvlan 121\n   name Tenant_A_WEBZone_2\n!\nvlan
+    130\n   name Tenant_A_APP_Zone_1\n!\nvlan 131\n   name Tenant_A_APP_Zone_2\n!\nvlan
+    140\n   name Tenant_A_DB_BZone_1\n!\nvlan 141\n   name Tenant_A_DB_Zone_2\n!\nvlan
+    210\n   name Tenant_B_OP_Zone_1\n!\nvlan 211\n   name Tenant_B_OP_Zone_2\n!\nvlan
+    310\n   name Tenant_C_OP_Zone_1\n!\nvlan 311\n   name Tenant_C_OP_Zone_2\n!\nvlan
+    3009\n   name MLAG_iBGP_Tenant_A_OP_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3010\n   name MLAG_iBGP_Tenant_A_WEB_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3011\n   name MLAG_iBGP_Tenant_A_APP_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3012\n   name MLAG_iBGP_Tenant_A_DB_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3019\n   name MLAG_iBGP_Tenant_B_OP_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3029\n   name MLAG_iBGP_Tenant_C_OP_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    4093\n   name LEAF_PEER_L3\n   trunk group LEAF_PEER_L3\n!\nvlan 4094\n   name
+    MLAG_PEER\n   trunk group MLAG\n!\nvrf instance MGMT\n!\nvrf instance Tenant_A_APP_Zone\n!\nvrf
+    instance Tenant_A_DB_Zone\n!\nvrf instance Tenant_A_OP_Zone\n!\nvrf instance Tenant_A_WEB_Zone\n!\nvrf
+    instance Tenant_B_OP_Zone\n!\nvrf instance Tenant_C_OP_Zone\n!\ninterface Port-Channel5\n
+    \  description MLAG_PEER_DC1-LEAF2A_Po5\n   no shutdown\n   switchport\n   switchport
+    mode trunk\n   switchport trunk group LEAF_PEER_L3\n   switchport trunk group
+    MLAG\n!\ninterface Port-Channel7\n   description DC1-L2LEAF1A_Po1\n   no shutdown\n
+    \  switchport\n   switchport trunk allowed vlan 110-111,120-121,130-131\n   switchport
+    mode trunk\n   mlag 7\n!\ninterface Port-Channel10\n   description server01_MLAG_PortChanne1\n
+    \  no shutdown\n   switchport\n   switchport trunk allowed vlan 210-211\n   switchport
+    mode trunk\n   mlag 10\n!\ninterface Ethernet1\n   description P2P_LINK_TO_DC1-SPINE1_Ethernet3\n
+    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.17/31\n!\ninterface
+    Ethernet2\n   description P2P_LINK_TO_DC1-SPINE2_Ethernet3\n   no shutdown\n   mtu
+    1500\n   no switchport\n   ip address 172.31.255.19/31\n!\ninterface Ethernet3\n
+    \  description P2P_LINK_TO_DC1-SPINE3_Ethernet3\n   no shutdown\n   mtu 1500\n
+    \  no switchport\n   ip address 172.31.255.21/31\n!\ninterface Ethernet4\n   description
+    P2P_LINK_TO_DC1-SPINE4_Ethernet3\n   no shutdown\n   mtu 1500\n   no switchport\n
+    \  ip address 172.31.255.23/31\n!\ninterface Ethernet5\n   description MLAG_PEER_DC1-LEAF2A_Ethernet5\n
+    \  no shutdown\n   channel-group 5 mode active\n!\ninterface Ethernet6\n   description
+    MLAG_PEER_DC1-LEAF2A_Ethernet6\n   no shutdown\n   channel-group 5 mode active\n!\ninterface
+    Ethernet7\n   description DC1-L2LEAF1A_Ethernet2\n   no shutdown\n   channel-group
+    7 mode active\n!\ninterface Ethernet10\n   description server01_MLAG_Eth3\n   no
+    shutdown\n   channel-group 10 mode active\n!\ninterface Loopback0\n   description
+    EVPN_Overlay_Peering\n   no shutdown\n   ip address 192.168.255.7/32\n!\ninterface
+    Loopback1\n   description VTEP_VXLAN_Tunnel_Source\n   no shutdown\n   ip address
+    192.168.254.6/32\n!\ninterface Loopback100\n   description Tenant_A_OP_Zone_VTEP_DIAGNOSTICS\n
+    \  no shutdown\n   vrf Tenant_A_OP_Zone\n   ip address 10.255.1.7/32\n!\ninterface
+    Management1\n   description oob_management\n   no shutdown\n   vrf MGMT\n   ip
+    address 192.168.200.107/24\n!\ninterface Vlan110\n   description Tenant_A_OP_Zone_1\n
+    \  no shutdown\n   vrf Tenant_A_OP_Zone\n   ip address virtual 10.1.10.1/24\n!\ninterface
+    Vlan111\n   description Tenant_A_OP_Zone_2\n   no shutdown\n   vrf Tenant_A_OP_Zone\n
+    \  ip helper-address 1.1.1.1 vrf MGMT source-interface lo100\n   ip address virtual
+    10.1.11.1/24\n!\ninterface Vlan120\n   description Tenant_A_WEB_Zone_1\n   no
+    shutdown\n   vrf Tenant_A_WEB_Zone\n   ip helper-address 1.1.1.1 vrf TEST source-interface
+    lo100\n   ip address virtual 10.1.20.1/24\n!\ninterface Vlan121\n   description
+    Tenant_A_WEBZone_2\n   shutdown\n   mtu 1560\n   vrf Tenant_A_WEB_Zone\n   ip
+    address virtual 10.1.10.254/24\n!\ninterface Vlan130\n   description Tenant_A_APP_Zone_1\n
+    \  no shutdown\n   vrf Tenant_A_APP_Zone\n   ip address virtual 10.1.30.1/24\n!\ninterface
+    Vlan131\n   description Tenant_A_APP_Zone_2\n   no shutdown\n   vrf Tenant_A_APP_Zone\n
+    \  ip address virtual 10.1.31.1/24\n!\ninterface Vlan140\n   description Tenant_A_DB_BZone_1\n
+    \  no shutdown\n   vrf Tenant_A_DB_Zone\n   ip address virtual 10.1.40.1/24\n!\ninterface
+    Vlan141\n   description Tenant_A_DB_Zone_2\n   no shutdown\n   vrf Tenant_A_DB_Zone\n
+    \  ip address virtual 10.1.41.1/24\n!\ninterface Vlan210\n   description Tenant_B_OP_Zone_1\n
+    \  no shutdown\n   vrf Tenant_B_OP_Zone\n   ip address virtual 10.2.10.1/24\n!\ninterface
+    Vlan211\n   description Tenant_B_OP_Zone_2\n   no shutdown\n   vrf Tenant_B_OP_Zone\n
+    \  ip address virtual 10.2.11.1/24\n!\ninterface Vlan310\n   description Tenant_C_OP_Zone_1\n
+    \  no shutdown\n   vrf Tenant_C_OP_Zone\n   ip address virtual 10.3.10.1/24\n!\ninterface
+    Vlan311\n   description Tenant_C_OP_Zone_2\n   no shutdown\n   vrf Tenant_C_OP_Zone\n
+    \  ip address virtual 10.3.11.1/24\n!\ninterface Vlan3009\n   description MLAG_PEER_L3_iBGP:
+    vrf Tenant_A_OP_Zone\n   no shutdown\n   mtu 1500\n   vrf Tenant_A_OP_Zone\n   ip
+    address 10.255.251.3/31\n!\ninterface Vlan3010\n   description MLAG_PEER_L3_iBGP:
+    vrf Tenant_A_WEB_Zone\n   no shutdown\n   mtu 1500\n   vrf Tenant_A_WEB_Zone\n
+    \  ip address 10.255.251.3/31\n!\ninterface Vlan3011\n   description MLAG_PEER_L3_iBGP:
+    vrf Tenant_A_APP_Zone\n   no shutdown\n   mtu 1500\n   vrf Tenant_A_APP_Zone\n
+    \  ip address 10.255.251.3/31\n!\ninterface Vlan3012\n   description MLAG_PEER_L3_iBGP:
+    vrf Tenant_A_DB_Zone\n   no shutdown\n   mtu 1500\n   vrf Tenant_A_DB_Zone\n   ip
+    address 10.255.251.3/31\n!\ninterface Vlan3019\n   description MLAG_PEER_L3_iBGP:
+    vrf Tenant_B_OP_Zone\n   no shutdown\n   mtu 1500\n   vrf Tenant_B_OP_Zone\n   ip
+    address 10.255.251.3/31\n!\ninterface Vlan3029\n   description MLAG_PEER_L3_iBGP:
+    vrf Tenant_C_OP_Zone\n   no shutdown\n   mtu 1500\n   vrf Tenant_C_OP_Zone\n   ip
+    address 10.255.251.3/31\n!\ninterface Vlan4093\n   description MLAG_PEER_L3_PEERING\n
+    \  no shutdown\n   mtu 1500\n   ip address 10.255.251.3/31\n!\ninterface Vlan4094\n
+    \  description MLAG_PEER\n   no shutdown\n   mtu 1500\n   no autostate\n   ip
+    address 10.255.252.3/31\n!\ninterface Vxlan1\n   description DC1-LEAF2B_VTEP\n
+    \  vxlan source-interface Loopback1\n   vxlan virtual-router encapsulation mac-address
+    mlag-system-id\n   vxlan udp-port 4789\n   vxlan vlan 110 vni 10110\n   vxlan
+    vlan 111 vni 50111\n   vxlan vlan 120 vni 10120\n   vxlan vlan 121 vni 10121\n
+    \  vxlan vlan 130 vni 10130\n   vxlan vlan 131 vni 10131\n   vxlan vlan 140 vni
+    10140\n   vxlan vlan 141 vni 10141\n   vxlan vlan 210 vni 20210\n   vxlan vlan
+    211 vni 20211\n   vxlan vlan 310 vni 30310\n   vxlan vlan 311 vni 30311\n   vxlan
+    vrf Tenant_A_APP_Zone vni 12\n   vxlan vrf Tenant_A_DB_Zone vni 13\n   vxlan vrf
+    Tenant_A_OP_Zone vni 10\n   vxlan vrf Tenant_A_WEB_Zone vni 11\n   vxlan vrf Tenant_B_OP_Zone
+    vni 20\n   vxlan vrf Tenant_C_OP_Zone vni 30\n!\nip virtual-router mac-address
+    00:dc:00:00:00:0a\n!\nip address virtual source-nat vrf Tenant_A_OP_Zone address
+    10.255.1.7\n!\nip routing\nno ip routing vrf MGMT\nip routing vrf Tenant_A_APP_Zone\nip
+    routing vrf Tenant_A_DB_Zone\nip routing vrf Tenant_A_OP_Zone\nip routing vrf
+    Tenant_A_WEB_Zone\nip routing vrf Tenant_B_OP_Zone\nip routing vrf Tenant_C_OP_Zone\n!\nip
+    prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n   seq 10 permit 192.168.255.0/24 eq 32\n
+    \  seq 20 permit 192.168.254.0/24 eq 32\n!\nmlag configuration\n   domain-id DC1_LEAF2\n
+    \  local-interface Vlan4094\n   peer-address 10.255.252.2\n   peer-link Port-Channel5\n
+    \  reload-delay mlag 300\n   reload-delay non-mlag 330\n!\nip route vrf MGMT 0.0.0.0/0
+    192.168.200.5\n!\nroute-map RM-CONN-2-BGP permit 10\n   match ip address prefix-list
+    PL-LOOPBACKS-EVPN-OVERLAY\n!\nroute-map RM-MLAG-PEER-IN permit 10\n   description
+    Make routes learned over MLAG Peer-link less preferred on spines to ensure optimal
+    routing\n   set origin incomplete\n!\nrouter bfd\n   multihop interval 1200 min-rx
+    1200 multiplier 3\n!\nrouter bgp 65102\n   router-id 192.168.255.7\n   maximum-paths
+    4 ecmp 4\n   update wait-install\n   no bgp default ipv4-unicast\n   distance
+    bgp 20 200 200\n   neighbor EVPN-OVERLAY-PEERS peer group\n   neighbor EVPN-OVERLAY-PEERS
+    update-source Loopback0\n   neighbor EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS
+    ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n
+    \  neighbor EVPN-OVERLAY-PEERS send-community\n   neighbor EVPN-OVERLAY-PEERS
+    maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS peer group\n   neighbor IPv4-UNDERLAY-PEERS
+    password 7 AQQvKeimxJu+uGQ/yYvv9w==\n   neighbor IPv4-UNDERLAY-PEERS send-community\n
+    \  neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000\n   neighbor MLAG-IPv4-UNDERLAY-PEER
+    peer group\n   neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65102\n   neighbor MLAG-IPv4-UNDERLAY-PEER
+    next-hop-self\n   neighbor MLAG-IPv4-UNDERLAY-PEER description DC1-LEAF2A\n   neighbor
+    MLAG-IPv4-UNDERLAY-PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==\n   neighbor MLAG-IPv4-UNDERLAY-PEER
+    send-community\n   neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000\n   neighbor
+    MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN in\n   neighbor 10.255.251.2
+    peer group MLAG-IPv4-UNDERLAY-PEER\n   neighbor 10.255.251.2 description DC1-LEAF2A\n
+    \  neighbor 172.31.255.16 peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.16
+    remote-as 65001\n   neighbor 172.31.255.16 description DC1-SPINE1_Ethernet3\n
+    \  neighbor 172.31.255.18 peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.18
+    remote-as 65001\n   neighbor 172.31.255.18 description DC1-SPINE2_Ethernet3\n
+    \  neighbor 172.31.255.20 peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.20
+    remote-as 65001\n   neighbor 172.31.255.20 description DC1-SPINE3_Ethernet3\n
+    \  neighbor 172.31.255.22 peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.22
+    remote-as 65001\n   neighbor 172.31.255.22 description DC1-SPINE4_Ethernet3\n
+    \  neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.1
+    remote-as 65001\n   neighbor 192.168.255.1 description DC1-SPINE1\n   neighbor
+    192.168.255.2 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.2 remote-as
+    65001\n   neighbor 192.168.255.2 description DC1-SPINE2\n   neighbor 192.168.255.3
+    peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.3 remote-as 65001\n   neighbor
+    192.168.255.3 description DC1-SPINE3\n   neighbor 192.168.255.4 peer group EVPN-OVERLAY-PEERS\n
+    \  neighbor 192.168.255.4 remote-as 65001\n   neighbor 192.168.255.4 description
+    DC1-SPINE4\n   redistribute connected route-map RM-CONN-2-BGP\n   !\n   vlan-aware-bundle
+    Tenant_A_APP_Zone\n      rd 192.168.255.7:12\n      route-target both 12:12\n
+    \     redistribute learned\n      vlan 130-131\n   !\n   vlan-aware-bundle Tenant_A_DB_Zone\n
+    \     rd 192.168.255.7:13\n      route-target both 13:13\n      redistribute learned\n
+    \     vlan 140-141\n   !\n   vlan-aware-bundle Tenant_A_OP_Zone\n      rd 192.168.255.7:10\n
+    \     route-target both 10:10\n      redistribute learned\n      vlan 110-111\n
+    \  !\n   vlan-aware-bundle Tenant_A_WEB_Zone\n      rd 192.168.255.7:11\n      route-target
+    both 11:11\n      redistribute learned\n      vlan 120-121\n   !\n   vlan-aware-bundle
+    Tenant_B_OP_Zone\n      rd 192.168.255.7:20\n      route-target both 20:20\n      redistribute
+    learned\n      vlan 210-211\n   !\n   vlan-aware-bundle Tenant_C_OP_Zone\n      rd
+    192.168.255.7:30\n      route-target both 30:30\n      redistribute learned\n
+    \     vlan 310-311\n   !\n   address-family evpn\n      neighbor EVPN-OVERLAY-PEERS
+    activate\n   !\n   address-family ipv4\n      no neighbor EVPN-OVERLAY-PEERS activate\n
+    \     neighbor IPv4-UNDERLAY-PEERS activate\n      neighbor MLAG-IPv4-UNDERLAY-PEER
+    activate\n   !\n   vrf Tenant_A_APP_Zone\n      rd 192.168.255.7:12\n      route-target
+    import evpn 12:12\n      route-target export evpn 12:12\n      router-id 192.168.255.7\n
+    \     update wait-install\n      neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER\n
+    \     redistribute connected\n   !\n   vrf Tenant_A_DB_Zone\n      rd 192.168.255.7:13\n
+    \     route-target import evpn 13:13\n      route-target export evpn 13:13\n      router-id
+    192.168.255.7\n      update wait-install\n      neighbor 10.255.251.2 peer group
+    MLAG-IPv4-UNDERLAY-PEER\n      redistribute connected\n   !\n   vrf Tenant_A_OP_Zone\n
+    \     rd 192.168.255.7:10\n      route-target import evpn 10:10\n      route-target
+    export evpn 10:10\n      router-id 192.168.255.7\n      update wait-install\n
+    \     neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n   !\n   vrf Tenant_A_WEB_Zone\n      rd 192.168.255.7:11\n      route-target
+    import evpn 11:11\n      route-target export evpn 11:11\n      router-id 192.168.255.7\n
+    \     update wait-install\n      neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER\n
+    \     redistribute connected\n   !\n   vrf Tenant_B_OP_Zone\n      rd 192.168.255.7:20\n
+    \     route-target import evpn 20:20\n      route-target export evpn 20:20\n      router-id
+    192.168.255.7\n      update wait-install\n      neighbor 10.255.251.2 peer group
+    MLAG-IPv4-UNDERLAY-PEER\n      redistribute connected\n   !\n   vrf Tenant_C_OP_Zone\n
+    \     rd 192.168.255.7:30\n      route-target import evpn 30:30\n      route-target
+    export evpn 30:30\n      router-id 192.168.255.7\n      update wait-install\n
+    \     neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n!\nmanagement api http-commands\n   protocol https\n   no shutdown\n
+    \  !\n   vrf MGMT\n      no shutdown\n!\nend\n"
+  AVD_DC1-SPINE1: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr
+    -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
+    -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
+    internal order ascending range 1006 1199\n!\ntransceiver qsfp default-mode 4x10G\n!\nservice
+    routing protocols model multi-agent\n!\nhostname DC1-SPINE1\nip name-server vrf
+    MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nntp local-interface vrf
+    MGMT Management1\nntp server vrf MGMT 192.168.200.5 prefer\n!\nspanning-tree mode
+    none\n!\nno enable password\nno aaa root\n!\nusername admin privilege 15 role
+    network-admin nopassword\nusername cvpadmin privilege 15 role network-admin secret
+    sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\nvrf
+    instance MGMT\n!\ninterface Ethernet1\n   description P2P_LINK_TO_DC1-LEAF1A_Ethernet1\n
+    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.0/31\n!\ninterface
+    Ethernet2\n   description P2P_LINK_TO_DC1-LEAF2A_Ethernet1\n   no shutdown\n   mtu
+    1500\n   no switchport\n   ip address 172.31.255.8/31\n!\ninterface Ethernet3\n
+    \  description P2P_LINK_TO_DC1-LEAF2B_Ethernet1\n   no shutdown\n   mtu 1500\n
+    \  no switchport\n   ip address 172.31.255.16/31\n!\ninterface Ethernet4\n   description
+    P2P_LINK_TO_DC1-SVC3A_Ethernet1\n   no shutdown\n   mtu 1500\n   no switchport\n
+    \  ip address 172.31.255.24/31\n!\ninterface Ethernet5\n   description P2P_LINK_TO_DC1-SVC3B_Ethernet1\n
+    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.32/31\n!\ninterface
+    Ethernet6\n   description P2P_LINK_TO_DC1-BL1A_Ethernet1\n   no shutdown\n   mtu
+    1500\n   no switchport\n   ip address 172.31.255.40/31\n!\ninterface Ethernet7\n
+    \  description P2P_LINK_TO_DC1-BL1B_Ethernet1\n   no shutdown\n   mtu 1500\n   no
+    switchport\n   ip address 172.31.255.48/31\n!\ninterface Loopback0\n   description
+    EVPN_Overlay_Peering\n   no shutdown\n   ip address 192.168.255.1/32\n!\ninterface
+    Management1\n   description oob_management\n   no shutdown\n   vrf MGMT\n   ip
+    address 192.168.200.101/24\n!\nip routing\nno ip routing vrf MGMT\n!\nip prefix-list
+    PL-LOOPBACKS-EVPN-OVERLAY\n   seq 10 permit 192.168.255.0/24 eq 32\n!\nip route
+    vrf MGMT 0.0.0.0/0 192.168.200.5\n!\nroute-map RM-CONN-2-BGP permit 10\n   match
+    ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n!\nrouter bfd\n   multihop interval
+    1200 min-rx 1200 multiplier 3\n!\nrouter bgp 65001\n   router-id 192.168.255.1\n
+    \  maximum-paths 4 ecmp 4\n   update wait-install\n   no bgp default ipv4-unicast\n
+    \  distance bgp 20 200 200\n   neighbor EVPN-OVERLAY-PEERS peer group\n   neighbor
+    EVPN-OVERLAY-PEERS next-hop-unchanged\n   neighbor EVPN-OVERLAY-PEERS update-source
+    Loopback0\n   neighbor EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS
+    ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n
+    \  neighbor EVPN-OVERLAY-PEERS send-community\n   neighbor EVPN-OVERLAY-PEERS
+    maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS peer group\n   neighbor IPv4-UNDERLAY-PEERS
+    password 7 AQQvKeimxJu+uGQ/yYvv9w==\n   neighbor IPv4-UNDERLAY-PEERS send-community\n
+    \  neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000\n   neighbor 172.31.255.1
+    peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.1 remote-as 65101\n   neighbor
+    172.31.255.1 description DC1-LEAF1A_Ethernet1\n   neighbor 172.31.255.9 peer group
+    IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.9 remote-as 65102\n   neighbor 172.31.255.9
+    description DC1-LEAF2A_Ethernet1\n   neighbor 172.31.255.17 peer group IPv4-UNDERLAY-PEERS\n
+    \  neighbor 172.31.255.17 remote-as 65102\n   neighbor 172.31.255.17 description
+    DC1-LEAF2B_Ethernet1\n   neighbor 172.31.255.25 peer group IPv4-UNDERLAY-PEERS\n
+    \  neighbor 172.31.255.25 remote-as 65103\n   neighbor 172.31.255.25 description
+    DC1-SVC3A_Ethernet1\n   neighbor 172.31.255.33 peer group IPv4-UNDERLAY-PEERS\n
+    \  neighbor 172.31.255.33 remote-as 65103\n   neighbor 172.31.255.33 description
+    DC1-SVC3B_Ethernet1\n   neighbor 172.31.255.41 peer group IPv4-UNDERLAY-PEERS\n
+    \  neighbor 172.31.255.41 remote-as 65104\n   neighbor 172.31.255.41 description
+    DC1-BL1A_Ethernet1\n   neighbor 172.31.255.49 peer group IPv4-UNDERLAY-PEERS\n
+    \  neighbor 172.31.255.49 remote-as 65104\n   neighbor 172.31.255.49 description
+    DC1-BL1B_Ethernet1\n   neighbor 192.168.255.5 peer group EVPN-OVERLAY-PEERS\n
+    \  neighbor 192.168.255.5 remote-as 65101\n   neighbor 192.168.255.5 description
+    DC1-LEAF1A\n   neighbor 192.168.255.6 peer group EVPN-OVERLAY-PEERS\n   neighbor
+    192.168.255.6 remote-as 65102\n   neighbor 192.168.255.6 description DC1-LEAF2A\n
+    \  neighbor 192.168.255.7 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.7
+    remote-as 65102\n   neighbor 192.168.255.7 description DC1-LEAF2B\n   neighbor
+    192.168.255.8 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.8 remote-as
+    65103\n   neighbor 192.168.255.8 description DC1-SVC3A\n   neighbor 192.168.255.9
+    peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.9 remote-as 65103\n   neighbor
+    192.168.255.9 description DC1-SVC3B\n   neighbor 192.168.255.10 peer group EVPN-OVERLAY-PEERS\n
+    \  neighbor 192.168.255.10 remote-as 65104\n   neighbor 192.168.255.10 description
+    DC1-BL1A\n   neighbor 192.168.255.11 peer group EVPN-OVERLAY-PEERS\n   neighbor
+    192.168.255.11 remote-as 65104\n   neighbor 192.168.255.11 description DC1-BL1B\n
+    \  redistribute connected route-map RM-CONN-2-BGP\n   !\n   address-family evpn\n
+    \     neighbor EVPN-OVERLAY-PEERS activate\n   !\n   address-family ipv4\n      no
+    neighbor EVPN-OVERLAY-PEERS activate\n      neighbor IPv4-UNDERLAY-PEERS activate\n!\nmanagement
+    api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no
+    shutdown\n!\nend\n"
+  AVD_DC1-SPINE2: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr
+    -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
+    -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
+    internal order ascending range 1006 1199\n!\ntransceiver qsfp default-mode 4x10G\n!\nservice
+    routing protocols model multi-agent\n!\nhostname DC1-SPINE2\nip name-server vrf
+    MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nntp local-interface vrf
+    MGMT Management1\nntp server vrf MGMT 192.168.200.5 prefer\n!\nspanning-tree mode
+    none\n!\nno enable password\nno aaa root\n!\nusername admin privilege 15 role
+    network-admin nopassword\nusername cvpadmin privilege 15 role network-admin secret
+    sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\nvrf
+    instance MGMT\n!\ninterface Ethernet1\n   description P2P_LINK_TO_DC1-LEAF1A_Ethernet2\n
+    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.2/31\n!\ninterface
+    Ethernet2\n   description P2P_LINK_TO_DC1-LEAF2A_Ethernet2\n   no shutdown\n   mtu
+    1500\n   no switchport\n   ip address 172.31.255.10/31\n!\ninterface Ethernet3\n
+    \  description P2P_LINK_TO_DC1-LEAF2B_Ethernet2\n   no shutdown\n   mtu 1500\n
+    \  no switchport\n   ip address 172.31.255.18/31\n!\ninterface Ethernet4\n   description
+    P2P_LINK_TO_DC1-SVC3A_Ethernet2\n   no shutdown\n   mtu 1500\n   no switchport\n
+    \  ip address 172.31.255.26/31\n!\ninterface Ethernet5\n   description P2P_LINK_TO_DC1-SVC3B_Ethernet2\n
+    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.34/31\n!\ninterface
+    Ethernet6\n   description P2P_LINK_TO_DC1-BL1A_Ethernet2\n   no shutdown\n   mtu
+    1500\n   no switchport\n   ip address 172.31.255.42/31\n!\ninterface Ethernet7\n
+    \  description P2P_LINK_TO_DC1-BL1B_Ethernet2\n   no shutdown\n   mtu 1500\n   no
+    switchport\n   ip address 172.31.255.50/31\n!\ninterface Loopback0\n   description
+    EVPN_Overlay_Peering\n   no shutdown\n   ip address 192.168.255.2/32\n!\ninterface
+    Management1\n   description oob_management\n   no shutdown\n   vrf MGMT\n   ip
+    address 192.168.200.102/24\n!\nip routing\nno ip routing vrf MGMT\n!\nip prefix-list
+    PL-LOOPBACKS-EVPN-OVERLAY\n   seq 10 permit 192.168.255.0/24 eq 32\n!\nip route
+    vrf MGMT 0.0.0.0/0 192.168.200.5\n!\nroute-map RM-CONN-2-BGP permit 10\n   match
+    ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n!\nrouter bfd\n   multihop interval
+    1200 min-rx 1200 multiplier 3\n!\nrouter bgp 65001\n   router-id 192.168.255.2\n
+    \  maximum-paths 4 ecmp 4\n   update wait-install\n   no bgp default ipv4-unicast\n
+    \  distance bgp 20 200 200\n   neighbor EVPN-OVERLAY-PEERS peer group\n   neighbor
+    EVPN-OVERLAY-PEERS next-hop-unchanged\n   neighbor EVPN-OVERLAY-PEERS update-source
+    Loopback0\n   neighbor EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS
+    ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n
+    \  neighbor EVPN-OVERLAY-PEERS send-community\n   neighbor EVPN-OVERLAY-PEERS
+    maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS peer group\n   neighbor IPv4-UNDERLAY-PEERS
+    password 7 AQQvKeimxJu+uGQ/yYvv9w==\n   neighbor IPv4-UNDERLAY-PEERS send-community\n
+    \  neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000\n   neighbor 172.31.255.3
+    peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.3 remote-as 65101\n   neighbor
+    172.31.255.3 description DC1-LEAF1A_Ethernet2\n   neighbor 172.31.255.11 peer
+    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.11 remote-as 65102\n   neighbor
+    172.31.255.11 description DC1-LEAF2A_Ethernet2\n   neighbor 172.31.255.19 peer
+    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.19 remote-as 65102\n   neighbor
+    172.31.255.19 description DC1-LEAF2B_Ethernet2\n   neighbor 172.31.255.27 peer
+    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.27 remote-as 65103\n   neighbor
+    172.31.255.27 description DC1-SVC3A_Ethernet2\n   neighbor 172.31.255.35 peer
+    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.35 remote-as 65103\n   neighbor
+    172.31.255.35 description DC1-SVC3B_Ethernet2\n   neighbor 172.31.255.43 peer
+    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.43 remote-as 65104\n   neighbor
+    172.31.255.43 description DC1-BL1A_Ethernet2\n   neighbor 172.31.255.51 peer group
+    IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.51 remote-as 65104\n   neighbor 172.31.255.51
+    description DC1-BL1B_Ethernet2\n   neighbor 192.168.255.5 peer group EVPN-OVERLAY-PEERS\n
+    \  neighbor 192.168.255.5 remote-as 65101\n   neighbor 192.168.255.5 description
+    DC1-LEAF1A\n   neighbor 192.168.255.6 peer group EVPN-OVERLAY-PEERS\n   neighbor
+    192.168.255.6 remote-as 65102\n   neighbor 192.168.255.6 description DC1-LEAF2A\n
+    \  neighbor 192.168.255.7 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.7
+    remote-as 65102\n   neighbor 192.168.255.7 description DC1-LEAF2B\n   neighbor
+    192.168.255.8 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.8 remote-as
+    65103\n   neighbor 192.168.255.8 description DC1-SVC3A\n   neighbor 192.168.255.9
+    peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.9 remote-as 65103\n   neighbor
+    192.168.255.9 description DC1-SVC3B\n   neighbor 192.168.255.10 peer group EVPN-OVERLAY-PEERS\n
+    \  neighbor 192.168.255.10 remote-as 65104\n   neighbor 192.168.255.10 description
+    DC1-BL1A\n   neighbor 192.168.255.11 peer group EVPN-OVERLAY-PEERS\n   neighbor
+    192.168.255.11 remote-as 65104\n   neighbor 192.168.255.11 description DC1-BL1B\n
+    \  redistribute connected route-map RM-CONN-2-BGP\n   !\n   address-family evpn\n
+    \     neighbor EVPN-OVERLAY-PEERS activate\n   !\n   address-family ipv4\n      no
+    neighbor EVPN-OVERLAY-PEERS activate\n      neighbor IPv4-UNDERLAY-PEERS activate\n!\nmanagement
+    api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no
+    shutdown\n!\nend\n"
+  AVD_DC1-SPINE3: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr
+    -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
+    -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
+    internal order ascending range 1006 1199\n!\ntransceiver qsfp default-mode 4x10G\n!\nservice
+    routing protocols model multi-agent\n!\nhostname DC1-SPINE3\nip name-server vrf
+    MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nntp local-interface vrf
+    MGMT Management1\nntp server vrf MGMT 192.168.200.5 prefer\n!\nspanning-tree mode
+    none\n!\nno enable password\nno aaa root\n!\nusername admin privilege 15 role
+    network-admin nopassword\nusername cvpadmin privilege 15 role network-admin secret
+    sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\nvrf
+    instance MGMT\n!\ninterface Ethernet1\n   description P2P_LINK_TO_DC1-LEAF1A_Ethernet3\n
+    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.4/31\n!\ninterface
+    Ethernet2\n   description P2P_LINK_TO_DC1-LEAF2A_Ethernet3\n   no shutdown\n   mtu
+    1500\n   no switchport\n   ip address 172.31.255.12/31\n!\ninterface Ethernet3\n
+    \  description P2P_LINK_TO_DC1-LEAF2B_Ethernet3\n   no shutdown\n   mtu 1500\n
+    \  no switchport\n   ip address 172.31.255.20/31\n!\ninterface Ethernet4\n   description
+    P2P_LINK_TO_DC1-SVC3A_Ethernet3\n   no shutdown\n   mtu 1500\n   no switchport\n
+    \  ip address 172.31.255.28/31\n!\ninterface Ethernet5\n   description P2P_LINK_TO_DC1-SVC3B_Ethernet3\n
+    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.36/31\n!\ninterface
+    Ethernet6\n   description P2P_LINK_TO_DC1-BL1A_Ethernet3\n   no shutdown\n   mtu
+    1500\n   no switchport\n   ip address 172.31.255.44/31\n!\ninterface Ethernet7\n
+    \  description P2P_LINK_TO_DC1-BL1B_Ethernet3\n   no shutdown\n   mtu 1500\n   no
+    switchport\n   ip address 172.31.255.52/31\n!\ninterface Loopback0\n   description
+    EVPN_Overlay_Peering\n   no shutdown\n   ip address 192.168.255.3/32\n!\ninterface
+    Management1\n   description oob_management\n   no shutdown\n   vrf MGMT\n   ip
+    address 192.168.200.103/24\n!\nip routing\nno ip routing vrf MGMT\n!\nip prefix-list
+    PL-LOOPBACKS-EVPN-OVERLAY\n   seq 10 permit 192.168.255.0/24 eq 32\n!\nip route
+    vrf MGMT 0.0.0.0/0 192.168.200.5\n!\nroute-map RM-CONN-2-BGP permit 10\n   match
+    ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n!\nrouter bfd\n   multihop interval
+    1200 min-rx 1200 multiplier 3\n!\nrouter bgp 65001\n   router-id 192.168.255.3\n
+    \  maximum-paths 4 ecmp 4\n   update wait-install\n   no bgp default ipv4-unicast\n
+    \  distance bgp 20 200 200\n   neighbor EVPN-OVERLAY-PEERS peer group\n   neighbor
+    EVPN-OVERLAY-PEERS next-hop-unchanged\n   neighbor EVPN-OVERLAY-PEERS update-source
+    Loopback0\n   neighbor EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS
+    ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n
+    \  neighbor EVPN-OVERLAY-PEERS send-community\n   neighbor EVPN-OVERLAY-PEERS
+    maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS peer group\n   neighbor IPv4-UNDERLAY-PEERS
+    password 7 AQQvKeimxJu+uGQ/yYvv9w==\n   neighbor IPv4-UNDERLAY-PEERS send-community\n
+    \  neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000\n   neighbor 172.31.255.5
+    peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.5 remote-as 65101\n   neighbor
+    172.31.255.5 description DC1-LEAF1A_Ethernet3\n   neighbor 172.31.255.13 peer
+    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.13 remote-as 65102\n   neighbor
+    172.31.255.13 description DC1-LEAF2A_Ethernet3\n   neighbor 172.31.255.21 peer
+    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.21 remote-as 65102\n   neighbor
+    172.31.255.21 description DC1-LEAF2B_Ethernet3\n   neighbor 172.31.255.29 peer
+    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.29 remote-as 65103\n   neighbor
+    172.31.255.29 description DC1-SVC3A_Ethernet3\n   neighbor 172.31.255.37 peer
+    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.37 remote-as 65103\n   neighbor
+    172.31.255.37 description DC1-SVC3B_Ethernet3\n   neighbor 172.31.255.45 peer
+    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.45 remote-as 65104\n   neighbor
+    172.31.255.45 description DC1-BL1A_Ethernet3\n   neighbor 172.31.255.53 peer group
+    IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.53 remote-as 65104\n   neighbor 172.31.255.53
+    description DC1-BL1B_Ethernet3\n   neighbor 192.168.255.5 peer group EVPN-OVERLAY-PEERS\n
+    \  neighbor 192.168.255.5 remote-as 65101\n   neighbor 192.168.255.5 description
+    DC1-LEAF1A\n   neighbor 192.168.255.6 peer group EVPN-OVERLAY-PEERS\n   neighbor
+    192.168.255.6 remote-as 65102\n   neighbor 192.168.255.6 description DC1-LEAF2A\n
+    \  neighbor 192.168.255.7 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.7
+    remote-as 65102\n   neighbor 192.168.255.7 description DC1-LEAF2B\n   neighbor
+    192.168.255.8 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.8 remote-as
+    65103\n   neighbor 192.168.255.8 description DC1-SVC3A\n   neighbor 192.168.255.9
+    peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.9 remote-as 65103\n   neighbor
+    192.168.255.9 description DC1-SVC3B\n   neighbor 192.168.255.10 peer group EVPN-OVERLAY-PEERS\n
+    \  neighbor 192.168.255.10 remote-as 65104\n   neighbor 192.168.255.10 description
+    DC1-BL1A\n   neighbor 192.168.255.11 peer group EVPN-OVERLAY-PEERS\n   neighbor
+    192.168.255.11 remote-as 65104\n   neighbor 192.168.255.11 description DC1-BL1B\n
+    \  redistribute connected route-map RM-CONN-2-BGP\n   !\n   address-family evpn\n
+    \     neighbor EVPN-OVERLAY-PEERS activate\n   !\n   address-family ipv4\n      no
+    neighbor EVPN-OVERLAY-PEERS activate\n      neighbor IPv4-UNDERLAY-PEERS activate\n!\nmanagement
+    api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no
+    shutdown\n!\nend\n"
+  AVD_DC1-SPINE4: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr
+    -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
+    -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
+    internal order ascending range 1006 1199\n!\ntransceiver qsfp default-mode 4x10G\n!\nservice
+    routing protocols model multi-agent\n!\nhostname DC1-SPINE4\nip name-server vrf
+    MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nntp local-interface vrf
+    MGMT Management1\nntp server vrf MGMT 192.168.200.5 prefer\n!\nspanning-tree mode
+    none\n!\nno enable password\nno aaa root\n!\nusername admin privilege 15 role
+    network-admin nopassword\nusername cvpadmin privilege 15 role network-admin secret
+    sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\nvrf
+    instance MGMT\n!\ninterface Ethernet1\n   description P2P_LINK_TO_DC1-LEAF1A_Ethernet4\n
+    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.6/31\n!\ninterface
+    Ethernet2\n   description P2P_LINK_TO_DC1-LEAF2A_Ethernet4\n   no shutdown\n   mtu
+    1500\n   no switchport\n   ip address 172.31.255.14/31\n!\ninterface Ethernet3\n
+    \  description P2P_LINK_TO_DC1-LEAF2B_Ethernet4\n   no shutdown\n   mtu 1500\n
+    \  no switchport\n   ip address 172.31.255.22/31\n!\ninterface Ethernet4\n   description
+    P2P_LINK_TO_DC1-SVC3A_Ethernet4\n   no shutdown\n   mtu 1500\n   no switchport\n
+    \  ip address 172.31.255.30/31\n!\ninterface Ethernet5\n   description P2P_LINK_TO_DC1-SVC3B_Ethernet4\n
+    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.38/31\n!\ninterface
+    Ethernet6\n   description P2P_LINK_TO_DC1-BL1A_Ethernet4\n   no shutdown\n   mtu
+    1500\n   no switchport\n   ip address 172.31.255.46/31\n!\ninterface Ethernet7\n
+    \  description P2P_LINK_TO_DC1-BL1B_Ethernet4\n   no shutdown\n   mtu 1500\n   no
+    switchport\n   ip address 172.31.255.54/31\n!\ninterface Loopback0\n   description
+    EVPN_Overlay_Peering\n   no shutdown\n   ip address 192.168.255.4/32\n!\ninterface
+    Management1\n   description oob_management\n   no shutdown\n   vrf MGMT\n   ip
+    address 192.168.200.104/24\n!\nip routing\nno ip routing vrf MGMT\n!\nip prefix-list
+    PL-LOOPBACKS-EVPN-OVERLAY\n   seq 10 permit 192.168.255.0/24 eq 32\n!\nip route
+    vrf MGMT 0.0.0.0/0 192.168.200.5\n!\nroute-map RM-CONN-2-BGP permit 10\n   match
+    ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n!\nrouter bfd\n   multihop interval
+    1200 min-rx 1200 multiplier 3\n!\nrouter bgp 65001\n   router-id 192.168.255.4\n
+    \  maximum-paths 4 ecmp 4\n   update wait-install\n   no bgp default ipv4-unicast\n
+    \  distance bgp 20 200 200\n   neighbor EVPN-OVERLAY-PEERS peer group\n   neighbor
+    EVPN-OVERLAY-PEERS next-hop-unchanged\n   neighbor EVPN-OVERLAY-PEERS update-source
+    Loopback0\n   neighbor EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS
+    ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n
+    \  neighbor EVPN-OVERLAY-PEERS send-community\n   neighbor EVPN-OVERLAY-PEERS
+    maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS peer group\n   neighbor IPv4-UNDERLAY-PEERS
+    password 7 AQQvKeimxJu+uGQ/yYvv9w==\n   neighbor IPv4-UNDERLAY-PEERS send-community\n
+    \  neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000\n   neighbor 172.31.255.7
+    peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.7 remote-as 65101\n   neighbor
+    172.31.255.7 description DC1-LEAF1A_Ethernet4\n   neighbor 172.31.255.15 peer
+    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.15 remote-as 65102\n   neighbor
+    172.31.255.15 description DC1-LEAF2A_Ethernet4\n   neighbor 172.31.255.23 peer
+    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.23 remote-as 65102\n   neighbor
+    172.31.255.23 description DC1-LEAF2B_Ethernet4\n   neighbor 172.31.255.31 peer
+    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.31 remote-as 65103\n   neighbor
+    172.31.255.31 description DC1-SVC3A_Ethernet4\n   neighbor 172.31.255.39 peer
+    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.39 remote-as 65103\n   neighbor
+    172.31.255.39 description DC1-SVC3B_Ethernet4\n   neighbor 172.31.255.47 peer
+    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.47 remote-as 65104\n   neighbor
+    172.31.255.47 description DC1-BL1A_Ethernet4\n   neighbor 172.31.255.55 peer group
+    IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.55 remote-as 65104\n   neighbor 172.31.255.55
+    description DC1-BL1B_Ethernet4\n   neighbor 192.168.255.5 peer group EVPN-OVERLAY-PEERS\n
+    \  neighbor 192.168.255.5 remote-as 65101\n   neighbor 192.168.255.5 description
+    DC1-LEAF1A\n   neighbor 192.168.255.6 peer group EVPN-OVERLAY-PEERS\n   neighbor
+    192.168.255.6 remote-as 65102\n   neighbor 192.168.255.6 description DC1-LEAF2A\n
+    \  neighbor 192.168.255.7 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.7
+    remote-as 65102\n   neighbor 192.168.255.7 description DC1-LEAF2B\n   neighbor
+    192.168.255.8 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.8 remote-as
+    65103\n   neighbor 192.168.255.8 description DC1-SVC3A\n   neighbor 192.168.255.9
+    peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.9 remote-as 65103\n   neighbor
+    192.168.255.9 description DC1-SVC3B\n   neighbor 192.168.255.10 peer group EVPN-OVERLAY-PEERS\n
+    \  neighbor 192.168.255.10 remote-as 65104\n   neighbor 192.168.255.10 description
+    DC1-BL1A\n   neighbor 192.168.255.11 peer group EVPN-OVERLAY-PEERS\n   neighbor
+    192.168.255.11 remote-as 65104\n   neighbor 192.168.255.11 description DC1-BL1B\n
+    \  redistribute connected route-map RM-CONN-2-BGP\n   !\n   address-family evpn\n
+    \     neighbor EVPN-OVERLAY-PEERS activate\n   !\n   address-family ipv4\n      no
+    neighbor EVPN-OVERLAY-PEERS activate\n      neighbor IPv4-UNDERLAY-PEERS activate\n!\nmanagement
+    api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no
+    shutdown\n!\nend\n"
+  AVD_DC1-SVC3A: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr
+    -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
+    -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
+    internal order ascending range 1006 1199\n!\nno ip igmp snooping vlan 120\n!\ntransceiver
+    qsfp default-mode 4x10G\n!\nservice routing protocols model multi-agent\n!\nhostname
+    DC1-SVC3A\nip name-server vrf MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nntp
+    local-interface vrf MGMT Management1\nntp server vrf MGMT 192.168.200.5 prefer\n!\nspanning-tree
+    mode mstp\nno spanning-tree vlan-id 4093-4094\nspanning-tree mst 0 priority 4096\n!\nno
+    enable password\nno aaa root\n!\nusername admin privilege 15 role network-admin
+    nopassword\nusername cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\nvlan
+    110\n   name Tenant_A_OP_Zone_1\n!\nvlan 111\n   name Tenant_A_OP_Zone_2\n!\nvlan
+    120\n   name Tenant_A_WEB_Zone_1\n!\nvlan 121\n   name Tenant_A_WEBZone_2\n!\nvlan
+    130\n   name Tenant_A_APP_Zone_1\n!\nvlan 131\n   name Tenant_A_APP_Zone_2\n!\nvlan
+    140\n   name Tenant_A_DB_BZone_1\n!\nvlan 141\n   name Tenant_A_DB_Zone_2\n!\nvlan
+    150\n   name Tenant_A_WAN_Zone_1\n!\nvlan 210\n   name Tenant_B_OP_Zone_1\n!\nvlan
+    211\n   name Tenant_B_OP_Zone_2\n!\nvlan 250\n   name Tenant_B_WAN_Zone_1\n!\nvlan
+    310\n   name Tenant_C_OP_Zone_1\n!\nvlan 311\n   name Tenant_C_OP_Zone_2\n!\nvlan
+    350\n   name Tenant_C_WAN_Zone_1\n!\nvlan 3009\n   name MLAG_iBGP_Tenant_A_OP_Zone\n
+    \  trunk group LEAF_PEER_L3\n!\nvlan 3010\n   name MLAG_iBGP_Tenant_A_WEB_Zone\n
+    \  trunk group LEAF_PEER_L3\n!\nvlan 3011\n   name MLAG_iBGP_Tenant_A_APP_Zone\n
+    \  trunk group LEAF_PEER_L3\n!\nvlan 3012\n   name MLAG_iBGP_Tenant_A_DB_Zone\n
+    \  trunk group LEAF_PEER_L3\n!\nvlan 3013\n   name MLAG_iBGP_Tenant_A_WAN_Zone\n
+    \  trunk group LEAF_PEER_L3\n!\nvlan 3019\n   name MLAG_iBGP_Tenant_B_OP_Zone\n
+    \  trunk group LEAF_PEER_L3\n!\nvlan 3020\n   name MLAG_iBGP_Tenant_B_WAN_Zone\n
+    \  trunk group LEAF_PEER_L3\n!\nvlan 3029\n   name MLAG_iBGP_Tenant_C_OP_Zone\n
+    \  trunk group LEAF_PEER_L3\n!\nvlan 3030\n   name MLAG_iBGP_Tenant_C_WAN_Zone\n
+    \  trunk group LEAF_PEER_L3\n!\nvlan 4093\n   name LEAF_PEER_L3\n   trunk group
+    LEAF_PEER_L3\n!\nvlan 4094\n   name MLAG_PEER\n   trunk group MLAG\n!\nvrf instance
+    MGMT\n!\nvrf instance Tenant_A_APP_Zone\n!\nvrf instance Tenant_A_DB_Zone\n!\nvrf
+    instance Tenant_A_OP_Zone\n!\nvrf instance Tenant_A_WAN_Zone\n!\nvrf instance
+    Tenant_A_WEB_Zone\n!\nvrf instance Tenant_B_OP_Zone\n!\nvrf instance Tenant_B_WAN_Zone\n!\nvrf
+    instance Tenant_C_OP_Zone\n!\nvrf instance Tenant_C_WAN_Zone\n!\ninterface Port-Channel5\n
+    \  description MLAG_PEER_DC1-SVC3B_Po5\n   no shutdown\n   switchport\n   switchport
+    mode trunk\n   switchport trunk group LEAF_PEER_L3\n   switchport trunk group
+    MLAG\n!\ninterface Port-Channel7\n   description DC1_L2LEAF2_Po1\n   no shutdown\n
+    \  switchport\n   switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350\n
+    \  switchport mode trunk\n   mlag 7\n!\ninterface Port-Channel10\n   description
+    server03_ESI_PortChanne1\n   no shutdown\n   switchport\n   switchport trunk allowed
+    vlan 110-111,210-211\n   switchport mode trunk\n   evpn ethernet-segment\n      identifier
+    0000:0000:0303:0202:0101\n      route-target import 03:03:02:02:01:01\n   lacp
+    system-id 0303.0202.0101\n!\ninterface Ethernet1\n   description P2P_LINK_TO_DC1-SPINE1_Ethernet4\n
+    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.25/31\n!\ninterface
+    Ethernet2\n   description P2P_LINK_TO_DC1-SPINE2_Ethernet4\n   no shutdown\n   mtu
+    1500\n   no switchport\n   ip address 172.31.255.27/31\n!\ninterface Ethernet3\n
+    \  description P2P_LINK_TO_DC1-SPINE3_Ethernet4\n   no shutdown\n   mtu 1500\n
+    \  no switchport\n   ip address 172.31.255.29/31\n!\ninterface Ethernet4\n   description
+    P2P_LINK_TO_DC1-SPINE4_Ethernet4\n   no shutdown\n   mtu 1500\n   no switchport\n
+    \  ip address 172.31.255.31/31\n!\ninterface Ethernet5\n   description MLAG_PEER_DC1-SVC3B_Ethernet5\n
+    \  no shutdown\n   channel-group 5 mode active\n!\ninterface Ethernet6\n   description
+    MLAG_PEER_DC1-SVC3B_Ethernet6\n   no shutdown\n   channel-group 5 mode active\n!\ninterface
+    Ethernet7\n   description DC1-L2LEAF2A_Ethernet1\n   no shutdown\n   channel-group
+    7 mode active\n!\ninterface Ethernet8\n   description DC1-L2LEAF2B_Ethernet1\n
+    \  no shutdown\n   channel-group 7 mode active\n!\ninterface Ethernet10\n   description
+    server03_ESI_Eth1\n   no shutdown\n   channel-group 10 mode active\n!\ninterface
+    Loopback0\n   description EVPN_Overlay_Peering\n   no shutdown\n   ip address
+    192.168.255.8/32\n!\ninterface Loopback1\n   description VTEP_VXLAN_Tunnel_Source\n
+    \  no shutdown\n   ip address 192.168.254.8/32\n!\ninterface Loopback100\n   description
+    Tenant_A_OP_Zone_VTEP_DIAGNOSTICS\n   no shutdown\n   vrf Tenant_A_OP_Zone\n   ip
+    address 10.255.1.8/32\n!\ninterface Management1\n   description oob_management\n
+    \  no shutdown\n   vrf MGMT\n   ip address 192.168.200.108/24\n!\ninterface Vlan110\n
+    \  description Tenant_A_OP_Zone_1\n   no shutdown\n   vrf Tenant_A_OP_Zone\n   ip
+    address virtual 10.1.10.1/24\n!\ninterface Vlan111\n   description Tenant_A_OP_Zone_2\n
+    \  no shutdown\n   vrf Tenant_A_OP_Zone\n   ip helper-address 1.1.1.1 vrf MGMT
+    source-interface lo100\n   ip address virtual 10.1.11.1/24\n!\ninterface Vlan120\n
+    \  description Tenant_A_WEB_Zone_1\n   no shutdown\n   vrf Tenant_A_WEB_Zone\n
+    \  ip helper-address 1.1.1.1 vrf TEST source-interface lo100\n   ip address virtual
+    10.1.20.1/24\n!\ninterface Vlan121\n   description Tenant_A_WEBZone_2\n   shutdown\n
+    \  mtu 1560\n   vrf Tenant_A_WEB_Zone\n   ip address virtual 10.1.10.254/24\n!\ninterface
+    Vlan130\n   description Tenant_A_APP_Zone_1\n   no shutdown\n   vrf Tenant_A_APP_Zone\n
+    \  ip address virtual 10.1.30.1/24\n!\ninterface Vlan131\n   description Tenant_A_APP_Zone_2\n
+    \  no shutdown\n   vrf Tenant_A_APP_Zone\n   ip address virtual 10.1.31.1/24\n!\ninterface
+    Vlan140\n   description Tenant_A_DB_BZone_1\n   no shutdown\n   vrf Tenant_A_DB_Zone\n
+    \  ip address virtual 10.1.40.1/24\n!\ninterface Vlan141\n   description Tenant_A_DB_Zone_2\n
+    \  no shutdown\n   vrf Tenant_A_DB_Zone\n   ip address virtual 10.1.41.1/24\n!\ninterface
+    Vlan150\n   description Tenant_A_WAN_Zone_1\n   no shutdown\n   vrf Tenant_A_WAN_Zone\n
+    \  ip address virtual 10.1.40.1/24\n!\ninterface Vlan210\n   description Tenant_B_OP_Zone_1\n
+    \  no shutdown\n   vrf Tenant_B_OP_Zone\n   ip address virtual 10.2.10.1/24\n!\ninterface
+    Vlan211\n   description Tenant_B_OP_Zone_2\n   no shutdown\n   vrf Tenant_B_OP_Zone\n
+    \  ip address virtual 10.2.11.1/24\n!\ninterface Vlan250\n   description Tenant_B_WAN_Zone_1\n
+    \  no shutdown\n   vrf Tenant_B_WAN_Zone\n   ip address virtual 10.2.50.1/24\n!\ninterface
+    Vlan310\n   description Tenant_C_OP_Zone_1\n   no shutdown\n   vrf Tenant_C_OP_Zone\n
+    \  ip address virtual 10.3.10.1/24\n!\ninterface Vlan311\n   description Tenant_C_OP_Zone_2\n
+    \  no shutdown\n   vrf Tenant_C_OP_Zone\n   ip address virtual 10.3.11.1/24\n!\ninterface
+    Vlan350\n   description Tenant_C_WAN_Zone_1\n   no shutdown\n   vrf Tenant_C_WAN_Zone\n
+    \  ip address virtual 10.3.50.1/24\n!\ninterface Vlan3009\n   description MLAG_PEER_L3_iBGP:
+    vrf Tenant_A_OP_Zone\n   no shutdown\n   mtu 1500\n   vrf Tenant_A_OP_Zone\n   ip
+    address 10.255.251.6/31\n!\ninterface Vlan3010\n   description MLAG_PEER_L3_iBGP:
+    vrf Tenant_A_WEB_Zone\n   no shutdown\n   mtu 1500\n   vrf Tenant_A_WEB_Zone\n
+    \  ip address 10.255.251.6/31\n!\ninterface Vlan3011\n   description MLAG_PEER_L3_iBGP:
+    vrf Tenant_A_APP_Zone\n   no shutdown\n   mtu 1500\n   vrf Tenant_A_APP_Zone\n
+    \  ip address 10.255.251.6/31\n!\ninterface Vlan3012\n   description MLAG_PEER_L3_iBGP:
+    vrf Tenant_A_DB_Zone\n   no shutdown\n   mtu 1500\n   vrf Tenant_A_DB_Zone\n   ip
+    address 10.255.251.6/31\n!\ninterface Vlan3013\n   description MLAG_PEER_L3_iBGP:
+    vrf Tenant_A_WAN_Zone\n   no shutdown\n   mtu 1500\n   vrf Tenant_A_WAN_Zone\n
+    \  ip address 10.255.251.6/31\n!\ninterface Vlan3019\n   description MLAG_PEER_L3_iBGP:
+    vrf Tenant_B_OP_Zone\n   no shutdown\n   mtu 1500\n   vrf Tenant_B_OP_Zone\n   ip
+    address 10.255.251.6/31\n!\ninterface Vlan3020\n   description MLAG_PEER_L3_iBGP:
+    vrf Tenant_B_WAN_Zone\n   no shutdown\n   mtu 1500\n   vrf Tenant_B_WAN_Zone\n
+    \  ip address 10.255.251.6/31\n!\ninterface Vlan3029\n   description MLAG_PEER_L3_iBGP:
+    vrf Tenant_C_OP_Zone\n   no shutdown\n   mtu 1500\n   vrf Tenant_C_OP_Zone\n   ip
+    address 10.255.251.6/31\n!\ninterface Vlan3030\n   description MLAG_PEER_L3_iBGP:
+    vrf Tenant_C_WAN_Zone\n   no shutdown\n   mtu 1500\n   vrf Tenant_C_WAN_Zone\n
+    \  ip address 10.255.251.6/31\n!\ninterface Vlan4093\n   description MLAG_PEER_L3_PEERING\n
+    \  no shutdown\n   mtu 1500\n   ip address 10.255.251.6/31\n!\ninterface Vlan4094\n
+    \  description MLAG_PEER\n   no shutdown\n   mtu 1500\n   no autostate\n   ip
+    address 10.255.252.6/31\n!\ninterface Vxlan1\n   description DC1-SVC3A_VTEP\n
+    \  vxlan source-interface Loopback1\n   vxlan virtual-router encapsulation mac-address
+    mlag-system-id\n   vxlan udp-port 4789\n   vxlan vlan 110 vni 10110\n   vxlan
+    vlan 111 vni 50111\n   vxlan vlan 120 vni 10120\n   vxlan vlan 121 vni 10121\n
+    \  vxlan vlan 130 vni 10130\n   vxlan vlan 131 vni 10131\n   vxlan vlan 140 vni
+    10140\n   vxlan vlan 141 vni 10141\n   vxlan vlan 150 vni 10150\n   vxlan vlan
+    210 vni 20210\n   vxlan vlan 211 vni 20211\n   vxlan vlan 250 vni 20250\n   vxlan
+    vlan 310 vni 30310\n   vxlan vlan 311 vni 30311\n   vxlan vlan 350 vni 30350\n
+    \  vxlan vrf Tenant_A_APP_Zone vni 12\n   vxlan vrf Tenant_A_DB_Zone vni 13\n
+    \  vxlan vrf Tenant_A_OP_Zone vni 10\n   vxlan vrf Tenant_A_WAN_Zone vni 14\n
+    \  vxlan vrf Tenant_A_WEB_Zone vni 11\n   vxlan vrf Tenant_B_OP_Zone vni 20\n
+    \  vxlan vrf Tenant_B_WAN_Zone vni 21\n   vxlan vrf Tenant_C_OP_Zone vni 30\n
+    \  vxlan vrf Tenant_C_WAN_Zone vni 31\n!\nip virtual-router mac-address 00:dc:00:00:00:0a\n!\nip
+    address virtual source-nat vrf Tenant_A_OP_Zone address 10.255.1.8\n!\nip routing\nno
+    ip routing vrf MGMT\nip routing vrf Tenant_A_APP_Zone\nip routing vrf Tenant_A_DB_Zone\nip
+    routing vrf Tenant_A_OP_Zone\nip routing vrf Tenant_A_WAN_Zone\nip routing vrf
+    Tenant_A_WEB_Zone\nip routing vrf Tenant_B_OP_Zone\nip routing vrf Tenant_B_WAN_Zone\nip
+    routing vrf Tenant_C_OP_Zone\nip routing vrf Tenant_C_WAN_Zone\n!\nip prefix-list
+    PL-LOOPBACKS-EVPN-OVERLAY\n   seq 10 permit 192.168.255.0/24 eq 32\n   seq 20
+    permit 192.168.254.0/24 eq 32\n!\nmlag configuration\n   domain-id DC1_SVC3\n
+    \  local-interface Vlan4094\n   peer-address 10.255.252.7\n   peer-link Port-Channel5\n
+    \  reload-delay mlag 300\n   reload-delay non-mlag 330\n!\nip route vrf MGMT 0.0.0.0/0
+    192.168.200.5\n!\nroute-map RM-CONN-2-BGP permit 10\n   match ip address prefix-list
+    PL-LOOPBACKS-EVPN-OVERLAY\n!\nroute-map RM-MLAG-PEER-IN permit 10\n   description
+    Make routes learned over MLAG Peer-link less preferred on spines to ensure optimal
+    routing\n   set origin incomplete\n!\nrouter bfd\n   multihop interval 1200 min-rx
+    1200 multiplier 3\n!\nrouter bgp 65103\n   router-id 192.168.255.8\n   maximum-paths
+    4 ecmp 4\n   update wait-install\n   no bgp default ipv4-unicast\n   distance
+    bgp 20 200 200\n   neighbor EVPN-OVERLAY-PEERS peer group\n   neighbor EVPN-OVERLAY-PEERS
+    update-source Loopback0\n   neighbor EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS
+    ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n
+    \  neighbor EVPN-OVERLAY-PEERS send-community\n   neighbor EVPN-OVERLAY-PEERS
+    maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS peer group\n   neighbor IPv4-UNDERLAY-PEERS
+    password 7 AQQvKeimxJu+uGQ/yYvv9w==\n   neighbor IPv4-UNDERLAY-PEERS send-community\n
+    \  neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000\n   neighbor MLAG-IPv4-UNDERLAY-PEER
+    peer group\n   neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65103\n   neighbor MLAG-IPv4-UNDERLAY-PEER
+    next-hop-self\n   neighbor MLAG-IPv4-UNDERLAY-PEER description DC1-SVC3B\n   neighbor
+    MLAG-IPv4-UNDERLAY-PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==\n   neighbor MLAG-IPv4-UNDERLAY-PEER
+    send-community\n   neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000\n   neighbor
+    MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN in\n   neighbor 10.255.251.7
+    peer group MLAG-IPv4-UNDERLAY-PEER\n   neighbor 10.255.251.7 description DC1-SVC3B\n
+    \  neighbor 172.31.255.24 peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.24
+    remote-as 65001\n   neighbor 172.31.255.24 description DC1-SPINE1_Ethernet4\n
+    \  neighbor 172.31.255.26 peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.26
+    remote-as 65001\n   neighbor 172.31.255.26 description DC1-SPINE2_Ethernet4\n
+    \  neighbor 172.31.255.28 peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.28
+    remote-as 65001\n   neighbor 172.31.255.28 description DC1-SPINE3_Ethernet4\n
+    \  neighbor 172.31.255.30 peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.30
+    remote-as 65001\n   neighbor 172.31.255.30 description DC1-SPINE4_Ethernet4\n
+    \  neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.1
+    remote-as 65001\n   neighbor 192.168.255.1 description DC1-SPINE1\n   neighbor
+    192.168.255.2 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.2 remote-as
+    65001\n   neighbor 192.168.255.2 description DC1-SPINE2\n   neighbor 192.168.255.3
+    peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.3 remote-as 65001\n   neighbor
+    192.168.255.3 description DC1-SPINE3\n   neighbor 192.168.255.4 peer group EVPN-OVERLAY-PEERS\n
+    \  neighbor 192.168.255.4 remote-as 65001\n   neighbor 192.168.255.4 description
+    DC1-SPINE4\n   redistribute connected route-map RM-CONN-2-BGP\n   !\n   vlan-aware-bundle
+    Tenant_A_APP_Zone\n      rd 192.168.255.8:12\n      route-target both 12:12\n
+    \     redistribute learned\n      vlan 130-131\n   !\n   vlan-aware-bundle Tenant_A_DB_Zone\n
+    \     rd 192.168.255.8:13\n      route-target both 13:13\n      redistribute learned\n
+    \     vlan 140-141\n   !\n   vlan-aware-bundle Tenant_A_OP_Zone\n      rd 192.168.255.8:10\n
+    \     route-target both 10:10\n      redistribute learned\n      vlan 110-111\n
+    \  !\n   vlan-aware-bundle Tenant_A_WAN_Zone\n      rd 192.168.255.8:14\n      route-target
+    both 14:14\n      redistribute learned\n      vlan 150\n   !\n   vlan-aware-bundle
+    Tenant_A_WEB_Zone\n      rd 192.168.255.8:11\n      route-target both 11:11\n
+    \     redistribute learned\n      vlan 120-121\n   !\n   vlan-aware-bundle Tenant_B_OP_Zone\n
+    \     rd 192.168.255.8:20\n      route-target both 20:20\n      redistribute learned\n
+    \     vlan 210-211\n   !\n   vlan-aware-bundle Tenant_B_WAN_Zone\n      rd 192.168.255.8:21\n
+    \     route-target both 21:21\n      redistribute learned\n      vlan 250\n   !\n
+    \  vlan-aware-bundle Tenant_C_OP_Zone\n      rd 192.168.255.8:30\n      route-target
+    both 30:30\n      redistribute learned\n      vlan 310-311\n   !\n   vlan-aware-bundle
+    Tenant_C_WAN_Zone\n      rd 192.168.255.8:31\n      route-target both 31:31\n
+    \     redistribute learned\n      vlan 350\n   !\n   address-family evpn\n      neighbor
+    EVPN-OVERLAY-PEERS activate\n   !\n   address-family ipv4\n      no neighbor EVPN-OVERLAY-PEERS
+    activate\n      neighbor IPv4-UNDERLAY-PEERS activate\n      neighbor MLAG-IPv4-UNDERLAY-PEER
+    activate\n   !\n   vrf Tenant_A_APP_Zone\n      rd 192.168.255.8:12\n      route-target
+    import evpn 12:12\n      route-target export evpn 12:12\n      router-id 192.168.255.8\n
+    \     update wait-install\n      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n
+    \     redistribute connected\n   !\n   vrf Tenant_A_DB_Zone\n      rd 192.168.255.8:13\n
+    \     route-target import evpn 13:13\n      route-target export evpn 13:13\n      router-id
+    192.168.255.8\n      update wait-install\n      neighbor 10.255.251.7 peer group
+    MLAG-IPv4-UNDERLAY-PEER\n      redistribute connected\n   !\n   vrf Tenant_A_OP_Zone\n
+    \     rd 192.168.255.8:10\n      route-target import evpn 10:10\n      route-target
+    export evpn 10:10\n      router-id 192.168.255.8\n      update wait-install\n
+    \     neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n   !\n   vrf Tenant_A_WAN_Zone\n      rd 192.168.255.8:14\n      route-target
+    import evpn 14:14\n      route-target export evpn 14:14\n      router-id 192.168.255.8\n
+    \     update wait-install\n      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n
+    \     redistribute connected\n   !\n   vrf Tenant_A_WEB_Zone\n      rd 192.168.255.8:11\n
+    \     route-target import evpn 11:11\n      route-target export evpn 11:11\n      router-id
+    192.168.255.8\n      update wait-install\n      neighbor 10.255.251.7 peer group
+    MLAG-IPv4-UNDERLAY-PEER\n      redistribute connected\n   !\n   vrf Tenant_B_OP_Zone\n
+    \     rd 192.168.255.8:20\n      route-target import evpn 20:20\n      route-target
+    export evpn 20:20\n      router-id 192.168.255.8\n      update wait-install\n
+    \     neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n   !\n   vrf Tenant_B_WAN_Zone\n      rd 192.168.255.8:21\n      route-target
+    import evpn 21:21\n      route-target export evpn 21:21\n      router-id 192.168.255.8\n
+    \     update wait-install\n      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n
+    \     redistribute connected\n   !\n   vrf Tenant_C_OP_Zone\n      rd 192.168.255.8:30\n
+    \     route-target import evpn 30:30\n      route-target export evpn 30:30\n      router-id
+    192.168.255.8\n      update wait-install\n      neighbor 10.255.251.7 peer group
+    MLAG-IPv4-UNDERLAY-PEER\n      redistribute connected\n   !\n   vrf Tenant_C_WAN_Zone\n
+    \     rd 192.168.255.8:31\n      route-target import evpn 31:31\n      route-target
+    export evpn 31:31\n      router-id 192.168.255.8\n      update wait-install\n
+    \     neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n!\nmanagement api http-commands\n   protocol https\n   no shutdown\n
+    \  !\n   vrf MGMT\n      no shutdown\n!\nend\n"
+  AVD_DC1-SVC3B: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr
+    -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
+    -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
+    internal order ascending range 1006 1199\n!\nno ip igmp snooping vlan 120\n!\ntransceiver
+    qsfp default-mode 4x10G\n!\nservice routing protocols model multi-agent\n!\nhostname
+    DC1-SVC3B\nip name-server vrf MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nntp
+    local-interface vrf MGMT Management1\nntp server vrf MGMT 192.168.200.5 prefer\n!\nspanning-tree
+    mode mstp\nno spanning-tree vlan-id 4093-4094\nspanning-tree mst 0 priority 4096\n!\nno
+    enable password\nno aaa root\n!\nusername admin privilege 15 role network-admin
+    nopassword\nusername cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\nvlan
+    110\n   name Tenant_A_OP_Zone_1\n!\nvlan 111\n   name Tenant_A_OP_Zone_2\n!\nvlan
+    120\n   name Tenant_A_WEB_Zone_1\n!\nvlan 121\n   name Tenant_A_WEBZone_2\n!\nvlan
+    130\n   name Tenant_A_APP_Zone_1\n!\nvlan 131\n   name Tenant_A_APP_Zone_2\n!\nvlan
+    140\n   name Tenant_A_DB_BZone_1\n!\nvlan 141\n   name Tenant_A_DB_Zone_2\n!\nvlan
+    150\n   name Tenant_A_WAN_Zone_1\n!\nvlan 210\n   name Tenant_B_OP_Zone_1\n!\nvlan
+    211\n   name Tenant_B_OP_Zone_2\n!\nvlan 250\n   name Tenant_B_WAN_Zone_1\n!\nvlan
+    310\n   name Tenant_C_OP_Zone_1\n!\nvlan 311\n   name Tenant_C_OP_Zone_2\n!\nvlan
+    350\n   name Tenant_C_WAN_Zone_1\n!\nvlan 3009\n   name MLAG_iBGP_Tenant_A_OP_Zone\n
+    \  trunk group LEAF_PEER_L3\n!\nvlan 3010\n   name MLAG_iBGP_Tenant_A_WEB_Zone\n
+    \  trunk group LEAF_PEER_L3\n!\nvlan 3011\n   name MLAG_iBGP_Tenant_A_APP_Zone\n
+    \  trunk group LEAF_PEER_L3\n!\nvlan 3012\n   name MLAG_iBGP_Tenant_A_DB_Zone\n
+    \  trunk group LEAF_PEER_L3\n!\nvlan 3013\n   name MLAG_iBGP_Tenant_A_WAN_Zone\n
+    \  trunk group LEAF_PEER_L3\n!\nvlan 3019\n   name MLAG_iBGP_Tenant_B_OP_Zone\n
+    \  trunk group LEAF_PEER_L3\n!\nvlan 3020\n   name MLAG_iBGP_Tenant_B_WAN_Zone\n
+    \  trunk group LEAF_PEER_L3\n!\nvlan 3029\n   name MLAG_iBGP_Tenant_C_OP_Zone\n
+    \  trunk group LEAF_PEER_L3\n!\nvlan 3030\n   name MLAG_iBGP_Tenant_C_WAN_Zone\n
+    \  trunk group LEAF_PEER_L3\n!\nvlan 4093\n   name LEAF_PEER_L3\n   trunk group
+    LEAF_PEER_L3\n!\nvlan 4094\n   name MLAG_PEER\n   trunk group MLAG\n!\nvrf instance
+    MGMT\n!\nvrf instance Tenant_A_APP_Zone\n!\nvrf instance Tenant_A_DB_Zone\n!\nvrf
+    instance Tenant_A_OP_Zone\n!\nvrf instance Tenant_A_WAN_Zone\n!\nvrf instance
+    Tenant_A_WEB_Zone\n!\nvrf instance Tenant_B_OP_Zone\n!\nvrf instance Tenant_B_WAN_Zone\n!\nvrf
+    instance Tenant_C_OP_Zone\n!\nvrf instance Tenant_C_WAN_Zone\n!\ninterface Port-Channel5\n
+    \  description MLAG_PEER_DC1-SVC3A_Po5\n   no shutdown\n   switchport\n   switchport
+    mode trunk\n   switchport trunk group LEAF_PEER_L3\n   switchport trunk group
+    MLAG\n!\ninterface Port-Channel7\n   description DC1_L2LEAF2_Po1\n   no shutdown\n
+    \  switchport\n   switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350\n
+    \  switchport mode trunk\n   mlag 7\n!\ninterface Ethernet1\n   description P2P_LINK_TO_DC1-SPINE1_Ethernet5\n
+    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.33/31\n!\ninterface
+    Ethernet2\n   description P2P_LINK_TO_DC1-SPINE2_Ethernet5\n   no shutdown\n   mtu
+    1500\n   no switchport\n   ip address 172.31.255.35/31\n!\ninterface Ethernet3\n
+    \  description P2P_LINK_TO_DC1-SPINE3_Ethernet5\n   no shutdown\n   mtu 1500\n
+    \  no switchport\n   ip address 172.31.255.37/31\n!\ninterface Ethernet4\n   description
+    P2P_LINK_TO_DC1-SPINE4_Ethernet5\n   no shutdown\n   mtu 1500\n   no switchport\n
+    \  ip address 172.31.255.39/31\n!\ninterface Ethernet5\n   description MLAG_PEER_DC1-SVC3A_Ethernet5\n
+    \  no shutdown\n   channel-group 5 mode active\n!\ninterface Ethernet6\n   description
+    MLAG_PEER_DC1-SVC3A_Ethernet6\n   no shutdown\n   channel-group 5 mode active\n!\ninterface
+    Ethernet7\n   description DC1-L2LEAF2A_Ethernet2\n   no shutdown\n   channel-group
+    7 mode active\n!\ninterface Ethernet8\n   description DC1-L2LEAF2B_Ethernet2\n
+    \  no shutdown\n   channel-group 7 mode active\n!\ninterface Loopback0\n   description
+    EVPN_Overlay_Peering\n   no shutdown\n   ip address 192.168.255.9/32\n!\ninterface
+    Loopback1\n   description VTEP_VXLAN_Tunnel_Source\n   no shutdown\n   ip address
+    192.168.254.8/32\n!\ninterface Loopback100\n   description Tenant_A_OP_Zone_VTEP_DIAGNOSTICS\n
+    \  no shutdown\n   vrf Tenant_A_OP_Zone\n   ip address 10.255.1.9/32\n!\ninterface
+    Management1\n   description oob_management\n   no shutdown\n   vrf MGMT\n   ip
+    address 192.168.200.109/24\n!\ninterface Vlan110\n   description Tenant_A_OP_Zone_1\n
+    \  no shutdown\n   vrf Tenant_A_OP_Zone\n   ip address virtual 10.1.10.1/24\n!\ninterface
+    Vlan111\n   description Tenant_A_OP_Zone_2\n   no shutdown\n   vrf Tenant_A_OP_Zone\n
+    \  ip helper-address 1.1.1.1 vrf MGMT source-interface lo100\n   ip address virtual
+    10.1.11.1/24\n!\ninterface Vlan120\n   description Tenant_A_WEB_Zone_1\n   no
+    shutdown\n   vrf Tenant_A_WEB_Zone\n   ip helper-address 1.1.1.1 vrf TEST source-interface
+    lo100\n   ip address virtual 10.1.20.1/24\n!\ninterface Vlan121\n   description
+    Tenant_A_WEBZone_2\n   shutdown\n   mtu 1560\n   vrf Tenant_A_WEB_Zone\n   ip
+    address virtual 10.1.10.254/24\n!\ninterface Vlan130\n   description Tenant_A_APP_Zone_1\n
+    \  no shutdown\n   vrf Tenant_A_APP_Zone\n   ip address virtual 10.1.30.1/24\n!\ninterface
+    Vlan131\n   description Tenant_A_APP_Zone_2\n   no shutdown\n   vrf Tenant_A_APP_Zone\n
+    \  ip address virtual 10.1.31.1/24\n!\ninterface Vlan140\n   description Tenant_A_DB_BZone_1\n
+    \  no shutdown\n   vrf Tenant_A_DB_Zone\n   ip address virtual 10.1.40.1/24\n!\ninterface
+    Vlan141\n   description Tenant_A_DB_Zone_2\n   no shutdown\n   vrf Tenant_A_DB_Zone\n
+    \  ip address virtual 10.1.41.1/24\n!\ninterface Vlan150\n   description Tenant_A_WAN_Zone_1\n
+    \  no shutdown\n   vrf Tenant_A_WAN_Zone\n   ip address virtual 10.1.40.1/24\n!\ninterface
+    Vlan210\n   description Tenant_B_OP_Zone_1\n   no shutdown\n   vrf Tenant_B_OP_Zone\n
+    \  ip address virtual 10.2.10.1/24\n!\ninterface Vlan211\n   description Tenant_B_OP_Zone_2\n
+    \  no shutdown\n   vrf Tenant_B_OP_Zone\n   ip address virtual 10.2.11.1/24\n!\ninterface
+    Vlan250\n   description Tenant_B_WAN_Zone_1\n   no shutdown\n   vrf Tenant_B_WAN_Zone\n
+    \  ip address virtual 10.2.50.1/24\n!\ninterface Vlan310\n   description Tenant_C_OP_Zone_1\n
+    \  no shutdown\n   vrf Tenant_C_OP_Zone\n   ip address virtual 10.3.10.1/24\n!\ninterface
+    Vlan311\n   description Tenant_C_OP_Zone_2\n   no shutdown\n   vrf Tenant_C_OP_Zone\n
+    \  ip address virtual 10.3.11.1/24\n!\ninterface Vlan350\n   description Tenant_C_WAN_Zone_1\n
+    \  no shutdown\n   vrf Tenant_C_WAN_Zone\n   ip address virtual 10.3.50.1/24\n!\ninterface
+    Vlan3009\n   description MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_A_OP_Zone\n   ip address 10.255.251.7/31\n!\ninterface
+    Vlan3010\n   description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_A_WEB_Zone\n   ip address 10.255.251.7/31\n!\ninterface
+    Vlan3011\n   description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_A_APP_Zone\n   ip address 10.255.251.7/31\n!\ninterface
+    Vlan3012\n   description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_A_DB_Zone\n   ip address 10.255.251.7/31\n!\ninterface
+    Vlan3013\n   description MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_A_WAN_Zone\n   ip address 10.255.251.7/31\n!\ninterface
+    Vlan3019\n   description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_B_OP_Zone\n   ip address 10.255.251.7/31\n!\ninterface
+    Vlan3020\n   description MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_B_WAN_Zone\n   ip address 10.255.251.7/31\n!\ninterface
+    Vlan3029\n   description MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_C_OP_Zone\n   ip address 10.255.251.7/31\n!\ninterface
+    Vlan3030\n   description MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_C_WAN_Zone\n   ip address 10.255.251.7/31\n!\ninterface
+    Vlan4093\n   description MLAG_PEER_L3_PEERING\n   no shutdown\n   mtu 1500\n   ip
+    address 10.255.251.7/31\n!\ninterface Vlan4094\n   description MLAG_PEER\n   no
+    shutdown\n   mtu 1500\n   no autostate\n   ip address 10.255.252.7/31\n!\ninterface
+    Vxlan1\n   description DC1-SVC3B_VTEP\n   vxlan source-interface Loopback1\n   vxlan
+    virtual-router encapsulation mac-address mlag-system-id\n   vxlan udp-port 4789\n
+    \  vxlan vlan 110 vni 10110\n   vxlan vlan 111 vni 50111\n   vxlan vlan 120 vni
+    10120\n   vxlan vlan 121 vni 10121\n   vxlan vlan 130 vni 10130\n   vxlan vlan
+    131 vni 10131\n   vxlan vlan 140 vni 10140\n   vxlan vlan 141 vni 10141\n   vxlan
+    vlan 150 vni 10150\n   vxlan vlan 210 vni 20210\n   vxlan vlan 211 vni 20211\n
+    \  vxlan vlan 250 vni 20250\n   vxlan vlan 310 vni 30310\n   vxlan vlan 311 vni
+    30311\n   vxlan vlan 350 vni 30350\n   vxlan vrf Tenant_A_APP_Zone vni 12\n   vxlan
+    vrf Tenant_A_DB_Zone vni 13\n   vxlan vrf Tenant_A_OP_Zone vni 10\n   vxlan vrf
+    Tenant_A_WAN_Zone vni 14\n   vxlan vrf Tenant_A_WEB_Zone vni 11\n   vxlan vrf
+    Tenant_B_OP_Zone vni 20\n   vxlan vrf Tenant_B_WAN_Zone vni 21\n   vxlan vrf Tenant_C_OP_Zone
+    vni 30\n   vxlan vrf Tenant_C_WAN_Zone vni 31\n!\nip virtual-router mac-address
+    00:dc:00:00:00:0a\n!\nip address virtual source-nat vrf Tenant_A_OP_Zone address
+    10.255.1.9\n!\nip routing\nno ip routing vrf MGMT\nip routing vrf Tenant_A_APP_Zone\nip
+    routing vrf Tenant_A_DB_Zone\nip routing vrf Tenant_A_OP_Zone\nip routing vrf
+    Tenant_A_WAN_Zone\nip routing vrf Tenant_A_WEB_Zone\nip routing vrf Tenant_B_OP_Zone\nip
+    routing vrf Tenant_B_WAN_Zone\nip routing vrf Tenant_C_OP_Zone\nip routing vrf
+    Tenant_C_WAN_Zone\n!\nip prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n   seq 10 permit
+    192.168.255.0/24 eq 32\n   seq 20 permit 192.168.254.0/24 eq 32\n!\nmlag configuration\n
+    \  domain-id DC1_SVC3\n   local-interface Vlan4094\n   peer-address 10.255.252.6\n
+    \  peer-link Port-Channel5\n   reload-delay mlag 300\n   reload-delay non-mlag
+    330\n!\nip route vrf MGMT 0.0.0.0/0 192.168.200.5\n!\nroute-map RM-CONN-2-BGP
+    permit 10\n   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n!\nroute-map
+    RM-MLAG-PEER-IN permit 10\n   description Make routes learned over MLAG Peer-link
+    less preferred on spines to ensure optimal routing\n   set origin incomplete\n!\nrouter
+    bfd\n   multihop interval 1200 min-rx 1200 multiplier 3\n!\nrouter bgp 65103\n
+    \  router-id 192.168.255.9\n   maximum-paths 4 ecmp 4\n   update wait-install\n
+    \  no bgp default ipv4-unicast\n   distance bgp 20 200 200\n   neighbor EVPN-OVERLAY-PEERS
+    peer group\n   neighbor EVPN-OVERLAY-PEERS update-source Loopback0\n   neighbor
+    EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3\n   neighbor
+    EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n   neighbor EVPN-OVERLAY-PEERS
+    send-community\n   neighbor EVPN-OVERLAY-PEERS maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS
+    peer group\n   neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==\n
+    \  neighbor IPv4-UNDERLAY-PEERS send-community\n   neighbor IPv4-UNDERLAY-PEERS
+    maximum-routes 12000\n   neighbor MLAG-IPv4-UNDERLAY-PEER peer group\n   neighbor
+    MLAG-IPv4-UNDERLAY-PEER remote-as 65103\n   neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self\n
+    \  neighbor MLAG-IPv4-UNDERLAY-PEER description DC1-SVC3A\n   neighbor MLAG-IPv4-UNDERLAY-PEER
+    password 7 vnEaG8gMeQf3d3cN6PktXQ==\n   neighbor MLAG-IPv4-UNDERLAY-PEER send-community\n
+    \  neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000\n   neighbor MLAG-IPv4-UNDERLAY-PEER
+    route-map RM-MLAG-PEER-IN in\n   neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n
+    \  neighbor 10.255.251.6 description DC1-SVC3A\n   neighbor 172.31.255.32 peer
+    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.32 remote-as 65001\n   neighbor
+    172.31.255.32 description DC1-SPINE1_Ethernet5\n   neighbor 172.31.255.34 peer
+    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.34 remote-as 65001\n   neighbor
+    172.31.255.34 description DC1-SPINE2_Ethernet5\n   neighbor 172.31.255.36 peer
+    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.36 remote-as 65001\n   neighbor
+    172.31.255.36 description DC1-SPINE3_Ethernet5\n   neighbor 172.31.255.38 peer
+    group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.38 remote-as 65001\n   neighbor
+    172.31.255.38 description DC1-SPINE4_Ethernet5\n   neighbor 192.168.255.1 peer
+    group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.1 remote-as 65001\n   neighbor
+    192.168.255.1 description DC1-SPINE1\n   neighbor 192.168.255.2 peer group EVPN-OVERLAY-PEERS\n
+    \  neighbor 192.168.255.2 remote-as 65001\n   neighbor 192.168.255.2 description
+    DC1-SPINE2\n   neighbor 192.168.255.3 peer group EVPN-OVERLAY-PEERS\n   neighbor
+    192.168.255.3 remote-as 65001\n   neighbor 192.168.255.3 description DC1-SPINE3\n
+    \  neighbor 192.168.255.4 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.4
+    remote-as 65001\n   neighbor 192.168.255.4 description DC1-SPINE4\n   redistribute
+    connected route-map RM-CONN-2-BGP\n   !\n   vlan-aware-bundle Tenant_A_APP_Zone\n
+    \     rd 192.168.255.9:12\n      route-target both 12:12\n      redistribute learned\n
+    \     vlan 130-131\n   !\n   vlan-aware-bundle Tenant_A_DB_Zone\n      rd 192.168.255.9:13\n
+    \     route-target both 13:13\n      redistribute learned\n      vlan 140-141\n
+    \  !\n   vlan-aware-bundle Tenant_A_OP_Zone\n      rd 192.168.255.9:10\n      route-target
+    both 10:10\n      redistribute learned\n      vlan 110-111\n   !\n   vlan-aware-bundle
+    Tenant_A_WAN_Zone\n      rd 192.168.255.9:14\n      route-target both 14:14\n
+    \     redistribute learned\n      vlan 150\n   !\n   vlan-aware-bundle Tenant_A_WEB_Zone\n
+    \     rd 192.168.255.9:11\n      route-target both 11:11\n      redistribute learned\n
+    \     vlan 120-121\n   !\n   vlan-aware-bundle Tenant_B_OP_Zone\n      rd 192.168.255.9:20\n
+    \     route-target both 20:20\n      redistribute learned\n      vlan 210-211\n
+    \  !\n   vlan-aware-bundle Tenant_B_WAN_Zone\n      rd 192.168.255.9:21\n      route-target
+    both 21:21\n      redistribute learned\n      vlan 250\n   !\n   vlan-aware-bundle
+    Tenant_C_OP_Zone\n      rd 192.168.255.9:30\n      route-target both 30:30\n      redistribute
+    learned\n      vlan 310-311\n   !\n   vlan-aware-bundle Tenant_C_WAN_Zone\n      rd
+    192.168.255.9:31\n      route-target both 31:31\n      redistribute learned\n
+    \     vlan 350\n   !\n   address-family evpn\n      neighbor EVPN-OVERLAY-PEERS
+    activate\n   !\n   address-family ipv4\n      no neighbor EVPN-OVERLAY-PEERS activate\n
+    \     neighbor IPv4-UNDERLAY-PEERS activate\n      neighbor MLAG-IPv4-UNDERLAY-PEER
+    activate\n   !\n   vrf Tenant_A_APP_Zone\n      rd 192.168.255.9:12\n      route-target
+    import evpn 12:12\n      route-target export evpn 12:12\n      router-id 192.168.255.9\n
+    \     update wait-install\n      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n
+    \     redistribute connected\n   !\n   vrf Tenant_A_DB_Zone\n      rd 192.168.255.9:13\n
+    \     route-target import evpn 13:13\n      route-target export evpn 13:13\n      router-id
+    192.168.255.9\n      update wait-install\n      neighbor 10.255.251.6 peer group
+    MLAG-IPv4-UNDERLAY-PEER\n      redistribute connected\n   !\n   vrf Tenant_A_OP_Zone\n
+    \     rd 192.168.255.9:10\n      route-target import evpn 10:10\n      route-target
+    export evpn 10:10\n      router-id 192.168.255.9\n      update wait-install\n
+    \     neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n   !\n   vrf Tenant_A_WAN_Zone\n      rd 192.168.255.9:14\n      route-target
+    import evpn 14:14\n      route-target export evpn 14:14\n      router-id 192.168.255.9\n
+    \     update wait-install\n      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n
+    \     redistribute connected\n   !\n   vrf Tenant_A_WEB_Zone\n      rd 192.168.255.9:11\n
+    \     route-target import evpn 11:11\n      route-target export evpn 11:11\n      router-id
+    192.168.255.9\n      update wait-install\n      neighbor 10.255.251.6 peer group
+    MLAG-IPv4-UNDERLAY-PEER\n      redistribute connected\n   !\n   vrf Tenant_B_OP_Zone\n
+    \     rd 192.168.255.9:20\n      route-target import evpn 20:20\n      route-target
+    export evpn 20:20\n      router-id 192.168.255.9\n      update wait-install\n
+    \     neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n   !\n   vrf Tenant_B_WAN_Zone\n      rd 192.168.255.9:21\n      route-target
+    import evpn 21:21\n      route-target export evpn 21:21\n      router-id 192.168.255.9\n
+    \     update wait-install\n      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n
+    \     redistribute connected\n   !\n   vrf Tenant_C_OP_Zone\n      rd 192.168.255.9:30\n
+    \     route-target import evpn 30:30\n      route-target export evpn 30:30\n      router-id
+    192.168.255.9\n      update wait-install\n      neighbor 10.255.251.6 peer group
+    MLAG-IPv4-UNDERLAY-PEER\n      redistribute connected\n   !\n   vrf Tenant_C_WAN_Zone\n
+    \     rd 192.168.255.9:31\n      route-target import evpn 31:31\n      route-target
+    export evpn 31:31\n      router-id 192.168.255.9\n      update wait-install\n
+    \     neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n!\nmanagement api http-commands\n   protocol https\n   no shutdown\n
+    \  !\n   vrf MGMT\n      no shutdown\n!\nend\n"
+cvp_topology:
+  DC1_BL1:
+    devices: []
+    parent_container: DC1_LEAFS
+  DC1_FABRIC:
+    devices: []
+    parent_container: Tenant
+  DC1_L2LEAF1:
+    devices: []
+    parent_container: DC1_L2LEAFS
+  DC1_L2LEAF2:
+    devices: []
+    parent_container: DC1_L2LEAFS
+  DC1_L2LEAFS:
+    devices: []
+    parent_container: DC1_FABRIC
+  DC1_LEAF1:
+    devices: []
+    parent_container: DC1_LEAFS
+  DC1_LEAF2:
+    devices: []
+    parent_container: DC1_LEAFS
+  DC1_LEAFS:
+    devices: []
+    parent_container: DC1_FABRIC
+  DC1_SPINES:
+    devices: []
+    parent_container: DC1_FABRIC
+  DC1_SVC3:
+    devices: []
+    parent_container: DC1_LEAFS

--- a/ansible_collections/arista/avd/plugins/action/inventory_to_container.py
+++ b/ansible_collections/arista/avd/plugins/action/inventory_to_container.py
@@ -9,16 +9,28 @@ from ansible.inventory.host import Host
 from ansible.inventory.manager import InventoryManager
 from ansible.parsing.yaml.dumper import AnsibleDumper
 from ansible.plugins.action import ActionBase
+from ansible.utils.display import Display
 
 # Root container on CloudVision.
 # Shall not be changed unless CloudVision changes it in the core.
 CVP_ROOT_CONTAINER = "Tenant"
 
+display = Display()
+
 
 class ActionModule(ActionBase):
+    def _maybe_convert_device_filter(self):
+        # Converting string device filter to list
+        device_filter = self._task.args["device_filter"]
+        if not isinstance(device_filter, list):
+            display.debug(f"device_filter must be of type list, got '{device_filter}' of type {type(device_filter)} instead. Converting...")
+            self._task.args["device_filter"] = [device_filter]
+
     def run(self, tmp=None, task_vars=None):
         if task_vars is None:
             task_vars = {}
+
+        # self._maybe_convert_device_filter()
 
         module_args = self._task.args.copy()
 

--- a/ansible_collections/arista/avd/plugins/action/inventory_to_container.py
+++ b/ansible_collections/arista/avd/plugins/action/inventory_to_container.py
@@ -30,7 +30,7 @@ class ActionModule(ActionBase):
         if task_vars is None:
             task_vars = {}
 
-        # self._maybe_convert_device_filter()
+        self._maybe_convert_device_filter()
 
         module_args = self._task.args.copy()
 

--- a/ansible_collections/arista/avd/plugins/action/inventory_to_container.py
+++ b/ansible_collections/arista/avd/plugins/action/inventory_to_container.py
@@ -21,8 +21,8 @@ display = Display()
 class ActionModule(ActionBase):
     def _maybe_convert_device_filter(self):
         # Converting string device filter to list
-        device_filter = self._task.args["device_filter"]
-        if not isinstance(device_filter, list):
+        device_filter = self._task.args.get("device_filter")
+        if device_filter is not None and not isinstance(device_filter, list):
             display.debug(f"device_filter must be of type list, got '{device_filter}' of type {type(device_filter)} instead. Converting...")
             self._task.args["device_filter"] = [device_filter]
 

--- a/ansible_collections/arista/avd/tests/integration/targets/inventory_to_container/tests/test_with_device_filter_as_string.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/inventory_to_container/tests/test_with_device_filter_as_string.yml
@@ -1,0 +1,33 @@
+- name: Test with device_filter as a string
+  register: cvp_vars
+  inventory_to_container:
+    inventory: '{{ inventory_path }}/inventory.yml'
+    container_root: 'DC1_FABRIC'
+    configlet_dir: '{{ configlet_path }}'
+    configlet_prefix: 'AVD'
+    device_filter: 'DC1-LE'
+    destination: "{{ actual_output }}"
+
+- name: Compare actual output with expected output
+  ansible.builtin.shell: diff "{{ expected_output }}/expected_with_device_filter_as_string.yml" "{{ actual_output }}"
+  failed_when: "diff_output.rc > 1"
+  register: diff_output
+  delegate_to: localhost
+
+- name: Validate output
+  assert:
+    that:
+      - cvp_vars is success
+      - cvp_vars.cvp_topology != {}
+      - cvp_vars.cvp_configlets != {}
+      - item is defined
+      - "'AVD_DC1-LE' in item[0:10]"
+      - diff_output.stdout == ""
+  with_items: "{{ cvp_vars.cvp_configlets }}"
+
+- name: Validate cvp_topology
+  assert:
+    that:
+      - item is defined
+      - item == "Tenant"
+  with_items: "{{ cvp_vars.cvp_topology.DC1_FABRIC.parent_container }}"

--- a/ansible_collections/arista/avd/tests/integration/targets/inventory_to_container/tests/test_with_device_filter_empty_string.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/inventory_to_container/tests/test_with_device_filter_empty_string.yml
@@ -1,0 +1,33 @@
+- name: Test with device_filter as empty string
+  register: cvp_vars
+  inventory_to_container:
+    inventory: '{{ inventory_path }}/inventory.yml'
+    container_root: 'DC1_FABRIC'
+    configlet_dir: '{{ configlet_path }}'
+    configlet_prefix: 'AVD'
+    device_filter: ""
+    destination: "{{ actual_output }}"
+
+- name: Compare actual output with expected output
+  ansible.builtin.shell: diff "{{ expected_output }}/expected_with_device_filter_empty_string.yml" "{{ actual_output }}"
+  failed_when: "diff_output.rc > 1"
+  register: diff_output
+  delegate_to: localhost
+
+- name: Validate output
+  assert:
+    that:
+      - cvp_vars is success
+      - cvp_vars.cvp_topology != {}
+      - cvp_vars.cvp_configlets != {}
+      - item is defined
+      - "'AVD' in item[0:3]"
+      - diff_output.stdout == ""
+  with_items: "{{ cvp_vars.cvp_configlets }}"
+
+- name: Validate cvp_topology
+  assert:
+    that:
+      - item is defined
+      - item == "Tenant"
+  with_items: "{{ cvp_vars.cvp_topology.DC1_FABRIC.parent_container }}"

--- a/ansible_collections/arista/avd/tests/inventory/inventory_to_container/expected_output/expected_with_device_filter_as_string.yml
+++ b/ansible_collections/arista/avd/tests/inventory/inventory_to_container/expected_output/expected_with_device_filter_as_string.yml
@@ -1,0 +1,819 @@
+cvp_configlets:
+  AVD_DC1-LEAF1A: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr
+    -cvaddr=10.255.0.1:9910 -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
+    -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
+    internal order ascending range 1006 1199\n!\ntransceiver qsfp default-mode 4x10G\n!\nservice
+    routing protocols model multi-agent\n!\nhostname DC1-LEAF1A\nip name-server vrf
+    MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.2.1\n!\nntp local-interface vrf
+    MGMT Management1\nntp server vrf MGMT 0.fr.pool.ntp.org prefer\nntp server vrf
+    MGMT 1.fr.pool.ntp.org\n!\nspanning-tree mode mstp\nno spanning-tree vlan-id 4093-4094\nspanning-tree
+    mst 0 priority 16384\n!\nno aaa root\nno enable password\n!\nusername admin privilege
+    15 role network-admin secret sha512 $6$Df86J4/SFMDE3/1K$Hef4KstdoxNDaami37cBquTWOTplC.miMPjXVgQxMe92.e5wxlnXOLlebgPj8Fz1KO0za/RCO7ZIs4Q6Eiq1g1\nusername
+    ansible privilege 15 role network-admin secret sha512 $6$Dzu11L7yp9j3nCM9$FSptxMPyIL555OMO.ldnjDXgwZmrfMYwHSr0uznE5Qoqvd9a6UdjiFcJUhGLtvXVZR1r.A/iF5aAt50hf/EK4/\nusername
+    cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\nvlan
+    110\n   name Tenant_A_OP_Zone_1\n!\nvlan 111\n   name Tenant_A_OP_Zone_2\n!\nvlan
+    112\n   name Tenant_A_OP_Zone_3\n!\nvlan 120\n   name Tenant_A_WEB_Zone_1\n!\nvlan
+    121\n   name Tenant_A_WEBZone_2\n!\nvlan 130\n   name Tenant_A_APP_Zone_1\n!\nvlan
+    131\n   name Tenant_A_APP_Zone_2\n!\nvlan 140\n   name Tenant_A_DB_BZone_1\n!\nvlan
+    141\n   name Tenant_A_DB_Zone_2\n!\nvlan 150\n   name Tenant_A_WAN_Zone_1\n!\nvlan
+    160\n   name Tenant_A_VMOTION\n!\nvlan 161\n   name Tenant_A_NFS\n!\nvlan 210\n
+    \  name Tenant_B_OP_Zone_1\n!\nvlan 211\n   name Tenant_B_OP_Zone_2\n!\nvlan 250\n
+    \  name Tenant_B_WAN_Zone_1\n!\nvlan 310\n   name Tenant_C_OP_Zone_1\n!\nvlan
+    311\n   name Tenant_C_OP_Zone_2\n!\nvlan 350\n   name Tenant_C_WAN_Zone_1\n!\nvlan
+    3009\n   name MLAG_iBGP_Tenant_A_OP_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3010\n   name MLAG_iBGP_Tenant_A_WEB_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3011\n   name MLAG_iBGP_Tenant_A_APP_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3012\n   name MLAG_iBGP_Tenant_A_DB_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3013\n   name MLAG_iBGP_Tenant_A_WAN_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3019\n   name MLAG_iBGP_Tenant_B_OP_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3020\n   name MLAG_iBGP_Tenant_B_WAN_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3029\n   name MLAG_iBGP_Tenant_C_OP_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3030\n   name MLAG_iBGP_Tenant_C_WAN_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    4093\n   name LEAF_PEER_L3\n   trunk group LEAF_PEER_L3\n!\nvlan 4094\n   name
+    MLAG_PEER\n   trunk group MLAG\n!\nvrf instance MGMT\n!\nvrf instance Tenant_A_APP_Zone\n!\nvrf
+    instance Tenant_A_DB_Zone\n!\nvrf instance Tenant_A_OP_Zone\n!\nvrf instance Tenant_A_WAN_Zone\n!\nvrf
+    instance Tenant_A_WEB_Zone\n!\nvrf instance Tenant_B_OP_Zone\n!\nvrf instance
+    Tenant_B_WAN_Zone\n!\nvrf instance Tenant_C_OP_Zone\n!\nvrf instance Tenant_C_WAN_Zone\n!\ninterface
+    Port-Channel3\n   description MLAG_PEER_DC1-LEAF1B_Po3\n   no shutdown\n   switchport\n
+    \  switchport trunk allowed vlan 2-4094\n   switchport mode trunk\n   switchport
+    trunk group LEAF_PEER_L3\n   switchport trunk group MLAG\n!\ninterface Port-Channel5\n
+    \  description DC1-L2LEAF1A_Po1\n   no shutdown\n   switchport\n   switchport
+    trunk allowed vlan 110-112,120-121,130-131\n   switchport mode trunk\n   mlag
+    5\n!\ninterface Ethernet1\n   description P2P_LINK_TO_DC1-SPINE1_Ethernet1\n   no
+    shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.1/31\n!\ninterface
+    Ethernet2\n   description P2P_LINK_TO_DC1-SPINE2_Ethernet1\n   no shutdown\n   mtu
+    1500\n   no switchport\n   ip address 172.31.255.3/31\n!\ninterface Ethernet3\n
+    \  description MLAG_PEER_DC1-LEAF1B_Ethernet3\n   no shutdown\n   channel-group
+    3 mode active\n!\ninterface Ethernet4\n   description MLAG_PEER_DC1-LEAF1B_Ethernet4\n
+    \  no shutdown\n   channel-group 3 mode active\n!\ninterface Ethernet5\n   description
+    DC1-L2LEAF1A_Ethernet1\n   no shutdown\n   channel-group 5 mode active\n!\ninterface
+    Loopback0\n   description EVPN_Overlay_Peering\n   no shutdown\n   ip address
+    192.168.255.3/32\n!\ninterface Loopback1\n   description VTEP_VXLAN_Tunnel_Source\n
+    \  no shutdown\n   ip address 192.168.254.3/32\n!\ninterface Loopback100\n   description
+    Tenant_A_OP_Zone_VTEP_DIAGNOSTICS\n   no shutdown\n   vrf Tenant_A_OP_Zone\n   ip
+    address 10.255.1.3/32\n!\ninterface Management1\n   description oob_management\n
+    \  no shutdown\n   vrf MGMT\n   ip address 10.255.0.13/24\n!\ninterface Vlan110\n
+    \  description Tenant_A_OP_Zone_1\n   no shutdown\n   vrf Tenant_A_OP_Zone\n   ip
+    address virtual 10.1.10.1/24\n!\ninterface Vlan111\n   description Tenant_A_OP_Zone_2\n
+    \  no shutdown\n   vrf Tenant_A_OP_Zone\n   ip address virtual 10.1.11.1/24\n!\ninterface
+    Vlan112\n   description Tenant_A_OP_Zone_3\n   no shutdown\n   vrf Tenant_A_OP_Zone\n
+    \  ip address virtual 10.1.12.254/24\n!\ninterface Vlan120\n   description Tenant_A_WEB_Zone_1\n
+    \  no shutdown\n   vrf Tenant_A_WEB_Zone\n!\ninterface Vlan121\n   description
+    Tenant_A_WEBZone_2\n   no shutdown\n   vrf Tenant_A_WEB_Zone\n   ip address virtual
+    10.1.21.1/24\n!\ninterface Vlan130\n   description Tenant_A_APP_Zone_1\n   no
+    shutdown\n   vrf Tenant_A_APP_Zone\n!\ninterface Vlan131\n   description Tenant_A_APP_Zone_2\n
+    \  no shutdown\n   vrf Tenant_A_APP_Zone\n   ip address virtual 10.1.31.254/24\n!\ninterface
+    Vlan140\n   description Tenant_A_DB_BZone_1\n   no shutdown\n   vrf Tenant_A_DB_Zone\n
+    \  ip address virtual 10.1.40.1/24\n!\ninterface Vlan141\n   description Tenant_A_DB_Zone_2\n
+    \  no shutdown\n   vrf Tenant_A_DB_Zone\n   ip address virtual 10.1.41.1/24\n!\ninterface
+    Vlan150\n   description Tenant_A_WAN_Zone_1\n   no shutdown\n   vrf Tenant_A_WAN_Zone\n
+    \  ip address virtual 10.1.40.1/24\n!\ninterface Vlan210\n   description Tenant_B_OP_Zone_1\n
+    \  no shutdown\n   vrf Tenant_B_OP_Zone\n!\ninterface Vlan211\n   description
+    Tenant_B_OP_Zone_2\n   no shutdown\n   vrf Tenant_B_OP_Zone\n   ip address virtual
+    10.2.11.1/24\n!\ninterface Vlan250\n   description Tenant_B_WAN_Zone_1\n   no
+    shutdown\n   vrf Tenant_B_WAN_Zone\n   ip address virtual 10.2.50.1/24\n!\ninterface
+    Vlan310\n   description Tenant_C_OP_Zone_1\n   no shutdown\n   vrf Tenant_C_OP_Zone\n!\ninterface
+    Vlan311\n   description Tenant_C_OP_Zone_2\n   no shutdown\n   vrf Tenant_C_OP_Zone\n!\ninterface
+    Vlan350\n   description Tenant_C_WAN_Zone_1\n   no shutdown\n   vrf Tenant_C_WAN_Zone\n!\ninterface
+    Vlan3009\n   description MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_A_OP_Zone\n   ip address 10.255.251.0/31\n!\ninterface
+    Vlan3010\n   description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_A_WEB_Zone\n   ip address 10.255.251.0/31\n!\ninterface
+    Vlan3011\n   description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_A_APP_Zone\n   ip address 10.255.251.0/31\n!\ninterface
+    Vlan3012\n   description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_A_DB_Zone\n   ip address 10.255.251.0/31\n!\ninterface
+    Vlan3013\n   description MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_A_WAN_Zone\n   ip address 10.255.251.0/31\n!\ninterface
+    Vlan3019\n   description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_B_OP_Zone\n   ip address 10.255.251.0/31\n!\ninterface
+    Vlan3020\n   description MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_B_WAN_Zone\n   ip address 10.255.251.0/31\n!\ninterface
+    Vlan3029\n   description MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_C_OP_Zone\n   ip address 10.255.251.0/31\n!\ninterface
+    Vlan3030\n   description MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_C_WAN_Zone\n   ip address 10.255.251.0/31\n!\ninterface
+    Vlan4093\n   description MLAG_PEER_L3_PEERING\n   no shutdown\n   mtu 1500\n   ip
+    address 10.255.251.0/31\n!\ninterface Vlan4094\n   description MLAG_PEER\n   no
+    shutdown\n   mtu 1500\n   no autostate\n   ip address 10.255.252.0/31\n!\ninterface
+    Vxlan1\n   description DC1-LEAF1A_VTEP\n   vxlan source-interface Loopback1\n
+    \  vxlan virtual-router encapsulation mac-address mlag-system-id\n   vxlan udp-port
+    4789\n   vxlan vlan 110 vni 10110\n   vxlan vlan 111 vni 50111\n   vxlan vlan
+    112 vni 50112\n   vxlan vlan 120 vni 10120\n   vxlan vlan 121 vni 10121\n   vxlan
+    vlan 130 vni 10130\n   vxlan vlan 131 vni 10131\n   vxlan vlan 140 vni 10140\n
+    \  vxlan vlan 141 vni 10141\n   vxlan vlan 150 vni 10150\n   vxlan vlan 160 vni
+    55160\n   vxlan vlan 161 vni 10161\n   vxlan vlan 210 vni 20210\n   vxlan vlan
+    211 vni 20211\n   vxlan vlan 250 vni 20250\n   vxlan vlan 310 vni 30310\n   vxlan
+    vlan 311 vni 30311\n   vxlan vlan 350 vni 30350\n   vxlan vrf Tenant_A_APP_Zone
+    vni 12\n   vxlan vrf Tenant_A_DB_Zone vni 13\n   vxlan vrf Tenant_A_OP_Zone vni
+    10\n   vxlan vrf Tenant_A_WAN_Zone vni 14\n   vxlan vrf Tenant_A_WEB_Zone vni
+    11\n   vxlan vrf Tenant_B_OP_Zone vni 20\n   vxlan vrf Tenant_B_WAN_Zone vni 21\n
+    \  vxlan vrf Tenant_C_OP_Zone vni 30\n   vxlan vrf Tenant_C_WAN_Zone vni 31\n!\nip
+    virtual-router mac-address 00:1c:73:00:dc:01\n!\nip address virtual source-nat
+    vrf Tenant_A_OP_Zone address 10.255.1.3\n!\nip routing\nno ip routing vrf MGMT\nip
+    routing vrf Tenant_A_APP_Zone\nip routing vrf Tenant_A_DB_Zone\nip routing vrf
+    Tenant_A_OP_Zone\nip routing vrf Tenant_A_WAN_Zone\nip routing vrf Tenant_A_WEB_Zone\nip
+    routing vrf Tenant_B_OP_Zone\nip routing vrf Tenant_B_WAN_Zone\nip routing vrf
+    Tenant_C_OP_Zone\nip routing vrf Tenant_C_WAN_Zone\n!\nip prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n
+    \  seq 10 permit 192.168.255.0/24 eq 32\n   seq 20 permit 192.168.254.0/24 eq
+    32\n!\nmlag configuration\n   domain-id DC1_LEAF1\n   local-interface Vlan4094\n
+    \  peer-address 10.255.252.1\n   peer-link Port-Channel3\n   reload-delay mlag
+    300\n   reload-delay non-mlag 330\n!\nip route vrf MGMT 0.0.0.0/0 10.255.0.1\n!\nroute-map
+    RM-CONN-2-BGP permit 10\n   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n!\nroute-map
+    RM-MLAG-PEER-IN permit 10\n   description Make routes learned over MLAG Peer-link
+    less preferred on spines to ensure optimal routing\n   set origin incomplete\n!\nrouter
+    bfd\n   multihop interval 1200 min-rx 1200 multiplier 3\n!\nrouter bgp 65101\n
+    \  router-id 192.168.255.3\n   no bgp default ipv4-unicast\n   distance bgp 20
+    200 200\n   graceful-restart restart-time 300\n   graceful-restart\n   maximum-paths
+    4 ecmp 4\n   neighbor EVPN-OVERLAY-PEERS peer group\n   neighbor EVPN-OVERLAY-PEERS
+    update-source Loopback0\n   neighbor EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS
+    ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n
+    \  neighbor EVPN-OVERLAY-PEERS send-community\n   neighbor EVPN-OVERLAY-PEERS
+    maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS peer group\n   neighbor IPv4-UNDERLAY-PEERS
+    password 7 AQQvKeimxJu+uGQ/yYvv9w==\n   neighbor IPv4-UNDERLAY-PEERS send-community\n
+    \  neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000\n   neighbor MLAG-IPv4-UNDERLAY-PEER
+    peer group\n   neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65101\n   neighbor MLAG-IPv4-UNDERLAY-PEER
+    next-hop-self\n   neighbor MLAG-IPv4-UNDERLAY-PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==\n
+    \  neighbor MLAG-IPv4-UNDERLAY-PEER send-community\n   neighbor MLAG-IPv4-UNDERLAY-PEER
+    maximum-routes 12000\n   neighbor MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN
+    in\n   neighbor 10.255.251.1 peer group MLAG-IPv4-UNDERLAY-PEER\n   neighbor 10.255.251.1
+    description DC1-LEAF1B\n   neighbor 172.31.255.0 peer group IPv4-UNDERLAY-PEERS\n
+    \  neighbor 172.31.255.0 remote-as 65001\n   neighbor 172.31.255.0 description
+    DC1-SPINE1_Ethernet1\n   neighbor 172.31.255.2 peer group IPv4-UNDERLAY-PEERS\n
+    \  neighbor 172.31.255.2 remote-as 65001\n   neighbor 172.31.255.2 description
+    DC1-SPINE2_Ethernet1\n   neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS\n
+    \  neighbor 192.168.255.1 remote-as 65001\n   neighbor 192.168.255.1 description
+    DC1-SPINE1\n   neighbor 192.168.255.2 peer group EVPN-OVERLAY-PEERS\n   neighbor
+    192.168.255.2 remote-as 65001\n   neighbor 192.168.255.2 description DC1-SPINE2\n
+    \  redistribute connected route-map RM-CONN-2-BGP\n   !\n   vlan-aware-bundle
+    Tenant_A_APP_Zone\n      rd 192.168.255.3:12\n      route-target both 12:12\n
+    \     redistribute learned\n      vlan 130-131\n   !\n   vlan-aware-bundle Tenant_A_DB_Zone\n
+    \     rd 192.168.255.3:13\n      route-target both 13:13\n      redistribute learned\n
+    \     vlan 140-141\n   !\n   vlan-aware-bundle Tenant_A_NFS\n      rd 192.168.255.3:10161\n
+    \     route-target both 10161:10161\n      redistribute learned\n      vlan 161\n
+    \  !\n   vlan-aware-bundle Tenant_A_OP_Zone\n      rd 192.168.255.3:10\n      route-target
+    both 10:10\n      redistribute learned\n      vlan 110-112\n   !\n   vlan-aware-bundle
+    Tenant_A_VMOTION\n      rd 192.168.255.3:55160\n      route-target both 55160:55160\n
+    \     redistribute learned\n      vlan 160\n   !\n   vlan-aware-bundle Tenant_A_WAN_Zone\n
+    \     rd 192.168.255.3:14\n      route-target both 14:14\n      redistribute learned\n
+    \     vlan 150\n   !\n   vlan-aware-bundle Tenant_A_WEB_Zone\n      rd 192.168.255.3:11\n
+    \     route-target both 11:11\n      redistribute learned\n      vlan 120-121\n
+    \  !\n   vlan-aware-bundle Tenant_B_OP_Zone\n      rd 192.168.255.3:20\n      route-target
+    both 20:20\n      redistribute learned\n      vlan 210-211\n   !\n   vlan-aware-bundle
+    Tenant_B_WAN_Zone\n      rd 192.168.255.3:21\n      route-target both 21:21\n
+    \     redistribute learned\n      vlan 250\n   !\n   vlan-aware-bundle Tenant_C_OP_Zone\n
+    \     rd 192.168.255.3:30\n      route-target both 30:30\n      redistribute learned\n
+    \     vlan 310-311\n   !\n   vlan-aware-bundle Tenant_C_WAN_Zone\n      rd 192.168.255.3:31\n
+    \     route-target both 31:31\n      redistribute learned\n      vlan 350\n   !\n
+    \  address-family evpn\n      neighbor EVPN-OVERLAY-PEERS activate\n   !\n   address-family
+    ipv4\n      no neighbor EVPN-OVERLAY-PEERS activate\n      neighbor IPv4-UNDERLAY-PEERS
+    activate\n      neighbor MLAG-IPv4-UNDERLAY-PEER activate\n   !\n   vrf Tenant_A_APP_Zone\n
+    \     rd 192.168.255.3:12\n      route-target import evpn 12:12\n      route-target
+    export evpn 12:12\n      router-id 192.168.255.3\n      neighbor 10.255.251.1
+    peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute connected\n   !\n   vrf
+    Tenant_A_DB_Zone\n      rd 192.168.255.3:13\n      route-target import evpn 13:13\n
+    \     route-target export evpn 13:13\n      router-id 192.168.255.3\n      neighbor
+    10.255.251.1 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute connected\n
+    \  !\n   vrf Tenant_A_OP_Zone\n      rd 192.168.255.3:10\n      route-target import
+    evpn 10:10\n      route-target export evpn 10:10\n      router-id 192.168.255.3\n
+    \     neighbor 10.255.251.1 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n   !\n   vrf Tenant_A_WAN_Zone\n      rd 192.168.255.3:14\n      route-target
+    import evpn 14:14\n      route-target export evpn 14:14\n      router-id 192.168.255.3\n
+    \     neighbor 10.255.251.1 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n   !\n   vrf Tenant_A_WEB_Zone\n      rd 192.168.255.3:11\n      route-target
+    import evpn 11:11\n      route-target export evpn 11:11\n      router-id 192.168.255.3\n
+    \     neighbor 10.255.251.1 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n   !\n   vrf Tenant_B_OP_Zone\n      rd 192.168.255.3:20\n      route-target
+    import evpn 20:20\n      route-target export evpn 20:20\n      router-id 192.168.255.3\n
+    \     neighbor 10.255.251.1 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n   !\n   vrf Tenant_B_WAN_Zone\n      rd 192.168.255.3:21\n      route-target
+    import evpn 21:21\n      route-target export evpn 21:21\n      router-id 192.168.255.3\n
+    \     neighbor 10.255.251.1 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n   !\n   vrf Tenant_C_OP_Zone\n      rd 192.168.255.3:30\n      route-target
+    import evpn 30:30\n      route-target export evpn 30:30\n      router-id 192.168.255.3\n
+    \     neighbor 10.255.251.1 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n   !\n   vrf Tenant_C_WAN_Zone\n      rd 192.168.255.3:31\n      route-target
+    import evpn 31:31\n      route-target export evpn 31:31\n      router-id 192.168.255.3\n
+    \     neighbor 10.255.251.1 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n!\nmanagement api http-commands\n   protocol https\n   no shutdown\n
+    \  !\n   vrf MGMT\n      no shutdown\n!\nend\n"
+  AVD_DC1-LEAF1B: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr
+    -cvaddr=10.255.0.1:9910 -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
+    -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
+    internal order ascending range 1006 1199\n!\ntransceiver qsfp default-mode 4x10G\n!\nservice
+    routing protocols model multi-agent\n!\nhostname DC1-LEAF1B\nip name-server vrf
+    MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.2.1\n!\nntp local-interface vrf
+    MGMT Management1\nntp server vrf MGMT 0.fr.pool.ntp.org prefer\nntp server vrf
+    MGMT 1.fr.pool.ntp.org\n!\nspanning-tree mode mstp\nno spanning-tree vlan-id 4093-4094\nspanning-tree
+    mst 0 priority 16384\n!\nno aaa root\nno enable password\n!\nusername admin privilege
+    15 role network-admin secret sha512 $6$Df86J4/SFMDE3/1K$Hef4KstdoxNDaami37cBquTWOTplC.miMPjXVgQxMe92.e5wxlnXOLlebgPj8Fz1KO0za/RCO7ZIs4Q6Eiq1g1\nusername
+    ansible privilege 15 role network-admin secret sha512 $6$Dzu11L7yp9j3nCM9$FSptxMPyIL555OMO.ldnjDXgwZmrfMYwHSr0uznE5Qoqvd9a6UdjiFcJUhGLtvXVZR1r.A/iF5aAt50hf/EK4/\nusername
+    cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\nvlan
+    110\n   name Tenant_A_OP_Zone_1\n!\nvlan 111\n   name Tenant_A_OP_Zone_2\n!\nvlan
+    112\n   name Tenant_A_OP_Zone_3\n!\nvlan 120\n   name Tenant_A_WEB_Zone_1\n!\nvlan
+    121\n   name Tenant_A_WEBZone_2\n!\nvlan 130\n   name Tenant_A_APP_Zone_1\n!\nvlan
+    131\n   name Tenant_A_APP_Zone_2\n!\nvlan 140\n   name Tenant_A_DB_BZone_1\n!\nvlan
+    141\n   name Tenant_A_DB_Zone_2\n!\nvlan 150\n   name Tenant_A_WAN_Zone_1\n!\nvlan
+    160\n   name Tenant_A_VMOTION\n!\nvlan 161\n   name Tenant_A_NFS\n!\nvlan 210\n
+    \  name Tenant_B_OP_Zone_1\n!\nvlan 211\n   name Tenant_B_OP_Zone_2\n!\nvlan 250\n
+    \  name Tenant_B_WAN_Zone_1\n!\nvlan 310\n   name Tenant_C_OP_Zone_1\n!\nvlan
+    311\n   name Tenant_C_OP_Zone_2\n!\nvlan 350\n   name Tenant_C_WAN_Zone_1\n!\nvlan
+    3009\n   name MLAG_iBGP_Tenant_A_OP_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3010\n   name MLAG_iBGP_Tenant_A_WEB_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3011\n   name MLAG_iBGP_Tenant_A_APP_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3012\n   name MLAG_iBGP_Tenant_A_DB_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3013\n   name MLAG_iBGP_Tenant_A_WAN_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3019\n   name MLAG_iBGP_Tenant_B_OP_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3020\n   name MLAG_iBGP_Tenant_B_WAN_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3029\n   name MLAG_iBGP_Tenant_C_OP_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3030\n   name MLAG_iBGP_Tenant_C_WAN_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    4093\n   name LEAF_PEER_L3\n   trunk group LEAF_PEER_L3\n!\nvlan 4094\n   name
+    MLAG_PEER\n   trunk group MLAG\n!\nvrf instance MGMT\n!\nvrf instance Tenant_A_APP_Zone\n!\nvrf
+    instance Tenant_A_DB_Zone\n!\nvrf instance Tenant_A_OP_Zone\n!\nvrf instance Tenant_A_WAN_Zone\n!\nvrf
+    instance Tenant_A_WEB_Zone\n!\nvrf instance Tenant_B_OP_Zone\n!\nvrf instance
+    Tenant_B_WAN_Zone\n!\nvrf instance Tenant_C_OP_Zone\n!\nvrf instance Tenant_C_WAN_Zone\n!\ninterface
+    Port-Channel3\n   description MLAG_PEER_DC1-LEAF1A_Po3\n   no shutdown\n   switchport\n
+    \  switchport trunk allowed vlan 2-4094\n   switchport mode trunk\n   switchport
+    trunk group LEAF_PEER_L3\n   switchport trunk group MLAG\n!\ninterface Port-Channel5\n
+    \  description DC1-L2LEAF1A_Po1\n   no shutdown\n   switchport\n   switchport
+    trunk allowed vlan 110-112,120-121,130-131\n   switchport mode trunk\n   mlag
+    5\n!\ninterface Ethernet1\n   description P2P_LINK_TO_DC1-SPINE1_Ethernet2\n   no
+    shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.5/31\n!\ninterface
+    Ethernet2\n   description P2P_LINK_TO_DC1-SPINE2_Ethernet2\n   no shutdown\n   mtu
+    1500\n   no switchport\n   ip address 172.31.255.7/31\n!\ninterface Ethernet3\n
+    \  description MLAG_PEER_DC1-LEAF1A_Ethernet3\n   no shutdown\n   channel-group
+    3 mode active\n!\ninterface Ethernet4\n   description MLAG_PEER_DC1-LEAF1A_Ethernet4\n
+    \  no shutdown\n   channel-group 3 mode active\n!\ninterface Ethernet5\n   description
+    DC1-L2LEAF1A_Ethernet2\n   no shutdown\n   channel-group 5 mode active\n!\ninterface
+    Loopback0\n   description EVPN_Overlay_Peering\n   no shutdown\n   ip address
+    192.168.255.4/32\n!\ninterface Loopback1\n   description VTEP_VXLAN_Tunnel_Source\n
+    \  no shutdown\n   ip address 192.168.254.3/32\n!\ninterface Loopback100\n   description
+    Tenant_A_OP_Zone_VTEP_DIAGNOSTICS\n   no shutdown\n   vrf Tenant_A_OP_Zone\n   ip
+    address 10.255.1.4/32\n!\ninterface Management1\n   description oob_management\n
+    \  no shutdown\n   vrf MGMT\n   ip address 10.255.0.14/24\n!\ninterface Vlan110\n
+    \  description Tenant_A_OP_Zone_1\n   no shutdown\n   vrf Tenant_A_OP_Zone\n   ip
+    address virtual 10.1.10.1/24\n!\ninterface Vlan111\n   description Tenant_A_OP_Zone_2\n
+    \  no shutdown\n   vrf Tenant_A_OP_Zone\n   ip address virtual 10.1.11.1/24\n!\ninterface
+    Vlan112\n   description Tenant_A_OP_Zone_3\n   no shutdown\n   vrf Tenant_A_OP_Zone\n
+    \  ip address virtual 10.1.12.254/24\n!\ninterface Vlan120\n   description Tenant_A_WEB_Zone_1\n
+    \  no shutdown\n   vrf Tenant_A_WEB_Zone\n!\ninterface Vlan121\n   description
+    Tenant_A_WEBZone_2\n   no shutdown\n   vrf Tenant_A_WEB_Zone\n   ip address virtual
+    10.1.21.1/24\n!\ninterface Vlan130\n   description Tenant_A_APP_Zone_1\n   no
+    shutdown\n   vrf Tenant_A_APP_Zone\n!\ninterface Vlan131\n   description Tenant_A_APP_Zone_2\n
+    \  no shutdown\n   vrf Tenant_A_APP_Zone\n   ip address virtual 10.1.31.254/24\n!\ninterface
+    Vlan140\n   description Tenant_A_DB_BZone_1\n   no shutdown\n   vrf Tenant_A_DB_Zone\n
+    \  ip address virtual 10.1.40.1/24\n!\ninterface Vlan141\n   description Tenant_A_DB_Zone_2\n
+    \  no shutdown\n   vrf Tenant_A_DB_Zone\n   ip address virtual 10.1.41.1/24\n!\ninterface
+    Vlan150\n   description Tenant_A_WAN_Zone_1\n   no shutdown\n   vrf Tenant_A_WAN_Zone\n
+    \  ip address virtual 10.1.40.1/24\n!\ninterface Vlan210\n   description Tenant_B_OP_Zone_1\n
+    \  no shutdown\n   vrf Tenant_B_OP_Zone\n!\ninterface Vlan211\n   description
+    Tenant_B_OP_Zone_2\n   no shutdown\n   vrf Tenant_B_OP_Zone\n   ip address virtual
+    10.2.11.1/24\n!\ninterface Vlan250\n   description Tenant_B_WAN_Zone_1\n   no
+    shutdown\n   vrf Tenant_B_WAN_Zone\n   ip address virtual 10.2.50.1/24\n!\ninterface
+    Vlan310\n   description Tenant_C_OP_Zone_1\n   no shutdown\n   vrf Tenant_C_OP_Zone\n!\ninterface
+    Vlan311\n   description Tenant_C_OP_Zone_2\n   no shutdown\n   vrf Tenant_C_OP_Zone\n!\ninterface
+    Vlan350\n   description Tenant_C_WAN_Zone_1\n   no shutdown\n   vrf Tenant_C_WAN_Zone\n!\ninterface
+    Vlan3009\n   description MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_A_OP_Zone\n   ip address 10.255.251.1/31\n!\ninterface
+    Vlan3010\n   description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_A_WEB_Zone\n   ip address 10.255.251.1/31\n!\ninterface
+    Vlan3011\n   description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_A_APP_Zone\n   ip address 10.255.251.1/31\n!\ninterface
+    Vlan3012\n   description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_A_DB_Zone\n   ip address 10.255.251.1/31\n!\ninterface
+    Vlan3013\n   description MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_A_WAN_Zone\n   ip address 10.255.251.1/31\n!\ninterface
+    Vlan3019\n   description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_B_OP_Zone\n   ip address 10.255.251.1/31\n!\ninterface
+    Vlan3020\n   description MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_B_WAN_Zone\n   ip address 10.255.251.1/31\n!\ninterface
+    Vlan3029\n   description MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_C_OP_Zone\n   ip address 10.255.251.1/31\n!\ninterface
+    Vlan3030\n   description MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_C_WAN_Zone\n   ip address 10.255.251.1/31\n!\ninterface
+    Vlan4093\n   description MLAG_PEER_L3_PEERING\n   no shutdown\n   mtu 1500\n   ip
+    address 10.255.251.1/31\n!\ninterface Vlan4094\n   description MLAG_PEER\n   no
+    shutdown\n   mtu 1500\n   no autostate\n   ip address 10.255.252.1/31\n!\ninterface
+    Vxlan1\n   description DC1-LEAF1B_VTEP\n   vxlan source-interface Loopback1\n
+    \  vxlan virtual-router encapsulation mac-address mlag-system-id\n   vxlan udp-port
+    4789\n   vxlan vlan 110 vni 10110\n   vxlan vlan 111 vni 50111\n   vxlan vlan
+    112 vni 50112\n   vxlan vlan 120 vni 10120\n   vxlan vlan 121 vni 10121\n   vxlan
+    vlan 130 vni 10130\n   vxlan vlan 131 vni 10131\n   vxlan vlan 140 vni 10140\n
+    \  vxlan vlan 141 vni 10141\n   vxlan vlan 150 vni 10150\n   vxlan vlan 160 vni
+    55160\n   vxlan vlan 161 vni 10161\n   vxlan vlan 210 vni 20210\n   vxlan vlan
+    211 vni 20211\n   vxlan vlan 250 vni 20250\n   vxlan vlan 310 vni 30310\n   vxlan
+    vlan 311 vni 30311\n   vxlan vlan 350 vni 30350\n   vxlan vrf Tenant_A_APP_Zone
+    vni 12\n   vxlan vrf Tenant_A_DB_Zone vni 13\n   vxlan vrf Tenant_A_OP_Zone vni
+    10\n   vxlan vrf Tenant_A_WAN_Zone vni 14\n   vxlan vrf Tenant_A_WEB_Zone vni
+    11\n   vxlan vrf Tenant_B_OP_Zone vni 20\n   vxlan vrf Tenant_B_WAN_Zone vni 21\n
+    \  vxlan vrf Tenant_C_OP_Zone vni 30\n   vxlan vrf Tenant_C_WAN_Zone vni 31\n!\nip
+    virtual-router mac-address 00:1c:73:00:dc:01\n!\nip address virtual source-nat
+    vrf Tenant_A_OP_Zone address 10.255.1.4\n!\nip routing\nno ip routing vrf MGMT\nip
+    routing vrf Tenant_A_APP_Zone\nip routing vrf Tenant_A_DB_Zone\nip routing vrf
+    Tenant_A_OP_Zone\nip routing vrf Tenant_A_WAN_Zone\nip routing vrf Tenant_A_WEB_Zone\nip
+    routing vrf Tenant_B_OP_Zone\nip routing vrf Tenant_B_WAN_Zone\nip routing vrf
+    Tenant_C_OP_Zone\nip routing vrf Tenant_C_WAN_Zone\n!\nip prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n
+    \  seq 10 permit 192.168.255.0/24 eq 32\n   seq 20 permit 192.168.254.0/24 eq
+    32\n!\nmlag configuration\n   domain-id DC1_LEAF1\n   local-interface Vlan4094\n
+    \  peer-address 10.255.252.0\n   peer-link Port-Channel3\n   reload-delay mlag
+    300\n   reload-delay non-mlag 330\n!\nip route vrf MGMT 0.0.0.0/0 10.255.0.1\n!\nroute-map
+    RM-CONN-2-BGP permit 10\n   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n!\nroute-map
+    RM-MLAG-PEER-IN permit 10\n   description Make routes learned over MLAG Peer-link
+    less preferred on spines to ensure optimal routing\n   set origin incomplete\n!\nrouter
+    bfd\n   multihop interval 1200 min-rx 1200 multiplier 3\n!\nrouter bgp 65101\n
+    \  router-id 192.168.255.4\n   no bgp default ipv4-unicast\n   distance bgp 20
+    200 200\n   graceful-restart restart-time 300\n   graceful-restart\n   maximum-paths
+    4 ecmp 4\n   neighbor EVPN-OVERLAY-PEERS peer group\n   neighbor EVPN-OVERLAY-PEERS
+    update-source Loopback0\n   neighbor EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS
+    ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n
+    \  neighbor EVPN-OVERLAY-PEERS send-community\n   neighbor EVPN-OVERLAY-PEERS
+    maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS peer group\n   neighbor IPv4-UNDERLAY-PEERS
+    password 7 AQQvKeimxJu+uGQ/yYvv9w==\n   neighbor IPv4-UNDERLAY-PEERS send-community\n
+    \  neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000\n   neighbor MLAG-IPv4-UNDERLAY-PEER
+    peer group\n   neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65101\n   neighbor MLAG-IPv4-UNDERLAY-PEER
+    next-hop-self\n   neighbor MLAG-IPv4-UNDERLAY-PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==\n
+    \  neighbor MLAG-IPv4-UNDERLAY-PEER send-community\n   neighbor MLAG-IPv4-UNDERLAY-PEER
+    maximum-routes 12000\n   neighbor MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN
+    in\n   neighbor 10.255.251.0 peer group MLAG-IPv4-UNDERLAY-PEER\n   neighbor 10.255.251.0
+    description DC1-LEAF1A\n   neighbor 172.31.255.4 peer group IPv4-UNDERLAY-PEERS\n
+    \  neighbor 172.31.255.4 remote-as 65001\n   neighbor 172.31.255.4 description
+    DC1-SPINE1_Ethernet2\n   neighbor 172.31.255.6 peer group IPv4-UNDERLAY-PEERS\n
+    \  neighbor 172.31.255.6 remote-as 65001\n   neighbor 172.31.255.6 description
+    DC1-SPINE2_Ethernet2\n   neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS\n
+    \  neighbor 192.168.255.1 remote-as 65001\n   neighbor 192.168.255.1 description
+    DC1-SPINE1\n   neighbor 192.168.255.2 peer group EVPN-OVERLAY-PEERS\n   neighbor
+    192.168.255.2 remote-as 65001\n   neighbor 192.168.255.2 description DC1-SPINE2\n
+    \  redistribute connected route-map RM-CONN-2-BGP\n   !\n   vlan-aware-bundle
+    Tenant_A_APP_Zone\n      rd 192.168.255.4:12\n      route-target both 12:12\n
+    \     redistribute learned\n      vlan 130-131\n   !\n   vlan-aware-bundle Tenant_A_DB_Zone\n
+    \     rd 192.168.255.4:13\n      route-target both 13:13\n      redistribute learned\n
+    \     vlan 140-141\n   !\n   vlan-aware-bundle Tenant_A_NFS\n      rd 192.168.255.4:10161\n
+    \     route-target both 10161:10161\n      redistribute learned\n      vlan 161\n
+    \  !\n   vlan-aware-bundle Tenant_A_OP_Zone\n      rd 192.168.255.4:10\n      route-target
+    both 10:10\n      redistribute learned\n      vlan 110-112\n   !\n   vlan-aware-bundle
+    Tenant_A_VMOTION\n      rd 192.168.255.4:55160\n      route-target both 55160:55160\n
+    \     redistribute learned\n      vlan 160\n   !\n   vlan-aware-bundle Tenant_A_WAN_Zone\n
+    \     rd 192.168.255.4:14\n      route-target both 14:14\n      redistribute learned\n
+    \     vlan 150\n   !\n   vlan-aware-bundle Tenant_A_WEB_Zone\n      rd 192.168.255.4:11\n
+    \     route-target both 11:11\n      redistribute learned\n      vlan 120-121\n
+    \  !\n   vlan-aware-bundle Tenant_B_OP_Zone\n      rd 192.168.255.4:20\n      route-target
+    both 20:20\n      redistribute learned\n      vlan 210-211\n   !\n   vlan-aware-bundle
+    Tenant_B_WAN_Zone\n      rd 192.168.255.4:21\n      route-target both 21:21\n
+    \     redistribute learned\n      vlan 250\n   !\n   vlan-aware-bundle Tenant_C_OP_Zone\n
+    \     rd 192.168.255.4:30\n      route-target both 30:30\n      redistribute learned\n
+    \     vlan 310-311\n   !\n   vlan-aware-bundle Tenant_C_WAN_Zone\n      rd 192.168.255.4:31\n
+    \     route-target both 31:31\n      redistribute learned\n      vlan 350\n   !\n
+    \  address-family evpn\n      neighbor EVPN-OVERLAY-PEERS activate\n   !\n   address-family
+    ipv4\n      no neighbor EVPN-OVERLAY-PEERS activate\n      neighbor IPv4-UNDERLAY-PEERS
+    activate\n      neighbor MLAG-IPv4-UNDERLAY-PEER activate\n   !\n   vrf Tenant_A_APP_Zone\n
+    \     rd 192.168.255.4:12\n      route-target import evpn 12:12\n      route-target
+    export evpn 12:12\n      router-id 192.168.255.4\n      neighbor 10.255.251.0
+    peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute connected\n   !\n   vrf
+    Tenant_A_DB_Zone\n      rd 192.168.255.4:13\n      route-target import evpn 13:13\n
+    \     route-target export evpn 13:13\n      router-id 192.168.255.4\n      neighbor
+    10.255.251.0 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute connected\n
+    \  !\n   vrf Tenant_A_OP_Zone\n      rd 192.168.255.4:10\n      route-target import
+    evpn 10:10\n      route-target export evpn 10:10\n      router-id 192.168.255.4\n
+    \     neighbor 10.255.251.0 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n   !\n   vrf Tenant_A_WAN_Zone\n      rd 192.168.255.4:14\n      route-target
+    import evpn 14:14\n      route-target export evpn 14:14\n      router-id 192.168.255.4\n
+    \     neighbor 10.255.251.0 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n   !\n   vrf Tenant_A_WEB_Zone\n      rd 192.168.255.4:11\n      route-target
+    import evpn 11:11\n      route-target export evpn 11:11\n      router-id 192.168.255.4\n
+    \     neighbor 10.255.251.0 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n   !\n   vrf Tenant_B_OP_Zone\n      rd 192.168.255.4:20\n      route-target
+    import evpn 20:20\n      route-target export evpn 20:20\n      router-id 192.168.255.4\n
+    \     neighbor 10.255.251.0 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n   !\n   vrf Tenant_B_WAN_Zone\n      rd 192.168.255.4:21\n      route-target
+    import evpn 21:21\n      route-target export evpn 21:21\n      router-id 192.168.255.4\n
+    \     neighbor 10.255.251.0 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n   !\n   vrf Tenant_C_OP_Zone\n      rd 192.168.255.4:30\n      route-target
+    import evpn 30:30\n      route-target export evpn 30:30\n      router-id 192.168.255.4\n
+    \     neighbor 10.255.251.0 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n   !\n   vrf Tenant_C_WAN_Zone\n      rd 192.168.255.4:31\n      route-target
+    import evpn 31:31\n      route-target export evpn 31:31\n      router-id 192.168.255.4\n
+    \     neighbor 10.255.251.0 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n!\nmanagement api http-commands\n   protocol https\n   no shutdown\n
+    \  !\n   vrf MGMT\n      no shutdown\n!\nend\n"
+  AVD_DC1-LEAF2A: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr
+    -cvaddr=10.255.0.1:9910 -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
+    -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
+    internal order ascending range 1006 1199\n!\ntransceiver qsfp default-mode 4x10G\n!\nservice
+    routing protocols model multi-agent\n!\nhostname DC1-LEAF2A\nip name-server vrf
+    MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.2.1\n!\nntp local-interface vrf
+    MGMT Management1\nntp server vrf MGMT 0.fr.pool.ntp.org prefer\nntp server vrf
+    MGMT 1.fr.pool.ntp.org\n!\nspanning-tree mode mstp\nno spanning-tree vlan-id 4093-4094\nspanning-tree
+    mst 0 priority 16384\n!\nno aaa root\nno enable password\n!\nusername admin privilege
+    15 role network-admin secret sha512 $6$Df86J4/SFMDE3/1K$Hef4KstdoxNDaami37cBquTWOTplC.miMPjXVgQxMe92.e5wxlnXOLlebgPj8Fz1KO0za/RCO7ZIs4Q6Eiq1g1\nusername
+    ansible privilege 15 role network-admin secret sha512 $6$Dzu11L7yp9j3nCM9$FSptxMPyIL555OMO.ldnjDXgwZmrfMYwHSr0uznE5Qoqvd9a6UdjiFcJUhGLtvXVZR1r.A/iF5aAt50hf/EK4/\nusername
+    cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\nvlan
+    110\n   name Tenant_A_OP_Zone_1\n!\nvlan 111\n   name Tenant_A_OP_Zone_2\n!\nvlan
+    112\n   name Tenant_A_OP_Zone_3\n!\nvlan 120\n   name Tenant_A_WEB_Zone_1\n!\nvlan
+    121\n   name Tenant_A_WEBZone_2\n!\nvlan 130\n   name Tenant_A_APP_Zone_1\n!\nvlan
+    131\n   name Tenant_A_APP_Zone_2\n!\nvlan 140\n   name Tenant_A_DB_BZone_1\n!\nvlan
+    141\n   name Tenant_A_DB_Zone_2\n!\nvlan 150\n   name Tenant_A_WAN_Zone_1\n!\nvlan
+    160\n   name Tenant_A_VMOTION\n!\nvlan 161\n   name Tenant_A_NFS\n!\nvlan 210\n
+    \  name Tenant_B_OP_Zone_1\n!\nvlan 211\n   name Tenant_B_OP_Zone_2\n!\nvlan 250\n
+    \  name Tenant_B_WAN_Zone_1\n!\nvlan 310\n   name Tenant_C_OP_Zone_1\n!\nvlan
+    311\n   name Tenant_C_OP_Zone_2\n!\nvlan 350\n   name Tenant_C_WAN_Zone_1\n!\nvlan
+    3009\n   name MLAG_iBGP_Tenant_A_OP_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3010\n   name MLAG_iBGP_Tenant_A_WEB_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3011\n   name MLAG_iBGP_Tenant_A_APP_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3012\n   name MLAG_iBGP_Tenant_A_DB_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3013\n   name MLAG_iBGP_Tenant_A_WAN_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3019\n   name MLAG_iBGP_Tenant_B_OP_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3020\n   name MLAG_iBGP_Tenant_B_WAN_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3029\n   name MLAG_iBGP_Tenant_C_OP_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3030\n   name MLAG_iBGP_Tenant_C_WAN_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    4093\n   name LEAF_PEER_L3\n   trunk group LEAF_PEER_L3\n!\nvlan 4094\n   name
+    MLAG_PEER\n   trunk group MLAG\n!\nvrf instance MGMT\n!\nvrf instance Tenant_A_APP_Zone\n!\nvrf
+    instance Tenant_A_DB_Zone\n!\nvrf instance Tenant_A_OP_Zone\n!\nvrf instance Tenant_A_WAN_Zone\n!\nvrf
+    instance Tenant_A_WEB_Zone\n!\nvrf instance Tenant_B_OP_Zone\n!\nvrf instance
+    Tenant_B_WAN_Zone\n!\nvrf instance Tenant_C_OP_Zone\n!\nvrf instance Tenant_C_WAN_Zone\n!\ninterface
+    Port-Channel3\n   description MLAG_PEER_DC1-LEAF2B_Po3\n   no shutdown\n   switchport\n
+    \  switchport trunk allowed vlan 2-4094\n   switchport mode trunk\n   switchport
+    trunk group LEAF_PEER_L3\n   switchport trunk group MLAG\n!\ninterface Port-Channel5\n
+    \  description DC1-L2LEAF2A_Po1\n   no shutdown\n   switchport\n   switchport
+    trunk allowed vlan 110-112,120-121,130-131\n   switchport mode trunk\n   mlag
+    5\n!\ninterface Ethernet1\n   description P2P_LINK_TO_DC1-SPINE1_Ethernet3\n   no
+    shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.9/31\n!\ninterface
+    Ethernet2\n   description P2P_LINK_TO_DC1-SPINE2_Ethernet3\n   no shutdown\n   mtu
+    1500\n   no switchport\n   ip address 172.31.255.11/31\n!\ninterface Ethernet3\n
+    \  description MLAG_PEER_DC1-LEAF2B_Ethernet3\n   no shutdown\n   channel-group
+    3 mode active\n!\ninterface Ethernet4\n   description MLAG_PEER_DC1-LEAF2B_Ethernet4\n
+    \  no shutdown\n   channel-group 3 mode active\n!\ninterface Ethernet5\n   description
+    DC1-L2LEAF2A_Ethernet1\n   no shutdown\n   channel-group 5 mode active\n!\ninterface
+    Loopback0\n   description EVPN_Overlay_Peering\n   no shutdown\n   ip address
+    192.168.255.5/32\n!\ninterface Loopback1\n   description VTEP_VXLAN_Tunnel_Source\n
+    \  no shutdown\n   ip address 192.168.254.5/32\n!\ninterface Loopback100\n   description
+    Tenant_A_OP_Zone_VTEP_DIAGNOSTICS\n   no shutdown\n   vrf Tenant_A_OP_Zone\n   ip
+    address 10.255.1.5/32\n!\ninterface Management1\n   description oob_management\n
+    \  no shutdown\n   vrf MGMT\n   ip address 10.255.0.15/24\n!\ninterface Vlan110\n
+    \  description Tenant_A_OP_Zone_1\n   no shutdown\n   vrf Tenant_A_OP_Zone\n   ip
+    address virtual 10.1.10.1/24\n!\ninterface Vlan111\n   description Tenant_A_OP_Zone_2\n
+    \  no shutdown\n   vrf Tenant_A_OP_Zone\n   ip address virtual 10.1.11.1/24\n!\ninterface
+    Vlan112\n   description Tenant_A_OP_Zone_3\n   no shutdown\n   vrf Tenant_A_OP_Zone\n
+    \  ip address virtual 10.1.12.254/24\n!\ninterface Vlan120\n   description Tenant_A_WEB_Zone_1\n
+    \  no shutdown\n   vrf Tenant_A_WEB_Zone\n!\ninterface Vlan121\n   description
+    Tenant_A_WEBZone_2\n   no shutdown\n   vrf Tenant_A_WEB_Zone\n   ip address virtual
+    10.1.21.1/24\n!\ninterface Vlan130\n   description Tenant_A_APP_Zone_1\n   no
+    shutdown\n   vrf Tenant_A_APP_Zone\n!\ninterface Vlan131\n   description Tenant_A_APP_Zone_2\n
+    \  no shutdown\n   vrf Tenant_A_APP_Zone\n   ip address virtual 10.1.31.254/24\n!\ninterface
+    Vlan140\n   description Tenant_A_DB_BZone_1\n   no shutdown\n   vrf Tenant_A_DB_Zone\n
+    \  ip address virtual 10.1.40.1/24\n!\ninterface Vlan141\n   description Tenant_A_DB_Zone_2\n
+    \  no shutdown\n   vrf Tenant_A_DB_Zone\n   ip address virtual 10.1.41.1/24\n!\ninterface
+    Vlan150\n   description Tenant_A_WAN_Zone_1\n   no shutdown\n   vrf Tenant_A_WAN_Zone\n
+    \  ip address virtual 10.1.40.1/24\n!\ninterface Vlan210\n   description Tenant_B_OP_Zone_1\n
+    \  no shutdown\n   vrf Tenant_B_OP_Zone\n!\ninterface Vlan211\n   description
+    Tenant_B_OP_Zone_2\n   no shutdown\n   vrf Tenant_B_OP_Zone\n   ip address virtual
+    10.2.11.1/24\n!\ninterface Vlan250\n   description Tenant_B_WAN_Zone_1\n   no
+    shutdown\n   vrf Tenant_B_WAN_Zone\n   ip address virtual 10.2.50.1/24\n!\ninterface
+    Vlan310\n   description Tenant_C_OP_Zone_1\n   no shutdown\n   vrf Tenant_C_OP_Zone\n!\ninterface
+    Vlan311\n   description Tenant_C_OP_Zone_2\n   no shutdown\n   vrf Tenant_C_OP_Zone\n!\ninterface
+    Vlan350\n   description Tenant_C_WAN_Zone_1\n   no shutdown\n   vrf Tenant_C_WAN_Zone\n!\ninterface
+    Vlan3009\n   description MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_A_OP_Zone\n   ip address 10.255.251.4/31\n!\ninterface
+    Vlan3010\n   description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_A_WEB_Zone\n   ip address 10.255.251.4/31\n!\ninterface
+    Vlan3011\n   description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_A_APP_Zone\n   ip address 10.255.251.4/31\n!\ninterface
+    Vlan3012\n   description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_A_DB_Zone\n   ip address 10.255.251.4/31\n!\ninterface
+    Vlan3013\n   description MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_A_WAN_Zone\n   ip address 10.255.251.4/31\n!\ninterface
+    Vlan3019\n   description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_B_OP_Zone\n   ip address 10.255.251.4/31\n!\ninterface
+    Vlan3020\n   description MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_B_WAN_Zone\n   ip address 10.255.251.4/31\n!\ninterface
+    Vlan3029\n   description MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_C_OP_Zone\n   ip address 10.255.251.4/31\n!\ninterface
+    Vlan3030\n   description MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_C_WAN_Zone\n   ip address 10.255.251.4/31\n!\ninterface
+    Vlan4093\n   description MLAG_PEER_L3_PEERING\n   no shutdown\n   mtu 1500\n   ip
+    address 10.255.251.4/31\n!\ninterface Vlan4094\n   description MLAG_PEER\n   no
+    shutdown\n   mtu 1500\n   no autostate\n   ip address 10.255.252.4/31\n!\ninterface
+    Vxlan1\n   description DC1-LEAF2A_VTEP\n   vxlan source-interface Loopback1\n
+    \  vxlan virtual-router encapsulation mac-address mlag-system-id\n   vxlan udp-port
+    4789\n   vxlan vlan 110 vni 10110\n   vxlan vlan 111 vni 50111\n   vxlan vlan
+    112 vni 50112\n   vxlan vlan 120 vni 10120\n   vxlan vlan 121 vni 10121\n   vxlan
+    vlan 130 vni 10130\n   vxlan vlan 131 vni 10131\n   vxlan vlan 140 vni 10140\n
+    \  vxlan vlan 141 vni 10141\n   vxlan vlan 150 vni 10150\n   vxlan vlan 160 vni
+    55160\n   vxlan vlan 161 vni 10161\n   vxlan vlan 210 vni 20210\n   vxlan vlan
+    211 vni 20211\n   vxlan vlan 250 vni 20250\n   vxlan vlan 310 vni 30310\n   vxlan
+    vlan 311 vni 30311\n   vxlan vlan 350 vni 30350\n   vxlan vrf Tenant_A_APP_Zone
+    vni 12\n   vxlan vrf Tenant_A_DB_Zone vni 13\n   vxlan vrf Tenant_A_OP_Zone vni
+    10\n   vxlan vrf Tenant_A_WAN_Zone vni 14\n   vxlan vrf Tenant_A_WEB_Zone vni
+    11\n   vxlan vrf Tenant_B_OP_Zone vni 20\n   vxlan vrf Tenant_B_WAN_Zone vni 21\n
+    \  vxlan vrf Tenant_C_OP_Zone vni 30\n   vxlan vrf Tenant_C_WAN_Zone vni 31\n!\nip
+    virtual-router mac-address 00:1c:73:00:dc:01\n!\nip address virtual source-nat
+    vrf Tenant_A_OP_Zone address 10.255.1.5\n!\nip routing\nno ip routing vrf MGMT\nip
+    routing vrf Tenant_A_APP_Zone\nip routing vrf Tenant_A_DB_Zone\nip routing vrf
+    Tenant_A_OP_Zone\nip routing vrf Tenant_A_WAN_Zone\nip routing vrf Tenant_A_WEB_Zone\nip
+    routing vrf Tenant_B_OP_Zone\nip routing vrf Tenant_B_WAN_Zone\nip routing vrf
+    Tenant_C_OP_Zone\nip routing vrf Tenant_C_WAN_Zone\n!\nip prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n
+    \  seq 10 permit 192.168.255.0/24 eq 32\n   seq 20 permit 192.168.254.0/24 eq
+    32\n!\nmlag configuration\n   domain-id DC1_LEAF2\n   local-interface Vlan4094\n
+    \  peer-address 10.255.252.5\n   peer-link Port-Channel3\n   reload-delay mlag
+    300\n   reload-delay non-mlag 330\n!\nip route vrf MGMT 0.0.0.0/0 10.255.0.1\n!\nroute-map
+    RM-CONN-2-BGP permit 10\n   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n!\nroute-map
+    RM-MLAG-PEER-IN permit 10\n   description Make routes learned over MLAG Peer-link
+    less preferred on spines to ensure optimal routing\n   set origin incomplete\n!\nrouter
+    bfd\n   multihop interval 1200 min-rx 1200 multiplier 3\n!\nrouter bgp 65102\n
+    \  router-id 192.168.255.5\n   no bgp default ipv4-unicast\n   distance bgp 20
+    200 200\n   graceful-restart restart-time 300\n   graceful-restart\n   maximum-paths
+    4 ecmp 4\n   neighbor EVPN-OVERLAY-PEERS peer group\n   neighbor EVPN-OVERLAY-PEERS
+    update-source Loopback0\n   neighbor EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS
+    ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n
+    \  neighbor EVPN-OVERLAY-PEERS send-community\n   neighbor EVPN-OVERLAY-PEERS
+    maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS peer group\n   neighbor IPv4-UNDERLAY-PEERS
+    password 7 AQQvKeimxJu+uGQ/yYvv9w==\n   neighbor IPv4-UNDERLAY-PEERS send-community\n
+    \  neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000\n   neighbor MLAG-IPv4-UNDERLAY-PEER
+    peer group\n   neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65102\n   neighbor MLAG-IPv4-UNDERLAY-PEER
+    next-hop-self\n   neighbor MLAG-IPv4-UNDERLAY-PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==\n
+    \  neighbor MLAG-IPv4-UNDERLAY-PEER send-community\n   neighbor MLAG-IPv4-UNDERLAY-PEER
+    maximum-routes 12000\n   neighbor MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN
+    in\n   neighbor 10.255.251.5 peer group MLAG-IPv4-UNDERLAY-PEER\n   neighbor 10.255.251.5
+    description DC1-LEAF2B\n   neighbor 172.31.255.8 peer group IPv4-UNDERLAY-PEERS\n
+    \  neighbor 172.31.255.8 remote-as 65001\n   neighbor 172.31.255.8 description
+    DC1-SPINE1_Ethernet3\n   neighbor 172.31.255.10 peer group IPv4-UNDERLAY-PEERS\n
+    \  neighbor 172.31.255.10 remote-as 65001\n   neighbor 172.31.255.10 description
+    DC1-SPINE2_Ethernet3\n   neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS\n
+    \  neighbor 192.168.255.1 remote-as 65001\n   neighbor 192.168.255.1 description
+    DC1-SPINE1\n   neighbor 192.168.255.2 peer group EVPN-OVERLAY-PEERS\n   neighbor
+    192.168.255.2 remote-as 65001\n   neighbor 192.168.255.2 description DC1-SPINE2\n
+    \  redistribute connected route-map RM-CONN-2-BGP\n   !\n   vlan-aware-bundle
+    Tenant_A_APP_Zone\n      rd 192.168.255.5:12\n      route-target both 12:12\n
+    \     redistribute learned\n      vlan 130-131\n   !\n   vlan-aware-bundle Tenant_A_DB_Zone\n
+    \     rd 192.168.255.5:13\n      route-target both 13:13\n      redistribute learned\n
+    \     vlan 140-141\n   !\n   vlan-aware-bundle Tenant_A_NFS\n      rd 192.168.255.5:10161\n
+    \     route-target both 10161:10161\n      redistribute learned\n      vlan 161\n
+    \  !\n   vlan-aware-bundle Tenant_A_OP_Zone\n      rd 192.168.255.5:10\n      route-target
+    both 10:10\n      redistribute learned\n      vlan 110-112\n   !\n   vlan-aware-bundle
+    Tenant_A_VMOTION\n      rd 192.168.255.5:55160\n      route-target both 55160:55160\n
+    \     redistribute learned\n      vlan 160\n   !\n   vlan-aware-bundle Tenant_A_WAN_Zone\n
+    \     rd 192.168.255.5:14\n      route-target both 14:14\n      redistribute learned\n
+    \     vlan 150\n   !\n   vlan-aware-bundle Tenant_A_WEB_Zone\n      rd 192.168.255.5:11\n
+    \     route-target both 11:11\n      redistribute learned\n      vlan 120-121\n
+    \  !\n   vlan-aware-bundle Tenant_B_OP_Zone\n      rd 192.168.255.5:20\n      route-target
+    both 20:20\n      redistribute learned\n      vlan 210-211\n   !\n   vlan-aware-bundle
+    Tenant_B_WAN_Zone\n      rd 192.168.255.5:21\n      route-target both 21:21\n
+    \     redistribute learned\n      vlan 250\n   !\n   vlan-aware-bundle Tenant_C_OP_Zone\n
+    \     rd 192.168.255.5:30\n      route-target both 30:30\n      redistribute learned\n
+    \     vlan 310-311\n   !\n   vlan-aware-bundle Tenant_C_WAN_Zone\n      rd 192.168.255.5:31\n
+    \     route-target both 31:31\n      redistribute learned\n      vlan 350\n   !\n
+    \  address-family evpn\n      neighbor EVPN-OVERLAY-PEERS activate\n   !\n   address-family
+    ipv4\n      no neighbor EVPN-OVERLAY-PEERS activate\n      neighbor IPv4-UNDERLAY-PEERS
+    activate\n      neighbor MLAG-IPv4-UNDERLAY-PEER activate\n   !\n   vrf Tenant_A_APP_Zone\n
+    \     rd 192.168.255.5:12\n      route-target import evpn 12:12\n      route-target
+    export evpn 12:12\n      router-id 192.168.255.5\n      neighbor 10.255.251.5
+    peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute connected\n   !\n   vrf
+    Tenant_A_DB_Zone\n      rd 192.168.255.5:13\n      route-target import evpn 13:13\n
+    \     route-target export evpn 13:13\n      router-id 192.168.255.5\n      neighbor
+    10.255.251.5 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute connected\n
+    \  !\n   vrf Tenant_A_OP_Zone\n      rd 192.168.255.5:10\n      route-target import
+    evpn 10:10\n      route-target export evpn 10:10\n      router-id 192.168.255.5\n
+    \     neighbor 10.255.251.5 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n   !\n   vrf Tenant_A_WAN_Zone\n      rd 192.168.255.5:14\n      route-target
+    import evpn 14:14\n      route-target export evpn 14:14\n      router-id 192.168.255.5\n
+    \     neighbor 10.255.251.5 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n   !\n   vrf Tenant_A_WEB_Zone\n      rd 192.168.255.5:11\n      route-target
+    import evpn 11:11\n      route-target export evpn 11:11\n      router-id 192.168.255.5\n
+    \     neighbor 10.255.251.5 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n   !\n   vrf Tenant_B_OP_Zone\n      rd 192.168.255.5:20\n      route-target
+    import evpn 20:20\n      route-target export evpn 20:20\n      router-id 192.168.255.5\n
+    \     neighbor 10.255.251.5 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n   !\n   vrf Tenant_B_WAN_Zone\n      rd 192.168.255.5:21\n      route-target
+    import evpn 21:21\n      route-target export evpn 21:21\n      router-id 192.168.255.5\n
+    \     neighbor 10.255.251.5 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n   !\n   vrf Tenant_C_OP_Zone\n      rd 192.168.255.5:30\n      route-target
+    import evpn 30:30\n      route-target export evpn 30:30\n      router-id 192.168.255.5\n
+    \     neighbor 10.255.251.5 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n   !\n   vrf Tenant_C_WAN_Zone\n      rd 192.168.255.5:31\n      route-target
+    import evpn 31:31\n      route-target export evpn 31:31\n      router-id 192.168.255.5\n
+    \     neighbor 10.255.251.5 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n!\nmanagement api http-commands\n   protocol https\n   no shutdown\n
+    \  !\n   vrf MGMT\n      no shutdown\n!\nend\n"
+  AVD_DC1-LEAF2B: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr
+    -cvaddr=10.255.0.1:9910 -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
+    -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
+    internal order ascending range 1006 1199\n!\ntransceiver qsfp default-mode 4x10G\n!\nservice
+    routing protocols model multi-agent\n!\nhostname DC1-LEAF2B\nip name-server vrf
+    MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.2.1\n!\nntp local-interface vrf
+    MGMT Management1\nntp server vrf MGMT 0.fr.pool.ntp.org prefer\nntp server vrf
+    MGMT 1.fr.pool.ntp.org\n!\nspanning-tree mode mstp\nno spanning-tree vlan-id 4093-4094\nspanning-tree
+    mst 0 priority 16384\n!\nno aaa root\nno enable password\n!\nusername admin privilege
+    15 role network-admin secret sha512 $6$Df86J4/SFMDE3/1K$Hef4KstdoxNDaami37cBquTWOTplC.miMPjXVgQxMe92.e5wxlnXOLlebgPj8Fz1KO0za/RCO7ZIs4Q6Eiq1g1\nusername
+    ansible privilege 15 role network-admin secret sha512 $6$Dzu11L7yp9j3nCM9$FSptxMPyIL555OMO.ldnjDXgwZmrfMYwHSr0uznE5Qoqvd9a6UdjiFcJUhGLtvXVZR1r.A/iF5aAt50hf/EK4/\nusername
+    cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\nvlan
+    110\n   name Tenant_A_OP_Zone_1\n!\nvlan 111\n   name Tenant_A_OP_Zone_2\n!\nvlan
+    112\n   name Tenant_A_OP_Zone_3\n!\nvlan 120\n   name Tenant_A_WEB_Zone_1\n!\nvlan
+    121\n   name Tenant_A_WEBZone_2\n!\nvlan 130\n   name Tenant_A_APP_Zone_1\n!\nvlan
+    131\n   name Tenant_A_APP_Zone_2\n!\nvlan 140\n   name Tenant_A_DB_BZone_1\n!\nvlan
+    141\n   name Tenant_A_DB_Zone_2\n!\nvlan 150\n   name Tenant_A_WAN_Zone_1\n!\nvlan
+    160\n   name Tenant_A_VMOTION\n!\nvlan 161\n   name Tenant_A_NFS\n!\nvlan 210\n
+    \  name Tenant_B_OP_Zone_1\n!\nvlan 211\n   name Tenant_B_OP_Zone_2\n!\nvlan 250\n
+    \  name Tenant_B_WAN_Zone_1\n!\nvlan 310\n   name Tenant_C_OP_Zone_1\n!\nvlan
+    311\n   name Tenant_C_OP_Zone_2\n!\nvlan 350\n   name Tenant_C_WAN_Zone_1\n!\nvlan
+    3009\n   name MLAG_iBGP_Tenant_A_OP_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3010\n   name MLAG_iBGP_Tenant_A_WEB_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3011\n   name MLAG_iBGP_Tenant_A_APP_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3012\n   name MLAG_iBGP_Tenant_A_DB_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3013\n   name MLAG_iBGP_Tenant_A_WAN_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3019\n   name MLAG_iBGP_Tenant_B_OP_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3020\n   name MLAG_iBGP_Tenant_B_WAN_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3029\n   name MLAG_iBGP_Tenant_C_OP_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3030\n   name MLAG_iBGP_Tenant_C_WAN_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    4093\n   name LEAF_PEER_L3\n   trunk group LEAF_PEER_L3\n!\nvlan 4094\n   name
+    MLAG_PEER\n   trunk group MLAG\n!\nvrf instance MGMT\n!\nvrf instance Tenant_A_APP_Zone\n!\nvrf
+    instance Tenant_A_DB_Zone\n!\nvrf instance Tenant_A_OP_Zone\n!\nvrf instance Tenant_A_WAN_Zone\n!\nvrf
+    instance Tenant_A_WEB_Zone\n!\nvrf instance Tenant_B_OP_Zone\n!\nvrf instance
+    Tenant_B_WAN_Zone\n!\nvrf instance Tenant_C_OP_Zone\n!\nvrf instance Tenant_C_WAN_Zone\n!\ninterface
+    Port-Channel3\n   description MLAG_PEER_DC1-LEAF2A_Po3\n   no shutdown\n   switchport\n
+    \  switchport trunk allowed vlan 2-4094\n   switchport mode trunk\n   switchport
+    trunk group LEAF_PEER_L3\n   switchport trunk group MLAG\n!\ninterface Port-Channel5\n
+    \  description DC1-L2LEAF2A_Po1\n   no shutdown\n   switchport\n   switchport
+    trunk allowed vlan 110-112,120-121,130-131\n   switchport mode trunk\n   mlag
+    5\n!\ninterface Ethernet1\n   description P2P_LINK_TO_DC1-SPINE1_Ethernet4\n   no
+    shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.13/31\n!\ninterface
+    Ethernet2\n   description P2P_LINK_TO_DC1-SPINE2_Ethernet4\n   no shutdown\n   mtu
+    1500\n   no switchport\n   ip address 172.31.255.15/31\n!\ninterface Ethernet3\n
+    \  description MLAG_PEER_DC1-LEAF2A_Ethernet3\n   no shutdown\n   channel-group
+    3 mode active\n!\ninterface Ethernet4\n   description MLAG_PEER_DC1-LEAF2A_Ethernet4\n
+    \  no shutdown\n   channel-group 3 mode active\n!\ninterface Ethernet5\n   description
+    DC1-L2LEAF2A_Ethernet2\n   no shutdown\n   channel-group 5 mode active\n!\ninterface
+    Loopback0\n   description EVPN_Overlay_Peering\n   no shutdown\n   ip address
+    192.168.255.6/32\n!\ninterface Loopback1\n   description VTEP_VXLAN_Tunnel_Source\n
+    \  no shutdown\n   ip address 192.168.254.5/32\n!\ninterface Loopback100\n   description
+    Tenant_A_OP_Zone_VTEP_DIAGNOSTICS\n   no shutdown\n   vrf Tenant_A_OP_Zone\n   ip
+    address 10.255.1.6/32\n!\ninterface Management1\n   description oob_management\n
+    \  no shutdown\n   vrf MGMT\n   ip address 10.255.0.16/24\n!\ninterface Vlan110\n
+    \  description Tenant_A_OP_Zone_1\n   no shutdown\n   vrf Tenant_A_OP_Zone\n   ip
+    address virtual 10.1.10.1/24\n!\ninterface Vlan111\n   description Tenant_A_OP_Zone_2\n
+    \  no shutdown\n   vrf Tenant_A_OP_Zone\n   ip address virtual 10.1.11.1/24\n!\ninterface
+    Vlan112\n   description Tenant_A_OP_Zone_3\n   no shutdown\n   vrf Tenant_A_OP_Zone\n
+    \  ip address virtual 10.1.12.254/24\n!\ninterface Vlan120\n   description Tenant_A_WEB_Zone_1\n
+    \  no shutdown\n   vrf Tenant_A_WEB_Zone\n!\ninterface Vlan121\n   description
+    Tenant_A_WEBZone_2\n   no shutdown\n   vrf Tenant_A_WEB_Zone\n   ip address virtual
+    10.1.21.1/24\n!\ninterface Vlan130\n   description Tenant_A_APP_Zone_1\n   no
+    shutdown\n   vrf Tenant_A_APP_Zone\n!\ninterface Vlan131\n   description Tenant_A_APP_Zone_2\n
+    \  no shutdown\n   vrf Tenant_A_APP_Zone\n   ip address virtual 10.1.31.254/24\n!\ninterface
+    Vlan140\n   description Tenant_A_DB_BZone_1\n   no shutdown\n   vrf Tenant_A_DB_Zone\n
+    \  ip address virtual 10.1.40.1/24\n!\ninterface Vlan141\n   description Tenant_A_DB_Zone_2\n
+    \  no shutdown\n   vrf Tenant_A_DB_Zone\n   ip address virtual 10.1.41.1/24\n!\ninterface
+    Vlan150\n   description Tenant_A_WAN_Zone_1\n   no shutdown\n   vrf Tenant_A_WAN_Zone\n
+    \  ip address virtual 10.1.40.1/24\n!\ninterface Vlan210\n   description Tenant_B_OP_Zone_1\n
+    \  no shutdown\n   vrf Tenant_B_OP_Zone\n!\ninterface Vlan211\n   description
+    Tenant_B_OP_Zone_2\n   no shutdown\n   vrf Tenant_B_OP_Zone\n   ip address virtual
+    10.2.11.1/24\n!\ninterface Vlan250\n   description Tenant_B_WAN_Zone_1\n   no
+    shutdown\n   vrf Tenant_B_WAN_Zone\n   ip address virtual 10.2.50.1/24\n!\ninterface
+    Vlan310\n   description Tenant_C_OP_Zone_1\n   no shutdown\n   vrf Tenant_C_OP_Zone\n!\ninterface
+    Vlan311\n   description Tenant_C_OP_Zone_2\n   no shutdown\n   vrf Tenant_C_OP_Zone\n!\ninterface
+    Vlan350\n   description Tenant_C_WAN_Zone_1\n   no shutdown\n   vrf Tenant_C_WAN_Zone\n!\ninterface
+    Vlan3009\n   description MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_A_OP_Zone\n   ip address 10.255.251.5/31\n!\ninterface
+    Vlan3010\n   description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_A_WEB_Zone\n   ip address 10.255.251.5/31\n!\ninterface
+    Vlan3011\n   description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_A_APP_Zone\n   ip address 10.255.251.5/31\n!\ninterface
+    Vlan3012\n   description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_A_DB_Zone\n   ip address 10.255.251.5/31\n!\ninterface
+    Vlan3013\n   description MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_A_WAN_Zone\n   ip address 10.255.251.5/31\n!\ninterface
+    Vlan3019\n   description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_B_OP_Zone\n   ip address 10.255.251.5/31\n!\ninterface
+    Vlan3020\n   description MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_B_WAN_Zone\n   ip address 10.255.251.5/31\n!\ninterface
+    Vlan3029\n   description MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_C_OP_Zone\n   ip address 10.255.251.5/31\n!\ninterface
+    Vlan3030\n   description MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_C_WAN_Zone\n   ip address 10.255.251.5/31\n!\ninterface
+    Vlan4093\n   description MLAG_PEER_L3_PEERING\n   no shutdown\n   mtu 1500\n   ip
+    address 10.255.251.5/31\n!\ninterface Vlan4094\n   description MLAG_PEER\n   no
+    shutdown\n   mtu 1500\n   no autostate\n   ip address 10.255.252.5/31\n!\ninterface
+    Vxlan1\n   description DC1-LEAF2B_VTEP\n   vxlan source-interface Loopback1\n
+    \  vxlan virtual-router encapsulation mac-address mlag-system-id\n   vxlan udp-port
+    4789\n   vxlan vlan 110 vni 10110\n   vxlan vlan 111 vni 50111\n   vxlan vlan
+    112 vni 50112\n   vxlan vlan 120 vni 10120\n   vxlan vlan 121 vni 10121\n   vxlan
+    vlan 130 vni 10130\n   vxlan vlan 131 vni 10131\n   vxlan vlan 140 vni 10140\n
+    \  vxlan vlan 141 vni 10141\n   vxlan vlan 150 vni 10150\n   vxlan vlan 160 vni
+    55160\n   vxlan vlan 161 vni 10161\n   vxlan vlan 210 vni 20210\n   vxlan vlan
+    211 vni 20211\n   vxlan vlan 250 vni 20250\n   vxlan vlan 310 vni 30310\n   vxlan
+    vlan 311 vni 30311\n   vxlan vlan 350 vni 30350\n   vxlan vrf Tenant_A_APP_Zone
+    vni 12\n   vxlan vrf Tenant_A_DB_Zone vni 13\n   vxlan vrf Tenant_A_OP_Zone vni
+    10\n   vxlan vrf Tenant_A_WAN_Zone vni 14\n   vxlan vrf Tenant_A_WEB_Zone vni
+    11\n   vxlan vrf Tenant_B_OP_Zone vni 20\n   vxlan vrf Tenant_B_WAN_Zone vni 21\n
+    \  vxlan vrf Tenant_C_OP_Zone vni 30\n   vxlan vrf Tenant_C_WAN_Zone vni 31\n!\nip
+    virtual-router mac-address 00:1c:73:00:dc:01\n!\nip address virtual source-nat
+    vrf Tenant_A_OP_Zone address 10.255.1.6\n!\nip routing\nno ip routing vrf MGMT\nip
+    routing vrf Tenant_A_APP_Zone\nip routing vrf Tenant_A_DB_Zone\nip routing vrf
+    Tenant_A_OP_Zone\nip routing vrf Tenant_A_WAN_Zone\nip routing vrf Tenant_A_WEB_Zone\nip
+    routing vrf Tenant_B_OP_Zone\nip routing vrf Tenant_B_WAN_Zone\nip routing vrf
+    Tenant_C_OP_Zone\nip routing vrf Tenant_C_WAN_Zone\n!\nip prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n
+    \  seq 10 permit 192.168.255.0/24 eq 32\n   seq 20 permit 192.168.254.0/24 eq
+    32\n!\nmlag configuration\n   domain-id DC1_LEAF2\n   local-interface Vlan4094\n
+    \  peer-address 10.255.252.4\n   peer-link Port-Channel3\n   reload-delay mlag
+    300\n   reload-delay non-mlag 330\n!\nip route vrf MGMT 0.0.0.0/0 10.255.0.1\n!\nroute-map
+    RM-CONN-2-BGP permit 10\n   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n!\nroute-map
+    RM-MLAG-PEER-IN permit 10\n   description Make routes learned over MLAG Peer-link
+    less preferred on spines to ensure optimal routing\n   set origin incomplete\n!\nrouter
+    bfd\n   multihop interval 1200 min-rx 1200 multiplier 3\n!\nrouter bgp 65102\n
+    \  router-id 192.168.255.6\n   no bgp default ipv4-unicast\n   distance bgp 20
+    200 200\n   graceful-restart restart-time 300\n   graceful-restart\n   maximum-paths
+    4 ecmp 4\n   neighbor EVPN-OVERLAY-PEERS peer group\n   neighbor EVPN-OVERLAY-PEERS
+    update-source Loopback0\n   neighbor EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS
+    ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n
+    \  neighbor EVPN-OVERLAY-PEERS send-community\n   neighbor EVPN-OVERLAY-PEERS
+    maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS peer group\n   neighbor IPv4-UNDERLAY-PEERS
+    password 7 AQQvKeimxJu+uGQ/yYvv9w==\n   neighbor IPv4-UNDERLAY-PEERS send-community\n
+    \  neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000\n   neighbor MLAG-IPv4-UNDERLAY-PEER
+    peer group\n   neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65102\n   neighbor MLAG-IPv4-UNDERLAY-PEER
+    next-hop-self\n   neighbor MLAG-IPv4-UNDERLAY-PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==\n
+    \  neighbor MLAG-IPv4-UNDERLAY-PEER send-community\n   neighbor MLAG-IPv4-UNDERLAY-PEER
+    maximum-routes 12000\n   neighbor MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN
+    in\n   neighbor 10.255.251.4 peer group MLAG-IPv4-UNDERLAY-PEER\n   neighbor 10.255.251.4
+    description DC1-LEAF2A\n   neighbor 172.31.255.12 peer group IPv4-UNDERLAY-PEERS\n
+    \  neighbor 172.31.255.12 remote-as 65001\n   neighbor 172.31.255.12 description
+    DC1-SPINE1_Ethernet4\n   neighbor 172.31.255.14 peer group IPv4-UNDERLAY-PEERS\n
+    \  neighbor 172.31.255.14 remote-as 65001\n   neighbor 172.31.255.14 description
+    DC1-SPINE2_Ethernet4\n   neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS\n
+    \  neighbor 192.168.255.1 remote-as 65001\n   neighbor 192.168.255.1 description
+    DC1-SPINE1\n   neighbor 192.168.255.2 peer group EVPN-OVERLAY-PEERS\n   neighbor
+    192.168.255.2 remote-as 65001\n   neighbor 192.168.255.2 description DC1-SPINE2\n
+    \  redistribute connected route-map RM-CONN-2-BGP\n   !\n   vlan-aware-bundle
+    Tenant_A_APP_Zone\n      rd 192.168.255.6:12\n      route-target both 12:12\n
+    \     redistribute learned\n      vlan 130-131\n   !\n   vlan-aware-bundle Tenant_A_DB_Zone\n
+    \     rd 192.168.255.6:13\n      route-target both 13:13\n      redistribute learned\n
+    \     vlan 140-141\n   !\n   vlan-aware-bundle Tenant_A_NFS\n      rd 192.168.255.6:10161\n
+    \     route-target both 10161:10161\n      redistribute learned\n      vlan 161\n
+    \  !\n   vlan-aware-bundle Tenant_A_OP_Zone\n      rd 192.168.255.6:10\n      route-target
+    both 10:10\n      redistribute learned\n      vlan 110-112\n   !\n   vlan-aware-bundle
+    Tenant_A_VMOTION\n      rd 192.168.255.6:55160\n      route-target both 55160:55160\n
+    \     redistribute learned\n      vlan 160\n   !\n   vlan-aware-bundle Tenant_A_WAN_Zone\n
+    \     rd 192.168.255.6:14\n      route-target both 14:14\n      redistribute learned\n
+    \     vlan 150\n   !\n   vlan-aware-bundle Tenant_A_WEB_Zone\n      rd 192.168.255.6:11\n
+    \     route-target both 11:11\n      redistribute learned\n      vlan 120-121\n
+    \  !\n   vlan-aware-bundle Tenant_B_OP_Zone\n      rd 192.168.255.6:20\n      route-target
+    both 20:20\n      redistribute learned\n      vlan 210-211\n   !\n   vlan-aware-bundle
+    Tenant_B_WAN_Zone\n      rd 192.168.255.6:21\n      route-target both 21:21\n
+    \     redistribute learned\n      vlan 250\n   !\n   vlan-aware-bundle Tenant_C_OP_Zone\n
+    \     rd 192.168.255.6:30\n      route-target both 30:30\n      redistribute learned\n
+    \     vlan 310-311\n   !\n   vlan-aware-bundle Tenant_C_WAN_Zone\n      rd 192.168.255.6:31\n
+    \     route-target both 31:31\n      redistribute learned\n      vlan 350\n   !\n
+    \  address-family evpn\n      neighbor EVPN-OVERLAY-PEERS activate\n   !\n   address-family
+    ipv4\n      no neighbor EVPN-OVERLAY-PEERS activate\n      neighbor IPv4-UNDERLAY-PEERS
+    activate\n      neighbor MLAG-IPv4-UNDERLAY-PEER activate\n   !\n   vrf Tenant_A_APP_Zone\n
+    \     rd 192.168.255.6:12\n      route-target import evpn 12:12\n      route-target
+    export evpn 12:12\n      router-id 192.168.255.6\n      neighbor 10.255.251.4
+    peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute connected\n   !\n   vrf
+    Tenant_A_DB_Zone\n      rd 192.168.255.6:13\n      route-target import evpn 13:13\n
+    \     route-target export evpn 13:13\n      router-id 192.168.255.6\n      neighbor
+    10.255.251.4 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute connected\n
+    \  !\n   vrf Tenant_A_OP_Zone\n      rd 192.168.255.6:10\n      route-target import
+    evpn 10:10\n      route-target export evpn 10:10\n      router-id 192.168.255.6\n
+    \     neighbor 10.255.251.4 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n   !\n   vrf Tenant_A_WAN_Zone\n      rd 192.168.255.6:14\n      route-target
+    import evpn 14:14\n      route-target export evpn 14:14\n      router-id 192.168.255.6\n
+    \     neighbor 10.255.251.4 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n   !\n   vrf Tenant_A_WEB_Zone\n      rd 192.168.255.6:11\n      route-target
+    import evpn 11:11\n      route-target export evpn 11:11\n      router-id 192.168.255.6\n
+    \     neighbor 10.255.251.4 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n   !\n   vrf Tenant_B_OP_Zone\n      rd 192.168.255.6:20\n      route-target
+    import evpn 20:20\n      route-target export evpn 20:20\n      router-id 192.168.255.6\n
+    \     neighbor 10.255.251.4 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n   !\n   vrf Tenant_B_WAN_Zone\n      rd 192.168.255.6:21\n      route-target
+    import evpn 21:21\n      route-target export evpn 21:21\n      router-id 192.168.255.6\n
+    \     neighbor 10.255.251.4 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n   !\n   vrf Tenant_C_OP_Zone\n      rd 192.168.255.6:30\n      route-target
+    import evpn 30:30\n      route-target export evpn 30:30\n      router-id 192.168.255.6\n
+    \     neighbor 10.255.251.4 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n   !\n   vrf Tenant_C_WAN_Zone\n      rd 192.168.255.6:31\n      route-target
+    import evpn 31:31\n      route-target export evpn 31:31\n      router-id 192.168.255.6\n
+    \     neighbor 10.255.251.4 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n!\nmanagement api http-commands\n   protocol https\n   no shutdown\n
+    \  !\n   vrf MGMT\n      no shutdown\n!\nend\n"
+cvp_topology:
+  DC1_FABRIC:
+    parent_container: Tenant
+  DC1_L2LEAF1:
+    devices: []
+    parent_container: DC1_L2LEAFS
+  DC1_L2LEAF2:
+    devices: []
+    parent_container: DC1_L2LEAFS
+  DC1_L2LEAFS:
+    parent_container: DC1_FABRIC
+  DC1_L3LEAFS:
+    parent_container: DC1_FABRIC
+  DC1_LEAF1:
+    devices:
+    - DC1-LEAF1A
+    - DC1-LEAF1B
+    parent_container: DC1_L3LEAFS
+  DC1_LEAF2:
+    devices:
+    - DC1-LEAF2A
+    - DC1-LEAF2B
+    parent_container: DC1_L3LEAFS
+  DC1_SPINES:
+    devices: []
+    parent_container: DC1_FABRIC

--- a/ansible_collections/arista/avd/tests/inventory/inventory_to_container/expected_output/expected_with_device_filter_empty_string.yml
+++ b/ansible_collections/arista/avd/tests/inventory/inventory_to_container/expected_output/expected_with_device_filter_empty_string.yml
@@ -1,0 +1,1009 @@
+cvp_configlets:
+  AVD_DC1-L2LEAF1A: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr
+    -cvaddr=10.255.0.1:9910 -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
+    -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
+    internal order ascending range 1006 1199\n!\ntransceiver qsfp default-mode 4x10G\n!\nservice
+    routing protocols model multi-agent\n!\nhostname DC1-L2LEAF1A\nip name-server
+    vrf MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.2.1\n!\nntp local-interface
+    vrf MGMT Management1\nntp server vrf MGMT 0.fr.pool.ntp.org prefer\nntp server
+    vrf MGMT 1.fr.pool.ntp.org\n!\nspanning-tree mode mstp\nspanning-tree mst 0 priority
+    16384\n!\nno aaa root\nno enable password\n!\nusername admin privilege 15 role
+    network-admin secret sha512 $6$Df86J4/SFMDE3/1K$Hef4KstdoxNDaami37cBquTWOTplC.miMPjXVgQxMe92.e5wxlnXOLlebgPj8Fz1KO0za/RCO7ZIs4Q6Eiq1g1\nusername
+    ansible privilege 15 role network-admin secret sha512 $6$Dzu11L7yp9j3nCM9$FSptxMPyIL555OMO.ldnjDXgwZmrfMYwHSr0uznE5Qoqvd9a6UdjiFcJUhGLtvXVZR1r.A/iF5aAt50hf/EK4/\nusername
+    cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\nvlan
+    110\n   name Tenant_A_OP_Zone_1\n!\nvlan 111\n   name Tenant_A_OP_Zone_2\n!\nvlan
+    112\n   name Tenant_A_OP_Zone_3\n!\nvlan 120\n   name Tenant_A_WEB_Zone_1\n!\nvlan
+    121\n   name Tenant_A_WEBZone_2\n!\nvlan 130\n   name Tenant_A_APP_Zone_1\n!\nvlan
+    131\n   name Tenant_A_APP_Zone_2\n!\nvrf instance MGMT\n!\ninterface Port-Channel1\n
+    \  description DC1_LEAF1_Po5\n   no shutdown\n   switchport\n   switchport trunk
+    allowed vlan 110-112,120-121,130-131\n   switchport mode trunk\n!\ninterface Ethernet1\n
+    \  description DC1-LEAF1A_Ethernet5\n   no shutdown\n   channel-group 1 mode active\n!\ninterface
+    Ethernet2\n   description DC1-LEAF1B_Ethernet5\n   no shutdown\n   channel-group
+    1 mode active\n!\ninterface Ethernet5\n   description server01_Eth0\n   no shutdown\n
+    \  switchport\n   switchport access vlan 110\n   switchport mode access\n!\ninterface
+    Management1\n   description oob_management\n   no shutdown\n   vrf MGMT\n   ip
+    address 10.255.0.17/24\n!\nip routing\nno ip routing vrf MGMT\n!\nip route vrf
+    MGMT 0.0.0.0/0 10.255.0.1\n!\nmanagement api http-commands\n   protocol https\n
+    \  no shutdown\n   !\n   vrf MGMT\n      no shutdown\n!\nend\n"
+  AVD_DC1-L2LEAF2A: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr
+    -cvaddr=10.255.0.1:9910 -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
+    -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
+    internal order ascending range 1006 1199\n!\ntransceiver qsfp default-mode 4x10G\n!\nservice
+    routing protocols model multi-agent\n!\nhostname DC1-L2LEAF2A\nip name-server
+    vrf MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.2.1\n!\nntp local-interface
+    vrf MGMT Management1\nntp server vrf MGMT 0.fr.pool.ntp.org prefer\nntp server
+    vrf MGMT 1.fr.pool.ntp.org\n!\nspanning-tree mode mstp\nspanning-tree mst 0 priority
+    16384\n!\nno aaa root\nno enable password\n!\nusername admin privilege 15 role
+    network-admin secret sha512 $6$Df86J4/SFMDE3/1K$Hef4KstdoxNDaami37cBquTWOTplC.miMPjXVgQxMe92.e5wxlnXOLlebgPj8Fz1KO0za/RCO7ZIs4Q6Eiq1g1\nusername
+    ansible privilege 15 role network-admin secret sha512 $6$Dzu11L7yp9j3nCM9$FSptxMPyIL555OMO.ldnjDXgwZmrfMYwHSr0uznE5Qoqvd9a6UdjiFcJUhGLtvXVZR1r.A/iF5aAt50hf/EK4/\nusername
+    cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\nvlan
+    110\n   name Tenant_A_OP_Zone_1\n!\nvlan 111\n   name Tenant_A_OP_Zone_2\n!\nvlan
+    112\n   name Tenant_A_OP_Zone_3\n!\nvlan 120\n   name Tenant_A_WEB_Zone_1\n!\nvlan
+    121\n   name Tenant_A_WEBZone_2\n!\nvlan 130\n   name Tenant_A_APP_Zone_1\n!\nvlan
+    131\n   name Tenant_A_APP_Zone_2\n!\nvrf instance MGMT\n!\ninterface Port-Channel1\n
+    \  description DC1_LEAF2_Po5\n   no shutdown\n   switchport\n   switchport trunk
+    allowed vlan 110-112,120-121,130-131\n   switchport mode trunk\n!\ninterface Ethernet1\n
+    \  description DC1-LEAF2A_Ethernet5\n   no shutdown\n   channel-group 1 mode active\n!\ninterface
+    Ethernet2\n   description DC1-LEAF2B_Ethernet5\n   no shutdown\n   channel-group
+    1 mode active\n!\ninterface Ethernet5\n   description server02_Eth0\n   no shutdown\n
+    \  switchport\n   switchport access vlan 110\n   switchport mode access\n!\ninterface
+    Management1\n   description oob_management\n   no shutdown\n   vrf MGMT\n   ip
+    address 10.255.0.18/24\n!\nip routing\nno ip routing vrf MGMT\n!\nip route vrf
+    MGMT 0.0.0.0/0 10.255.0.1\n!\nmanagement api http-commands\n   protocol https\n
+    \  no shutdown\n   !\n   vrf MGMT\n      no shutdown\n!\nend\n"
+  AVD_DC1-LEAF1A: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr
+    -cvaddr=10.255.0.1:9910 -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
+    -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
+    internal order ascending range 1006 1199\n!\ntransceiver qsfp default-mode 4x10G\n!\nservice
+    routing protocols model multi-agent\n!\nhostname DC1-LEAF1A\nip name-server vrf
+    MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.2.1\n!\nntp local-interface vrf
+    MGMT Management1\nntp server vrf MGMT 0.fr.pool.ntp.org prefer\nntp server vrf
+    MGMT 1.fr.pool.ntp.org\n!\nspanning-tree mode mstp\nno spanning-tree vlan-id 4093-4094\nspanning-tree
+    mst 0 priority 16384\n!\nno aaa root\nno enable password\n!\nusername admin privilege
+    15 role network-admin secret sha512 $6$Df86J4/SFMDE3/1K$Hef4KstdoxNDaami37cBquTWOTplC.miMPjXVgQxMe92.e5wxlnXOLlebgPj8Fz1KO0za/RCO7ZIs4Q6Eiq1g1\nusername
+    ansible privilege 15 role network-admin secret sha512 $6$Dzu11L7yp9j3nCM9$FSptxMPyIL555OMO.ldnjDXgwZmrfMYwHSr0uznE5Qoqvd9a6UdjiFcJUhGLtvXVZR1r.A/iF5aAt50hf/EK4/\nusername
+    cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\nvlan
+    110\n   name Tenant_A_OP_Zone_1\n!\nvlan 111\n   name Tenant_A_OP_Zone_2\n!\nvlan
+    112\n   name Tenant_A_OP_Zone_3\n!\nvlan 120\n   name Tenant_A_WEB_Zone_1\n!\nvlan
+    121\n   name Tenant_A_WEBZone_2\n!\nvlan 130\n   name Tenant_A_APP_Zone_1\n!\nvlan
+    131\n   name Tenant_A_APP_Zone_2\n!\nvlan 140\n   name Tenant_A_DB_BZone_1\n!\nvlan
+    141\n   name Tenant_A_DB_Zone_2\n!\nvlan 150\n   name Tenant_A_WAN_Zone_1\n!\nvlan
+    160\n   name Tenant_A_VMOTION\n!\nvlan 161\n   name Tenant_A_NFS\n!\nvlan 210\n
+    \  name Tenant_B_OP_Zone_1\n!\nvlan 211\n   name Tenant_B_OP_Zone_2\n!\nvlan 250\n
+    \  name Tenant_B_WAN_Zone_1\n!\nvlan 310\n   name Tenant_C_OP_Zone_1\n!\nvlan
+    311\n   name Tenant_C_OP_Zone_2\n!\nvlan 350\n   name Tenant_C_WAN_Zone_1\n!\nvlan
+    3009\n   name MLAG_iBGP_Tenant_A_OP_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3010\n   name MLAG_iBGP_Tenant_A_WEB_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3011\n   name MLAG_iBGP_Tenant_A_APP_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3012\n   name MLAG_iBGP_Tenant_A_DB_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3013\n   name MLAG_iBGP_Tenant_A_WAN_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3019\n   name MLAG_iBGP_Tenant_B_OP_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3020\n   name MLAG_iBGP_Tenant_B_WAN_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3029\n   name MLAG_iBGP_Tenant_C_OP_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3030\n   name MLAG_iBGP_Tenant_C_WAN_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    4093\n   name LEAF_PEER_L3\n   trunk group LEAF_PEER_L3\n!\nvlan 4094\n   name
+    MLAG_PEER\n   trunk group MLAG\n!\nvrf instance MGMT\n!\nvrf instance Tenant_A_APP_Zone\n!\nvrf
+    instance Tenant_A_DB_Zone\n!\nvrf instance Tenant_A_OP_Zone\n!\nvrf instance Tenant_A_WAN_Zone\n!\nvrf
+    instance Tenant_A_WEB_Zone\n!\nvrf instance Tenant_B_OP_Zone\n!\nvrf instance
+    Tenant_B_WAN_Zone\n!\nvrf instance Tenant_C_OP_Zone\n!\nvrf instance Tenant_C_WAN_Zone\n!\ninterface
+    Port-Channel3\n   description MLAG_PEER_DC1-LEAF1B_Po3\n   no shutdown\n   switchport\n
+    \  switchport trunk allowed vlan 2-4094\n   switchport mode trunk\n   switchport
+    trunk group LEAF_PEER_L3\n   switchport trunk group MLAG\n!\ninterface Port-Channel5\n
+    \  description DC1-L2LEAF1A_Po1\n   no shutdown\n   switchport\n   switchport
+    trunk allowed vlan 110-112,120-121,130-131\n   switchport mode trunk\n   mlag
+    5\n!\ninterface Ethernet1\n   description P2P_LINK_TO_DC1-SPINE1_Ethernet1\n   no
+    shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.1/31\n!\ninterface
+    Ethernet2\n   description P2P_LINK_TO_DC1-SPINE2_Ethernet1\n   no shutdown\n   mtu
+    1500\n   no switchport\n   ip address 172.31.255.3/31\n!\ninterface Ethernet3\n
+    \  description MLAG_PEER_DC1-LEAF1B_Ethernet3\n   no shutdown\n   channel-group
+    3 mode active\n!\ninterface Ethernet4\n   description MLAG_PEER_DC1-LEAF1B_Ethernet4\n
+    \  no shutdown\n   channel-group 3 mode active\n!\ninterface Ethernet5\n   description
+    DC1-L2LEAF1A_Ethernet1\n   no shutdown\n   channel-group 5 mode active\n!\ninterface
+    Loopback0\n   description EVPN_Overlay_Peering\n   no shutdown\n   ip address
+    192.168.255.3/32\n!\ninterface Loopback1\n   description VTEP_VXLAN_Tunnel_Source\n
+    \  no shutdown\n   ip address 192.168.254.3/32\n!\ninterface Loopback100\n   description
+    Tenant_A_OP_Zone_VTEP_DIAGNOSTICS\n   no shutdown\n   vrf Tenant_A_OP_Zone\n   ip
+    address 10.255.1.3/32\n!\ninterface Management1\n   description oob_management\n
+    \  no shutdown\n   vrf MGMT\n   ip address 10.255.0.13/24\n!\ninterface Vlan110\n
+    \  description Tenant_A_OP_Zone_1\n   no shutdown\n   vrf Tenant_A_OP_Zone\n   ip
+    address virtual 10.1.10.1/24\n!\ninterface Vlan111\n   description Tenant_A_OP_Zone_2\n
+    \  no shutdown\n   vrf Tenant_A_OP_Zone\n   ip address virtual 10.1.11.1/24\n!\ninterface
+    Vlan112\n   description Tenant_A_OP_Zone_3\n   no shutdown\n   vrf Tenant_A_OP_Zone\n
+    \  ip address virtual 10.1.12.254/24\n!\ninterface Vlan120\n   description Tenant_A_WEB_Zone_1\n
+    \  no shutdown\n   vrf Tenant_A_WEB_Zone\n!\ninterface Vlan121\n   description
+    Tenant_A_WEBZone_2\n   no shutdown\n   vrf Tenant_A_WEB_Zone\n   ip address virtual
+    10.1.21.1/24\n!\ninterface Vlan130\n   description Tenant_A_APP_Zone_1\n   no
+    shutdown\n   vrf Tenant_A_APP_Zone\n!\ninterface Vlan131\n   description Tenant_A_APP_Zone_2\n
+    \  no shutdown\n   vrf Tenant_A_APP_Zone\n   ip address virtual 10.1.31.254/24\n!\ninterface
+    Vlan140\n   description Tenant_A_DB_BZone_1\n   no shutdown\n   vrf Tenant_A_DB_Zone\n
+    \  ip address virtual 10.1.40.1/24\n!\ninterface Vlan141\n   description Tenant_A_DB_Zone_2\n
+    \  no shutdown\n   vrf Tenant_A_DB_Zone\n   ip address virtual 10.1.41.1/24\n!\ninterface
+    Vlan150\n   description Tenant_A_WAN_Zone_1\n   no shutdown\n   vrf Tenant_A_WAN_Zone\n
+    \  ip address virtual 10.1.40.1/24\n!\ninterface Vlan210\n   description Tenant_B_OP_Zone_1\n
+    \  no shutdown\n   vrf Tenant_B_OP_Zone\n!\ninterface Vlan211\n   description
+    Tenant_B_OP_Zone_2\n   no shutdown\n   vrf Tenant_B_OP_Zone\n   ip address virtual
+    10.2.11.1/24\n!\ninterface Vlan250\n   description Tenant_B_WAN_Zone_1\n   no
+    shutdown\n   vrf Tenant_B_WAN_Zone\n   ip address virtual 10.2.50.1/24\n!\ninterface
+    Vlan310\n   description Tenant_C_OP_Zone_1\n   no shutdown\n   vrf Tenant_C_OP_Zone\n!\ninterface
+    Vlan311\n   description Tenant_C_OP_Zone_2\n   no shutdown\n   vrf Tenant_C_OP_Zone\n!\ninterface
+    Vlan350\n   description Tenant_C_WAN_Zone_1\n   no shutdown\n   vrf Tenant_C_WAN_Zone\n!\ninterface
+    Vlan3009\n   description MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_A_OP_Zone\n   ip address 10.255.251.0/31\n!\ninterface
+    Vlan3010\n   description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_A_WEB_Zone\n   ip address 10.255.251.0/31\n!\ninterface
+    Vlan3011\n   description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_A_APP_Zone\n   ip address 10.255.251.0/31\n!\ninterface
+    Vlan3012\n   description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_A_DB_Zone\n   ip address 10.255.251.0/31\n!\ninterface
+    Vlan3013\n   description MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_A_WAN_Zone\n   ip address 10.255.251.0/31\n!\ninterface
+    Vlan3019\n   description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_B_OP_Zone\n   ip address 10.255.251.0/31\n!\ninterface
+    Vlan3020\n   description MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_B_WAN_Zone\n   ip address 10.255.251.0/31\n!\ninterface
+    Vlan3029\n   description MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_C_OP_Zone\n   ip address 10.255.251.0/31\n!\ninterface
+    Vlan3030\n   description MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_C_WAN_Zone\n   ip address 10.255.251.0/31\n!\ninterface
+    Vlan4093\n   description MLAG_PEER_L3_PEERING\n   no shutdown\n   mtu 1500\n   ip
+    address 10.255.251.0/31\n!\ninterface Vlan4094\n   description MLAG_PEER\n   no
+    shutdown\n   mtu 1500\n   no autostate\n   ip address 10.255.252.0/31\n!\ninterface
+    Vxlan1\n   description DC1-LEAF1A_VTEP\n   vxlan source-interface Loopback1\n
+    \  vxlan virtual-router encapsulation mac-address mlag-system-id\n   vxlan udp-port
+    4789\n   vxlan vlan 110 vni 10110\n   vxlan vlan 111 vni 50111\n   vxlan vlan
+    112 vni 50112\n   vxlan vlan 120 vni 10120\n   vxlan vlan 121 vni 10121\n   vxlan
+    vlan 130 vni 10130\n   vxlan vlan 131 vni 10131\n   vxlan vlan 140 vni 10140\n
+    \  vxlan vlan 141 vni 10141\n   vxlan vlan 150 vni 10150\n   vxlan vlan 160 vni
+    55160\n   vxlan vlan 161 vni 10161\n   vxlan vlan 210 vni 20210\n   vxlan vlan
+    211 vni 20211\n   vxlan vlan 250 vni 20250\n   vxlan vlan 310 vni 30310\n   vxlan
+    vlan 311 vni 30311\n   vxlan vlan 350 vni 30350\n   vxlan vrf Tenant_A_APP_Zone
+    vni 12\n   vxlan vrf Tenant_A_DB_Zone vni 13\n   vxlan vrf Tenant_A_OP_Zone vni
+    10\n   vxlan vrf Tenant_A_WAN_Zone vni 14\n   vxlan vrf Tenant_A_WEB_Zone vni
+    11\n   vxlan vrf Tenant_B_OP_Zone vni 20\n   vxlan vrf Tenant_B_WAN_Zone vni 21\n
+    \  vxlan vrf Tenant_C_OP_Zone vni 30\n   vxlan vrf Tenant_C_WAN_Zone vni 31\n!\nip
+    virtual-router mac-address 00:1c:73:00:dc:01\n!\nip address virtual source-nat
+    vrf Tenant_A_OP_Zone address 10.255.1.3\n!\nip routing\nno ip routing vrf MGMT\nip
+    routing vrf Tenant_A_APP_Zone\nip routing vrf Tenant_A_DB_Zone\nip routing vrf
+    Tenant_A_OP_Zone\nip routing vrf Tenant_A_WAN_Zone\nip routing vrf Tenant_A_WEB_Zone\nip
+    routing vrf Tenant_B_OP_Zone\nip routing vrf Tenant_B_WAN_Zone\nip routing vrf
+    Tenant_C_OP_Zone\nip routing vrf Tenant_C_WAN_Zone\n!\nip prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n
+    \  seq 10 permit 192.168.255.0/24 eq 32\n   seq 20 permit 192.168.254.0/24 eq
+    32\n!\nmlag configuration\n   domain-id DC1_LEAF1\n   local-interface Vlan4094\n
+    \  peer-address 10.255.252.1\n   peer-link Port-Channel3\n   reload-delay mlag
+    300\n   reload-delay non-mlag 330\n!\nip route vrf MGMT 0.0.0.0/0 10.255.0.1\n!\nroute-map
+    RM-CONN-2-BGP permit 10\n   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n!\nroute-map
+    RM-MLAG-PEER-IN permit 10\n   description Make routes learned over MLAG Peer-link
+    less preferred on spines to ensure optimal routing\n   set origin incomplete\n!\nrouter
+    bfd\n   multihop interval 1200 min-rx 1200 multiplier 3\n!\nrouter bgp 65101\n
+    \  router-id 192.168.255.3\n   no bgp default ipv4-unicast\n   distance bgp 20
+    200 200\n   graceful-restart restart-time 300\n   graceful-restart\n   maximum-paths
+    4 ecmp 4\n   neighbor EVPN-OVERLAY-PEERS peer group\n   neighbor EVPN-OVERLAY-PEERS
+    update-source Loopback0\n   neighbor EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS
+    ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n
+    \  neighbor EVPN-OVERLAY-PEERS send-community\n   neighbor EVPN-OVERLAY-PEERS
+    maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS peer group\n   neighbor IPv4-UNDERLAY-PEERS
+    password 7 AQQvKeimxJu+uGQ/yYvv9w==\n   neighbor IPv4-UNDERLAY-PEERS send-community\n
+    \  neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000\n   neighbor MLAG-IPv4-UNDERLAY-PEER
+    peer group\n   neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65101\n   neighbor MLAG-IPv4-UNDERLAY-PEER
+    next-hop-self\n   neighbor MLAG-IPv4-UNDERLAY-PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==\n
+    \  neighbor MLAG-IPv4-UNDERLAY-PEER send-community\n   neighbor MLAG-IPv4-UNDERLAY-PEER
+    maximum-routes 12000\n   neighbor MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN
+    in\n   neighbor 10.255.251.1 peer group MLAG-IPv4-UNDERLAY-PEER\n   neighbor 10.255.251.1
+    description DC1-LEAF1B\n   neighbor 172.31.255.0 peer group IPv4-UNDERLAY-PEERS\n
+    \  neighbor 172.31.255.0 remote-as 65001\n   neighbor 172.31.255.0 description
+    DC1-SPINE1_Ethernet1\n   neighbor 172.31.255.2 peer group IPv4-UNDERLAY-PEERS\n
+    \  neighbor 172.31.255.2 remote-as 65001\n   neighbor 172.31.255.2 description
+    DC1-SPINE2_Ethernet1\n   neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS\n
+    \  neighbor 192.168.255.1 remote-as 65001\n   neighbor 192.168.255.1 description
+    DC1-SPINE1\n   neighbor 192.168.255.2 peer group EVPN-OVERLAY-PEERS\n   neighbor
+    192.168.255.2 remote-as 65001\n   neighbor 192.168.255.2 description DC1-SPINE2\n
+    \  redistribute connected route-map RM-CONN-2-BGP\n   !\n   vlan-aware-bundle
+    Tenant_A_APP_Zone\n      rd 192.168.255.3:12\n      route-target both 12:12\n
+    \     redistribute learned\n      vlan 130-131\n   !\n   vlan-aware-bundle Tenant_A_DB_Zone\n
+    \     rd 192.168.255.3:13\n      route-target both 13:13\n      redistribute learned\n
+    \     vlan 140-141\n   !\n   vlan-aware-bundle Tenant_A_NFS\n      rd 192.168.255.3:10161\n
+    \     route-target both 10161:10161\n      redistribute learned\n      vlan 161\n
+    \  !\n   vlan-aware-bundle Tenant_A_OP_Zone\n      rd 192.168.255.3:10\n      route-target
+    both 10:10\n      redistribute learned\n      vlan 110-112\n   !\n   vlan-aware-bundle
+    Tenant_A_VMOTION\n      rd 192.168.255.3:55160\n      route-target both 55160:55160\n
+    \     redistribute learned\n      vlan 160\n   !\n   vlan-aware-bundle Tenant_A_WAN_Zone\n
+    \     rd 192.168.255.3:14\n      route-target both 14:14\n      redistribute learned\n
+    \     vlan 150\n   !\n   vlan-aware-bundle Tenant_A_WEB_Zone\n      rd 192.168.255.3:11\n
+    \     route-target both 11:11\n      redistribute learned\n      vlan 120-121\n
+    \  !\n   vlan-aware-bundle Tenant_B_OP_Zone\n      rd 192.168.255.3:20\n      route-target
+    both 20:20\n      redistribute learned\n      vlan 210-211\n   !\n   vlan-aware-bundle
+    Tenant_B_WAN_Zone\n      rd 192.168.255.3:21\n      route-target both 21:21\n
+    \     redistribute learned\n      vlan 250\n   !\n   vlan-aware-bundle Tenant_C_OP_Zone\n
+    \     rd 192.168.255.3:30\n      route-target both 30:30\n      redistribute learned\n
+    \     vlan 310-311\n   !\n   vlan-aware-bundle Tenant_C_WAN_Zone\n      rd 192.168.255.3:31\n
+    \     route-target both 31:31\n      redistribute learned\n      vlan 350\n   !\n
+    \  address-family evpn\n      neighbor EVPN-OVERLAY-PEERS activate\n   !\n   address-family
+    ipv4\n      no neighbor EVPN-OVERLAY-PEERS activate\n      neighbor IPv4-UNDERLAY-PEERS
+    activate\n      neighbor MLAG-IPv4-UNDERLAY-PEER activate\n   !\n   vrf Tenant_A_APP_Zone\n
+    \     rd 192.168.255.3:12\n      route-target import evpn 12:12\n      route-target
+    export evpn 12:12\n      router-id 192.168.255.3\n      neighbor 10.255.251.1
+    peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute connected\n   !\n   vrf
+    Tenant_A_DB_Zone\n      rd 192.168.255.3:13\n      route-target import evpn 13:13\n
+    \     route-target export evpn 13:13\n      router-id 192.168.255.3\n      neighbor
+    10.255.251.1 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute connected\n
+    \  !\n   vrf Tenant_A_OP_Zone\n      rd 192.168.255.3:10\n      route-target import
+    evpn 10:10\n      route-target export evpn 10:10\n      router-id 192.168.255.3\n
+    \     neighbor 10.255.251.1 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n   !\n   vrf Tenant_A_WAN_Zone\n      rd 192.168.255.3:14\n      route-target
+    import evpn 14:14\n      route-target export evpn 14:14\n      router-id 192.168.255.3\n
+    \     neighbor 10.255.251.1 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n   !\n   vrf Tenant_A_WEB_Zone\n      rd 192.168.255.3:11\n      route-target
+    import evpn 11:11\n      route-target export evpn 11:11\n      router-id 192.168.255.3\n
+    \     neighbor 10.255.251.1 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n   !\n   vrf Tenant_B_OP_Zone\n      rd 192.168.255.3:20\n      route-target
+    import evpn 20:20\n      route-target export evpn 20:20\n      router-id 192.168.255.3\n
+    \     neighbor 10.255.251.1 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n   !\n   vrf Tenant_B_WAN_Zone\n      rd 192.168.255.3:21\n      route-target
+    import evpn 21:21\n      route-target export evpn 21:21\n      router-id 192.168.255.3\n
+    \     neighbor 10.255.251.1 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n   !\n   vrf Tenant_C_OP_Zone\n      rd 192.168.255.3:30\n      route-target
+    import evpn 30:30\n      route-target export evpn 30:30\n      router-id 192.168.255.3\n
+    \     neighbor 10.255.251.1 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n   !\n   vrf Tenant_C_WAN_Zone\n      rd 192.168.255.3:31\n      route-target
+    import evpn 31:31\n      route-target export evpn 31:31\n      router-id 192.168.255.3\n
+    \     neighbor 10.255.251.1 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n!\nmanagement api http-commands\n   protocol https\n   no shutdown\n
+    \  !\n   vrf MGMT\n      no shutdown\n!\nend\n"
+  AVD_DC1-LEAF1B: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr
+    -cvaddr=10.255.0.1:9910 -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
+    -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
+    internal order ascending range 1006 1199\n!\ntransceiver qsfp default-mode 4x10G\n!\nservice
+    routing protocols model multi-agent\n!\nhostname DC1-LEAF1B\nip name-server vrf
+    MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.2.1\n!\nntp local-interface vrf
+    MGMT Management1\nntp server vrf MGMT 0.fr.pool.ntp.org prefer\nntp server vrf
+    MGMT 1.fr.pool.ntp.org\n!\nspanning-tree mode mstp\nno spanning-tree vlan-id 4093-4094\nspanning-tree
+    mst 0 priority 16384\n!\nno aaa root\nno enable password\n!\nusername admin privilege
+    15 role network-admin secret sha512 $6$Df86J4/SFMDE3/1K$Hef4KstdoxNDaami37cBquTWOTplC.miMPjXVgQxMe92.e5wxlnXOLlebgPj8Fz1KO0za/RCO7ZIs4Q6Eiq1g1\nusername
+    ansible privilege 15 role network-admin secret sha512 $6$Dzu11L7yp9j3nCM9$FSptxMPyIL555OMO.ldnjDXgwZmrfMYwHSr0uznE5Qoqvd9a6UdjiFcJUhGLtvXVZR1r.A/iF5aAt50hf/EK4/\nusername
+    cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\nvlan
+    110\n   name Tenant_A_OP_Zone_1\n!\nvlan 111\n   name Tenant_A_OP_Zone_2\n!\nvlan
+    112\n   name Tenant_A_OP_Zone_3\n!\nvlan 120\n   name Tenant_A_WEB_Zone_1\n!\nvlan
+    121\n   name Tenant_A_WEBZone_2\n!\nvlan 130\n   name Tenant_A_APP_Zone_1\n!\nvlan
+    131\n   name Tenant_A_APP_Zone_2\n!\nvlan 140\n   name Tenant_A_DB_BZone_1\n!\nvlan
+    141\n   name Tenant_A_DB_Zone_2\n!\nvlan 150\n   name Tenant_A_WAN_Zone_1\n!\nvlan
+    160\n   name Tenant_A_VMOTION\n!\nvlan 161\n   name Tenant_A_NFS\n!\nvlan 210\n
+    \  name Tenant_B_OP_Zone_1\n!\nvlan 211\n   name Tenant_B_OP_Zone_2\n!\nvlan 250\n
+    \  name Tenant_B_WAN_Zone_1\n!\nvlan 310\n   name Tenant_C_OP_Zone_1\n!\nvlan
+    311\n   name Tenant_C_OP_Zone_2\n!\nvlan 350\n   name Tenant_C_WAN_Zone_1\n!\nvlan
+    3009\n   name MLAG_iBGP_Tenant_A_OP_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3010\n   name MLAG_iBGP_Tenant_A_WEB_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3011\n   name MLAG_iBGP_Tenant_A_APP_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3012\n   name MLAG_iBGP_Tenant_A_DB_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3013\n   name MLAG_iBGP_Tenant_A_WAN_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3019\n   name MLAG_iBGP_Tenant_B_OP_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3020\n   name MLAG_iBGP_Tenant_B_WAN_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3029\n   name MLAG_iBGP_Tenant_C_OP_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3030\n   name MLAG_iBGP_Tenant_C_WAN_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    4093\n   name LEAF_PEER_L3\n   trunk group LEAF_PEER_L3\n!\nvlan 4094\n   name
+    MLAG_PEER\n   trunk group MLAG\n!\nvrf instance MGMT\n!\nvrf instance Tenant_A_APP_Zone\n!\nvrf
+    instance Tenant_A_DB_Zone\n!\nvrf instance Tenant_A_OP_Zone\n!\nvrf instance Tenant_A_WAN_Zone\n!\nvrf
+    instance Tenant_A_WEB_Zone\n!\nvrf instance Tenant_B_OP_Zone\n!\nvrf instance
+    Tenant_B_WAN_Zone\n!\nvrf instance Tenant_C_OP_Zone\n!\nvrf instance Tenant_C_WAN_Zone\n!\ninterface
+    Port-Channel3\n   description MLAG_PEER_DC1-LEAF1A_Po3\n   no shutdown\n   switchport\n
+    \  switchport trunk allowed vlan 2-4094\n   switchport mode trunk\n   switchport
+    trunk group LEAF_PEER_L3\n   switchport trunk group MLAG\n!\ninterface Port-Channel5\n
+    \  description DC1-L2LEAF1A_Po1\n   no shutdown\n   switchport\n   switchport
+    trunk allowed vlan 110-112,120-121,130-131\n   switchport mode trunk\n   mlag
+    5\n!\ninterface Ethernet1\n   description P2P_LINK_TO_DC1-SPINE1_Ethernet2\n   no
+    shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.5/31\n!\ninterface
+    Ethernet2\n   description P2P_LINK_TO_DC1-SPINE2_Ethernet2\n   no shutdown\n   mtu
+    1500\n   no switchport\n   ip address 172.31.255.7/31\n!\ninterface Ethernet3\n
+    \  description MLAG_PEER_DC1-LEAF1A_Ethernet3\n   no shutdown\n   channel-group
+    3 mode active\n!\ninterface Ethernet4\n   description MLAG_PEER_DC1-LEAF1A_Ethernet4\n
+    \  no shutdown\n   channel-group 3 mode active\n!\ninterface Ethernet5\n   description
+    DC1-L2LEAF1A_Ethernet2\n   no shutdown\n   channel-group 5 mode active\n!\ninterface
+    Loopback0\n   description EVPN_Overlay_Peering\n   no shutdown\n   ip address
+    192.168.255.4/32\n!\ninterface Loopback1\n   description VTEP_VXLAN_Tunnel_Source\n
+    \  no shutdown\n   ip address 192.168.254.3/32\n!\ninterface Loopback100\n   description
+    Tenant_A_OP_Zone_VTEP_DIAGNOSTICS\n   no shutdown\n   vrf Tenant_A_OP_Zone\n   ip
+    address 10.255.1.4/32\n!\ninterface Management1\n   description oob_management\n
+    \  no shutdown\n   vrf MGMT\n   ip address 10.255.0.14/24\n!\ninterface Vlan110\n
+    \  description Tenant_A_OP_Zone_1\n   no shutdown\n   vrf Tenant_A_OP_Zone\n   ip
+    address virtual 10.1.10.1/24\n!\ninterface Vlan111\n   description Tenant_A_OP_Zone_2\n
+    \  no shutdown\n   vrf Tenant_A_OP_Zone\n   ip address virtual 10.1.11.1/24\n!\ninterface
+    Vlan112\n   description Tenant_A_OP_Zone_3\n   no shutdown\n   vrf Tenant_A_OP_Zone\n
+    \  ip address virtual 10.1.12.254/24\n!\ninterface Vlan120\n   description Tenant_A_WEB_Zone_1\n
+    \  no shutdown\n   vrf Tenant_A_WEB_Zone\n!\ninterface Vlan121\n   description
+    Tenant_A_WEBZone_2\n   no shutdown\n   vrf Tenant_A_WEB_Zone\n   ip address virtual
+    10.1.21.1/24\n!\ninterface Vlan130\n   description Tenant_A_APP_Zone_1\n   no
+    shutdown\n   vrf Tenant_A_APP_Zone\n!\ninterface Vlan131\n   description Tenant_A_APP_Zone_2\n
+    \  no shutdown\n   vrf Tenant_A_APP_Zone\n   ip address virtual 10.1.31.254/24\n!\ninterface
+    Vlan140\n   description Tenant_A_DB_BZone_1\n   no shutdown\n   vrf Tenant_A_DB_Zone\n
+    \  ip address virtual 10.1.40.1/24\n!\ninterface Vlan141\n   description Tenant_A_DB_Zone_2\n
+    \  no shutdown\n   vrf Tenant_A_DB_Zone\n   ip address virtual 10.1.41.1/24\n!\ninterface
+    Vlan150\n   description Tenant_A_WAN_Zone_1\n   no shutdown\n   vrf Tenant_A_WAN_Zone\n
+    \  ip address virtual 10.1.40.1/24\n!\ninterface Vlan210\n   description Tenant_B_OP_Zone_1\n
+    \  no shutdown\n   vrf Tenant_B_OP_Zone\n!\ninterface Vlan211\n   description
+    Tenant_B_OP_Zone_2\n   no shutdown\n   vrf Tenant_B_OP_Zone\n   ip address virtual
+    10.2.11.1/24\n!\ninterface Vlan250\n   description Tenant_B_WAN_Zone_1\n   no
+    shutdown\n   vrf Tenant_B_WAN_Zone\n   ip address virtual 10.2.50.1/24\n!\ninterface
+    Vlan310\n   description Tenant_C_OP_Zone_1\n   no shutdown\n   vrf Tenant_C_OP_Zone\n!\ninterface
+    Vlan311\n   description Tenant_C_OP_Zone_2\n   no shutdown\n   vrf Tenant_C_OP_Zone\n!\ninterface
+    Vlan350\n   description Tenant_C_WAN_Zone_1\n   no shutdown\n   vrf Tenant_C_WAN_Zone\n!\ninterface
+    Vlan3009\n   description MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_A_OP_Zone\n   ip address 10.255.251.1/31\n!\ninterface
+    Vlan3010\n   description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_A_WEB_Zone\n   ip address 10.255.251.1/31\n!\ninterface
+    Vlan3011\n   description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_A_APP_Zone\n   ip address 10.255.251.1/31\n!\ninterface
+    Vlan3012\n   description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_A_DB_Zone\n   ip address 10.255.251.1/31\n!\ninterface
+    Vlan3013\n   description MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_A_WAN_Zone\n   ip address 10.255.251.1/31\n!\ninterface
+    Vlan3019\n   description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_B_OP_Zone\n   ip address 10.255.251.1/31\n!\ninterface
+    Vlan3020\n   description MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_B_WAN_Zone\n   ip address 10.255.251.1/31\n!\ninterface
+    Vlan3029\n   description MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_C_OP_Zone\n   ip address 10.255.251.1/31\n!\ninterface
+    Vlan3030\n   description MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_C_WAN_Zone\n   ip address 10.255.251.1/31\n!\ninterface
+    Vlan4093\n   description MLAG_PEER_L3_PEERING\n   no shutdown\n   mtu 1500\n   ip
+    address 10.255.251.1/31\n!\ninterface Vlan4094\n   description MLAG_PEER\n   no
+    shutdown\n   mtu 1500\n   no autostate\n   ip address 10.255.252.1/31\n!\ninterface
+    Vxlan1\n   description DC1-LEAF1B_VTEP\n   vxlan source-interface Loopback1\n
+    \  vxlan virtual-router encapsulation mac-address mlag-system-id\n   vxlan udp-port
+    4789\n   vxlan vlan 110 vni 10110\n   vxlan vlan 111 vni 50111\n   vxlan vlan
+    112 vni 50112\n   vxlan vlan 120 vni 10120\n   vxlan vlan 121 vni 10121\n   vxlan
+    vlan 130 vni 10130\n   vxlan vlan 131 vni 10131\n   vxlan vlan 140 vni 10140\n
+    \  vxlan vlan 141 vni 10141\n   vxlan vlan 150 vni 10150\n   vxlan vlan 160 vni
+    55160\n   vxlan vlan 161 vni 10161\n   vxlan vlan 210 vni 20210\n   vxlan vlan
+    211 vni 20211\n   vxlan vlan 250 vni 20250\n   vxlan vlan 310 vni 30310\n   vxlan
+    vlan 311 vni 30311\n   vxlan vlan 350 vni 30350\n   vxlan vrf Tenant_A_APP_Zone
+    vni 12\n   vxlan vrf Tenant_A_DB_Zone vni 13\n   vxlan vrf Tenant_A_OP_Zone vni
+    10\n   vxlan vrf Tenant_A_WAN_Zone vni 14\n   vxlan vrf Tenant_A_WEB_Zone vni
+    11\n   vxlan vrf Tenant_B_OP_Zone vni 20\n   vxlan vrf Tenant_B_WAN_Zone vni 21\n
+    \  vxlan vrf Tenant_C_OP_Zone vni 30\n   vxlan vrf Tenant_C_WAN_Zone vni 31\n!\nip
+    virtual-router mac-address 00:1c:73:00:dc:01\n!\nip address virtual source-nat
+    vrf Tenant_A_OP_Zone address 10.255.1.4\n!\nip routing\nno ip routing vrf MGMT\nip
+    routing vrf Tenant_A_APP_Zone\nip routing vrf Tenant_A_DB_Zone\nip routing vrf
+    Tenant_A_OP_Zone\nip routing vrf Tenant_A_WAN_Zone\nip routing vrf Tenant_A_WEB_Zone\nip
+    routing vrf Tenant_B_OP_Zone\nip routing vrf Tenant_B_WAN_Zone\nip routing vrf
+    Tenant_C_OP_Zone\nip routing vrf Tenant_C_WAN_Zone\n!\nip prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n
+    \  seq 10 permit 192.168.255.0/24 eq 32\n   seq 20 permit 192.168.254.0/24 eq
+    32\n!\nmlag configuration\n   domain-id DC1_LEAF1\n   local-interface Vlan4094\n
+    \  peer-address 10.255.252.0\n   peer-link Port-Channel3\n   reload-delay mlag
+    300\n   reload-delay non-mlag 330\n!\nip route vrf MGMT 0.0.0.0/0 10.255.0.1\n!\nroute-map
+    RM-CONN-2-BGP permit 10\n   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n!\nroute-map
+    RM-MLAG-PEER-IN permit 10\n   description Make routes learned over MLAG Peer-link
+    less preferred on spines to ensure optimal routing\n   set origin incomplete\n!\nrouter
+    bfd\n   multihop interval 1200 min-rx 1200 multiplier 3\n!\nrouter bgp 65101\n
+    \  router-id 192.168.255.4\n   no bgp default ipv4-unicast\n   distance bgp 20
+    200 200\n   graceful-restart restart-time 300\n   graceful-restart\n   maximum-paths
+    4 ecmp 4\n   neighbor EVPN-OVERLAY-PEERS peer group\n   neighbor EVPN-OVERLAY-PEERS
+    update-source Loopback0\n   neighbor EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS
+    ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n
+    \  neighbor EVPN-OVERLAY-PEERS send-community\n   neighbor EVPN-OVERLAY-PEERS
+    maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS peer group\n   neighbor IPv4-UNDERLAY-PEERS
+    password 7 AQQvKeimxJu+uGQ/yYvv9w==\n   neighbor IPv4-UNDERLAY-PEERS send-community\n
+    \  neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000\n   neighbor MLAG-IPv4-UNDERLAY-PEER
+    peer group\n   neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65101\n   neighbor MLAG-IPv4-UNDERLAY-PEER
+    next-hop-self\n   neighbor MLAG-IPv4-UNDERLAY-PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==\n
+    \  neighbor MLAG-IPv4-UNDERLAY-PEER send-community\n   neighbor MLAG-IPv4-UNDERLAY-PEER
+    maximum-routes 12000\n   neighbor MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN
+    in\n   neighbor 10.255.251.0 peer group MLAG-IPv4-UNDERLAY-PEER\n   neighbor 10.255.251.0
+    description DC1-LEAF1A\n   neighbor 172.31.255.4 peer group IPv4-UNDERLAY-PEERS\n
+    \  neighbor 172.31.255.4 remote-as 65001\n   neighbor 172.31.255.4 description
+    DC1-SPINE1_Ethernet2\n   neighbor 172.31.255.6 peer group IPv4-UNDERLAY-PEERS\n
+    \  neighbor 172.31.255.6 remote-as 65001\n   neighbor 172.31.255.6 description
+    DC1-SPINE2_Ethernet2\n   neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS\n
+    \  neighbor 192.168.255.1 remote-as 65001\n   neighbor 192.168.255.1 description
+    DC1-SPINE1\n   neighbor 192.168.255.2 peer group EVPN-OVERLAY-PEERS\n   neighbor
+    192.168.255.2 remote-as 65001\n   neighbor 192.168.255.2 description DC1-SPINE2\n
+    \  redistribute connected route-map RM-CONN-2-BGP\n   !\n   vlan-aware-bundle
+    Tenant_A_APP_Zone\n      rd 192.168.255.4:12\n      route-target both 12:12\n
+    \     redistribute learned\n      vlan 130-131\n   !\n   vlan-aware-bundle Tenant_A_DB_Zone\n
+    \     rd 192.168.255.4:13\n      route-target both 13:13\n      redistribute learned\n
+    \     vlan 140-141\n   !\n   vlan-aware-bundle Tenant_A_NFS\n      rd 192.168.255.4:10161\n
+    \     route-target both 10161:10161\n      redistribute learned\n      vlan 161\n
+    \  !\n   vlan-aware-bundle Tenant_A_OP_Zone\n      rd 192.168.255.4:10\n      route-target
+    both 10:10\n      redistribute learned\n      vlan 110-112\n   !\n   vlan-aware-bundle
+    Tenant_A_VMOTION\n      rd 192.168.255.4:55160\n      route-target both 55160:55160\n
+    \     redistribute learned\n      vlan 160\n   !\n   vlan-aware-bundle Tenant_A_WAN_Zone\n
+    \     rd 192.168.255.4:14\n      route-target both 14:14\n      redistribute learned\n
+    \     vlan 150\n   !\n   vlan-aware-bundle Tenant_A_WEB_Zone\n      rd 192.168.255.4:11\n
+    \     route-target both 11:11\n      redistribute learned\n      vlan 120-121\n
+    \  !\n   vlan-aware-bundle Tenant_B_OP_Zone\n      rd 192.168.255.4:20\n      route-target
+    both 20:20\n      redistribute learned\n      vlan 210-211\n   !\n   vlan-aware-bundle
+    Tenant_B_WAN_Zone\n      rd 192.168.255.4:21\n      route-target both 21:21\n
+    \     redistribute learned\n      vlan 250\n   !\n   vlan-aware-bundle Tenant_C_OP_Zone\n
+    \     rd 192.168.255.4:30\n      route-target both 30:30\n      redistribute learned\n
+    \     vlan 310-311\n   !\n   vlan-aware-bundle Tenant_C_WAN_Zone\n      rd 192.168.255.4:31\n
+    \     route-target both 31:31\n      redistribute learned\n      vlan 350\n   !\n
+    \  address-family evpn\n      neighbor EVPN-OVERLAY-PEERS activate\n   !\n   address-family
+    ipv4\n      no neighbor EVPN-OVERLAY-PEERS activate\n      neighbor IPv4-UNDERLAY-PEERS
+    activate\n      neighbor MLAG-IPv4-UNDERLAY-PEER activate\n   !\n   vrf Tenant_A_APP_Zone\n
+    \     rd 192.168.255.4:12\n      route-target import evpn 12:12\n      route-target
+    export evpn 12:12\n      router-id 192.168.255.4\n      neighbor 10.255.251.0
+    peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute connected\n   !\n   vrf
+    Tenant_A_DB_Zone\n      rd 192.168.255.4:13\n      route-target import evpn 13:13\n
+    \     route-target export evpn 13:13\n      router-id 192.168.255.4\n      neighbor
+    10.255.251.0 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute connected\n
+    \  !\n   vrf Tenant_A_OP_Zone\n      rd 192.168.255.4:10\n      route-target import
+    evpn 10:10\n      route-target export evpn 10:10\n      router-id 192.168.255.4\n
+    \     neighbor 10.255.251.0 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n   !\n   vrf Tenant_A_WAN_Zone\n      rd 192.168.255.4:14\n      route-target
+    import evpn 14:14\n      route-target export evpn 14:14\n      router-id 192.168.255.4\n
+    \     neighbor 10.255.251.0 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n   !\n   vrf Tenant_A_WEB_Zone\n      rd 192.168.255.4:11\n      route-target
+    import evpn 11:11\n      route-target export evpn 11:11\n      router-id 192.168.255.4\n
+    \     neighbor 10.255.251.0 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n   !\n   vrf Tenant_B_OP_Zone\n      rd 192.168.255.4:20\n      route-target
+    import evpn 20:20\n      route-target export evpn 20:20\n      router-id 192.168.255.4\n
+    \     neighbor 10.255.251.0 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n   !\n   vrf Tenant_B_WAN_Zone\n      rd 192.168.255.4:21\n      route-target
+    import evpn 21:21\n      route-target export evpn 21:21\n      router-id 192.168.255.4\n
+    \     neighbor 10.255.251.0 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n   !\n   vrf Tenant_C_OP_Zone\n      rd 192.168.255.4:30\n      route-target
+    import evpn 30:30\n      route-target export evpn 30:30\n      router-id 192.168.255.4\n
+    \     neighbor 10.255.251.0 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n   !\n   vrf Tenant_C_WAN_Zone\n      rd 192.168.255.4:31\n      route-target
+    import evpn 31:31\n      route-target export evpn 31:31\n      router-id 192.168.255.4\n
+    \     neighbor 10.255.251.0 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n!\nmanagement api http-commands\n   protocol https\n   no shutdown\n
+    \  !\n   vrf MGMT\n      no shutdown\n!\nend\n"
+  AVD_DC1-LEAF2A: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr
+    -cvaddr=10.255.0.1:9910 -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
+    -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
+    internal order ascending range 1006 1199\n!\ntransceiver qsfp default-mode 4x10G\n!\nservice
+    routing protocols model multi-agent\n!\nhostname DC1-LEAF2A\nip name-server vrf
+    MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.2.1\n!\nntp local-interface vrf
+    MGMT Management1\nntp server vrf MGMT 0.fr.pool.ntp.org prefer\nntp server vrf
+    MGMT 1.fr.pool.ntp.org\n!\nspanning-tree mode mstp\nno spanning-tree vlan-id 4093-4094\nspanning-tree
+    mst 0 priority 16384\n!\nno aaa root\nno enable password\n!\nusername admin privilege
+    15 role network-admin secret sha512 $6$Df86J4/SFMDE3/1K$Hef4KstdoxNDaami37cBquTWOTplC.miMPjXVgQxMe92.e5wxlnXOLlebgPj8Fz1KO0za/RCO7ZIs4Q6Eiq1g1\nusername
+    ansible privilege 15 role network-admin secret sha512 $6$Dzu11L7yp9j3nCM9$FSptxMPyIL555OMO.ldnjDXgwZmrfMYwHSr0uznE5Qoqvd9a6UdjiFcJUhGLtvXVZR1r.A/iF5aAt50hf/EK4/\nusername
+    cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\nvlan
+    110\n   name Tenant_A_OP_Zone_1\n!\nvlan 111\n   name Tenant_A_OP_Zone_2\n!\nvlan
+    112\n   name Tenant_A_OP_Zone_3\n!\nvlan 120\n   name Tenant_A_WEB_Zone_1\n!\nvlan
+    121\n   name Tenant_A_WEBZone_2\n!\nvlan 130\n   name Tenant_A_APP_Zone_1\n!\nvlan
+    131\n   name Tenant_A_APP_Zone_2\n!\nvlan 140\n   name Tenant_A_DB_BZone_1\n!\nvlan
+    141\n   name Tenant_A_DB_Zone_2\n!\nvlan 150\n   name Tenant_A_WAN_Zone_1\n!\nvlan
+    160\n   name Tenant_A_VMOTION\n!\nvlan 161\n   name Tenant_A_NFS\n!\nvlan 210\n
+    \  name Tenant_B_OP_Zone_1\n!\nvlan 211\n   name Tenant_B_OP_Zone_2\n!\nvlan 250\n
+    \  name Tenant_B_WAN_Zone_1\n!\nvlan 310\n   name Tenant_C_OP_Zone_1\n!\nvlan
+    311\n   name Tenant_C_OP_Zone_2\n!\nvlan 350\n   name Tenant_C_WAN_Zone_1\n!\nvlan
+    3009\n   name MLAG_iBGP_Tenant_A_OP_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3010\n   name MLAG_iBGP_Tenant_A_WEB_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3011\n   name MLAG_iBGP_Tenant_A_APP_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3012\n   name MLAG_iBGP_Tenant_A_DB_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3013\n   name MLAG_iBGP_Tenant_A_WAN_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3019\n   name MLAG_iBGP_Tenant_B_OP_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3020\n   name MLAG_iBGP_Tenant_B_WAN_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3029\n   name MLAG_iBGP_Tenant_C_OP_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3030\n   name MLAG_iBGP_Tenant_C_WAN_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    4093\n   name LEAF_PEER_L3\n   trunk group LEAF_PEER_L3\n!\nvlan 4094\n   name
+    MLAG_PEER\n   trunk group MLAG\n!\nvrf instance MGMT\n!\nvrf instance Tenant_A_APP_Zone\n!\nvrf
+    instance Tenant_A_DB_Zone\n!\nvrf instance Tenant_A_OP_Zone\n!\nvrf instance Tenant_A_WAN_Zone\n!\nvrf
+    instance Tenant_A_WEB_Zone\n!\nvrf instance Tenant_B_OP_Zone\n!\nvrf instance
+    Tenant_B_WAN_Zone\n!\nvrf instance Tenant_C_OP_Zone\n!\nvrf instance Tenant_C_WAN_Zone\n!\ninterface
+    Port-Channel3\n   description MLAG_PEER_DC1-LEAF2B_Po3\n   no shutdown\n   switchport\n
+    \  switchport trunk allowed vlan 2-4094\n   switchport mode trunk\n   switchport
+    trunk group LEAF_PEER_L3\n   switchport trunk group MLAG\n!\ninterface Port-Channel5\n
+    \  description DC1-L2LEAF2A_Po1\n   no shutdown\n   switchport\n   switchport
+    trunk allowed vlan 110-112,120-121,130-131\n   switchport mode trunk\n   mlag
+    5\n!\ninterface Ethernet1\n   description P2P_LINK_TO_DC1-SPINE1_Ethernet3\n   no
+    shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.9/31\n!\ninterface
+    Ethernet2\n   description P2P_LINK_TO_DC1-SPINE2_Ethernet3\n   no shutdown\n   mtu
+    1500\n   no switchport\n   ip address 172.31.255.11/31\n!\ninterface Ethernet3\n
+    \  description MLAG_PEER_DC1-LEAF2B_Ethernet3\n   no shutdown\n   channel-group
+    3 mode active\n!\ninterface Ethernet4\n   description MLAG_PEER_DC1-LEAF2B_Ethernet4\n
+    \  no shutdown\n   channel-group 3 mode active\n!\ninterface Ethernet5\n   description
+    DC1-L2LEAF2A_Ethernet1\n   no shutdown\n   channel-group 5 mode active\n!\ninterface
+    Loopback0\n   description EVPN_Overlay_Peering\n   no shutdown\n   ip address
+    192.168.255.5/32\n!\ninterface Loopback1\n   description VTEP_VXLAN_Tunnel_Source\n
+    \  no shutdown\n   ip address 192.168.254.5/32\n!\ninterface Loopback100\n   description
+    Tenant_A_OP_Zone_VTEP_DIAGNOSTICS\n   no shutdown\n   vrf Tenant_A_OP_Zone\n   ip
+    address 10.255.1.5/32\n!\ninterface Management1\n   description oob_management\n
+    \  no shutdown\n   vrf MGMT\n   ip address 10.255.0.15/24\n!\ninterface Vlan110\n
+    \  description Tenant_A_OP_Zone_1\n   no shutdown\n   vrf Tenant_A_OP_Zone\n   ip
+    address virtual 10.1.10.1/24\n!\ninterface Vlan111\n   description Tenant_A_OP_Zone_2\n
+    \  no shutdown\n   vrf Tenant_A_OP_Zone\n   ip address virtual 10.1.11.1/24\n!\ninterface
+    Vlan112\n   description Tenant_A_OP_Zone_3\n   no shutdown\n   vrf Tenant_A_OP_Zone\n
+    \  ip address virtual 10.1.12.254/24\n!\ninterface Vlan120\n   description Tenant_A_WEB_Zone_1\n
+    \  no shutdown\n   vrf Tenant_A_WEB_Zone\n!\ninterface Vlan121\n   description
+    Tenant_A_WEBZone_2\n   no shutdown\n   vrf Tenant_A_WEB_Zone\n   ip address virtual
+    10.1.21.1/24\n!\ninterface Vlan130\n   description Tenant_A_APP_Zone_1\n   no
+    shutdown\n   vrf Tenant_A_APP_Zone\n!\ninterface Vlan131\n   description Tenant_A_APP_Zone_2\n
+    \  no shutdown\n   vrf Tenant_A_APP_Zone\n   ip address virtual 10.1.31.254/24\n!\ninterface
+    Vlan140\n   description Tenant_A_DB_BZone_1\n   no shutdown\n   vrf Tenant_A_DB_Zone\n
+    \  ip address virtual 10.1.40.1/24\n!\ninterface Vlan141\n   description Tenant_A_DB_Zone_2\n
+    \  no shutdown\n   vrf Tenant_A_DB_Zone\n   ip address virtual 10.1.41.1/24\n!\ninterface
+    Vlan150\n   description Tenant_A_WAN_Zone_1\n   no shutdown\n   vrf Tenant_A_WAN_Zone\n
+    \  ip address virtual 10.1.40.1/24\n!\ninterface Vlan210\n   description Tenant_B_OP_Zone_1\n
+    \  no shutdown\n   vrf Tenant_B_OP_Zone\n!\ninterface Vlan211\n   description
+    Tenant_B_OP_Zone_2\n   no shutdown\n   vrf Tenant_B_OP_Zone\n   ip address virtual
+    10.2.11.1/24\n!\ninterface Vlan250\n   description Tenant_B_WAN_Zone_1\n   no
+    shutdown\n   vrf Tenant_B_WAN_Zone\n   ip address virtual 10.2.50.1/24\n!\ninterface
+    Vlan310\n   description Tenant_C_OP_Zone_1\n   no shutdown\n   vrf Tenant_C_OP_Zone\n!\ninterface
+    Vlan311\n   description Tenant_C_OP_Zone_2\n   no shutdown\n   vrf Tenant_C_OP_Zone\n!\ninterface
+    Vlan350\n   description Tenant_C_WAN_Zone_1\n   no shutdown\n   vrf Tenant_C_WAN_Zone\n!\ninterface
+    Vlan3009\n   description MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_A_OP_Zone\n   ip address 10.255.251.4/31\n!\ninterface
+    Vlan3010\n   description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_A_WEB_Zone\n   ip address 10.255.251.4/31\n!\ninterface
+    Vlan3011\n   description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_A_APP_Zone\n   ip address 10.255.251.4/31\n!\ninterface
+    Vlan3012\n   description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_A_DB_Zone\n   ip address 10.255.251.4/31\n!\ninterface
+    Vlan3013\n   description MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_A_WAN_Zone\n   ip address 10.255.251.4/31\n!\ninterface
+    Vlan3019\n   description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_B_OP_Zone\n   ip address 10.255.251.4/31\n!\ninterface
+    Vlan3020\n   description MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_B_WAN_Zone\n   ip address 10.255.251.4/31\n!\ninterface
+    Vlan3029\n   description MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_C_OP_Zone\n   ip address 10.255.251.4/31\n!\ninterface
+    Vlan3030\n   description MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_C_WAN_Zone\n   ip address 10.255.251.4/31\n!\ninterface
+    Vlan4093\n   description MLAG_PEER_L3_PEERING\n   no shutdown\n   mtu 1500\n   ip
+    address 10.255.251.4/31\n!\ninterface Vlan4094\n   description MLAG_PEER\n   no
+    shutdown\n   mtu 1500\n   no autostate\n   ip address 10.255.252.4/31\n!\ninterface
+    Vxlan1\n   description DC1-LEAF2A_VTEP\n   vxlan source-interface Loopback1\n
+    \  vxlan virtual-router encapsulation mac-address mlag-system-id\n   vxlan udp-port
+    4789\n   vxlan vlan 110 vni 10110\n   vxlan vlan 111 vni 50111\n   vxlan vlan
+    112 vni 50112\n   vxlan vlan 120 vni 10120\n   vxlan vlan 121 vni 10121\n   vxlan
+    vlan 130 vni 10130\n   vxlan vlan 131 vni 10131\n   vxlan vlan 140 vni 10140\n
+    \  vxlan vlan 141 vni 10141\n   vxlan vlan 150 vni 10150\n   vxlan vlan 160 vni
+    55160\n   vxlan vlan 161 vni 10161\n   vxlan vlan 210 vni 20210\n   vxlan vlan
+    211 vni 20211\n   vxlan vlan 250 vni 20250\n   vxlan vlan 310 vni 30310\n   vxlan
+    vlan 311 vni 30311\n   vxlan vlan 350 vni 30350\n   vxlan vrf Tenant_A_APP_Zone
+    vni 12\n   vxlan vrf Tenant_A_DB_Zone vni 13\n   vxlan vrf Tenant_A_OP_Zone vni
+    10\n   vxlan vrf Tenant_A_WAN_Zone vni 14\n   vxlan vrf Tenant_A_WEB_Zone vni
+    11\n   vxlan vrf Tenant_B_OP_Zone vni 20\n   vxlan vrf Tenant_B_WAN_Zone vni 21\n
+    \  vxlan vrf Tenant_C_OP_Zone vni 30\n   vxlan vrf Tenant_C_WAN_Zone vni 31\n!\nip
+    virtual-router mac-address 00:1c:73:00:dc:01\n!\nip address virtual source-nat
+    vrf Tenant_A_OP_Zone address 10.255.1.5\n!\nip routing\nno ip routing vrf MGMT\nip
+    routing vrf Tenant_A_APP_Zone\nip routing vrf Tenant_A_DB_Zone\nip routing vrf
+    Tenant_A_OP_Zone\nip routing vrf Tenant_A_WAN_Zone\nip routing vrf Tenant_A_WEB_Zone\nip
+    routing vrf Tenant_B_OP_Zone\nip routing vrf Tenant_B_WAN_Zone\nip routing vrf
+    Tenant_C_OP_Zone\nip routing vrf Tenant_C_WAN_Zone\n!\nip prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n
+    \  seq 10 permit 192.168.255.0/24 eq 32\n   seq 20 permit 192.168.254.0/24 eq
+    32\n!\nmlag configuration\n   domain-id DC1_LEAF2\n   local-interface Vlan4094\n
+    \  peer-address 10.255.252.5\n   peer-link Port-Channel3\n   reload-delay mlag
+    300\n   reload-delay non-mlag 330\n!\nip route vrf MGMT 0.0.0.0/0 10.255.0.1\n!\nroute-map
+    RM-CONN-2-BGP permit 10\n   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n!\nroute-map
+    RM-MLAG-PEER-IN permit 10\n   description Make routes learned over MLAG Peer-link
+    less preferred on spines to ensure optimal routing\n   set origin incomplete\n!\nrouter
+    bfd\n   multihop interval 1200 min-rx 1200 multiplier 3\n!\nrouter bgp 65102\n
+    \  router-id 192.168.255.5\n   no bgp default ipv4-unicast\n   distance bgp 20
+    200 200\n   graceful-restart restart-time 300\n   graceful-restart\n   maximum-paths
+    4 ecmp 4\n   neighbor EVPN-OVERLAY-PEERS peer group\n   neighbor EVPN-OVERLAY-PEERS
+    update-source Loopback0\n   neighbor EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS
+    ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n
+    \  neighbor EVPN-OVERLAY-PEERS send-community\n   neighbor EVPN-OVERLAY-PEERS
+    maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS peer group\n   neighbor IPv4-UNDERLAY-PEERS
+    password 7 AQQvKeimxJu+uGQ/yYvv9w==\n   neighbor IPv4-UNDERLAY-PEERS send-community\n
+    \  neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000\n   neighbor MLAG-IPv4-UNDERLAY-PEER
+    peer group\n   neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65102\n   neighbor MLAG-IPv4-UNDERLAY-PEER
+    next-hop-self\n   neighbor MLAG-IPv4-UNDERLAY-PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==\n
+    \  neighbor MLAG-IPv4-UNDERLAY-PEER send-community\n   neighbor MLAG-IPv4-UNDERLAY-PEER
+    maximum-routes 12000\n   neighbor MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN
+    in\n   neighbor 10.255.251.5 peer group MLAG-IPv4-UNDERLAY-PEER\n   neighbor 10.255.251.5
+    description DC1-LEAF2B\n   neighbor 172.31.255.8 peer group IPv4-UNDERLAY-PEERS\n
+    \  neighbor 172.31.255.8 remote-as 65001\n   neighbor 172.31.255.8 description
+    DC1-SPINE1_Ethernet3\n   neighbor 172.31.255.10 peer group IPv4-UNDERLAY-PEERS\n
+    \  neighbor 172.31.255.10 remote-as 65001\n   neighbor 172.31.255.10 description
+    DC1-SPINE2_Ethernet3\n   neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS\n
+    \  neighbor 192.168.255.1 remote-as 65001\n   neighbor 192.168.255.1 description
+    DC1-SPINE1\n   neighbor 192.168.255.2 peer group EVPN-OVERLAY-PEERS\n   neighbor
+    192.168.255.2 remote-as 65001\n   neighbor 192.168.255.2 description DC1-SPINE2\n
+    \  redistribute connected route-map RM-CONN-2-BGP\n   !\n   vlan-aware-bundle
+    Tenant_A_APP_Zone\n      rd 192.168.255.5:12\n      route-target both 12:12\n
+    \     redistribute learned\n      vlan 130-131\n   !\n   vlan-aware-bundle Tenant_A_DB_Zone\n
+    \     rd 192.168.255.5:13\n      route-target both 13:13\n      redistribute learned\n
+    \     vlan 140-141\n   !\n   vlan-aware-bundle Tenant_A_NFS\n      rd 192.168.255.5:10161\n
+    \     route-target both 10161:10161\n      redistribute learned\n      vlan 161\n
+    \  !\n   vlan-aware-bundle Tenant_A_OP_Zone\n      rd 192.168.255.5:10\n      route-target
+    both 10:10\n      redistribute learned\n      vlan 110-112\n   !\n   vlan-aware-bundle
+    Tenant_A_VMOTION\n      rd 192.168.255.5:55160\n      route-target both 55160:55160\n
+    \     redistribute learned\n      vlan 160\n   !\n   vlan-aware-bundle Tenant_A_WAN_Zone\n
+    \     rd 192.168.255.5:14\n      route-target both 14:14\n      redistribute learned\n
+    \     vlan 150\n   !\n   vlan-aware-bundle Tenant_A_WEB_Zone\n      rd 192.168.255.5:11\n
+    \     route-target both 11:11\n      redistribute learned\n      vlan 120-121\n
+    \  !\n   vlan-aware-bundle Tenant_B_OP_Zone\n      rd 192.168.255.5:20\n      route-target
+    both 20:20\n      redistribute learned\n      vlan 210-211\n   !\n   vlan-aware-bundle
+    Tenant_B_WAN_Zone\n      rd 192.168.255.5:21\n      route-target both 21:21\n
+    \     redistribute learned\n      vlan 250\n   !\n   vlan-aware-bundle Tenant_C_OP_Zone\n
+    \     rd 192.168.255.5:30\n      route-target both 30:30\n      redistribute learned\n
+    \     vlan 310-311\n   !\n   vlan-aware-bundle Tenant_C_WAN_Zone\n      rd 192.168.255.5:31\n
+    \     route-target both 31:31\n      redistribute learned\n      vlan 350\n   !\n
+    \  address-family evpn\n      neighbor EVPN-OVERLAY-PEERS activate\n   !\n   address-family
+    ipv4\n      no neighbor EVPN-OVERLAY-PEERS activate\n      neighbor IPv4-UNDERLAY-PEERS
+    activate\n      neighbor MLAG-IPv4-UNDERLAY-PEER activate\n   !\n   vrf Tenant_A_APP_Zone\n
+    \     rd 192.168.255.5:12\n      route-target import evpn 12:12\n      route-target
+    export evpn 12:12\n      router-id 192.168.255.5\n      neighbor 10.255.251.5
+    peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute connected\n   !\n   vrf
+    Tenant_A_DB_Zone\n      rd 192.168.255.5:13\n      route-target import evpn 13:13\n
+    \     route-target export evpn 13:13\n      router-id 192.168.255.5\n      neighbor
+    10.255.251.5 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute connected\n
+    \  !\n   vrf Tenant_A_OP_Zone\n      rd 192.168.255.5:10\n      route-target import
+    evpn 10:10\n      route-target export evpn 10:10\n      router-id 192.168.255.5\n
+    \     neighbor 10.255.251.5 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n   !\n   vrf Tenant_A_WAN_Zone\n      rd 192.168.255.5:14\n      route-target
+    import evpn 14:14\n      route-target export evpn 14:14\n      router-id 192.168.255.5\n
+    \     neighbor 10.255.251.5 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n   !\n   vrf Tenant_A_WEB_Zone\n      rd 192.168.255.5:11\n      route-target
+    import evpn 11:11\n      route-target export evpn 11:11\n      router-id 192.168.255.5\n
+    \     neighbor 10.255.251.5 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n   !\n   vrf Tenant_B_OP_Zone\n      rd 192.168.255.5:20\n      route-target
+    import evpn 20:20\n      route-target export evpn 20:20\n      router-id 192.168.255.5\n
+    \     neighbor 10.255.251.5 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n   !\n   vrf Tenant_B_WAN_Zone\n      rd 192.168.255.5:21\n      route-target
+    import evpn 21:21\n      route-target export evpn 21:21\n      router-id 192.168.255.5\n
+    \     neighbor 10.255.251.5 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n   !\n   vrf Tenant_C_OP_Zone\n      rd 192.168.255.5:30\n      route-target
+    import evpn 30:30\n      route-target export evpn 30:30\n      router-id 192.168.255.5\n
+    \     neighbor 10.255.251.5 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n   !\n   vrf Tenant_C_WAN_Zone\n      rd 192.168.255.5:31\n      route-target
+    import evpn 31:31\n      route-target export evpn 31:31\n      router-id 192.168.255.5\n
+    \     neighbor 10.255.251.5 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n!\nmanagement api http-commands\n   protocol https\n   no shutdown\n
+    \  !\n   vrf MGMT\n      no shutdown\n!\nend\n"
+  AVD_DC1-LEAF2B: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr
+    -cvaddr=10.255.0.1:9910 -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
+    -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
+    internal order ascending range 1006 1199\n!\ntransceiver qsfp default-mode 4x10G\n!\nservice
+    routing protocols model multi-agent\n!\nhostname DC1-LEAF2B\nip name-server vrf
+    MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.2.1\n!\nntp local-interface vrf
+    MGMT Management1\nntp server vrf MGMT 0.fr.pool.ntp.org prefer\nntp server vrf
+    MGMT 1.fr.pool.ntp.org\n!\nspanning-tree mode mstp\nno spanning-tree vlan-id 4093-4094\nspanning-tree
+    mst 0 priority 16384\n!\nno aaa root\nno enable password\n!\nusername admin privilege
+    15 role network-admin secret sha512 $6$Df86J4/SFMDE3/1K$Hef4KstdoxNDaami37cBquTWOTplC.miMPjXVgQxMe92.e5wxlnXOLlebgPj8Fz1KO0za/RCO7ZIs4Q6Eiq1g1\nusername
+    ansible privilege 15 role network-admin secret sha512 $6$Dzu11L7yp9j3nCM9$FSptxMPyIL555OMO.ldnjDXgwZmrfMYwHSr0uznE5Qoqvd9a6UdjiFcJUhGLtvXVZR1r.A/iF5aAt50hf/EK4/\nusername
+    cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\nvlan
+    110\n   name Tenant_A_OP_Zone_1\n!\nvlan 111\n   name Tenant_A_OP_Zone_2\n!\nvlan
+    112\n   name Tenant_A_OP_Zone_3\n!\nvlan 120\n   name Tenant_A_WEB_Zone_1\n!\nvlan
+    121\n   name Tenant_A_WEBZone_2\n!\nvlan 130\n   name Tenant_A_APP_Zone_1\n!\nvlan
+    131\n   name Tenant_A_APP_Zone_2\n!\nvlan 140\n   name Tenant_A_DB_BZone_1\n!\nvlan
+    141\n   name Tenant_A_DB_Zone_2\n!\nvlan 150\n   name Tenant_A_WAN_Zone_1\n!\nvlan
+    160\n   name Tenant_A_VMOTION\n!\nvlan 161\n   name Tenant_A_NFS\n!\nvlan 210\n
+    \  name Tenant_B_OP_Zone_1\n!\nvlan 211\n   name Tenant_B_OP_Zone_2\n!\nvlan 250\n
+    \  name Tenant_B_WAN_Zone_1\n!\nvlan 310\n   name Tenant_C_OP_Zone_1\n!\nvlan
+    311\n   name Tenant_C_OP_Zone_2\n!\nvlan 350\n   name Tenant_C_WAN_Zone_1\n!\nvlan
+    3009\n   name MLAG_iBGP_Tenant_A_OP_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3010\n   name MLAG_iBGP_Tenant_A_WEB_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3011\n   name MLAG_iBGP_Tenant_A_APP_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3012\n   name MLAG_iBGP_Tenant_A_DB_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3013\n   name MLAG_iBGP_Tenant_A_WAN_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3019\n   name MLAG_iBGP_Tenant_B_OP_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3020\n   name MLAG_iBGP_Tenant_B_WAN_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3029\n   name MLAG_iBGP_Tenant_C_OP_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    3030\n   name MLAG_iBGP_Tenant_C_WAN_Zone\n   trunk group LEAF_PEER_L3\n!\nvlan
+    4093\n   name LEAF_PEER_L3\n   trunk group LEAF_PEER_L3\n!\nvlan 4094\n   name
+    MLAG_PEER\n   trunk group MLAG\n!\nvrf instance MGMT\n!\nvrf instance Tenant_A_APP_Zone\n!\nvrf
+    instance Tenant_A_DB_Zone\n!\nvrf instance Tenant_A_OP_Zone\n!\nvrf instance Tenant_A_WAN_Zone\n!\nvrf
+    instance Tenant_A_WEB_Zone\n!\nvrf instance Tenant_B_OP_Zone\n!\nvrf instance
+    Tenant_B_WAN_Zone\n!\nvrf instance Tenant_C_OP_Zone\n!\nvrf instance Tenant_C_WAN_Zone\n!\ninterface
+    Port-Channel3\n   description MLAG_PEER_DC1-LEAF2A_Po3\n   no shutdown\n   switchport\n
+    \  switchport trunk allowed vlan 2-4094\n   switchport mode trunk\n   switchport
+    trunk group LEAF_PEER_L3\n   switchport trunk group MLAG\n!\ninterface Port-Channel5\n
+    \  description DC1-L2LEAF2A_Po1\n   no shutdown\n   switchport\n   switchport
+    trunk allowed vlan 110-112,120-121,130-131\n   switchport mode trunk\n   mlag
+    5\n!\ninterface Ethernet1\n   description P2P_LINK_TO_DC1-SPINE1_Ethernet4\n   no
+    shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.13/31\n!\ninterface
+    Ethernet2\n   description P2P_LINK_TO_DC1-SPINE2_Ethernet4\n   no shutdown\n   mtu
+    1500\n   no switchport\n   ip address 172.31.255.15/31\n!\ninterface Ethernet3\n
+    \  description MLAG_PEER_DC1-LEAF2A_Ethernet3\n   no shutdown\n   channel-group
+    3 mode active\n!\ninterface Ethernet4\n   description MLAG_PEER_DC1-LEAF2A_Ethernet4\n
+    \  no shutdown\n   channel-group 3 mode active\n!\ninterface Ethernet5\n   description
+    DC1-L2LEAF2A_Ethernet2\n   no shutdown\n   channel-group 5 mode active\n!\ninterface
+    Loopback0\n   description EVPN_Overlay_Peering\n   no shutdown\n   ip address
+    192.168.255.6/32\n!\ninterface Loopback1\n   description VTEP_VXLAN_Tunnel_Source\n
+    \  no shutdown\n   ip address 192.168.254.5/32\n!\ninterface Loopback100\n   description
+    Tenant_A_OP_Zone_VTEP_DIAGNOSTICS\n   no shutdown\n   vrf Tenant_A_OP_Zone\n   ip
+    address 10.255.1.6/32\n!\ninterface Management1\n   description oob_management\n
+    \  no shutdown\n   vrf MGMT\n   ip address 10.255.0.16/24\n!\ninterface Vlan110\n
+    \  description Tenant_A_OP_Zone_1\n   no shutdown\n   vrf Tenant_A_OP_Zone\n   ip
+    address virtual 10.1.10.1/24\n!\ninterface Vlan111\n   description Tenant_A_OP_Zone_2\n
+    \  no shutdown\n   vrf Tenant_A_OP_Zone\n   ip address virtual 10.1.11.1/24\n!\ninterface
+    Vlan112\n   description Tenant_A_OP_Zone_3\n   no shutdown\n   vrf Tenant_A_OP_Zone\n
+    \  ip address virtual 10.1.12.254/24\n!\ninterface Vlan120\n   description Tenant_A_WEB_Zone_1\n
+    \  no shutdown\n   vrf Tenant_A_WEB_Zone\n!\ninterface Vlan121\n   description
+    Tenant_A_WEBZone_2\n   no shutdown\n   vrf Tenant_A_WEB_Zone\n   ip address virtual
+    10.1.21.1/24\n!\ninterface Vlan130\n   description Tenant_A_APP_Zone_1\n   no
+    shutdown\n   vrf Tenant_A_APP_Zone\n!\ninterface Vlan131\n   description Tenant_A_APP_Zone_2\n
+    \  no shutdown\n   vrf Tenant_A_APP_Zone\n   ip address virtual 10.1.31.254/24\n!\ninterface
+    Vlan140\n   description Tenant_A_DB_BZone_1\n   no shutdown\n   vrf Tenant_A_DB_Zone\n
+    \  ip address virtual 10.1.40.1/24\n!\ninterface Vlan141\n   description Tenant_A_DB_Zone_2\n
+    \  no shutdown\n   vrf Tenant_A_DB_Zone\n   ip address virtual 10.1.41.1/24\n!\ninterface
+    Vlan150\n   description Tenant_A_WAN_Zone_1\n   no shutdown\n   vrf Tenant_A_WAN_Zone\n
+    \  ip address virtual 10.1.40.1/24\n!\ninterface Vlan210\n   description Tenant_B_OP_Zone_1\n
+    \  no shutdown\n   vrf Tenant_B_OP_Zone\n!\ninterface Vlan211\n   description
+    Tenant_B_OP_Zone_2\n   no shutdown\n   vrf Tenant_B_OP_Zone\n   ip address virtual
+    10.2.11.1/24\n!\ninterface Vlan250\n   description Tenant_B_WAN_Zone_1\n   no
+    shutdown\n   vrf Tenant_B_WAN_Zone\n   ip address virtual 10.2.50.1/24\n!\ninterface
+    Vlan310\n   description Tenant_C_OP_Zone_1\n   no shutdown\n   vrf Tenant_C_OP_Zone\n!\ninterface
+    Vlan311\n   description Tenant_C_OP_Zone_2\n   no shutdown\n   vrf Tenant_C_OP_Zone\n!\ninterface
+    Vlan350\n   description Tenant_C_WAN_Zone_1\n   no shutdown\n   vrf Tenant_C_WAN_Zone\n!\ninterface
+    Vlan3009\n   description MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_A_OP_Zone\n   ip address 10.255.251.5/31\n!\ninterface
+    Vlan3010\n   description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_A_WEB_Zone\n   ip address 10.255.251.5/31\n!\ninterface
+    Vlan3011\n   description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_A_APP_Zone\n   ip address 10.255.251.5/31\n!\ninterface
+    Vlan3012\n   description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_A_DB_Zone\n   ip address 10.255.251.5/31\n!\ninterface
+    Vlan3013\n   description MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_A_WAN_Zone\n   ip address 10.255.251.5/31\n!\ninterface
+    Vlan3019\n   description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_B_OP_Zone\n   ip address 10.255.251.5/31\n!\ninterface
+    Vlan3020\n   description MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_B_WAN_Zone\n   ip address 10.255.251.5/31\n!\ninterface
+    Vlan3029\n   description MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_C_OP_Zone\n   ip address 10.255.251.5/31\n!\ninterface
+    Vlan3030\n   description MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone\n   no shutdown\n
+    \  mtu 1500\n   vrf Tenant_C_WAN_Zone\n   ip address 10.255.251.5/31\n!\ninterface
+    Vlan4093\n   description MLAG_PEER_L3_PEERING\n   no shutdown\n   mtu 1500\n   ip
+    address 10.255.251.5/31\n!\ninterface Vlan4094\n   description MLAG_PEER\n   no
+    shutdown\n   mtu 1500\n   no autostate\n   ip address 10.255.252.5/31\n!\ninterface
+    Vxlan1\n   description DC1-LEAF2B_VTEP\n   vxlan source-interface Loopback1\n
+    \  vxlan virtual-router encapsulation mac-address mlag-system-id\n   vxlan udp-port
+    4789\n   vxlan vlan 110 vni 10110\n   vxlan vlan 111 vni 50111\n   vxlan vlan
+    112 vni 50112\n   vxlan vlan 120 vni 10120\n   vxlan vlan 121 vni 10121\n   vxlan
+    vlan 130 vni 10130\n   vxlan vlan 131 vni 10131\n   vxlan vlan 140 vni 10140\n
+    \  vxlan vlan 141 vni 10141\n   vxlan vlan 150 vni 10150\n   vxlan vlan 160 vni
+    55160\n   vxlan vlan 161 vni 10161\n   vxlan vlan 210 vni 20210\n   vxlan vlan
+    211 vni 20211\n   vxlan vlan 250 vni 20250\n   vxlan vlan 310 vni 30310\n   vxlan
+    vlan 311 vni 30311\n   vxlan vlan 350 vni 30350\n   vxlan vrf Tenant_A_APP_Zone
+    vni 12\n   vxlan vrf Tenant_A_DB_Zone vni 13\n   vxlan vrf Tenant_A_OP_Zone vni
+    10\n   vxlan vrf Tenant_A_WAN_Zone vni 14\n   vxlan vrf Tenant_A_WEB_Zone vni
+    11\n   vxlan vrf Tenant_B_OP_Zone vni 20\n   vxlan vrf Tenant_B_WAN_Zone vni 21\n
+    \  vxlan vrf Tenant_C_OP_Zone vni 30\n   vxlan vrf Tenant_C_WAN_Zone vni 31\n!\nip
+    virtual-router mac-address 00:1c:73:00:dc:01\n!\nip address virtual source-nat
+    vrf Tenant_A_OP_Zone address 10.255.1.6\n!\nip routing\nno ip routing vrf MGMT\nip
+    routing vrf Tenant_A_APP_Zone\nip routing vrf Tenant_A_DB_Zone\nip routing vrf
+    Tenant_A_OP_Zone\nip routing vrf Tenant_A_WAN_Zone\nip routing vrf Tenant_A_WEB_Zone\nip
+    routing vrf Tenant_B_OP_Zone\nip routing vrf Tenant_B_WAN_Zone\nip routing vrf
+    Tenant_C_OP_Zone\nip routing vrf Tenant_C_WAN_Zone\n!\nip prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n
+    \  seq 10 permit 192.168.255.0/24 eq 32\n   seq 20 permit 192.168.254.0/24 eq
+    32\n!\nmlag configuration\n   domain-id DC1_LEAF2\n   local-interface Vlan4094\n
+    \  peer-address 10.255.252.4\n   peer-link Port-Channel3\n   reload-delay mlag
+    300\n   reload-delay non-mlag 330\n!\nip route vrf MGMT 0.0.0.0/0 10.255.0.1\n!\nroute-map
+    RM-CONN-2-BGP permit 10\n   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n!\nroute-map
+    RM-MLAG-PEER-IN permit 10\n   description Make routes learned over MLAG Peer-link
+    less preferred on spines to ensure optimal routing\n   set origin incomplete\n!\nrouter
+    bfd\n   multihop interval 1200 min-rx 1200 multiplier 3\n!\nrouter bgp 65102\n
+    \  router-id 192.168.255.6\n   no bgp default ipv4-unicast\n   distance bgp 20
+    200 200\n   graceful-restart restart-time 300\n   graceful-restart\n   maximum-paths
+    4 ecmp 4\n   neighbor EVPN-OVERLAY-PEERS peer group\n   neighbor EVPN-OVERLAY-PEERS
+    update-source Loopback0\n   neighbor EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS
+    ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n
+    \  neighbor EVPN-OVERLAY-PEERS send-community\n   neighbor EVPN-OVERLAY-PEERS
+    maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS peer group\n   neighbor IPv4-UNDERLAY-PEERS
+    password 7 AQQvKeimxJu+uGQ/yYvv9w==\n   neighbor IPv4-UNDERLAY-PEERS send-community\n
+    \  neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000\n   neighbor MLAG-IPv4-UNDERLAY-PEER
+    peer group\n   neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65102\n   neighbor MLAG-IPv4-UNDERLAY-PEER
+    next-hop-self\n   neighbor MLAG-IPv4-UNDERLAY-PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==\n
+    \  neighbor MLAG-IPv4-UNDERLAY-PEER send-community\n   neighbor MLAG-IPv4-UNDERLAY-PEER
+    maximum-routes 12000\n   neighbor MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN
+    in\n   neighbor 10.255.251.4 peer group MLAG-IPv4-UNDERLAY-PEER\n   neighbor 10.255.251.4
+    description DC1-LEAF2A\n   neighbor 172.31.255.12 peer group IPv4-UNDERLAY-PEERS\n
+    \  neighbor 172.31.255.12 remote-as 65001\n   neighbor 172.31.255.12 description
+    DC1-SPINE1_Ethernet4\n   neighbor 172.31.255.14 peer group IPv4-UNDERLAY-PEERS\n
+    \  neighbor 172.31.255.14 remote-as 65001\n   neighbor 172.31.255.14 description
+    DC1-SPINE2_Ethernet4\n   neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS\n
+    \  neighbor 192.168.255.1 remote-as 65001\n   neighbor 192.168.255.1 description
+    DC1-SPINE1\n   neighbor 192.168.255.2 peer group EVPN-OVERLAY-PEERS\n   neighbor
+    192.168.255.2 remote-as 65001\n   neighbor 192.168.255.2 description DC1-SPINE2\n
+    \  redistribute connected route-map RM-CONN-2-BGP\n   !\n   vlan-aware-bundle
+    Tenant_A_APP_Zone\n      rd 192.168.255.6:12\n      route-target both 12:12\n
+    \     redistribute learned\n      vlan 130-131\n   !\n   vlan-aware-bundle Tenant_A_DB_Zone\n
+    \     rd 192.168.255.6:13\n      route-target both 13:13\n      redistribute learned\n
+    \     vlan 140-141\n   !\n   vlan-aware-bundle Tenant_A_NFS\n      rd 192.168.255.6:10161\n
+    \     route-target both 10161:10161\n      redistribute learned\n      vlan 161\n
+    \  !\n   vlan-aware-bundle Tenant_A_OP_Zone\n      rd 192.168.255.6:10\n      route-target
+    both 10:10\n      redistribute learned\n      vlan 110-112\n   !\n   vlan-aware-bundle
+    Tenant_A_VMOTION\n      rd 192.168.255.6:55160\n      route-target both 55160:55160\n
+    \     redistribute learned\n      vlan 160\n   !\n   vlan-aware-bundle Tenant_A_WAN_Zone\n
+    \     rd 192.168.255.6:14\n      route-target both 14:14\n      redistribute learned\n
+    \     vlan 150\n   !\n   vlan-aware-bundle Tenant_A_WEB_Zone\n      rd 192.168.255.6:11\n
+    \     route-target both 11:11\n      redistribute learned\n      vlan 120-121\n
+    \  !\n   vlan-aware-bundle Tenant_B_OP_Zone\n      rd 192.168.255.6:20\n      route-target
+    both 20:20\n      redistribute learned\n      vlan 210-211\n   !\n   vlan-aware-bundle
+    Tenant_B_WAN_Zone\n      rd 192.168.255.6:21\n      route-target both 21:21\n
+    \     redistribute learned\n      vlan 250\n   !\n   vlan-aware-bundle Tenant_C_OP_Zone\n
+    \     rd 192.168.255.6:30\n      route-target both 30:30\n      redistribute learned\n
+    \     vlan 310-311\n   !\n   vlan-aware-bundle Tenant_C_WAN_Zone\n      rd 192.168.255.6:31\n
+    \     route-target both 31:31\n      redistribute learned\n      vlan 350\n   !\n
+    \  address-family evpn\n      neighbor EVPN-OVERLAY-PEERS activate\n   !\n   address-family
+    ipv4\n      no neighbor EVPN-OVERLAY-PEERS activate\n      neighbor IPv4-UNDERLAY-PEERS
+    activate\n      neighbor MLAG-IPv4-UNDERLAY-PEER activate\n   !\n   vrf Tenant_A_APP_Zone\n
+    \     rd 192.168.255.6:12\n      route-target import evpn 12:12\n      route-target
+    export evpn 12:12\n      router-id 192.168.255.6\n      neighbor 10.255.251.4
+    peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute connected\n   !\n   vrf
+    Tenant_A_DB_Zone\n      rd 192.168.255.6:13\n      route-target import evpn 13:13\n
+    \     route-target export evpn 13:13\n      router-id 192.168.255.6\n      neighbor
+    10.255.251.4 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute connected\n
+    \  !\n   vrf Tenant_A_OP_Zone\n      rd 192.168.255.6:10\n      route-target import
+    evpn 10:10\n      route-target export evpn 10:10\n      router-id 192.168.255.6\n
+    \     neighbor 10.255.251.4 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n   !\n   vrf Tenant_A_WAN_Zone\n      rd 192.168.255.6:14\n      route-target
+    import evpn 14:14\n      route-target export evpn 14:14\n      router-id 192.168.255.6\n
+    \     neighbor 10.255.251.4 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n   !\n   vrf Tenant_A_WEB_Zone\n      rd 192.168.255.6:11\n      route-target
+    import evpn 11:11\n      route-target export evpn 11:11\n      router-id 192.168.255.6\n
+    \     neighbor 10.255.251.4 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n   !\n   vrf Tenant_B_OP_Zone\n      rd 192.168.255.6:20\n      route-target
+    import evpn 20:20\n      route-target export evpn 20:20\n      router-id 192.168.255.6\n
+    \     neighbor 10.255.251.4 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n   !\n   vrf Tenant_B_WAN_Zone\n      rd 192.168.255.6:21\n      route-target
+    import evpn 21:21\n      route-target export evpn 21:21\n      router-id 192.168.255.6\n
+    \     neighbor 10.255.251.4 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n   !\n   vrf Tenant_C_OP_Zone\n      rd 192.168.255.6:30\n      route-target
+    import evpn 30:30\n      route-target export evpn 30:30\n      router-id 192.168.255.6\n
+    \     neighbor 10.255.251.4 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n   !\n   vrf Tenant_C_WAN_Zone\n      rd 192.168.255.6:31\n      route-target
+    import evpn 31:31\n      route-target export evpn 31:31\n      router-id 192.168.255.6\n
+    \     neighbor 10.255.251.4 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
+    connected\n!\nmanagement api http-commands\n   protocol https\n   no shutdown\n
+    \  !\n   vrf MGMT\n      no shutdown\n!\nend\n"
+  AVD_DC1-SPINE1: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr
+    -cvaddr=10.255.0.1:9910 -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
+    -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
+    internal order ascending range 1006 1199\n!\ntransceiver qsfp default-mode 4x10G\n!\nservice
+    routing protocols model multi-agent\n!\nhostname DC1-SPINE1\nip name-server vrf
+    MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.2.1\n!\nntp local-interface vrf
+    MGMT Management1\nntp server vrf MGMT 0.fr.pool.ntp.org prefer\nntp server vrf
+    MGMT 1.fr.pool.ntp.org\n!\nspanning-tree mode none\n!\nno aaa root\nno enable
+    password\n!\nusername admin privilege 15 role network-admin secret sha512 $6$Df86J4/SFMDE3/1K$Hef4KstdoxNDaami37cBquTWOTplC.miMPjXVgQxMe92.e5wxlnXOLlebgPj8Fz1KO0za/RCO7ZIs4Q6Eiq1g1\nusername
+    ansible privilege 15 role network-admin secret sha512 $6$Dzu11L7yp9j3nCM9$FSptxMPyIL555OMO.ldnjDXgwZmrfMYwHSr0uznE5Qoqvd9a6UdjiFcJUhGLtvXVZR1r.A/iF5aAt50hf/EK4/\nusername
+    cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\nvrf
+    instance MGMT\n!\ninterface Ethernet1\n   description P2P_LINK_TO_DC1-LEAF1A_Ethernet1\n
+    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.0/31\n!\ninterface
+    Ethernet2\n   description P2P_LINK_TO_DC1-LEAF1B_Ethernet1\n   no shutdown\n   mtu
+    1500\n   no switchport\n   ip address 172.31.255.4/31\n!\ninterface Ethernet3\n
+    \  description P2P_LINK_TO_DC1-LEAF2A_Ethernet1\n   no shutdown\n   mtu 1500\n
+    \  no switchport\n   ip address 172.31.255.8/31\n!\ninterface Ethernet4\n   description
+    P2P_LINK_TO_DC1-LEAF2B_Ethernet1\n   no shutdown\n   mtu 1500\n   no switchport\n
+    \  ip address 172.31.255.12/31\n!\ninterface Loopback0\n   description EVPN_Overlay_Peering\n
+    \  no shutdown\n   ip address 192.168.255.1/32\n!\ninterface Management1\n   description
+    oob_management\n   no shutdown\n   vrf MGMT\n   ip address 10.255.0.11/24\n!\nip
+    routing\nno ip routing vrf MGMT\n!\nip prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n
+    \  seq 10 permit 192.168.255.0/24 eq 32\n!\nip route vrf MGMT 0.0.0.0/0 10.255.0.1\n!\nroute-map
+    RM-CONN-2-BGP permit 10\n   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n!\nrouter
+    bfd\n   multihop interval 1200 min-rx 1200 multiplier 3\n!\nrouter bgp 65001\n
+    \  router-id 192.168.255.1\n   no bgp default ipv4-unicast\n   distance bgp 20
+    200 200\n   graceful-restart restart-time 300\n   graceful-restart\n   maximum-paths
+    4 ecmp 4\n   neighbor EVPN-OVERLAY-PEERS peer group\n   neighbor EVPN-OVERLAY-PEERS
+    next-hop-unchanged\n   neighbor EVPN-OVERLAY-PEERS update-source Loopback0\n   neighbor
+    EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3\n   neighbor
+    EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n   neighbor EVPN-OVERLAY-PEERS
+    send-community\n   neighbor EVPN-OVERLAY-PEERS maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS
+    peer group\n   neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==\n
+    \  neighbor IPv4-UNDERLAY-PEERS send-community\n   neighbor IPv4-UNDERLAY-PEERS
+    maximum-routes 12000\n   neighbor 172.31.255.1 peer group IPv4-UNDERLAY-PEERS\n
+    \  neighbor 172.31.255.1 remote-as 65101\n   neighbor 172.31.255.1 description
+    DC1-LEAF1A_Ethernet1\n   neighbor 172.31.255.5 peer group IPv4-UNDERLAY-PEERS\n
+    \  neighbor 172.31.255.5 remote-as 65101\n   neighbor 172.31.255.5 description
+    DC1-LEAF1B_Ethernet1\n   neighbor 172.31.255.9 peer group IPv4-UNDERLAY-PEERS\n
+    \  neighbor 172.31.255.9 remote-as 65102\n   neighbor 172.31.255.9 description
+    DC1-LEAF2A_Ethernet1\n   neighbor 172.31.255.13 peer group IPv4-UNDERLAY-PEERS\n
+    \  neighbor 172.31.255.13 remote-as 65102\n   neighbor 172.31.255.13 description
+    DC1-LEAF2B_Ethernet1\n   neighbor 192.168.255.3 peer group EVPN-OVERLAY-PEERS\n
+    \  neighbor 192.168.255.3 remote-as 65101\n   neighbor 192.168.255.3 description
+    DC1-LEAF1A\n   neighbor 192.168.255.4 peer group EVPN-OVERLAY-PEERS\n   neighbor
+    192.168.255.4 remote-as 65101\n   neighbor 192.168.255.4 description DC1-LEAF1B\n
+    \  neighbor 192.168.255.5 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.5
+    remote-as 65102\n   neighbor 192.168.255.5 description DC1-LEAF2A\n   neighbor
+    192.168.255.6 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.6 remote-as
+    65102\n   neighbor 192.168.255.6 description DC1-LEAF2B\n   redistribute connected
+    route-map RM-CONN-2-BGP\n   !\n   address-family evpn\n      neighbor EVPN-OVERLAY-PEERS
+    activate\n   !\n   address-family ipv4\n      no neighbor EVPN-OVERLAY-PEERS activate\n
+    \     neighbor IPv4-UNDERLAY-PEERS activate\n!\nmanagement api http-commands\n
+    \  protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no shutdown\n!\nend\n"
+  AVD_DC1-SPINE2: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr
+    -cvaddr=10.255.0.1:9910 -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
+    -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
+    internal order ascending range 1006 1199\n!\ntransceiver qsfp default-mode 4x10G\n!\nservice
+    routing protocols model multi-agent\n!\nhostname DC1-SPINE2\nip name-server vrf
+    MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.2.1\n!\nntp local-interface vrf
+    MGMT Management1\nntp server vrf MGMT 0.fr.pool.ntp.org prefer\nntp server vrf
+    MGMT 1.fr.pool.ntp.org\n!\nspanning-tree mode none\n!\nno aaa root\nno enable
+    password\n!\nusername admin privilege 15 role network-admin secret sha512 $6$Df86J4/SFMDE3/1K$Hef4KstdoxNDaami37cBquTWOTplC.miMPjXVgQxMe92.e5wxlnXOLlebgPj8Fz1KO0za/RCO7ZIs4Q6Eiq1g1\nusername
+    ansible privilege 15 role network-admin secret sha512 $6$Dzu11L7yp9j3nCM9$FSptxMPyIL555OMO.ldnjDXgwZmrfMYwHSr0uznE5Qoqvd9a6UdjiFcJUhGLtvXVZR1r.A/iF5aAt50hf/EK4/\nusername
+    cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\nvrf
+    instance MGMT\n!\ninterface Ethernet1\n   description P2P_LINK_TO_DC1-LEAF1A_Ethernet2\n
+    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.2/31\n!\ninterface
+    Ethernet2\n   description P2P_LINK_TO_DC1-LEAF1B_Ethernet2\n   no shutdown\n   mtu
+    1500\n   no switchport\n   ip address 172.31.255.6/31\n!\ninterface Ethernet3\n
+    \  description P2P_LINK_TO_DC1-LEAF2A_Ethernet2\n   no shutdown\n   mtu 1500\n
+    \  no switchport\n   ip address 172.31.255.10/31\n!\ninterface Ethernet4\n   description
+    P2P_LINK_TO_DC1-LEAF2B_Ethernet2\n   no shutdown\n   mtu 1500\n   no switchport\n
+    \  ip address 172.31.255.14/31\n!\ninterface Loopback0\n   description EVPN_Overlay_Peering\n
+    \  no shutdown\n   ip address 192.168.255.2/32\n!\ninterface Management1\n   description
+    oob_management\n   no shutdown\n   vrf MGMT\n   ip address 10.255.0.12/24\n!\nip
+    routing\nno ip routing vrf MGMT\n!\nip prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n
+    \  seq 10 permit 192.168.255.0/24 eq 32\n!\nip route vrf MGMT 0.0.0.0/0 10.255.0.1\n!\nroute-map
+    RM-CONN-2-BGP permit 10\n   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n!\nrouter
+    bfd\n   multihop interval 1200 min-rx 1200 multiplier 3\n!\nrouter bgp 65001\n
+    \  router-id 192.168.255.2\n   no bgp default ipv4-unicast\n   distance bgp 20
+    200 200\n   graceful-restart restart-time 300\n   graceful-restart\n   maximum-paths
+    4 ecmp 4\n   neighbor EVPN-OVERLAY-PEERS peer group\n   neighbor EVPN-OVERLAY-PEERS
+    next-hop-unchanged\n   neighbor EVPN-OVERLAY-PEERS update-source Loopback0\n   neighbor
+    EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3\n   neighbor
+    EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n   neighbor EVPN-OVERLAY-PEERS
+    send-community\n   neighbor EVPN-OVERLAY-PEERS maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS
+    peer group\n   neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==\n
+    \  neighbor IPv4-UNDERLAY-PEERS send-community\n   neighbor IPv4-UNDERLAY-PEERS
+    maximum-routes 12000\n   neighbor 172.31.255.3 peer group IPv4-UNDERLAY-PEERS\n
+    \  neighbor 172.31.255.3 remote-as 65101\n   neighbor 172.31.255.3 description
+    DC1-LEAF1A_Ethernet2\n   neighbor 172.31.255.7 peer group IPv4-UNDERLAY-PEERS\n
+    \  neighbor 172.31.255.7 remote-as 65101\n   neighbor 172.31.255.7 description
+    DC1-LEAF1B_Ethernet2\n   neighbor 172.31.255.11 peer group IPv4-UNDERLAY-PEERS\n
+    \  neighbor 172.31.255.11 remote-as 65102\n   neighbor 172.31.255.11 description
+    DC1-LEAF2A_Ethernet2\n   neighbor 172.31.255.15 peer group IPv4-UNDERLAY-PEERS\n
+    \  neighbor 172.31.255.15 remote-as 65102\n   neighbor 172.31.255.15 description
+    DC1-LEAF2B_Ethernet2\n   neighbor 192.168.255.3 peer group EVPN-OVERLAY-PEERS\n
+    \  neighbor 192.168.255.3 remote-as 65101\n   neighbor 192.168.255.3 description
+    DC1-LEAF1A\n   neighbor 192.168.255.4 peer group EVPN-OVERLAY-PEERS\n   neighbor
+    192.168.255.4 remote-as 65101\n   neighbor 192.168.255.4 description DC1-LEAF1B\n
+    \  neighbor 192.168.255.5 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.5
+    remote-as 65102\n   neighbor 192.168.255.5 description DC1-LEAF2A\n   neighbor
+    192.168.255.6 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.6 remote-as
+    65102\n   neighbor 192.168.255.6 description DC1-LEAF2B\n   redistribute connected
+    route-map RM-CONN-2-BGP\n   !\n   address-family evpn\n      neighbor EVPN-OVERLAY-PEERS
+    activate\n   !\n   address-family ipv4\n      no neighbor EVPN-OVERLAY-PEERS activate\n
+    \     neighbor IPv4-UNDERLAY-PEERS activate\n!\nmanagement api http-commands\n
+    \  protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no shutdown\n!\nend\n"
+  AVD_default_filter: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec
+    /usr/bin/TerminAttr -cvaddr=10.255.0.1:9910 -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
+    -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
+    internal order ascending range 1006 1199\n!\ntransceiver qsfp default-mode 4x10G\n!\nservice
+    routing protocols model multi-agent\n!\nhostname DC1-L2LEAF1A\nip name-server
+    vrf MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.2.1\n!\nntp local-interface
+    vrf MGMT Management1\nntp server vrf MGMT 0.fr.pool.ntp.org prefer\nntp server
+    vrf MGMT 1.fr.pool.ntp.org\n!\nspanning-tree mode mstp\nspanning-tree mst 0 priority
+    16384\n!\nno aaa root\nno enable password\n!\nusername admin privilege 15 role
+    network-admin secret sha512 $6$Df86J4/SFMDE3/1K$Hef4KstdoxNDaami37cBquTWOTplC.miMPjXVgQxMe92.e5wxlnXOLlebgPj8Fz1KO0za/RCO7ZIs4Q6Eiq1g1\nusername
+    ansible privilege 15 role network-admin secret sha512 $6$Dzu11L7yp9j3nCM9$FSptxMPyIL555OMO.ldnjDXgwZmrfMYwHSr0uznE5Qoqvd9a6UdjiFcJUhGLtvXVZR1r.A/iF5aAt50hf/EK4/\nusername
+    cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\nvlan
+    110\n   name Tenant_A_OP_Zone_1\n!\nvlan 111\n   name Tenant_A_OP_Zone_2\n!\nvlan
+    112\n   name Tenant_A_OP_Zone_3\n!\nvlan 120\n   name Tenant_A_WEB_Zone_1\n!\nvlan
+    121\n   name Tenant_A_WEBZone_2\n!\nvlan 130\n   name Tenant_A_APP_Zone_1\n!\nvlan
+    131\n   name Tenant_A_APP_Zone_2\n!\nvrf instance MGMT\n!\ninterface Port-Channel1\n
+    \  description DC1_LEAF1_Po5\n   no shutdown\n   switchport\n   switchport trunk
+    allowed vlan 110-112,120-121,130-131\n   switchport mode trunk\n!\ninterface Ethernet1\n
+    \  description DC1-LEAF1A_Ethernet5\n   no shutdown\n   channel-group 1 mode active\n!\ninterface
+    Ethernet2\n   description DC1-LEAF1B_Ethernet5\n   no shutdown\n   channel-group
+    1 mode active\n!\ninterface Ethernet5\n   description server01_Eth0\n   no shutdown\n
+    \  switchport\n   switchport access vlan 110\n   switchport mode access\n!\ninterface
+    Management1\n   description oob_management\n   no shutdown\n   vrf MGMT\n   ip
+    address 10.255.0.17/24\n!\nip routing\nno ip routing vrf MGMT\n!\nip route vrf
+    MGMT 0.0.0.0/0 10.255.0.1\n!\nmanagement api http-commands\n   protocol https\n
+    \  no shutdown\n   !\n   vrf MGMT\n      no shutdown\n!\nend\n"
+cvp_topology:
+  DC1_FABRIC:
+    parent_container: Tenant
+  DC1_L2LEAF1:
+    devices:
+    - DC1-L2LEAF1A
+    parent_container: DC1_L2LEAFS
+  DC1_L2LEAF2:
+    devices:
+    - DC1-L2LEAF2A
+    parent_container: DC1_L2LEAFS
+  DC1_L2LEAFS:
+    parent_container: DC1_FABRIC
+  DC1_L3LEAFS:
+    parent_container: DC1_FABRIC
+  DC1_LEAF1:
+    devices:
+    - DC1-LEAF1A
+    - DC1-LEAF1B
+    parent_container: DC1_L3LEAFS
+  DC1_LEAF2:
+    devices:
+    - DC1-LEAF2A
+    - DC1-LEAF2B
+    parent_container: DC1_L3LEAFS
+  DC1_SPINES:
+    devices:
+    - DC1-SPINE1
+    - DC1-SPINE2
+    parent_container: DC1_FABRIC


### PR DESCRIPTION
## Change Summary

In AVD 4.0, the move to use v3 of CVP collection by default broke the integration with inventory_to_container module in some cases.

With v1 tasks, if a string was given as `device_filter`, it was converted to the list `[<string>]` by the v1 tasks. This is not the case anymore.

This leads to some misleading result in particular with the empty string device_filter `""`

Additionally, while this has been transparent to the user, if a string like "DC1" was given as device_filter, the `inventory_to_container` action was actually comparing the hostnames to `"D"`, `"C"` and `"1"`, potentially leading to bad filtering. For instance if you had DC1 and DC2 devices and wanted to generate CVP config only for DC1 it would have failed and selecting also the device from DC2 because they have "D" or "C" in their name.

## Related Issue(s)

Reported internally

## Component(s) name

`arista.avd.eos_config_deploy_cvp`

## Proposed changes

Add a step in the `inventory_to_container` action plugin to convert a string `"a"` to a list `["a"]` by default

## How to test

Added a molecule scenario.
First commit shows output before the fix, second commit shows after the fix the difference (notice the parentContainers are back and so are devices - yeah!)

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
