### PR TITLE
Feat(eos_cli_config_gen): Ethernet interfaces ip address dhcp support

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
@@ -186,6 +186,7 @@ sFlow is disabled.
 | Ethernet10 | interface_with_mpls_disabled | routed | - | 172.31.128.10/31 | default | - | - | - | - |
 | Ethernet18 | PBR Description | routed | - | 192.0.2.1/31 | default | 1500 | - | - | - |
 | Ethernet47 | IP Helper | routed | - | 172.31.255.1/31 | default | - | - | - | - |
+| Ethernet63 | DHCP interface | routed | - | dhcp | default | - | - | - | - |
 
 ##### IP NAT: Source Static
 
@@ -853,6 +854,12 @@ interface Ethernet62
    switchport phone trunk tagged phone
    switchport mode trunk phone
    switchport
+!
+interface Ethernet63
+   description DHCP interface
+   no switchport
+   ip address dhcp
+   dhcp client accept default-route
 ```
 
 ## BFD

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
@@ -568,6 +568,12 @@ interface Ethernet62
    switchport mode trunk phone
    switchport
 !
+interface Ethernet63
+   description DHCP interface
+   no switchport
+   ip address dhcp
+   dhcp client accept default-route
+!
 interface Management1
    description oob_management
    vrf MGMT

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
@@ -853,3 +853,8 @@ ethernet_interfaces:
     phone:
       trunk: "tagged phone"
       vlan: 70
+  - name: Ethernet63
+    description: DHCP interface
+    type: routed
+    ip_address: "dhcp"
+    dhcp_client_accept_default_route: true

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ethernet-interfaces.md
@@ -73,9 +73,10 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;inner</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.dot1q.inner") | Integer |  |  |  | Network inner VLAN ID |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;client</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.client") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vlan_id</samp>](## "ethernet_interfaces.[].vlan_id") | Integer |  |  | Min: 1<br>Max: 4094 |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_address</samp>](## "ethernet_interfaces.[].ip_address") | String |  |  |  | IPv4 address/mask |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_address</samp>](## "ethernet_interfaces.[].ip_address") | String |  |  |  | IPv4 address/mask or "dhcp" |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_address_secondaries</samp>](## "ethernet_interfaces.[].ip_address_secondaries") | List, items: String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "ethernet_interfaces.[].ip_address_secondaries.[].&lt;str&gt;") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;dhcp_client_accept_default_route</samp>](## "ethernet_interfaces.[].dhcp_client_accept_default_route") | Boolean |  |  |  | Install default-route obtained via DHCP |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_helpers</samp>](## "ethernet_interfaces.[].ip_helpers") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- ip_helper</samp>](## "ethernet_interfaces.[].ip_helpers.[].ip_helper") | String | Required, Unique |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_interface</samp>](## "ethernet_interfaces.[].ip_helpers.[].source_interface") | String |  |  |  | Source interface name |
@@ -413,6 +414,7 @@
         ip_address: <str>
         ip_address_secondaries:
           - <str>
+        dhcp_client_accept_default_route: <bool>
         ip_helpers:
           - ip_helper: <str>
             source_interface: <str>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -2146,7 +2146,7 @@
           },
           "ip_address": {
             "type": "string",
-            "description": "IPv4 address/mask",
+            "description": "IPv4 address/mask or \"dhcp\"",
             "title": "IP Address"
           },
           "ip_address_secondaries": {
@@ -2155,6 +2155,11 @@
               "type": "string"
             },
             "title": "IP Address Secondaries"
+          },
+          "dhcp_client_accept_default_route": {
+            "type": "boolean",
+            "description": "Install default-route obtained via DHCP",
+            "title": "DHCP Client Accept Default Route"
           },
           "ip_helpers": {
             "type": "array",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -1450,11 +1450,14 @@ keys:
           - str
         ip_address:
           type: str
-          description: IPv4 address/mask
+          description: IPv4 address/mask or "dhcp"
         ip_address_secondaries:
           type: list
           items:
             type: str
+        dhcp_client_accept_default_route:
+          type: bool
+          description: Install default-route obtained via DHCP
         ip_helpers:
           type: list
           primary_key: ip_helper

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ethernet_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ethernet_interfaces.schema.yml
@@ -253,13 +253,17 @@ keys:
           max: 4094
           convert_types:
             - str
+        # TODO Format to validate ipv4 CIDR or "dhcp"
         ip_address:
           type: str
-          description: IPv4 address/mask
+          description: IPv4 address/mask or "dhcp"
         ip_address_secondaries:
           type: list
           items:
             type: str
+        dhcp_client_accept_default_route:
+          type: bool
+          description: Install default-route obtained via DHCP
         ip_helpers:
           type: list
           primary_key: ip_helper

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -332,6 +332,9 @@ interface {{ ethernet_interface.name }}
    {{ ip_helper_cli }}
 {%         endfor %}
 {%     endif %}
+{%     if ethernet_interface.ip_address is arista.avd.defined("dhcp") and ethernet_interface.dhcp_client_accept_default_route is arista.avd.defined(true) %}
+   dhcp client accept default-route
+{%     endif %}
 {%     if ethernet_interface.bfd.interval is arista.avd.defined and
           ethernet_interface.bfd.min_rx is arista.avd.defined and
           ethernet_interface.bfd.multiplier is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -7164,7 +7164,7 @@
               },
               "ip_address": {
                 "type": "string",
-                "description": "IPv4 address/mask",
+                "description": "IPv4 address/mask or \"dhcp\"",
                 "title": "IP Address"
               },
               "ip_address_secondaries": {
@@ -7173,6 +7173,11 @@
                   "type": "string"
                 },
                 "title": "IP Address Secondaries"
+              },
+              "dhcp_client_accept_default_route": {
+                "type": "boolean",
+                "description": "Install default-route obtained via DHCP",
+                "title": "DHCP Client Accept Default Route"
               },
               "ip_helpers": {
                 "type": "array",
@@ -12723,7 +12728,7 @@
               },
               "ip_address": {
                 "type": "string",
-                "description": "IPv4 address/mask",
+                "description": "IPv4 address/mask or \"dhcp\"",
                 "title": "IP Address"
               },
               "ip_address_secondaries": {
@@ -12732,6 +12737,11 @@
                   "type": "string"
                 },
                 "title": "IP Address Secondaries"
+              },
+              "dhcp_client_accept_default_route": {
+                "type": "boolean",
+                "description": "Install default-route obtained via DHCP",
+                "title": "DHCP Client Accept Default Route"
               },
               "ip_helpers": {
                 "type": "array",


### PR DESCRIPTION
## Change Summary

Add support for dhcp configuration on ethernet interface

```
interface Ethernet1
   ip address dhcp
   dhcp client accept default-route
```

## Related Issue(s)

Fixes aristanetworks/avd-internal#121

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

```yaml
ethernet_interfaces:
  - name: Ethernet1
    ip_address: "dhcp"
    dhcp_client_accept_default_route: true
```
## How to test

See molecule test case
