### PR TITLE
Feat(eos_cli_config_gen): add dot1x unauthorized access/native vlan membership egress to ethernet interfaces

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
@@ -710,6 +710,8 @@ interface Ethernet45
    dot1x timeout reauth-period server
    dot1x timeout idle-host 10 seconds
    dot1x reauthorization request limit 2
+   dot1x unauthorized access vlan membership egress
+   dot1x unauthorized native vlan membership egress
    dot1x eapol authentication failure fallback mba timeout 600
 !
 interface Ethernet46

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
@@ -424,6 +424,8 @@ interface Ethernet45
    dot1x timeout reauth-period server
    dot1x timeout idle-host 10 seconds
    dot1x reauthorization request limit 2
+   dot1x unauthorized access vlan membership egress
+   dot1x unauthorized native vlan membership egress
    dot1x eapol authentication failure fallback mba timeout 600
 !
 interface Ethernet46

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
@@ -574,6 +574,9 @@ ethernet_interfaces:
           enabled: true
           timeout: 600
       reauthorization_request_limit: 2
+      unauthorized:
+        access_vlan_membership_egress: true
+        native_vlan_membership_egress: true
 
   - name: Ethernet46
     description: native-vlan-tag-precedence

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ethernet-interfaces.md
@@ -250,6 +250,9 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;reauth_timeout_ignore</samp>](## "ethernet_interfaces.[].dot1x.timeout.reauth_timeout_ignore") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tx_period</samp>](## "ethernet_interfaces.[].dot1x.timeout.tx_period") | Integer |  |  | Min: 1<br>Max: 65535 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;reauthorization_request_limit</samp>](## "ethernet_interfaces.[].dot1x.reauthorization_request_limit") | Integer |  |  | Min: 1<br>Max: 10 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unauthorized</samp>](## "ethernet_interfaces.[].dot1x.unauthorized") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;access_vlan_membership_egress</samp>](## "ethernet_interfaces.[].dot1x.unauthorized.access_vlan_membership_egress") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;native_vlan_membership_egress</samp>](## "ethernet_interfaces.[].dot1x.unauthorized.native_vlan_membership_egress") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;eapol</samp>](## "ethernet_interfaces.[].dot1x.eapol") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;disabled</samp>](## "ethernet_interfaces.[].dot1x.eapol.disabled") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;authentication_failure_fallback_mba</samp>](## "ethernet_interfaces.[].dot1x.eapol.authentication_failure_fallback_mba") | Dictionary |  |  |  |  |
@@ -562,6 +565,9 @@
             reauth_timeout_ignore: <bool>
             tx_period: <int>
           reauthorization_request_limit: <int>
+          unauthorized:
+            access_vlan_membership_egress: <bool>
+            native_vlan_membership_egress: <bool>
           eapol:
             disabled: <bool>
             authentication_failure_fallback_mba:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -3397,6 +3397,24 @@
                 "maximum": 10,
                 "title": "Reauthorization Request Limit"
               },
+              "unauthorized": {
+                "type": "object",
+                "properties": {
+                  "access_vlan_membership_egress": {
+                    "type": "boolean",
+                    "title": "Access VLAN Membership Egress"
+                  },
+                  "native_vlan_membership_egress": {
+                    "type": "boolean",
+                    "title": "Native VLAN Membership Egress"
+                  }
+                },
+                "additionalProperties": false,
+                "patternProperties": {
+                  "^_.+$": {}
+                },
+                "title": "Unauthorized"
+              },
               "eapol": {
                 "type": "object",
                 "properties": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -2037,6 +2037,13 @@ keys:
               max: 10
               convert_types:
               - str
+            unauthorized:
+              type: dict
+              keys:
+                access_vlan_membership_egress:
+                  type: bool
+                native_vlan_membership_egress:
+                  type: bool
             eapol:
               type: dict
               keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ethernet_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ethernet_interfaces.schema.yml
@@ -772,6 +772,13 @@ keys:
               max: 10
               convert_types:
                 - str
+            unauthorized:
+              type: dict
+              keys:
+                access_vlan_membership_egress:
+                  type: bool
+                native_vlan_membership_egress:
+                  type: bool
             eapol:
               type: dict
               keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -270,6 +270,12 @@ interface {{ ethernet_interface.name }}
 {%         if ethernet_interface.dot1x.reauthorization_request_limit is arista.avd.defined %}
    dot1x reauthorization request limit {{ ethernet_interface.dot1x.reauthorization_request_limit }}
 {%         endif %}
+{%         if ethernet_interface.dot1x.unauthorized.access_vlan_membership_egress is arista.avd.defined(true) %}
+   dot1x unauthorized access vlan membership egress
+{%         endif %}
+{%         if ethernet_interface.dot1x.unauthorized.native_vlan_membership_egress is arista.avd.defined(true) %}
+   dot1x unauthorized native vlan membership egress
+{%         endif %}
 {%         if ethernet_interface.dot1x.eapol is arista.avd.defined %}
 {%             if ethernet_interface.dot1x.eapol.disabled is arista.avd.defined(true) %}
    dot1x eapol disabled


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Add dot1x unauthorized access|native vlan membership egress to ethernet interfaces
```
access-10-021-01.LAN.MU__17:12:30(config-if-Et82)#dot1x unauthorized ?
  access  Applied to access VLAN of access port
  native  Applied to native VLAN of phone trunk port
```

## Related Issue(s)

Fixes #2826

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->
```
ethernet_interfaces:
  - name: <str>
     dot1x:
       unauthorized:
         access_vlan_membership_egress: <bool>
         native_vlan_membership_egress: <bool>
```      
         
## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
```
ethernet_interfaces:
  - name: Ethernet8
     dot1x:
       unauthorized:
         access_vlan_membership_egress: true
         native_vlan_membership_egress: true
```      
renders to:
```
interface Ethernet8
   dot1x unauthorized access vlan membership egress
   dot1x unauthorized native vlan membership egress
```

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
