### PR TITLE
Feat(eos_cli_config_gen): Add 'router service-insertion' CLI

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-service-insertion.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-service-insertion.md
@@ -35,3 +35,5 @@ interface Management1
 ```
 
 ## Routing
+
+Router service-insertion is enabled.

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-service-insertion.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-service-insertion.md
@@ -35,5 +35,3 @@ interface Management1
 ```
 
 ## Routing
-
-Router service-insertion configured.

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-service-insertion.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-service-insertion.md
@@ -1,0 +1,39 @@
+# router-service-insertion
+
+## Table of Contents
+
+- [Management](#management)
+  - [Management Interfaces](#management-interfaces)
+- [Routing](#routing)
+
+## Management
+
+### Management Interfaces
+
+#### Management Interfaces Summary
+
+##### IPv4
+
+| Management Interface | description | Type | VRF | IP Address | Gateway |
+| -------------------- | ----------- | ---- | --- | ---------- | ------- |
+| Management1 | oob_management | oob | MGMT | 10.73.255.122/24 | 10.73.255.2 |
+
+##### IPv6
+
+| Management Interface | description | Type | VRF | IPv6 Address | IPv6 Gateway |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ |
+| Management1 | oob_management | oob | MGMT | - | - |
+
+#### Management Interfaces Device Configuration
+
+```eos
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+```
+
+## Routing
+
+Router service-insertion configured.

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-service-insertion.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-service-insertion.cfg
@@ -1,0 +1,17 @@
+!RANCID-CONTENT-TYPE: arista
+!
+transceiver qsfp default-mode 4x10G
+!
+hostname router-service-insertion
+!
+router service-insertion
+!
+no enable password
+no aaa root
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-service-insertion.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-service-insertion.cfg
@@ -4,8 +4,6 @@ transceiver qsfp default-mode 4x10G
 !
 hostname router-service-insertion
 !
-router service-insertion
-!
 no enable password
 no aaa root
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-service-insertion.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-service-insertion.cfg
@@ -4,6 +4,8 @@ transceiver qsfp default-mode 4x10G
 !
 hostname router-service-insertion
 !
+router service-insertion
+!
 no enable password
 no aaa root
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-service-insertion.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-service-insertion.yml
@@ -1,0 +1,2 @@
+### Router service-insertion ###
+router_service_insertion: true

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-service-insertion.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-service-insertion.yml
@@ -1,2 +1,3 @@
 ### Router service-insertion ###
-router_service_insertion: true
+router_service_insertion:
+  enabled: true

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts.ini
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts.ini
@@ -124,6 +124,7 @@ router-msdp
 router-multicast
 router-ospf
 router-pim-sparse-mode
+router-service-insertion
 router-igmp
 service-routing-configuration-bgp
 service-routing-protocols-model

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/input-variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/input-variables.md
@@ -811,6 +811,12 @@ roles/eos_cli_config_gen/docs/tables/router-l2-vpn.md
 roles/eos_cli_config_gen/docs/tables/router-ospf.md
 --8<--
 
+### Router service-insertion
+
+--8<--
+roles/eos_cli_config_gen/docs/tables/router-service-insertion.md
+--8<--
+
 ### Router traffic engineering
 
 --8<--
@@ -833,6 +839,12 @@ roles/eos_cli_config_gen/docs/tables/service-routing-protocols-model.md
 
 --8<--
 roles/eos_cli_config_gen/docs/tables/static-routes.md
+--8<--
+
+### STUN
+
+--8<--
+roles/eos_cli_config_gen/docs/tables/stun.md
 --8<--
 
 ### VRFs

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-service-insertion.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-service-insertion.md
@@ -7,10 +7,12 @@
 
     | Variable | Type | Required | Default | Value Restrictions | Description |
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
-    | [<samp>router_service_insertion</samp>](## "router_service_insertion") | Boolean |  |  |  | Configure network services inserted to data forwarding |
+    | [<samp>router_service_insertion</samp>](## "router_service_insertion") | Dictionary |  |  |  | Configure network services inserted to data forwarding |
+    | [<samp>&nbsp;&nbsp;enabled</samp>](## "router_service_insertion.enabled") | Boolean |  |  |  |  |
 
 === "YAML"
 
     ```yaml
-    router_service_insertion: <bool>
+    router_service_insertion:
+      enabled: <bool>
     ```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-service-insertion.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-service-insertion.md
@@ -1,0 +1,16 @@
+<!--
+  ~ Copyright (c) 2023 Arista Networks, Inc.
+  ~ Use of this source code is governed by the Apache License 2.0
+  ~ that can be found in the LICENSE file.
+  -->
+=== "Table"
+
+    | Variable | Type | Required | Default | Value Restrictions | Description |
+    | -------- | ---- | -------- | ------- | ------------------ | ----------- |
+    | [<samp>router_service_insertion</samp>](## "router_service_insertion") | Boolean |  |  |  | Configure network services inserted to data forwarding |
+
+=== "YAML"
+
+    ```yaml
+    router_service_insertion: <bool>
+    ```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -18378,8 +18378,18 @@
       "title": "Router PIM Sparse Mode"
     },
     "router_service_insertion": {
-      "type": "boolean",
+      "type": "object",
       "description": "Configure network services inserted to data forwarding",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "title": "Enabled"
+        }
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^_.+$": {}
+      },
       "title": "Router Service Insertion"
     },
     "router_traffic_engineering": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -18377,6 +18377,11 @@
       },
       "title": "Router PIM Sparse Mode"
     },
+    "router_service_insertion": {
+      "type": "boolean",
+      "description": "Configure network services inserted to data forwarding",
+      "title": "Router Service Insertion"
+    },
     "router_traffic_engineering": {
       "type": "object",
       "properties": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -10770,8 +10770,11 @@ keys:
                       override:
                         type: bool
   router_service_insertion:
-    type: bool
+    type: dict
     description: Configure network services inserted to data forwarding
+    keys:
+      enabled:
+        type: bool
   router_traffic_engineering:
     type: dict
     keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -10769,6 +10769,9 @@ keys:
                         max: 32
                       override:
                         type: bool
+  router_service_insertion:
+    type: bool
+    description: Configure network services inserted to data forwarding
   router_traffic_engineering:
     type: dict
     keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_service_insertion.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_service_insertion.schema.yml
@@ -7,5 +7,8 @@
 type: dict
 keys:
   router_service_insertion:
-    type: bool
+    type: dict
     description: Configure network services inserted to data forwarding
+    keys:
+      enabled:
+        type: bool

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_service_insertion.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_service_insertion.schema.yml
@@ -1,0 +1,11 @@
+# Copyright (c) 2023 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the LICENSE file.
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  router_service_insertion:
+    type: bool
+    description: Configure network services inserted to data forwarding

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-service-insertion.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-service-insertion.j2
@@ -4,7 +4,7 @@
  that can be found in the LICENSE file.
 #}
 {# doc - router service-insertion #}
-{% if router_service_insertion is arista.avd.defined(true) %}
+{% if router_service_insertion.enabled is arista.avd.defined(true) %}
 
-Router service-insertion configured.
+Router service-insertion is enabled.
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-service-insertion.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-service-insertion.j2
@@ -1,0 +1,10 @@
+{#
+ Copyright (c) 2023 Arista Networks, Inc.
+ Use of this source code is governed by the Apache License 2.0
+ that can be found in the LICENSE file.
+#}
+{# doc - router service-insertion #}
+{% if router_service_insertion is arista.avd.defined(true) %}
+
+Router service-insertion configured.
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/routing.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/routing.j2
@@ -13,6 +13,7 @@
        or ipv6_static_routes is arista.avd.defined
        or arp is arista.avd.defined
        or router_general is arista.avd.defined
+       or router_service_insertion is arista.avd.defined
        or router_traffic_engineering is arista.avd.defined
        or router_ospf is arista.avd.defined
        or router_isis is arista.avd.defined
@@ -38,6 +39,8 @@
 {%     include 'documentation/arp.j2' %}
 {## Router General #}
 {%     include 'documentation/router-general.j2' %}
+{## Router Service Insertionl #}
+{%     include 'documentation/router-service-insertion.j2' %}
 {## Router Traffic Engineering #}
 {%     include 'documentation/router-traffic-engineering.j2' %}
 {## Router OSPF #}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/routing.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/routing.j2
@@ -39,7 +39,7 @@
 {%     include 'documentation/arp.j2' %}
 {## Router General #}
 {%     include 'documentation/router-general.j2' %}
-{## Router Service Insertionl #}
+{## Router Service Insertion #}
 {%     include 'documentation/router-service-insertion.j2' %}
 {## Router Traffic Engineering #}
 {%     include 'documentation/router-traffic-engineering.j2' %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-intended-config.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-intended-config.j2
@@ -101,6 +101,8 @@
 {% include 'eos/redundancy.j2' %}
 {# qos-profiles #}
 {% include 'eos/qos-profiles.j2' %}
+{# router service-inserion #}
+{% include 'eos/router-service-insertion.j2' %}
 {# snmp settings #}
 {% include 'eos/snmp-server.j2' %}
 {# hardware configuration #}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-service-insertion.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-service-insertion.j2
@@ -1,0 +1,10 @@
+{#
+ Copyright (c) 2023 Arista Networks, Inc.
+ Use of this source code is governed by the Apache License 2.0
+ that can be found in the LICENSE file.
+#}
+{# eos - router service-insertion #}
+{% if router_service_insertion is arista.avd.defined(true) %}
+!
+router service-insertion
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-service-insertion.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-service-insertion.j2
@@ -4,7 +4,7 @@
  that can be found in the LICENSE file.
 #}
 {# eos - router service-insertion #}
-{% if router_service_insertion is arista.avd.defined(true) %}
+{% if router_service_insertion.enabled is arista.avd.defined(true) %}
 !
 router service-insertion
 {% endif %}


### PR DESCRIPTION
## Change Summary

implements

```
router service-insertion
```

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Added in schem

## How to test

molecule

## Checklist
### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
