### PR TITLE
Fix(eos_cli_config_gen): Correct schema for class-maps vlans and cos options

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/class-maps.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/class-maps.md
@@ -46,6 +46,8 @@ interface Management1
 | CM_REPLICATION_LD | acl | ACL_REPLICATION_LD |
 | CM_REPLICATION_LD2 | vlan | 200 |
 | CM_REPLICATION_LD3 | cos | 3 |
+| COS_RANGE | vlan | 1-3 |
+| VLAN_RANGE | vlan | 200-400 |
 
 #### Class-maps Device Configuration
 
@@ -59,6 +61,12 @@ class-map type qos match-any CM_REPLICATION_LD2
 !
 class-map type qos match-any CM_REPLICATION_LD3
    match cos 3
+!
+class-map type qos match-any COS_RANGE
+   match vlan 1-3
+!
+class-map type qos match-any VLAN_RANGE
+   match vlan 200-400
 !
 class-map type pbr match-any CM_PBR_EXCLUDE
    match ip access-group ACL_PBR_EXCLUDE

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/class-maps.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/class-maps.cfg
@@ -21,6 +21,12 @@ class-map type qos match-any CM_REPLICATION_LD2
 class-map type qos match-any CM_REPLICATION_LD3
    match cos 3
 !
+class-map type qos match-any COS_RANGE
+   match vlan 1-3
+!
+class-map type qos match-any VLAN_RANGE
+   match vlan 200-400
+!
 class-map type pbr match-any CM_PBR_EXCLUDE
    match ip access-group ACL_PBR_EXCLUDE
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/class-maps.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/class-maps.yml
@@ -5,9 +5,13 @@ class_maps:
       ip:
         access_group: ACL_REPLICATION_LD
     - name: CM_REPLICATION_LD2
-      vlan: "200"
+      vlan: 200
     - name: CM_REPLICATION_LD3
       cos: 3
+    - name: VLAN_RANGE
+      vlan: 200-400
+    - name: COS_RANGE
+      vlan: 1-3
   pbr:
     - name: CM_PBR_EXCLUDE
       ip:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/class-maps.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/class-maps.md
@@ -14,8 +14,8 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;access_group</samp>](## "class_maps.pbr.[].ip.access_group") | String |  |  |  | Standard Access-List Name |
     | [<samp>&nbsp;&nbsp;qos</samp>](## "class_maps.qos") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "class_maps.qos.[].name") | String | Required, Unique |  |  | Class-Map Name |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlan</samp>](## "class_maps.qos.[].vlan") | Integer |  |  |  | VLAN value(s) or range(s) of VLAN values |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;cos</samp>](## "class_maps.qos.[].cos") | Integer |  |  |  | CoS value(s) or range(s) of CoS values |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlan</samp>](## "class_maps.qos.[].vlan") | String |  |  |  | VLAN value(s) or range(s) of VLAN values |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;cos</samp>](## "class_maps.qos.[].cos") | String |  |  |  | CoS value(s) or range(s) of CoS values |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ip</samp>](## "class_maps.qos.[].ip") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;access_group</samp>](## "class_maps.qos.[].ip.access_group") | String |  |  |  | IPv4 Access-List Name |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6</samp>](## "class_maps.qos.[].ipv6") | Dictionary |  |  |  |  |
@@ -31,8 +31,8 @@
             access_group: <str>
       qos:
         - name: <str>
-          vlan: <int>
-          cos: <int>
+          vlan: <str>
+          cos: <str>
           ip:
             access_group: <str>
           ipv6:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -933,12 +933,12 @@
                 "title": "Name"
               },
               "vlan": {
-                "type": "integer",
+                "type": "string",
                 "description": "VLAN value(s) or range(s) of VLAN values",
                 "title": "VLAN"
               },
               "cos": {
-                "type": "integer",
+                "type": "string",
                 "description": "CoS value(s) or range(s) of CoS values",
                 "title": "COS"
               },

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -588,14 +588,14 @@ keys:
               type: str
               description: Class-Map Name
             vlan:
-              type: int
+              type: str
               convert_types:
-              - str
+              - int
               description: VLAN value(s) or range(s) of VLAN values
             cos:
-              type: int
+              type: str
               convert_types:
-              - str
+              - int
               description: CoS value(s) or range(s) of CoS values
             ip:
               type: dict

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/class_maps.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/class_maps.schema.yml
@@ -39,14 +39,14 @@ keys:
               type: str
               description: Class-Map Name
             vlan:
-              type: int
+              type: str
               convert_types:
-                - str
+                - int
               description: VLAN value(s) or range(s) of VLAN values
             cos:
-              type: int
+              type: str
               convert_types:
-                - str
+                - int
               description: CoS value(s) or range(s) of CoS values
             ip:
               type: dict


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Correct schema for class-maps vlans and cos options

## Related Issue(s)

Fixes #3214
Fixes #3165 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

Change schema type to string for fields supporting ranges.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Added tests of ranges to molecule scenario.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
