### PR TITLE
Feat(eos_cli_config_gen): Add other valid_values for event-handler trigger 'on-boot'

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/event-handlers.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/event-handlers.md
@@ -46,11 +46,6 @@ interface Management1
 | CONFIG_VERSIONING | bash | <code>FN=/mnt/flash/startup-config; LFN="`ls -1 $FN.*-* \| tail -n 1`"; if [ -z "$LFN" -o -n "`diff -I 'last modified' $FN $LFN`" ]; then cp $FN $FN.`date +%Y%m%d-%H%M%S`; ls -1r $FN.*-* \| tail -n +11 \| xargs -I % rm %; fi</code> | on-startup-config |
 | evpn-blacklist-recovery | bash | <code>FastCli -p 15 -c "clear bgp evpn host-flap"</code> | on-logging |
 | trigger-on-boot | bash | <code>echo "on-boot"</code> | on-boot |
-| trigger-on-config | bash | <code>echo "on-config"</code> | on-config |
-| trigger-on-counters | bash | <code>echo "on-counters"</code> | on-counters |
-| trigger-on-intf | bash | <code>echo "on-intf"</code> | on-intf |
-| trigger-on-maintenance | bash | <code>echo "on-maintenance"</code> | on-maintenance |
-| trigger-vm-tracer | bash | <code>echo "vm-tracer"</code> | vm-tracer |
 
 #### Event Handler Device Configuration
 
@@ -71,24 +66,4 @@ event-handler evpn-blacklist-recovery
 event-handler trigger-on-boot
    trigger on-boot
    action bash echo "on-boot"
-!
-event-handler trigger-on-config
-   trigger on-config
-   action bash echo "on-config"
-!
-event-handler trigger-on-counters
-   trigger on-counters
-   action bash echo "on-counters"
-!
-event-handler trigger-on-intf
-   trigger on-intf
-   action bash echo "on-intf"
-!
-event-handler trigger-on-maintenance
-   trigger on-maintenance
-   action bash echo "on-maintenance"
-!
-event-handler trigger-vm-tracer
-   trigger vm-tracer
-   action bash echo "vm-tracer"
 ```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/event-handlers.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/event-handlers.md
@@ -45,6 +45,12 @@ interface Management1
 | ------- | ----------- | ------ | ------- |
 | CONFIG_VERSIONING | bash | <code>FN=/mnt/flash/startup-config; LFN="`ls -1 $FN.*-* \| tail -n 1`"; if [ -z "$LFN" -o -n "`diff -I 'last modified' $FN $LFN`" ]; then cp $FN $FN.`date +%Y%m%d-%H%M%S`; ls -1r $FN.*-* \| tail -n +11 \| xargs -I % rm %; fi</code> | on-startup-config |
 | evpn-blacklist-recovery | bash | <code>FastCli -p 15 -c "clear bgp evpn host-flap"</code> | on-logging |
+| trigger-on-boot | bash | <code>echo "on-boot"</code> | on-boot |
+| trigger-on-config | bash | <code>echo "on-config"</code> | on-config |
+| trigger-on-counters | bash | <code>echo "on-counters"</code> | on-counters |
+| trigger-on-intf | bash | <code>echo "on-intf"</code> | on-intf |
+| trigger-on-maintenance | bash | <code>echo "on-maintenance"</code> | on-maintenance |
+| trigger-vm-tracer | bash | <code>echo "vm-tracer"</code> | vm-tracer |
 
 #### Event Handler Device Configuration
 
@@ -61,4 +67,28 @@ event-handler evpn-blacklist-recovery
    action bash FastCli -p 15 -c "clear bgp evpn host-flap"
    delay 300
    asynchronous
+!
+event-handler trigger-on-boot
+   trigger on-boot
+   action bash echo "on-boot"
+!
+event-handler trigger-on-config
+   trigger on-config
+   action bash echo "on-config"
+!
+event-handler trigger-on-counters
+   trigger on-counters
+   action bash echo "on-counters"
+!
+event-handler trigger-on-intf
+   trigger on-intf
+   action bash echo "on-intf"
+!
+event-handler trigger-on-maintenance
+   trigger on-maintenance
+   action bash echo "on-maintenance"
+!
+event-handler trigger-vm-tracer
+   trigger vm-tracer
+   action bash echo "vm-tracer"
 ```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/event-handlers.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/event-handlers.cfg
