### PR TITLE
Feat(eos_cli_config_gen): Add enabled flag to router traffic-engineering

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-traffic-engineering.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-traffic-engineering.md
@@ -39,6 +39,8 @@ interface Management1
 
 ### Router Traffic-Engineering
 
+- Traffic Engineering is enabled.
+
 #### Segment Routing Summary
 
 - SRTE is enabled.

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-traffic-engineering.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-traffic-engineering.yml
@@ -1,5 +1,7 @@
 ### Routing - Traffic Engineering ###
 router_traffic_engineering:
+  # enabled is not enforced in AVD 4.x but will be in 5.x
+  enabled: true
   router_id:
     ipv4: 10.0.0.1
     ipv6: 2001:beef:cafe::1

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-traffic-engineering.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-traffic-engineering.md
@@ -8,6 +8,7 @@
     | Variable | Type | Required | Default | Value Restrictions | Description |
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
     | [<samp>router_traffic_engineering</samp>](## "router_traffic_engineering") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;enabled</samp>](## "router_traffic_engineering.enabled") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;router_id</samp>](## "router_traffic_engineering.router_id") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv4</samp>](## "router_traffic_engineering.router_id.ipv4") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6</samp>](## "router_traffic_engineering.router_id.ipv6") | String |  |  |  |  |
@@ -33,6 +34,7 @@
 
     ```yaml
     router_traffic_engineering:
+      enabled: <bool>
       router_id:
         ipv4: <str>
         ipv6: <str>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -19654,6 +19654,10 @@
     "router_traffic_engineering": {
       "type": "object",
       "properties": {
+        "enabled": {
+          "type": "boolean",
+          "title": "Enabled"
+        },
         "router_id": {
           "type": "object",
           "properties": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -11354,6 +11354,8 @@ keys:
   router_traffic_engineering:
     type: dict
     keys:
+      enabled:
+        type: bool
       router_id:
         type: dict
         keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_traffic_engineering.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_traffic_engineering.schema.yml
@@ -9,6 +9,8 @@ keys:
   router_traffic_engineering:
     type: dict
     keys:
+      enabled:
+        type: bool
       router_id:
         type: dict
         keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-traffic-engineering.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-traffic-engineering.j2
@@ -4,9 +4,14 @@
  that can be found in the LICENSE file.
 #}
 {# doc - router traffic engineering #}
-{% if router_traffic_engineering is arista.avd.defined %}
+{# for AVD 5.0.0, the first part of the if statement will be removed #}
+{% if router_traffic_engineering is arista.avd.defined or router_traffic_engineering.enabled is arista.avd.defined(true) %}
 
 ### Router Traffic-Engineering
+{%     if router_traffic_engineering.enabled is arista.avd.defined(true) %}
+
+- Traffic Engineering is enabled.
+{%     endif %}
 {%     if router_traffic_engineering.segment_routing is arista.avd.defined %}
 
 #### Segment Routing Summary

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-traffic-engineering.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-traffic-engineering.j2
@@ -4,7 +4,8 @@
  that can be found in the LICENSE file.
 #}
 {# eos - router traffic engineering #}
-{% if router_traffic_engineering is arista.avd.defined %}
+{# for AVD 5.0.0, the first part of the if statement will be removed #}
+{% if router_traffic_engineering is arista.avd.defined or router_traffic_engineering.enabled is arista.avd.defined(true) %}
 !
 router traffic-engineering
 {%     if router_traffic_engineering.segment_routing is arista.avd.defined %}


### PR DESCRIPTION
## Change Summary

This is to be able to render alone

```
router traffic-engineering
```

Today it is required to do:

```
router_traffic_engineering: {}
```

Which we want to avoid in AVD (having to define an empty dict to generate some conf

The flags is for now optional (it only renders a line in the documentation. It WILL become mandatory in  AVD 5.0.0

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Adding `enabled` flag to `router_traffic_engineering`

## How to test

molecule test  allow to verify in doc

## Checklist

### User Checklist

- [x] open issue for AVD 5.0.0: #3281 
 
### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
