### PR TITLE
Feat(eos_cli_config_gen): Add additional-path for evpn address-family peer-groups

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-evpn.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-evpn.md
@@ -105,6 +105,12 @@ interface Management1
 
 | Peer Group | Activate | Encapsulation |
 | ---------- | -------- | ------------- |
+| ADDITIONAL-PATH-PG-1 | True | default |
+| ADDITIONAL-PATH-PG-2 | True | default |
+| ADDITIONAL-PATH-PG-3 | True | default |
+| ADDITIONAL-PATH-PG-4 | True | default |
+| ADDITIONAL-PATH-PG-5 | True | default |
+| ADDITIONAL-PATH-PG-6 | True | default |
 | EVPN-OVERLAY-PEERS | True | vxlan |
 | MLAG-IPv4-UNDERLAY-PEER | False | default |
 
@@ -238,6 +244,19 @@ router bgp 65101
       bgp next-hop-unchanged
       host-flap detection window 10 threshold 1 expiry timeout 3 seconds
       domain identifier 65101:0
+      neighbor ADDITIONAL-PATH-PG-1 activate
+      neighbor ADDITIONAL-PATH-PG-1 additional-paths receive
+      neighbor ADDITIONAL-PATH-PG-1 additional-paths send any
+      neighbor ADDITIONAL-PATH-PG-2 activate
+      neighbor ADDITIONAL-PATH-PG-2 additional-paths send backup
+      neighbor ADDITIONAL-PATH-PG-3 activate
+      neighbor ADDITIONAL-PATH-PG-3 additional-paths send ecmp
+      neighbor ADDITIONAL-PATH-PG-4 activate
+      neighbor ADDITIONAL-PATH-PG-4 additional-paths send ecmp limit 42
+      neighbor ADDITIONAL-PATH-PG-5 activate
+      neighbor ADDITIONAL-PATH-PG-5 additional-paths send limit 42
+      neighbor ADDITIONAL-PATH-PG-6 activate
+      no neighbor ADDITIONAL-PATH-PG-6 additional-paths send any
       neighbor EVPN-OVERLAY-PEERS activate
       neighbor EVPN-OVERLAY-PEERS domain remote
       neighbor EVPN-OVERLAY-PEERS encapsulation vxlan

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-evpn.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-evpn.cfg
@@ -97,6 +97,19 @@ router bgp 65101
       bgp next-hop-unchanged
       host-flap detection window 10 threshold 1 expiry timeout 3 seconds
       domain identifier 65101:0
+      neighbor ADDITIONAL-PATH-PG-1 activate
+      neighbor ADDITIONAL-PATH-PG-1 additional-paths receive
+      neighbor ADDITIONAL-PATH-PG-1 additional-paths send any
+      neighbor ADDITIONAL-PATH-PG-2 activate
+      neighbor ADDITIONAL-PATH-PG-2 additional-paths send backup
+      neighbor ADDITIONAL-PATH-PG-3 activate
+      neighbor ADDITIONAL-PATH-PG-3 additional-paths send ecmp
+      neighbor ADDITIONAL-PATH-PG-4 activate
+      neighbor ADDITIONAL-PATH-PG-4 additional-paths send ecmp limit 42
+      neighbor ADDITIONAL-PATH-PG-5 activate
+      neighbor ADDITIONAL-PATH-PG-5 additional-paths send limit 42
+      neighbor ADDITIONAL-PATH-PG-6 activate
+      no neighbor ADDITIONAL-PATH-PG-6 additional-paths send any
       neighbor EVPN-OVERLAY-PEERS activate
       neighbor EVPN-OVERLAY-PEERS domain remote
       neighbor EVPN-OVERLAY-PEERS encapsulation vxlan

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-evpn.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-evpn.yml
@@ -62,6 +62,38 @@ router_bgp:
         encapsulation: vxlan
       - name: MLAG-IPv4-UNDERLAY-PEER
         activate: false
