### PR TITLE
Feat(eos_cli_config_gen): Support for "agents" config

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/agents.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/agents.md
@@ -1,0 +1,62 @@
+# agents
+
+## Table of Contents
+
+- [Management](#management)
+  - [Agents](#agents)
+  - [Management Interfaces](#management-interfaces)
+
+## Management
+
+### Agents
+
+#### Agent Dummy
+
+##### Environment variables
+
+| Name | Value |
+| ---- | ----- |
+| V1 | 42 |
+| V2 | 666 |
+
+#### Agent KernelFib
+
+##### Environment variables
+
+| Name | Value |
+| ---- | ----- |
+| KERNELFIB_PROGRAM_ALL_ECMP | true |
+
+#### Agents Device Configuration
+
+```eos
+!
+agent Dummy environment  V1=42:V2=666
+agent KernelFib environment  KERNELFIB_PROGRAM_ALL_ECMP=true
+```
+
+### Management Interfaces
+
+#### Management Interfaces Summary
+
+##### IPv4
+
+| Management Interface | description | Type | VRF | IP Address | Gateway |
+| -------------------- | ----------- | ---- | --- | ---------- | ------- |
+| Management1 | oob_management | oob | MGMT | 10.73.255.122/24 | 10.73.255.2 |
+
+##### IPv6
+
+| Management Interface | description | Type | VRF | IPv6 Address | IPv6 Gateway |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ |
+| Management1 | oob_management | oob | MGMT | - | - |
+
+#### Management Interfaces Device Configuration
+
+```eos
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/agents.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/agents.md
@@ -31,8 +31,8 @@
 
 ```eos
 !
-agent Dummy environment  V1=42:V2=666
-agent KernelFib environment  KERNELFIB_PROGRAM_ALL_ECMP=true
+agent Dummy environment V1=42:V2=666
+agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP=true
 ```
 
 ### Management Interfaces

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/agents.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/agents.cfg
@@ -1,7 +1,7 @@
 !RANCID-CONTENT-TYPE: arista
 !
-agent Dummy environment  V1=42:V2=666
-agent KernelFib environment  KERNELFIB_PROGRAM_ALL_ECMP=true
+agent Dummy environment V1=42:V2=666
+agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP=true
 !
 transceiver qsfp default-mode 4x10G
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/agents.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/agents.cfg
@@ -1,0 +1,18 @@
+!RANCID-CONTENT-TYPE: arista
+!
+agent Dummy environment  V1=42:V2=666
+agent KernelFib environment  KERNELFIB_PROGRAM_ALL_ECMP=true
+!
+transceiver qsfp default-mode 4x10G
+!
+hostname agents
+!
+no enable password
+no aaa root
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/agents.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/agents.yml
@@ -1,0 +1,14 @@
+---
+agents:
+  - name: KernelFib
+    environments:
+      - name: KERNELFIB_PROGRAM_ALL_ECMP
+        value: 'true'
+  - name: Dummy
+    environments:
+      - name: V1
+        value: 42
+      - name: V2
+        value: 666
+  # This next one is not rendered because there is no config to render for it
+  - name: NotRendered

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/agents.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/agents.yml
@@ -1,11 +1,11 @@
 ---
 agents:
   - name: KernelFib
-    environments:
+    environment_variables:
       - name: KERNELFIB_PROGRAM_ALL_ECMP
         value: 'true'
   - name: Dummy
-    environments:
+    environment_variables:
       - name: V1
         value: 42
       - name: V2

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts.ini
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts.ini
@@ -5,6 +5,7 @@ aaa-2
 acl
 address-locking
 aliases
+agents
 arp
 as-path
 base

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/input-variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/input-variables.md
@@ -889,6 +889,12 @@ roles/eos_cli_config_gen/docs/tables/vlans.md
 
 ## System settings
 
+### Agents
+
+--8<--
+roles/eos_cli_config_gen/docs/tables/agents.md
+--8<--
+
 ### Hardware counters
 
 --8<--

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/agents.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/agents.md
@@ -9,16 +9,16 @@
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
     | [<samp>agents</samp>](## "agents") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;- name</samp>](## "agents.[].name") | String | Required, Unique |  |  | Agent name. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;environments</samp>](## "agents.[].environments") | List, items: Dictionary |  |  | Min Length: 1 |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "agents.[].environments.[].name") | String | Required, Unique |  |  | Environment variable name. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;value</samp>](## "agents.[].environments.[].value") | String | Required |  |  | Environment variable value. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;environment_variables</samp>](## "agents.[].environment_variables") | List, items: Dictionary |  |  | Min Length: 1 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "agents.[].environment_variables.[].name") | String | Required, Unique |  |  | Environment variable name. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;value</samp>](## "agents.[].environment_variables.[].value") | String | Required |  |  | Environment variable value. |
 
 === "YAML"
 
     ```yaml
     agents:
       - name: <str>
-        environments:
+        environment_variables:
           - name: <str>
             value: <str>
     ```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/agents.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/agents.md
@@ -1,0 +1,24 @@
+<!--
+  ~ Copyright (c) 2023 Arista Networks, Inc.
+  ~ Use of this source code is governed by the Apache License 2.0
+  ~ that can be found in the LICENSE file.
+  -->
+=== "Table"
+
+    | Variable | Type | Required | Default | Value Restrictions | Description |
+    | -------- | ---- | -------- | ------- | ------------------ | ----------- |
+    | [<samp>agents</samp>](## "agents") | List, items: Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;- name</samp>](## "agents.[].name") | String | Required, Unique |  |  | Agent name. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;environments</samp>](## "agents.[].environments") | List, items: Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "agents.[].environments.[].name") | String | Required, Unique |  |  | Environment variable name. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;value</samp>](## "agents.[].environments.[].value") | String | Required |  |  | Environment variable value. |
+
+=== "YAML"
+
+    ```yaml
+    agents:
+      - name: <str>
+        environments:
+          - name: <str>
+            value: <str>
+    ```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/agents.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/agents.md
@@ -9,7 +9,7 @@
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
     | [<samp>agents</samp>](## "agents") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;- name</samp>](## "agents.[].name") | String | Required, Unique |  |  | Agent name. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;environments</samp>](## "agents.[].environments") | List, items: Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;environments</samp>](## "agents.[].environments") | List, items: Dictionary |  |  | Min Length: 1 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "agents.[].environments.[].name") | String | Required, Unique |  |  | Environment variable name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;value</samp>](## "agents.[].environments.[].value") | String | Required |  |  | Environment variable value. |
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -667,6 +667,7 @@
           },
           "environments": {
             "type": "array",
+            "minItems": 1,
             "items": {
               "type": "object",
               "properties": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -655,6 +655,54 @@
       },
       "title": "Address Locking"
     },
+    "agents": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Agent name.",
+            "title": "Name"
+          },
+          "environments": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "Environment variable name.",
+                  "title": "Name"
+                },
+                "value": {
+                  "type": "string",
+                  "description": "Environment variable value.",
+                  "title": "Value"
+                }
+              },
+              "required": [
+                "value",
+                "name"
+              ],
+              "additionalProperties": false,
+              "patternProperties": {
+                "^_.+$": {}
+              }
+            },
+            "title": "Environments"
+          }
+        },
+        "additionalProperties": false,
+        "patternProperties": {
+          "^_.+$": {}
+        },
+        "required": [
+          "name"
+        ]
+      },
+      "title": "Agents"
+    },
     "aliases": {
       "type": "string",
       "description": "Multi-line string with one or more alias commands.\n\nExample:\n\n```yaml\naliases: |\n  alias wr copy running-config startup-config\n  alias siib show ip interface brief\n```",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -665,7 +665,7 @@
             "description": "Agent name.",
             "title": "Name"
           },
-          "environments": {
+          "environment_variables": {
             "type": "array",
             "minItems": 1,
             "items": {
@@ -691,7 +691,7 @@
                 "^_.+$": {}
               }
             },
-            "title": "Environments"
+            "title": "Environment Variables"
           }
         },
         "additionalProperties": false,

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -400,7 +400,7 @@ keys:
         environments:
           type: list
           primary_key: name
-          min_lenth: 1
+          min_length: 1
           items:
             type: dict
             keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -397,7 +397,7 @@ keys:
         name:
           type: str
           description: Agent name.
-        environments:
+        environment_variables:
           type: list
           primary_key: name
           min_length: 1

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -388,6 +388,32 @@ keys:
           ipv6_enforcement_disabled:
             type: bool
             description: Configure enforcement for locked IPv6 addresses
+  agents:
+    type: list
+    primary_key: name
+    items:
+      type: dict
+      keys:
+        name:
+          type: str
+          description: Agent name.
+        environments:
+          type: list
+          primary_key: name
+          min_lenth: 1
+          items:
+            type: dict
+            keys:
+              name:
+                type: str
+                description: Environment variable name.
+              value:
+                type: str
+                convert_types:
+                - int
+                - bool
+                required: true
+                description: Environment variable value.
   aliases:
     type: str
     description: "Multi-line string with one or more alias commands.\n\nExample:\n\n```yaml\naliases:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/agents.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/agents.schema.yml
@@ -15,7 +15,7 @@ keys:
         name:
           type: str
           description: Agent name.
-        environments:
+        environment_variables:
           type: list
           primary_key: name
           min_length: 1

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/agents.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/agents.schema.yml
@@ -1,0 +1,34 @@
+# Copyright (c) 2023 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the LICENSE file.
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  agents:
+    type: list
+    primary_key: name
+    items:
+      type: dict
+      keys:
+        name:
+          type: str
+          description: Agent name.
+        environments:
+          type: list
+          primary_key: name
+          min_length: 1
+          items:
+            type: dict
+            keys:
+              name:
+                type: str
+                description: Environment variable name.
+              value:
+                type: str
+                convert_types:
+                  - int
+                  - bool
+                required: true
+                description: Environment variable value.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/agents.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/agents.j2
@@ -1,0 +1,31 @@
+{#
+ Copyright (c) 2023 Arista Networks, Inc.
+ Use of this source code is governed by the Apache License 2.0
+ that can be found in the LICENSE file.
+#}
+{# doc - agents #}
+{% if agents is arista.avd.defined %}
+
+### Agents
+{%     for agent in agents | arista.avd.natural_sort('name') %}
+{# For now only environments supported so if not present do not show the agent at all as no config would be rendered #}
+{%         if agent.environments is arista.avd.defined %}
+
+#### Agent {{ agent.name }}
+
+##### Environment variables
+
+| Name | Value |
+| ---- | ----- |
+{%             for envvar in agent.environments %}
+| {{ envvar.name }} | {{ envvar.value }} |
+{%             endfor %}
+{%         endif %}
+{%     endfor %}
+
+#### Agents Device Configuration
+
+```eos
+{%     include 'eos/agents.j2' %}
+```
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/agents.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/agents.j2
@@ -8,8 +8,8 @@
 
 ### Agents
 {%     for agent in agents | arista.avd.natural_sort('name') %}
-{# For now only environments supported so if not present do not show the agent at all as no config would be rendered #}
-{%         if agent.environments is arista.avd.defined %}
+{# For now only environment_variables supported so if not present do not show the agent at all as no config would be rendered #}
+{%         if agent.environment_variables is arista.avd.defined %}
 
 #### Agent {{ agent.name }}
 
@@ -17,7 +17,7 @@
 
 | Name | Value |
 | ---- | ----- |
-{%             for envvar in agent.environments %}
+{%             for envvar in agent.environment_variables %}
 | {{ envvar.name }} | {{ envvar.value }} |
 {%             endfor %}
 {%         endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management.j2
@@ -26,9 +26,12 @@
        or ip_http_client_source_interfaces is arista.avd.defined
        or ip_ftp_client_source_interfaces is arista.avd.defined
        or ip_tftp_client_source_interfaces is arista.avd.defined
-       or ip_telnet_client_source_interfaces is arista.avd.defined %}
+       or ip_telnet_client_source_interfaces is arista.avd.defined
+       or agent is arista.avd.defined %}
 
 ## Management
+{## Agents #}
+{%     include 'documentation/agents.j2' %}
 {## Management Interface #}
 {%     include 'documentation/management-interfaces.j2' %}
 {## DNS Domain #}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-intended-config.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-intended-config.j2
@@ -9,6 +9,8 @@
 {% include 'eos/rancid-content-type.j2' %}
 {# System Boot Configuration #}
 {% include 'eos/boot.j2' %}
+{# Agents #}
+{% include 'eos/agents.j2' %}
 {# terminal settings #}
 {% include 'eos/terminal.j2' %}
 {# cli prompt #}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/agents.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/agents.j2
@@ -8,11 +8,11 @@
 {%     if loop.first %}
 !
 {%     endif %}
-{%     if agent.environments is arista.avd.defined %}
+{%     if agent.environment_variables is arista.avd.defined %}
 {%         set env_list = [] %}
-{%         for envvar in agent.environments %}
+{%         for envvar in agent.environment_variables %}
 {%             do env_list.append(envvar.name ~ "=" ~ envvar.value) %}
 {%         endfor %}
-agent {{ agent.name }} environment  {{ env_list | join(":") }}
+agent {{ agent.name }} environment {{ env_list | join(":") }}
 {%     endif %}
 {% endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/agents.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/agents.j2
@@ -1,0 +1,18 @@
+{#
+ Copyright (c) 2023 Arista Networks, Inc.
+ Use of this source code is governed by the Apache License 2.0
+ that can be found in the LICENSE file.
+#}
+{# eos - agents #}
+{% for agent in agents | arista.avd.natural_sort('name') %}
+{%     if loop.first %}
+!
+{%     endif %}
+{%     if agent.environments is arista.avd.defined %}
+{%         set env_list = [] %}
+{%         for envvar in agent.environments %}
+{%             do env_list.append(envvar.name ~ "=" ~ envvar.value) %}
+{%         endfor %}
+agent {{ agent.name }} environment  {{ env_list | join(":") }}
+{%     endif %}
+{% endfor %}


### PR DESCRIPTION
## Change Summary

Render stuff like:

```
agent BLAH environment BLAH=BLAH
agent KernelFib environment TOTO=TEAH
```

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
```
ceos2(config)#show cli commands | grep agent
[no|default] agent AGENT environment ENVIRON_CONFIG
[no|default] agent AGENT memory allocations heap fastbin limit SIZE
[no|default] agent AGENT shutdown [ supervisor ( active | standby | all ) ]
[no|default] agent AGENT_NAME warm-restart ( ( allowed ALLOWED_NUM ) | ( window WINDOW_NUM ) | always )
agent fatal-error action ACTION
```

```
ceos2(config)#agent BLAH environment ?
  EXPR  Agent environment configuration in the form of VAR1=VAL1:VAR2=VAL2:...
```

```yaml
    agents:
      - name: <str>
        environments:
          - name: <str>
            value: <str>
```

## How to test

molecule

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
