### PR TITLE
Feat(eos_cli_config_gen): Implement platform sfe cpu allocation maximum

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/platform.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/platform.md
@@ -86,6 +86,12 @@ interface Management1
 | 1 | 7 |
 | 2 | 15 |
 
+#### Platform Software Forwarding Engine Summary
+
+| Settings | Value |
+| -------- | ----- |
+| Maximum CPU Allocation | 42 |
+
 ### Platform Configuration
 
 ```eos
@@ -98,4 +104,5 @@ platform sand lag hardware-only
 platform sand lag mode 512x32
 platform sand forwarding mode arad
 platform sand multicast replication default ingress
+platform sfe data-plane cpu allocation maximum 42
 ```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/platform.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/platform.cfg
@@ -33,6 +33,7 @@ platform sand lag hardware-only
 platform sand lag mode 512x32
 platform sand forwarding mode arad
 platform sand multicast replication default ingress
+platform sfe data-plane cpu allocation maximum 42
 !
 no enable password
 no aaa root

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/platform.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/platform.yml
@@ -65,3 +65,8 @@ platform:
     multicast_replication:
       default: ingress
     forwarding_mode: arad
+  sfe:
+    data_plane:
+      cpu:
+        allocation:
+          maximum: 42

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/platform.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/platform.yml
@@ -66,7 +66,4 @@ platform:
       default: ingress
     forwarding_mode: arad
   sfe:
-    data_plane:
-      cpu:
-        allocation:
-          maximum: 42
+    data_plane_cpu_allocation_max: 42

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ethernet-interfaces.md
@@ -210,16 +210,16 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;storm_control</samp>](## "ethernet_interfaces.[].storm_control") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;all</samp>](## "ethernet_interfaces.[].storm_control.all") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level</samp>](## "ethernet_interfaces.[].storm_control.all.level") | String |  |  |  | Configure maximum storm-control level |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unit</samp>](## "ethernet_interfaces.[].storm_control.all.unit") | String |  | `percent` | Valid Values:<br>- percent<br>- pps | Optional field and is hardware dependant |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unit</samp>](## "ethernet_interfaces.[].storm_control.all.unit") | String |  | `percent` | Valid Values:<br>- percent<br>- pps | Optional field and is hardware dependent |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;broadcast</samp>](## "ethernet_interfaces.[].storm_control.broadcast") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level</samp>](## "ethernet_interfaces.[].storm_control.broadcast.level") | String |  |  |  | Configure maximum storm-control level |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unit</samp>](## "ethernet_interfaces.[].storm_control.broadcast.unit") | String |  | `percent` | Valid Values:<br>- percent<br>- pps | Optional field and is hardware dependant |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unit</samp>](## "ethernet_interfaces.[].storm_control.broadcast.unit") | String |  | `percent` | Valid Values:<br>- percent<br>- pps | Optional field and is hardware dependent |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;multicast</samp>](## "ethernet_interfaces.[].storm_control.multicast") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level</samp>](## "ethernet_interfaces.[].storm_control.multicast.level") | String |  |  |  | Configure maximum storm-control level |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unit</samp>](## "ethernet_interfaces.[].storm_control.multicast.unit") | String |  | `percent` | Valid Values:<br>- percent<br>- pps | Optional field and is hardware dependant |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unit</samp>](## "ethernet_interfaces.[].storm_control.multicast.unit") | String |  | `percent` | Valid Values:<br>- percent<br>- pps | Optional field and is hardware dependent |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unknown_unicast</samp>](## "ethernet_interfaces.[].storm_control.unknown_unicast") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level</samp>](## "ethernet_interfaces.[].storm_control.unknown_unicast.level") | String |  |  |  | Configure maximum storm-control level |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unit</samp>](## "ethernet_interfaces.[].storm_control.unknown_unicast.unit") | String |  | `percent` | Valid Values:<br>- percent<br>- pps | Optional field and is hardware dependant |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unit</samp>](## "ethernet_interfaces.[].storm_control.unknown_unicast.unit") | String |  | `percent` | Valid Values:<br>- percent<br>- pps | Optional field and is hardware dependent |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;logging</samp>](## "ethernet_interfaces.[].logging") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;event</samp>](## "ethernet_interfaces.[].logging.event") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;link_status</samp>](## "ethernet_interfaces.[].logging.event.link_status") | Boolean |  |  |  |  |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/platform.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/platform.md
@@ -7,7 +7,7 @@
 
     | Variable | Type | Required | Default | Value Restrictions | Description |
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
-    | [<samp>platform</samp>](## "platform") | Dictionary |  |  |  |  |
+    | [<samp>platform</samp>](## "platform") | Dictionary |  |  |  | Every key below this point is platform dependent. |
     | [<samp>&nbsp;&nbsp;trident</samp>](## "platform.trident") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;forwarding_table_partition</samp>](## "platform.trident.forwarding_table_partition") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mmu</samp>](## "platform.trident.mmu") | Dictionary |  |  |  | Memory Management Unit settings.<br> |
@@ -30,7 +30,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;drop</samp>](## "platform.trident.mmu.queue_profiles.[].unicast_queues.[].drop") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;precedence</samp>](## "platform.trident.mmu.queue_profiles.[].unicast_queues.[].drop.precedence") | Integer | Required |  | Valid Values:<br>- 1<br>- 2 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;threshold</samp>](## "platform.trident.mmu.queue_profiles.[].unicast_queues.[].drop.threshold") | String | Required |  |  | Drop Treshold. This value may also be fractions.<br>Example: 7/8 or 3/4 or 1/2<br> |
-    | [<samp>&nbsp;&nbsp;sand</samp>](## "platform.sand") | Dictionary |  |  |  | Most of the platform sand options are hardware dependant and optional |
+    | [<samp>&nbsp;&nbsp;sand</samp>](## "platform.sand") | Dictionary |  |  |  | Most of the platform sand options are hardware dependent and optional |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;qos_maps</samp>](## "platform.sand.qos_maps") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- traffic_class</samp>](## "platform.sand.qos_maps.[].traffic_class") | Integer |  |  | Min: 0<br>Max: 7 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;to_network_qos</samp>](## "platform.sand.qos_maps.[].to_network_qos") | Integer |  |  | Min: 0<br>Max: 63 |  |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/platform.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/platform.md
@@ -40,6 +40,11 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;forwarding_mode</samp>](## "platform.sand.forwarding_mode") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;multicast_replication</samp>](## "platform.sand.multicast_replication") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;default</samp>](## "platform.sand.multicast_replication.default") | String |  |  | Valid Values:<br>- ingress<br>- egress |  |
+    | [<samp>&nbsp;&nbsp;sfe</samp>](## "platform.sfe") | Dictionary |  |  |  | Sfe (Software Forwarding Engine) settings. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;data_plane</samp>](## "platform.sfe.data_plane") | Dictionary |  |  |  | Data plane configuration. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;cpu</samp>](## "platform.sfe.data_plane.cpu") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;allocation</samp>](## "platform.sfe.data_plane.cpu.allocation") | Dictionary |  |  |  | Control the number of physical CPUs used for data plane traffic forwarding. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;maximum</samp>](## "platform.sfe.data_plane.cpu.allocation.maximum") | Integer |  |  | Min: 1<br>Max: 128 | Maximum number of CPUs assigned for forwarding traffic. |
 
 === "YAML"
 
@@ -77,4 +82,9 @@
         forwarding_mode: <str>
         multicast_replication:
           default: <str>
+      sfe:
+        data_plane:
+          cpu:
+            allocation:
+              maximum: <int>
     ```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/platform.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/platform.md
@@ -41,10 +41,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;multicast_replication</samp>](## "platform.sand.multicast_replication") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;default</samp>](## "platform.sand.multicast_replication.default") | String |  |  | Valid Values:<br>- ingress<br>- egress |  |
     | [<samp>&nbsp;&nbsp;sfe</samp>](## "platform.sfe") | Dictionary |  |  |  | Sfe (Software Forwarding Engine) settings. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;data_plane</samp>](## "platform.sfe.data_plane") | Dictionary |  |  |  | Data plane configuration. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;cpu</samp>](## "platform.sfe.data_plane.cpu") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;allocation</samp>](## "platform.sfe.data_plane.cpu.allocation") | Dictionary |  |  |  | Control the number of physical CPUs used for data plane traffic forwarding. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;maximum</samp>](## "platform.sfe.data_plane.cpu.allocation.maximum") | Integer |  |  | Min: 1<br>Max: 128 | Maximum number of CPUs assigned for forwarding traffic. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;data_plane_cpu_allocation_max</samp>](## "platform.sfe.data_plane_cpu_allocation_max") | Integer |  |  | Min: 1<br>Max: 128 | Maximum number of CPUs used for data plane traffic forwarding. |
 
 === "YAML"
 
@@ -83,8 +80,5 @@
         multicast_replication:
           default: <str>
       sfe:
-        data_plane:
-          cpu:
-            allocation:
-              maximum: <int>
+        data_plane_cpu_allocation_max: <int>
     ```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/port-channel-interfaces.md
@@ -82,16 +82,16 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;storm_control</samp>](## "port_channel_interfaces.[].storm_control") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;all</samp>](## "port_channel_interfaces.[].storm_control.all") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level</samp>](## "port_channel_interfaces.[].storm_control.all.level") | String |  |  |  | Configure maximum storm-control level |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unit</samp>](## "port_channel_interfaces.[].storm_control.all.unit") | String |  | `percent` | Valid Values:<br>- percent<br>- pps | Optional field and is hardware dependant |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unit</samp>](## "port_channel_interfaces.[].storm_control.all.unit") | String |  | `percent` | Valid Values:<br>- percent<br>- pps | Optional field and is hardware dependent |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;broadcast</samp>](## "port_channel_interfaces.[].storm_control.broadcast") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level</samp>](## "port_channel_interfaces.[].storm_control.broadcast.level") | String |  |  |  | Configure maximum storm-control level |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unit</samp>](## "port_channel_interfaces.[].storm_control.broadcast.unit") | String |  | `percent` | Valid Values:<br>- percent<br>- pps | Optional field and is hardware dependant |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unit</samp>](## "port_channel_interfaces.[].storm_control.broadcast.unit") | String |  | `percent` | Valid Values:<br>- percent<br>- pps | Optional field and is hardware dependent |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;multicast</samp>](## "port_channel_interfaces.[].storm_control.multicast") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level</samp>](## "port_channel_interfaces.[].storm_control.multicast.level") | String |  |  |  | Configure maximum storm-control level |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unit</samp>](## "port_channel_interfaces.[].storm_control.multicast.unit") | String |  | `percent` | Valid Values:<br>- percent<br>- pps | Optional field and is hardware dependant |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unit</samp>](## "port_channel_interfaces.[].storm_control.multicast.unit") | String |  | `percent` | Valid Values:<br>- percent<br>- pps | Optional field and is hardware dependent |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unknown_unicast</samp>](## "port_channel_interfaces.[].storm_control.unknown_unicast") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level</samp>](## "port_channel_interfaces.[].storm_control.unknown_unicast.level") | String |  |  |  | Configure maximum storm-control level |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unit</samp>](## "port_channel_interfaces.[].storm_control.unknown_unicast.unit") | String |  | `percent` | Valid Values:<br>- percent<br>- pps | Optional field and is hardware dependant |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unit</samp>](## "port_channel_interfaces.[].storm_control.unknown_unicast.unit") | String |  | `percent` | Valid Values:<br>- percent<br>- pps | Optional field and is hardware dependent |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_proxy_arp</samp>](## "port_channel_interfaces.[].ip_proxy_arp") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;isis_enable</samp>](## "port_channel_interfaces.[].isis_enable") | String |  |  |  | ISIS instance |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;isis_passive</samp>](## "port_channel_interfaces.[].isis_passive") | Boolean |  |  |  |  |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -9974,6 +9974,56 @@
             "^_.+$": {}
           },
           "title": "Sand"
+        },
+        "sfe": {
+          "type": "object",
+          "description": "Sfe (Software Forwarding Engine) settings.",
+          "properties": {
+            "data_plane": {
+              "type": "object",
+              "description": "Data plane configuration.",
+              "properties": {
+                "cpu": {
+                  "type": "object",
+                  "properties": {
+                    "allocation": {
+                      "type": "object",
+                      "description": "Control the number of physical CPUs used for data plane traffic forwarding.",
+                      "properties": {
+                        "maximum": {
+                          "type": "integer",
+                          "description": "Maximum number of CPUs assigned for forwarding traffic.",
+                          "minimum": 1,
+                          "maximum": 128,
+                          "title": "Maximum"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      },
+                      "title": "Allocation"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "patternProperties": {
+                    "^_.+$": {}
+                  },
+                  "title": "CPU"
+                }
+              },
+              "additionalProperties": false,
+              "patternProperties": {
+                "^_.+$": {}
+              },
+              "title": "Data Plane"
+            }
+          },
+          "additionalProperties": false,
+          "patternProperties": {
+            "^_.+$": {}
+          },
+          "title": "Sfe"
         }
       },
       "additionalProperties": false,

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -9979,44 +9979,12 @@
           "type": "object",
           "description": "Sfe (Software Forwarding Engine) settings.",
           "properties": {
-            "data_plane": {
-              "type": "object",
-              "description": "Data plane configuration.",
-              "properties": {
-                "cpu": {
-                  "type": "object",
-                  "properties": {
-                    "allocation": {
-                      "type": "object",
-                      "description": "Control the number of physical CPUs used for data plane traffic forwarding.",
-                      "properties": {
-                        "maximum": {
-                          "type": "integer",
-                          "description": "Maximum number of CPUs assigned for forwarding traffic.",
-                          "minimum": 1,
-                          "maximum": 128,
-                          "title": "Maximum"
-                        }
-                      },
-                      "additionalProperties": false,
-                      "patternProperties": {
-                        "^_.+$": {}
-                      },
-                      "title": "Allocation"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "patternProperties": {
-                    "^_.+$": {}
-                  },
-                  "title": "CPU"
-                }
-              },
-              "additionalProperties": false,
-              "patternProperties": {
-                "^_.+$": {}
-              },
-              "title": "Data Plane"
+            "data_plane_cpu_allocation_max": {
+              "type": "integer",
+              "description": "Maximum number of CPUs used for data plane traffic forwarding.",
+              "minimum": 1,
+              "maximum": 128,
+              "title": "Data Plane CPU Allocation Max"
             }
           },
           "additionalProperties": false,

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -3185,7 +3185,7 @@
                       "percent",
                       "pps"
                     ],
-                    "description": "Optional field and is hardware dependant",
+                    "description": "Optional field and is hardware dependent",
                     "title": "Unit"
                   }
                 },
@@ -3210,7 +3210,7 @@
                       "percent",
                       "pps"
                     ],
-                    "description": "Optional field and is hardware dependant",
+                    "description": "Optional field and is hardware dependent",
                     "title": "Unit"
                   }
                 },
@@ -3235,7 +3235,7 @@
                       "percent",
                       "pps"
                     ],
-                    "description": "Optional field and is hardware dependant",
+                    "description": "Optional field and is hardware dependent",
                     "title": "Unit"
                   }
                 },
@@ -3260,7 +3260,7 @@
                       "percent",
                       "pps"
                     ],
