### PR TITLE
Feat(eos_designs): Custom prefix length for P2P uplinks and MLAG

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MLAG_ODD_ID_L3LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MLAG_ODD_ID_L3LEAF1A.cfg
@@ -41,6 +41,13 @@ interface Ethernet6
    no shutdown
    channel-group 5 mode active
 !
+interface Ethernet10
+   description P2P_LINK_TO_P2P-UPLINKS-IPV4-PREFIX-LENGTH_Ethernet1
+   no shutdown
+   mtu 9214
+   no switchport
+   ip address 10.254.255.249/30
+!
 interface Loopback0
    description EVPN_Overlay_Peering
    no shutdown
@@ -124,6 +131,9 @@ router bgp 923
    neighbor MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN in
    neighbor 10.10.224.3 peer group MLAG-IPv4-UNDERLAY-PEER
    neighbor 10.10.224.3 description MLAG_ODD_ID_L3LEAF1B
+   neighbor 10.254.255.250 peer group IPv4-UNDERLAY-PEERS
+   neighbor 10.254.255.250 remote-as 65123
+   neighbor 10.254.255.250 description P2P-UPLINKS-IPV4-PREFIX-LENGTH_Ethernet1
    redistribute connected route-map RM-CONN-2-BGP
    !
    address-family evpn

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MLAG_ODD_ID_L3LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MLAG_ODD_ID_L3LEAF1B.cfg
@@ -41,6 +41,13 @@ interface Ethernet6
    no shutdown
    channel-group 5 mode active
 !
+interface Ethernet10
+   description P2P_LINK_TO_P2P-UPLINKS-IPV4-PREFIX-LENGTH_Ethernet2
+   no shutdown
+   mtu 9214
+   no switchport
+   ip address 10.254.255.253/30
+!
 interface Loopback0
    description EVPN_Overlay_Peering
    no shutdown
@@ -124,6 +131,9 @@ router bgp 923
    neighbor MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN in
    neighbor 10.10.224.2 peer group MLAG-IPv4-UNDERLAY-PEER
    neighbor 10.10.224.2 description MLAG_ODD_ID_L3LEAF1A
+   neighbor 10.254.255.254 peer group IPv4-UNDERLAY-PEERS
+   neighbor 10.254.255.254 remote-as 65123
+   neighbor 10.254.255.254 description P2P-UPLINKS-IPV4-PREFIX-LENGTH_Ethernet2
    redistribute connected route-map RM-CONN-2-BGP
    !
    address-family evpn

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MLAG_SAME_SUBNET_L3LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MLAG_SAME_SUBNET_L3LEAF1A.cfg
@@ -13,6 +13,13 @@ no spanning-tree vlan-id 4093-4094
 no enable password
 no aaa root
 !
+vlan 10
+   name VLAN10
+!
+vlan 3000
+   name MLAG_iBGP_TEST
+   trunk group LEAF_PEER_L3
+!
 vlan 4093
    name LEAF_PEER_L3
    trunk group LEAF_PEER_L3
@@ -22,6 +29,8 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+vrf instance TEST
 !
 interface Port-Channel5
    description MLAG_PEER_MLAG_SAME_SUBNET_L3LEAF1B_Po5
@@ -57,27 +66,45 @@ interface Management1
    vrf MGMT
    ip address 192.168.201.116/24
 !
+interface Vlan10
+   description VLAN10
+   shutdown
+   vrf TEST
+   ip address virtual 10.10.10.1/24
+!
+interface Vlan3000
+   description MLAG_PEER_L3_iBGP: vrf TEST
+   no shutdown
+   mtu 9214
+   vrf TEST
+   ip address 10.10.224.1/30
+!
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
    no shutdown
    mtu 9214
-   ip address 10.10.224.0/31
+   ip address 10.10.224.1/30
 !
 interface Vlan4094
    description MLAG_PEER
    no shutdown
    mtu 9214
    no autostate
-   ip address 10.10.255.0/31
+   ip address 10.10.255.1/30
 !
 interface Vxlan1
    description MLAG_SAME_SUBNET_L3LEAF1A_VTEP
    vxlan source-interface Loopback1
    vxlan virtual-router encapsulation mac-address mlag-system-id
    vxlan udp-port 4789
+   vxlan vlan 10 vni 10
+   vxlan vrf TEST vni 1
+!
+ip virtual-router mac-address 00:1c:73:00:00:99
 !
 ip routing
 no ip routing vrf MGMT
+ip routing vrf TEST
 !
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.168.255.0/24 eq 32
@@ -86,7 +113,7 @@ ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
 mlag configuration
    domain-id MLAG_SAME_SUBNET_L3LEAF1
    local-interface Vlan4094
-   peer-address 10.10.255.1
+   peer-address 10.10.255.2
    peer-link Port-Channel5
    reload-delay mlag 300
    reload-delay non-mlag 330
@@ -122,9 +149,14 @@ router bgp 923
    neighbor MLAG-IPv4-UNDERLAY-PEER send-community
    neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000
    neighbor MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN in
-   neighbor 10.10.224.1 peer group MLAG-IPv4-UNDERLAY-PEER
-   neighbor 10.10.224.1 description MLAG_SAME_SUBNET_L3LEAF1B
+   neighbor 10.10.224.2 peer group MLAG-IPv4-UNDERLAY-PEER
+   neighbor 10.10.224.2 description MLAG_SAME_SUBNET_L3LEAF1B
    redistribute connected route-map RM-CONN-2-BGP
+   !
+   vlan 10
+      rd 192.168.255.32:10
+      route-target both 10:10
+      redistribute learned
    !
    address-family evpn
       neighbor EVPN-OVERLAY-PEERS activate
@@ -133,6 +165,15 @@ router bgp 923
       no neighbor EVPN-OVERLAY-PEERS activate
       neighbor IPv4-UNDERLAY-PEERS activate
       neighbor MLAG-IPv4-UNDERLAY-PEER activate
+   !
+   vrf TEST
+      rd 192.168.255.32:1
+      route-target import evpn 1:1
+      route-target export evpn 1:1
+      router-id 192.168.255.32
+      update wait-install
+      neighbor 10.10.224.2 peer group MLAG-IPv4-UNDERLAY-PEER
+      redistribute connected
 !
 management api http-commands
    protocol https

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MLAG_SAME_SUBNET_L3LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MLAG_SAME_SUBNET_L3LEAF1B.cfg
@@ -13,6 +13,13 @@ no spanning-tree vlan-id 4093-4094
 no enable password
 no aaa root
 !
+vlan 10
+   name VLAN10
+!
+vlan 3000
+   name MLAG_iBGP_TEST
+   trunk group LEAF_PEER_L3
+!
 vlan 4093
    name LEAF_PEER_L3
    trunk group LEAF_PEER_L3
@@ -22,6 +29,8 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+vrf instance TEST
 !
 interface Port-Channel5
    description MLAG_PEER_MLAG_SAME_SUBNET_L3LEAF1A_Po5
@@ -57,27 +66,45 @@ interface Management1
    vrf MGMT
    ip address 192.168.201.117/24
 !
+interface Vlan10
+   description VLAN10
+   shutdown
+   vrf TEST
+   ip address virtual 10.10.10.1/24
+!
+interface Vlan3000
+   description MLAG_PEER_L3_iBGP: vrf TEST
+   no shutdown
+   mtu 9214
+   vrf TEST
+   ip address 10.10.224.2/30
+!
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
    no shutdown
    mtu 9214
-   ip address 10.10.224.1/31
+   ip address 10.10.224.2/30
 !
 interface Vlan4094
    description MLAG_PEER
    no shutdown
    mtu 9214
    no autostate
-   ip address 10.10.255.1/31
+   ip address 10.10.255.2/30
 !
 interface Vxlan1
    description MLAG_SAME_SUBNET_L3LEAF1B_VTEP
    vxlan source-interface Loopback1
    vxlan virtual-router encapsulation mac-address mlag-system-id
    vxlan udp-port 4789
+   vxlan vlan 10 vni 10
+   vxlan vrf TEST vni 1
+!
+ip virtual-router mac-address 00:1c:73:00:00:99
 !
 ip routing
 no ip routing vrf MGMT
+ip routing vrf TEST
 !
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.168.255.0/24 eq 32
@@ -86,7 +113,7 @@ ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
 mlag configuration
    domain-id MLAG_SAME_SUBNET_L3LEAF1
    local-interface Vlan4094
-   peer-address 10.10.255.0
+   peer-address 10.10.255.1
    peer-link Port-Channel5
    reload-delay mlag 300
    reload-delay non-mlag 330
@@ -122,9 +149,14 @@ router bgp 923
    neighbor MLAG-IPv4-UNDERLAY-PEER send-community
    neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000
    neighbor MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN in
-   neighbor 10.10.224.0 peer group MLAG-IPv4-UNDERLAY-PEER
-   neighbor 10.10.224.0 description MLAG_SAME_SUBNET_L3LEAF1A
+   neighbor 10.10.224.1 peer group MLAG-IPv4-UNDERLAY-PEER
+   neighbor 10.10.224.1 description MLAG_SAME_SUBNET_L3LEAF1A
    redistribute connected route-map RM-CONN-2-BGP
+   !
+   vlan 10
+      rd 192.168.255.33:10
+      route-target both 10:10
+      redistribute learned
    !
    address-family evpn
       neighbor EVPN-OVERLAY-PEERS activate