@@ -28,24 +28,4 @@ event-handler trigger-on-boot
    trigger on-boot
    action bash echo "on-boot"
 !
-event-handler trigger-on-config
-   trigger on-config
-   action bash echo "on-config"
-!
-event-handler trigger-on-counters
-   trigger on-counters
-   action bash echo "on-counters"
-!
-event-handler trigger-on-intf
-   trigger on-intf
-   action bash echo "on-intf"
-!
-event-handler trigger-on-maintenance
-   trigger on-maintenance
-   action bash echo "on-maintenance"
-!
-event-handler trigger-vm-tracer
-   trigger vm-tracer
-   action bash echo "vm-tracer"
-!
 end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/event-handlers.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/event-handlers.cfg
@@ -24,4 +24,28 @@ event-handler evpn-blacklist-recovery
    delay 300
    asynchronous
 !
+event-handler trigger-on-boot
+   trigger on-boot
+   action bash echo "on-boot"
+!
+event-handler trigger-on-config
+   trigger on-config
+   action bash echo "on-config"
+!
+event-handler trigger-on-counters
+   trigger on-counters
+   action bash echo "on-counters"
+!
+event-handler trigger-on-intf
+   trigger on-intf
+   action bash echo "on-intf"
+!
+event-handler trigger-on-maintenance
+   trigger on-maintenance
+   action bash echo "on-maintenance"
+!
+event-handler trigger-vm-tracer
+   trigger vm-tracer
+   action bash echo "vm-tracer"
+!
 end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/event-handlers.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/event-handlers.yml
@@ -11,3 +11,27 @@ event_handlers:
     action: FN=/mnt/flash/startup-config; LFN="`ls -1 $FN.*-* | tail -n 1`"; if [ -z "$LFN" -o -n "`diff -I 'last modified' $FN $LFN`" ]; then cp $FN $FN.`date +%Y%m%d-%H%M%S`; ls -1r $FN.*-* | tail -n +11 | xargs -I % rm %; fi
     delay: 0
     trigger: on-startup-config
+  - name: trigger-on-boot
+    trigger: on-boot
+    action_type: bash
+    action: echo "on-boot"
+  - name: trigger-on-config
+    trigger: on-config
+    action_type: bash
+    action: echo "on-config"
+  - name: trigger-on-counters
+    trigger: on-counters
+    action_type: bash
+    action: echo "on-counters"
+  - name: trigger-on-intf
+    trigger: on-intf
+    action_type: bash
+    action: echo "on-intf"
+  - name: trigger-on-maintenance
+    trigger: on-maintenance
+    action_type: bash
+    action: echo "on-maintenance"
+  - name: trigger-vm-tracer
+    trigger: vm-tracer
+    action_type: bash
+    action: echo "vm-tracer"

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/event-handlers.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/event-handlers.yml
@@ -15,23 +15,3 @@ event_handlers:
     trigger: on-boot
     action_type: bash
     action: echo "on-boot"
