### PR TITLE
Test: Update pyavd test vars with play_vars

### DIFF
--- a/python-avd/scripts/export_test_vars.yml
+++ b/python-avd/scripts/export_test_vars.yml
@@ -11,6 +11,8 @@
   vars:
     scenario_dir: "{{ inventory_dir }}/.."
     pyavd_test_artifacts_dir: "{{ playbook_dir }}/../tests"
+    tacacs_key_set_as_play_var: "071B245F5A" ## setting dummy value to avoid error for key set in molecule playbook
+    string_set_as_play_var: "test of var set under play vars" ## setting dummy value to avoid error for key set in molecule playbook
   tasks:
     - name: Clear directory
       ansible.builtin.file:


### PR DESCRIPTION
Manual adding "play vars" from molecule when exporting vars for pyavd testing.