### PR TITLE
Fix(eos_config_deploy_cvp): Avoid duplicate AVD configlet (#3124)

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/templates/cvp-devices-v3.j2
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/templates/cvp-devices-v3.j2
@@ -10,12 +10,12 @@
 CVP_DEVICES:
 {% for device in groups[container_root] | arista.avd.natural_sort %}
 {%     if device | arista.avd.is_in_filter(local_var.device_filter) %}
-{%         if hostvars[device]['is_deployed'] is arista.avd.defined(true) or hostvars[device]['is_deployed'] is not arista.avd.defined %}
+{%         if hostvars[device].is_deployed is arista.avd.defined(true) or hostvars[device].is_deployed is not arista.avd.defined %}
   - fqdn: {{ device }}
 {%             set dev_cntr.value = dev_cntr.value + 1 %}
 {%             for container_name, container in CVP_VARS.CVP_TOPOLOGY.items() | arista.avd.natural_sort %}
 {%                 if 'devices' in container %}
-{%                     for device_container in container['devices'] %}
+{%                     for device_container in container.devices %}
 {%                         if device == device_container %}
     parentContainerName: {{ container_name }}
 {%                         endif %}
@@ -23,12 +23,13 @@ CVP_DEVICES:
 {%                 endif %}
 {%             endfor %}
     configlets:
-{%             if hostvars[groups[container_root][0]]['cv_configlets']['devices'][device] is arista.avd.defined %}
-{%                 for configlet in hostvars[groups[container_root][0]]['cv_configlets']['devices'][device] | arista.avd.natural_sort %}
+{%             set device_configlets = hostvars[groups[container_root][0]].cv_configlets.devices[device] | arista.avd.default([]) %}
+{%             for configlet in device_configlets %}
       - {{ configlet }}
-{%                 endfor %}
-{%             endif %}
+{%             endfor %}
+{%             if configlets_prefix ~ "_" ~ device not in device_configlets %}
       - {{ configlets_prefix }}_{{ device }}
+{%             endif %}
 {%         endif %}
 {%     endif %}
 {% endfor %}
@@ -38,10 +39,10 @@ CVP_DEVICES:
 CVP_CONTAINERS:
 {% for container_name, container in CVP_VARS.CVP_TOPOLOGY.items() | arista.avd.natural_sort %}
   {{ container_name }}:
-    parentContainerName: {{ container['parent_container'] }}
-{%     if hostvars[groups[container_root][0]]['cv_configlets']['containers'][container_name] is defined and hostvars[groups[container_root][0]]['cv_configlets']['containers'][container_name] is iterable %}
+    parentContainerName: {{ container.parent_container }}
+{%     if hostvars[groups[container_root][0]].cv_configlets.containers[container_name] is defined and hostvars[groups[container_root][0]].cv_configlets.containers[container_name] is iterable %}
     configlets:
-{%         for configlet in hostvars[groups[container_root][0]]['cv_configlets']['containers'][container_name] | arista.avd.natural_sort %}
+{%         for configlet in hostvars[groups[container_root][0]].cv_configlets.containers[container_name] | arista.avd.natural_sort %}
       - {{ configlet }}
 {%         endfor %}
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/templates/cvp-devices.j2
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/templates/cvp-devices.j2
@@ -9,12 +9,12 @@
 CVP_DEVICES:
 {% for device in groups[container_root] | arista.avd.natural_sort %}
 {%     if device | arista.avd.is_in_filter(local_var.device_filter) %}
-{%         if (hostvars[device]['is_deployed'] is defined and hostvars[device]['is_deployed'] == true) or (hostvars[device]['is_deployed'] is not defined) %}
+{%         if (hostvars[device].is_deployed is defined and hostvars[device].is_deployed == true) or (hostvars[device].is_deployed is not defined) %}
   {{ device }}:
     name: {{ device }}
 {%             for container_name, container in CVP_VARS.CVP_TOPOLOGY.items() | arista.avd.natural_sort %}
 {%                 if 'devices' in container %}
-{%                     for device_container in container['devices'] %}
+{%                     for device_container in container.devices %}
 {%                         if device == device_container %}
     parentContainerName: {{ container_name }}
 {%                         endif %}
@@ -22,12 +22,13 @@ CVP_DEVICES:
 {%                 endif %}
 {%             endfor %}
     configlets:
-{%             if hostvars[groups[container_root][0]]['cv_configlets']['devices'][device] is defined %}
-{%                 for configlet in hostvars[groups[container_root][0]]['cv_configlets']['devices'][device] | arista.avd.natural_sort %}
+{%             set device_configlets = hostvars[groups[container_root][0]].cv_configlets.devices[device] | arista.avd.default([]) %}
+{%             for configlet in device_configlets %}
       - {{ configlet }}
-{%                 endfor %}
-{%             endif %}
+{%             endfor %}
+{%             if configlets_prefix ~ "_" ~ device not in device_configlets %}
       - {{ configlets_prefix }}_{{ device }}
+{%             endif %}
     imageBundle: []
 {%         endif %}
 {%     endif %}
@@ -35,10 +36,10 @@ CVP_DEVICES:
 CVP_CONTAINERS:
 {% for container_name, container in CVP_VARS.CVP_TOPOLOGY.items() | arista.avd.natural_sort %}
   {{ container_name }}:
-    parent_container: {{ container['parent_container'] }}
-{%     if hostvars[groups[container_root][0]]['cv_configlets']['containers'][container_name] is defined and hostvars[groups[container_root][0]]['cv_configlets']['containers'][container_name] is iterable %}
+    parent_container: {{ container.parent_container }}
+{%     if hostvars[groups[container_root][0]].cv_configlets.containers[container_name] is defined and hostvars[groups[container_root][0]].cv_configlets.containers[container_name] is iterable %}
     configlets:
-{%         for configlet in hostvars[groups[container_root][0]]['cv_configlets']['containers'][container_name] | arista.avd.natural_sort %}
+{%         for configlet in hostvars[groups[container_root][0]].cv_configlets.containers[container_name] | arista.avd.natural_sort %}
       - {{ configlet }}
 {%         endfor %}
 {%     endif %}


### PR DESCRIPTION
## Change Summary

Partial cherry-pick of #3124 

The following lines were conflicting when cherry-picking as this was a new feature #2718 introduced in 4.x: 
![image](https://github.com/aristanetworks/ansible-avd/assets/20460062/89deeeb8-491c-4cbc-b773-451ede2c32c9)

The modifications appear to be code quality/linting related only, so the changes were not carried over.

## Related Issue(s)

Fixes #3107 

## Component(s) name

`arista.avd.eos_config_deploy_cvp`

## How to test

Test manually


