### PR TITLE
Refactor(eos_designs): Remove unused code

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/mlag/avdstructuredconfig.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/mlag/avdstructuredconfig.py
@@ -260,6 +260,7 @@ class AvdStructuredConfigMlag(AvdFacts):
         Return structured config for router bgp
 
         Peer group and underlay MLAG iBGP peering is created only for BGP underlay.
+        For other underlay protocols the MLAG peer-group may be created as part of the network services logic.
         """
 
         if not (self.shared_utils.mlag_l3 is True and self.shared_utils.underlay_bgp):
@@ -270,9 +271,6 @@ class AvdStructuredConfigMlag(AvdFacts):
         router_bgp = self._router_bgp_mlag_peer_group()
 
         # Underlay MLAG peering
-        if not self.shared_utils.underlay_bgp:
-            return strip_empties_from_dict(router_bgp)
-
         if self.shared_utils.underlay_rfc5549:
             vlan = default(self.shared_utils.mlag_peer_l3_vlan, self.shared_utils.mlag_peer_vlan)
             neighbor_interface_name = f"Vlan{vlan}"


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Remove unused code

## Related Issue(s)

Fixes #3134 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

Removing an unneeded if and unreachable code below.

Also verified with pyavd code coverage report that indeed this code was never exercised.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

No changes expected anywhere.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
