### PR TITLE
CI: Cap molecule<6.0 until we can upgrade

### DIFF
--- a/ansible_collections/arista/avd/requirements-dev.txt
+++ b/ansible_collections/arista/avd/requirements-dev.txt
@@ -10,7 +10,7 @@ pre-commit>=3.2.0
 pre-commit-hooks>=3.3.0
 identify>=1.4.20
 docker
-molecule>=3.2.0
+molecule>=3.2.0,<6.0
 molecule-plugins[docker]>=23.4.0 ; python_version >= "3.9" #Not supported in 3.8
 yamllint
 treelib


### PR DESCRIPTION
## Change Summary

several changes in molecule 6.0 that we need to work on before we can put it in our requirements

## Component(s) name

`ci`

## Proposed changes

Cap molecule to <6.0

## How to test

install locally and run molecule

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
