### PR TITLE
Fix: ip reachability test with l3dge endpoint not managed by AVD

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/ip_reachability.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/ip_reachability.yml
@@ -18,7 +18,7 @@
     ethernet_interface.ip_address is arista.avd.defined and
     ethernet_interface.peer is arista.avd.defined and
     ethernet_interface.peer_interface is arista.avd.defined and
-    peer_ip is arista.avd.defined
+    peer_ip is arista.avd.defined and peer_ip
   vars:
     peer_ip: "{{ (hostvars[ethernet_interface.peer | arista.avd.default('_')].ethernet_interfaces | arista.avd.default({}) | arista.avd.convert_dicts('name') | selectattr('name', 'eq', ethernet_interface.peer_interface | arista.avd.default) | map(attribute='ip_address'))[0] | arista.avd.default }}"
 


### PR DESCRIPTION
## Change Summary

Fix for ip reachability test failure in eos_validate_state when  using l3_edge for a link to a device not modeled in AVD.

## Related Issue(s)

Issue and fix discussed with @ClausHolbechArista in AVD_Field: 
eos_validate_state fails ip reachability tests when using l3_edge to a device not modeled by AVD.

In this case, the peer IP address is set to `False`, and - later on - used as the destination of the IP reachability test.

This then results in this CLI and a failed test (reported as 100% packet loss)

[output from ansible-playbook -vvv]
```
    "invocation": {
        "module_args": {
            "commands": [
                "ping False source 192.168.3.4 repeat 1"
            ],
            "interval": 1,
            "match": "all",
            "retries": 10,
            "wait_for": null
        }
    },
```
## Component(s) name

`arista.avd.eos_validate_state`

## Proposed changes

In ip_reachability.yml, just skip the test if the destination address is defined, but set to False.
In other words, if you do not know a remote IP address, do not try to use it for reachability testing.

## How to test
This is a snippet of the l3edge definition for one of the service leaf switches:

```
---
l3_edge:
  p2p_links_ip_pools:
    - name: dci_links
      ipv4_pool: 192.168.3.0/24
  p2p_links:
    - id: 1
      ip_pool: dci_links
      nodes: [leaf1, DCI-ROUTER]
      interfaces: [Ethernet27, Ethernet1]
      as: ["65000.1", "65000.65000"]
      include_in_underlay_protocol: true
```
Validation fails for this link on avd-4.3.0.

Retested with the proposed fix caused the test to be skipped rather than be reported as failure.


## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [*] My code has been rebased from devel before I start
- [*] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