-                    "description": "Optional field and is hardware dependant",
+                    "description": "Optional field and is hardware dependent",
                     "title": "Unit"
                   }
                 },
@@ -9712,6 +9712,7 @@
     },
     "platform": {
       "type": "object",
+      "description": "Every key below this point is platform dependent.",
       "properties": {
         "trident": {
           "type": "object",
@@ -9901,7 +9902,7 @@
         },
         "sand": {
           "type": "object",
-          "description": "Most of the platform sand options are hardware dependant and optional",
+          "description": "Most of the platform sand options are hardware dependent and optional",
           "properties": {
             "qos_maps": {
               "type": "array",
@@ -10719,7 +10720,7 @@
                       "percent",
                       "pps"
                     ],
-                    "description": "Optional field and is hardware dependant",
+                    "description": "Optional field and is hardware dependent",
                     "title": "Unit"
                   }
                 },
@@ -10744,7 +10745,7 @@
                       "percent",
                       "pps"
                     ],
-                    "description": "Optional field and is hardware dependant",
+                    "description": "Optional field and is hardware dependent",
                     "title": "Unit"
                   }
                 },
@@ -10769,7 +10770,7 @@
                       "percent",
                       "pps"
                     ],
-                    "description": "Optional field and is hardware dependant",
+                    "description": "Optional field and is hardware dependent",
                     "title": "Unit"
                   }
                 },
