### PR TITLE
Fix(eos_designs): Ensure consistent ordering of underlay route-maps

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/utils.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/utils.py
@@ -39,8 +39,8 @@ class UtilsMixin:
         if self.shared_utils.underlay_filter_peer_as is False:
             return []
 
-        # using set comprehension with `{}`
-        return list({link["peer_bgp_as"] for link in self._underlay_links if link["type"] == "underlay_p2p"})
+        # using set comprehension with `{}` to remove duplicates and then run natural_sort to convert to list.
+        return natural_sort({link["peer_bgp_as"] for link in self._underlay_links if link["type"] == "underlay_p2p"})
 
     @cached_property
     def _underlay_links(self) -> list:


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Ensure consistent ordering of underlay route-maps

## Related Issue(s)

Since route-maps for underlay peerings are generated using a `set()`, they may change order between runs on different platforms.

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

Ensure to natural_sort the ASNs before generating the route-maps.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Tested manually.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