@@ -133,6 +165,15 @@ router bgp 923
       no neighbor EVPN-OVERLAY-PEERS activate
       neighbor IPv4-UNDERLAY-PEERS activate
       neighbor MLAG-IPv4-UNDERLAY-PEER activate
+   !
+   vrf TEST
+      rd 192.168.255.33:1
+      route-target import evpn 1:1
+      route-target export evpn 1:1
+      router-id 192.168.255.33
+      update wait-install
+      neighbor 10.10.224.1 peer group MLAG-IPv4-UNDERLAY-PEER
+      redistribute connected
 !
 management api http-commands
    protocol https

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MLAG_SAME_SUBNET_L3LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MLAG_SAME_SUBNET_L3LEAF2A.cfg
@@ -13,6 +13,13 @@ no spanning-tree vlan-id 4093-4094
 no enable password
 no aaa root
 !
+vlan 10
+   name VLAN10
+!
+vlan 3000
+   name MLAG_iBGP_TEST
+   trunk group LEAF_PEER_L3
+!
 vlan 4093
    name LEAF_PEER_L3
    trunk group LEAF_PEER_L3
@@ -22,6 +29,8 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+vrf instance TEST
 !
 interface Port-Channel5
    description MLAG_PEER_MLAG_SAME_SUBNET_L3LEAF2B_Po5
@@ -57,27 +66,45 @@ interface Management1
    vrf MGMT
    ip address 192.168.201.118/24
 !
+interface Vlan10
+   description VLAN10
+   shutdown
+   vrf TEST
+   ip address virtual 10.10.10.1/24
+!
+interface Vlan3000
+   description MLAG_PEER_L3_iBGP: vrf TEST
+   no shutdown
+   mtu 9214
+   vrf TEST
+   ip address 10.10.224.1/30
+!
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
    no shutdown
    mtu 9214
-   ip address 10.10.224.0/31
+   ip address 10.10.224.1/30
 !
 interface Vlan4094
    description MLAG_PEER
    no shutdown
    mtu 9214
    no autostate
-   ip address 10.10.255.0/31
+   ip address 10.10.255.1/30
 !
 interface Vxlan1
    description MLAG_SAME_SUBNET_L3LEAF2A_VTEP
    vxlan source-interface Loopback1
    vxlan virtual-router encapsulation mac-address mlag-system-id
    vxlan udp-port 4789
+   vxlan vlan 10 vni 10
+   vxlan vrf TEST vni 1
+!
+ip virtual-router mac-address 00:1c:73:00:00:99
 !
 ip routing
 no ip routing vrf MGMT
+ip routing vrf TEST
 !
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.168.255.0/24 eq 32
@@ -86,7 +113,7 @@ ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
 mlag configuration
    domain-id MLAG_SAME_SUBNET_L3LEAF2
    local-interface Vlan4094
-   peer-address 10.10.255.1
+   peer-address 10.10.255.2
    peer-link Port-Channel5
    reload-delay mlag 300
    reload-delay non-mlag 330
@@ -122,9 +149,14 @@ router bgp 923
    neighbor MLAG-IPv4-UNDERLAY-PEER send-community
    neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000
    neighbor MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN in
-   neighbor 10.10.224.1 peer group MLAG-IPv4-UNDERLAY-PEER
-   neighbor 10.10.224.1 description MLAG_SAME_SUBNET_L3LEAF2B
+   neighbor 10.10.224.2 peer group MLAG-IPv4-UNDERLAY-PEER
+   neighbor 10.10.224.2 description MLAG_SAME_SUBNET_L3LEAF2B
    redistribute connected route-map RM-CONN-2-BGP
+   !
+   vlan 10
+      rd 192.168.255.34:10
+      route-target both 10:10
+      redistribute learned
    !
    address-family evpn
       neighbor EVPN-OVERLAY-PEERS activate
@@ -133,6 +165,15 @@ router bgp 923
       no neighbor EVPN-OVERLAY-PEERS activate
       neighbor IPv4-UNDERLAY-PEERS activate
       neighbor MLAG-IPv4-UNDERLAY-PEER activate
+   !
+   vrf TEST
+      rd 192.168.255.34:1
+      route-target import evpn 1:1
+      route-target export evpn 1:1
+      router-id 192.168.255.34
+      update wait-install
+      neighbor 10.10.224.2 peer group MLAG-IPv4-UNDERLAY-PEER
+      redistribute connected
 !
 management api http-commands
    protocol https

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MLAG_SAME_SUBNET_L3LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MLAG_SAME_SUBNET_L3LEAF2B.cfg
@@ -13,6 +13,13 @@ no spanning-tree vlan-id 4093-4094
 no enable password
 no aaa root
 !
+vlan 10
+   name VLAN10
+!
+vlan 3000
+   name MLAG_iBGP_TEST
+   trunk group LEAF_PEER_L3
+!
 vlan 4093
    name LEAF_PEER_L3
    trunk group LEAF_PEER_L3
@@ -22,6 +29,8 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+vrf instance TEST
 !
 interface Port-Channel5
    description MLAG_PEER_MLAG_SAME_SUBNET_L3LEAF2A_Po5
@@ -57,27 +66,45 @@ interface Management1
    vrf MGMT
    ip address 192.168.201.119/24
 !
+interface Vlan10
+   description VLAN10
+   shutdown
+   vrf TEST
+   ip address virtual 10.10.10.1/24
+!
+interface Vlan3000
+   description MLAG_PEER_L3_iBGP: vrf TEST
+   no shutdown
+   mtu 9214
+   vrf TEST
+   ip address 10.10.224.2/30
+!
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
    no shutdown
    mtu 9214
-   ip address 10.10.224.1/31
+   ip address 10.10.224.2/30
 !
 interface Vlan4094
    description MLAG_PEER
    no shutdown
    mtu 9214
    no autostate
-   ip address 10.10.255.1/31
+   ip address 10.10.255.2/30
 !
 interface Vxlan1
    description MLAG_SAME_SUBNET_L3LEAF2B_VTEP
    vxlan source-interface Loopback1
    vxlan virtual-router encapsulation mac-address mlag-system-id
    vxlan udp-port 4789
+   vxlan vlan 10 vni 10
+   vxlan vrf TEST vni 1
+!
+ip virtual-router mac-address 00:1c:73:00:00:99
 !
 ip routing
 no ip routing vrf MGMT
+ip routing vrf TEST
 !
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.168.255.0/24 eq 32
@@ -86,7 +113,7 @@ ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
 mlag configuration
    domain-id MLAG_SAME_SUBNET_L3LEAF2
    local-interface Vlan4094
-   peer-address 10.10.255.0
+   peer-address 10.10.255.1
    peer-link Port-Channel5
    reload-delay mlag 300
    reload-delay non-mlag 330
@@ -122,9 +149,14 @@ router bgp 923
    neighbor MLAG-IPv4-UNDERLAY-PEER send-community
    neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000
    neighbor MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN in
-   neighbor 10.10.224.0 peer group MLAG-IPv4-UNDERLAY-PEER
-   neighbor 10.10.224.0 description MLAG_SAME_SUBNET_L3LEAF2A
+   neighbor 10.10.224.1 peer group MLAG-IPv4-UNDERLAY-PEER
+   neighbor 10.10.224.1 description MLAG_SAME_SUBNET_L3LEAF2A
    redistribute connected route-map RM-CONN-2-BGP
+   !
+   vlan 10
+      rd 192.168.255.35:10
+      route-target both 10:10
+      redistribute learned
    !
    address-family evpn
       neighbor EVPN-OVERLAY-PEERS activate
@@ -133,6 +165,15 @@ router bgp 923
       no neighbor EVPN-OVERLAY-PEERS activate
       neighbor IPv4-UNDERLAY-PEERS activate
       neighbor MLAG-IPv4-UNDERLAY-PEER activate
+   !
+   vrf TEST
+      rd 192.168.255.35:1
+      route-target import evpn 1:1
+      route-target export evpn 1:1
+      router-id 192.168.255.35
+      update wait-install
+      neighbor 10.10.224.1 peer group MLAG-IPv4-UNDERLAY-PEER
+      redistribute connected
 !
 management api http-commands
    protocol https

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/P2P-UPLINKS-IPV4-PREFIX-LENGTH.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/P2P-UPLINKS-IPV4-PREFIX-LENGTH.cfg
@@ -1,0 +1,86 @@
+!RANCID-CONTENT-TYPE: arista
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname P2P-UPLINKS-IPV4-PREFIX-LENGTH
+!
+spanning-tree mode none
+!
+no enable password
+no aaa root
+!
+vrf instance MGMT
+!
+interface Ethernet1
+   description P2P_LINK_TO_MLAG_ODD_ID_L3LEAF1A_Ethernet10
+   no shutdown
+   mtu 9214
+   no switchport
+   ip address 10.254.255.250/30
+!
+interface Ethernet2
+   description P2P_LINK_TO_MLAG_ODD_ID_L3LEAF1B_Ethernet10
+   no shutdown
+   mtu 9214
+   no switchport
+   ip address 10.254.255.254/30
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 10.254.254.32/32
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 10.254.254.0/24 eq 32
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+router bfd
+   multihop interval 300 min-rx 300 multiplier 3
+!
+router bgp 65123
+   router-id 10.254.254.32
+   maximum-paths 4 ecmp 4
+   update wait-install
+   no bgp default ipv4-unicast
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor IPv4-UNDERLAY-PEERS peer group
+   neighbor IPv4-UNDERLAY-PEERS send-community
+   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   neighbor 10.254.255.249 peer group IPv4-UNDERLAY-PEERS
+   neighbor 10.254.255.249 remote-as 923
+   neighbor 10.254.255.249 description MLAG_ODD_ID_L3LEAF1A_Ethernet10
+   neighbor 10.254.255.253 peer group IPv4-UNDERLAY-PEERS
+   neighbor 10.254.255.253 remote-as 923
+   neighbor 10.254.255.253 description MLAG_ODD_ID_L3LEAF1B_Ethernet10
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   address-family evpn
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor IPv4-UNDERLAY-PEERS activate
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG_ODD_ID_L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG_ODD_ID_L3LEAF1A.yml
@@ -46,6 +46,10 @@ router_bgp:
     peer_group: MLAG-IPv4-UNDERLAY-PEER
     peer: MLAG_ODD_ID_L3LEAF1B
     description: MLAG_ODD_ID_L3LEAF1B
