### PR TITLE
Doc: Add updated requirements to release-notes for 3.8.x train

### DIFF
--- a/ansible_collections/arista/avd/docs/release-notes/3.x.x.md
+++ b/ansible_collections/arista/avd/docs/release-notes/3.x.x.md
@@ -13,6 +13,13 @@
 - Documentation for AVD version `3.4.0` [available here](https://www.avd.sh/en/v3.4.0/)
 - Documentation for AVD version <= `3.3.3` [available here](https://www.avd.sh/en/releases-v3.x.x/)
 
+## Release 3.8.7
+
+### Changes to requirements
+
+- AVD now requires an upper bound on the version of the Python package `jsonschema>=4.5.1,<4.18`.<br>
+  A supported version can be installed with `pip install "jsonschema>=4.5.1,<4.18"`.
+
 ## Release 3.8.6
 
 ### Fixed issues


### PR DESCRIPTION
## Change Summary

as explained in title - jsonschema >= 4..18 introduces breaking changes with our schema. The cap has been added in 4.x in #3018 but needs to be ported in 3.8.x

## Component(s) name

`requirements.txt`

## Proposed changes

When cherry-picked, need to add fixes in req & dev

## How to test

CI completes

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