@@ -10794,7 +10795,7 @@
                       "percent",
                       "pps"
                     ],
-                    "description": "Optional field and is hardware dependant",
+                    "description": "Optional field and is hardware dependent",
                     "title": "Unit"
                   }
                 },

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -1912,7 +1912,7 @@ keys:
                   valid_values:
                   - percent
                   - pps
-                  description: Optional field and is hardware dependant
+                  description: Optional field and is hardware dependent
             broadcast:
               type: dict
               keys:
@@ -1928,7 +1928,7 @@ keys:
                   valid_values:
                   - percent
                   - pps
-                  description: Optional field and is hardware dependant
+                  description: Optional field and is hardware dependent
             multicast:
               type: dict
               keys:
@@ -1944,7 +1944,7 @@ keys:
                   valid_values:
                   - percent
                   - pps
-                  description: Optional field and is hardware dependant
+                  description: Optional field and is hardware dependent
             unknown_unicast:
               type: dict
               keys:
@@ -1960,7 +1960,7 @@ keys:
                   valid_values:
                   - percent
                   - pps
-                  description: Optional field and is hardware dependant
+                  description: Optional field and is hardware dependent
         logging:
           type: dict
           keys:
@@ -5785,6 +5785,7 @@ keys:
                   Example: "as-range 1-100 result accept"'
   platform:
     type: dict
