### PR TITLE
Fix(eos_cli_config_gen): STUN server supports multiple local interfaces

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/stun.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/stun.md
@@ -50,9 +50,12 @@ interface Management1
 
 ### STUN Server
 
-| Server local interface |
-| ---------------------- |
-| ethernet1 |
+| Server local interfaces |
+| ----------------------- |
+| Ethernet1 |
+| Ethernet13 |
+| Vlan42 |
+| Vlan666 |
 
 ### STUN Device Configuration
 
@@ -65,5 +68,8 @@ stun
       server-profile server2
          ip address 2.3.4.5
    server
-      local-interface ethernet1
+      local-interface Ethernet1
+      local-interface Ethernet13
+      local-interface Vlan42
+      local-interface Vlan666
 ```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/stun.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/stun.cfg
@@ -19,6 +19,9 @@ stun
       server-profile server2
          ip address 2.3.4.5
    server
-      local-interface ethernet1
+      local-interface Ethernet1
+      local-interface Ethernet13
+      local-interface Vlan42
+      local-interface Vlan666
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/stun.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/stun.yml
@@ -2,7 +2,11 @@
 ---
 stun:
   server:
-    local_interface: ethernet1
+    local_interfaces:
+      - Ethernet1
+      - Vlan42
+      - Vlan666
+      - Ethernet13
   client:
     server_profiles:
       # The servers are on purpose not in order in order to test the sorting

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/documentation/devices/host1.md
@@ -79,6 +79,9 @@
   - [QOS Class Maps](#qos-class-maps)
   - [QOS Policy Maps](#qos-policy-maps)
   - [QOS Profiles](#qos-profiles)
+- [STUN](#stun)
+  - [STUN Server](#stun-server)
+  - [STUN Device Configuration](#stun-device-configuration)
 - [Maintenance Mode](#maintenance-mode)
   - [BGP Groups](#bgp-groups)
   - [Interface Groups](#interface-groups)
@@ -1802,6 +1805,23 @@ qos profile test
    mc-tx-queue 3
       bandwidth percent 50
       no priority
+```
+
+## STUN
+
+### STUN Server
+
+| Server local interfaces |
+| ----------------------- |
+| ethernet1 |
+
+### STUN Device Configuration
+
+```eos
+!
+stun
+   server
+      local-interface ethernet1
 ```
 
 ## Maintenance Mode

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/intended/configs/host1.cfg
@@ -609,6 +609,10 @@ management api gnmi
       vrf MONITORING
    provider eos-native
 !
+stun
+   server
+      local-interface ethernet1
+!
 management ssh
    !
    vrf mgt

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/inventory/host_vars/host1/stun.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/inventory/host_vars/host1/stun.yml
@@ -1,0 +1,6 @@
+### stun
+---
+stun:
+  server:
+    # deprecatd in favor of local_interfaces
+    local_interface: ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/inventory/host_vars/host1/stun.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/inventory/host_vars/host1/stun.yml
@@ -2,5 +2,5 @@
 ---
 stun:
   server:
-    # deprecatd in favor of local_interfaces
+    # deprecated in favor of local_interfaces
     local_interface: ethernet1

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/stun.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/stun.md
@@ -13,7 +13,9 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "stun.client.server_profiles.[].name") | String | Required, Unique |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ip_address</samp>](## "stun.client.server_profiles.[].ip_address") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;server</samp>](## "stun.server") | Dictionary |  |  |  | STUN server settings |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;local_interface</samp>](## "stun.server.local_interface") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;local_interface</samp>](## "stun.server.local_interface") <span style="color:red">deprecated</span> | String |  |  |  | <span style="color:red">This key is deprecated. Support will be removed in AVD version v5.0.0. Use <samp>local_interfaces</samp> instead.</span> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;local_interfaces</samp>](## "stun.server.local_interfaces") | List, items: String |  |  | Min Length: 1 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- &lt;str&gt;</samp>](## "stun.server.local_interfaces.[].&lt;str&gt;") | String |  |  |  |  |
 
 === "YAML"
 
@@ -25,4 +27,6 @@
             ip_address: <str>
       server:
         local_interface: <str>
+        local_interfaces:
+          - <str>
     ```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -20848,6 +20848,14 @@
             "local_interface": {
               "type": "string",
               "title": "Local Interface"
+            },
+            "local_interfaces": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string"
+              },
+              "title": "Local Interfaces"
             }
           },
           "additionalProperties": false,

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -12072,6 +12072,15 @@ keys:
         keys:
           local_interface:
             type: str
+            deprecation:
+              warning: true
+              new_key: local_interfaces
+              remove_in_version: v5.0.0
+          local_interfaces:
+            type: list
+            min_length: 1
+            items:
+              type: str
   switchport_default:
     type: dict
     keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/stun.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/stun.schema.yml
@@ -31,3 +31,12 @@ keys:
         keys:
           local_interface:
             type: str
+            deprecation:
+              warning: true
+              new_key: local_interfaces
+              remove_in_version: v5.0.0
+          local_interfaces:
+            type: list
+            min_length: 1
+            items:
+              type: str

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/stun.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/stun.j2
@@ -25,8 +25,12 @@
 
 ### STUN Server
 
-| Server local interface |
-| ---------------------- |
+| Server local interfaces |
+| ----------------------- |
+{%         for local_interface in stun.server.local_interfaces | arista.avd.natural_sort %}
+| {{ stun.server.local_interface }} |
+{%         endfor %}
+{# next is deprecated remove in v5.0.0 #}
 {%         if stun.server.local_interface is arista.avd.defined %}
 | {{ stun.server.local_interface }} |
 {%         endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/stun.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/stun.j2
@@ -28,7 +28,7 @@
 | Server local interfaces |
 | ----------------------- |
 {%         for local_interface in stun.server.local_interfaces | arista.avd.natural_sort %}
-| {{ stun.server.local_interface }} |
+| {{ local_interface }} |
 {%         endfor %}
 {# next is deprecated remove in v5.0.0 #}
 {%         if stun.server.local_interface is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/stun.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/stun.j2
@@ -18,6 +18,9 @@ stun
 {%     endif %}
 {%     if stun.server is arista.avd.defined %}
    server
+{%         for local_interface in stun.server.local_interfaces | arista.avd.natural_sort %}
+      local-interface {{ local_interface }}
+{%         endfor %}
 {%         if stun.server.local_interface is arista.avd.defined %}
       local-interface {{ stun.server.local_interface }}
 {%         endif %}


### PR DESCRIPTION
## Change Summary

STUN server configuration can support multiple local interfaces as follow:

```
ceos2(config-stun-server)#show active
stun
   server
      local-interface Ethernet1
      local-interface Ethernet13
      local-interface Vlan42
      local-interface Vlan6
      local-interface Vlan666
```

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

This PR deprecates the `stun.server.local_interface` key and replace it with `stun.server.local_interfaces`

## How to test

molecule (`eos_cli_config_gen` AND `eos_cli_config_gen_deprecated_vars`)

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