-  - name: trigger-on-config
-    trigger: on-config
-    action_type: bash
-    action: echo "on-config"
-  - name: trigger-on-counters
-    trigger: on-counters
-    action_type: bash
-    action: echo "on-counters"
-  - name: trigger-on-intf
-    trigger: on-intf
-    action_type: bash
-    action: echo "on-intf"
-  - name: trigger-on-maintenance
-    trigger: on-maintenance
-    action_type: bash
-    action: echo "on-maintenance"
-  - name: trigger-vm-tracer
-    trigger: vm-tracer
-    action_type: bash
-    action: echo "vm-tracer"

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/event-handlers.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/event-handlers.md
@@ -12,7 +12,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;action_type</samp>](## "event_handlers.[].action_type") | String |  |  | Valid Values:<br>- bash<br>- increment<br>- log |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;action</samp>](## "event_handlers.[].action") | String |  |  |  | Command to execute<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;delay</samp>](## "event_handlers.[].delay") | Integer |  |  |  | Event-handler delay in seconds<br> |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger</samp>](## "event_handlers.[].trigger") | String |  |  | Valid Values:<br>- on-boot<br>- on-config<br>- on-counters<br>- on-intf<br>- on-logging<br>- on-maintenance<br>- on-startup-config<br>- vm-tracer | Configure event trigger condition.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger</samp>](## "event_handlers.[].trigger") | String |  |  | Valid Values:<br>- on-boot<br>- on-logging<br>- on-startup-config | Configure event trigger condition.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;regex</samp>](## "event_handlers.[].regex") | String |  |  |  | Regular expression to use for searching log messages. Required for on-logging trigger<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;asynchronous</samp>](## "event_handlers.[].asynchronous") | Boolean |  | `False` |  | Set the action to be non-blocking. |
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/event-handlers.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/event-handlers.md
@@ -12,7 +12,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;action_type</samp>](## "event_handlers.[].action_type") | String |  |  | Valid Values:<br>- bash<br>- increment<br>- log |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;action</samp>](## "event_handlers.[].action") | String |  |  |  | Command to execute<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;delay</samp>](## "event_handlers.[].delay") | Integer |  |  |  | Event-handler delay in seconds<br> |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger</samp>](## "event_handlers.[].trigger") | String |  |  | Valid Values:<br>- on-logging<br>- on-startup-config | Configure event trigger condition.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger</samp>](## "event_handlers.[].trigger") | String |  |  | Valid Values:<br>- on-boot<br>- on-config<br>- on-counters<br>- on-intf<br>- on-logging<br>- on-maintenance<br>- on-startup-config<br>- vm-tracer | Configure event trigger condition.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;regex</samp>](## "event_handlers.[].regex") | String |  |  |  | Regular expression to use for searching log messages. Required for on-logging trigger<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;asynchronous</samp>](## "event_handlers.[].asynchronous") | Boolean |  | `False` |  | Set the action to be non-blocking. |
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -4220,8 +4220,14 @@
             "type": "string",
             "description": "Configure event trigger condition.\n",
             "enum": [
+              "on-boot",
+              "on-config",
+              "on-counters",
+              "on-intf",
               "on-logging",
-              "on-startup-config"
+              "on-maintenance",
+              "on-startup-config",
+              "vm-tracer"
             ],
             "title": "Trigger"
           },

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -4221,13 +4221,8 @@
             "description": "Configure event trigger condition.\n",
             "enum": [
               "on-boot",
-              "on-config",
-              "on-counters",
-              "on-intf",
               "on-logging",
-              "on-maintenance",
-              "on-startup-config",
-              "vm-tracer"
+              "on-startup-config"
             ],
             "title": "Trigger"
           },

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -2523,13 +2523,8 @@ keys:
             '
           valid_values:
           - on-boot
-          - on-config
-          - on-counters
-          - on-intf
           - on-logging
-          - on-maintenance
           - on-startup-config
-          - vm-tracer
         regex:
           type: str
           description: 'Regular expression to use for searching log messages. Required

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -2522,8 +2522,14 @@ keys:
 
             '
           valid_values:
+          - on-boot
+          - on-config
+          - on-counters
+          - on-intf
           - on-logging
+          - on-maintenance
           - on-startup-config
+          - vm-tracer
         regex:
           type: str
           description: 'Regular expression to use for searching log messages. Required

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/event_handlers.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/event_handlers.schema.yml
@@ -38,7 +38,15 @@ keys:
           type: str
           description: |
             Configure event trigger condition.
-          valid_values: ["on-logging", "on-startup-config"]
+          valid_values:
+            - on-boot
+            - on-config
+            - on-counters
+            - on-intf
+            - on-logging
+            - on-maintenance
+            - on-startup-config
+            - vm-tracer
         regex:
           type: str
           description: |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/event_handlers.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/event_handlers.schema.yml
@@ -40,13 +40,8 @@ keys:
             Configure event trigger condition.
           valid_values:
           - on-boot
-          - on-config
-          - on-counters
-          - on-intf
           - on-logging
-          - on-maintenance
           - on-startup-config
-          - vm-tracer
         regex:
           type: str
           description: |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/event_handlers.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/event_handlers.schema.yml
@@ -39,14 +39,14 @@ keys:
           description: |
             Configure event trigger condition.
           valid_values:
-            - on-boot
-            - on-config
-            - on-counters
-            - on-intf
-            - on-logging
-            - on-maintenance
-            - on-startup-config
-            - vm-tracer
+          - on-boot
+          - on-config
+          - on-counters
+          - on-intf
+          - on-logging
+          - on-maintenance
+          - on-startup-config
+          - vm-tracer
         regex:
           type: str
           description: |

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-settings.md
@@ -12,7 +12,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;action_type</samp>](## "event_handlers.[].action_type") | String |  |  | Valid Values:<br>- bash<br>- increment<br>- log |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;action</samp>](## "event_handlers.[].action") | String |  |  |  | Command to execute<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;delay</samp>](## "event_handlers.[].delay") | Integer |  |  |  | Event-handler delay in seconds<br> |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger</samp>](## "event_handlers.[].trigger") | String |  |  | Valid Values:<br>- on-boot<br>- on-config<br>- on-counters<br>- on-intf<br>- on-logging<br>- on-maintenance<br>- on-startup-config<br>- vm-tracer | Configure event trigger condition.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger</samp>](## "event_handlers.[].trigger") | String |  |  | Valid Values:<br>- on-boot<br>- on-logging<br>- on-startup-config | Configure event trigger condition.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;regex</samp>](## "event_handlers.[].regex") | String |  |  |  | Regular expression to use for searching log messages. Required for on-logging trigger<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;asynchronous</samp>](## "event_handlers.[].asynchronous") | Boolean |  | `False` |  | Set the action to be non-blocking. |
     | [<samp>ipv6_mgmt_destination_networks</samp>](## "ipv6_mgmt_destination_networks") | List, items: String |  |  |  | List of IPv6 prefixes to configure as static routes towards the OOB IPv6 Management interface gateway.<br>Replaces the default route.<br> |

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-settings.md
@@ -12,7 +12,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;action_type</samp>](## "event_handlers.[].action_type") | String |  |  | Valid Values:<br>- bash<br>- increment<br>- log |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;action</samp>](## "event_handlers.[].action") | String |  |  |  | Command to execute<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;delay</samp>](## "event_handlers.[].delay") | Integer |  |  |  | Event-handler delay in seconds<br> |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger</samp>](## "event_handlers.[].trigger") | String |  |  | Valid Values:<br>- on-logging<br>- on-startup-config | Configure event trigger condition.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger</samp>](## "event_handlers.[].trigger") | String |  |  | Valid Values:<br>- on-boot<br>- on-config<br>- on-counters<br>- on-intf<br>- on-logging<br>- on-maintenance<br>- on-startup-config<br>- vm-tracer | Configure event trigger condition.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;regex</samp>](## "event_handlers.[].regex") | String |  |  |  | Regular expression to use for searching log messages. Required for on-logging trigger<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;asynchronous</samp>](## "event_handlers.[].asynchronous") | Boolean |  | `False` |  | Set the action to be non-blocking. |
     | [<samp>ipv6_mgmt_destination_networks</samp>](## "ipv6_mgmt_destination_networks") | List, items: String |  |  |  | List of IPv6 prefixes to configure as static routes towards the OOB IPv6 Management interface gateway.<br>Replaces the default route.<br> |

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -3233,8 +3233,14 @@
             "type": "string",
             "description": "Configure event trigger condition.\n",
             "enum": [
+              "on-boot",
+              "on-config",
+              "on-counters",
+              "on-intf",
               "on-logging",
-              "on-startup-config"
+              "on-maintenance",
+              "on-startup-config",
+              "vm-tracer"
             ],
             "title": "Trigger"
           },

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -3234,13 +3234,8 @@
             "description": "Configure event trigger condition.\n",
             "enum": [
               "on-boot",
-              "on-config",
-              "on-counters",
-              "on-intf",
               "on-logging",
-              "on-maintenance",
-              "on-startup-config",
-              "vm-tracer"
+              "on-startup-config"
             ],
             "title": "Trigger"
           },


### PR DESCRIPTION
## Change Summary

Add additional valid_values for event-handler trigger 'on-boot'

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Uses the value from EOS:

```
ceos2(config-handler-TOTO)#trigger ?
  on-boot            Trigger condition occurs on system boot
  on-config          Trigger the event handler when it is configured
  on-counters        Trigger condition occurs on evaluating statistical counters
  on-intf            trigger condition occurs on specified interface changes
  on-logging         Trigger condition occurs when regex match any log message
  on-maintenance     Trigger condition occurs on maintenance operation
  on-startup-config  trigger condition occurs on startup config changes
  vm-tracer          Trigger condition occurs on VmTracer events
```

## How to test

molecule

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