+    description: Every key below this point is platform dependent.
     keys:
       trident:
         type: dict
@@ -5938,7 +5939,7 @@ keys:
                                   '
       sand:
         type: dict
-        description: Most of the platform sand options are hardware dependant and
+        description: Most of the platform sand options are hardware dependent and
           optional
         keys:
           qos_maps:
@@ -6447,7 +6448,7 @@ keys:
                   valid_values:
                   - percent
                   - pps
-                  description: Optional field and is hardware dependant
+                  description: Optional field and is hardware dependent
             broadcast:
               type: dict
               keys:
@@ -6463,7 +6464,7 @@ keys:
                   valid_values:
                   - percent
                   - pps
-                  description: Optional field and is hardware dependant
+                  description: Optional field and is hardware dependent
             multicast:
               type: dict
               keys:
@@ -6479,7 +6480,7 @@ keys:
                   valid_values:
                   - percent
                   - pps
-                  description: Optional field and is hardware dependant
+                  description: Optional field and is hardware dependent
             unknown_unicast:
               type: dict
               keys:
@@ -6495,7 +6496,7 @@ keys:
                   valid_values:
                   - percent
                   - pps
-                  description: Optional field and is hardware dependant
+                  description: Optional field and is hardware dependent
         ip_proxy_arp:
           type: bool
         isis_enable:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -5979,26 +5979,13 @@ keys:
         type: dict
         description: Sfe (Software Forwarding Engine) settings.
         keys:
-          data_plane:
-            type: dict
-            description: Data plane configuration.
-            keys:
-              cpu:
-                type: dict
-                keys:
-                  allocation:
-                    type: dict
-                    description: Control the number of physical CPUs used for data
-                      plane traffic forwarding.
-                    keys:
-                      maximum:
-                        type: int
-                        description: Maximum number of CPUs assigned for forwarding
-                          traffic.
-                        convert_types:
-                        - str
-                        min: 1
-                        max: 128
+          data_plane_cpu_allocation_max:
+            type: int
+            description: Maximum number of CPUs used for data plane traffic forwarding.
+            convert_types:
+            - str
+            min: 1
+            max: 128
   poe:
     type: dict
     keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -5975,6 +5975,30 @@ keys:
                 valid_values:
                 - ingress
                 - egress
