### PR TITLE
Feat(eos_cli_config_gen): Add support for qos map exp

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/qos.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/qos.md
@@ -208,12 +208,10 @@ QOS random-detect ECN is set to allow **non-ect** **chip-based**
 
 ##### QOS Mappings
 
-
 | COS to Traffic Class mappings |
 | ----------------------------- |
 | 1 2 3 4 to traffic-class 2 |
 | 3 to traffic-class 3 |
-
 
 | DSCP to Traffic Class mappings |
 | ------------------------------ |
@@ -221,11 +219,9 @@ QOS random-detect ECN is set to allow **non-ect** **chip-based**
 | 18 20 22 26 28 30 34 36 38 to traffic-class 4 drop-precedence 2 |
 | 46 to traffic-class 5 |
 
-
 | EXP to Traffic Class mappings |
 | ----------------------------- |
 | 0 to traffic-class 0 |
-
 
 | Traffic Class to DSCP or COS mappings |
 | ------------------------------------- |

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/qos.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/qos.md
@@ -241,6 +241,7 @@ qos map dscp 46 to traffic-class 5
 qos map traffic-class 1 to dscp 56
 qos map traffic-class 2 4 5 to cos 7
 qos map traffic-class 6 to tx-queue 2
+qos map exp 0 to traffic-class 0
 !
 qos random-detect ecn allow non-ect chip-based
 ```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/qos.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/qos.md
@@ -222,6 +222,11 @@ QOS random-detect ECN is set to allow **non-ect** **chip-based**
 | 46 to traffic-class 5 |
 
 
+| EXP to Traffic Class mappings |
+| ----------------------------- |
+| 0 to traffic-class 0 |
+
+
 | Traffic Class to DSCP or COS mappings |
 | ------------------------------------- |
 | 1 to dscp 56 |

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/qos.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/qos.cfg
@@ -193,6 +193,7 @@ qos map dscp 46 to traffic-class 5
 qos map traffic-class 1 to dscp 56
 qos map traffic-class 2 4 5 to cos 7
 qos map traffic-class 6 to tx-queue 2
+qos map exp 0 to traffic-class 0
 !
 qos random-detect ecn allow non-ect chip-based
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/qos.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/qos.yml
@@ -8,6 +8,8 @@ qos:
       - "8 9 10 11 12 13 14 15 16 17 19 21 23 24 25 27 29 31 32 33 35 37 39 40 41 42 43 44 45 47 49 50 51 52 53 54 55 57 58 59 60 61 62 63 to traffic-class 1"
       - "46 to traffic-class 5"
       - "18 20 22 26 28 30 34 36 38 to traffic-class 4 drop-precedence 2"
+    exp:
+      - "0 to traffic-class 0"
     traffic_class:
       - "2 4 5 to cos 7"
       - "1 to dscp 56"

--- a/ansible_collections/arista/avd/plugins/plugin_utils/schema/key_to_display_name.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/schema/key_to_display_name.py
@@ -23,6 +23,7 @@ WORDLIST = {
     "dscp": "DSCP",
     "eos": "EOS",
     "evpn": "EVPN",
+    "exp": "EXP",
     "fcs": "FCS",
     "gnmi": "gNMI",
     "http": "HTTP",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/qos.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/qos.md
@@ -13,6 +13,8 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "qos.map.cos.[].&lt;str&gt;") | String |  |  |  | Example: "0 1 to traffic-class 1"<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;dscp</samp>](## "qos.map.dscp") | List, items: String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "qos.map.dscp.[].&lt;str&gt;") | String |  |  |  | Example: "8 9 10 to traffic-class 1"<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;exp</samp>](## "qos.map.exp") | List, items: String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "qos.map.exp.[].&lt;str&gt;") | String |  |  |  | Example "0 to traffic-class 0"<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;traffic_class</samp>](## "qos.map.traffic_class") | List, items: String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "qos.map.traffic_class.[].&lt;str&gt;") | String |  |  |  | Example: "1 to dscp 32"<br> |
     | [<samp>&nbsp;&nbsp;rewrite_dscp</samp>](## "qos.rewrite_dscp") | Boolean |  |  |  |  |
@@ -30,6 +32,8 @@
         cos:
           - <str>
         dscp:
+          - <str>
+        exp:
           - <str>
         traffic_class:
           - <str>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -11335,6 +11335,14 @@
               },
               "title": "DSCP"
             },
+            "exp": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "description": "Example \"0 to traffic-class 0\"\n"
+              },
+              "title": "Exp"
+            },
             "traffic_class": {
               "type": "array",
               "items": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -11341,7 +11341,7 @@
                 "type": "string",
                 "description": "Example \"0 to traffic-class 0\"\n"
               },
-              "title": "Exp"
+              "title": "EXP"
             },
             "traffic_class": {
               "type": "array",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -6820,6 +6820,13 @@ keys:
               description: 'Example: "8 9 10 to traffic-class 1"
 
                 '
+          exp:
+            type: list
+            items:
+              type: str
+              description: 'Example "0 to traffic-class 0"
+
+                '
           traffic_class:
             type: list
             items:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/qos.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/qos.schema.yml
@@ -24,6 +24,12 @@ keys:
               type: str
               description: |
                 Example: "8 9 10 to traffic-class 1"
+          exp:
+            type: list
+            items:
+              type: str
+              description: |
+                Example "0 to traffic-class 0"
           traffic_class:
             type: list
             items:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/qos.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/qos.j2
@@ -48,6 +48,15 @@ QOS rewrite DSCP: **disabled**
 
 {%         if qos.map.traffic_class is arista.avd.defined %}
 
+| EXP to Traffic Class mappings |
+| ----------------------------- |
+{%             for exp_map in qos.map.exp | arista.avd.natural_sort %}
+| {{ exp_map | default('-') }} |
+{%             endfor %}
+{%         endif %}
+
+{%         if qos.map.traffic_class is arista.avd.defined %}
+
 | Traffic Class to DSCP or COS mappings |
 | ------------------------------------- |
 {%             for tc_map in qos.map.traffic_class | arista.avd.natural_sort %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/qos.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/qos.j2
@@ -43,7 +43,7 @@ QOS rewrite DSCP: **disabled**
 | {{ dscp_map | default('-') }} |
 {%             endfor %}
 {%         endif %}
-{%         if qos.map.traffic_class is arista.avd.defined %}
+{%         if qos.map.exp is arista.avd.defined %}
 
 | EXP to Traffic Class mappings |
 | ----------------------------- |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/qos.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/qos.j2
@@ -27,7 +27,6 @@ QOS rewrite DSCP: **disabled**
 {%     if qos.map is arista.avd.defined %}
 
 ##### QOS Mappings
-
 {%         if qos.map.cos is arista.avd.defined %}
 
 | COS to Traffic Class mappings |
@@ -36,7 +35,6 @@ QOS rewrite DSCP: **disabled**
 | {{ cos_map | default('-') }} |
 {%             endfor %}
 {%         endif %}
-
 {%         if qos.map.dscp is arista.avd.defined %}
 
 | DSCP to Traffic Class mappings |
@@ -45,7 +43,6 @@ QOS rewrite DSCP: **disabled**
 | {{ dscp_map | default('-') }} |
 {%             endfor %}
 {%         endif %}
-
 {%         if qos.map.traffic_class is arista.avd.defined %}
 
 | EXP to Traffic Class mappings |
@@ -54,7 +51,6 @@ QOS rewrite DSCP: **disabled**
 | {{ exp_map | default('-') }} |
 {%             endfor %}
 {%         endif %}
-
 {%         if qos.map.traffic_class is arista.avd.defined %}
 
 | Traffic Class to DSCP or COS mappings |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/qos.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/qos.j2
@@ -18,6 +18,9 @@ qos map dscp {{ dscp_map }}
 {%     for tc_map in qos.map.traffic_class | arista.avd.natural_sort %}
 qos map traffic-class {{ tc_map }}
 {%     endfor %}
+{%     for exp_map in qos.map.exp | arista.avd.natural_sort %}
+qos map exp {{ exp_map }}
+{%     endfor %}
 {%     if qos.random_detect.ecn.allow_non_ect.enabled is arista.avd.defined %}
 !
 {%         set ecn_command = "qos random-detect ecn allow non-ect" %}


### PR DESCRIPTION
## Change Summary

add knob in eos_cli_config_gen to configure qos map exp 

## Related Issue(s)

N/A

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
adding a key under qos.map for exp field

Addition to qos.schema:
```
type: dict
  keys:
    qos:
      map:
          exp:
            type: list
            items:
              type: str
              description: |
                Example "0 to traffic-class 0"
```

## How to test

See molecule test 

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