+  - ip_address: 10.254.255.250
+    peer_group: IPv4-UNDERLAY-PEERS
+    remote_as: '65123'
+    description: P2P-UPLINKS-IPV4-PREFIX-LENGTH_Ethernet1
   redistribute_routes:
   - source_protocol: connected
     route_map: RM-CONN-2-BGP
@@ -130,6 +134,15 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
+- name: Ethernet10
+  peer: P2P-UPLINKS-IPV4-PREFIX-LENGTH
+  peer_interface: Ethernet1
+  peer_type: overlay-controller
+  description: P2P_LINK_TO_P2P-UPLINKS-IPV4-PREFIX-LENGTH_Ethernet1
+  shutdown: false
+  mtu: 9214
+  type: routed
+  ip_address: 10.254.255.249/30
 mlag_configuration:
   domain_id: MLAG_ODD_ID_L3LEAF1
   local_interface: Vlan4094

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG_ODD_ID_L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG_ODD_ID_L3LEAF1A.yml
@@ -49,6 +49,7 @@ router_bgp:
   - ip_address: 10.254.255.250
     peer_group: IPv4-UNDERLAY-PEERS
     remote_as: '65123'
+    peer: P2P-UPLINKS-IPV4-PREFIX-LENGTH
     description: P2P-UPLINKS-IPV4-PREFIX-LENGTH_Ethernet1
   redistribute_routes:
   - source_protocol: connected

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG_ODD_ID_L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG_ODD_ID_L3LEAF1B.yml
@@ -46,6 +46,10 @@ router_bgp:
     peer_group: MLAG-IPv4-UNDERLAY-PEER
     peer: MLAG_ODD_ID_L3LEAF1A
     description: MLAG_ODD_ID_L3LEAF1A
+  - ip_address: 10.254.255.254
+    peer_group: IPv4-UNDERLAY-PEERS
+    remote_as: '65123'
+    description: P2P-UPLINKS-IPV4-PREFIX-LENGTH_Ethernet2
   redistribute_routes:
   - source_protocol: connected
     route_map: RM-CONN-2-BGP
@@ -130,6 +134,15 @@ ethernet_interfaces:
   channel_group:
     id: 5
     mode: active
+- name: Ethernet10
+  peer: P2P-UPLINKS-IPV4-PREFIX-LENGTH
+  peer_interface: Ethernet2
+  peer_type: overlay-controller
+  description: P2P_LINK_TO_P2P-UPLINKS-IPV4-PREFIX-LENGTH_Ethernet2
+  shutdown: false
+  mtu: 9214
+  type: routed
+  ip_address: 10.254.255.253/30
 mlag_configuration:
   domain_id: MLAG_ODD_ID_L3LEAF1
   local_interface: Vlan4094

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG_ODD_ID_L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG_ODD_ID_L3LEAF1B.yml
@@ -49,6 +49,7 @@ router_bgp:
   - ip_address: 10.254.255.254
     peer_group: IPv4-UNDERLAY-PEERS
     remote_as: '65123'
+    peer: P2P-UPLINKS-IPV4-PREFIX-LENGTH
     description: P2P-UPLINKS-IPV4-PREFIX-LENGTH_Ethernet2
   redistribute_routes:
   - source_protocol: connected

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG_SAME_SUBNET_L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG_SAME_SUBNET_L3LEAF1A.yml
@@ -42,7 +42,7 @@ router_bgp:
     - name: EVPN-OVERLAY-PEERS
       activate: false
   neighbors:
-  - ip_address: 10.10.224.1
+  - ip_address: 10.10.224.2
     peer_group: MLAG-IPv4-UNDERLAY-PEER
     peer: MLAG_SAME_SUBNET_L3LEAF1B
     description: MLAG_SAME_SUBNET_L3LEAF1B
@@ -53,6 +53,35 @@ router_bgp:
     peer_groups:
     - name: EVPN-OVERLAY-PEERS
       activate: true
+  vrfs:
+  - name: TEST
+    router_id: 192.168.255.32
+    rd: 192.168.255.32:1
+    route_targets:
+      import:
+      - address_family: evpn
+        route_targets:
+        - '1:1'
+      export:
+      - address_family: evpn
+        route_targets:
+        - '1:1'
+    redistribute_routes:
+    - source_protocol: connected
+    neighbors:
+    - ip_address: 10.10.224.2
+      peer_group: MLAG-IPv4-UNDERLAY-PEER
+    updates:
+      wait_install: true
+  vlans:
+  - id: 10
+    tenant: TEST_MLAG_SAME_SUBNET_ON_VRF
+    rd: 192.168.255.32:10
+    route_targets:
+      both:
+      - '10:10'
+    redistribute_routes:
+    - learned
 service_routing_protocols_model: multi-agent
 ip_routing: true
 vlan_internal_order:
@@ -63,6 +92,9 @@ vlan_internal_order:
 vrfs:
 - name: MGMT
   ip_routing: false
+- name: TEST
+  tenant: TEST_MLAG_SAME_SUBNET_ON_VRF
+  ip_routing: true
 management_interfaces:
 - name: Management1
   description: oob_management
@@ -88,18 +120,40 @@ vlans:
   name: MLAG_PEER
   trunk_groups:
   - MLAG
+- id: 10
+  name: VLAN10
+  tenant: TEST_MLAG_SAME_SUBNET_ON_VRF
+- id: 3000
+  name: MLAG_iBGP_TEST
+  trunk_groups:
+  - LEAF_PEER_L3
+  tenant: TEST_MLAG_SAME_SUBNET_ON_VRF
 vlan_interfaces:
 - name: Vlan4093
   description: MLAG_PEER_L3_PEERING
   shutdown: false
   mtu: 9214
-  ip_address: 10.10.224.0/31
+  ip_address: 10.10.224.1/30
 - name: Vlan4094
   description: MLAG_PEER
   shutdown: false
-  ip_address: 10.10.255.0/31
+  ip_address: 10.10.255.1/30
   no_autostate: true
   mtu: 9214
+- name: Vlan10
+  tenant: TEST_MLAG_SAME_SUBNET_ON_VRF
+  description: VLAN10
+  shutdown: true
+  ip_address_virtual: 10.10.10.1/24
+  vrf: TEST
+- name: Vlan3000
+  tenant: TEST_MLAG_SAME_SUBNET_ON_VRF
+  type: underlay_peering
+  shutdown: false
+  description: 'MLAG_PEER_L3_iBGP: vrf TEST'
+  vrf: TEST
+  mtu: 9214
+  ip_address: 10.10.224.1/30
 port_channel_interfaces:
 - name: Port-Channel5
   description: MLAG_PEER_MLAG_SAME_SUBNET_L3LEAF1B_Po5
@@ -133,7 +187,7 @@ ethernet_interfaces:
 mlag_configuration:
   domain_id: MLAG_SAME_SUBNET_L3LEAF1
   local_interface: Vlan4094
-  peer_address: 10.10.255.1
+  peer_address: 10.10.255.2
   peer_link: Port-Channel5
   reload_delay_mlag: '300'
   reload_delay_non_mlag: '330'
@@ -174,6 +228,7 @@ router_bfd:
     multiplier: 3
 ip_igmp_snooping:
   globally_enabled: true
+ip_virtual_router_mac_address: 00:1c:73:00:00:99
 vxlan_interface:
   Vxlan1:
     description: MLAG_SAME_SUBNET_L3LEAF1A_VTEP
@@ -181,3 +236,9 @@ vxlan_interface:
       udp_port: 4789
       source_interface: Loopback1
       virtual_router_encapsulation_mac_address: mlag-system-id
+      vlans:
+      - id: 10
+        vni: 10
+      vrfs:
+      - name: TEST
+        vni: 1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG_SAME_SUBNET_L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG_SAME_SUBNET_L3LEAF1B.yml
@@ -42,7 +42,7 @@ router_bgp:
     - name: EVPN-OVERLAY-PEERS
       activate: false
   neighbors:
-  - ip_address: 10.10.224.0
+  - ip_address: 10.10.224.1
     peer_group: MLAG-IPv4-UNDERLAY-PEER
     peer: MLAG_SAME_SUBNET_L3LEAF1A
     description: MLAG_SAME_SUBNET_L3LEAF1A
@@ -53,6 +53,35 @@ router_bgp:
     peer_groups:
     - name: EVPN-OVERLAY-PEERS
       activate: true
