### PR TITLE
Feat(eos_cli_config_gen): Implement management-ssh client-alive

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-ssh.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-ssh.md
@@ -77,6 +77,8 @@ management ssh
    idle-timeout 15
    connection limit 50
    connection per-host 10
+   client-alive interval 666
+   client-alive count-max 42
    no shutdown
    log-level debug
    !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/management-ssh.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/management-ssh.cfg
@@ -18,6 +18,8 @@ management ssh
    idle-timeout 15
    connection limit 50
    connection per-host 10
+   client-alive interval 666
+   client-alive count-max 42
    no shutdown
    log-level debug
    !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/management-ssh.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/management-ssh.yml
@@ -12,3 +12,6 @@ management_ssh:
     - name: mgt
       enable: true
   log_level: debug
+  client_alive:
+    count_max: 42
+    interval: 666

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/management-ssh.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/management-ssh.md
@@ -32,6 +32,9 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "management_ssh.vrfs.[].name") | String | Required, Unique |  |  | VRF Name |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enable</samp>](## "management_ssh.vrfs.[].enable") | Boolean |  |  |  | Enable SSH in VRF |
     | [<samp>&nbsp;&nbsp;log_level</samp>](## "management_ssh.log_level") | String |  |  |  | SSH daemon log level |
+    | [<samp>&nbsp;&nbsp;client_alive</samp>](## "management_ssh.client_alive") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;count_max</samp>](## "management_ssh.client_alive.count_max") | Integer |  |  | Min: 1<br>Max: 1000 | Number of keep-alive packets that can be sent without a response before the connection is assumed dead. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;interval</samp>](## "management_ssh.client_alive.interval") | Integer |  |  | Min: 1<br>Max: 1000 | Time period (in seconds) to send SSH keep-alive packets. |
 
 === "YAML"
 
@@ -61,4 +64,7 @@
         - name: <str>
           enable: <bool>
       log_level: <str>
+      client_alive:
+        count_max: <int>
+        interval: <int>
     ```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -8735,6 +8735,30 @@
           "type": "string",
           "description": "SSH daemon log level",
           "title": "Log Level"
+        },
+        "client_alive": {
+          "type": "object",
+          "properties": {
+            "count_max": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 1000,
+              "description": "Number of keep-alive packets that can be sent without a response before the connection is assumed dead.",
+              "title": "Count Max"
+            },
+            "interval": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 1000,
+              "description": "Time period (in seconds) to send SSH keep-alive packets.",
+              "title": "Interval"
+            }
+          },
+          "additionalProperties": false,
+          "patternProperties": {
+            "^_.+$": {}
+          },
+          "title": "Client Alive"
         }
       },
       "additionalProperties": false,

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -5210,6 +5210,24 @@ keys:
       log_level:
         type: str
         description: SSH daemon log level
+      client_alive:
+        type: dict
+        keys:
+          count_max:
+            type: int
+            convert_types:
+            - str
+            min: 1
+            max: 1000
+            description: Number of keep-alive packets that can be sent without a response
+              before the connection is assumed dead.
+          interval:
+            type: int
+            convert_types:
+            - str
+            min: 1
+            max: 1000
+            description: Time period (in seconds) to send SSH keep-alive packets.
   management_tech_support:
     type: dict
     keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_ssh.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_ssh.schema.yml
@@ -105,3 +105,20 @@ keys:
       log_level:
         type: str
         description: SSH daemon log level
+      client_alive:
+        type: dict
+        keys:
+          count_max:
+            type: int
+            convert_types:
+              - str
+            min: 1
+            max: 1000
+            description: Number of keep-alive packets that can be sent without a response before the connection is assumed dead.
+          interval:
+            type: int
+            convert_types:
+              - str
+            min: 1
+            max: 1000
+            description: Time period (in seconds) to send SSH keep-alive packets.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-ssh.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-ssh.j2
@@ -36,6 +36,12 @@ management ssh
 {%     if management_ssh.connection.per_host is arista.avd.defined %}
    connection per-host {{ management_ssh.connection.per_host }}
 {%     endif %}
+{%     if management_ssh.client_alive.interval is arista.avd.defined %}
+   client-alive interval {{ management_ssh.client_alive.interval }}
+{%     endif %}
+{%     if management_ssh.client_alive.count_max is arista.avd.defined %}
+   client-alive count-max {{ management_ssh.client_alive.count_max }}
+{%     endif %}
 {%     if management_ssh.cipher is arista.avd.defined %}
    cipher {{ management_ssh.cipher | join(" ") }}
 {%     endif %}


### PR DESCRIPTION
## Change Summary

Add `client-alive` options for `management-ssh`

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

CLI output

```
ceos2(config-mgmt-ssh)#client-alive ?
  count-max  Number of keep-alive packets that can be sent without a response before the connection is assumed dead
  interval   Time period ( in seconds ) to send SSH keep-alive packets

ceos2(config-mgmt-ssh)#client-alive count-max ?
  <1-1000>  Set Value

ceos2(config-mgmt-ssh)#client-alive interval ?
  <1-1000>  Set Value
```

Adding the following schema:

```
      client_alive:
        type: dict
        keys:
          count_max:
            type: int
            convert_types:
              - str
            min: 1
            max: 1000
            description: Number of keep-alive packets that can be sent without a response before the connection is assumed dead.
          interval:
            type: int
            convert_types:
              - str
            min: 1
            max: 1000
            description: Time period (in seconds) to send SSH keep-alive packets.
```

## How to test

molecule

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
