### PR TITLE
Doc: Remove old release notes from mkdocs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -171,16 +171,8 @@ nav:
   - External Resources:
       - Ansible Collection User Guide: https://docs.ansible.com/ansible/latest/user_guide/collections_using.html
       - Ansible User Guide: https://docs.ansible.com/ansible/latest/user_guide/index.html
-  - Release Notes:
-      - 4.x.x: docs/release-notes/4.x.x.md
-        # Pointing to 3.8 since avd.arista.com does not include older versions.
-        # Going forward we will point to the relevant version.
-      - 3.x.x: https://avd.arista.com/3.8/docs/release-notes/3.x.x.html
-      - 2.x.x: https://avd.arista.com/3.8/docs/release-notes/2.x.x.html
-      - 1.1.x: https://avd.arista.com/3.8/docs/release-notes/1.1.x.html
-      - 1.0.x: https://avd.arista.com/3.8/docs/release-notes/1.0.x.html
-  - Porting Guides:
-      - 4.x.x: docs/porting-guides/4.x.x.md
+  - Release Notes: docs/release-notes/4.x.x.md
+  - Porting Guide: docs/porting-guides/4.x.x.md
   - pyavd: docs/pyavd.md
   - About:
       - AVD on Ansible Galaxy: https://galaxy.ansible.com/arista/avd

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,6 +71,10 @@ plugins:
       glob:
         - molecule/*
         - tests/*
+        - docs/release-notes/1.0.x.md
+        - docs/release-notes/1.1.x.md
+        - docs/release-notes/2.x.x.md
+        - docs/release-notes/3.x.x.md
   - include_dir_to_nav
   - git-revision-date-localized:
       type: date
@@ -169,10 +173,12 @@ nav:
       - Ansible User Guide: https://docs.ansible.com/ansible/latest/user_guide/index.html
   - Release Notes:
       - 4.x.x: docs/release-notes/4.x.x.md
-      - 3.x.x: docs/release-notes/3.x.x.md
-      - 2.x.x: docs/release-notes/2.x.x.md
-      - 1.1.x: docs/release-notes/1.1.x.md
-      - 1.0.x: docs/release-notes/1.0.x.md
+        # Pointing to 3.8 since avd.arista.com does not include older versions.
+        # Going forward we will point to the relevant version.
+      - 3.x.x: https://avd.arista.com/3.8/docs/release-notes/3.x.x.html
+      - 2.x.x: https://avd.arista.com/3.8/docs/release-notes/2.x.x.html
+      - 1.1.x: https://avd.arista.com/3.8/docs/release-notes/1.1.x.html
+      - 1.0.x: https://avd.arista.com/3.8/docs/release-notes/1.0.x.html
   - Porting Guides:
       - 4.x.x: docs/porting-guides/4.x.x.md
   - pyavd: docs/pyavd.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -137,7 +137,7 @@ nav:
       - ISIS-LDP IPVPN: examples/isis-ldp-ipvpn/README.md
   - Installation:
       - Collection Installation: docs/installation/collection-installation.md
-  - Ansible Collection Roles Documentation:
+  - Ansible Collection Roles:
       - eos_designs:
           - Overview: roles/eos_designs/README.md
           - Role Configuration: roles/eos_designs/docs/role-configuration.md
@@ -158,7 +158,7 @@ nav:
       - eos_snapshot: roles/eos_snapshot/README.md
       - dhcp_provisioner: roles/dhcp_provisioner/README.md
       - build_output_folders: roles/build_output_folders/README.md
-  - Ansible Collection Plugins Documentation: docs/plugins/
+  - Ansible Collection Plugins: docs/plugins/
   - Contributing to AVD:
       - Overview: docs/contribution/overview.md
       - Setup Environment: docs/contribution/setup-environment.md


### PR DESCRIPTION
Use hyperlinks to versioned docs instead of regenerating release-notes for historic versions. This will avoid the link checker to run on historic docs on every new PR.