+  vrfs:
+  - name: TEST
+    router_id: 192.168.255.33
+    rd: 192.168.255.33:1
+    route_targets:
+      import:
+      - address_family: evpn
+        route_targets:
+        - '1:1'
+      export:
+      - address_family: evpn
+        route_targets:
+        - '1:1'
+    redistribute_routes:
+    - source_protocol: connected
+    neighbors:
+    - ip_address: 10.10.224.1
+      peer_group: MLAG-IPv4-UNDERLAY-PEER
+    updates:
+      wait_install: true
+  vlans:
+  - id: 10
+    tenant: TEST_MLAG_SAME_SUBNET_ON_VRF
+    rd: 192.168.255.33:10
+    route_targets:
+      both:
+      - '10:10'
+    redistribute_routes:
+    - learned
 service_routing_protocols_model: multi-agent
 ip_routing: true
 vlan_internal_order:
@@ -63,6 +92,9 @@ vlan_internal_order:
 vrfs:
 - name: MGMT
   ip_routing: false
+- name: TEST
+  tenant: TEST_MLAG_SAME_SUBNET_ON_VRF
+  ip_routing: true
 management_interfaces:
 - name: Management1
   description: oob_management
@@ -88,18 +120,40 @@ vlans:
   name: MLAG_PEER
   trunk_groups:
   - MLAG
+- id: 10
+  name: VLAN10
+  tenant: TEST_MLAG_SAME_SUBNET_ON_VRF
+- id: 3000
+  name: MLAG_iBGP_TEST
+  trunk_groups:
+  - LEAF_PEER_L3
+  tenant: TEST_MLAG_SAME_SUBNET_ON_VRF
 vlan_interfaces:
 - name: Vlan4093
   description: MLAG_PEER_L3_PEERING
   shutdown: false
   mtu: 9214
-  ip_address: 10.10.224.1/31
+  ip_address: 10.10.224.2/30
 - name: Vlan4094
   description: MLAG_PEER
   shutdown: false
-  ip_address: 10.10.255.1/31
+  ip_address: 10.10.255.2/30
   no_autostate: true
   mtu: 9214
+- name: Vlan10
+  tenant: TEST_MLAG_SAME_SUBNET_ON_VRF
+  description: VLAN10
+  shutdown: true
+  ip_address_virtual: 10.10.10.1/24
+  vrf: TEST
+- name: Vlan3000
+  tenant: TEST_MLAG_SAME_SUBNET_ON_VRF
+  type: underlay_peering
+  shutdown: false
+  description: 'MLAG_PEER_L3_iBGP: vrf TEST'
+  vrf: TEST
+  mtu: 9214
+  ip_address: 10.10.224.2/30
 port_channel_interfaces:
 - name: Port-Channel5
   description: MLAG_PEER_MLAG_SAME_SUBNET_L3LEAF1A_Po5
@@ -133,7 +187,7 @@ ethernet_interfaces:
 mlag_configuration:
   domain_id: MLAG_SAME_SUBNET_L3LEAF1
   local_interface: Vlan4094
-  peer_address: 10.10.255.0
+  peer_address: 10.10.255.1
   peer_link: Port-Channel5
   reload_delay_mlag: '300'
   reload_delay_non_mlag: '330'
@@ -174,6 +228,7 @@ router_bfd:
     multiplier: 3
 ip_igmp_snooping:
   globally_enabled: true
+ip_virtual_router_mac_address: 00:1c:73:00:00:99
 vxlan_interface:
   Vxlan1:
     description: MLAG_SAME_SUBNET_L3LEAF1B_VTEP
@@ -181,3 +236,9 @@ vxlan_interface:
       udp_port: 4789
       source_interface: Loopback1
       virtual_router_encapsulation_mac_address: mlag-system-id
+      vlans:
+      - id: 10
+        vni: 10
+      vrfs:
+      - name: TEST
+        vni: 1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG_SAME_SUBNET_L3LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG_SAME_SUBNET_L3LEAF2A.yml
@@ -42,7 +42,7 @@ router_bgp:
     - name: EVPN-OVERLAY-PEERS
       activate: false
   neighbors:
-  - ip_address: 10.10.224.1
+  - ip_address: 10.10.224.2
     peer_group: MLAG-IPv4-UNDERLAY-PEER
     peer: MLAG_SAME_SUBNET_L3LEAF2B
     description: MLAG_SAME_SUBNET_L3LEAF2B
@@ -53,6 +53,35 @@ router_bgp:
     peer_groups:
     - name: EVPN-OVERLAY-PEERS
       activate: true
+  vrfs:
+  - name: TEST
+    router_id: 192.168.255.34
+    rd: 192.168.255.34:1
+    route_targets:
+      import:
+      - address_family: evpn
+        route_targets:
+        - '1:1'
+      export:
+      - address_family: evpn
+        route_targets:
+        - '1:1'
+    redistribute_routes:
+    - source_protocol: connected
+    neighbors:
+    - ip_address: 10.10.224.2
+      peer_group: MLAG-IPv4-UNDERLAY-PEER
+    updates:
+      wait_install: true
+  vlans:
+  - id: 10
+    tenant: TEST_MLAG_SAME_SUBNET_ON_VRF
+    rd: 192.168.255.34:10
+    route_targets:
+      both:
+      - '10:10'
+    redistribute_routes:
+    - learned
 service_routing_protocols_model: multi-agent
 ip_routing: true
 vlan_internal_order:
@@ -63,6 +92,9 @@ vlan_internal_order:
 vrfs:
 - name: MGMT
   ip_routing: false
+- name: TEST
+  tenant: TEST_MLAG_SAME_SUBNET_ON_VRF
+  ip_routing: true
 management_interfaces:
 - name: Management1
   description: oob_management
@@ -88,18 +120,40 @@ vlans:
   name: MLAG_PEER
   trunk_groups:
   - MLAG
+- id: 10
+  name: VLAN10
+  tenant: TEST_MLAG_SAME_SUBNET_ON_VRF
+- id: 3000
+  name: MLAG_iBGP_TEST
+  trunk_groups:
+  - LEAF_PEER_L3
+  tenant: TEST_MLAG_SAME_SUBNET_ON_VRF
 vlan_interfaces:
 - name: Vlan4093
   description: MLAG_PEER_L3_PEERING
   shutdown: false
   mtu: 9214
-  ip_address: 10.10.224.0/31
+  ip_address: 10.10.224.1/30
 - name: Vlan4094
   description: MLAG_PEER
   shutdown: false
-  ip_address: 10.10.255.0/31
+  ip_address: 10.10.255.1/30
   no_autostate: true
   mtu: 9214
+- name: Vlan10
+  tenant: TEST_MLAG_SAME_SUBNET_ON_VRF
+  description: VLAN10
+  shutdown: true
+  ip_address_virtual: 10.10.10.1/24
+  vrf: TEST
+- name: Vlan3000
+  tenant: TEST_MLAG_SAME_SUBNET_ON_VRF
+  type: underlay_peering
+  shutdown: false
+  description: 'MLAG_PEER_L3_iBGP: vrf TEST'
+  vrf: TEST
+  mtu: 9214
+  ip_address: 10.10.224.1/30
 port_channel_interfaces:
 - name: Port-Channel5
   description: MLAG_PEER_MLAG_SAME_SUBNET_L3LEAF2B_Po5
@@ -133,7 +187,7 @@ ethernet_interfaces:
 mlag_configuration:
   domain_id: MLAG_SAME_SUBNET_L3LEAF2
   local_interface: Vlan4094
-  peer_address: 10.10.255.1
+  peer_address: 10.10.255.2
   peer_link: Port-Channel5
   reload_delay_mlag: '300'
   reload_delay_non_mlag: '330'
@@ -174,6 +228,7 @@ router_bfd:
     multiplier: 3
 ip_igmp_snooping:
   globally_enabled: true
+ip_virtual_router_mac_address: 00:1c:73:00:00:99
 vxlan_interface:
   Vxlan1:
     description: MLAG_SAME_SUBNET_L3LEAF2A_VTEP
@@ -181,3 +236,9 @@ vxlan_interface:
       udp_port: 4789
       source_interface: Loopback1
       virtual_router_encapsulation_mac_address: mlag-system-id
+      vlans:
+      - id: 10
+        vni: 10
+      vrfs:
+      - name: TEST
+        vni: 1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG_SAME_SUBNET_L3LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG_SAME_SUBNET_L3LEAF2B.yml
@@ -42,7 +42,7 @@ router_bgp:
     - name: EVPN-OVERLAY-PEERS
       activate: false
   neighbors:
-  - ip_address: 10.10.224.0
+  - ip_address: 10.10.224.1
     peer_group: MLAG-IPv4-UNDERLAY-PEER
     peer: MLAG_SAME_SUBNET_L3LEAF2A
     description: MLAG_SAME_SUBNET_L3LEAF2A
@@ -53,6 +53,35 @@ router_bgp:
     peer_groups:
     - name: EVPN-OVERLAY-PEERS
       activate: true
+  vrfs:
+  - name: TEST
+    router_id: 192.168.255.35
+    rd: 192.168.255.35:1
+    route_targets:
+      import:
+      - address_family: evpn
+        route_targets:
+        - '1:1'
+      export:
+      - address_family: evpn
+        route_targets:
+        - '1:1'
+    redistribute_routes:
+    - source_protocol: connected
+    neighbors:
+    - ip_address: 10.10.224.1
+      peer_group: MLAG-IPv4-UNDERLAY-PEER
+    updates:
+      wait_install: true
+  vlans:
+  - id: 10
+    tenant: TEST_MLAG_SAME_SUBNET_ON_VRF
+    rd: 192.168.255.35:10
+    route_targets:
+      both:
+      - '10:10'
+    redistribute_routes:
+    - learned
 service_routing_protocols_model: multi-agent
 ip_routing: true
 vlan_internal_order:
@@ -63,6 +92,9 @@ vlan_internal_order:
 vrfs:
 - name: MGMT
   ip_routing: false
+- name: TEST
+  tenant: TEST_MLAG_SAME_SUBNET_ON_VRF
+  ip_routing: true
 management_interfaces:
 - name: Management1
   description: oob_management
@@ -88,18 +120,40 @@ vlans:
   name: MLAG_PEER
   trunk_groups:
   - MLAG
+- id: 10
+  name: VLAN10
+  tenant: TEST_MLAG_SAME_SUBNET_ON_VRF
+- id: 3000
+  name: MLAG_iBGP_TEST
+  trunk_groups:
+  - LEAF_PEER_L3
+  tenant: TEST_MLAG_SAME_SUBNET_ON_VRF
 vlan_interfaces:
 - name: Vlan4093
   description: MLAG_PEER_L3_PEERING
   shutdown: false
   mtu: 9214
-  ip_address: 10.10.224.1/31
+  ip_address: 10.10.224.2/30
 - name: Vlan4094
   description: MLAG_PEER
   shutdown: false
-  ip_address: 10.10.255.1/31
+  ip_address: 10.10.255.2/30
   no_autostate: true
   mtu: 9214
+- name: Vlan10
+  tenant: TEST_MLAG_SAME_SUBNET_ON_VRF
+  description: VLAN10
+  shutdown: true
+  ip_address_virtual: 10.10.10.1/24
+  vrf: TEST
+- name: Vlan3000
+  tenant: TEST_MLAG_SAME_SUBNET_ON_VRF
+  type: underlay_peering
+  shutdown: false
+  description: 'MLAG_PEER_L3_iBGP: vrf TEST'
+  vrf: TEST
+  mtu: 9214
+  ip_address: 10.10.224.2/30
 port_channel_interfaces:
 - name: Port-Channel5
   description: MLAG_PEER_MLAG_SAME_SUBNET_L3LEAF2A_Po5
@@ -133,7 +187,7 @@ ethernet_interfaces:
 mlag_configuration:
   domain_id: MLAG_SAME_SUBNET_L3LEAF2
   local_interface: Vlan4094
-  peer_address: 10.10.255.0
+  peer_address: 10.10.255.1
   peer_link: Port-Channel5
   reload_delay_mlag: '300'
   reload_delay_non_mlag: '330'
@@ -174,6 +228,7 @@ router_bfd:
     multiplier: 3
 ip_igmp_snooping:
   globally_enabled: true
+ip_virtual_router_mac_address: 00:1c:73:00:00:99
 vxlan_interface:
   Vxlan1:
     description: MLAG_SAME_SUBNET_L3LEAF2B_VTEP
@@ -181,3 +236,9 @@ vxlan_interface:
       udp_port: 4789
       source_interface: Loopback1
       virtual_router_encapsulation_mac_address: mlag-system-id
+      vlans:
+      - id: 10
+        vni: 10
+      vrfs:
+      - name: TEST
+        vni: 1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/P2P-UPLINKS-IPV4-PREFIX-LENGTH.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/P2P-UPLINKS-IPV4-PREFIX-LENGTH.yml
@@ -1,0 +1,105 @@
+hostname: P2P-UPLINKS-IPV4-PREFIX-LENGTH
+is_deployed: true
+router_bgp:
+  as: '65123'
+  router_id: 10.254.254.32
+  bgp:
+    default:
+      ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
+  updates:
+    wait_install: true
+  peer_groups:
+  - name: IPv4-UNDERLAY-PEERS
+    type: ipv4
+    maximum_routes: 12000
+    send_community: all
+  - name: EVPN-OVERLAY-PEERS
+    type: evpn
+    update_source: Loopback0
+    bfd: true
+    send_community: all
+    maximum_routes: 0
+    ebgp_multihop: 3
+    next_hop_unchanged: true
+  address_family_ipv4:
+    peer_groups:
+    - name: IPv4-UNDERLAY-PEERS
+      activate: true
+    - name: EVPN-OVERLAY-PEERS
+      activate: false
+  redistribute_routes:
+  - source_protocol: connected
+    route_map: RM-CONN-2-BGP
+  neighbors:
+  - ip_address: 10.254.255.249
+    peer_group: IPv4-UNDERLAY-PEERS
+    remote_as: '923'
+    description: MLAG_ODD_ID_L3LEAF1A_Ethernet10
+  - ip_address: 10.254.255.253
+    peer_group: IPv4-UNDERLAY-PEERS
+    remote_as: '923'
+    description: MLAG_ODD_ID_L3LEAF1B_Ethernet10
+  address_family_evpn:
+    peer_groups:
+    - name: EVPN-OVERLAY-PEERS
+      activate: true
+service_routing_protocols_model: multi-agent
+ip_routing: true
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+spanning_tree:
+  mode: none
+vrfs:
+- name: MGMT
+  ip_routing: false
+management_api_http:
+  enable_vrfs:
+  - name: MGMT
+  enable_https: true
+ethernet_interfaces:
+- name: Ethernet1
+  peer: MLAG_ODD_ID_L3LEAF1A
+  peer_interface: Ethernet10
+  peer_type: l3leaf
+  description: P2P_LINK_TO_MLAG_ODD_ID_L3LEAF1A_Ethernet10
+  shutdown: false
+  mtu: 9214
+  type: routed
+  ip_address: 10.254.255.250/30
+- name: Ethernet2
+  peer: MLAG_ODD_ID_L3LEAF1B
+  peer_interface: Ethernet10
+  peer_type: l3leaf
+  description: P2P_LINK_TO_MLAG_ODD_ID_L3LEAF1B_Ethernet10
+  shutdown: false
+  mtu: 9214
+  type: routed
+  ip_address: 10.254.255.254/30
+loopback_interfaces:
+- name: Loopback0
+  description: EVPN_Overlay_Peering
+  shutdown: false
+  ip_address: 10.254.254.32/32
+prefix_lists:
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 10.254.254.0/24 eq 32
+route_maps:
+- name: RM-CONN-2-BGP
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    match:
+    - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+router_bfd:
+  multihop:
+    interval: 300
+    min_rx: 300
+    multiplier: 3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/P2P-UPLINKS-IPV4-PREFIX-LENGTH.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/P2P-UPLINKS-IPV4-PREFIX-LENGTH.yml
@@ -37,10 +37,12 @@ router_bgp:
   - ip_address: 10.254.255.249
     peer_group: IPv4-UNDERLAY-PEERS
     remote_as: '923'
+    peer: MLAG_ODD_ID_L3LEAF1A
     description: MLAG_ODD_ID_L3LEAF1A_Ethernet10
   - ip_address: 10.254.255.253
     peer_group: IPv4-UNDERLAY-PEERS
     remote_as: '923'
+    peer: MLAG_ODD_ID_L3LEAF1B
     description: MLAG_ODD_ID_L3LEAF1B_Ethernet10
   address_family_evpn:
     peer_groups:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/FABRIC_IP_ADDRESSING.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/FABRIC_IP_ADDRESSING.yml
@@ -1,4 +1,3 @@
 ---
 fabric_name: FABRIC_IP_ADDRESSING
-mlag_support: true
 type: l3leaf

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/MLAG_OSPF_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/MLAG_OSPF_TESTS.yml
@@ -1,6 +1,5 @@
 ---
 underlay_routing_protocol: ospf
-mlag_support: true
 
 type: l3leaf
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/MLAG_SAME_SUBNET.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/MLAG_SAME_SUBNET.yml
@@ -2,15 +2,17 @@
 fabric_ip_addressing:
   mlag:
     algorithm: "same_subnet"
+    ipv4_prefix_length: 30
 l3leaf:
   defaults:
-    mlag_peer_ipv4_pool: 10.10.255.0/31
-    mlag_peer_l3_ipv4_pool: 10.10.224.0/31
+    mlag_peer_ipv4_pool: 10.10.255.0/30
+    mlag_peer_l3_ipv4_pool: 10.10.224.0/30
     loopback_ipv4_pool: 192.168.255.0/24
     loopback_ipv4_offset: 32
     vtep_loopback_ipv4_pool: 192.168.254.0/24
     platform: vEOS-LAB
     mlag_interfaces: [Ethernet5, Ethernet6]
+    virtual_router_mac_address: 00:1c:73:00:00:99
   node_groups:
     - group: MLAG_SAME_SUBNET_L3LEAF1
       bgp_as: 923
@@ -30,3 +32,13 @@ l3leaf:
         - name: MLAG_SAME_SUBNET_L3LEAF2B
           id: 3
           mgmt_ip: 192.168.201.119/24
+tenants:
+  - name: TEST_MLAG_SAME_SUBNET_ON_VRF
+    mac_vrf_vni_base: 0
+    vrfs:
+      - name: TEST
+        vrf_id: 1
+        svis:
+          - id: 10
+            name: VLAN10
+            ip_address_virtual: 10.10.10.1/24

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/P2P-UPLINKS-IPV4-PREFIX-LENGTH.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/P2P-UPLINKS-IPV4-PREFIX-LENGTH.yml
@@ -1,0 +1,15 @@
+fabric_ip_addressing:
+  p2p_uplinks:
+    ipv4_prefix_length: 30
+
+type: overlay-controller
+overlay_controller:
+  nodes:
+    - name: P2P-UPLINKS-IPV4-PREFIX-LENGTH
+      bgp_as: 65123
+      uplink_switches: [MLAG_ODD_ID_L3LEAF1A, MLAG_ODD_ID_L3LEAF1B]
+      uplink_switch_interfaces: [Ethernet10, Ethernet10]
+      uplink_interfaces: [Ethernet1, Ethernet2]
+      loopback_ipv4_pool: 10.254.254.0/24
+      uplink_ipv4_pool: 10.254.255.0/24
+      id: 32

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
@@ -71,6 +71,8 @@ all:
                 MLAG_SAME_SUBNET_L3LEAF1B:
                 MLAG_SAME_SUBNET_L3LEAF2A:
                 MLAG_SAME_SUBNET_L3LEAF2B:
+          hosts:
+            P2P-UPLINKS-IPV4-PREFIX-LENGTH:
         NODE_TYPE_OVERRIDES_TESTS:
           children:
             OVERRIDE_VTEP_LEAFS:

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_facts/uplinks.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_facts/uplinks.py
@@ -229,6 +229,7 @@ class UplinksMixin:
                 if self.shared_utils.underlay_rfc5549:
                     uplink["ipv6_enable"] = True
                 else:
+                    uplink["prefix_length"] = self.shared_utils.fabric_ip_addressing_p2p_uplinks_ipv4_prefix_length
                     uplink["ip_address"] = self.shared_utils.ip_addressing.p2p_uplinks_ip(uplink_index)
                     uplink["peer_ip_address"] = self.shared_utils.ip_addressing.p2p_uplinks_peer_ip(uplink_index)
 

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/misc.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/misc.py
@@ -235,6 +235,10 @@ class MiscMixin:
         return get(self.hostvars, "fabric_ip_addressing.mlag.algorithm", default="first_id")
 
     @cached_property
+    def fabric_ip_addressing_mlag_ipv4_prefix_length(self: SharedUtils) -> int:
+        return get(self.hostvars, "fabric_ip_addressing.mlag.ipv4_prefix_length", default=31)
+
+    @cached_property
     def fabric_sflow_uplinks(self: SharedUtils) -> bool | None:
         return get(self.hostvars, "fabric_sflow.uplinks")
 

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/misc.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/misc.py
@@ -239,6 +239,10 @@ class MiscMixin:
         return get(self.hostvars, "fabric_ip_addressing.mlag.ipv4_prefix_length", default=31)
 
     @cached_property
+    def fabric_ip_addressing_p2p_uplinks_ipv4_prefix_length(self: SharedUtils) -> int:
+        return get(self.hostvars, "fabric_ip_addressing.p2p_uplinks.ipv4_prefix_length", default=31)
+
+    @cached_property
     def fabric_sflow_uplinks(self: SharedUtils) -> bool | None:
         return get(self.hostvars, "fabric_sflow.uplinks")
 

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/fabric-ip-addressing.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/fabric-ip-addressing.md
@@ -9,7 +9,10 @@
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
     | [<samp>fabric_ip_addressing</samp>](## "fabric_ip_addressing") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;mlag</samp>](## "fabric_ip_addressing.mlag") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;algorithm</samp>](## "fabric_ip_addressing.mlag.algorithm") | String |  | `first_id` | Valid Values:<br>- <code>first_id</code><br>- <code>odd_id</code><br>- <code>same_subnet</code> | This variable defines the Multi-chassis Link Aggregation (MLAG) algorithm used.<br>Each MLAG link will have a /31 subnet with each subnet allocated from the relevant MLAG pool via a calculated offset.<br>The offset is calculated using one of the following algorithms:<br>  - first_id: `(mlag_primary_id - 1) * 2` where `mlag_primary_id` is the ID of the first node defined under the node_group.<br>    This allocation method will skip every other /31 subnet making it less space efficient than `odd_id`.<br>  - odd_id: `(odd_id - 1) / 2`. Requires the node_group to have a node with an odd ID and a node with an even ID.<br>  - same_subnet: the offset will always be zero.<br>    This allocation method will cause every MLAG link to be addressed with the same /31 subnet.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;algorithm</samp>](## "fabric_ip_addressing.mlag.algorithm") | String |  | `first_id` | Valid Values:<br>- <code>first_id</code><br>- <code>odd_id</code><br>- <code>same_subnet</code> | This variable defines the Multi-chassis Link Aggregation (MLAG) algorithm used.<br>Each MLAG link will have a /31* subnet with each subnet allocated from the relevant MLAG pool via a calculated offset.<br>The offset is calculated using one of the following algorithms:<br>  - first_id: `(mlag_primary_id - 1) * 2` where `mlag_primary_id` is the ID of the first node defined under the node_group.<br>    This allocation method will skip every other /31* subnet making it less space efficient than `odd_id`.<br>  - odd_id: `(odd_id - 1) / 2`. Requires the node_group to have a node with an odd ID and a node with an even ID.<br>  - same_subnet: the offset will always be zero.<br>    This allocation method will cause every MLAG link to be addressed with the same /31* subnet.<br>\* - The prefix length is configurable with a default of /31. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv4_prefix_length</samp>](## "fabric_ip_addressing.mlag.ipv4_prefix_length") | Integer |  | `31` |  | IPv4 prefix length used for MLAG peer-vlan and L3 point-to-point SVIs over the MLAG peer-link. |
+    | [<samp>&nbsp;&nbsp;p2p_uplinks</samp>](## "fabric_ip_addressing.p2p_uplinks") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv4_prefix_length</samp>](## "fabric_ip_addressing.p2p_uplinks.ipv4_prefix_length") | Integer |  | `31` |  | IPv4 prefix length used for L3 point-to-point uplinks. |
 
 === "YAML"
 
@@ -18,12 +21,20 @@
       mlag:
 
         # This variable defines the Multi-chassis Link Aggregation (MLAG) algorithm used.
-        # Each MLAG link will have a /31 subnet with each subnet allocated from the relevant MLAG pool via a calculated offset.
+        # Each MLAG link will have a /31* subnet with each subnet allocated from the relevant MLAG pool via a calculated offset.
         # The offset is calculated using one of the following algorithms:
         #   - first_id: `(mlag_primary_id - 1) * 2` where `mlag_primary_id` is the ID of the first node defined under the node_group.
-        #     This allocation method will skip every other /31 subnet making it less space efficient than `odd_id`.
+        #     This allocation method will skip every other /31* subnet making it less space efficient than `odd_id`.
         #   - odd_id: `(odd_id - 1) / 2`. Requires the node_group to have a node with an odd ID and a node with an even ID.
         #   - same_subnet: the offset will always be zero.
-        #     This allocation method will cause every MLAG link to be addressed with the same /31 subnet.
+        #     This allocation method will cause every MLAG link to be addressed with the same /31* subnet.
+        # \* - The prefix length is configurable with a default of /31.
         algorithm: <str; "first_id" | "odd_id" | "same_subnet"; default="first_id">
+
+        # IPv4 prefix length used for MLAG peer-vlan and L3 point-to-point SVIs over the MLAG peer-link.
+        ipv4_prefix_length: <int; default=31>
+      p2p_uplinks:
+
+        # IPv4 prefix length used for L3 point-to-point uplinks.
+        ipv4_prefix_length: <int; default=31>
     ```

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/fabric-ip-addressing.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/fabric-ip-addressing.md
@@ -10,9 +10,9 @@
     | [<samp>fabric_ip_addressing</samp>](## "fabric_ip_addressing") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;mlag</samp>](## "fabric_ip_addressing.mlag") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;algorithm</samp>](## "fabric_ip_addressing.mlag.algorithm") | String |  | `first_id` | Valid Values:<br>- <code>first_id</code><br>- <code>odd_id</code><br>- <code>same_subnet</code> | This variable defines the Multi-chassis Link Aggregation (MLAG) algorithm used.<br>Each MLAG link will have a /31* subnet with each subnet allocated from the relevant MLAG pool via a calculated offset.<br>The offset is calculated using one of the following algorithms:<br>  - first_id: `(mlag_primary_id - 1) * 2` where `mlag_primary_id` is the ID of the first node defined under the node_group.<br>    This allocation method will skip every other /31* subnet making it less space efficient than `odd_id`.<br>  - odd_id: `(odd_id - 1) / 2`. Requires the node_group to have a node with an odd ID and a node with an even ID.<br>  - same_subnet: the offset will always be zero.<br>    This allocation method will cause every MLAG link to be addressed with the same /31* subnet.<br>\* - The prefix length is configurable with a default of /31. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv4_prefix_length</samp>](## "fabric_ip_addressing.mlag.ipv4_prefix_length") | Integer |  | `31` |  | IPv4 prefix length used for MLAG peer-vlan and L3 point-to-point SVIs over the MLAG peer-link. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv4_prefix_length</samp>](## "fabric_ip_addressing.mlag.ipv4_prefix_length") | Integer |  | `31` | Min: 1<br>Max: 31 | IPv4 prefix length used for MLAG peer-vlan and L3 point-to-point SVIs over the MLAG peer-link. |
     | [<samp>&nbsp;&nbsp;p2p_uplinks</samp>](## "fabric_ip_addressing.p2p_uplinks") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv4_prefix_length</samp>](## "fabric_ip_addressing.p2p_uplinks.ipv4_prefix_length") | Integer |  | `31` |  | IPv4 prefix length used for L3 point-to-point uplinks. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv4_prefix_length</samp>](## "fabric_ip_addressing.p2p_uplinks.ipv4_prefix_length") | Integer |  | `31` | Min: 1<br>Max: 31 | IPv4 prefix length used for L3 point-to-point uplinks. |
 
 === "YAML"
 
@@ -32,9 +32,9 @@
         algorithm: <str; "first_id" | "odd_id" | "same_subnet"; default="first_id">
 
         # IPv4 prefix length used for MLAG peer-vlan and L3 point-to-point SVIs over the MLAG peer-link.
-        ipv4_prefix_length: <int; default=31>
+        ipv4_prefix_length: <int; 1-31; default=31>
       p2p_uplinks:
 
         # IPv4 prefix length used for L3 point-to-point uplinks.
-        ipv4_prefix_length: <int; default=31>
+        ipv4_prefix_length: <int; 1-31; default=31>
     ```

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/ip_addressing/avdipaddressing.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/ip_addressing/avdipaddressing.py
@@ -37,21 +37,23 @@ class AvdIpAddressing(AvdFacts, UtilsMixin):
         Different addressing algorithms:
             - first_id: offset from pool is `(mlag_primary_id - 1) * 2`
             - odd_id: offset from pool is `(odd_id - 1) * 2`. Requires MLAG pair to have a node with odd and a node with an even ID
-            - same_subnet: offset from pool is always 0. All MLAG pairs will be the same /31. Requires pool to be a /31
+            - same_subnet: offset from pool is always 0. All MLAG pairs will be using the same subnet (default /31).
+              Requires the pool to have the same prefix length.
         """
+        prefixlen = self._fabric_ip_addressing_mlag_ipv4_prefix_length
         if self._fabric_ipaddress_mlag_algorithm == "odd_id":
             offset = self._mlag_odd_id_based_offset
-            return get_ip_from_pool(pool, 31, offset, ip_offset)
+            return get_ip_from_pool(pool, prefixlen, offset, ip_offset)
 
         if self._fabric_ipaddress_mlag_algorithm == "same_subnet":
             pool_network = ipaddress.ip_network(pool, strict=False)
-            if pool_network.prefixlen != 31:
-                raise AristaAvdError("MLAG same_subnet addressing requires the pool to be a /31")
-            return get_ip_from_pool(pool, 31, 0, ip_offset)
+            if pool_network.prefixlen != prefixlen:
+                raise AristaAvdError(f"MLAG same_subnet addressing requires the pool to be a /{prefixlen}")
+            return get_ip_from_pool(pool, prefixlen, 0, ip_offset)
 
         # Use default first_id
         offset = self._mlag_primary_id - 1
-        return get_ip_from_pool(pool, 31, offset, ip_offset)
+        return get_ip_from_pool(pool, prefixlen, offset, ip_offset)
 
     def mlag_ibgp_peering_ip_primary(self, mlag_ibgp_peering_ipv4_pool: str) -> str:
         """

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/ip_addressing/avdipaddressing.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/ip_addressing/avdipaddressing.py
@@ -157,8 +157,9 @@ class AvdIpAddressing(AvdFacts, UtilsMixin):
                 uplink_switch_index=uplink_switch_index,
             )
 
+        prefixlen = self._fabric_ip_addressing_p2p_uplinks_ipv4_prefix_length
         offset = ((self._id - 1) * self._max_uplink_switches * self._max_parallel_uplinks) + uplink_switch_index
-        return get_ip_from_pool(self._uplink_ipv4_pool, 31, offset, 1)
+        return get_ip_from_pool(self._uplink_ipv4_pool, prefixlen, offset, 1)
 
     def p2p_uplinks_peer_ip(self, uplink_switch_index: int) -> str:
         """
@@ -174,8 +175,9 @@ class AvdIpAddressing(AvdFacts, UtilsMixin):
                 uplink_switch_index=uplink_switch_index,
             )
 
+        prefixlen = self._fabric_ip_addressing_p2p_uplinks_ipv4_prefix_length
         offset = ((self._id - 1) * self._max_uplink_switches * self._max_parallel_uplinks) + uplink_switch_index
-        return get_ip_from_pool(self._uplink_ipv4_pool, 31, offset, 0)
+        return get_ip_from_pool(self._uplink_ipv4_pool, prefixlen, offset, 0)
 
     def router_id(self) -> str:
         """

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/ip_addressing/utils.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/ip_addressing/utils.py
@@ -39,6 +39,10 @@ class UtilsMixin:
         return self.shared_utils.fabric_ip_addressing_mlag_ipv4_prefix_length
 
     @cached_property
+    def _fabric_ip_addressing_p2p_uplinks_ipv4_prefix_length(self: "AvdIpAddressing") -> int:
+        return self.shared_utils.fabric_ip_addressing_p2p_uplinks_ipv4_prefix_length
+
+    @cached_property
     def _mlag_peer_ipv4_pool(self: "AvdIpAddressing") -> str:
         return self.shared_utils.mlag_peer_ipv4_pool
 

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/ip_addressing/utils.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/ip_addressing/utils.py
@@ -35,6 +35,10 @@ class UtilsMixin:
         return self.shared_utils.fabric_ip_addressing_mlag_algorithm
 
     @cached_property
+    def _fabric_ip_addressing_mlag_ipv4_prefix_length(self: "AvdIpAddressing") -> int:
+        return self.shared_utils.fabric_ip_addressing_mlag_ipv4_prefix_length
+
+    @cached_property
     def _mlag_peer_ipv4_pool(self: "AvdIpAddressing") -> str:
         return self.shared_utils.mlag_peer_ipv4_pool
 

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/mlag/avdstructuredconfig.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/mlag/avdstructuredconfig.py
@@ -76,7 +76,7 @@ class AvdStructuredConfigMlag(AvdFacts):
             "name": main_vlan_interface_name,
             "description": "MLAG_PEER",
             "shutdown": False,
-            "ip_address": f"{self.shared_utils.mlag_ip}/31",
+            "ip_address": f"{self.shared_utils.mlag_ip}/{self.shared_utils.fabric_ip_addressing_mlag_ipv4_prefix_length}",
             "no_autostate": True,
             "struct_cfg": self.shared_utils.mlag_peer_vlan_structured_config,
             "mtu": self.shared_utils.p2p_uplinks_mtu,
@@ -129,7 +129,7 @@ class AvdStructuredConfigMlag(AvdFacts):
             "mtu": self.shared_utils.p2p_uplinks_mtu,
         }
         if not self.shared_utils.underlay_rfc5549:
-            l3_vlan_interface["ip_address"] = f"{self.shared_utils.mlag_l3_ip}/31"
+            l3_vlan_interface["ip_address"] = f"{self.shared_utils.mlag_l3_ip}/{self.shared_utils.fabric_ip_addressing_mlag_ipv4_prefix_length}"
 
         l3_vlan_interface.update(l3_cfg)
 

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/vlan_interfaces.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/vlan_interfaces.py
@@ -194,10 +194,16 @@ class VlanInterfacesMixin(UtilsMixin):
             vlan_interface_config["ipv6_enable"] = True
         elif (mlag_ibgp_peering_ipv4_pool := vrf.get("mlag_ibgp_peering_ipv4_pool")) is not None:
             if self.shared_utils.mlag_role == "primary":
-                vlan_interface_config["ip_address"] = f"{self.shared_utils.ip_addressing.mlag_ibgp_peering_ip_primary(mlag_ibgp_peering_ipv4_pool)}/31"
+                vlan_interface_config["ip_address"] = (
+                    f"{self.shared_utils.ip_addressing.mlag_ibgp_peering_ip_primary(mlag_ibgp_peering_ipv4_pool)}/"
+                    f"{self.shared_utils.fabric_ip_addressing_mlag_ipv4_prefix_length}"
+                )
             else:
-                vlan_interface_config["ip_address"] = f"{self.shared_utils.ip_addressing.mlag_ibgp_peering_ip_secondary(mlag_ibgp_peering_ipv4_pool)}/31"
+                vlan_interface_config["ip_address"] = (
+                    f"{self.shared_utils.ip_addressing.mlag_ibgp_peering_ip_secondary(mlag_ibgp_peering_ipv4_pool)}/"
+                    f"{self.shared_utils.fabric_ip_addressing_mlag_ipv4_prefix_length}"
+                )
         else:
-            vlan_interface_config["ip_address"] = f"{self.shared_utils.mlag_ibgp_ip}/31"
+            vlan_interface_config["ip_address"] = f"{self.shared_utils.mlag_ibgp_ip}/{self.shared_utils.fabric_ip_addressing_mlag_ipv4_prefix_length}"
 
         return vlan_interface_config

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/ethernet_interfaces.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/ethernet_interfaces.py
@@ -88,7 +88,7 @@ class EthernetInterfacesMixin(UtilsMixin):
                     if "unnumbered" in link["ip_address"].lower():
                         ethernet_interface["ip_address"] = link["ip_address"]
                     else:
-                        ethernet_interface["ip_address"] = f"{link['ip_address']}/31"
+                        ethernet_interface["ip_address"] = f"{link['ip_address']}/{link['prefix_length']}"
 
                 if self.shared_utils.underlay_ospf is True:
                     ethernet_interface["ospf_network_point_to_point"] = True

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/utils.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/utils.py
@@ -68,6 +68,7 @@ class UtilsMixin:
                         "speed": get(uplink, "peer_speed", default=get(uplink, "speed")),
                         "ip_address": get(uplink, "peer_ip_address"),
                         "peer_ip_address": get(uplink, "ip_address"),
+                        "prefix_length": get(uplink, "prefix_length"),
                         "channel_group_id": get(uplink, "peer_channel_group_id"),
                         "peer_channel_group_id": get(uplink, "channel_group_id"),
                         "channel_description": get(uplink, "peer_channel_description"),

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -9153,6 +9153,8 @@
             "ipv4_prefix_length": {
               "type": "integer",
               "default": 31,
+              "minimum": 1,
+              "maximum": 31,
               "description": "IPv4 prefix length used for MLAG peer-vlan and L3 point-to-point SVIs over the MLAG peer-link.",
               "title": "IPv4 Prefix Length"
             }
