### PR TITLE
Feat(pyavd): Adding "path" attribute to validation_errors and deprecation_warnings.

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/removed-schema-connected-endpoints.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/removed-schema-connected-endpoints.yml
@@ -13,4 +13,4 @@ servers:
         switches: [removed-schema-connected-endpoints]
 
 expected_error_message: >-
-  [DEPRECATED]: [removed-schema-connected-endpoints]: The input data model 'servers.[0].adapters.[0].server_ports' was removed. Use 'endpoint_ports' instead. This feature was removed from arista.avd.eos_designs in version 4.0.0. Please update your playbooks.
+  [DEPRECATED]: [removed-schema-connected-endpoints]: The input data model 'servers[0].adapters[0].server_ports' was removed. Use 'endpoint_ports' instead. This feature was removed from arista.avd.eos_designs in version 4.0.0. Please update your playbooks.

--- a/ansible_collections/arista/avd/plugins/plugin_utils/errors/errors.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/errors/errors.py
@@ -50,7 +50,7 @@ class AvdValidationError(AristaAvdError):
 
         if isinstance(error, (jsonschema.ValidationError)):
             self.path = self._json_path_to_string(error.absolute_path)
-            self.message = f"'Validation Error: {self._json_path_to_string(error.absolute_path)}': {error.message}"
+            self.message = f"'Validation Error: {self.path}': {error.message}"
         else:
             self.message = message
         super().__init__(self.message)
@@ -59,7 +59,8 @@ class AvdValidationError(AristaAvdError):
 class AvdConversionWarning(AristaAvdError):
     def __init__(self, message: str = "Data was converted to conform to schema", key=None, oldtype="unknown", newtype="unknown"):
         if key is not None:
-            self.message = f"'Data Type Converted: {key} from '{oldtype}' to '{newtype}'"
+            self.path = self._json_path_to_string(key)
+            self.message = f"'Data Type Converted: {self.path} from '{oldtype}' to '{newtype}'"
         else:
             self.message = message
         super().__init__(self.message)
@@ -68,14 +69,16 @@ class AvdConversionWarning(AristaAvdError):
 class AvdDeprecationWarning(AristaAvdError):
     def __init__(self, key, new_key=None, remove_in_version=None, remove_after_date=None, url=None, removed=False):
         messages = []
+        self.path = self._json_path_to_string(key)
+
         if removed:
-            messages.append(f"The input data model '{key}' was removed.")
+            messages.append(f"The input data model '{self.path}' was removed.")
         else:
-            messages.append(f"The input data model '{key}' is deprecated.")
+            messages.append(f"The input data model '{self.path}' is deprecated.")
+
         self.version = remove_in_version
         self.date = remove_after_date
         self.removed = removed
-        self.path = key
 
         if new_key is not None:
             messages.append(f"Use '{new_key}' instead.")

--- a/ansible_collections/arista/avd/plugins/plugin_utils/errors/errors.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/errors/errors.py
@@ -49,6 +49,7 @@ class AvdValidationError(AristaAvdError):
             raise AristaAvdError('Python library "jsonschema" must be installed to use this plugin') from JSONSCHEMA_IMPORT_ERROR
 
         if isinstance(error, (jsonschema.ValidationError)):
+            self.path = self._json_path_to_string(error.absolute_path)
             self.message = f"'Validation Error: {self._json_path_to_string(error.absolute_path)}': {error.message}"
         else:
             self.message = message
@@ -74,6 +75,7 @@ class AvdDeprecationWarning(AristaAvdError):
         self.version = remove_in_version
         self.date = remove_after_date
         self.removed = removed
+        self.path = key
 
         if new_key is not None:
             messages.append(f"Use '{new_key}' instead.")

--- a/ansible_collections/arista/avd/plugins/plugin_utils/schema/avddataconverter.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/schema/avddataconverter.py
@@ -112,16 +112,18 @@ class AvdDataConverter:
             return
 
         for index, item in enumerate(data):
+            path[-1] += f"[{index}]"
+
             # Perform type conversion of the items data if required based on "convert_types"
             if "convert_types" in items:
-                yield from self.convert_types(items["convert_types"], data, index, items, path + [f"[{index}]"])
+                yield from self.convert_types(items["convert_types"], data, index, items, path)
 
             # Convert to lower case if set in schema and item is a string
             if items.get("convert_to_lower_case") and isinstance(item, str):
                 data[index] = item.lower()
 
             # Dive in to child items/schema
-            yield from self.convert_data(item, items, path + [f"[{index}]"])
+            yield from self.convert_data(item, items, path)
 
     def convert_types(self, convert_types: list, data: dict | list, index: str | int, schema: dict, path: list[str]):
         """


### PR DESCRIPTION
## Change Summary

Adding "path" attribute to validation_errors and deprecation_warnings.

## Proposed changes

- Added `path` attribute to AvdValidationError, AvdConversionWarning and AvdDeprecationWarning class.
- Fixed the path for list elements in deprecation warnings.

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
