### PR TITLE
Feat(eos_cli_config_gen): support for mlag peer-link requests disabled under dhcp_relay

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/dhcp-relay.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/dhcp-relay.md
@@ -55,4 +55,5 @@ dhcp relay
    server dhcp-relay-server1
    server dhcp-relay-server2
    tunnel requests disabled
+   mlag peer-link requests disabled
 ```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/dhcp-relay.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/dhcp-relay.md
@@ -41,6 +41,7 @@ interface Management1
 ### DHCP Relay Summary
 
 - DHCP Relay is disabled for tunnelled requests
+- DHCP Relay is disabled for MLAG peer-link requests
 
 | DHCP Relay Servers |
 | ------------------ |

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/dhcp-relay.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/dhcp-relay.cfg
@@ -4,6 +4,7 @@ dhcp relay
    server dhcp-relay-server1
    server dhcp-relay-server2
    tunnel requests disabled
+   mlag peer-link requests disabled
 !
 transceiver qsfp default-mode 4x10G
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/dhcp-relay.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/dhcp-relay.yml
@@ -3,3 +3,4 @@ dhcp_relay:
     - dhcp-relay-server2
     - dhcp-relay-server1
   tunnel_requests_disabled: true
+  mlag_peerlink_requests_disabled: true

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/dhcp-relay.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/dhcp-relay.md
@@ -11,6 +11,7 @@
     | [<samp>&nbsp;&nbsp;servers</samp>](## "dhcp_relay.servers") | List, items: String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "dhcp_relay.servers.[].&lt;str&gt;") | String |  |  |  | Server IP or Hostname |
     | [<samp>&nbsp;&nbsp;tunnel_requests_disabled</samp>](## "dhcp_relay.tunnel_requests_disabled") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;mlag_peerlink_requests_disabled</samp>](## "dhcp_relay.mlag_peerlink_requests_disabled") | Boolean |  |  |  |  |
 
 === "YAML"
 
@@ -19,4 +20,5 @@
       servers:
         - <str>
       tunnel_requests_disabled: <bool>
+      mlag_peerlink_requests_disabled: <bool>
     ```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -1442,6 +1442,10 @@
         "tunnel_requests_disabled": {
           "type": "boolean",
           "title": "Tunnel Requests Disabled"
+        },
+        "mlag_peerlink_requests_disabled": {
+          "type": "boolean",
+          "title": "MLAG Peerlink Requests Disabled"
         }
       },
       "additionalProperties": false,

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -1012,6 +1012,8 @@ keys:
           description: Server IP or Hostname
       tunnel_requests_disabled:
         type: bool
+      mlag_peerlink_requests_disabled:
+        type: bool
   dns_domain:
     type: str
     description: Domain Name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/dhcp_relay.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/dhcp_relay.schema.yml
@@ -16,3 +16,5 @@ keys:
           description: Server IP or Hostname
       tunnel_requests_disabled:
         type: bool
+      mlag_peerlink_requests_disabled:
+        type: bool

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/dhcp-relay.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/dhcp-relay.j2
@@ -12,9 +12,14 @@
 {%     if dhcp_relay.tunnel_requests_disabled is arista.avd.defined(true) %}
 
 - DHCP Relay is disabled for tunnelled requests
-{%     elif dhcp_relay.tunnel_requests_disabled is arista.avd.defined(false) %}
+{%     else %}
 
 - DHCP Relay is enabled for tunnelled requests
+{%     endif %}
+{%     if dhcp_relay.mlag_peerlink_requests_disabled is arista.avd.defined(true) %}
+- DHCP Relay is disabled for MLAG peer-link requests
+{%     else %}
+- DHCP Relay is enabled for MLAG peer-link requests
 {%     endif %}
 {%     if dhcp_relay.servers is arista.avd.defined %}
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/dhcp-relay.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/dhcp-relay.j2
@@ -15,4 +15,9 @@ dhcp relay
 {%     elif dhcp_relay.tunnel_requests_disabled is arista.avd.defined(false) %}
    no tunnel requests disabled
 {%     endif %}
+{%     if dhcp_relay.mlag_peerlink_requests_disabled is arista.avd.defined(true) %}
+   mlag peer-link requests disabled
+{%     elif dhcp_relay.mlag_peerlink_requests_disabled is arista.avd.defined(false) %}
+   no mlag peer-link requests disabled
+{%     endif %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/dhcp-relay.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/dhcp-relay.j2
@@ -12,12 +12,8 @@ dhcp relay
 {%     endfor %}
 {%     if dhcp_relay.tunnel_requests_disabled is arista.avd.defined(true) %}
    tunnel requests disabled
-{%     elif dhcp_relay.tunnel_requests_disabled is arista.avd.defined(false) %}
-   no tunnel requests disabled
 {%     endif %}
 {%     if dhcp_relay.mlag_peerlink_requests_disabled is arista.avd.defined(true) %}
    mlag peer-link requests disabled
-{%     elif dhcp_relay.mlag_peerlink_requests_disabled is arista.avd.defined(false) %}
-   no mlag peer-link requests disabled
 {%     endif %}
 {% endif %}


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
add mlag peer-link requests disabled to dhcp relay

## Related Issue(s)

Fixes #3254

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->
1. modified dhcp_relay.j2
2. add schema in dhcp_relay.yml
3. added molecule test

```
dhcp_relay:
  mlag_peerlink_requests_disabled: <bool>
```

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
```
dhcp_relay:
  mlag_peerlink_requests_disabled: true
```
will render
```
dhcp relay
  mlag peer-link requests disabled
```
## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
