### PR TITLE
Fix: Remove "anta" from requirements while the integration is in preview

### DIFF
--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -343,10 +343,12 @@ jobs:
         avd_scenario:
           - 'eos_validate_state'
         ansible_version:
-          - 'ansible-core<2.16.0 --upgrade'
+          # Temporarily installing anta manually while the feature is in preview.
+          - 'ansible-core<2.16.0 anta==0.9.0 --upgrade'
         include:
           - avd_scenario: 'eos_validate_state'
-            ansible_version: 'ansible-core==2.12.6'
+            # Temporarily installing anta manually while the feature is in preview.
+            ansible_version: 'ansible-core==2.12.6 anta==0.9.0'
             galaxy_server: 'https://old-galaxy.ansible.com'
     needs: [ pre_commit ]
     if: needs.file-changes.outputs.eos_design == 'true' || needs.file-changes.outputs.validate_state == 'true'
@@ -366,9 +368,7 @@ jobs:
           molecule_parentdir: 'ansible_collections/arista/avd'
           molecule_command: 'test'
           molecule_args: '--scenario-name ${{ matrix.avd_scenario }}'
-          # Temporarily adding anta to the requirements while the feature is in preview.
-          # pip_file: ansible_collections/arista/avd/requirements.txt
-          pip_file: "ansible_collections/arista/avd/requirements.txt anta==0.9.0"
+          pip_file: ansible_collections/arista/avd/requirements.txt
           galaxy_file: "ansible_collections/arista/avd/collections.yml"
           ansible: ${{ matrix.ansible_version }}
           check_git: true

--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -343,12 +343,10 @@ jobs:
         avd_scenario:
           - 'eos_validate_state'
         ansible_version:
-          # Temporarily installing anta manually while the feature is in preview.
-          - 'ansible-core<2.16.0 anta==0.9.0 --upgrade'
+          - 'ansible-core<2.16.0 --upgrade'
         include:
           - avd_scenario: 'eos_validate_state'
-            # Temporarily installing anta manually while the feature is in preview.
-            ansible_version: 'ansible-core==2.12.6 anta==0.9.0'
+            ansible_version: 'ansible-core==2.12.6'
             galaxy_server: 'https://old-galaxy.ansible.com'
     needs: [ pre_commit ]
     if: needs.file-changes.outputs.eos_design == 'true' || needs.file-changes.outputs.validate_state == 'true'
@@ -368,7 +366,8 @@ jobs:
           molecule_parentdir: 'ansible_collections/arista/avd'
           molecule_command: 'test'
           molecule_args: '--scenario-name ${{ matrix.avd_scenario }}'
-          pip_file: ansible_collections/arista/avd/requirements.txt
+          # Temporarily using special requirements to install anta while the feature is in preview.
+          pip_file: ansible_collections/arista/avd/roles/eos_validate_state/preview_requirements.txt
           galaxy_file: "ansible_collections/arista/avd/collections.yml"
           ansible: ${{ matrix.ansible_version }}
           check_git: true

--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -366,7 +366,9 @@ jobs:
           molecule_parentdir: 'ansible_collections/arista/avd'
           molecule_command: 'test'
           molecule_args: '--scenario-name ${{ matrix.avd_scenario }}'
-          pip_file: ansible_collections/arista/avd/requirements.txt
+          # Temporarily adding anta to the requirements while the feature is in preview.
+          # pip_file: ansible_collections/arista/avd/requirements.txt
+          pip_file: "ansible_collections/arista/avd/requirements.txt anta==0.9.0"
           galaxy_file: "ansible_collections/arista/avd/collections.yml"
           ansible: ${{ matrix.ansible_version }}
           check_git: true

--- a/ansible_collections/arista/avd/requirements.txt
+++ b/ansible_collections/arista/avd/requirements.txt
@@ -9,5 +9,6 @@ PyYAML>=5.4.1
 md-toc>=7.1.0
 deepmerge>=1.1.0
 cryptography>=38.0.4
+# Removed anta requirement until the eos_validate_state integration is out of preview.
 # Pinned to specific version until anta reaches 1.0.0 and follows semver.
-anta==0.9.0
+# anta==0.9.0

--- a/ansible_collections/arista/avd/requirements.txt
+++ b/ansible_collections/arista/avd/requirements.txt
@@ -9,6 +9,5 @@ PyYAML>=5.4.1
 md-toc>=7.1.0
 deepmerge>=1.1.0
 cryptography>=38.0.4
