### PR TITLE
Feat(eos_cli_config_gen): Add IPv4 and IPv6 SR-TE address families

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-v4-v6-sr-te.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-v4-v6-sr-te.md
@@ -1,0 +1,125 @@
+# router-bgp-v4-v6-sr-te
+
+## Table of Contents
+
+- [Management](#management)
+  - [Management Interfaces](#management-interfaces)
+- [Routing](#routing)
+  - [Router BGP](#router-bgp)
+
+## Management
+
+### Management Interfaces
+
+#### Management Interfaces Summary
+
+##### IPv4
+
+| Management Interface | description | Type | VRF | IP Address | Gateway |
+| -------------------- | ----------- | ---- | --- | ---------- | ------- |
+| Management1 | oob_management | oob | MGMT | 10.73.255.122/24 | 10.73.255.2 |
+
+##### IPv6
+
+| Management Interface | description | Type | VRF | IPv6 Address | IPv6 Gateway |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ |
+| Management1 | oob_management | oob | MGMT | - | - |
+
+#### Management Interfaces Device Configuration
+
+```eos
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+```
+
+## Routing
+
+### Router BGP
+
+#### Router BGP Summary
+
+| BGP AS | Router ID |
+| ------ | --------- |
+| 65103 | 192.168.255.3 |
+
+#### Router BGP Peer Groups
+
+##### SR-TE-PG-1
+
+| Settings | Value |
+| -------- | ----- |
+| Remote AS | 65000 |
+
+##### SR-TE-PG-2
+
+| Settings | Value |
+| -------- | ----- |
+| Remote AS | 65000 |
+
+#### BGP Neighbors
+
+| Neighbor | Remote AS | VRF | Shutdown | Send-community | Maximum-routes | Allowas-in | BFD | RIB Pre-Policy Retain | Route-Reflector Client | Passive |
+| -------- | --------- | --- | -------- | -------------- | -------------- | ---------- | --- | --------------------- | ---------------------- | ------- |
+| 192.168.42.42 | 65004 | default | - | - | - | - | - | - | - | - |
+| 2001:db8::dead:beef:cafe | 65004 | default | - | - | - | - | - | - | - | - |
+
+#### Router BGP IPv4 SR-TE Address Family
+
+##### IPv4 SR-TE Neighbors
+
+| Neighbor | Activate | Route-map In | Route-map Out |
+| -------- | -------- | ------------ | ------------- |
+| 192.168.42.42 | True | RM-SR-TE-PEER-IN4 | RM-SR-TE-PEER-OUT4 |
+
+##### IPv4 SR-TE Peer Groups
+
+| Peer Group | Activate | Route-map In | Route-map Out |
+| ---------- | -------- | ------------ | ------------- |
+| SR-TE-PG-1 | True | RM-SR-TE-PEER-IN4 | RM-SR-TE-PEER-OUT4 |
+
+#### Router BGP IPv6 SR-TE Address Family
+
+##### IPv6 SR-TE Neighbors
+
+| Neighbor | Activate | Route-map In | Route-map Out |
+| -------- | -------- | ------------ | ------------- |
+| 2001:db8::dead:beef:cafe | True | RM-SR-TE-PEER-IN6 | RM-SR-TE-PEER-OUT6 |
+
+##### IPv6 SR-TE Peer Groups
+
+| Peer Group | Activate | Route-map In | Route-map Out |
+| ---------- | -------- | ------------ | ------------- |
+| SR-TE-PG-2 | True | RM-SR-TE-PEER-IN6 | RM-SR-TE-PEER-OUT6 |
+
+#### Router BGP Device Configuration
+
+```eos
+!
+router bgp 65103
+   router-id 192.168.255.3
+   neighbor SR-TE-PG-1 peer group
+   neighbor SR-TE-PG-1 remote-as 65000
+   neighbor SR-TE-PG-2 peer group
+   neighbor SR-TE-PG-2 remote-as 65000
+   neighbor 192.168.42.42 remote-as 65004
+   neighbor 2001:db8::dead:beef:cafe remote-as 65004
+   !
+   address-family ipv4 sr-te
+      neighbor SR-TE-PG-1 activate
+      neighbor SR-TE-PG-1 route-map RM-SR-TE-PEER-IN4 in
+      neighbor SR-TE-PG-1 route-map RM-SR-TE-PEER-OUT4 out
+      neighbor 192.168.42.42 activate
+      neighbor 192.168.42.42 route-map RM-SR-TE-PEER-IN4 in
+      neighbor 192.168.42.42 route-map RM-SR-TE-PEER-OUT4 out
+   !
+   address-family ipv6 sr-te
+      neighbor SR-TE-PG-2 activate
+      neighbor SR-TE-PG-2 route-map RM-SR-TE-PEER-IN6 in
+      neighbor SR-TE-PG-2 route-map RM-SR-TE-PEER-OUT6 out
+      neighbor 2001:db8::dead:beef:cafe activate
+      neighbor 2001:db8::dead:beef:cafe route-map RM-SR-TE-PEER-IN6 in
+      neighbor 2001:db8::dead:beef:cafe route-map RM-SR-TE-PEER-OUT6 out
+```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-v4-v6-sr-te.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-v4-v6-sr-te.cfg
@@ -1,0 +1,40 @@
+!RANCID-CONTENT-TYPE: arista
+!
+transceiver qsfp default-mode 4x10G
+!
+hostname router-bgp-v4-v6-sr-te
+!
+no enable password
+no aaa root
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+!
+router bgp 65103
+   router-id 192.168.255.3
+   neighbor SR-TE-PG-1 peer group
+   neighbor SR-TE-PG-1 remote-as 65000
+   neighbor SR-TE-PG-2 peer group
+   neighbor SR-TE-PG-2 remote-as 65000
+   neighbor 192.168.42.42 remote-as 65004
+   neighbor 2001:db8::dead:beef:cafe remote-as 65004
+   !
+   address-family ipv4 sr-te
+      neighbor SR-TE-PG-1 activate
+      neighbor SR-TE-PG-1 route-map RM-SR-TE-PEER-IN4 in
+      neighbor SR-TE-PG-1 route-map RM-SR-TE-PEER-OUT4 out
+      neighbor 192.168.42.42 activate
+      neighbor 192.168.42.42 route-map RM-SR-TE-PEER-IN4 in
+      neighbor 192.168.42.42 route-map RM-SR-TE-PEER-OUT4 out
+   !
+   address-family ipv6 sr-te
+      neighbor SR-TE-PG-2 activate
+      neighbor SR-TE-PG-2 route-map RM-SR-TE-PEER-IN6 in
+      neighbor SR-TE-PG-2 route-map RM-SR-TE-PEER-OUT6 out
+      neighbor 2001:db8::dead:beef:cafe activate
+      neighbor 2001:db8::dead:beef:cafe route-map RM-SR-TE-PEER-IN6 in
+      neighbor 2001:db8::dead:beef:cafe route-map RM-SR-TE-PEER-OUT6 out
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-v4-v6-sr-te.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-v4-v6-sr-te.yml
@@ -1,0 +1,36 @@
+### Routing - BGP vpn-ipv4 ###
+router_bgp:
+  as: 65103
+  router_id: 192.168.255.3
+  peer_groups:
+    - name: SR-TE-PG-1
+      remote_as: 65000
+    - name: SR-TE-PG-2
+      remote_as: 65000
+  neighbors:
+    - ip_address: 192.168.42.42
+      remote_as: 65004
+    - ip_address: 2001:db8::dead:beef:cafe
+      remote_as: 65004
+  address_family_ipv4_sr_te:
+    peer_groups:
+      - name: SR-TE-PG-1
+        activate: true
+        route_map_in: RM-SR-TE-PEER-IN4
+        route_map_out: RM-SR-TE-PEER-OUT4
+    neighbors:
+      - ip_address: 192.168.42.42
+        activate: true
+        route_map_in: RM-SR-TE-PEER-IN4
+        route_map_out: RM-SR-TE-PEER-OUT4
+  address_family_ipv6_sr_te:
+    peer_groups:
+      - name: SR-TE-PG-2
+        activate: true
+        route_map_in: RM-SR-TE-PEER-IN6
+        route_map_out: RM-SR-TE-PEER-OUT6
+    neighbors:
+      - ip_address: 2001:db8::dead:beef:cafe
+        activate: true
+        route_map_in: RM-SR-TE-PEER-IN6
+        route_map_out: RM-SR-TE-PEER-OUT6

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts.ini
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts.ini
@@ -112,6 +112,7 @@ router-bgp-evpn-mpls
 router-bgp-rtc
 router-bgp-v4-evpn
 router-bgp-v4-v6-evpn
+router-bgp-v4-v6-sr-te
 router-bgp-vpn-ipv4-vpn-ipv6
 router-bgp-vpws
 router-bgp-vrf-address-families

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-bgp.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-bgp.md
@@ -299,6 +299,17 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;redistribute_routes</samp>](## "router_bgp.address_family_ipv4_multicast.redistribute_routes") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- source_protocol</samp>](## "router_bgp.address_family_ipv4_multicast.redistribute_routes.[].source_protocol") | String | Required, Unique |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "router_bgp.address_family_ipv4_multicast.redistribute_routes.[].route_map") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;address_family_ipv4_sr_te</samp>](## "router_bgp.address_family_ipv4_sr_te") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;neighbors</samp>](## "router_bgp.address_family_ipv4_sr_te.neighbors") | List, items: Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- ip_address</samp>](## "router_bgp.address_family_ipv4_sr_te.neighbors.[].ip_address") | String | Required, Unique |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;activate</samp>](## "router_bgp.address_family_ipv4_sr_te.neighbors.[].activate") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map_in</samp>](## "router_bgp.address_family_ipv4_sr_te.neighbors.[].route_map_in") | String |  |  |  | Inbound route-map name |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map_out</samp>](## "router_bgp.address_family_ipv4_sr_te.neighbors.[].route_map_out") | String |  |  |  | Outbound route-map name |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;peer_groups</samp>](## "router_bgp.address_family_ipv4_sr_te.peer_groups") | List, items: Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "router_bgp.address_family_ipv4_sr_te.peer_groups.[].name") | String | Required, Unique |  |  | Peer-group name |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;activate</samp>](## "router_bgp.address_family_ipv4_sr_te.peer_groups.[].activate") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map_in</samp>](## "router_bgp.address_family_ipv4_sr_te.peer_groups.[].route_map_in") | String |  |  |  | Inbound route-map name |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map_out</samp>](## "router_bgp.address_family_ipv4_sr_te.peer_groups.[].route_map_out") | String |  |  |  | Outbound route-map name |
     | [<samp>&nbsp;&nbsp;address_family_ipv6</samp>](## "router_bgp.address_family_ipv6") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;networks</samp>](## "router_bgp.address_family_ipv6.networks") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- prefix</samp>](## "router_bgp.address_family_ipv6.networks.[].prefix") | String | Required, Unique |  |  | IPv4 prefix "A.B.C.D/E" or IPv6 prefix "A:B:C:D:E:F:G:H/I" |
@@ -339,6 +350,17 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;networks</samp>](## "router_bgp.address_family_ipv6_multicast.networks") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- prefix</samp>](## "router_bgp.address_family_ipv6_multicast.networks.[].prefix") | String | Required, Unique |  |  | IPv6 prefix "A:B:C:D:E:F:G:H/I" |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "router_bgp.address_family_ipv6_multicast.networks.[].route_map") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;address_family_ipv6_sr_te</samp>](## "router_bgp.address_family_ipv6_sr_te") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;neighbors</samp>](## "router_bgp.address_family_ipv6_sr_te.neighbors") | List, items: Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- ip_address</samp>](## "router_bgp.address_family_ipv6_sr_te.neighbors.[].ip_address") | String | Required, Unique |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;activate</samp>](## "router_bgp.address_family_ipv6_sr_te.neighbors.[].activate") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map_in</samp>](## "router_bgp.address_family_ipv6_sr_te.neighbors.[].route_map_in") | String |  |  |  | Inbound route-map name |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map_out</samp>](## "router_bgp.address_family_ipv6_sr_te.neighbors.[].route_map_out") | String |  |  |  | Outbound route-map name |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;peer_groups</samp>](## "router_bgp.address_family_ipv6_sr_te.peer_groups") | List, items: Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "router_bgp.address_family_ipv6_sr_te.peer_groups.[].name") | String | Required, Unique |  |  | Peer-group name |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;activate</samp>](## "router_bgp.address_family_ipv6_sr_te.peer_groups.[].activate") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map_in</samp>](## "router_bgp.address_family_ipv6_sr_te.peer_groups.[].route_map_in") | String |  |  |  | Inbound route-map name |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map_out</samp>](## "router_bgp.address_family_ipv6_sr_te.peer_groups.[].route_map_out") | String |  |  |  | Outbound route-map name |
     | [<samp>&nbsp;&nbsp;address_family_flow_spec_ipv4</samp>](## "router_bgp.address_family_flow_spec_ipv4") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;bgp</samp>](## "router_bgp.address_family_flow_spec_ipv4.bgp") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;missing_policy</samp>](## "router_bgp.address_family_flow_spec_ipv4.bgp.missing_policy") | Dictionary |  |  |  |  |
@@ -901,6 +923,17 @@
         redistribute_routes:
           - source_protocol: <str>
             route_map: <str>
+      address_family_ipv4_sr_te:
+        neighbors:
+          - ip_address: <str>
+            activate: <bool>
+            route_map_in: <str>
+            route_map_out: <str>
+        peer_groups:
+          - name: <str>
+            activate: <bool>
+            route_map_in: <str>
+            route_map_out: <str>
       address_family_ipv6:
         networks:
           - prefix: <str>
@@ -941,6 +974,17 @@
         networks:
           - prefix: <str>
             route_map: <str>
+      address_family_ipv6_sr_te:
+        neighbors:
+          - ip_address: <str>
+            activate: <bool>
+            route_map_in: <str>
+            route_map_out: <str>
+        peer_groups:
+          - name: <str>
+            activate: <bool>
+            route_map_in: <str>
+            route_map_out: <str>
       address_family_flow_spec_ipv4:
         bgp:
           missing_policy:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -14316,6 +14316,85 @@
           },
           "title": "Address Family IPv4 Multicast"
         },
+        "address_family_ipv4_sr_te": {
+          "type": "object",
+          "properties": {
+            "neighbors": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "ip_address": {
+                    "type": "string",
+                    "title": "IP Address"
+                  },
+                  "activate": {
+                    "type": "boolean",
+                    "title": "Activate"
+                  },
+                  "route_map_in": {
+                    "type": "string",
+                    "description": "Inbound route-map name",
+                    "title": "Route Map In"
+                  },
+                  "route_map_out": {
+                    "type": "string",
+                    "description": "Outbound route-map name",
+                    "title": "Route Map Out"
+                  }
+                },
+                "additionalProperties": false,
+                "patternProperties": {
+                  "^_.+$": {}
+                },
+                "required": [
+                  "ip_address"
+                ]
+              },
+              "title": "Neighbors"
+            },
+            "peer_groups": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "Peer-group name",
+                    "title": "Name"
+                  },
+                  "activate": {
+                    "type": "boolean",
+                    "title": "Activate"
+                  },
+                  "route_map_in": {
+                    "type": "string",
+                    "description": "Inbound route-map name",
+                    "title": "Route Map In"
+                  },
+                  "route_map_out": {
+                    "type": "string",
+                    "description": "Outbound route-map name",
+                    "title": "Route Map Out"
+                  }
+                },
+                "additionalProperties": false,
+                "patternProperties": {
+                  "^_.+$": {}
+                },
+                "required": [
+                  "name"
+                ]
+              },
+              "title": "Peer Groups"
+            }
+          },
+          "additionalProperties": false,
+          "patternProperties": {
+            "^_.+$": {}
+          },
+          "title": "Address Family IPv4 Sr Te"
+        },
         "address_family_ipv6": {
           "type": "object",
           "properties": {
@@ -14614,6 +14693,85 @@
             "^_.+$": {}
           },
           "title": "Address Family IPv6 Multicast"
+        },
+        "address_family_ipv6_sr_te": {
+          "type": "object",
+          "properties": {
+            "neighbors": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "ip_address": {
+                    "type": "string",
+                    "title": "IP Address"
+                  },
+                  "activate": {
+                    "type": "boolean",
+                    "title": "Activate"
+                  },
+                  "route_map_in": {
+                    "type": "string",
+                    "description": "Inbound route-map name",
+                    "title": "Route Map In"
+                  },
+                  "route_map_out": {
+                    "type": "string",
+                    "description": "Outbound route-map name",
+                    "title": "Route Map Out"
+                  }
+                },
+                "additionalProperties": false,
+                "patternProperties": {
+                  "^_.+$": {}
+                },
+                "required": [
+                  "ip_address"
+                ]
+              },
+              "title": "Neighbors"
+            },
+            "peer_groups": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "Peer-group name",
+                    "title": "Name"
+                  },
+                  "activate": {
+                    "type": "boolean",
+                    "title": "Activate"
+                  },
+                  "route_map_in": {
+                    "type": "string",
+                    "description": "Inbound route-map name",
+                    "title": "Route Map In"
+                  },
+                  "route_map_out": {
+                    "type": "string",
+                    "description": "Outbound route-map name",
+                    "title": "Route Map Out"
+                  }
+                },
+                "additionalProperties": false,
+                "patternProperties": {
+                  "^_.+$": {}
+                },
+                "required": [
+                  "name"
+                ]
+              },
+              "title": "Peer Groups"
+            }
+          },
+          "additionalProperties": false,
+          "patternProperties": {
+            "^_.+$": {}
+          },
+          "title": "Address Family IPv6 Sr Te"
         },
         "address_family_flow_spec_ipv4": {
           "type": "object",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -8617,6 +8617,46 @@ keys:
                   type: str
                 route_map:
                   type: str
+      address_family_ipv4_sr_te:
+        type: dict
+        keys:
+          neighbors:
+            type: list
+            primary_key: ip_address
+            convert_types:
+            - dict
+            items:
+              type: dict
+              keys:
+                ip_address:
+                  type: str
+                activate:
+                  type: bool
+                route_map_in:
+                  type: str
+                  description: Inbound route-map name
+                route_map_out:
+                  type: str
+                  description: Outbound route-map name
+          peer_groups:
+            type: list
+            primary_key: name
+            convert_types:
+            - dict
+            items:
+              type: dict
+              keys:
+                name:
+                  type: str
+                  description: Peer-group name
+                activate:
+                  type: bool
+                route_map_in:
+                  type: str
+                  description: Inbound route-map name
+                route_map_out:
+                  type: str
+                  description: Outbound route-map name
       address_family_ipv6:
         type: dict
         keys:
@@ -8767,6 +8807,46 @@ keys:
                   description: IPv6 prefix "A:B:C:D:E:F:G:H/I"
                 route_map:
                   type: str
+      address_family_ipv6_sr_te:
+        type: dict
+        keys:
+          neighbors:
+            type: list
+            primary_key: ip_address
+            convert_types:
+            - dict
+            items:
+              type: dict
+              keys:
+                ip_address:
+                  type: str
+                activate:
+                  type: bool
+                route_map_in:
+                  type: str
+                  description: Inbound route-map name
+                route_map_out:
+                  type: str
+                  description: Outbound route-map name
+          peer_groups:
+            type: list
+            primary_key: name
+            convert_types:
+            - dict
+            items:
+              type: dict
+              keys:
+                name:
+                  type: str
+                  description: Peer-group name
+                activate:
+                  type: bool
+                route_map_in:
+                  type: str
+                  description: Inbound route-map name
+                route_map_out:
+                  type: str
+                  description: Outbound route-map name
       address_family_flow_spec_ipv4:
         type: dict
         keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -8639,8 +8639,6 @@ keys:
           peer_groups:
             type: list
             primary_key: name
-            convert_types:
-            - dict
             items:
               type: dict
               keys:
@@ -8827,8 +8825,6 @@ keys:
           peer_groups:
             type: list
             primary_key: name
-            convert_types:
-            - dict
             items:
               type: dict
               keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -8623,8 +8623,6 @@ keys:
           neighbors:
             type: list
             primary_key: ip_address
-            convert_types:
-            - dict
             items:
               type: dict
               keys:
@@ -8813,8 +8811,6 @@ keys:
           neighbors:
             type: list
             primary_key: ip_address
-            convert_types:
-            - dict
             items:
               type: dict
               keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_bgp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_bgp.schema.yml
@@ -1057,8 +1057,6 @@ keys:
           peer_groups:
             type: list
             primary_key: name
-            convert_types:
-              - dict
             items:
               type: dict
               keys:
@@ -1245,8 +1243,6 @@ keys:
           peer_groups:
             type: list
             primary_key: name
-            convert_types:
-              - dict
             items:
               type: dict
               keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_bgp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_bgp.schema.yml
@@ -1041,8 +1041,6 @@ keys:
           neighbors:
             type: list
             primary_key: ip_address
-            convert_types:
-              - dict
             items:
               type: dict
               keys:
@@ -1231,8 +1229,6 @@ keys:
           neighbors:
             type: list
             primary_key: ip_address
-            convert_types:
-              - dict
             items:
               type: dict
               keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_bgp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_bgp.schema.yml
@@ -1035,6 +1035,46 @@ keys:
                   type: str
                 route_map:
                   type: str
+      address_family_ipv4_sr_te:
+        type: dict
+        keys:
+          neighbors:
+            type: list
+            primary_key: ip_address
+            convert_types:
+              - dict
+            items:
+              type: dict
+              keys:
+                ip_address:
+                  type: str
+                activate:
+                  type: bool
+                route_map_in:
+                  type: str
+                  description: Inbound route-map name
+                route_map_out:
+                  type: str
+                  description: Outbound route-map name
+          peer_groups:
+            type: list
+            primary_key: name
+            convert_types:
+              - dict
+            items:
+              type: dict
+              keys:
+                name:
+                  type: str
+                  description: Peer-group name
+                activate:
+                  type: bool
+                route_map_in:
+                  type: str
+                  description: Inbound route-map name
+                route_map_out:
+                  type: str
+                  description: Outbound route-map name
       address_family_ipv6:
         type: dict
         keys:
@@ -1185,6 +1225,46 @@ keys:
                   description: IPv6 prefix "A:B:C:D:E:F:G:H/I"
                 route_map:
                   type: str
+      address_family_ipv6_sr_te:
+        type: dict
+        keys:
+          neighbors:
+            type: list
+            primary_key: ip_address
+            convert_types:
+              - dict
+            items:
+              type: dict
+              keys:
+                ip_address:
+                  type: str
+                activate:
+                  type: bool
+                route_map_in:
+                  type: str
+                  description: Inbound route-map name
+                route_map_out:
+                  type: str
+                  description: Outbound route-map name
+          peer_groups:
+            type: list
+            primary_key: name
+            convert_types:
+              - dict
+            items:
+              type: dict
+              keys:
+                name:
+                  type: str
+                  description: Peer-group name
+                activate:
+                  type: bool
+                route_map_in:
+                  type: str
+                  description: Inbound route-map name
+                route_map_out:
+                  type: str
+                  description: Outbound route-map name
       address_family_flow_spec_ipv4:
         type: dict
         keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
@@ -563,6 +563,62 @@
 | L3 Gateway Inter-domain | True |
 {%         endif %}
 {%     endif %}
+{%     if router_bgp.address_family_ipv4_sr_te is arista.avd.defined %}
+
+#### Router BGP IPv4 SR-TE Address Family
+{%         if router_bgp.address_family_ipv4_sr_te.neighbors is arista.avd.defined %}
+
+##### IPv4 SR-TE Neighbors
+
+| Neighbor | Activate | Route-map In | Route-map Out |
+| -------- | -------- | ------------ | ------------- |
+{%             for neighbor in router_bgp.address_family_ipv4_sr_te.neighbors | arista.avd.natural_sort('ip_address') %}
+{%                 set route_map_in = neighbor.route_map_in | arista.avd.default("-") %}
+{%                 set route_map_out = neighbor.route_map_out | arista.avd.default("-") %}
+| {{ neighbor.ip_address }} | {{ neighbor.activate | arista.avd.default(false) }} | {{ route_map_in }} | {{ route_map_out }} |
+{%             endfor %}
+{%         endif %}
+{%         if router_bgp.address_family_ipv4_sr_te.peer_groups is arista.avd.defined %}
+
+##### IPv4 SR-TE Peer Groups
+
+| Peer Group | Activate | Route-map In | Route-map Out |
+| ---------- | -------- | ------------ | ------------- |
+{%             for peer_group in router_bgp.address_family_ipv4_sr_te.peer_groups | arista.avd.natural_sort('name') %}
+{%                 set route_map_in = peer_group.route_map_in | arista.avd.default("-") %}
+{%                 set route_map_out = peer_group.route_map_out | arista.avd.default("-") %}
+| {{ peer_group.name }} | {{ peer_group.activate | arista.avd.default(false) }} | {{ route_map_in }} | {{ route_map_out }} |
+{%             endfor %}
+{%         endif %}
+{%     endif %}
+{%     if router_bgp.address_family_ipv6_sr_te is arista.avd.defined %}
+
+#### Router BGP IPv6 SR-TE Address Family
+{%         if router_bgp.address_family_ipv6_sr_te.neighbors is arista.avd.defined %}
+
+##### IPv6 SR-TE Neighbors
+
+| Neighbor | Activate | Route-map In | Route-map Out |
+| -------- | -------- | ------------ | ------------- |
+{%             for neighbor in router_bgp.address_family_ipv6_sr_te.neighbors | arista.avd.natural_sort('ip_address') %}
+{%                 set route_map_in = neighbor.route_map_in | arista.avd.default("-") %}
+{%                 set route_map_out = neighbor.route_map_out | arista.avd.default("-") %}
+| {{ neighbor.ip_address }} | {{ neighbor.activate | arista.avd.default(false) }} | {{ route_map_in }} | {{ route_map_out }} |
+{%             endfor %}
+{%         endif %}
+{%         if router_bgp.address_family_ipv6_sr_te.peer_groups is arista.avd.defined %}
+
+##### IPv6 SR-TE Peer Groups
+
+| Peer Group | Activate | Route-map In | Route-map Out |
+| ---------- | -------- | ------------ | ------------- |
+{%             for peer_group in router_bgp.address_family_ipv6_sr_te.peer_groups | arista.avd.natural_sort('name') %}
+{%                 set route_map_in = peer_group.route_map_in | arista.avd.default("-") %}
+{%                 set route_map_out = peer_group.route_map_out | arista.avd.default("-") %}
+| {{ peer_group.name }} | {{ peer_group.activate | arista.avd.default(false) }} | {{ route_map_in }} | {{ route_map_out }} |
+{%             endfor %}
+{%         endif %}
+{%     endif %}
 {%     if router_bgp.address_family_vpn_ipv4 is arista.avd.defined %}
 
 #### Router BGP VPN-IPv4 Address Family

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -762,6 +762,37 @@ router bgp {{ router_bgp.as }}
 {%             endif %}
 {%         endfor %}
 {%     endif %}
+{# address family ipv4 sr-te activation #}
+{%     if router_bgp.address_family_ipv4_sr_te is arista.avd.defined %}
+   !
+   address-family ipv4 sr-te
+{%         for peer_group in router_bgp.address_family_ipv4_sr_te.peer_groups | arista.avd.natural_sort('name') %}
+{%             if peer_group.activate is arista.avd.defined(true) %}
+      neighbor {{ peer_group.name }} activate
+{%             elif peer_group.activate is arista.avd.defined(false) %}
+      no neighbor {{ peer_group.name }} activate
+{%             endif %}
+{%             if peer_group.route_map_in is arista.avd.defined %}
+      neighbor {{ peer_group.name }} route-map {{ peer_group.route_map_in }} in
+{%             endif %}
+{%             if peer_group.route_map_out is arista.avd.defined %}
+      neighbor {{ peer_group.name }} route-map {{ peer_group.route_map_out }} out
+{%             endif %}
+{%         endfor %}
+{%         for neighbor in router_bgp.address_family_ipv4_sr_te.neighbors | arista.avd.natural_sort('ip_address') %}
+{%             if neighbor.activate is arista.avd.defined(true) %}
+      neighbor {{ neighbor.ip_address }} activate
+{%             elif neighbor.activate is arista.avd.defined(false) %}
+      no neighbor {{ neighbor.ip_address }} activate
+{%             endif %}
+{%             if neighbor.route_map_in is arista.avd.defined %}
+      neighbor {{ neighbor.ip_address }} route-map {{ neighbor.route_map_in }} in
+{%             endif %}
+{%             if neighbor.route_map_out is arista.avd.defined %}
+      neighbor {{ neighbor.ip_address }} route-map {{ neighbor.route_map_out }} out
+{%             endif %}
+{%         endfor %}
+{%     endif %}
 {# address family ipv6 activation #}
 {%     if router_bgp.address_family_ipv6 is arista.avd.defined %}
    !
@@ -861,6 +892,37 @@ router bgp {{ router_bgp.as }}
 {%                 set network_cli = network_cli ~ " route-map " ~ network.route_map %}
 {%             endif %}
       {{ network_cli }}
+{%         endfor %}
+{%     endif %}
+{# address family ipv6 sr-te activation #}
+{%     if router_bgp.address_family_ipv6_sr_te is arista.avd.defined %}
+   !
+   address-family ipv6 sr-te
+{%         for peer_group in router_bgp.address_family_ipv6_sr_te.peer_groups | arista.avd.natural_sort('name') %}
+{%             if peer_group.activate is arista.avd.defined(true) %}
+      neighbor {{ peer_group.name }} activate
+{%             elif peer_group.activate is arista.avd.defined(false) %}
+      no neighbor {{ peer_group.name }} activate
+{%             endif %}
+{%             if peer_group.route_map_in is arista.avd.defined %}
+      neighbor {{ peer_group.name }} route-map {{ peer_group.route_map_in }} in
+{%             endif %}
+{%             if peer_group.route_map_out is arista.avd.defined %}
+      neighbor {{ peer_group.name }} route-map {{ peer_group.route_map_out }} out
+{%             endif %}
+{%         endfor %}
+{%         for neighbor in router_bgp.address_family_ipv6_sr_te.neighbors | arista.avd.natural_sort('ip_address') %}
+{%             if neighbor.activate is arista.avd.defined(true) %}
+      neighbor {{ neighbor.ip_address }} activate
+{%             elif neighbor.activate is arista.avd.defined(false) %}
+      no neighbor {{ neighbor.ip_address }} activate
+{%             endif %}
+{%             if neighbor.route_map_in is arista.avd.defined %}
+      neighbor {{ neighbor.ip_address }} route-map {{ neighbor.route_map_in }} in
+{%             endif %}
+{%             if neighbor.route_map_out is arista.avd.defined %}
+      neighbor {{ neighbor.ip_address }} route-map {{ neighbor.route_map_out }} out
+{%             endif %}
 {%         endfor %}
 {%     endif %}
 {# address family vpn-ipv4 activation #}


### PR DESCRIPTION
## Change Summary

Add SR-TE BGP address families - ipv4 one is required for WAN config and it was cheap to add v6 at the same time.

## Component(s) name

`arista.avd.eos_cli_config_gem`

## Proposed changes

```
      address_family_ipv4_sr_te:
        neighbors:
          - ip_address: <str>
            activate: <bool>
            route_map_in: <str>
            route_map_out: <str>
        peer_groups:
          - name: <str>
            activate: <bool>
            route_map_in: <str>
            route_map_out: <str>
[...]
      address_family_ipv6_sr_te:
        neighbors:
          - ip_address: <str>
            activate: <bool>
            route_map_in: <str>
            route_map_out: <str>
        peer_groups:
          - name: <str>
            activate: <bool>
            route_map_in: <str>
            route_map_out: <str>
```

## How to test

molecule

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
