### PR TITLE
Feat(eos_designs): Set spanning-tree priority per VLAN

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/spanning-tree-mode-rapid-pvst.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/spanning-tree-mode-rapid-pvst.cfg
@@ -1,0 +1,53 @@
+!RANCID-CONTENT-TYPE: arista
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname spanning-tree-mode-rapid-pvst
+!
+spanning-tree mode rapid-pvst
+spanning-tree vlan-id 1-10,13-20,23-4093 priority 8192
+spanning-tree vlan-id 11,21 priority 16384
+spanning-tree vlan-id 12,22 priority 32768
+!
+no enable password
+no aaa root
+!
+vlan 10
+   name DEFAULTPRIORITY
+!
+vlan 11
+   name PRIORITY16384
+!
+vlan 12
+   name PRIORITY32768
+!
+vlan 13
+   name PRIORITY8192
+!
+vlan 20
+   name DEFAULTPRIORITY
+!
+vlan 21
+   name PRIORITY16384
+!
+vlan 22
+   name PRIORITY32768
+!
+vlan 23
+   name PRIORITY8192
+!
+vrf instance MGMT
+no ip routing vrf MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/spanning-tree-mode-rapid-pvst.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/spanning-tree-mode-rapid-pvst.yml
@@ -1,0 +1,51 @@
+hostname: spanning-tree-mode-rapid-pvst
+is_deployed: true
+service_routing_protocols_model: multi-agent
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+spanning_tree:
+  mode: rapid-pvst
+  rapid_pvst_instances:
+  - id: 11,21
+    priority: 16384
+  - id: 12,22
+    priority: 32768
+  - id: 1-10,13-20,23-4093
+    priority: 8192
+vrfs:
+- name: MGMT
+  ip_routing: false
+management_api_http:
+  enable_vrfs:
+  - name: MGMT
+  enable_https: true
+vlans:
+- id: 10
+  name: DEFAULTPRIORITY
+  tenant: test
+- id: 11
+  name: PRIORITY16384
+  tenant: test
+- id: 12
+  name: PRIORITY32768
+  tenant: test
+- id: 13
+  name: PRIORITY8192
+  tenant: test
+- id: 20
+  name: DEFAULTPRIORITY
+  tenant: test
+- id: 21
+  name: PRIORITY16384
+  tenant: test
+- id: 22
+  name: PRIORITY32768
+  tenant: test
+- id: 23
+  name: PRIORITY8192
+  tenant: test
+ip_igmp_snooping:
+  globally_enabled: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/spanning-tree-mode-rapid-pvst.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/spanning-tree-mode-rapid-pvst.yml
@@ -1,0 +1,36 @@
+type: l2leaf
+
+l2leaf:
+  nodes:
+    - name: spanning-tree-mode-rapid-pvst
+      spanning_tree_mode: rapid-pvst
+      spanning_tree_priority: 8192
+
+tenants:
+  - name: test
+    vrfs:
+      - name: test
+        svis:
+          - id: 10
+            name: DEFAULTPRIORITY
+          - id: 11
+            name: PRIORITY16384
+            spanning_tree_priority: 16384
+          - id: 12
+            name: PRIORITY32768
+            spanning_tree_priority: 32768
+          - id: 13
+            name: PRIORITY8192
+            spanning_tree_priority: 8192
+    l2vlans:
+      - id: 20
+        name: DEFAULTPRIORITY
+      - id: 21
+        name: PRIORITY16384
+        spanning_tree_priority: 16384
+      - id: 22
+        name: PRIORITY32768
+        spanning_tree_priority: 32768
+      - id: 23
+        name: PRIORITY8192
+        spanning_tree_priority: 8192

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
@@ -31,6 +31,7 @@ all:
             default_interface_mtu_platform:
             evpn-to-ipvpn-gateway:
             vrfs_rd_rt_override:
+            spanning-tree-mode-rapid-pvst:
         OVERRIDE_UPLINK_TYPE:
           hosts:
             override_uplink_type-d:

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-l2vlans-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-l2vlans-settings.md
@@ -18,6 +18,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tags</samp>](## "<network_services_keys.name>.[].l2vlans.[].tags") | List, items: String |  |  |  | Tags leveraged for networks services filtering.<br>Tags are matched against filter.tags defined under node type settings.<br>Tags are also matched against the node_group name under node type settings.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<network_services_keys.name>.[].l2vlans.[].tags.[]") | String |  | `all` |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vxlan</samp>](## "<network_services_keys.name>.[].l2vlans.[].vxlan") | Boolean |  | `True` |  | Extend this L2VLAN over VXLAN. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;spanning_tree_priority</samp>](## "<network_services_keys.name>.[].l2vlans.[].spanning_tree_priority") | Integer |  |  |  | Setting spanning-tree priority per VLAN is only supported with `spanning_tree_mode: rapid-pvst` under node type settings.<br>The default priority for rapid-PVST is set under the node type settings with `spanning_tree_priority` (default=32768). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;evpn_vlan_bundle</samp>](## "<network_services_keys.name>.[].l2vlans.[].evpn_vlan_bundle") | String |  |  |  | Name of a bundle defined under 'evpn_vlan_bundles' to inherit configuration.<br>To use this option the common "evpn_vlan_aware_bundles" option must be set to true.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;trunk_groups</samp>](## "<network_services_keys.name>.[].l2vlans.[].trunk_groups") | List, items: String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<network_services_keys.name>.[].l2vlans.[].trunk_groups.[]") | String |  |  |  | Trunk groups are used for limiting vlans to trunk ports assigned to the same trunk group.<br>Requires enable_trunk_groups: true.<br> |
@@ -74,6 +75,10 @@
 
             # Extend this L2VLAN over VXLAN.
             vxlan: <bool; default=True>
+
+            # Setting spanning-tree priority per VLAN is only supported with `spanning_tree_mode: rapid-pvst` under node type settings.
+            # The default priority for rapid-PVST is set under the node type settings with `spanning_tree_priority` (default=32768).
+            spanning_tree_priority: <int>
 
             # Name of a bundle defined under 'evpn_vlan_bundles' to inherit configuration.
             # To use this option the common "evpn_vlan_aware_bundles" option must be set to true.

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-svis-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-svis-settings.md
@@ -47,6 +47,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;trunk_groups</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].trunk_groups") | List, items: String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].trunk_groups.[]") | String |  |  |  | Trunk groups are used for limiting vlans to trunk ports assigned to the same trunk group.<br>Requires "enable_trunk_groups: true".<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vxlan</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].vxlan") | Boolean |  | `True` |  | Extend this SVI over VXLAN. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;spanning_tree_priority</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].spanning_tree_priority") | Integer |  |  |  | Setting spanning-tree priority per VLAN is only supported with `spanning_tree_mode: rapid-pvst` under node type settings.<br>The default priority for rapid-PVST is set under the node type settings with `spanning_tree_priority` (default=32768). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mtu</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].mtu") | Integer |  |  |  | Interface MTU. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bgp</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].bgp") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;structured_config</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].bgp.structured_config") | Dictionary |  |  |  | Structured configuration and EOS CLI commands rendered on router_bgp.vlans.[id=<vlan>]<br>This configuration will not be applied to vlan aware bundles<br> |
@@ -78,6 +79,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;trunk_groups</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].trunk_groups") | List, items: String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].trunk_groups.[]") | String |  |  |  | Trunk groups are used for limiting vlans to trunk ports assigned to the same trunk group.<br>Requires "enable_trunk_groups: true".<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vxlan</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].vxlan") | Boolean |  | `True` |  | Extend this SVI over VXLAN. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;spanning_tree_priority</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].spanning_tree_priority") | Integer |  |  |  | Setting spanning-tree priority per VLAN is only supported with `spanning_tree_mode: rapid-pvst` under node type settings.<br>The default priority for rapid-PVST is set under the node type settings with `spanning_tree_priority` (default=32768). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mtu</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].mtu") | Integer |  |  |  | Interface MTU. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bgp</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].bgp") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;structured_config</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].bgp.structured_config") | Dictionary |  |  |  | Structured configuration and EOS CLI commands rendered on router_bgp.vlans.[id=<vlan>]<br>This configuration will not be applied to vlan aware bundles<br> |
@@ -248,6 +250,10 @@
                     # Extend this SVI over VXLAN.
                     vxlan: <bool; default=True>
 
+                    # Setting spanning-tree priority per VLAN is only supported with `spanning_tree_mode: rapid-pvst` under node type settings.
+                    # The default priority for rapid-PVST is set under the node type settings with `spanning_tree_priority` (default=32768).
+                    spanning_tree_priority: <int>
+
                     # Interface MTU.
                     mtu: <int>
                     bgp:
@@ -366,6 +372,10 @@
 
                 # Extend this SVI over VXLAN.
                 vxlan: <bool; default=True>
+
+                # Setting spanning-tree priority per VLAN is only supported with `spanning_tree_mode: rapid-pvst` under node type settings.
+                # The default priority for rapid-PVST is set under the node type settings with `spanning_tree_priority` (default=32768).
+                spanning_tree_priority: <int>
 
                 # Interface MTU.
                 mtu: <int>

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/node-type-l2-mlag-configuration.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/node-type-l2-mlag-configuration.md
@@ -26,7 +26,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mlag_port_channel_id</samp>](## "<node_type_keys.key>.defaults.mlag_port_channel_id") | Integer |  |  |  | If not set, the mlag port-channel id is generated based on the digits of the first interface present in 'mlag_interfaces'.<br>Valid port-channel id numbers are < 1-2000 > for EOS < 4.25.0F and < 1 - 999999 > for EOS >= 4.25.0F.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mlag_domain_id</samp>](## "<node_type_keys.key>.defaults.mlag_domain_id") | String |  |  |  | MLAG Domain ID. If not set the node group name (Set with "group" key) will be used. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;spanning_tree_mode</samp>](## "<node_type_keys.key>.defaults.spanning_tree_mode") | String |  |  | Valid Values:<br>- <code>mstp</code><br>- <code>rstp</code><br>- <code>rapid-pvst</code><br>- <code>none</code> |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;spanning_tree_priority</samp>](## "<node_type_keys.key>.defaults.spanning_tree_priority") | Integer |  | `32768` |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;spanning_tree_priority</samp>](## "<node_type_keys.key>.defaults.spanning_tree_priority") | Integer |  | `32768` |  | Spanning-tree priority configured for the selected mode.<br>For `rapid-pvst` the priority can also be set per VLAN under network services. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;spanning_tree_root_super</samp>](## "<node_type_keys.key>.defaults.spanning_tree_root_super") | Boolean |  | `False` |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;virtual_router_mac_address</samp>](## "<node_type_keys.key>.defaults.virtual_router_mac_address") | String |  |  | Format: mac | Virtual router mac address for anycast gateway. |
     | [<samp>&nbsp;&nbsp;node_groups</samp>](## "<node_type_keys.key>.node_groups") | List, items: Dictionary |  |  |  | Define variables related to all nodes part of this group. |
@@ -50,7 +50,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_port_channel_id</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].mlag_port_channel_id") | Integer |  |  |  | If not set, the mlag port-channel id is generated based on the digits of the first interface present in 'mlag_interfaces'.<br>Valid port-channel id numbers are < 1-2000 > for EOS < 4.25.0F and < 1 - 999999 > for EOS >= 4.25.0F.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_domain_id</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].mlag_domain_id") | String |  |  |  | MLAG Domain ID. If not set the node group name (Set with "group" key) will be used. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;spanning_tree_mode</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].spanning_tree_mode") | String |  |  | Valid Values:<br>- <code>mstp</code><br>- <code>rstp</code><br>- <code>rapid-pvst</code><br>- <code>none</code> |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;spanning_tree_priority</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].spanning_tree_priority") | Integer |  | `32768` |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;spanning_tree_priority</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].spanning_tree_priority") | Integer |  | `32768` |  | Spanning-tree priority configured for the selected mode.<br>For `rapid-pvst` the priority can also be set per VLAN under network services. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;spanning_tree_root_super</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].spanning_tree_root_super") | Boolean |  | `False` |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;virtual_router_mac_address</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].virtual_router_mac_address") | String |  |  | Format: mac | Virtual router mac address for anycast gateway. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_port_channel_structured_config</samp>](## "<node_type_keys.key>.node_groups.[].mlag_port_channel_structured_config") | Dictionary |  |  |  | Custom structured config applied to MLAG peer link port-channel id.<br>Added under port_channel_interfaces.[name=<interface>] for eos_cli_config_gen.<br>Overrides the settings on the port-channel interface level.<br>"mlag_port_channel_structured_config" is applied after "structured_config", so it can override "structured_config" defined on node-level.<br> |
@@ -70,7 +70,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_port_channel_id</samp>](## "<node_type_keys.key>.node_groups.[].mlag_port_channel_id") | Integer |  |  |  | If not set, the mlag port-channel id is generated based on the digits of the first interface present in 'mlag_interfaces'.<br>Valid port-channel id numbers are < 1-2000 > for EOS < 4.25.0F and < 1 - 999999 > for EOS >= 4.25.0F.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_domain_id</samp>](## "<node_type_keys.key>.node_groups.[].mlag_domain_id") | String |  |  |  | MLAG Domain ID. If not set the node group name (Set with "group" key) will be used. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;spanning_tree_mode</samp>](## "<node_type_keys.key>.node_groups.[].spanning_tree_mode") | String |  |  | Valid Values:<br>- <code>mstp</code><br>- <code>rstp</code><br>- <code>rapid-pvst</code><br>- <code>none</code> |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;spanning_tree_priority</samp>](## "<node_type_keys.key>.node_groups.[].spanning_tree_priority") | Integer |  | `32768` |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;spanning_tree_priority</samp>](## "<node_type_keys.key>.node_groups.[].spanning_tree_priority") | Integer |  | `32768` |  | Spanning-tree priority configured for the selected mode.<br>For `rapid-pvst` the priority can also be set per VLAN under network services. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;spanning_tree_root_super</samp>](## "<node_type_keys.key>.node_groups.[].spanning_tree_root_super") | Boolean |  | `False` |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;virtual_router_mac_address</samp>](## "<node_type_keys.key>.node_groups.[].virtual_router_mac_address") | String |  |  | Format: mac | Virtual router mac address for anycast gateway. |
     | [<samp>&nbsp;&nbsp;nodes</samp>](## "<node_type_keys.key>.nodes") | List, items: Dictionary |  |  |  | Define variables per node. |
@@ -92,7 +92,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_port_channel_id</samp>](## "<node_type_keys.key>.nodes.[].mlag_port_channel_id") | Integer |  |  |  | If not set, the mlag port-channel id is generated based on the digits of the first interface present in 'mlag_interfaces'.<br>Valid port-channel id numbers are < 1-2000 > for EOS < 4.25.0F and < 1 - 999999 > for EOS >= 4.25.0F.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_domain_id</samp>](## "<node_type_keys.key>.nodes.[].mlag_domain_id") | String |  |  |  | MLAG Domain ID. If not set the node group name (Set with "group" key) will be used. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;spanning_tree_mode</samp>](## "<node_type_keys.key>.nodes.[].spanning_tree_mode") | String |  |  | Valid Values:<br>- <code>mstp</code><br>- <code>rstp</code><br>- <code>rapid-pvst</code><br>- <code>none</code> |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;spanning_tree_priority</samp>](## "<node_type_keys.key>.nodes.[].spanning_tree_priority") | Integer |  | `32768` |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;spanning_tree_priority</samp>](## "<node_type_keys.key>.nodes.[].spanning_tree_priority") | Integer |  | `32768` |  | Spanning-tree priority configured for the selected mode.<br>For `rapid-pvst` the priority can also be set per VLAN under network services. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;spanning_tree_root_super</samp>](## "<node_type_keys.key>.nodes.[].spanning_tree_root_super") | Boolean |  | `False` |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;virtual_router_mac_address</samp>](## "<node_type_keys.key>.nodes.[].virtual_router_mac_address") | String |  |  | Format: mac | Virtual router mac address for anycast gateway. |
 
@@ -165,6 +165,9 @@
         # MLAG Domain ID. If not set the node group name (Set with "group" key) will be used.
         mlag_domain_id: <str>
         spanning_tree_mode: <str; "mstp" | "rstp" | "rapid-pvst" | "none">
+
+        # Spanning-tree priority configured for the selected mode.
+        # For `rapid-pvst` the priority can also be set per VLAN under network services.
         spanning_tree_priority: <int; default=32768>
         spanning_tree_root_super: <bool; default=False>
 
@@ -245,6 +248,9 @@
               # MLAG Domain ID. If not set the node group name (Set with "group" key) will be used.
               mlag_domain_id: <str>
               spanning_tree_mode: <str; "mstp" | "rstp" | "rapid-pvst" | "none">
+
+              # Spanning-tree priority configured for the selected mode.
+              # For `rapid-pvst` the priority can also be set per VLAN under network services.
               spanning_tree_priority: <int; default=32768>
               spanning_tree_root_super: <bool; default=False>
 
@@ -312,6 +318,9 @@
           # MLAG Domain ID. If not set the node group name (Set with "group" key) will be used.
           mlag_domain_id: <str>
           spanning_tree_mode: <str; "mstp" | "rstp" | "rapid-pvst" | "none">
+
+          # Spanning-tree priority configured for the selected mode.
+          # For `rapid-pvst` the priority can also be set per VLAN under network services.
           spanning_tree_priority: <int; default=32768>
           spanning_tree_root_super: <bool; default=False>
 
@@ -385,6 +394,9 @@
           # MLAG Domain ID. If not set the node group name (Set with "group" key) will be used.
           mlag_domain_id: <str>
           spanning_tree_mode: <str; "mstp" | "rstp" | "rapid-pvst" | "none">
+
+          # Spanning-tree priority configured for the selected mode.
+          # For `rapid-pvst` the priority can also be set per VLAN under network services.
           spanning_tree_priority: <int; default=32768>
           spanning_tree_root_super: <bool; default=False>
 

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/svi-profiles.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/svi-profiles.md
@@ -38,6 +38,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;trunk_groups</samp>](## "svi_profiles.[].nodes.[].trunk_groups") | List, items: String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "svi_profiles.[].nodes.[].trunk_groups.[]") | String |  |  |  | Trunk groups are used for limiting vlans to trunk ports assigned to the same trunk group.<br>Requires "enable_trunk_groups: true".<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vxlan</samp>](## "svi_profiles.[].nodes.[].vxlan") | Boolean |  | `True` |  | Extend this SVI over VXLAN. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;spanning_tree_priority</samp>](## "svi_profiles.[].nodes.[].spanning_tree_priority") | Integer |  |  |  | Setting spanning-tree priority per VLAN is only supported with `spanning_tree_mode: rapid-pvst` under node type settings.<br>The default priority for rapid-PVST is set under the node type settings with `spanning_tree_priority` (default=32768). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mtu</samp>](## "svi_profiles.[].nodes.[].mtu") | Integer |  |  |  | Interface MTU. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bgp</samp>](## "svi_profiles.[].nodes.[].bgp") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;structured_config</samp>](## "svi_profiles.[].nodes.[].bgp.structured_config") | Dictionary |  |  |  | Structured configuration and EOS CLI commands rendered on router_bgp.vlans.[id=<vlan>]<br>This configuration will not be applied to vlan aware bundles<br> |
@@ -70,6 +71,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trunk_groups</samp>](## "svi_profiles.[].trunk_groups") | List, items: String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "svi_profiles.[].trunk_groups.[]") | String |  |  |  | Trunk groups are used for limiting vlans to trunk ports assigned to the same trunk group.<br>Requires "enable_trunk_groups: true".<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vxlan</samp>](## "svi_profiles.[].vxlan") | Boolean |  | `True` |  | Extend this SVI over VXLAN. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;spanning_tree_priority</samp>](## "svi_profiles.[].spanning_tree_priority") | Integer |  |  |  | Setting spanning-tree priority per VLAN is only supported with `spanning_tree_mode: rapid-pvst` under node type settings.<br>The default priority for rapid-PVST is set under the node type settings with `spanning_tree_priority` (default=32768). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mtu</samp>](## "svi_profiles.[].mtu") | Integer |  |  |  | Interface MTU. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;bgp</samp>](## "svi_profiles.[].bgp") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;structured_config</samp>](## "svi_profiles.[].bgp.structured_config") | Dictionary |  |  |  | Structured configuration and EOS CLI commands rendered on router_bgp.vlans.[id=<vlan>]<br>This configuration will not be applied to vlan aware bundles<br> |
@@ -210,6 +212,10 @@
             # Extend this SVI over VXLAN.
             vxlan: <bool; default=True>
 
+            # Setting spanning-tree priority per VLAN is only supported with `spanning_tree_mode: rapid-pvst` under node type settings.
+            # The default priority for rapid-PVST is set under the node type settings with `spanning_tree_priority` (default=32768).
+            spanning_tree_priority: <int>
+
             # Interface MTU.
             mtu: <int>
             bgp:
@@ -331,6 +337,10 @@
 
         # Extend this SVI over VXLAN.
         vxlan: <bool; default=True>
+
+        # Setting spanning-tree priority per VLAN is only supported with `spanning_tree_mode: rapid-pvst` under node type settings.
+        # The default priority for rapid-PVST is set under the node type settings with `spanning_tree_priority` (default=32768).
+        spanning_tree_priority: <int>
 
         # Interface MTU.
         mtu: <int>

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/base/avdstructuredconfig.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/base/avdstructuredconfig.py
@@ -417,7 +417,8 @@ class AvdStructuredConfigBase(AvdFacts, NtpMixin, SnmpServerMixin):
             if spanning_tree_mode == "mstp":
                 spanning_tree["mst_instances"] = [{"id": "0", "priority": priority}]
             elif spanning_tree_mode == "rapid-pvst":
-                spanning_tree["rapid_pvst_instances"] = [{"id": "1-4094", "priority": priority}]
+                pass
+                # Per vlan spanning-tree priorities are set under network-services.
             elif spanning_tree_mode == "rstp":
                 spanning_tree["rstp_priority"] = priority
 

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/avdstructuredconfig.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/avdstructuredconfig.py
@@ -18,6 +18,7 @@ from .router_isis import RouterIsisMixin
 from .router_multicast import RouterMulticastMixin
 from .router_ospf import RouterOspfMixin
 from .router_pim_sparse_mode import RouterPimSparseModeMixin
+from .spanning_tree import SpanningTreeMixin
 from .standard_access_lists import StandardAccessListsMixin
 from .static_routes import StaticRoutesMixin
 from .struct_cfgs import StructCfgsMixin
@@ -30,6 +31,7 @@ from .vxlan_interface import VxlanInterfaceMixin
 
 class AvdStructuredConfigNetworkServices(
     AvdFacts,
+    SpanningTreeMixin,
     PatchPanelMixin,
     VlansMixin,
     IpIgmpSnoopingMixin,

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/spanning_tree.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/spanning_tree.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2023 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the LICENSE file.
+from __future__ import annotations
+
+from functools import cached_property
+
+from ansible_collections.arista.avd.plugins.filter.list_compress import list_compress
+from ansible_collections.arista.avd.plugins.plugin_utils.utils import get
+from ansible_collections.arista.avd.roles.eos_designs.python_modules.network_services.utils import UtilsMixin
+
+
+class SpanningTreeMixin(UtilsMixin):
+    """
+    Mixin Class used to generate structured config for one key.
+    Class should only be used as Mixin to a AvdStructuredConfig class
+    """
+
+    @cached_property
+    def spanning_tree(self) -> dict | None:
+        """
+        spanning_tree priorities set per VLAN if spanning_tree mode is "rapid-pvst"
+        """
+        if not self.shared_utils.network_services_l2:
+            return None
+
+        spanning_tree_mode = get(self.shared_utils.switch_data_combined, "spanning_tree_mode")
+        if spanning_tree_mode != "rapid-pvst":
+            return None
+
+        default_priority = int(get(self.shared_utils.switch_data_combined, "spanning_tree_priority", default=32768))
+
+        vlan_stp_priorities = {}
+        non_default_vlans = set()
+        for tenant in self._filtered_tenants:
+            for vrf in tenant["vrfs"]:
+                for svi in vrf["svis"]:
+                    if (priority := get(svi, "spanning_tree_priority")) is None:
+                        continue
+                    vlan_stp_priorities.setdefault(priority, set()).add(svi["id"])
+                    non_default_vlans.add(svi["id"])
+            for l2vlan in tenant["l2vlans"]:
+                if (priority := get(l2vlan, "spanning_tree_priority")) is None:
+                    continue
+                vlan_stp_priorities.setdefault(priority, set()).add(l2vlan["id"])
+                non_default_vlans.add(l2vlan["id"])
+
+        if not non_default_vlans:
+            # Quick return with only default
+            return {"rapid_pvst_instances": [{"id": "1-4094", "priority": default_priority}]}
+
+        default_vlans = non_default_vlans.symmetric_difference(range(1, 4094))
+        vlan_stp_priorities.setdefault(default_priority, set()).update(default_vlans)
+        return {
+            "rapid_pvst_instances": [
+                {
+                    "id": list_compress(list(vlans)),
+                    "priority": priority,
+                }
+                for priority, vlans in vlan_stp_priorities.items()
+            ]
+        }

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -27081,6 +27081,11 @@
                   "description": "Extend this SVI over VXLAN.",
                   "title": "VxLAN"
                 },
+                "spanning_tree_priority": {
+                  "type": "integer",
+                  "description": "Setting spanning-tree priority per VLAN is only supported with `spanning_tree_mode: rapid-pvst` under node type settings.\nThe default priority for rapid-PVST is set under the node type settings with `spanning_tree_priority` (default=32768).",
+                  "title": "Spanning Tree Priority"
+                },
                 "mtu": {
                   "type": "integer",
                   "description": "Interface MTU.",
@@ -28712,6 +28717,11 @@
             "default": true,
             "description": "Extend this SVI over VXLAN.",
             "title": "VxLAN"
+          },
+          "spanning_tree_priority": {
+            "type": "integer",
+            "description": "Setting spanning-tree priority per VLAN is only supported with `spanning_tree_mode: rapid-pvst` under node type settings.\nThe default priority for rapid-PVST is set under the node type settings with `spanning_tree_priority` (default=32768).",
+            "title": "Spanning Tree Priority"
           },
           "mtu": {
             "type": "integer",

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
@@ -5201,6 +5201,15 @@ $defs:
                 type: bool
                 default: true
                 description: Extend this L2VLAN over VXLAN.
+              spanning_tree_priority:
+                type: int
+                convert_types:
+                - str
+                description: 'Setting spanning-tree priority per VLAN is only supported
+                  with `spanning_tree_mode: rapid-pvst` under node type settings.
+
+                  The default priority for rapid-PVST is set under the node type settings
+                  with `spanning_tree_priority` (default=32768).'
               evpn_vlan_bundle:
                 type: str
                 description: 'Name of a bundle defined under ''evpn_vlan_bundles''
@@ -6293,6 +6302,10 @@ $defs:
             convert_types:
             - str
             default: 32768
+            description: 'Spanning-tree priority configured for the selected mode.
+
+              For `rapid-pvst` the priority can also be set per VLAN under network
+              services.'
           spanning_tree_root_super:
             documentation_options:
               table: node-type-l2-mlag-configuration
@@ -7175,6 +7188,15 @@ $defs:
         type: bool
         default: true
         description: Extend this SVI over VXLAN.
+      spanning_tree_priority:
+        type: int
+        convert_types:
+        - str
+        description: 'Setting spanning-tree priority per VLAN is only supported with
+          `spanning_tree_mode: rapid-pvst` under node type settings.
+
+          The default priority for rapid-PVST is set under the node type settings
+          with `spanning_tree_priority` (default=32768).'
       mtu:
         type: int
         convert_types:

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/defs_network_services.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/defs_network_services.schema.yml
@@ -1040,6 +1040,13 @@ $defs:
                 type: bool
                 default: true
                 description: Extend this L2VLAN over VXLAN.
+              spanning_tree_priority:
+                type: int
+                convert_types:
+                  - str
+                description: |-
+                  Setting spanning-tree priority per VLAN is only supported with `spanning_tree_mode: rapid-pvst` under node type settings.
+                  The default priority for rapid-PVST is set under the node type settings with `spanning_tree_priority` (default=32768).
               evpn_vlan_bundle:
                 type: str
                 description: |

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/defs_node_type.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/defs_node_type.schema.yml
@@ -753,6 +753,9 @@ $defs:
             convert_types:
               - str
             default: 32768
+            description: |-
+              Spanning-tree priority configured for the selected mode.
+              For `rapid-pvst` the priority can also be set per VLAN under network services.
           spanning_tree_root_super:
             documentation_options:
               table: node-type-l2-mlag-configuration

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/defs_svi_settings.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/defs_svi_settings.schema.yml
@@ -192,6 +192,13 @@ $defs:
         type: bool
         default: true
         description: Extend this SVI over VXLAN.
+      spanning_tree_priority:
+        type: int
+        convert_types:
+          - str
+        description: |-
+          Setting spanning-tree priority per VLAN is only supported with `spanning_tree_mode: rapid-pvst` under node type settings.
+          The default priority for rapid-PVST is set under the node type settings with `spanning_tree_priority` (default=32768).
       mtu:
         type: int
         convert_types:


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Set spanning-tree priority per VLAN

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

- Allow setting `spanning_tree_priority` under l2vlans and svis for `rapid-pvst` only.
- Update schema doc for node setting to hint to this setting.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

- Added molecule case for rapid-pvst in eos_designs including this new feature.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
