### PR TITLE
CI: Add readthedocs.yaml configuration file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,21 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+# Build documentation with mkdocs
+mkdocs:
+  configuration: mkdocs.yml
+  fail_on_warning: true
+
+python:
+  install:
+    - requirements: ansible_collections/arista/avd/docs/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,7 +14,7 @@ build:
 # Build documentation with mkdocs
 mkdocs:
   configuration: mkdocs.yml
-  fail_on_warning: true
+  fail_on_warning: false
 
 python:
   install:


### PR DESCRIPTION
Readthedocs are deprecating build configuration in the portal. Instead they require a configuration file in the repo.