### PR TITLE
Feat(eos_cli_config_gen): Add mtu to Dps interfaces

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/dps-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/dps-interfaces.md
@@ -41,9 +41,9 @@ interface Management1
 
 #### DPS Interfaces Summary
 
-| Interface | IP address | Shutdown | Flow tracker(s) | TCP MSS Ceiling |
-| --------- | ---------- | -------- | --------------- | --------------- |
-| Dps1 | 192.168.42.42/24 | True | Hardware: FT-HW<br>Sampled: FT-S | IPv4: 666<br>IPv6: 666<br>Direction: ingress |
+| Interface | IP address | Shutdown | MTU | Flow tracker(s) | TCP MSS Ceiling |
+| --------- | ---------- | -------- | --- | --------------- | --------------- |
+| Dps1 | 192.168.42.42/24 | True | 666 | Hardware: FT-HW<br>Sampled: FT-S | IPv4: 666<br>IPv6: 666<br>Direction: ingress |
 
 #### DPS Interfaces Device Configuration
 
@@ -52,6 +52,7 @@ interface Management1
 interface Dps1
    description Test DPS Interface
    shutdown
+   mtu 666
    flow tracker hardware FT-HW
    flow tracker sampled FT-S
    ip address 192.168.42.42/24

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/dps-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/dps-interfaces.cfg
@@ -10,6 +10,7 @@ no aaa root
 interface Dps1
    description Test DPS Interface
    shutdown
+   mtu 666
    flow tracker hardware FT-HW
    flow tracker sampled FT-S
    ip address 192.168.42.42/24

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/dps-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/dps-interfaces.yml
@@ -4,6 +4,7 @@ dps_interfaces:
   - name: Dps1
     description: Test DPS Interface
     shutdown: true
