### PR TITLE
Feat: Support inline comments in requirements.txt

### DIFF
--- a/ansible_collections/arista/avd/plugins/action/verify_requirements.py
+++ b/ansible_collections/arista/avd/plugins/action/verify_requirements.py
@@ -80,7 +80,6 @@ def _validate_python_requirements(requirements: list, result: dict) -> bool:
     requirements = [_remove_inline_comment(req) for req in requirements if req[0] != "#"]
     for raw_req in requirements:
         try:
-            raw_req = _remove_inline_comment(raw_req)
             req = Requirement(raw_req)
         except InvalidRequirement as exc:
             raise AristaAvdError(f"Wrong format for requirement {raw_req}") from exc

--- a/ansible_collections/arista/avd/plugins/action/verify_requirements.py
+++ b/ansible_collections/arista/avd/plugins/action/verify_requirements.py
@@ -70,8 +70,8 @@ def _validate_python_requirements(requirements: list, result: dict) -> bool:
         "parsing_failed": [],
     }
 
-    # Remove the comments
-    requirements = [req.split(" # ")[0] for req in requirements if req[0] != "#"]
+    # Remove the comments including inline comments
+    requirements = [req.split(" #")[0] for req in requirements if req[0] != "#"]
     for raw_req in requirements:
         try:
             req = Requirement(raw_req)

--- a/ansible_collections/arista/avd/plugins/action/verify_requirements.py
+++ b/ansible_collections/arista/avd/plugins/action/verify_requirements.py
@@ -70,10 +70,17 @@ def _validate_python_requirements(requirements: list, result: dict) -> bool:
         "parsing_failed": [],
     }
 
+    def _remove_inline_comment(raw_req: str) -> str:
+        """
+        Remove trailing comments if present
+        """
+        return raw_req.split(" # ")[0]
+
     # Remove the comments
-    requirements = [req for req in requirements if req[0] != "#"]
+    requirements = [_remove_inline_comment(req) for req in requirements if req[0] != "#"]
     for raw_req in requirements:
         try:
+            raw_req = _remove_inline_comment(raw_req)
             req = Requirement(raw_req)
         except InvalidRequirement as exc:
             raise AristaAvdError(f"Wrong format for requirement {raw_req}") from exc

--- a/ansible_collections/arista/avd/plugins/action/verify_requirements.py
+++ b/ansible_collections/arista/avd/plugins/action/verify_requirements.py
@@ -71,7 +71,7 @@ def _validate_python_requirements(requirements: list, result: dict) -> bool:
     }
 
     # Remove the comments including inline comments
-    requirements = [req.split(" #")[0] for req in requirements if req[0] != "#"]
+    requirements = [req.split(" #", maxsplit=1)[0] for req in requirements if req[0] != "#"]
     for raw_req in requirements:
         try:
             req = Requirement(raw_req)

--- a/ansible_collections/arista/avd/plugins/action/verify_requirements.py
+++ b/ansible_collections/arista/avd/plugins/action/verify_requirements.py
@@ -70,14 +70,8 @@ def _validate_python_requirements(requirements: list, result: dict) -> bool:
         "parsing_failed": [],
     }
 
-    def _remove_inline_comment(raw_req: str) -> str:
-        """
-        Remove trailing comments if present
-        """
-        return raw_req.split(" # ")[0]
-
     # Remove the comments
-    requirements = [_remove_inline_comment(req) for req in requirements if req[0] != "#"]
+    requirements = [req.split(" # ")[0] for req in requirements if req[0] != "#"]
     for raw_req in requirements:
         try:
             req = Requirement(raw_req)

--- a/ansible_collections/arista/avd/tests/unit/action/test_verify_requirements.py
+++ b/ansible_collections/arista/avd/tests/unit/action/test_verify_requirements.py
@@ -64,6 +64,13 @@ def test__validate_python_version(mocked_version, expected_return):
             id="valid version",
         ),
         pytest.param(
+            1,
+            "4.3",
+            "4.2 # inline comment",
+            True,
+            id="requirement with inline comment",
+        ),
+        pytest.param(
             2,
             "4.0",
             "4.2",


### PR DESCRIPTION
## Related Issue(s)

Fixes #3122 

## Component(s) name

`plugins`

## Proposed changes

Added logic to remove inline comments

## How to test

Unit test added

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