@@ -9169,6 +9171,8 @@
             "ipv4_prefix_length": {
               "type": "integer",
               "default": 31,
+              "minimum": 1,
+              "maximum": 31,
               "description": "IPv4 prefix length used for L3 point-to-point uplinks.",
               "title": "IPv4 Prefix Length"
             }

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -9142,13 +9142,19 @@
             "algorithm": {
               "type": "string",
               "default": "first_id",
-              "description": "This variable defines the Multi-chassis Link Aggregation (MLAG) algorithm used.\nEach MLAG link will have a /31 subnet with each subnet allocated from the relevant MLAG pool via a calculated offset.\nThe offset is calculated using one of the following algorithms:\n  - first_id: `(mlag_primary_id - 1) * 2` where `mlag_primary_id` is the ID of the first node defined under the node_group.\n    This allocation method will skip every other /31 subnet making it less space efficient than `odd_id`.\n  - odd_id: `(odd_id - 1) / 2`. Requires the node_group to have a node with an odd ID and a node with an even ID.\n  - same_subnet: the offset will always be zero.\n    This allocation method will cause every MLAG link to be addressed with the same /31 subnet.\n",
+              "description": "This variable defines the Multi-chassis Link Aggregation (MLAG) algorithm used.\nEach MLAG link will have a /31* subnet with each subnet allocated from the relevant MLAG pool via a calculated offset.\nThe offset is calculated using one of the following algorithms:\n  - first_id: `(mlag_primary_id - 1) * 2` where `mlag_primary_id` is the ID of the first node defined under the node_group.\n    This allocation method will skip every other /31* subnet making it less space efficient than `odd_id`.\n  - odd_id: `(odd_id - 1) / 2`. Requires the node_group to have a node with an odd ID and a node with an even ID.\n  - same_subnet: the offset will always be zero.\n    This allocation method will cause every MLAG link to be addressed with the same /31* subnet.\n\\* - The prefix length is configurable with a default of /31.",
               "enum": [
                 "first_id",
                 "odd_id",
                 "same_subnet"
               ],
               "title": "Algorithm"
+            },
+            "ipv4_prefix_length": {
+              "type": "integer",
+              "default": 31,
+              "description": "IPv4 prefix length used for MLAG peer-vlan and L3 point-to-point SVIs over the MLAG peer-link.",
+              "title": "IPv4 Prefix Length"
             }
           },
           "additionalProperties": false,
@@ -9156,6 +9162,22 @@
             "^_.+$": {}
           },
           "title": "MLAG"
+        },
+        "p2p_uplinks": {
+          "type": "object",
+          "properties": {
+            "ipv4_prefix_length": {
+              "type": "integer",
+              "default": 31,
+              "description": "IPv4 prefix length used for L3 point-to-point uplinks.",
+              "title": "IPv4 Prefix Length"
+            }
+          },
+          "additionalProperties": false,
+          "patternProperties": {
+            "^_.+$": {}
+          },
+          "title": "P2P Uplinks"
         }
       },
       "additionalProperties": false,

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
@@ -1048,20 +1048,37 @@ keys:
             type: str
             default: first_id
             description: "This variable defines the Multi-chassis Link Aggregation
-              (MLAG) algorithm used.\nEach MLAG link will have a /31 subnet with each
-              subnet allocated from the relevant MLAG pool via a calculated offset.\nThe
+              (MLAG) algorithm used.\nEach MLAG link will have a /31* subnet with
+              each subnet allocated from the relevant MLAG pool via a calculated offset.\nThe
               offset is calculated using one of the following algorithms:\n  - first_id:
               `(mlag_primary_id - 1) * 2` where `mlag_primary_id` is the ID of the
               first node defined under the node_group.\n    This allocation method
-              will skip every other /31 subnet making it less space efficient than
+              will skip every other /31* subnet making it less space efficient than
               `odd_id`.\n  - odd_id: `(odd_id - 1) / 2`. Requires the node_group to
               have a node with an odd ID and a node with an even ID.\n  - same_subnet:
               the offset will always be zero.\n    This allocation method will cause
-              every MLAG link to be addressed with the same /31 subnet.\n"
+              every MLAG link to be addressed with the same /31* subnet.\n\\* - The
+              prefix length is configurable with a default of /31."
             valid_values:
             - first_id
             - odd_id
             - same_subnet
+          ipv4_prefix_length:
+            type: int
+            default: 31
+            convert_types:
+            - str
+            description: IPv4 prefix length used for MLAG peer-vlan and L3 point-to-point
+              SVIs over the MLAG peer-link.
+      p2p_uplinks:
+        type: dict
+        keys:
+          ipv4_prefix_length:
+            type: int
+            default: 31
+            convert_types:
+            - str
+            description: IPv4 prefix length used for L3 point-to-point uplinks.
   fabric_name:
     documentation_options:
       table: fabric-topology

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
@@ -1066,6 +1066,8 @@ keys:
           ipv4_prefix_length:
             type: int
             default: 31
+            min: 1
+            max: 31
             convert_types:
             - str
             description: IPv4 prefix length used for MLAG peer-vlan and L3 point-to-point
@@ -1076,6 +1078,8 @@ keys:
           ipv4_prefix_length:
             type: int
             default: 31
+            min: 1
+            max: 31
             convert_types:
             - str
             description: IPv4 prefix length used for L3 point-to-point uplinks.

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/fabric_ip_addressing.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/fabric_ip_addressing.schema.yml
@@ -32,6 +32,8 @@ keys:
           ipv4_prefix_length:
             type: int
             default: 31
+            min: 1
+            max: 31
             convert_types:
               - str
             description: IPv4 prefix length used for MLAG peer-vlan and L3 point-to-point SVIs over the MLAG peer-link.
@@ -41,6 +43,8 @@ keys:
           ipv4_prefix_length:
             type: int
             default: 31
+            min: 1
+            max: 31
             convert_types:
               - str
             description: IPv4 prefix length used for L3 point-to-point uplinks.

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/fabric_ip_addressing.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/fabric_ip_addressing.schema.yml
@@ -15,16 +15,32 @@ keys:
           algorithm:
             type: str
             default: "first_id"
-            description: |
+            description: |-
               This variable defines the Multi-chassis Link Aggregation (MLAG) algorithm used.
-              Each MLAG link will have a /31 subnet with each subnet allocated from the relevant MLAG pool via a calculated offset.
+              Each MLAG link will have a /31* subnet with each subnet allocated from the relevant MLAG pool via a calculated offset.
               The offset is calculated using one of the following algorithms:
                 - first_id: `(mlag_primary_id - 1) * 2` where `mlag_primary_id` is the ID of the first node defined under the node_group.
-                  This allocation method will skip every other /31 subnet making it less space efficient than `odd_id`.
+                  This allocation method will skip every other /31* subnet making it less space efficient than `odd_id`.
                 - odd_id: `(odd_id - 1) / 2`. Requires the node_group to have a node with an odd ID and a node with an even ID.
                 - same_subnet: the offset will always be zero.
-                  This allocation method will cause every MLAG link to be addressed with the same /31 subnet.
+                  This allocation method will cause every MLAG link to be addressed with the same /31* subnet.
+              \* - The prefix length is configurable with a default of /31.
             valid_values:
               - "first_id"
               - "odd_id"
               - "same_subnet"
+          ipv4_prefix_length:
+            type: int
+            default: 31
+            convert_types:
+              - str
+            description: IPv4 prefix length used for MLAG peer-vlan and L3 point-to-point SVIs over the MLAG peer-link.
+      p2p_uplinks:
+        type: dict
+        keys:
+          ipv4_prefix_length:
+            type: int
+            default: 31
+            convert_types:
+              - str
+            description: IPv4 prefix length used for L3 point-to-point uplinks.

--- a/ansible_collections/arista/avd/tests/unit/plugins/plugin_utils/utils/test_get_ip_from_pool.py
+++ b/ansible_collections/arista/avd/tests/unit/plugins/plugin_utils/utils/test_get_ip_from_pool.py
@@ -33,7 +33,7 @@ def test_get_ip_from_pool_invalid(pool, prefixlen, subnet_offset, ip_offset, exp
     "pool, prefixlen, subnet_offset, ip_offset, expected",
     [
         ("1.2.3.0/31", PREFIXLEN, SUBNET_OFFSET, IP_OFFSET, "1.2.3.1"),
-        (POOL, 25, SUBNET_OFFSET, IP_OFFSET, "1.2.3.128"),
+        (POOL, 25, SUBNET_OFFSET, IP_OFFSET, "1.2.3.129"),
         (POOL, PREFIXLEN, 0, IP_OFFSET, "1.2.3.0"),
         (POOL, PREFIXLEN, 255, IP_OFFSET, "1.2.3.255"),
         (POOL, 31, SUBNET_OFFSET, 1, "1.2.3.3"),


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Custom prefix length for P2P uplinks and MLAG

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

Added to existing model.

```yaml
fabric_ip_addressing:
  mlag:
    algorithm: <str>
    ipv4_prefix_length: <int> # <-- new
  p2p_uplinks:                # <-- new
    ipv4_prefix_length: <int> # <-- new
```

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Added molecule coverage for both scenarios.
No other changes seen in molecule tests.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
