### PR TITLE
Feat(eos_cli_config_gen): Support path-selection bgp address-family

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-path-selection.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-path-selection.md
@@ -1,0 +1,159 @@
+# router-bgp-path-selection
+
+## Table of Contents
+
+- [Management](#management)
+  - [Management Interfaces](#management-interfaces)
+- [Routing](#routing)
+  - [Router BGP](#router-bgp)
+
+## Management
+
+### Management Interfaces
+
+#### Management Interfaces Summary
+
+##### IPv4
+
+| Management Interface | description | Type | VRF | IP Address | Gateway |
+| -------------------- | ----------- | ---- | --- | ---------- | ------- |
+| Management1 | oob_management | oob | MGMT | 10.73.255.122/24 | 10.73.255.2 |
+
+##### IPv6
+
+| Management Interface | description | Type | VRF | IPv6 Address | IPv6 Gateway |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ |
+| Management1 | oob_management | oob | MGMT | - | - |
+
+#### Management Interfaces Device Configuration
+
+```eos
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+```
+
+## Routing
+
+### Router BGP
+
+#### Router BGP Summary
+
+| BGP AS | Router ID |
+| ------ | --------- |
+| 65101 | 192.168.255.42 |
+
+#### Router BGP Peer Groups
+
+##### PATH-SELECTION-PG-1
+
+| Settings | Value |
+| -------- | ----- |
+| Address Family | ipv4 |
+| Remote AS | 65001 |
+
+##### PATH-SELECTION-PG-2
+
+| Settings | Value |
+| -------- | ----- |
+| Address Family | ipv4 |
+| Remote AS | 65001 |
+
+##### PATH-SELECTION-PG-3
+
+| Settings | Value |
+| -------- | ----- |
+| Address Family | ipv4 |
+| Remote AS | 65001 |
+
+##### PATH-SELECTION-PG-4
+
+| Settings | Value |
+| -------- | ----- |
+| Address Family | ipv4 |
+| Remote AS | 65001 |
+
+##### PATH-SELECTION-PG-5
+
+| Settings | Value |
+| -------- | ----- |
+| Address Family | ipv4 |
+| Remote AS | 65001 |
+
+#### BGP Neighbors
+
+| Neighbor | Remote AS | VRF | Shutdown | Send-community | Maximum-routes | Allowas-in | BFD | RIB Pre-Policy Retain | Route-Reflector Client | Passive |
+| -------- | --------- | --- | -------- | -------------- | -------------- | ---------- | --- | --------------------- | ---------------------- | ------- |
+| 172.31.255.0 | - | default | - | - | - | - | - | - | - | - |
+| 172.31.255.2 | - | default | - | - | - | - | - | - | - | - |
+| 172.31.255.3 | - | default | - | - | - | - | - | - | - | - |
+| 172.31.255.4 | - | default | - | - | - | - | - | - | - | - |
+| 192.168.255.1 | - | default | - | - | - | - | - | - | - | - |
+
+#### Router BGP Path-Selection Address Family
+
+##### Path-Selection Neighbors
+
+| Neighbor | Activate |
+| -------- | -------- |
+| 172.31.255.0 | True |
+| 172.31.255.1 | True |
+| 172.31.255.2 | True |
+| 172.31.255.3 | True |
+| 172.31.255.4 | True |
+
+##### Path-Selection Peer Groups
+
+| Peer Group | Activate |
+| ---------- | -------- |
+| PATH-SELECTION-PG-1 | True |
+| PATH-SELECTION-PG-2 | True |
+| PATH-SELECTION-PG-3 | True |
+| PATH-SELECTION-PG-4 | True |
+| PATH-SELECTION-PG-5 | True |
+
+#### Router BGP Device Configuration
+
+```eos
+!
+router bgp 65101
+   router-id 192.168.255.42
+   neighbor PATH-SELECTION-PG-1 peer group
+   neighbor PATH-SELECTION-PG-1 remote-as 65001
+   neighbor PATH-SELECTION-PG-2 peer group
+   neighbor PATH-SELECTION-PG-2 remote-as 65001
+   neighbor PATH-SELECTION-PG-3 peer group
+   neighbor PATH-SELECTION-PG-3 remote-as 65001
+   neighbor PATH-SELECTION-PG-4 peer group
+   neighbor PATH-SELECTION-PG-4 remote-as 65001
+   neighbor PATH-SELECTION-PG-5 peer group
+   neighbor PATH-SELECTION-PG-5 remote-as 65001
+   !
+   address-family path-selection
+      bgp additional-paths receive
+      bgp additional-paths send ecmp limit 42
+      neighbor PATH-SELECTION-PG-1 activate
+      neighbor PATH-SELECTION-PG-1 additional-paths receive
+      neighbor PATH-SELECTION-PG-1 additional-paths send any
+      neighbor PATH-SELECTION-PG-2 activate
+      neighbor PATH-SELECTION-PG-2 additional-paths send backup
+      neighbor PATH-SELECTION-PG-3 activate
+      neighbor PATH-SELECTION-PG-3 additional-paths send ecmp
+      neighbor PATH-SELECTION-PG-4 activate
+      neighbor PATH-SELECTION-PG-4 additional-paths send ecmp limit 42
+      neighbor PATH-SELECTION-PG-5 activate
+      neighbor PATH-SELECTION-PG-5 additional-paths send limit 42
+      neighbor 172.31.255.0 activate
+      neighbor 172.31.255.0 additional-paths receive
+      neighbor 172.31.255.0 additional-paths send any
+      neighbor 172.31.255.1 activate
+      neighbor 172.31.255.1 additional-paths send backup
+      neighbor 172.31.255.2 activate
+      neighbor 172.31.255.2 additional-paths send ecmp
+      neighbor 172.31.255.3 activate
+      neighbor 172.31.255.3 additional-paths send ecmp limit 42
+      neighbor 172.31.255.4 activate
+      neighbor 172.31.255.4 additional-paths send limit 42
+```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-path-selection.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-path-selection.cfg
@@ -1,0 +1,54 @@
+!RANCID-CONTENT-TYPE: arista
+!
+transceiver qsfp default-mode 4x10G
+!
+hostname router-bgp-path-selection
+!
+no enable password
+no aaa root
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+!
+router bgp 65101
+   router-id 192.168.255.42
+   neighbor PATH-SELECTION-PG-1 peer group
+   neighbor PATH-SELECTION-PG-1 remote-as 65001
+   neighbor PATH-SELECTION-PG-2 peer group
+   neighbor PATH-SELECTION-PG-2 remote-as 65001
+   neighbor PATH-SELECTION-PG-3 peer group
+   neighbor PATH-SELECTION-PG-3 remote-as 65001
+   neighbor PATH-SELECTION-PG-4 peer group
+   neighbor PATH-SELECTION-PG-4 remote-as 65001
+   neighbor PATH-SELECTION-PG-5 peer group
+   neighbor PATH-SELECTION-PG-5 remote-as 65001
+   !
+   address-family path-selection
+      bgp additional-paths receive
+      bgp additional-paths send ecmp limit 42
+      neighbor PATH-SELECTION-PG-1 activate
+      neighbor PATH-SELECTION-PG-1 additional-paths receive
+      neighbor PATH-SELECTION-PG-1 additional-paths send any
+      neighbor PATH-SELECTION-PG-2 activate
+      neighbor PATH-SELECTION-PG-2 additional-paths send backup
+      neighbor PATH-SELECTION-PG-3 activate
+      neighbor PATH-SELECTION-PG-3 additional-paths send ecmp
+      neighbor PATH-SELECTION-PG-4 activate
+      neighbor PATH-SELECTION-PG-4 additional-paths send ecmp limit 42
+      neighbor PATH-SELECTION-PG-5 activate
+      neighbor PATH-SELECTION-PG-5 additional-paths send limit 42
+      neighbor 172.31.255.0 activate
+      neighbor 172.31.255.0 additional-paths receive
+      neighbor 172.31.255.0 additional-paths send any
+      neighbor 172.31.255.1 activate
+      neighbor 172.31.255.1 additional-paths send backup
+      neighbor 172.31.255.2 activate
+      neighbor 172.31.255.2 additional-paths send ecmp
+      neighbor 172.31.255.3 activate
+      neighbor 172.31.255.3 additional-paths send ecmp limit 42
+      neighbor 172.31.255.4 activate
+      neighbor 172.31.255.4 additional-paths send limit 42
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-path-selection.yaml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-path-selection.yaml
@@ -1,0 +1,92 @@
+### Routing - BGP ###
+# Testing for address-family path-selection
+router_bgp:
+  as: 65101
+  router_id: 192.168.255.42
+  peer_groups:
+    - name: PATH-SELECTION-PG-1
+      type: ipv4
+      remote_as: 65001
+    - name: PATH-SELECTION-PG-2
+      type: ipv4
+      remote_as: 65001
+    - name: PATH-SELECTION-PG-3
+      type: ipv4
+      remote_as: 65001
+    - name: PATH-SELECTION-PG-4
+      type: ipv4
+      remote_as: 65001
+    - name: PATH-SELECTION-PG-5
+      type: ipv4
+      remote_as: 65001
+  neighbors:
+    - ip_address: 172.31.255.0
+    - ip_address: 192.168.255.1
+    - ip_address: 172.31.255.2
+    - ip_address: 172.31.255.3
+    - ip_address: 172.31.255.4
+  address_family_path_selection:
+    bgp:
+      additional_paths:
+        receive: true
+        send:
+          # Need to choose what to test here or create multiple hosts...
+          #any: true
+          #backup: true
+          #ecmp: true
+          ecmp_limit: 42
+          #limit: 42
+    peer_groups:
+      - name: PATH-SELECTION-PG-1
+        activate: true
+        additional_paths:
+          receive: true
+          send:
+            any: true
+      - name: PATH-SELECTION-PG-2
+        activate: true
+        additional_paths:
+          send:
+            backup: true
+      - name: PATH-SELECTION-PG-3
+        activate: true
+        additional_paths:
+          send:
+            ecmp: true
+      - name: PATH-SELECTION-PG-4
+        activate: true
+        additional_paths:
+          send:
+            ecmp_limit: 42
+      - name: PATH-SELECTION-PG-5
+        activate: true
+        additional_paths:
+          send:
+            limit: 42
+    neighbors:
+      - ip_address: 172.31.255.0
+        activate: true
+        additional_paths:
+          receive: true
+          send:
+            any: true
+      - ip_address: 172.31.255.1
+        activate: true
+        additional_paths:
+          send:
+            backup: true
+      - ip_address: 172.31.255.2
+        activate: true
+        additional_paths:
+          send:
+            ecmp: true
+      - ip_address: 172.31.255.3
+        activate: true
+        additional_paths:
+          send:
+            ecmp_limit: 42
+      - ip_address: 172.31.255.4
+        activate: true
+        additional_paths:
+          send:
+            limit: 42

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts.ini
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts.ini
@@ -110,6 +110,7 @@ router-bgp-evpn
 router-bgp-evpn-vpn-import-pruning
 router-bgp-evpn-mpls
 router-bgp-link-state
+router-bgp-path-selection
 router-bgp-rtc
 router-bgp-v4-evpn
 router-bgp-v4-v6-evpn

--- a/ansible_collections/arista/avd/plugins/plugin_utils/schema/key_to_display_name.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/schema/key_to_display_name.py
@@ -21,6 +21,7 @@ WORDLIST = {
     "dot1x": "dot1x",
     "dr": "DR",
     "dscp": "DSCP",
+    "ecmp": "ECMP",
     "eos": "EOS",
     "evpn": "EVPN",
     "fcs": "FCS",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-bgp.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-bgp.md
@@ -407,6 +407,42 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;peer_groups</samp>](## "router_bgp.address_family_flow_spec_ipv6.peer_groups") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "router_bgp.address_family_flow_spec_ipv6.peer_groups.[].name") | String | Required, Unique |  |  | Peer-group name |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;activate</samp>](## "router_bgp.address_family_flow_spec_ipv6.peer_groups.[].activate") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;address_family_path_selection</samp>](## "router_bgp.address_family_path_selection") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;bgp</samp>](## "router_bgp.address_family_path_selection.bgp") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;additional_paths</samp>](## "router_bgp.address_family_path_selection.bgp.additional_paths") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;receive</samp>](## "router_bgp.address_family_path_selection.bgp.additional_paths.receive") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;send</samp>](## "router_bgp.address_family_path_selection.bgp.additional_paths.send") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;any</samp>](## "router_bgp.address_family_path_selection.bgp.additional_paths.send.any") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;backup</samp>](## "router_bgp.address_family_path_selection.bgp.additional_paths.send.backup") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ecmp</samp>](## "router_bgp.address_family_path_selection.bgp.additional_paths.send.ecmp") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ecmp_limit</samp>](## "router_bgp.address_family_path_selection.bgp.additional_paths.send.ecmp_limit") | Integer |  |  | Min: 2<br>Max: 64 | Amount of ECMP paths to send |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;limit</samp>](## "router_bgp.address_family_path_selection.bgp.additional_paths.send.limit") | Integer |  |  | Min: 2<br>Max: 64 | Amount of paths to send |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;neighbors</samp>](## "router_bgp.address_family_path_selection.neighbors") | List, items: Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- ip_address</samp>](## "router_bgp.address_family_path_selection.neighbors.[].ip_address") | String | Required, Unique |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;activate</samp>](## "router_bgp.address_family_path_selection.neighbors.[].activate") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;additional_paths</samp>](## "router_bgp.address_family_path_selection.neighbors.[].additional_paths") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;install</samp>](## "router_bgp.address_family_path_selection.neighbors.[].additional_paths.install") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;install_ecmp_primary</samp>](## "router_bgp.address_family_path_selection.neighbors.[].additional_paths.install_ecmp_primary") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;receive</samp>](## "router_bgp.address_family_path_selection.neighbors.[].additional_paths.receive") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;send</samp>](## "router_bgp.address_family_path_selection.neighbors.[].additional_paths.send") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;any</samp>](## "router_bgp.address_family_path_selection.neighbors.[].additional_paths.send.any") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;backup</samp>](## "router_bgp.address_family_path_selection.neighbors.[].additional_paths.send.backup") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ecmp</samp>](## "router_bgp.address_family_path_selection.neighbors.[].additional_paths.send.ecmp") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ecmp_limit</samp>](## "router_bgp.address_family_path_selection.neighbors.[].additional_paths.send.ecmp_limit") | Integer |  |  | Min: 2<br>Max: 64 | Amount of ECMP paths to send |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;limit</samp>](## "router_bgp.address_family_path_selection.neighbors.[].additional_paths.send.limit") | Integer |  |  | Min: 2<br>Max: 64 | Amount of paths to send |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;peer_groups</samp>](## "router_bgp.address_family_path_selection.peer_groups") | List, items: Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "router_bgp.address_family_path_selection.peer_groups.[].name") | String | Required, Unique |  |  | Peer-group name |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;activate</samp>](## "router_bgp.address_family_path_selection.peer_groups.[].activate") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;additional_paths</samp>](## "router_bgp.address_family_path_selection.peer_groups.[].additional_paths") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;install</samp>](## "router_bgp.address_family_path_selection.peer_groups.[].additional_paths.install") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;install_ecmp_primary</samp>](## "router_bgp.address_family_path_selection.peer_groups.[].additional_paths.install_ecmp_primary") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;receive</samp>](## "router_bgp.address_family_path_selection.peer_groups.[].additional_paths.receive") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;send</samp>](## "router_bgp.address_family_path_selection.peer_groups.[].additional_paths.send") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;any</samp>](## "router_bgp.address_family_path_selection.peer_groups.[].additional_paths.send.any") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;backup</samp>](## "router_bgp.address_family_path_selection.peer_groups.[].additional_paths.send.backup") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ecmp</samp>](## "router_bgp.address_family_path_selection.peer_groups.[].additional_paths.send.ecmp") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ecmp_limit</samp>](## "router_bgp.address_family_path_selection.peer_groups.[].additional_paths.send.ecmp_limit") | Integer |  |  | Min: 2<br>Max: 64 | Amount of ECMP paths to send |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;limit</samp>](## "router_bgp.address_family_path_selection.peer_groups.[].additional_paths.send.limit") | Integer |  |  | Min: 2<br>Max: 64 | Amount of paths to send |
     | [<samp>&nbsp;&nbsp;address_family_vpn_ipv4</samp>](## "router_bgp.address_family_vpn_ipv4") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;domain_identifier</samp>](## "router_bgp.address_family_vpn_ipv4.domain_identifier") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;peer_groups</samp>](## "router_bgp.address_family_vpn_ipv4.peer_groups") | List, items: Dictionary |  |  |  |  |
@@ -1057,6 +1093,42 @@
         peer_groups:
           - name: <str>
             activate: <bool>
+      address_family_path_selection:
+        bgp:
+          additional_paths:
+            receive: <bool>
+            send:
+              any: <bool>
+              backup: <bool>
+              ecmp: <bool>
+              ecmp_limit: <int>
+              limit: <int>
+        neighbors:
+          - ip_address: <str>
+            activate: <bool>
+            additional_paths:
+              install: <bool>
+              install_ecmp_primary: <bool>
+              receive: <bool>
+              send:
+                any: <bool>
+                backup: <bool>
+                ecmp: <bool>
+                ecmp_limit: <int>
+                limit: <int>
+        peer_groups:
+          - name: <str>
+            activate: <bool>
+            additional_paths:
+              install: <bool>
+              install_ecmp_primary: <bool>
+              receive: <bool>
+              send:
+                any: <bool>
+                backup: <bool>
+                ecmp: <bool>
+                ecmp_limit: <int>
+                limit: <int>
       address_family_vpn_ipv4:
         domain_identifier: <str>
         peer_groups:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -12563,7 +12563,7 @@
               "type": "integer",
               "minimum": 1,
               "maximum": 600,
-              "title": "Ecmp"
+              "title": "ECMP"
             }
           },
           "required": [
@@ -15166,6 +15166,241 @@
           },
           "title": "Address Family Flow Spec IPv6"
         },
+        "address_family_path_selection": {
+          "type": "object",
+          "properties": {
+            "bgp": {
+              "type": "object",
+              "properties": {
+                "additional_paths": {
+                  "type": "object",
+                  "properties": {
+                    "receive": {
+                      "type": "boolean",
+                      "title": "Receive"
+                    },
+                    "send": {
+                      "type": "object",
+                      "properties": {
+                        "any": {
+                          "type": "boolean",
+                          "title": "Any"
+                        },
+                        "backup": {
+                          "type": "boolean",
+                          "title": "Backup"
+                        },
+                        "ecmp": {
+                          "type": "boolean",
+                          "title": "ECMP"
+                        },
+                        "ecmp_limit": {
+                          "type": "integer",
+                          "description": "Amount of ECMP paths to send",
+                          "minimum": 2,
+                          "maximum": 64,
+                          "title": "ECMP Limit"
+                        },
+                        "limit": {
+                          "type": "integer",
+                          "description": "Amount of paths to send",
+                          "minimum": 2,
+                          "maximum": 64,
+                          "title": "Limit"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      },
+                      "title": "Send"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "patternProperties": {
+                    "^_.+$": {}
+                  },
+                  "title": "Additional Paths"
+                }
+              },
+              "additionalProperties": false,
+              "patternProperties": {
+                "^_.+$": {}
+              },
+              "title": "BGP"
+            },
+            "neighbors": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "ip_address": {
+                    "type": "string",
+                    "title": "IP Address"
+                  },
+                  "activate": {
+                    "type": "boolean",
+                    "title": "Activate"
+                  },
+                  "additional_paths": {
+                    "type": "object",
+                    "properties": {
+                      "install": {
+                        "type": "boolean",
+                        "title": "Install"
+                      },
+                      "install_ecmp_primary": {
+                        "type": "boolean",
+                        "title": "Install ECMP Primary"
+                      },
+                      "receive": {
+                        "type": "boolean",
+                        "title": "Receive"
+                      },
+                      "send": {
+                        "type": "object",
+                        "properties": {
+                          "any": {
+                            "type": "boolean",
+                            "title": "Any"
+                          },
+                          "backup": {
+                            "type": "boolean",
+                            "title": "Backup"
+                          },
+                          "ecmp": {
+                            "type": "boolean",
+                            "title": "ECMP"
+                          },
+                          "ecmp_limit": {
+                            "type": "integer",
+                            "description": "Amount of ECMP paths to send",
+                            "minimum": 2,
+                            "maximum": 64,
+                            "title": "ECMP Limit"
+                          },
+                          "limit": {
+                            "type": "integer",
+                            "description": "Amount of paths to send",
+                            "minimum": 2,
+                            "maximum": 64,
+                            "title": "Limit"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Send"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Additional Paths"
+                  }
+                },
+                "additionalProperties": false,
+                "patternProperties": {
+                  "^_.+$": {}
+                },
+                "required": [
+                  "ip_address"
+                ]
+              },
+              "title": "Neighbors"
+            },
+            "peer_groups": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "Peer-group name",
+                    "title": "Name"
+                  },
+                  "activate": {
+                    "type": "boolean",
+                    "title": "Activate"
+                  },
+                  "additional_paths": {
+                    "type": "object",
+                    "properties": {
+                      "install": {
+                        "type": "boolean",
+                        "title": "Install"
+                      },
+                      "install_ecmp_primary": {
+                        "type": "boolean",
+                        "title": "Install ECMP Primary"
+                      },
+                      "receive": {
+                        "type": "boolean",
+                        "title": "Receive"
+                      },
+                      "send": {
+                        "type": "object",
+                        "properties": {
+                          "any": {
+                            "type": "boolean",
+                            "title": "Any"
+                          },
+                          "backup": {
+                            "type": "boolean",
+                            "title": "Backup"
+                          },
+                          "ecmp": {
+                            "type": "boolean",
+                            "title": "ECMP"
+                          },
+                          "ecmp_limit": {
+                            "type": "integer",
+                            "description": "Amount of ECMP paths to send",
+                            "minimum": 2,
+                            "maximum": 64,
+                            "title": "ECMP Limit"
+                          },
+                          "limit": {
+                            "type": "integer",
+                            "description": "Amount of paths to send",
+                            "minimum": 2,
+                            "maximum": 64,
+                            "title": "Limit"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Send"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Additional Paths"
+                  }
+                },
+                "additionalProperties": false,
+                "patternProperties": {
+                  "^_.+$": {}
+                },
+                "required": [
+                  "name"
+                ]
+              },
+              "title": "Peer Groups"
+            }
+          },
+          "additionalProperties": false,
+          "patternProperties": {
+            "^_.+$": {}
+          },
+          "title": "Address Family Path Selection"
+        },
         "address_family_vpn_ipv4": {
           "type": "object",
           "properties": {
@@ -16003,7 +16238,7 @@
                           },
                           "install_ecmp_primary": {
                             "type": "boolean",
-                            "title": "Install Ecmp Primary"
+                            "title": "Install ECMP Primary"
                           },
                           "receive": {
                             "type": "boolean",
@@ -16022,14 +16257,14 @@
                               },
                               "ecmp": {
                                 "type": "boolean",
-                                "title": "Ecmp"
+                                "title": "ECMP"
                               },
                               "ecmp_limit": {
                                 "type": "integer",
                                 "description": "Amount of ECMP paths to send",
                                 "minimum": 2,
                                 "maximum": 64,
-                                "title": "Ecmp Limit"
+                                "title": "ECMP Limit"
                               },
                               "limit": {
                                 "type": "integer",
@@ -16199,7 +16434,7 @@
                           },
                           "install_ecmp_primary": {
                             "type": "boolean",
-                            "title": "Install Ecmp Primary"
+                            "title": "Install ECMP Primary"
                           },
                           "receive": {
                             "type": "boolean",
@@ -16218,14 +16453,14 @@
                               },
                               "ecmp": {
                                 "type": "boolean",
-                                "title": "Ecmp"
+                                "title": "ECMP"
                               },
                               "ecmp_limit": {
                                 "type": "integer",
                                 "description": "Amount of ECMP paths to send",
                                 "minimum": 2,
                                 "maximum": 64,
-                                "title": "Ecmp Limit"
+                                "title": "ECMP Limit"
                               },
                               "limit": {
                                 "type": "integer",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -9020,6 +9020,127 @@ keys:
                   description: Peer-group name
                 activate:
                   type: bool
+      address_family_path_selection:
+        type: dict
+        keys:
+          bgp:
+            type: dict
+            keys:
+              additional_paths:
+                type: dict
+                keys:
+                  receive:
+                    type: bool
+                  send:
+                    type: dict
+                    keys:
+                      any:
+                        type: bool
+                      backup:
+                        type: bool
+                      ecmp:
+                        type: bool
+                      ecmp_limit:
+                        type: int
+                        description: Amount of ECMP paths to send
+                        convert_types:
+                        - str
+                        min: 2
+                        max: 64
+                      limit:
+                        type: int
+                        description: Amount of paths to send
+                        convert_types:
+                        - str
+                        min: 2
+                        max: 64
+          neighbors:
+            type: list
+            primary_key: ip_address
+            convert_types:
+            - dict
+            items:
+              type: dict
+              keys:
+                ip_address:
+                  type: str
+                activate:
+                  type: bool
+                additional_paths:
+                  type: dict
+                  keys:
+                    install:
+                      type: bool
+                    install_ecmp_primary:
+                      type: bool
+                    receive:
+                      type: bool
+                    send:
+                      type: dict
+                      keys:
+                        any:
+                          type: bool
+                        backup:
+                          type: bool
+                        ecmp:
+                          type: bool
+                        ecmp_limit:
+                          type: int
+                          description: Amount of ECMP paths to send
+                          convert_types:
+                          - str
+                          min: 2
+                          max: 64
+                        limit:
+                          type: int
+                          description: Amount of paths to send
+                          convert_types:
+                          - str
+                          min: 2
+                          max: 64
+          peer_groups:
+            type: list
+            primary_key: name
+            items:
+              type: dict
+              keys:
+                name:
+                  type: str
+                  description: Peer-group name
+                activate:
+                  type: bool
+                additional_paths:
+                  type: dict
+                  keys:
+                    install:
+                      type: bool
+                    install_ecmp_primary:
+                      type: bool
+                    receive:
+                      type: bool
+                    send:
+                      type: dict
+                      keys:
+                        any:
+                          type: bool
+                        backup:
+                          type: bool
+                        ecmp:
+                          type: bool
+                        ecmp_limit:
+                          type: int
+                          description: Amount of ECMP paths to send
+                          convert_types:
+                          - str
+                          min: 2
+                          max: 64
+                        limit:
+                          type: int
+                          description: Amount of paths to send
+                          convert_types:
+                          - str
+                          min: 2
+                          max: 64
       address_family_vpn_ipv4:
         type: dict
         keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_bgp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_bgp.schema.yml
@@ -1438,6 +1438,127 @@ keys:
                   description: Peer-group name
                 activate:
                   type: bool
+      address_family_path_selection:
+        type: dict
+        keys:
+          bgp:
+            type: dict
+            keys:
+              additional_paths:
+                type: dict
+                keys:
+                  receive:
+                    type: bool
+                  send:
+                    type: dict
+                    keys:
+                      any:
+                        type: bool
+                      backup:
+                        type: bool
+                      ecmp:
+                        type: bool
+                      ecmp_limit:
+                        type: int
+                        description: Amount of ECMP paths to send
+                        convert_types:
+                          - str
+                        min: 2
+                        max: 64
+                      limit:
+                        type: int
+                        description: Amount of paths to send
+                        convert_types:
+                          - str
+                        min: 2
+                        max: 64
+          neighbors:
+            type: list
+            primary_key: ip_address
+            convert_types:
+              - dict
+            items:
+              type: dict
+              keys:
+                ip_address:
+                  type: str
+                activate:
+                  type: bool
+                additional_paths:
+                  type: dict
+                  keys:
+                    install:
+                      type: bool
+                    install_ecmp_primary:
+                      type: bool
+                    receive:
+                      type: bool
+                    send:
+                      type: dict
+                      keys:
+                        any:
+                          type: bool
+                        backup:
+                          type: bool
+                        ecmp:
+                          type: bool
+                        ecmp_limit:
+                          type: int
+                          description: Amount of ECMP paths to send
+                          convert_types:
+                            - str
+                          min: 2
+                          max: 64
+                        limit:
+                          type: int
+                          description: Amount of paths to send
+                          convert_types:
+                            - str
+                          min: 2
+                          max: 64
+          peer_groups:
+            type: list
+            primary_key: name
+            items:
+              type: dict
+              keys:
+                name:
+                  type: str
+                  description: Peer-group name
+                activate:
+                  type: bool
+                additional_paths:
+                  type: dict
+                  keys:
+                    install:
+                      type: bool
+                    install_ecmp_primary:
+                      type: bool
+                    receive:
+                      type: bool
+                    send:
+                      type: dict
+                      keys:
+                        any:
+                          type: bool
+                        backup:
+                          type: bool
+                        ecmp:
+                          type: bool
+                        ecmp_limit:
+                          type: int
+                          description: Amount of ECMP paths to send
+                          convert_types:
+                            - str
+                          min: 2
+                          max: 64
+                        limit:
+                          type: int
+                          description: Amount of paths to send
+                          convert_types:
+                            - str
+                          min: 2
+                          max: 64
       address_family_vpn_ipv4:
         type: dict
         keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
@@ -735,6 +735,30 @@
 {%             endfor %}
 {%         endif %}
 {%     endif %}
+{%     if router_bgp.address_family_path_selection is arista.avd.defined %}
+
+#### Router BGP Path-Selection Address Family
+{%         if router_bgp.address_family_path_selection.neighbors is arista.avd.defined %}
+
+##### Path-Selection Neighbors
+
+| Neighbor | Activate |
+| -------- | -------- |
+{%             for neighbor in router_bgp.address_family_path_selection.neighbors | arista.avd.natural_sort('ip_address') %}
+| {{ neighbor.ip_address }} | {{ neighbor.activate | arista.avd.default(false) }} |
+{%             endfor %}
+{%         endif %}
+{%         if router_bgp.address_family_path_selection.peer_groups is arista.avd.defined %}
+
+##### Path-Selection Peer Groups
+
+| Peer Group | Activate |
+| ---------- | -------- |
+{%             for peer_group in router_bgp.address_family_path_selection.peer_groups | arista.avd.natural_sort('name') %}
+| {{ peer_group.name }} | {{ peer_group.activate | arista.avd.default(false) }} |
+{%             endfor %}
+{%         endif %}
+{%     endif %}
 {%     if router_bgp.vlan_aware_bundles is arista.avd.defined %}
 
 #### Router BGP VLAN Aware Bundles

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -978,6 +978,67 @@ router bgp {{ router_bgp.as }}
 {%             endif %}
 {%         endif %}
 {%     endif %}
+{# address family path_selection activation #}
+{%     if router_bgp.address_family_path_selection is arista.avd.defined %}
+   !
+   address-family path-selection
+{%         if router_bgp.address_family_path_selection.bgp.additional_paths.receive is arista.avd.defined(true) %}
+      bgp additional-paths receive
+{%         endif %}
+{%         if router_bgp.address_family_path_selection.bgp.additional_paths.send.any is arista.avd.defined(true) %}
+      bgp additional-paths send any
+{%         elif router_bgp.address_family_path_selection.bgp.additional_paths.send.backup is arista.avd.defined(true) %}
+      bgp additional-paths send backup
+{%         elif router_bgp.address_family_path_selection.bgp.additional_paths.send.ecmp is arista.avd.defined(true) %}
+      bgp additional-paths send ecmp
+{%         elif router_bgp.address_family_path_selection.bgp.additional_paths.send.ecmp_limit is arista.avd.defined %}
+      bgp additional-paths send ecmp limit {{ router_bgp.address_family_path_selection.bgp.additional_paths.send.ecmp_limit }}
+{%         elif router_bgp.address_family_path_selection.bgp.additional_paths.send.limit is arista.avd.defined %}
+      bgp additional-paths send limit {{ router_bgp.address_family_path_selection.bgp.additional_paths.send.limit }}
+{%         endif %}
+{%         for peer_group in router_bgp.address_family_path_selection.peer_groups | arista.avd.natural_sort('name') %}
+{%             if peer_group.activate is arista.avd.defined(true) %}
+      neighbor {{ peer_group.name }} activate
+{%             elif peer_group.activate is arista.avd.defined(false) %}
+      no neighbor {{ peer_group.name }} activate
+{%             endif %}
+{%             if peer_group.additional_paths.receive is arista.avd.defined(true) %}
+      neighbor {{ peer_group.name }} additional-paths receive
+{%             endif %}
+{%             if peer_group.additional_paths.send.any is arista.avd.defined(true) %}
+      neighbor {{ peer_group.name }} additional-paths send any
+{%             elif peer_group.additional_paths.send.backup is arista.avd.defined(true) %}
+      neighbor {{ peer_group.name }} additional-paths send backup
+{%             elif peer_group.additional_paths.send.ecmp is arista.avd.defined(true) %}
+      neighbor {{ peer_group.name }} additional-paths send ecmp
+{%             elif peer_group.additional_paths.send.ecmp_limit is arista.avd.defined %}
+      neighbor {{ peer_group.name }} additional-paths send ecmp limit {{ peer_group.additional_paths.send.ecmp_limit }}
+{%             elif peer_group.additional_paths.send.limit is arista.avd.defined %}
+      neighbor {{ peer_group.name }} additional-paths send limit {{ peer_group.additional_paths.send.limit }}
+{%             endif %}
+{%         endfor %}
+{%         for neighbor in router_bgp.address_family_path_selection.neighbors | arista.avd.natural_sort('ip_address') %}
+{%             if neighbor.activate is arista.avd.defined(true) %}
+      neighbor {{ neighbor.ip_address }} activate
+{%             elif neighbor.activate is arista.avd.defined(false) %}
+      no neighbor {{ neighbor.ip_address }} activate
+{%             endif %}
+{%             if neighbor.additional_paths.receive is arista.avd.defined(true) %}
+      neighbor {{ neighbor.ip_address }} additional-paths receive
+{%             endif %}
+{%             if neighbor.additional_paths.send.any is arista.avd.defined(true) %}
+      neighbor {{ neighbor.ip_address }} additional-paths send any
+{%             elif neighbor.additional_paths.send.backup is arista.avd.defined(true) %}
+      neighbor {{ neighbor.ip_address }} additional-paths send backup
+{%             elif neighbor.additional_paths.send.ecmp is arista.avd.defined(true) %}
+      neighbor {{ neighbor.ip_address }} additional-paths send ecmp
+{%             elif neighbor.additional_paths.send.ecmp_limit is arista.avd.defined %}
+      neighbor {{ neighbor.ip_address }} additional-paths send ecmp limit {{ neighbor.additional_paths.send.ecmp_limit }}
+{%             elif neighbor.additional_paths.send.limit is arista.avd.defined %}
+      neighbor {{ neighbor.ip_address }} additional-paths send limit {{ neighbor.additional_paths.send.limit }}
+{%             endif %}
+{%         endfor %}
+{%     endif %}
 {# address family vpn-ipv4 activation #}
 {%     if router_bgp.address_family_vpn_ipv4 is arista.avd.defined %}
    !

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -115,7 +115,7 @@
       "description": "Maximum ECMP for BGP multi-path.",
       "type": "integer",
       "default": 4,
-      "title": "BGP Ecmp"
+      "title": "BGP ECMP"
     },
     "bgp_graceful_restart": {
       "description": "BGP graceful-restart allows a BGP speaker with separate control plane and data plane processing to continue forwarding traffic during a BGP restart.\nIts neighbors (receiving speakers) may retain routing information from the restarting speaker while a BGP session with it is being re-established, reducing route flapping.\n",


### PR DESCRIPTION
## Change Summary

For WAN and AutoVPN need to add the path-selection address family. 


## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Add to the documentation and template for router bgp as well as some of the schema to add a new address-family.

EOS 4.30.1.F
```
leaf1(config-router-bgp-af)#show cli command
APPEND [ COMMENT ]
[no|default] bgp additional-paths receive
[no|default] bgp additional-paths send ( any | backup | ( [ ecmp ] [ limit LIMIT ] ) )
[...]
[no|default] neighbor ( GROUP | IP_PEER | IP6_PEER | IP6_LL_PEER ) ( activate | deactivate )
[no|default] neighbor ( GROUP | IP_PEER | IP6_PEER | IP6_LL_PEER ) additional-paths receive [ disabled ]
[no|default] neighbor ( GROUP | IP_PEER | IP6_PEER | IP6_LL_PEER ) additional-paths send ( ( any [ ( prefix-list PREFIX_LIST_NAME ) | disabled ] ) | ( ( backup | ( [ ecmp ] [ limit LIMIT ] ) ) [ prefi ...
[no|default] neighbor ( GROUP | IP_PEER | IP6_PEER | IP6_LL_PEER ) prefix-list ( PREFIX_LIST_NAME ( in | out ) ) | ( ( NED_IN | NED_OUT ) disabled )
[...]
```


__NOTE__"

on same version - despite what `show cli command` says:

```
leaf1(config-router-bgp-af)#neighbor toto prefix-list toto out
! neighbor prefix-list unsupported in path-selection address family
```

so probably best to leave out `prefix-lists` for now.


### Repository Checklist

- [X] My code has been rebased from devel before I start
- [X] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [X] My change requires a change to the documentation and documentation have been updated accordingly.