+      sfe:
+        type: dict
+        description: Sfe (Software Forwarding Engine) settings.
+        keys:
+          data_plane:
+            type: dict
+            description: Data plane configuration.
+            keys:
+              cpu:
+                type: dict
+                keys:
+                  allocation:
+                    type: dict
+                    description: Control the number of physical CPUs used for data
+                      plane traffic forwarding.
+                    keys:
+                      maximum:
+                        type: int
+                        description: Maximum number of CPUs assigned for forwarding
+                          traffic.
+                        convert_types:
+                        - str
+                        min: 1
+                        max: 128
   poe:
     type: dict
     keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ethernet_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ethernet_interfaces.schema.yml
@@ -610,7 +610,7 @@ keys:
                   type: str
                   default: "percent"
                   valid_values: [ "percent", "pps" ]
-                  description: Optional field and is hardware dependant
+                  description: Optional field and is hardware dependent
             broadcast:
               type: dict
               keys:
@@ -624,7 +624,7 @@ keys:
                   type: str
                   default: "percent"
                   valid_values: ["percent", "pps"]
-                  description: Optional field and is hardware dependant
+                  description: Optional field and is hardware dependent
             multicast:
               type: dict
               keys:
@@ -638,7 +638,7 @@ keys:
                   type: str
                   default: "percent"
                   valid_values: ["percent", "pps"]
-                  description: Optional field and is hardware dependant
+                  description: Optional field and is hardware dependent
             unknown_unicast:
               type: dict
               keys:
@@ -652,7 +652,7 @@ keys:
                   type: str
                   default: "percent"
                   valid_values: [ "percent", "pps" ]
-                  description: Optional field and is hardware dependant
+                  description: Optional field and is hardware dependent
         logging:
           type: dict
           keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/platform.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/platform.schema.yml
@@ -169,21 +169,10 @@ keys:
         type: dict
         description: Sfe (Software Forwarding Engine) settings.
         keys:
-          data_plane:
-            type: dict
-            description: Data plane configuration.
-            keys:
-              cpu:
-                type: dict
-                keys:
-                  allocation:
-                    type: dict
-                    description: Control the number of physical CPUs used for data plane traffic forwarding.
-                    keys:
-                      maximum:
-                        type: int
-                        description: Maximum number of CPUs assigned for forwarding traffic.
-                        convert_types:
-                          - str
-                        min: 1
-                        max: 128
+          data_plane_cpu_allocation_max:
+            type: int
+            description: Maximum number of CPUs used for data plane traffic forwarding.
+            convert_types:
+              - str
+            min: 1
+            max: 128

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/platform.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/platform.schema.yml
@@ -8,6 +8,8 @@ type: dict
 keys:
   platform:
     type: dict
+    description: |-
+      Every key below this point is platform dependent.
     keys:
       trident:
         type: dict
@@ -131,7 +133,7 @@ keys:
                                   Example: 7/8 or 3/4 or 1/2
       sand:
         type: dict
-        description: Most of the platform sand options are hardware dependant and optional
+        description: Most of the platform sand options are hardware dependent and optional
         keys:
           qos_maps:
             type: list

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/platform.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/platform.schema.yml
@@ -165,3 +165,25 @@ keys:
               default:
                 type: str
                 valid_values: ["ingress", "egress"]
+      sfe:
+        type: dict
+        description: Sfe (Software Forwarding Engine) settings.
+        keys:
+          data_plane:
+            type: dict
+            description: Data plane configuration.
+            keys:
+              cpu:
+                type: dict
+                keys:
+                  allocation:
+                    type: dict
+                    description: Control the number of physical CPUs used for data plane traffic forwarding.
+                    keys:
+                      maximum:
+                        type: int
+                        description: Maximum number of CPUs assigned for forwarding traffic.
+                        convert_types:
+                          - str
+                        min: 1
+                        max: 128

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/port_channel_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/port_channel_interfaces.schema.yml
@@ -330,7 +330,7 @@ keys:
                   valid_values:
                     - percent
                     - pps
-                  description: Optional field and is hardware dependant
+                  description: Optional field and is hardware dependent
             broadcast:
               type: dict
               keys:
@@ -346,7 +346,7 @@ keys:
                   valid_values:
                     - percent
                     - pps
