### PR TITLE
Feat(plugins): Add deprecation for ansible-core<2.14 and python 3.8

### DIFF
--- a/ansible_collections/arista/avd/docs/plugins/Modules and action plugins/verify_requirements.md
+++ b/ansible_collections/arista/avd/docs/plugins/Modules and action plugins/verify_requirements.md
@@ -20,7 +20,7 @@ The \`arista.avd.verify\_requirements\` module is an Ansible Action Plugin provi
 \- Validate the ansible version against collection requirements
 \- Validate the collection requirements against the collection requirements
 \- Validate the running python version
-\- Emit deprecations warning for Python and Ansible versions
+\- Emit deprecation warnings for Python and Ansible versions
 
 ## Parameters
 

--- a/ansible_collections/arista/avd/docs/plugins/Modules and action plugins/verify_requirements.md
+++ b/ansible_collections/arista/avd/docs/plugins/Modules and action plugins/verify_requirements.md
@@ -20,6 +20,7 @@ The \`arista.avd.verify\_requirements\` module is an Ansible Action Plugin provi
 \- Validate the ansible version against collection requirements
 \- Validate the collection requirements against the collection requirements
 \- Validate the running python version
+\- Emit deprecations warning for Python and Ansible versions
 
 ## Parameters
 

--- a/ansible_collections/arista/avd/docs/release-notes/4.x.x.md
+++ b/ansible_collections/arista/avd/docs/release-notes/4.x.x.md
@@ -14,7 +14,7 @@
 
 - As per https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix, `ansible-core` version 2.12 was declared End-of-Life (EOL) on May 22nd 2023 and version 2.13 will be declared EOL on November 6th 2023.
 
-  AVD will drop support for `ansible-core<2.14` in the next **minor** release after November 6th 2023.
+  AVD will drop support for `ansible-core` versions 2.12 and 2.13 in the next **minor** release after November 6th 2023.
 
 - Since `ansible-core` versions above 2.14 do not support Python versions below 3.9, the support for Python 3.8 will be dropped from AVD at the same time.
 

--- a/ansible_collections/arista/avd/docs/release-notes/4.x.x.md
+++ b/ansible_collections/arista/avd/docs/release-notes/4.x.x.md
@@ -12,13 +12,13 @@
 
 ### Deprecation Warnings for Python 3.8 and ansible-core<2.14
 
-- As per https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix, `ansible-core` 2.13 is EOL on November 6th 2023.
+- As per https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix, `ansible-core` version 2.12 was declared End-of-Life (EOL) on May 22nd 2023 and version 2.13 will be declared EOL on November 6th 2023.
 
-  AVD will drop support for `ansible-core<2.14` in the next Minor Release after this date.
+  AVD will drop support for `ansible-core<2.14` in the next **minor** release after November 6th 2023.
 
-- Because `ansible-core>=2.14` does not support Python < 3.9, the support for Python 3.8 will be dropped at the same time.
+- Since `ansible-core` versions above 2.14 do not support Python versions below 3.9, the support for Python 3.8 will be dropped from AVD at the same time.
 
-- The `arista.avd.verify_requirements` module will start emitting deprecation warnings starting AVD 4.4 to warn users.
+- The `arista.avd.verify_requirements` module will start emitting deprecation warnings starting AVD 4.4 to warn users about these deprecations.
 
 ### Fixed issues in eos_designs
 

--- a/ansible_collections/arista/avd/docs/release-notes/4.x.x.md
+++ b/ansible_collections/arista/avd/docs/release-notes/4.x.x.md
@@ -10,6 +10,16 @@
 
 ## Release 4.4.0
 
+### Deprecation Warnings for Python 3.8 and ansible-core<2.14
+
+- As per https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix, `ansible-core` 2.13 is EOL on November 6th 2023.
+
+  AVD will drop support for `ansible-core<2.14` in the next Minor Release after this date.
+
+- Because `ansible-core>=2.14` does not support Python < 3.9, the support for Python 3.8 will be dropped at the same time.
+
+- The `arista.avd.verify_requirements` module will start emitting deprecation warnings starting AVD 4.4 to warn users.
+
 ### Fixed issues in eos_designs
 
 - Fix(eos_designs) - Configuration of PTP for port-channel uplinks by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/3112

--- a/ansible_collections/arista/avd/docs/release-notes/4.x.x.md
+++ b/ansible_collections/arista/avd/docs/release-notes/4.x.x.md
@@ -10,7 +10,7 @@
 
 ## Release 4.4.0
 
-### Deprecation Warnings for Python 3.8 and ansible-core<2.14
+### Deprecation warnings for Python 3.8 and ansible-core<2.14
 
 - As per https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix, `ansible-core` version 2.12 was declared End-of-Life (EOL) on May 22nd 2023 and version 2.13 will be declared EOL on November 6th 2023.
 

--- a/ansible_collections/arista/avd/plugins/action/verify_requirements.py
+++ b/ansible_collections/arista/avd/plugins/action/verify_requirements.py
@@ -31,33 +31,51 @@ except ImportError:
 MIN_PYTHON_SUPPORTED_VERSION = (3, 8)
 
 
-def _validate_python_version(result: dict) -> bool:
+def _validate_python_version(info: dict, result: dict) -> bool:
     """
     TODO - avoid hardcoding the min supported version
 
+    Args:
+      info (dict): Dictionary to store information to present in ansible logs
+      result (dict): Module result dictionary to store deprecation warnings
+
     return False if the python version is not valid
     """
-    result["python_version_info"] = {
+    info["python_version_info"] = {
         "major": sys.version_info.major,
         "minor": sys.version_info.minor,
         "micro": sys.version_info.micro,
         "releaselevel": sys.version_info.releaselevel,
         "serial": sys.version_info.serial,
     }
-    result["python_path"] = sys.path
+    info["python_path"] = sys.path
 
+    running_version = ".".join(str(v) for v in sys.version_info[:3])
+    min_version = ".".join(str(v) for v in MIN_PYTHON_SUPPORTED_VERSION)
     if sys.version_info < MIN_PYTHON_SUPPORTED_VERSION:
-        running_version = ".".join(str(v) for v in sys.version_info[:3])
-        min_version = ".".join(str(v) for v in MIN_PYTHON_SUPPORTED_VERSION)
         display.error(f"Python Version running {running_version} - Minimum Version required is {min_version}", False)
         return False
+    elif sys.version_info[:2] == MIN_PYTHON_SUPPORTED_VERSION:
+        result.setdefault("deprecations", []).append(
+            {
+                "msg": (
+                    f"You are currently running Python {running_version}. The next minor release of AVD  after November 6th 2023 will drop support for Python"
+                    f" {min_version} as it will be dropping support for ansible-core<2.14 and ansible-core>=2.14 does not support Python {min_version} as"
+                    " documented here: https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix"
+                )
+            }
+        )
 
     return True
 
 
-def _validate_python_requirements(requirements: list, result: dict) -> bool:
+def _validate_python_requirements(requirements: list, info: dict) -> bool:
     """
     Validate python lib versions
+
+    Args:
+      requirements (list): List of requirements for pythom modules
+      info (dict): Dictionary to store information to present in ansible logs
 
     return False if any python requirement is not valid
     """
@@ -140,35 +158,57 @@ def _validate_python_requirements(requirements: list, result: dict) -> bool:
             }
             valid = False
 
-    result["python_requirements"] = requirements_dict
+    info["python_requirements"] = requirements_dict
     return valid
 
 
-def _validate_ansible_version(collection_name: str, running_version: str, result: dict) -> bool:
+def _validate_ansible_version(collection_name: str, running_version: str, info: dict, result: dict) -> bool:
     """
     Validate ansible version in use, running_version, based on the collection requirements
+
+    Args:
+      collection_name (str): The collection name
+      running_version (str): A string representing the current Ansible version being run
+      info (dict): Dictionary to store information to present in ansible logs
+      result (dict): Module result dictionary to store deprecation warnings
 
     Return False if Ansible version is not valid
     """
     collection_meta = _get_collection_metadata(collection_name)
     specifiers_set = SpecifierSet(collection_meta.get("requires_ansible", ""))
-    result["ansible_version"] = running_version
+    deprecation_specifiers_set = SpecifierSet(">=2.14")
+    info["ansible_version"] = running_version
 
     if len(specifiers_set) > 0:
-        result["requires_ansible"] = str(specifiers_set)
+        info["requires_ansible"] = str(specifiers_set)
     if not specifiers_set.contains(running_version):
         display.error(
             f"Ansible Version running {running_version} - Requirement is {str(specifiers_set)}",
             False,
         )
         return False
+    # TODO remove this once dropping support of ansible-core<2.14 as the previous if will catch it.
+    elif not deprecation_specifiers_set.contains(running_version):
+        result.setdefault("deprecations", []).append(
+            {
+                "msg": (
+                    f"You are currently running ansible-core {running_version}. The next minor release of AVD after November 6th 2023 will drop support for"
+                    " ansible-core<2.14.Python 3.8 support will be dropped at the same time as ansible-core<2.14 does not support it. See the following link"
+                    " for more details: https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix"
+                )
+            }
+        )
 
     return True
 
 
-def _validate_ansible_collections(running_collection_name: str, result: dict) -> bool:
+def _validate_ansible_collections(running_collection_name: str, info: dict) -> bool:
     """
     Verify the version of required ansible collections running based on the collection requirements
+
+    Args:
+      collection_name (str): The collection name
+      info (dict): Dictionary to store information to present in ansible logs
 
     Return True if all collection requirements are valid, False otherwise
     """
@@ -227,7 +267,7 @@ def _validate_ansible_collections(running_collection_name: str, result: dict) ->
             }
             valid = False
 
-    result["collection_requirements"] = requirements_dict
+    info["collection_requirements"] = requirements_dict
     return valid
 
 
@@ -325,11 +365,11 @@ class ActionModule(ActionBase):
         if display.verbosity < 1:
             display.display("Use -v for details.")
 
-        if not _validate_python_version(info["python"]):
+        if not _validate_python_version(info["python"], result):
             result["failed"] = True
         if not _validate_python_requirements(py_requirements, info["python"]):
             result["failed"] = True
-        if not _validate_ansible_version(running_collection_name, running_ansible_version, info["ansible"]):
+        if not _validate_ansible_version(running_collection_name, running_ansible_version, info["ansible"], result):
             result["failed"] = True
         if not _validate_ansible_collections(running_collection_name, info["ansible"]):
             result["failed"] = True

--- a/ansible_collections/arista/avd/plugins/action/verify_requirements.py
+++ b/ansible_collections/arista/avd/plugins/action/verify_requirements.py
@@ -59,7 +59,7 @@ def _validate_python_version(info: dict, result: dict) -> bool:
         result.setdefault("deprecations", []).append(
             {
                 "msg": (
-                    f"You are currently running Python {running_version}. The next minor release of AVD  after November 6th 2023 will drop support for Python"
+                    f"You are currently running Python {running_version}. The next minor release of AVD after November 6th 2023 will drop support for Python"
                     f" {min_version} as it will be dropping support for ansible-core<2.14 and ansible-core>=2.14 does not support Python {min_version} as"
                     " documented here: https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix"
                 )
@@ -193,7 +193,7 @@ def _validate_ansible_version(collection_name: str, running_version: str, info: 
             {
                 "msg": (
                     f"You are currently running ansible-core {running_version}. The next minor release of AVD after November 6th 2023 will drop support for"
-                    " ansible-core<2.14.Python 3.8 support will be dropped at the same time as ansible-core<2.14 does not support it. See the following link"
+                    " ansible-core<2.14. Python 3.8 support will be dropped at the same time as ansible-core>=2.14 does not support it. See the following link"
                     " for more details: https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix"
                 )
             }

--- a/ansible_collections/arista/avd/plugins/modules/verify_requirements.py
+++ b/ansible_collections/arista/avd/plugins/modules/verify_requirements.py
@@ -16,6 +16,7 @@ description: |-
   - Validate the ansible version against collection requirements
   - Validate the collection requirements against the collection requirements
   - Validate the running python version
+  - Emit deprecations warning for Python and Ansible versions
 options:
   requirements:
     description:

--- a/ansible_collections/arista/avd/plugins/modules/verify_requirements.py
+++ b/ansible_collections/arista/avd/plugins/modules/verify_requirements.py
@@ -16,7 +16,7 @@ description: |-
   - Validate the ansible version against collection requirements
   - Validate the collection requirements against the collection requirements
   - Validate the running python version
-  - Emit deprecations warning for Python and Ansible versions
+  - Emit deprecation warnings for Python and Ansible versions
 options:
   requirements:
     description:


### PR DESCRIPTION
## Change Summary

`ansible-core` 2.13 will reached EOL on November 6th 2023
This PR introduces in `arista.avd.verify_requirements` action module a deprecation warning (ansible feature) stating that AVD will drop support for `ansible-core<2.14` and `python 3.8` in the next Minor Release after this date.

## Component(s) name

`plugins`

## Proposed changes

cf summary

## How to test

Updated unit tests

Example outputs of the deprecation warnings:

![Screenshot 2023-10-02 at 12 55 12](https://github.com/aristanetworks/ansible-avd/assets/3007422/a2cca004-bf57-438e-9ea2-fb34db975819)

![Screenshot 2023-10-02 at 12 40 22](https://github.com/aristanetworks/ansible-avd/assets/3007422/259b61bf-8bac-4067-a453-76063e9963f3)

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)

