### PR TITLE
Feat(eos_cli_config_gen): Add support for "include leaked" under BGP redistribution

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
@@ -225,6 +225,7 @@ router bgp 65101
       neighbor 2001:db8::1 prefix-list PL-FOO-v6-OUT out
       network 2001:db8:100::/40
       network 2001:db8:200::/40 route-map RM-BAR-MATCH
+      redistribute ospf include leaked
       redistribute static route-map RM-IPV6-STATIC-TO-BGP
    session tracker ST1
       recovery delay 666 seconds

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-vrf-lite.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-vrf-lite.md
@@ -145,7 +145,7 @@ ip route vrf BLUE-C1 193.1.2.0/24 Null0
 
 | VRF | Route-Distinguisher | Redistribute |
 | --- | ------------------- | ------------ |
-| BLUE-C1 | 1.0.1.1:101 | static |
+| BLUE-C1 | 1.0.1.1:101 | static<br>ospf |
 | RED-C1 | 1.0.1.1:102 | - |
 | YELLOW-C1 | 1.0.1.1:103 | - |
 
@@ -180,6 +180,7 @@ router bgp 65001
    neighbor WELCOME_ROUTERS peer group
    neighbor WELCOME_ROUTERS remote-as 65001
    neighbor WELCOME_ROUTERS description BGP Connection to WELCOME ROUTER 02
+   redistribute ospf include leaked route-map RM-OSPF-TO-BGP
    redistribute static
    !
    address-family ipv4
@@ -213,6 +214,7 @@ router bgp 65001
       neighbor 101.0.3.7 bfd
       aggregate-address 0.0.0.0/0 as-set summary-only attribute-map RM-BGP-AGG-APPLY-SET
       aggregate-address 193.1.0.0/16 as-set summary-only attribute-map RM-BGP-AGG-APPLY-SET
+      redistribute ospf include leaked
       redistribute static
       !
       comment

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-base.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-base.cfg
@@ -103,6 +103,7 @@ router bgp 65101
       neighbor 2001:db8::1 prefix-list PL-FOO-v6-OUT out
       network 2001:db8:100::/40
       network 2001:db8:200::/40 route-map RM-BAR-MATCH
+      redistribute ospf include leaked
       redistribute static route-map RM-IPV6-STATIC-TO-BGP
    session tracker ST1
       recovery delay 666 seconds

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-vrf-lite.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-vrf-lite.cfg
@@ -60,6 +60,7 @@ router bgp 65001
    neighbor WELCOME_ROUTERS peer group
    neighbor WELCOME_ROUTERS remote-as 65001
    neighbor WELCOME_ROUTERS description BGP Connection to WELCOME ROUTER 02
+   redistribute ospf include leaked route-map RM-OSPF-TO-BGP
    redistribute static
    !
    address-family ipv4
@@ -93,6 +94,7 @@ router bgp 65001
       neighbor 101.0.3.7 bfd
       aggregate-address 0.0.0.0/0 as-set summary-only attribute-map RM-BGP-AGG-APPLY-SET
       aggregate-address 193.1.0.0/16 as-set summary-only attribute-map RM-BGP-AGG-APPLY-SET
+      redistribute ospf include leaked
       redistribute static
       !
       comment

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-base.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-base.yml
@@ -101,6 +101,8 @@ router_bgp:
     redistribute_routes:
       - source_protocol: static
         route_map: RM-IPV6-STATIC-TO-BGP
+      - source_protocol: ospf
+        include_leaked: true
   neighbors:
     - ip_address: 192.0.3.1
       remote_as: 65432

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-vrf-lite.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-vrf-lite.yml
@@ -68,6 +68,9 @@ router_bgp:
       passive: true
   redistribute_routes:
     - source_protocol: static
+    - source_protocol: ospf
+      include_leaked: true
+      route_map: RM-OSPF-TO-BGP
   address_family_ipv4:
     peer_groups:
       - name: OBS_WAN
@@ -124,6 +127,8 @@ router_bgp:
           bfd: false
       redistribute_routes:
         - source_protocol: static
