### PR TITLE
Feat(eos_cli_config_gen): Add ethernet interface dhcp server config

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
@@ -4,6 +4,8 @@
 
 - [Management](#management)
   - [Management Interfaces](#management-interfaces)
+- [DHCP Server](#dhcp-server)
+  - [DHCP Server interfaces](#dhcp-server-interfaces)
 - [Monitoring](#monitoring)
   - [SFlow](#sflow)
 - [Interfaces](#interfaces)
@@ -47,6 +49,14 @@ interface Management1
    vrf MGMT
    ip address 10.73.255.122/24
 ```
+
+## DHCP Server
+
+### DHCP Server interfaces
+
+| Interface name | DHCP IPv4 | DHCP IPv6 |
+| -------------- | --------- | --------- |
+| Ethernet64 | True | True |
 
 ## Monitoring
 
@@ -186,7 +196,8 @@ sFlow is disabled.
 | Ethernet10 | interface_with_mpls_disabled | routed | - | 172.31.128.10/31 | default | - | - | - | - |
 | Ethernet18 | PBR Description | routed | - | 192.0.2.1/31 | default | 1500 | - | - | - |
 | Ethernet47 | IP Helper | routed | - | 172.31.255.1/31 | default | - | - | - | - |
-| Ethernet63 | DHCP interface | routed | - | dhcp | default | - | - | - | - |
+| Ethernet63 | DHCP client interface | routed | - | dhcp | default | - | - | - | - |
+| Ethernet64 | DHCP server interface | routed | - | 192.168.42.42/24 | default | - | - | - | - |
 
 ##### IP NAT: Source Static
 
@@ -856,10 +867,17 @@ interface Ethernet62
    switchport
 !
 interface Ethernet63
-   description DHCP interface
+   description DHCP client interface
    no switchport
    ip address dhcp
    dhcp client accept default-route
+!
+interface Ethernet64
+   description DHCP server interface
+   no switchport
+   ip address 192.168.42.42/24
+   dhcp server ipv4
+   dhcp server ipv6
 ```
 
 ## BFD

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
@@ -569,10 +569,17 @@ interface Ethernet62
    switchport
 !
 interface Ethernet63
-   description DHCP interface
+   description DHCP client interface
    no switchport
    ip address dhcp
    dhcp client accept default-route
+!
+interface Ethernet64
+   description DHCP server interface
+   no switchport
+   ip address 192.168.42.42/24
+   dhcp server ipv4
+   dhcp server ipv6
 !
 interface Management1
    description oob_management

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
@@ -854,7 +854,13 @@ ethernet_interfaces:
       trunk: "tagged phone"
       vlan: 70
   - name: Ethernet63
-    description: DHCP interface
+    description: DHCP client interface
     type: routed
     ip_address: "dhcp"
     dhcp_client_accept_default_route: true
+  - name: Ethernet64
+    description: DHCP server interface
+    type: routed
+    ip_address: 192.168.42.42/24
+    dhcp_server_ipv4: true
+    dhcp_server_ipv6: true

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ethernet-interfaces.md
@@ -77,6 +77,8 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_address_secondaries</samp>](## "ethernet_interfaces.[].ip_address_secondaries") | List, items: String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "ethernet_interfaces.[].ip_address_secondaries.[].&lt;str&gt;") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;dhcp_client_accept_default_route</samp>](## "ethernet_interfaces.[].dhcp_client_accept_default_route") | Boolean |  |  |  | Install default-route obtained via DHCP |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;dhcp_server_ipv4</samp>](## "ethernet_interfaces.[].dhcp_server_ipv4") | Boolean |  |  |  | Enable IPv4 DHCP server. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;dhcp_server_ipv6</samp>](## "ethernet_interfaces.[].dhcp_server_ipv6") | Boolean |  |  |  | Enable IPv6 DHCP server. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_helpers</samp>](## "ethernet_interfaces.[].ip_helpers") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- ip_helper</samp>](## "ethernet_interfaces.[].ip_helpers.[].ip_helper") | String | Required, Unique |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_interface</samp>](## "ethernet_interfaces.[].ip_helpers.[].source_interface") | String |  |  |  | Source interface name |
@@ -415,6 +417,8 @@
         ip_address_secondaries:
           - <str>
         dhcp_client_accept_default_route: <bool>
+        dhcp_server_ipv4: <bool>
+        dhcp_server_ipv6: <bool>
         ip_helpers:
           - ip_helper: <str>
             source_interface: <str>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -2161,6 +2161,16 @@
             "description": "Install default-route obtained via DHCP",
             "title": "DHCP Client Accept Default Route"
           },
+          "dhcp_server_ipv4": {
+            "type": "boolean",
+            "description": "Enable IPv4 DHCP server.",
+            "title": "DHCP Server IPv4"
+          },
+          "dhcp_server_ipv6": {
+            "type": "boolean",
+            "description": "Enable IPv6 DHCP server.",
+            "title": "DHCP Server IPv6"
+          },
           "ip_helpers": {
             "type": "array",
             "items": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -1458,6 +1458,12 @@ keys:
         dhcp_client_accept_default_route:
           type: bool
           description: Install default-route obtained via DHCP
+        dhcp_server_ipv4:
+          type: bool
+          description: Enable IPv4 DHCP server.
+        dhcp_server_ipv6:
+          type: bool
+          description: Enable IPv6 DHCP server.
         ip_helpers:
           type: list
           primary_key: ip_helper

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ethernet_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ethernet_interfaces.schema.yml
@@ -264,6 +264,12 @@ keys:
         dhcp_client_accept_default_route:
           type: bool
           description: Install default-route obtained via DHCP
+        dhcp_server_ipv4:
+          type: bool
+          description: Enable IPv4 DHCP server.
+        dhcp_server_ipv6:
+          type: bool
+          description: Enable IPv6 DHCP server.
         ip_helpers:
           type: list
           primary_key: ip_helper

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/dhcp-server.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/dhcp-server.j2
@@ -1,0 +1,25 @@
+{#
+ Copyright (c) 2023 Arista Networks, Inc.
+ Use of this source code is governed by the Apache License 2.0
+ that can be found in the LICENSE file.
+#}
+{# doc - dhcp server #}
+{% set ethernet_interfaces_dhcp_server = [] %}
+{% for ethernet_interface in ethernet_interfaces | arista.avd.natural_sort('name') %}
+{%     if ethernet_interface.dhcp_server_ipv4 is arista.avd.defined(true) or ethernet_interface.dhcp_server_ipv4 is arista.avd.defined(true) %}
+{%         do ethernet_interfaces_dhcp_server.append(ethernet_interface) %}
+{%     endif %}
+{% endfor %}
+{# later on this condition will change when top level key dhcp_server is implemented #}
+{% if ethernet_interfaces_dhcp_server | length > 0 %}
+
+## DHCP Server
+
+### DHCP Server interfaces
+
+| Interface name | DHCP IPv4 | DHCP IPv6 |
+| -------------- | --------- | --------- |
+{%     for ethernet_interface in ethernet_interfaces_dhcp_server | arista.avd.natural_sort %}
+| {{ ethernet_interface.name }} | {{ ethernet_interface.dhcp_server_ipv4 | arista.avd.default(false) }} | {{ ethernet_interface.dhcp_server_ipv6 | arista.avd.default(false) }} |
+{%     endfor %}
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-device-documentation.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-device-documentation.j2
@@ -27,6 +27,8 @@
 {% include 'documentation/aliases.j2' %}
 {# DHCP Relay #}
 {% include 'documentation/dhcp-relay.j2' %}
+{# DHCP Server #}
+{% include 'documentation/dhcp-server.j2' %}
 {# System Boot Configuration #}
 {% include 'documentation/boot.j2' %}
 {# Monitoring #}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -345,6 +345,12 @@ interface {{ ethernet_interface.name }}
 {%     elif ethernet_interface.bfd.echo is arista.avd.defined(false) %}
    no bfd echo
 {%     endif %}
+{%     if ethernet_interface.dhcp_server_ipv4 is arista.avd.defined(true) %}
+   dhcp server ipv4
+{%     endif %}
+{%     if ethernet_interface.dhcp_server_ipv6 is arista.avd.defined(true) %}
+   dhcp server ipv6
+{%     endif %}
 {%     if ethernet_interface.ipv6_enable is arista.avd.defined(true) %}
    ipv6 enable
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -7179,6 +7179,16 @@
                 "description": "Install default-route obtained via DHCP",
                 "title": "DHCP Client Accept Default Route"
               },
+              "dhcp_server_ipv4": {
+                "type": "boolean",
+                "description": "Enable IPv4 DHCP server.",
+                "title": "DHCP Server IPv4"
+              },
+              "dhcp_server_ipv6": {
+                "type": "boolean",
+                "description": "Enable IPv6 DHCP server.",
+                "title": "DHCP Server IPv6"
+              },
               "ip_helpers": {
                 "type": "array",
                 "items": {
@@ -12742,6 +12752,16 @@
                 "type": "boolean",
                 "description": "Install default-route obtained via DHCP",
                 "title": "DHCP Client Accept Default Route"
+              },
+              "dhcp_server_ipv4": {
+                "type": "boolean",
+                "description": "Enable IPv4 DHCP server.",
+                "title": "DHCP Server IPv4"
+              },
+              "dhcp_server_ipv6": {
+                "type": "boolean",
+                "description": "Enable IPv6 DHCP server.",
+                "title": "DHCP Server IPv6"
               },
               "ip_helpers": {
                 "type": "array",


### PR DESCRIPTION
## Change Summary

Adding
```
interface Ethernet2
  dhcp server ipv4
  dhcp server ipv6
```

the cli is introduced between `bfd` and `ipv6 enable` as per EOS cli:

```
ceos2(config-if-Et2)#show active
interface Ethernet2
   ip address 1.1.1.1/24
   bfd echo
   dhcp server ipv4
   dhcp server ipv6
   ipv6 enable
```

## Component(s) name

`arista.avd.eos_cli_config_gen`

## How to test

molecule

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