+      - name: ADDITIONAL-PATH-PG-1
+        activate: true
+        additional_paths:
+          receive: true
+          send:
+            any: true
+      - name: ADDITIONAL-PATH-PG-2
+        activate: true
+        additional_paths:
+          send:
+            backup: true
+      - name: ADDITIONAL-PATH-PG-3
+        activate: true
+        additional_paths:
+          send:
+            ecmp: true
+      - name: ADDITIONAL-PATH-PG-4
+        activate: true
+        additional_paths:
+          send:
+            ecmp_limit: 42
+      - name: ADDITIONAL-PATH-PG-5
+        activate: true
+        additional_paths:
+          send:
+            limit: 42
+      # Checking the `no neighbor <PG> additional-paths send any is rendered
+      - name: ADDITIONAL-PATH-PG-6
+        activate: true
+        additional_paths:
+          send:
+            any: false
     evpn_hostflap_detection:
       enabled: true
       window: 10

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-bgp.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-bgp.md
@@ -242,6 +242,14 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map_out</samp>](## "router_bgp.address_family_evpn.peer_groups.[].route_map_out") | String |  |  |  | Outbound route-map name |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;domain_remote</samp>](## "router_bgp.address_family_evpn.peer_groups.[].domain_remote") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;encapsulation</samp>](## "router_bgp.address_family_evpn.peer_groups.[].encapsulation") | String |  |  | Valid Values:<br>- vxlan<br>- mpls |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;additional_paths</samp>](## "router_bgp.address_family_evpn.peer_groups.[].additional_paths") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;receive</samp>](## "router_bgp.address_family_evpn.peer_groups.[].additional_paths.receive") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;send</samp>](## "router_bgp.address_family_evpn.peer_groups.[].additional_paths.send") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;any</samp>](## "router_bgp.address_family_evpn.peer_groups.[].additional_paths.send.any") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;backup</samp>](## "router_bgp.address_family_evpn.peer_groups.[].additional_paths.send.backup") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ecmp</samp>](## "router_bgp.address_family_evpn.peer_groups.[].additional_paths.send.ecmp") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ecmp_limit</samp>](## "router_bgp.address_family_evpn.peer_groups.[].additional_paths.send.ecmp_limit") | Integer |  |  | Min: 2<br>Max: 64 | Amount of ECMP paths to send |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;limit</samp>](## "router_bgp.address_family_evpn.peer_groups.[].additional_paths.send.limit") | Integer |  |  | Min: 2<br>Max: 64 | Amount of paths to send |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;evpn_hostflap_detection</samp>](## "router_bgp.address_family_evpn.evpn_hostflap_detection") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "router_bgp.address_family_evpn.evpn_hostflap_detection.enabled") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;window</samp>](## "router_bgp.address_family_evpn.evpn_hostflap_detection.window") | Integer |  |  | Min: 0<br>Max: 4294967295 | Time (in seconds) to detect a MAC duplication issue |
@@ -929,6 +937,14 @@
             route_map_out: <str>
             domain_remote: <bool>
             encapsulation: <str>
+            additional_paths:
+              receive: <bool>
+              send:
+                any: <bool>
+                backup: <bool>
+                ecmp: <bool>
+                ecmp_limit: <int>
+                limit: <int>
         evpn_hostflap_detection:
           enabled: <bool>
           window: <int>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -14561,6 +14561,56 @@
                       "mpls"
                     ],
                     "title": "Encapsulation"