+        - source_protocol: ospf
+          include_leaked: true
       aggregate_addresses:
         - prefix: 193.1.0.0/16
           as_set: true

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-bgp.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-bgp.md
@@ -151,6 +151,7 @@
     | [<samp>&nbsp;&nbsp;redistribute_routes</samp>](## "router_bgp.redistribute_routes") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- source_protocol</samp>](## "router_bgp.redistribute_routes.[].source_protocol") | String | Required, Unique |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "router_bgp.redistribute_routes.[].route_map") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;include_leaked</samp>](## "router_bgp.redistribute_routes.[].include_leaked") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;vlan_aware_bundles</samp>](## "router_bgp.vlan_aware_bundles") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "router_bgp.vlan_aware_bundles.[].name") | String | Required, Unique |  |  | VLAN aware bundle name |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tenant</samp>](## "router_bgp.vlan_aware_bundles.[].tenant") | String |  |  |  | Key only used for documentation or validation purposes |
@@ -313,6 +314,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;redistribute_routes</samp>](## "router_bgp.address_family_ipv6.redistribute_routes") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- source_protocol</samp>](## "router_bgp.address_family_ipv6.redistribute_routes.[].source_protocol") | String | Required, Unique |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "router_bgp.address_family_ipv6.redistribute_routes.[].route_map") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;include_leaked</samp>](## "router_bgp.address_family_ipv6.redistribute_routes.[].include_leaked") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;address_family_ipv6_multicast</samp>](## "router_bgp.address_family_ipv6_multicast") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;bgp</samp>](## "router_bgp.address_family_ipv6_multicast.bgp") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;missing_policy</samp>](## "router_bgp.address_family_ipv6_multicast.bgp.missing_policy") | Dictionary |  |  |  |  |
@@ -468,6 +470,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;redistribute_routes</samp>](## "router_bgp.vrfs.[].redistribute_routes") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- source_protocol</samp>](## "router_bgp.vrfs.[].redistribute_routes.[].source_protocol") | String | Required, Unique |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "router_bgp.vrfs.[].redistribute_routes.[].route_map") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;include_leaked</samp>](## "router_bgp.vrfs.[].redistribute_routes.[].include_leaked") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;aggregate_addresses</samp>](## "router_bgp.vrfs.[].aggregate_addresses") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- prefix</samp>](## "router_bgp.vrfs.[].aggregate_addresses.[].prefix") | String | Required, Unique |  |  | IPv4 prefix "A.B.C.D/E" or IPv6 prefix "A:B:C:D:E:F:G:H/I" |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;advertise_only</samp>](## "router_bgp.vrfs.[].aggregate_addresses.[].advertise_only") | Boolean |  |  |  |  |
@@ -749,6 +752,7 @@
       redistribute_routes:
         - source_protocol: <str>
           route_map: <str>
+          include_leaked: <bool>
       vlan_aware_bundles:
         - name: <str>
           tenant: <str>
@@ -911,6 +915,7 @@
         redistribute_routes:
           - source_protocol: <str>
             route_map: <str>
+            include_leaked: <bool>
       address_family_ipv6_multicast:
         bgp:
           missing_policy:
@@ -1066,6 +1071,7 @@
           redistribute_routes:
             - source_protocol: <str>
               route_map: <str>
+              include_leaked: <bool>
           aggregate_addresses:
             - prefix: <str>
               advertise_only: <bool>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -12570,6 +12570,10 @@
               "route_map": {
                 "type": "string",
                 "title": "Route Map"
+              },
+              "include_leaked": {
+                "type": "boolean",
+                "title": "Include Leaked"
               }
             },
             "additionalProperties": false,
@@ -13665,6 +13669,10 @@
                   "route_map": {
                     "type": "string",
                     "title": "Route Map"
+                  },
+                  "include_leaked": {
+                    "type": "boolean",
+                    "title": "Include Leaked"
                   }
                 },
                 "additionalProperties": false,
@@ -14753,6 +14761,10 @@
                     "route_map": {
                       "type": "string",
                       "title": "Route Map"
+                    },
+                    "include_leaked": {
+                      "type": "boolean",
+                      "title": "Include Leaked"
                     }
                   },
                   "additionalProperties": false,

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -7569,6 +7569,8 @@ keys:
               type: str
             route_map:
               type: str