-                  description: Optional field and is hardware dependant
+                  description: Optional field and is hardware dependent
             multicast:
               type: dict
               keys:
@@ -362,7 +362,7 @@ keys:
                   valid_values:
                     - percent
                     - pps
-                  description: Optional field and is hardware dependant
+                  description: Optional field and is hardware dependent
             unknown_unicast:
               type: dict
               keys:
@@ -378,7 +378,7 @@ keys:
                   valid_values:
                     - percent
                     - pps
-                  description: Optional field and is hardware dependant
+                  description: Optional field and is hardware dependent
         ip_proxy_arp:
           type: bool
         isis_enable:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/platform.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/platform.j2
@@ -77,8 +77,8 @@
 
 | Settings | Value |
 | -------- | ----- |
-{%             if platform.sfe.data_plane.cpu.allocation.maximum is arista.avd.defined %}
-| Maximum CPU Allocation | {{ platform.sfe.data_plane.cpu.allocation.maximum }} |
+{%             if platform.sfe.data_plane_cpu_allocation_max is arista.avd.defined %}
+| Maximum CPU Allocation | {{ platform.sfe.data_plane_cpu_allocation_max }} |
 {%             endif %}
 {%         endif %}
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/platform.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/platform.j2
@@ -7,7 +7,7 @@
 {% if platform is arista.avd.defined %}
 
 ## Platform
-{%     if platform.trident is arista.avd.defined or platform.sand is arista.avd.defined %}
+{%     if platform.trident is arista.avd.defined or platform.sand is arista.avd.defined or platform.sfe is arista.avd.defined %}
 
 ### Platform Summary
 {%         if platform.trident is arista.avd.defined %}
@@ -69,6 +69,16 @@
 | {{ qos_map.traffic_class }} | {{ qos_map.to_network_qos }} |
 {%                     endif %}
 {%                 endfor %}
+{%             endif %}
+{%         endif %}
+{%         if platform.sfe is arista.avd.defined %}
+
+#### Platform Software Forwarding Engine Summary
+
+| Settings | Value |
+| -------- | ----- |
+{%             if platform.sfe.data_plane.cpu.allocation.maximum is arista.avd.defined %}
+| Maximum CPU Allocation | {{ platform.sfe.data_plane.cpu.allocation.maximum }} |
 {%             endif %}
 {%         endif %}
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/platform.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/platform.j2
@@ -29,8 +29,8 @@ platform sand multicast replication default {{ platform.sand.multicast_replicati
 {%         endif %}
 {%     endif %}
 {%     if platform.sfe is arista.avd.defined %}
-{%         if platform.sfe.data_plane.cpu.allocation.maximum is arista.avd.defined %}
-platform sfe data-plane cpu allocation maximum {{ platform.sfe.data_plane.cpu.allocation.maximum }}
+{%         if platform.sfe.data_plane_cpu_allocation_max is arista.avd.defined %}
+platform sfe data-plane cpu allocation maximum {{ platform.sfe.data_plane_cpu_allocation_max }}
 {%         endif %}
 {%     endif %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/platform.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/platform.j2
@@ -28,4 +28,9 @@ platform sand forwarding mode {{ platform.sand.forwarding_mode }}
 platform sand multicast replication default {{ platform.sand.multicast_replication.default }}
 {%         endif %}
 {%     endif %}
+{%     if platform.sfe is arista.avd.defined %}
+{%         if platform.sfe.data_plane.cpu.allocation.maximum is arista.avd.defined %}
+platform sfe data-plane cpu allocation maximum {{ platform.sfe.data_plane.cpu.allocation.maximum }}
+{%         endif %}
+{%     endif %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -5837,7 +5837,7 @@
                               "percent",
                               "pps"
                             ],
-                            "description": "Optional field and is hardware dependant",
+                            "description": "Optional field and is hardware dependent",
                             "title": "Unit"
                           }
                         },
@@ -5862,7 +5862,7 @@
                               "percent",
                               "pps"
                             ],
-                            "description": "Optional field and is hardware dependant",
+                            "description": "Optional field and is hardware dependent",
                             "title": "Unit"
                           }
                         },
@@ -5887,7 +5887,7 @@
                               "percent",
                               "pps"
                             ],