+    mtu: 666
     ip_address: 192.168.42.42/24
     flow_tracker:
       hardware: FT-HW

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/dps-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/dps-interfaces.md
@@ -11,6 +11,7 @@
     | [<samp>&nbsp;&nbsp;- name</samp>](## "dps_interfaces.[].name") | String | Required, Unique |  | Valid Values:<br>- Dps1 | "Dps1" is currently the only supported interface. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;description</samp>](## "dps_interfaces.[].description") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;shutdown</samp>](## "dps_interfaces.[].shutdown") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mtu</samp>](## "dps_interfaces.[].mtu") | Integer |  |  | Min: 86<br>Max: 65535 | Maximum Transmission Unit in bytes. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_address</samp>](## "dps_interfaces.[].ip_address") | String |  |  |  | IPv4 address/mask. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;flow_tracker</samp>](## "dps_interfaces.[].flow_tracker") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;sampled</samp>](## "dps_interfaces.[].flow_tracker.sampled") | String |  |  |  | Sampled flow tracker name. |
@@ -28,6 +29,7 @@
       - name: <str>
         description: <str>
         shutdown: <bool>
+        mtu: <int>
         ip_address: <str>
         flow_tracker:
           sampled: <str>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/dps-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/dps-interfaces.md
@@ -11,7 +11,7 @@
     | [<samp>&nbsp;&nbsp;- name</samp>](## "dps_interfaces.[].name") | String | Required, Unique |  | Valid Values:<br>- Dps1 | "Dps1" is currently the only supported interface. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;description</samp>](## "dps_interfaces.[].description") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;shutdown</samp>](## "dps_interfaces.[].shutdown") | Boolean |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mtu</samp>](## "dps_interfaces.[].mtu") | Integer |  |  | Min: 86<br>Max: 65535 | Maximum Transmission Unit in bytes. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mtu</samp>](## "dps_interfaces.[].mtu") | Integer |  |  | Min: 68<br>Max: 65535 | Maximum Transmission Unit in bytes. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_address</samp>](## "dps_interfaces.[].ip_address") | String |  |  |  | IPv4 address/mask. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;flow_tracker</samp>](## "dps_interfaces.[].flow_tracker") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;sampled</samp>](## "dps_interfaces.[].flow_tracker.sampled") | String |  |  |  | Sampled flow tracker name. |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -1555,6 +1555,13 @@
             "type": "boolean",
             "title": "Shutdown"
           },
+          "mtu": {
+            "type": "integer",
+            "description": "Maximum Transmission Unit in bytes.",
+            "minimum": 86,
+            "maximum": 65535,
+            "title": "MTU"
+          },
           "ip_address": {
             "type": "string",
             "description": "IPv4 address/mask.",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -1558,7 +1558,7 @@
           "mtu": {
             "type": "integer",
             "description": "Maximum Transmission Unit in bytes.",
-            "minimum": 86,
+            "minimum": 68,
             "maximum": 65535,
             "title": "MTU"
           },

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -1076,6 +1076,13 @@ keys:
           type: str
         shutdown:
           type: bool
+        mtu:
+          type: int
+          description: Maximum Transmission Unit in bytes.
+          convert_types:
+          - str
+          min: 86
+          max: 65535
         ip_address:
           type: str
           description: IPv4 address/mask.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -1081,7 +1081,7 @@ keys:
           description: Maximum Transmission Unit in bytes.
           convert_types:
           - str
-          min: 86
+          min: 68
           max: 65535
         ip_address:
           type: str

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/dps-interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/dps-interfaces.schema.yml
@@ -24,6 +24,13 @@ keys:
           type: str
         shutdown:
           type: bool
+        mtu:
+          type: int
+          description: Maximum Transmission Unit in bytes.
+          convert_types:
+            - str
+          min: 86
+          max: 65535
         ip_address:
           type: str
           description: IPv4 address/mask.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/dps-interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/dps-interfaces.schema.yml
@@ -29,7 +29,7 @@ keys:
           description: Maximum Transmission Unit in bytes.
           convert_types:
             - str
-          min: 86
+          min: 68
           max: 65535
         ip_address:
           type: str

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/dps-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/dps-interfaces.j2
@@ -10,9 +10,10 @@
 
 #### DPS Interfaces Summary
 
-| Interface | IP address | Shutdown | Flow tracker(s) | TCP MSS Ceiling |
-| --------- | ---------- | -------- | --------------- | --------------- |
+| Interface | IP address | Shutdown | MTU | Flow tracker(s) | TCP MSS Ceiling |
+| --------- | ---------- | -------- | --- | --------------- | --------------- |
 {%     for dps_interface in dps_interfaces | arista.avd.natural_sort('name') %}
+{%         set mtu = dps_interface.mtu | arista.avd.default("-") %}
 {%         set ip_address = dps_interface.ip_address | arista.avd.default("-") %}
 {%         set flow_trackers = [] %}
 {%         if dps_interface.flow_tracker.hardware is arista.avd.defined %}
@@ -32,7 +33,7 @@
 {%         if dps_interface.tcp_mss_ceiling.direction is arista.avd.defined %}
 {%             do tcp_mss_settings.append("Direction: " ~ dps_interface.tcp_mss_ceiling.direction) %}
 {%         endif %}
-| {{ dps_interface.name }} | {{ ip_address }} | {{ shutdown }} | {{ flow_trackers | join("<br>") }} | {{ tcp_mss_settings | join("<br>") }} |
+| {{ dps_interface.name }} | {{ ip_address }} | {{ shutdown }} | {{ mtu }} | {{ flow_trackers | join("<br>") }} | {{ tcp_mss_settings | join("<br>") }} |
 {%     endfor %}
 
 #### DPS Interfaces Device Configuration

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/dps-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/dps-interfaces.j2
@@ -15,6 +15,9 @@ interface {{ dps_interface.name }}
 {%     elif dps_interface.shutdown is arista.avd.defined(false) %}
    no shutdown
 {%     endif %}
+{%     if dps_interface.mtu is arista.avd.defined %}
+   mtu {{ dps_interface.mtu }}
+{%     endif %}
 {%     if dps_interface.flow_tracker.hardware is arista.avd.defined %}
    flow tracker hardware {{ dps_interface.flow_tracker.hardware }}
 {%     endif %}


### PR DESCRIPTION
## Change Summary

Add mtu to Dps interfaces


## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

```
        mtu:
          type: int
          description: Maximum Transmission Unit in bytes.
          convert_types:
          - str
          min: 68
          max: 65535
```

```
ceos2(config-if-Dp1)#mtu ?
  <68-65535>  Maximum transmission unit in bytes
```

## How to test

molecule

## Checklist


### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
