### PR TITLE
Feat(eos_cli_config_gen): Support of a global tacacs timeout

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/aaa.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/aaa.md
@@ -67,14 +67,14 @@ username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC9OuVC4D+ARBrc9s
 
 #### TACACS Servers
 
-| VRF | TACACS Servers | Single-Connection |
-| --- | -------------- | ----------------- |
-| mgt | 10.10.10.157 | True |
-| default | 10.10.10.249 | False |
-| default | 10.10.10.158 | False |
-| default | 10.10.10.159 | False |
+| VRF | TACACS Servers | Single-Connection | Timeout |
+| --- | -------------- | ----------------- | ------- |
+| mgt | 10.10.10.157 | True | - |
+| default | 10.10.10.249 | False | 23 |
+| default | 10.10.10.158 | False | - |
+| default | 10.10.10.159 | False | - |
 
-Timeout: 10 seconds
+Global timeout: 10 seconds
 
 #### TACACS Servers Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/aaa.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/aaa.md
@@ -74,6 +74,8 @@ username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC9OuVC4D+ARBrc9s
 | default | 10.10.10.158 | False |
 | default | 10.10.10.159 | False |
 
+Timeout: 10 seconds
+
 #### TACACS Servers Device Configuration
 
 ```eos
@@ -82,6 +84,7 @@ tacacs-server host 10.10.10.157 single-connection vrf mgt key 7 <removed>
 tacacs-server host 10.10.10.158 key 7 <removed>
 tacacs-server host 10.10.10.159 key 8a <removed>
 tacacs-server host 10.10.10.249 timeout 23 key 7 <removed>
+tacacs-server timeout 10
 ```
 
 ### RADIUS Server

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/hide-passwords.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/hide-passwords.md
@@ -72,9 +72,9 @@ enable password sha512 <removed>
 
 #### TACACS Servers
 
-| VRF | TACACS Servers | Single-Connection |
-| --- | -------------- | ----------------- |
-| default | 10.10.10.157 | False |
+| VRF | TACACS Servers | Single-Connection | Timeout |
+| --- | -------------- | ----------------- | ------- |
+| default | 10.10.10.157 | False | - |
 
 #### TACACS Servers Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/aaa.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/aaa.cfg
@@ -12,6 +12,7 @@ tacacs-server host 10.10.10.157 single-connection vrf mgt key 7 071B245F5A
 tacacs-server host 10.10.10.158 key 7 071B245F5A
 tacacs-server host 10.10.10.159 key 8a $kUVyoj7FVQ//yw9D2lbqjA==$kxxohBiofI46IX3pw18KYQ==$DOOM0l9uU4TrQt2kyA7XCKtjUA==
 tacacs-server host 10.10.10.249 timeout 23 key 7 071B245F5A
+tacacs-server timeout 10
 !
 aaa group server tacacs+ TACACS1
    server 10.10.10.157 vrf mgt

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/aaa.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/aaa.yml
@@ -1,5 +1,6 @@
 ### Tacacs+ Servers
 tacacs_servers:
+  timeout: 10
   hosts:
     - host: 10.10.10.157
       vrf: mgt

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/tacacs-servers.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/tacacs-servers.md
@@ -8,14 +8,14 @@
     | Variable | Type | Required | Default | Value Restrictions | Description |
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
     | [<samp>tacacs_servers</samp>](## "tacacs_servers") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;timeout</samp>](## "tacacs_servers.timeout") | Integer |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;timeout</samp>](## "tacacs_servers.timeout") | Integer |  |  | Min: 1<br>Max: 1000 | Timeout in seconds |
     | [<samp>&nbsp;&nbsp;hosts</samp>](## "tacacs_servers.hosts") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- host</samp>](## "tacacs_servers.hosts.[].host") | String |  |  |  | Host IP address or name |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "tacacs_servers.hosts.[].vrf") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "tacacs_servers.hosts.[].key") | String |  |  |  | Encrypted key |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_type</samp>](## "tacacs_servers.hosts.[].key_type") | String |  | `7` | Valid Values:<br>- 0<br>- 7<br>- 8a |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;single_connection</samp>](## "tacacs_servers.hosts.[].single_connection") | Boolean |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;timeout</samp>](## "tacacs_servers.hosts.[].timeout") | Integer |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;timeout</samp>](## "tacacs_servers.hosts.[].timeout") | Integer |  |  | Min: 1<br>Max: 1000 | Timeout in seconds |
     | [<samp>&nbsp;&nbsp;policy_unknown_mandatory_attribute_ignore</samp>](## "tacacs_servers.policy_unknown_mandatory_attribute_ignore") | Boolean |  |  |  |  |
 
 === "YAML"

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/tacacs-servers.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/tacacs-servers.md
@@ -8,6 +8,7 @@
     | Variable | Type | Required | Default | Value Restrictions | Description |
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
     | [<samp>tacacs_servers</samp>](## "tacacs_servers") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;timeout</samp>](## "tacacs_servers.timeout") | Integer |  |  |  |  |
     | [<samp>&nbsp;&nbsp;hosts</samp>](## "tacacs_servers.hosts") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- host</samp>](## "tacacs_servers.hosts.[].host") | String |  |  |  | Host IP address or name |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "tacacs_servers.hosts.[].vrf") | String |  |  |  |  |
@@ -21,6 +22,7 @@
 
     ```yaml
     tacacs_servers:
+      timeout: <int>
       hosts:
         - host: <str>
           vrf: <str>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -19280,6 +19280,9 @@
       "properties": {
         "timeout": {
           "type": "integer",
+          "description": "Timeout in seconds",
+          "minimum": 1,
+          "maximum": 1000,
           "title": "Timeout"
         },
         "hosts": {
@@ -19317,6 +19320,9 @@
               },
               "timeout": {
                 "type": "integer",
+                "description": "Timeout in seconds",
+                "minimum": 1,
+                "maximum": 1000,
                 "title": "Timeout"
               }
             },

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -19278,6 +19278,10 @@
     "tacacs_servers": {
       "type": "object",
       "properties": {
+        "timeout": {
+          "type": "integer",
+          "title": "Timeout"
+        },
         "hosts": {
           "type": "array",
           "items": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -11310,6 +11310,9 @@ keys:
         type: int
         convert_types:
         - str
+        description: Timeout in seconds
+        min: 1
+        max: 1000
       hosts:
         type: list
         items:
@@ -11340,6 +11343,9 @@ keys:
               type: int
               convert_types:
               - str
+              description: Timeout in seconds
+              min: 1
+              max: 1000
       policy_unknown_mandatory_attribute_ignore:
         type: bool
   tap_aggregation:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -11306,6 +11306,10 @@ keys:
   tacacs_servers:
     type: dict
     keys:
+      timeout:
+        type: int
+        convert_types:
+        - str
       hosts:
         type: list
         items:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/tacacs_servers.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/tacacs_servers.schema.yml
@@ -9,6 +9,10 @@ keys:
   tacacs_servers:
     type: dict
     keys:
+      timeout:
+        type: int
+        convert_types:
+          - str
       hosts:
         type: list
         items:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/tacacs_servers.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/tacacs_servers.schema.yml
@@ -13,6 +13,9 @@ keys:
         type: int
         convert_types:
           - str
+        description: Timeout in seconds
+        min: 1
+        max: 1000
       hosts:
         type: list
         items:
@@ -40,5 +43,8 @@ keys:
               type: int
               convert_types:
                 - str
+              description: Timeout in seconds
+              min: 1
+              max: 1000
       policy_unknown_mandatory_attribute_ignore:
         type: bool

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/tacacs-servers.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/tacacs-servers.j2
@@ -10,15 +10,19 @@
 
 #### TACACS Servers
 
-| VRF | TACACS Servers | Single-Connection |
-| --- | -------------- | ----------------- |
+| VRF | TACACS Servers | Single-Connection | Timeout |
+| --- | -------------- | ----------------- | ------- |
 {%     for host in tacacs_servers.hosts %}
 {%         set vrf = host.vrf | arista.avd.default('default') %}
-| {{ vrf }} | {{ host.host }} | {{ host.single_connection | default(false) }} |
+| {{ vrf }} | {{ host.host }} | {{ host.single_connection | default(false) }} | {{ host.timeout | arista.avd.default("-") }} |
 {%     endfor %}
 
 {%     if tacacs_servers.policy_unknown_mandatory_attribute_ignore is arista.avd.defined and tacacs_servers.policy_unknown_mandatory_attribute_ignore == true %}
 Policy unknown-mandatory-attribute ignore is configured
+
+{%     endif %}
+{%     if tacacs_servers.timeout is arista.avd.defined %}
+Global timeout: {{ tacacs_servers.timeout }} seconds
 
 {%     endif %}
 #### TACACS Servers Device Configuration

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/tacacs-servers.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/tacacs-servers.j2
@@ -29,4 +29,7 @@
 {%     if tacacs_servers.policy_unknown_mandatory_attribute_ignore is arista.avd.defined(true) %}
 tacacs-server policy unknown-mandatory-attribute ignore
 {%     endif %}
+{%     if tacacs_servers.timeout is arista.avd.defined %}
+tacacs-server timeout {{ tacacs_servers.timeout }}
+{%     endif %}
 {% endif %}


### PR DESCRIPTION
## Change Summary

Support of tacacs glocal timer setting

## Related Issue(s)

Fixes #3126 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
1/ Changed schema fragment "tacacs_servers.schema.yml"
2/ Ran the pre-commit playbook
3/ Changed template eos/tacacs-servers.j2 accordingly

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