-# Removed anta requirement until the eos_validate_state integration is out of preview.
-# Pinned to specific version until anta reaches 1.0.0 and follows semver.
-# anta==0.9.0
+# No anta requirement until the eos_validate_state integration is out of preview.
+# anta>=1.0.0

--- a/ansible_collections/arista/avd/roles/eos_validate_state/ANTA-Preview.md
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/ANTA-Preview.md
@@ -34,9 +34,9 @@
 
 ## How to run eos_validate_state in ANTA mode
 
-- Install anta v0.9.0: `pip install anta==v0.9.0` (this is part of the `requirements.txt`)
+- Install "anta" version 0.9.0: `pip install anta==0.9.0` (this is *not* part of the `requirements.txt`)
 
-- Run eos_validate_state playbook by setting the variables `use_anta=true`
+- Run eos_validate_state playbook by setting the variable `use_anta=true`.
 
   This can be set for instance in your group_vars or under the task in your playbook.
 

--- a/ansible_collections/arista/avd/roles/eos_validate_state/ANTA-Preview.md
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/ANTA-Preview.md
@@ -36,9 +36,9 @@
 
 - Install the "anta" Python package (this is *not* part of the `requirements.txt`):
 
-    ```sh
-    --8<-- "preview_requirements.txt:4:4"
-    ```
+  ```shell
+  --8<-- "roles/eos_validate_state/preview_requirements.txt:4:4"
+  ```
 
 - Run eos_validate_state playbook by setting the variable `use_anta=true`.
 
@@ -49,11 +49,15 @@
 - Ansible tags are supported for backwards compatibility until AVD version 5.0.0.
   To run/skip tests use `--tags` or `--skip-tags`.
 
-  Example: `ansible-playbook playbooks/fabric-validate.yaml --tags routing_table`
+  ```shell
+  ansible-playbook playbooks/fabric-validate.yaml --tags routing_table
+  ```
 
 - You can now run the eos_validate_state role in check_mode. This will produce a report of tests that will be performed without running the tests on your network.
 
-  Example: `ansible-playbook playbooks/fabric-validate.yaml --check`
+  ```shell
+  ansible-playbook playbooks/fabric-validate.yaml --check
+  ```
 
 - You have the option to save the test catalog generate by the role for each device in the `intended/test_catalogs` folder by setting the variable `save_catalog` to `true`.
 

--- a/ansible_collections/arista/avd/roles/eos_validate_state/ANTA-Preview.md
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/ANTA-Preview.md
@@ -34,7 +34,11 @@
 
 ## How to run eos_validate_state in ANTA mode
 
-- Install the "anta" Python package: `--8<-- "preview_requirements.txt:4:4"` (this is *not* part of the `requirements.txt`)
+- Install the "anta" Python package (this is *not* part of the `requirements.txt`):
+
+    ```sh
+    --8<-- "preview_requirements.txt:4:4"
+    ```
 
 - Run eos_validate_state playbook by setting the variable `use_anta=true`.
 

--- a/ansible_collections/arista/avd/roles/eos_validate_state/ANTA-Preview.md
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/ANTA-Preview.md
@@ -34,7 +34,7 @@
 
 ## How to run eos_validate_state in ANTA mode
 
-- Install "anta" version 0.9.0: `pip install anta==0.9.0` (this is *not* part of the `requirements.txt`)
+- Install the "anta" Python package: `--8<-- "preview_requirements.txt:4:4"` (this is *not* part of the `requirements.txt`)
 
 - Run eos_validate_state playbook by setting the variable `use_anta=true`.
 

--- a/ansible_collections/arista/avd/roles/eos_validate_state/ANTA-Preview.md
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/ANTA-Preview.md
@@ -37,7 +37,9 @@
 - Install the "anta" Python package (this is *not* part of the `requirements.txt`):
 
   ```shell
+  pip3 install '
   --8<-- "roles/eos_validate_state/preview_requirements.txt:4:4"
+  '
   ```
 
 - Run eos_validate_state playbook by setting the variable `use_anta=true`.

--- a/ansible_collections/arista/avd/roles/eos_validate_state/preview_requirements.txt
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/preview_requirements.txt
@@ -1,0 +1,4 @@
+# Temporary requirements while ANTA integration is in preview state.
+# Once the integration is final, this file can be removed and the regular requirements can include ANTA.
+-r ../../requirements.txt
+anta==0.10.0


### PR DESCRIPTION
Remove "anta" from requirements while the integration is in preview