+            include_leaked:
+              type: bool
       vlan_aware_bundles:
         type: list
         primary_key: name
@@ -8140,6 +8142,8 @@ keys:
                   type: str
                 route_map:
                   type: str
+                include_leaked:
+                  type: bool
       address_family_ipv6_multicast:
         type: dict
         keys:
@@ -8727,6 +8731,8 @@ keys:
                     type: str
                   route_map:
                     type: str
+                  include_leaked:
+                    type: bool
             aggregate_addresses:
               type: list
               primary_key: prefix

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_bgp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_bgp.schema.yml
@@ -537,6 +537,8 @@ keys:
               type: str
             route_map:
               type: str
+            include_leaked:
+              type: bool
       vlan_aware_bundles:
         type: list
         primary_key: name
@@ -1106,6 +1108,8 @@ keys:
                   type: str
                 route_map:
                   type: str
+                include_leaked:
+                  type: bool
       address_family_ipv6_multicast:
         type: dict
         keys:
@@ -1668,6 +1672,8 @@ keys:
                     type: str
                   route_map:
                     type: str
+                  include_leaked:
+                    type: bool
             aggregate_addresses:
               type: list
               primary_key: prefix

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -382,6 +382,9 @@ router bgp {{ router_bgp.as }}
 {%     for redistribute_route in router_bgp.redistribute_routes | arista.avd.natural_sort('source_protocol') %}
 {%         if redistribute_route.source_protocol is arista.avd.defined %}
 {%             set redistribute_route_cli = "redistribute " ~ redistribute_route.source_protocol %}
+{%             if redistribute_route.include_leaked is arista.avd.defined %}
+{%                 set redistribute_route_cli = redistribute_route_cli ~ " include leaked" %}
+{%             endif %}
 {%             if redistribute_route.route_map is arista.avd.defined %}
 {%                 set redistribute_route_cli = redistribute_route_cli ~ " route-map " ~ redistribute_route.route_map %}
 {%             endif %}
@@ -802,6 +805,9 @@ router bgp {{ router_bgp.as }}
 {%         for redistribute_route in router_bgp.address_family_ipv6.redistribute_routes | arista.avd.natural_sort('source_protocol') %}
 {%             if redistribute_route.source_protocol is arista.avd.defined %}
 {%                 set redistribute_route_cli = "redistribute " ~ redistribute_route.source_protocol %}
+{%                 if redistribute_route.include_leaked is arista.avd.defined %}
+{%                     set redistribute_route_cli = redistribute_route_cli ~ " include leaked" %}
+{%                 endif %}
 {%                 if redistribute_route.route_map is arista.avd.defined %}
 {%                     set redistribute_route_cli = redistribute_route_cli ~ " route-map " ~ redistribute_route.route_map %}
 {%                 endif %}
@@ -1156,6 +1162,9 @@ router bgp {{ router_bgp.as }}
 {%         for redistribute_route in vrf.redistribute_routes | arista.avd.natural_sort('source_protocol') %}
 {%             if redistribute_route.source_protocol is arista.avd.defined %}
 {%                 set redistribute_route_cli = "redistribute " ~ redistribute_route.source_protocol %}
+{%                 if redistribute_route.include_leaked is arista.avd.defined %}
+{%                     set redistribute_route_cli = redistribute_route_cli ~ " include leaked" %}
+{%                 endif %}
 {%                 if redistribute_route.route_map is arista.avd.defined %}
 {%                     set redistribute_route_cli = redistribute_route_cli ~ " route-map " ~ redistribute_route.route_map %}
 {%                 endif %}


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Add support for "include leaked" under BGP redistribution

## Related Issue(s)

Fixes #1385 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

```yaml
router_bgp:
  redistribute_routes:
    - source_protocol: <str>
      include_leaked: <bool>
  address_family_ipv6:
    redistribute_routes:
      - source_protocol: <str>
        include_leaked: <bool>
  vrfs:
    - name: <str>
      redistribute_routes:
        - source_protocol: <str>
          include_leaked: <bool>
```

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Added molecule test cases.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
