### PR TITLE
Feat(eos_cli_config_gen): LLDP for Management interfaces

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
@@ -530,6 +530,7 @@ interface Ethernet19
    switchport
    no lldp transmit
    no lldp receive
+   lldp tlv transmit ztp vlan 666
 !
 interface Ethernet20
    description Port patched through patch-panel to pseudowire

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-interfaces.md
@@ -44,6 +44,9 @@ interface Management1
 !
 interface Management42
    shutdown
+   no lldp transmit
+   no lldp receive
+   lldp tlv transmit ztp vlan 666
 !
 interface Vlan123
    description inband_management

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
@@ -232,6 +232,7 @@ interface Ethernet19
    switchport
    no lldp transmit
    no lldp receive
+   lldp tlv transmit ztp vlan 666
 !
 interface Ethernet20
    description Port patched through patch-panel to pseudowire

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/management-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/management-interfaces.cfg
@@ -18,6 +18,9 @@ interface Management1
 !
 interface Management42
    shutdown
+   no lldp transmit
+   no lldp receive
+   lldp tlv transmit ztp vlan 666
 !
 interface Vlan123
    description inband_management

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
@@ -326,6 +326,7 @@ ethernet_interfaces:
     lldp:
       transmit: false
       receive: false
+      ztp_vlan: 666
 
   - name: Ethernet20
     description: Port patched through patch-panel to pseudowire

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/management-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/management-interfaces.yml
@@ -19,3 +19,7 @@ management_interfaces:
     eos_cli: "ip virtual-router address 10.73.0.1"
   - name: Management42
     shutdown: true
+    lldp:
+      transmit: false
+      receive: false
+      ztp_vlan: 666

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/management-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/management-interfaces.md
@@ -20,6 +20,10 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;gateway</samp>](## "management_interfaces.[].gateway") | String |  |  |  | IPv4 address of default gateway in management VRF |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_gateway</samp>](## "management_interfaces.[].ipv6_gateway") | String |  |  |  | IPv6 address of default gateway in management VRF |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mac_address</samp>](## "management_interfaces.[].mac_address") | String |  |  |  | MAC address |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;lldp</samp>](## "management_interfaces.[].lldp") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;transmit</samp>](## "management_interfaces.[].lldp.transmit") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;receive</samp>](## "management_interfaces.[].lldp.receive") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ztp_vlan</samp>](## "management_interfaces.[].lldp.ztp_vlan") | Integer |  |  |  | ZTP vlan number |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;eos_cli</samp>](## "management_interfaces.[].eos_cli") | String |  |  |  | Multiline EOS CLI rendered directly on the management interface in the final EOS configuration |
 
 === "YAML"
@@ -38,5 +42,9 @@
         gateway: <str>
         ipv6_gateway: <str>
         mac_address: <str>
+        lldp:
+          transmit: <bool>
+          receive: <bool>
+          ztp_vlan: <int>
         eos_cli: <str>
     ```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -8325,6 +8325,29 @@
             "description": "MAC address",
             "title": "MAC Address"
           },
+          "lldp": {
+            "type": "object",
+            "properties": {
+              "transmit": {
+                "type": "boolean",
+                "title": "Transmit"
+              },
+              "receive": {
+                "type": "boolean",
+                "title": "Receive"
+              },
+              "ztp_vlan": {
+                "type": "integer",
+                "description": "ZTP vlan number",
+                "title": "ZTP VLAN"
+              }
+            },
+            "additionalProperties": false,
+            "patternProperties": {
+              "^_.+$": {}
+            },
+            "title": "LLDP"
+          },
           "eos_cli": {
             "type": "string",
             "description": "Multiline EOS CLI rendered directly on the management interface in the final EOS configuration",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -4977,6 +4977,18 @@ keys:
         mac_address:
           type: str
           description: MAC address
+        lldp:
+          type: dict
+          keys:
+            transmit:
+              type: bool
+            receive:
+              type: bool
+            ztp_vlan:
+              type: int
+              convert_types:
+              - str
+              description: ZTP vlan number
         eos_cli:
           type: str
           description: Multiline EOS CLI rendered directly on the management interface

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_interfaces.schema.yml
@@ -50,6 +50,18 @@ keys:
         mac_address:
           type: str
           description: MAC address
+        lldp:
+          type: dict
+          keys:
+            transmit:
+              type: bool
+            receive:
+              type: bool
+            ztp_vlan:
+              type: int
+              convert_types:
+                - str
+              description: ZTP vlan number
         eos_cli:
           type: str
           description: Multiline EOS CLI rendered directly on the management interface in the final EOS configuration

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-interfaces.j2
@@ -33,6 +33,15 @@ interface {{ management_interface.name }}
 {%     if management_interface.ipv6_address is arista.avd.defined %}
    ipv6 address {{ management_interface.ipv6_address }}
 {%     endif %}
+{%     if management_interface.lldp.transmit is arista.avd.defined(false) %}
+   no lldp transmit
+{%     endif %}
+{%     if management_interface.lldp.receive is arista.avd.defined(false) %}
+   no lldp receive
+{%     endif %}
+{%     if management_interface.lldp.ztp_vlan is arista.avd.defined %}
+   lldp tlv transmit ztp vlan {{ management_interface.lldp.ztp_vlan }}
+{%     endif %}
 {%     if management_interface.eos_cli is arista.avd.defined %}
    {{ management_interface.eos_cli | indent(3, false) }}
 {%     endif %}


### PR DESCRIPTION
## Change Summary

Allow to configure
```
interface Management1
  no lldp transmit
  no lldp receive
  lldp tlv transmit ztp vlan 666
```

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Copied the schema from ethernet_interfaces

## How to test

checked all options are accepted on cEOS
molecule test

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
