### PR TITLE
Fix(eos_cli_config_gen): ip http client source interfaces cli not generated

### DIFF
--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -157,7 +157,7 @@ jobs:
         # Also test minimum ansible version for one scenario.
         include:
           - avd_scenario: 'eos_cli_config_gen'
-            ansible_version: 'ansible-core==2.12.6'
+            ansible_version: 'ansible-core==2.13.12'
     needs: [ pre_commit ]
     if: needs.file-changes.outputs.config_gen == 'true'
     steps:
@@ -245,8 +245,6 @@ jobs:
         # Also test minimum ansible version for one scenario.
         include:
           - avd_scenario: 'eos_designs_unit_tests'
-            ansible_version: 'ansible-core==2.12.6'
-          - avd_scenario: 'eos_designs_unit_tests'
             ansible_version: 'ansible-core>=2.13.1,<2.14.0 --upgrade'
           - avd_scenario: 'eos_designs_unit_tests'
             ansible_version: 'ansible-core>=2.14.0,<2.15.0 --upgrade'
@@ -283,7 +281,7 @@ jobs:
       fail-fast: true
       matrix:
         avd_scenario: ['eos_config_deploy_cvp']
-        ansible_version: ['ansible-core==2.12.6', 'ansible-core<2.16.0 --upgrade']
+        ansible_version: ['ansible-core==2.13.12', 'ansible-core<2.16.0 --upgrade']
     needs: [ pre_commit ]
     if: needs.file-changes.outputs.cloudvision == 'true'
     steps:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ip-client-source-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ip-client-source-interfaces.j2
@@ -5,7 +5,7 @@
 #}
 {# eos - ip client source-interfaces #}
 {% if ip_ftp_client_source_interfaces is arista.avd.defined
-      or ip_http_client_source_interface is arista.avd.defined
+      or ip_http_client_source_interfaces is arista.avd.defined
       or ip_ssh_client_source_interfaces is arista.avd.defined
       or ip_telnet_client_source_interfaces is arista.avd.defined
       or ip_tftp_client_source_interfaces is arista.avd.defined %}


### PR DESCRIPTION
## Change Summary

ip http client source interfaces cli not generated due to the incorrect if statement.
This only occurred when `ip_http_client_source_interfaces` was the only ip-client-source-interfaces key defined.

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Fix the typo in the if statement.

## How to test

All molecule tests pass.
