### PR TITLE
Feat(eos_cli_config_gen): Deprecate daemon_terminattr.cvcompression

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/terminattr-extra-flags.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/terminattr-extra-flags.yml
@@ -15,7 +15,6 @@ daemon_terminattr:
   cvproxy: "http://arista:arista@10.10.10.1:3128"
   disable_aaa: true
   grpcaddr: "mgmt/0.0.0.0:6042"
-  cvcompression: gzip
   grpcreadonly: true
   cvconfig: true
   cvsourceintf: Vlan100

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/inventory/host_vars/host1/daemon-terminattr.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/inventory/host_vars/host1/daemon-terminattr.yml
@@ -17,3 +17,5 @@ daemon_terminattr:
         method: "token"
         token_file: "/tmp/tokenDC2"
       cvvrf: mgt
+  # deprecated in 4.4.0. To be removed in 5.0.0
+  cvcompression: gzip

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/daemon-terminattr.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/daemon-terminattr.md
@@ -51,7 +51,7 @@
     | [<samp>&nbsp;&nbsp;sflow</samp>](## "daemon_terminattr.sflow") | Boolean |  |  |  | Enable sFlow provider (TerminAttr default is true).<br> |
     | [<samp>&nbsp;&nbsp;sflowaddr</samp>](## "daemon_terminattr.sflowaddr") | String |  |  |  | ECO sFlow Collector address to listen on to receive sFlow packets (TerminAttr default "127.0.0.1:6343").<br> |
     | [<samp>&nbsp;&nbsp;cvconfig</samp>](## "daemon_terminattr.cvconfig") | Boolean |  |  |  | Subscribe to dynamic device configuration from CloudVision (TerminAttr default is false).<br> |
-    | [<samp>&nbsp;&nbsp;cvcompression</samp>](## "daemon_terminattr.cvcompression") | String |  |  |  | The default compression scheme when streaming to CloudVision is gzip since TerminAttr 1.6.1 and CVP 2019.1.0.<br>There is no need to change the compression scheme. |
+    | [<samp>&nbsp;&nbsp;cvcompression</samp>](## "daemon_terminattr.cvcompression") <span style="color:red">deprecated</span> | String |  |  |  | The default compression scheme when streaming to CloudVision is gzip since TerminAttr 1.6.1 and CVP 2019.1.0.<br>There is no need to change the compression scheme.<span style="color:red">This key is deprecated. Support will be removed in AVD version v5.0.0.</span> |
 
 === "YAML"
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -1385,7 +1385,8 @@
         },
         "cvcompression": {
           "type": "string",
-          "description": "The default compression scheme when streaming to CloudVision is gzip since TerminAttr 1.6.1 and CVP 2019.1.0.\nThere is no need to change the compression scheme.",
+          "description": "The default compression scheme when streaming to CloudVision is gzip since TerminAttr 1.6.1 and CVP 2019.1.0.\nThere is no need to change the compression scheme.\nThis key is deprecated. Support will be removed in AVD version v5.0.0.",
+          "deprecated": true,
           "title": "Cvcompression"
         }
       },

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -974,6 +974,9 @@ keys:
 
           '
       cvcompression:
+        deprecation:
+          warning: true
+          remove_in_version: v5.0.0
         type: str
         description: 'The default compression scheme when streaming to CloudVision
           is gzip since TerminAttr 1.6.1 and CVP 2019.1.0.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/daemon_terminattr.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/daemon_terminattr.schema.yml
@@ -212,6 +212,9 @@ keys:
         description: |
           Subscribe to dynamic device configuration from CloudVision (TerminAttr default is false).
       cvcompression:
+        deprecation:
+          warning: true
+          remove_in_version: v5.0.0
         type: str
         description: |
           The default compression scheme when streaming to CloudVision is gzip since TerminAttr 1.6.1 and CVP 2019.1.0.


### PR DESCRIPTION
## Change Summary

The option is there in the schema but is NOT rendered (nothing in jinja templates) and not used anywhere.
There is no need nowadays to use compression anyway (cf description of the key)


## Component(s) name

`arista.avd.eos_cli_confiig_gen`

## Proposed changes
Deprecate key

## How to test

moved the key to molecule for deprecates variables and checked there is a warning.
Note that not change happens because the key is not used anywhere anyway.

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