-                            "description": "Optional field and is hardware dependant",
+                            "description": "Optional field and is hardware dependent",
                             "title": "Unit"
                           }
                         },
@@ -5912,7 +5912,7 @@
                               "percent",
                               "pps"
                             ],
-                            "description": "Optional field and is hardware dependant",
+                            "description": "Optional field and is hardware dependent",
                             "title": "Unit"
                           }
                         },
@@ -8163,7 +8163,7 @@
                           "percent",
                           "pps"
                         ],
-                        "description": "Optional field and is hardware dependant",
+                        "description": "Optional field and is hardware dependent",
                         "title": "Unit"
                       }
                     },
@@ -8188,7 +8188,7 @@
                           "percent",
                           "pps"
                         ],
-                        "description": "Optional field and is hardware dependant",
+                        "description": "Optional field and is hardware dependent",
                         "title": "Unit"
                       }
                     },
@@ -8213,7 +8213,7 @@
                           "percent",
                           "pps"
                         ],
-                        "description": "Optional field and is hardware dependant",
+                        "description": "Optional field and is hardware dependent",
                         "title": "Unit"
                       }
                     },
@@ -8238,7 +8238,7 @@
                           "percent",
                           "pps"
                         ],
-                        "description": "Optional field and is hardware dependant",
+                        "description": "Optional field and is hardware dependent",
                         "title": "Unit"
                       }
                     },
@@ -11421,7 +11421,7 @@
                               "percent",
                               "pps"
                             ],
-                            "description": "Optional field and is hardware dependant",
+                            "description": "Optional field and is hardware dependent",
                             "title": "Unit"
                           }
                         },
@@ -11446,7 +11446,7 @@
                               "percent",
                               "pps"
                             ],
-                            "description": "Optional field and is hardware dependant",
+                            "description": "Optional field and is hardware dependent",
                             "title": "Unit"
                           }
                         },
@@ -11471,7 +11471,7 @@
                               "percent",
                               "pps"
                             ],
-                            "description": "Optional field and is hardware dependant",
+                            "description": "Optional field and is hardware dependent",
                             "title": "Unit"
                           }
                         },
@@ -11496,7 +11496,7 @@
                               "percent",
                               "pps"
                             ],
-                            "description": "Optional field and is hardware dependant",
+                            "description": "Optional field and is hardware dependent",
                             "title": "Unit"
                           }
                         },
@@ -13747,7 +13747,7 @@
                           "percent",
                           "pps"
                         ],
-                        "description": "Optional field and is hardware dependant",
+                        "description": "Optional field and is hardware dependent",
                         "title": "Unit"
                       }
                     },
@@ -13772,7 +13772,7 @@
                           "percent",
                           "pps"
                         ],
-                        "description": "Optional field and is hardware dependant",
+                        "description": "Optional field and is hardware dependent",
                         "title": "Unit"
                       }
                     },
@@ -13797,7 +13797,7 @@
                           "percent",
                           "pps"
                         ],
-                        "description": "Optional field and is hardware dependant",
+                        "description": "Optional field and is hardware dependent",
                         "title": "Unit"
                       }
                     },
@@ -13822,7 +13822,7 @@
                           "percent",
                           "pps"
                         ],
-                        "description": "Optional field and is hardware dependant",
+                        "description": "Optional field and is hardware dependent",
                         "title": "Unit"
                       }
                     },


### PR DESCRIPTION
## Change Summary

```
platform sfe data-plane cpu allocation maximum <1-128>
```

show cli commands

```
ceos2(config)#show cli commands | grep platform
[...]
[no|default] platform sfe control-plane receive-limit LIMIT ( kbps | mbps )
[no|default] platform sfe data-plane cpu allocation maximum MAX_DP_CORES_NUM
[no|default] platform sfe debug trace TRACECONFIG
[no|default] platform sfe debug vlog VLOGCONFIG
[no|default] platform sfe nat learning-rate ENTRIES
[no|default] platform sfe nat trace ( ( cpu-decap | cpu-encap ) PKTS ) | ( flow-export ENTRIES )
[..]
```

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Dict structure

## How to test

molecule

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
