### PR TITLE
Fix(eos_cli_config_gen): Wrong CLI template for some ip_security options

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-security.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-security.md
@@ -67,21 +67,21 @@ interface Management1
 ip security
    !
    ike policy IKE-1
-      local_id 192.168.100.1
+      local-id 192.168.100.1
    !
    ike policy IKE-2
    !
    sa policy SA-1
       esp encryption aes128
-      pfs_dh_group 14
+      pfs dh-group 14
    !
    sa policy SA-2
       esp encryption aes128
-      pfs_dh_group 14
+      pfs dh-group 14
    !
    sa policy SA-3
       esp encryption null
-      pfs_dh_group 17
+      pfs dh-group 17
    !
    profile Profile-1
       ike-policy IKE-1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ip-security.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ip-security.cfg
@@ -10,21 +10,21 @@ no aaa root
 ip security
    !
    ike policy IKE-1
-      local_id 192.168.100.1
+      local-id 192.168.100.1
    !
    ike policy IKE-2
    !
    sa policy SA-1
       esp encryption aes128
-      pfs_dh_group 14
+      pfs dh-group 14
    !
    sa policy SA-2
       esp encryption aes128
-      pfs_dh_group 14
+      pfs dh-group 14
    !
    sa policy SA-3
       esp encryption null
-      pfs_dh_group 17
+      pfs dh-group 17
    !
    profile Profile-1
       ike-policy IKE-1

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ip-security.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ip-security.j2
@@ -11,7 +11,7 @@ ip security
    !
    ike policy {{ ike_policy.name }}
 {%         if ike_policy.local_id is arista.avd.defined %}
-      local_id {{ ike_policy.local_id }}
+      local-id {{ ike_policy.local_id }}
 {%         endif %}
 {%     endfor %}
 {%     for sa_policy in ip_security.sa_policies | arista.avd.default([]) %}
@@ -24,7 +24,7 @@ ip security
       esp encryption {{ sa_policy.esp.encryption }}
 {%         endif %}
 {%         if sa_policy.pfs_dh_group is arista.avd.defined %}
-      pfs_dh_group {{ sa_policy.pfs_dh_group }}
+      pfs dh-group {{ sa_policy.pfs_dh_group }}
 {%         endif %}
 {%     endfor %}
 {%     for profile in ip_security.profiles | arista.avd.default([]) %}


### PR DESCRIPTION
## Change Summary

During implementation of `ip-security` the template was not correctly implemented for two keys. This PR is fixing this.

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

* pfs_dh_group 14 -> pfs dh-group 14
* local_id 192.168.99.1 -> local-id 192.168.99.1

## How to test

molecule updated

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
