### PR TITLE
Fix(eos_cli_config_gen): Remove requirement for MACSec license and FIPS

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/mac-security.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/mac-security.md
@@ -8,10 +8,10 @@
     | Variable | Type | Required | Default | Value Restrictions | Description |
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
     | [<samp>mac_security</samp>](## "mac_security") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;license</samp>](## "mac_security.license") | Dictionary | Required |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;license_name</samp>](## "mac_security.license.license_name") | String | Required |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;license_key</samp>](## "mac_security.license.license_key") | String | Required |  |  |  |
-    | [<samp>&nbsp;&nbsp;fips_restrictions</samp>](## "mac_security.fips_restrictions") | Boolean | Required |  |  |  |
+    | [<samp>&nbsp;&nbsp;license</samp>](## "mac_security.license") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;license_name</samp>](## "mac_security.license.license_name") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;license_key</samp>](## "mac_security.license.license_key") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;fips_restrictions</samp>](## "mac_security.fips_restrictions") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;profiles</samp>](## "mac_security.profiles") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "mac_security.profiles.[].name") | String | Required, Unique |  |  | Profile-Name |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;cipher</samp>](## "mac_security.profiles.[].cipher") | String |  |  | Valid Values:<br>- aes128-gcm<br>- aes128-gcm-xpn<br>- aes256-gcm<br>- aes256-gcm-xpn |  |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/mac-security.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/mac-security.md
@@ -9,8 +9,8 @@
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
     | [<samp>mac_security</samp>](## "mac_security") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;license</samp>](## "mac_security.license") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;license_name</samp>](## "mac_security.license.license_name") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;license_key</samp>](## "mac_security.license.license_key") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;license_name</samp>](## "mac_security.license.license_name") | String | Required |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;license_key</samp>](## "mac_security.license.license_key") | String | Required |  |  |  |
     | [<samp>&nbsp;&nbsp;fips_restrictions</samp>](## "mac_security.fips_restrictions") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;profiles</samp>](## "mac_security.profiles") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "mac_security.profiles.[].name") | String | Required, Unique |  |  | Profile-Name |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -7406,10 +7406,6 @@
               "title": "License Key"
             }
           },
-          "required": [
-            "license_name",
-            "license_key"
-          ],
           "additionalProperties": false,
           "patternProperties": {
             "^_.+$": {}
@@ -7569,10 +7565,6 @@
           "title": "Profiles"
         }
       },
-      "required": [
-        "license",
-        "fips_restrictions"
-      ],
       "additionalProperties": false,
       "patternProperties": {
         "^_.+$": {}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -7406,6 +7406,10 @@
               "title": "License Key"
             }
           },
+          "required": [
+            "license_name",
+            "license_key"
+          ],
           "additionalProperties": false,
           "patternProperties": {
             "^_.+$": {}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -4444,8 +4444,10 @@ keys:
         keys:
           license_name:
             type: str
+            required: true
           license_key:
             type: str
+            required: true
       fips_restrictions:
         type: bool
       profiles:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -4441,17 +4441,13 @@ keys:
     keys:
       license:
         type: dict
-        required: true
         keys:
           license_name:
             type: str
-            required: true
           license_key:
             type: str
-            required: true
       fips_restrictions:
         type: bool
-        required: true
       profiles:
         type: list
         primary_key: name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/mac_security.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/mac_security.schema.yml
@@ -15,8 +15,10 @@ keys:
         keys:
           license_name:
             type: str
+            required: true
           license_key:
             type: str
+            required: true
       fips_restrictions:
         type: bool
       profiles:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/mac_security.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/mac_security.schema.yml
@@ -12,17 +12,13 @@ keys:
     keys:
       license:
         type: dict
-        required: true
         keys:
           license_name:
             type: str
-            required: true
           license_key:
             type: str
-            required: true
       fips_restrictions:
         type: bool
-        required: true
       profiles:
         type: list
         primary_key: name


### PR DESCRIPTION
## Change Summary

Today, AVD requests the user to define MACSec license file and key, a method we are changing for the EOS command `license import`. These variables are no longer a must to be able to use MACSec in the device.
Same way, FIPS is not a mandatory field for MACSec.

## Related Issue(s)

Fixes #3168 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Remove requirement for these variables in the schema.

## How to test

Molecule tests pass