+                  },
+                  "additional_paths": {
+                    "type": "object",
+                    "properties": {
+                      "receive": {
+                        "type": "boolean",
+                        "title": "Receive"
+                      },
+                      "send": {
+                        "type": "object",
+                        "properties": {
+                          "any": {
+                            "type": "boolean",
+                            "title": "Any"
+                          },
+                          "backup": {
+                            "type": "boolean",
+                            "title": "Backup"
+                          },
+                          "ecmp": {
+                            "type": "boolean",
+                            "title": "ECMP"
+                          },
+                          "ecmp_limit": {
+                            "type": "integer",
+                            "description": "Amount of ECMP paths to send",
+                            "minimum": 2,
+                            "maximum": 64,
+                            "title": "ECMP Limit"
+                          },
+                          "limit": {
+                            "type": "integer",
+                            "description": "Amount of paths to send",
+                            "minimum": 2,
+                            "maximum": 64,
+                            "title": "Limit"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Send"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Additional Paths"
                   }
                 },
                 "additionalProperties": false,

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -8701,6 +8701,34 @@ keys:
                   valid_values:
                   - vxlan
                   - mpls
+                additional_paths:
+                  type: dict
+                  keys:
+                    receive:
+                      type: bool
+                    send:
+                      type: dict
+                      keys:
+                        any:
+                          type: bool
+                        backup:
+                          type: bool
+                        ecmp:
+                          type: bool
+                        ecmp_limit:
+                          type: int
+                          description: Amount of ECMP paths to send
+                          convert_types:
+                          - str
+                          min: 2
+                          max: 64
+                        limit:
+                          type: int
+                          description: Amount of paths to send
+                          convert_types:
+                          - str
+                          min: 2
+                          max: 64
           evpn_hostflap_detection:
             type: dict
             keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_bgp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_bgp.schema.yml
@@ -828,6 +828,34 @@ keys:
                   valid_values:
                     - "vxlan"
                     - "mpls"
+                additional_paths:
+                  type: dict
+                  keys:
+                    receive:
+                      type: bool
+                    send:
+                      type: dict
+                      keys:
+                        any:
+                          type: bool
+                        backup:
+                          type: bool
+                        ecmp:
+                          type: bool
+                        ecmp_limit:
+                          type: int
+                          description: Amount of ECMP paths to send
+                          convert_types:
+                            - str
+                          min: 2
+                          max: 64
+                        limit:
+                          type: int
+                          description: Amount of paths to send
+                          convert_types:
+                            - str
+                          min: 2
+                          max: 64
           evpn_hostflap_detection:
             type: dict
             keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -560,6 +560,22 @@ router bgp {{ router_bgp.as }}
 {%             elif peer_group.activate is arista.avd.defined(false) %}
       no neighbor {{ peer_group.name }} activate
 {%             endif %}
+{%             if peer_group.additional_paths.receive is arista.avd.defined(true) %}
+      neighbor {{ peer_group.name }} additional-paths receive
+{%             endif %}
+{%             if peer_group.additional_paths.send.any is arista.avd.defined(true) %}
+      neighbor {{ peer_group.name }} additional-paths send any
+{%             elif peer_group.additional_paths.send.any is arista.avd.defined(false) %}
+      no neighbor {{ peer_group.name }} additional-paths send any
+{%             elif peer_group.additional_paths.send.backup is arista.avd.defined(true) %}
+      neighbor {{ peer_group.name }} additional-paths send backup
+{%             elif peer_group.additional_paths.send.ecmp is arista.avd.defined(true) %}
+      neighbor {{ peer_group.name }} additional-paths send ecmp
+{%             elif peer_group.additional_paths.send.ecmp_limit is arista.avd.defined %}
+      neighbor {{ peer_group.name }} additional-paths send ecmp limit {{ peer_group.additional_paths.send.ecmp_limit }}
+{%             elif peer_group.additional_paths.send.limit is arista.avd.defined %}
+      neighbor {{ peer_group.name }} additional-paths send limit {{ peer_group.additional_paths.send.limit }}
+{%             endif %}
 {%             if peer_group.domain_remote is arista.avd.defined(true) %}
       neighbor {{ peer_group.name }} domain remote
 {%             endif %}


### PR DESCRIPTION
## Change Summary

Add capability to configure additional-paths at the EVPN address family peer-group level
Introduces in Jinja2 template the rendering of `no neighbor <PG> additional-path send any` that _IS_ not supported in the other places where we have this (not so great) model.

> Follow up to this PR would be to refactor the model for 5.0 and to add the `no ..` syntax in other places.

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Reusing the same model as in other places in BGP schema, validated on cEOS

## How to test

molecule

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
