### PR TITLE
Fix(eos_designs): Don't require "mlag_peer_l3_ipv4_pool" with full rfc5549

### DIFF
--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/inventory/group_vars/DC1_FABRIC.yml
@@ -95,7 +95,7 @@ l3leaf:
     filter:
       tenants: [ Tenant_A, Tenant_B, Tenant_C ]
       tags: [ opzone, web, app, db, vmotion, nfs ]
-    mlag_peer_l3_ipv4_pool: 10.255.251.0/24
+    # mlag_peer_l3_ipv4_pool: 10.255.251.0/24 # Not needed since we run rfc5549
     mlag_peer_ipv4_pool: 10.255.252.0/24
   node_groups:
     - group: DC1_LEAF1
@@ -110,6 +110,8 @@ l3leaf:
           uplink_switch_interfaces: [ Ethernet1, Ethernet1, Ethernet1, Ethernet1 ]
     - group: DC1_LEAF2
       bgp_as: 65102
+      # since this device is not using rfc5549 for overlay, we need mlag_peer_l3_ipv4_pool set specifically.
+      mlag_peer_l3_ipv4_pool: 10.255.251.0/24
       nodes:
         - name: DC1-LEAF2A
           id: 2
@@ -200,7 +202,7 @@ l2leaf:
     mlag_interfaces: [ Ethernet3, Ethernet4 ]
     spanning_tree_mode: mstp
     spanning_tree_priority: 16384
-    mlag_peer_l3_ipv4_pool: 10.255.251.0/24
+    # mlag_peer_l3_ipv4_pool: 10.255.251.0/24 # Not needed since this is l2
     mlag_peer_ipv4_pool: 10.255.252.0/24
   node_groups:
     - group: DC1_L2LEAF1

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/inventory/group_vars/DC1_LEAF2.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/inventory/group_vars/DC1_LEAF2.yml
@@ -6,4 +6,6 @@
 #     vrf <vrf_name>
 #        address-family ipv4
 #           no neighbor <mlag-peer-ip> next-hop address-family ipv6
+#
+# since this device is not using rfc5549 for overlay, we need mlag_peer_l3_ipv4_pool set specifically.
 overlay_mlag_rfc5549: false

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_facts/mlag.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_facts/mlag.py
@@ -57,8 +57,14 @@ class MlagMixin:
     def mlag_l3_ip(self: EosDesignsFacts) -> str | None:
         """
         Exposed in avd_switch_facts
+
+        Only if L3 and not running rfc5549 for both underlay and overlay
         """
-        if self.shared_utils.mlag_l3 and self.shared_utils.mlag_peer_l3_vlan is not None:
+        if (
+            self.shared_utils.mlag_l3
+            and self.shared_utils.mlag_peer_l3_vlan is not None
+            and not (self.shared_utils.underlay_rfc5549 and self.shared_utils.overlay_mlag_rfc5549)
+        ):
             return self.shared_utils.mlag_l3_ip
         return None
 


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Don't require "mlag_peer_l3_ipv4_pool" with full rfc5549

## Related Issue(s)

When using rfc5549 for both underlay and mlag overlay peerings there should be no requirement for "mlag_peer_l3_ipv4_pool".

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

Add checks for rfc5549 before setting fact with mlag_l3_ip.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Added molecule test coverage. Verified error before fix.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
