### PR TITLE
Fix(eos_config_deploy_cvp): Avoid duplicate AVD configlet

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/templates/cvp-devices-v3.j2
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/templates/cvp-devices-v3.j2
@@ -15,16 +15,16 @@
 cvp_devices:
 {% for device in groups[container_root] | arista.avd.natural_sort %}
 {%     if device | arista.avd.is_in_filter(local_var.device_filter) %}
-{%         if hostvars[device]['is_deployed'] is arista.avd.defined(true) or hostvars[device]['is_deployed'] is not arista.avd.defined %}
+{%         if hostvars[device].is_deployed is arista.avd.defined(true) or hostvars[device].is_deployed is not arista.avd.defined %}
   - fqdn: {{ device }}
 {%             if device_search_key is arista.avd.defined('serialNumber')
-                  and hostvars[device]['serial_number'] is arista.avd.defined(fail_action="error", var_name="When using 'device_search_key: serialNumber', on device " ~ device ~ " 'serial_number'") %}
-    serialNumber: "{{ hostvars[device]['serial_number'] }}"
+                  and hostvars[device].serial_number is arista.avd.defined(fail_action="error", var_name="When using 'device_search_key: serialNumber', on device " ~ device ~ " 'serial_number'") %}
+    serialNumber: "{{ hostvars[device].serial_number }}"
 {%             endif %}
 {%             set dev_cntr.value = dev_cntr.value + 1 %}
 {%             for container_name, container in cvp_vars.cvp_topology.items() | arista.avd.natural_sort %}
 {%                 if 'devices' in container %}
-{%                     for device_container in container['devices'] %}
+{%                     for device_container in container.devices %}
 {%                         if device == device_container %}
     parentContainerName: {{ container_name }}
 {%                         endif %}
@@ -32,12 +32,13 @@ cvp_devices:
 {%                 endif %}
 {%             endfor %}
     configlets:
-{%             if hostvars[groups[container_root][0]]['cv_configlets']['devices'][device] is arista.avd.defined %}
-{%                 for configlet in hostvars[groups[container_root][0]]['cv_configlets']['devices'][device] | arista.avd.natural_sort %}
+{%             set device_configlets = hostvars[groups[container_root][0]].cv_configlets.devices[device] | arista.avd.default([]) %}
+{%             for configlet in device_configlets %}
       - {{ configlet }}
-{%                 endfor %}
-{%             endif %}
+{%             endfor %}
+{%             if configlets_prefix ~ "_" ~ device not in device_configlets %}
       - {{ configlets_prefix }}_{{ device }}
+{%             endif %}
 {%         endif %}
 {%     endif %}
 {% endfor %}
@@ -47,10 +48,10 @@ cvp_devices:
 cvp_containers:
 {% for container_name, container in cvp_vars.cvp_topology.items() | arista.avd.natural_sort %}
   {{ container_name }}:
-    parentContainerName: {{ container['parent_container'] }}
-{%     if hostvars[groups[container_root][0]]['cv_configlets']['containers'][container_name] is defined and hostvars[groups[container_root][0]]['cv_configlets']['containers'][container_name] is iterable %}
+    parentContainerName: {{ container.parent_container }}
+{%     if hostvars[groups[container_root][0]].cv_configlets.containers[container_name] is defined and hostvars[groups[container_root][0]].cv_configlets.containers[container_name] is iterable %}
     configlets:
-{%         for configlet in hostvars[groups[container_root][0]]['cv_configlets']['containers'][container_name] | arista.avd.natural_sort %}
+{%         for configlet in hostvars[groups[container_root][0]].cv_configlets.containers[container_name] | arista.avd.natural_sort %}
       - {{ configlet }}
 {%         endfor %}
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/templates/cvp-devices.j2
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/templates/cvp-devices.j2
@@ -14,12 +14,12 @@
 cvp_devices:
 {% for device in groups[container_root] | arista.avd.natural_sort %}
 {%     if device | arista.avd.is_in_filter(local_var.device_filter) %}
-{%         if (hostvars[device]['is_deployed'] is defined and hostvars[device]['is_deployed'] == true) or (hostvars[device]['is_deployed'] is not defined) %}
+{%         if (hostvars[device].is_deployed is defined and hostvars[device].is_deployed == true) or (hostvars[device].is_deployed is not defined) %}
   {{ device }}:
     name: {{ device }}
 {%             for container_name, container in cvp_vars.cvp_topology.items() | arista.avd.natural_sort %}
 {%                 if 'devices' in container %}
-{%                     for device_container in container['devices'] %}
+{%                     for device_container in container.devices %}
 {%                         if device == device_container %}
     parentContainerName: {{ container_name }}
 {%                         endif %}
@@ -27,12 +27,13 @@ cvp_devices:
 {%                 endif %}
 {%             endfor %}
     configlets:
-{%             if hostvars[groups[container_root][0]]['cv_configlets']['devices'][device] is defined %}
-{%                 for configlet in hostvars[groups[container_root][0]]['cv_configlets']['devices'][device] | arista.avd.natural_sort %}
+{%             set device_configlets = hostvars[groups[container_root][0]].cv_configlets.devices[device] | arista.avd.default([]) %}
+{%             for configlet in device_configlets %}
       - {{ configlet }}
-{%                 endfor %}
-{%             endif %}
+{%             endfor %}
+{%             if configlets_prefix ~ "_" ~ device not in device_configlets %}
       - {{ configlets_prefix }}_{{ device }}
+{%             endif %}
     imageBundle: []
 {%         endif %}
 {%     endif %}
@@ -40,10 +41,10 @@ cvp_devices:
 cvp_containers:
 {% for container_name, container in cvp_vars.cvp_topology.items() | arista.avd.natural_sort %}
   {{ container_name }}:
-    parent_container: {{ container['parent_container'] }}
-{%     if hostvars[groups[container_root][0]]['cv_configlets']['containers'][container_name] is defined and hostvars[groups[container_root][0]]['cv_configlets']['containers'][container_name] is iterable %}
+    parent_container: {{ container.parent_container }}
+{%     if hostvars[groups[container_root][0]].cv_configlets.containers[container_name] is defined and hostvars[groups[container_root][0]].cv_configlets.containers[container_name] is iterable %}
     configlets:
-{%         for configlet in hostvars[groups[container_root][0]]['cv_configlets']['containers'][container_name] | arista.avd.natural_sort %}
+{%         for configlet in hostvars[groups[container_root][0]].cv_configlets.containers[container_name] | arista.avd.natural_sort %}
       - {{ configlet }}
 {%         endfor %}
 {%     endif %}


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Avoid duplicate AVD configlet

## Related Issue(s)

Fixes #3107 

## Component(s) name

`arista.avd.eos_config_deploy_cvp`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

In case a user gives:
```yaml
cv_configlets:
  devices:
    device1:
      - AVD_device1
      - another_device1_configlet (this is a side configlet already existing in CVP)
```

Previously the generated assigned configlets would be:

```yaml
"CVP_VARS":
  "CVP_CONTAINERS": {...}
  "CVP_DEVICES":
     ...
     - "configlets":
       - "AVD_device1"
       - "another_device1_configlet"
       - "AVD_device1"
      "fqdn": "device1"
      "parentContainerName": "XXX"
```

With this fix the role will avoid adding the generated configlet, if it is already in the list of configlets:

```yaml
"CVP_VARS":
  "CVP_CONTAINERS": {...}
  "CVP_DEVICES":
     ...
     - "configlets":
       - "AVD_device1"
       - "another_device1_configlet"
      "fqdn": "device1"
      "parentContainerName": "XXX"
```

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Tested manually.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
