### PR TITLE
Feat(eos_cli_config_gen): Add ARP static entries

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/arp.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/arp.md
@@ -45,19 +45,12 @@ Global ARP timeout: 300
 
 | VRF | IPv4 address | MAC address |
 | --- | ------------ | ----------- |
- 
 | vrf | 42.42.42.42 | DEAD.BEEF.CAFE |
- 
 | vrf | 42.42.42.42 | DEAD.BEEF.CAFE |
- 
 | vrf | 41.42.42.42 | DEAD.BEEF.CAFE |
- 
 | vrf | 42.42.42.42 | DEAD.BEEF.CAFE |
- 
 | vrf | 43.42.42.42 | DEAD.BEEF.CAFE |
- 
 | vrf | 42.42.42.42 | DEAD.BEEF.CAFE |
- 
 | vrf | 42.42.42.42 | 1.2.3 |
 
 #### ARP Configuration
@@ -65,18 +58,11 @@ Global ARP timeout: 300
 ```eos
 !
 arp aging timeout default 300
- 
 arp vrf BLAH 42.42.42.42 DEAD.BEEF.CAFE arpa
- 
 arp vrf defauls 42.42.42.42 DEAD.BEEF.CAFE arpa
- 
 arp 41.42.42.42 DEAD.BEEF.CAFE arpa
- 
 arp 42.42.42.42 DEAD.BEEF.CAFE arpa
- 
 arp 43.42.42.42 DEAD.BEEF.CAFE arpa
- 
 arp vrf defaulu 42.42.42.42 DEAD.BEEF.CAFE arpa
- 
 arp vrf zeros 42.42.42.42 1.2.3 arpa
 ```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/arp.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/arp.md
@@ -40,3 +40,43 @@ interface Management1
 ### ARP
 
 Global ARP timeout: 300
+
+#### ARP static entries
+
+| VRF | IPv4 address | MAC address |
+| --- | ------------ | ----------- |
+ 
+| vrf | 42.42.42.42 | DEAD.BEEF.CAFE |
+ 
+| vrf | 42.42.42.42 | DEAD.BEEF.CAFE |
+ 
+| vrf | 41.42.42.42 | DEAD.BEEF.CAFE |
+ 
+| vrf | 42.42.42.42 | DEAD.BEEF.CAFE |
+ 
+| vrf | 43.42.42.42 | DEAD.BEEF.CAFE |
+ 
+| vrf | 42.42.42.42 | DEAD.BEEF.CAFE |
+ 
+| vrf | 42.42.42.42 | 1.2.3 |
+
+#### ARP Configuration
+
+```eos
+!
+arp aging timeout default 300
+ 
+arp vrf BLAH 42.42.42.42 DEAD.BEEF.CAFE arpa
+ 
+arp vrf defauls 42.42.42.42 DEAD.BEEF.CAFE arpa
+ 
+arp 41.42.42.42 DEAD.BEEF.CAFE arpa
+ 
+arp 42.42.42.42 DEAD.BEEF.CAFE arpa
+ 
+arp 43.42.42.42 DEAD.BEEF.CAFE arpa
+ 
+arp vrf defaulu 42.42.42.42 DEAD.BEEF.CAFE arpa
+ 
+arp vrf zeros 42.42.42.42 1.2.3 arpa
+```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/arp.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/arp.md
@@ -45,13 +45,13 @@ Global ARP timeout: 300
 
 | VRF | IPv4 address | MAC address |
 | --- | ------------ | ----------- |
-| vrf | 42.42.42.42 | DEAD.BEEF.CAFE |
-| vrf | 42.42.42.42 | DEAD.BEEF.CAFE |
-| vrf | 41.42.42.42 | DEAD.BEEF.CAFE |
-| vrf | 42.42.42.42 | DEAD.BEEF.CAFE |
-| vrf | 43.42.42.42 | DEAD.BEEF.CAFE |
-| vrf | 42.42.42.42 | DEAD.BEEF.CAFE |
-| vrf | 42.42.42.42 | 1.2.3 |
+| BLAH | 42.42.42.42 | DEAD.BEEF.CAFE |
+| defauls | 42.42.42.42 | DEAD.BEEF.CAFE |
+| default | 41.42.42.42 | DEAD.BEEF.CAFE |
+| default | 42.42.42.42 | DEAD.BEEF.CAFE |
+| default | 43.42.42.42 | DEAD.BEEF.CAFE |
+| defaulu | 42.42.42.42 | DEAD.BEEF.CAFE |
+| zeros | 42.42.42.42 | 1.2.3 |
 
 #### ARP Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/arp.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/arp.md
@@ -51,7 +51,6 @@ Global ARP timeout: 300
 | default | 42.42.42.42 | DEAD.BEEF.CAFE |
 | default | 43.42.42.42 | DEAD.BEEF.CAFE |
 | defaulu | 42.42.42.42 | DEAD.BEEF.CAFE |
-| zeros | 42.42.42.42 | 1.2.3 |
 
 #### ARP Configuration
 
@@ -64,5 +63,4 @@ arp 41.42.42.42 DEAD.BEEF.CAFE arpa
 arp 42.42.42.42 DEAD.BEEF.CAFE arpa
 arp 43.42.42.42 DEAD.BEEF.CAFE arpa
 arp vrf defaulu 42.42.42.42 DEAD.BEEF.CAFE arpa
-arp vrf zeros 42.42.42.42 1.2.3 arpa
 ```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/arp.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/arp.cfg
@@ -13,19 +13,12 @@ interface Management1
    ip address 10.73.255.122/24
 !
 arp aging timeout default 300
- 
 arp vrf BLAH 42.42.42.42 DEAD.BEEF.CAFE arpa
- 
 arp vrf defauls 42.42.42.42 DEAD.BEEF.CAFE arpa
- 
 arp 41.42.42.42 DEAD.BEEF.CAFE arpa
- 
 arp 42.42.42.42 DEAD.BEEF.CAFE arpa
- 
 arp 43.42.42.42 DEAD.BEEF.CAFE arpa
- 
 arp vrf defaulu 42.42.42.42 DEAD.BEEF.CAFE arpa
- 
 arp vrf zeros 42.42.42.42 1.2.3 arpa
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/arp.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/arp.cfg
@@ -13,5 +13,19 @@ interface Management1
    ip address 10.73.255.122/24
 !
 arp aging timeout default 300
+ 
+arp vrf BLAH 42.42.42.42 DEAD.BEEF.CAFE arpa
+ 
+arp vrf defauls 42.42.42.42 DEAD.BEEF.CAFE arpa
+ 
+arp 41.42.42.42 DEAD.BEEF.CAFE arpa
+ 
+arp 42.42.42.42 DEAD.BEEF.CAFE arpa
+ 
+arp 43.42.42.42 DEAD.BEEF.CAFE arpa
+ 
+arp vrf defaulu 42.42.42.42 DEAD.BEEF.CAFE arpa
+ 
+arp vrf zeros 42.42.42.42 1.2.3 arpa
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/arp.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/arp.cfg
@@ -19,6 +19,5 @@ arp 41.42.42.42 DEAD.BEEF.CAFE arpa
 arp 42.42.42.42 DEAD.BEEF.CAFE arpa
 arp 43.42.42.42 DEAD.BEEF.CAFE arpa
 arp vrf defaulu 42.42.42.42 DEAD.BEEF.CAFE arpa
-arp vrf zeros 42.42.42.42 1.2.3 arpa
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/arp.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/arp.yml
@@ -19,7 +19,3 @@ arp:
     - ipv4_address: 42.42.42.42
       vrf: defaulu
       mac_address: DEAD.BEEF.CAFE
-    # testing with implicit leading zeros
-    - ipv4_address: 42.42.42.42
-      vrf: zeros
-      mac_address: 1.2.3

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/arp.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/arp.yml
@@ -2,3 +2,24 @@
 arp:
   aging:
     timeout_default: 300
+  static_entries:
+    - ipv4_address: 42.42.42.42
+      vrf: BLAH
+      mac_address: DEAD.BEEF.CAFE
+    - ipv4_address: 42.42.42.42
+      vrf: defauls
+      mac_address: DEAD.BEEF.CAFE
+    # default VRF - testing sorting on ipv4 addresses and MAC addresses
+    - ipv4_address: 43.42.42.42
+      mac_address: DEAD.BEEF.CAFE
+    - ipv4_address: 42.42.42.42
+      mac_address: DEAD.BEEF.CAFE
+    - ipv4_address: 41.42.42.42
+      mac_address: DEAD.BEEF.CAFE
+    - ipv4_address: 42.42.42.42
+      vrf: defaulu
+      mac_address: DEAD.BEEF.CAFE
+    # testing with implicit leading zeros
+    - ipv4_address: 42.42.42.42
+      vrf: zeros
+      mac_address: 1.2.3

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/arp.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/arp.md
@@ -10,6 +10,10 @@
     | [<samp>arp</samp>](## "arp") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;aging</samp>](## "arp.aging") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;timeout_default</samp>](## "arp.aging.timeout_default") | Integer |  |  | Min: 60<br>Max: 65535 | Timeout in seconds |
+    | [<samp>&nbsp;&nbsp;static_entries</samp>](## "arp.static_entries") | List, items: Dictionary |  |  |  | Static ARP entries. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- ipv4_address</samp>](## "arp.static_entries.[].ipv4_address") | String | Required |  |  | ARP entry IPv4 address. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "arp.static_entries.[].vrf") | String |  |  |  | ARP entry VRF - default to "default". |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mac_address</samp>](## "arp.static_entries.[].mac_address") | String | Required |  | Pattern: ^[0-9A-Fa-f]{1,4}\.[0-9A-Fa-f]{1,4}\.[0-9A-Fa-f]{1,4}$ | ARP entry MAC address. |
 
 === "YAML"
 
@@ -17,4 +21,8 @@
     arp:
       aging:
         timeout_default: <int>
+      static_entries:
+        - ipv4_address: <str>
+          vrf: <str>
+          mac_address: <str>
     ```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/arp.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/arp.md
@@ -13,7 +13,7 @@
     | [<samp>&nbsp;&nbsp;static_entries</samp>](## "arp.static_entries") | List, items: Dictionary |  |  |  | Static ARP entries. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- ipv4_address</samp>](## "arp.static_entries.[].ipv4_address") | String | Required |  |  | ARP entry IPv4 address. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "arp.static_entries.[].vrf") | String |  |  |  | ARP entry VRF. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mac_address</samp>](## "arp.static_entries.[].mac_address") | String | Required |  | Pattern: ^[0-9A-Fa-f]{1,4}\.[0-9A-Fa-f]{1,4}\.[0-9A-Fa-f]{1,4}$ | ARP entry MAC address. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mac_address</samp>](## "arp.static_entries.[].mac_address") | String | Required |  | Pattern: ^[0-9A-Fa-f]{4}\.[0-9A-Fa-f]{4}\.[0-9A-Fa-f]{4}$ | ARP entry MAC address. |
 
 === "YAML"
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/arp.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/arp.md
@@ -12,7 +12,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;timeout_default</samp>](## "arp.aging.timeout_default") | Integer |  |  | Min: 60<br>Max: 65535 | Timeout in seconds |
     | [<samp>&nbsp;&nbsp;static_entries</samp>](## "arp.static_entries") | List, items: Dictionary |  |  |  | Static ARP entries. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- ipv4_address</samp>](## "arp.static_entries.[].ipv4_address") | String | Required |  |  | ARP entry IPv4 address. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "arp.static_entries.[].vrf") | String |  |  |  | ARP entry VRF - default to "default". |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "arp.static_entries.[].vrf") | String |  |  |  | ARP entry VRF. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mac_address</samp>](## "arp.static_entries.[].mac_address") | String | Required |  | Pattern: ^[0-9A-Fa-f]{1,4}\.[0-9A-Fa-f]{1,4}\.[0-9A-Fa-f]{1,4}$ | ARP entry MAC address. |
 
 === "YAML"

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -679,6 +679,40 @@
             "^_.+$": {}
           },
           "title": "Aging"
+        },
+        "static_entries": {
+          "type": "array",
+          "description": "Static ARP entries.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "ipv4_address": {
+                "type": "string",
+                "description": "ARP entry IPv4 address.",
+                "title": "IPv4 Address"
+              },
+              "vrf": {
+                "type": "string",
+                "description": "ARP entry VRF - default to \"default\".",
+                "title": "VRF"
+              },
+              "mac_address": {
+                "type": "string",
+                "description": "ARP entry MAC address.",
+                "pattern": "^[0-9A-Fa-f]{1,4}\\.[0-9A-Fa-f]{1,4}\\.[0-9A-Fa-f]{1,4}$",
+                "title": "MAC Address"
+              }
+            },
+            "required": [
+              "ipv4_address",
+              "mac_address"
+            ],
+            "additionalProperties": false,
+            "patternProperties": {
+              "^_.+$": {}
+            }
+          },
+          "title": "Static Entries"
         }
       },
       "additionalProperties": false,

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -699,7 +699,7 @@
               "mac_address": {
                 "type": "string",
                 "description": "ARP entry MAC address.",
-                "pattern": "^[0-9A-Fa-f]{1,4}\\.[0-9A-Fa-f]{1,4}\\.[0-9A-Fa-f]{1,4}$",
+                "pattern": "^[0-9A-Fa-f]{4}\\.[0-9A-Fa-f]{4}\\.[0-9A-Fa-f]{4}$",
                 "title": "MAC Address"
               }
             },

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -693,7 +693,7 @@
               },
               "vrf": {
                 "type": "string",
-                "description": "ARP entry VRF - default to \"default\".",
+                "description": "ARP entry VRF.",
                 "title": "VRF"
               },
               "mac_address": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -404,6 +404,24 @@ keys:
             type: int
             min: 60
             max: 65535
+      static_entries:
+        type: list
+        description: Static ARP entries.
+        items:
+          type: dict
+          keys:
+            ipv4_address:
+              type: str
+              required: true
+              description: ARP entry IPv4 address.
+            vrf:
+              type: str
+              description: ARP entry VRF - default to "default".
+            mac_address:
+              type: str
+              description: ARP entry MAC address.
+              required: true
+              pattern: ^[0-9A-Fa-f]{1,4}\.[0-9A-Fa-f]{1,4}\.[0-9A-Fa-f]{1,4}$
   as_path:
     type: dict
     keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -423,7 +423,7 @@ keys:
               type: str
               description: ARP entry MAC address.
               required: true
-              pattern: ^[0-9A-Fa-f]{1,4}\.[0-9A-Fa-f]{1,4}\.[0-9A-Fa-f]{1,4}$
+              pattern: ^[0-9A-Fa-f]{4}\.[0-9A-Fa-f]{4}\.[0-9A-Fa-f]{4}$
   as_path:
     type: dict
     keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -416,7 +416,9 @@ keys:
               description: ARP entry IPv4 address.
             vrf:
               type: str
-              description: ARP entry VRF - default to "default".
+              convert_types:
+              - int
+              description: ARP entry VRF.
             mac_address:
               type: str
               description: ARP entry MAC address.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/arp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/arp.schema.yml
@@ -36,4 +36,4 @@ keys:
               type: str
               description: ARP entry MAC address.
               required: true
-              pattern: "^[0-9A-Fa-f]{1,4}\\.[0-9A-Fa-f]{1,4}\\.[0-9A-Fa-f]{1,4}$"
+              pattern: "^[0-9A-Fa-f]{4}\\.[0-9A-Fa-f]{4}\\.[0-9A-Fa-f]{4}$"

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/arp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/arp.schema.yml
@@ -29,7 +29,9 @@ keys:
               description: ARP entry IPv4 address.
             vrf:
               type: str
-              description: ARP entry VRF - default to "default".
+              convert_types:
+                - int
+              description: ARP entry VRF.
             mac_address:
               type: str
               description: ARP entry MAC address.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/arp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/arp.schema.yml
@@ -17,3 +17,21 @@ keys:
             type: int
             min: 60
             max: 65535
+      static_entries:
+        type: list
+        description: Static ARP entries.
+        items:
+          type: dict
+          keys:
+            ipv4_address:
+              type: str
+              required: true
+              description: ARP entry IPv4 address.
+            vrf:
+              type: str
+              description: ARP entry VRF - default to "default".
+            mac_address:
+              type: str
+              description: ARP entry MAC address.
+              required: true
+              pattern:  "^[0-9A-Fa-f]{1,4}\\.[0-9A-Fa-f]{1,4}\\.[0-9A-Fa-f]{1,4}$"

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/arp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/arp.schema.yml
@@ -34,4 +34,4 @@ keys:
               type: str
               description: ARP entry MAC address.
               required: true
-              pattern:  "^[0-9A-Fa-f]{1,4}\\.[0-9A-Fa-f]{1,4}\\.[0-9A-Fa-f]{1,4}$"
+              pattern: "^[0-9A-Fa-f]{1,4}\\.[0-9A-Fa-f]{1,4}\\.[0-9A-Fa-f]{1,4}$"

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/arp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/arp.j2
@@ -12,12 +12,18 @@
 Global ARP timeout: {{ arp.aging.timeout_default }}
 {%     endif %}
 {%     if arp.static_entries is arista.avd.defined %}
+{# HACK - remove when dropping support for ansible 2.12.6 and its jinja2 hack #}
+{%         for entry in arp.static_entries %}
+{%             if entry.vrf is not arista.avd.defined %}
+{%                 do entry.update({"vrf": "default"}) %}
+{%             endif %}
+{%         endfor %}
 
 #### ARP static entries
 
 | VRF | IPv4 address | MAC address |
 | --- | ------------ | ----------- |
-{%         for vrf, entries in arp.static_entries | arista.avd.default([]) | groupby("vrf", default="default") | arista.avd.natural_sort %}
+{%         for vrf, entries in arp.static_entries | groupby("vrf") | arista.avd.natural_sort %}
 {%             for entry in entries | arista.avd.natural_sort("ipv4_address") %}
 | vrf | {{ entry.ipv4_address }} | {{ entry.mac_address }} |
 {%             endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/arp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/arp.j2
@@ -12,7 +12,7 @@
 Global ARP timeout: {{ arp.aging.timeout_default }}
 {%     endif %}
 {%     if arp.static_entries is arista.avd.defined %}
-{# HACK - remove when dropping support for ansible 2.12.6 and its jinja2 hack #}
+{# TODO - remove when dropping support for ansible 2.12.6 and its jinja2 hack #}
 {%         for entry in arp.static_entries %}
 {%             if entry.vrf is not arista.avd.defined %}
 {%                 do entry.update({"vrf": "default"}) %}
@@ -25,7 +25,7 @@ Global ARP timeout: {{ arp.aging.timeout_default }}
 | --- | ------------ | ----------- |
 {%         for vrf, entries in arp.static_entries | groupby("vrf") | arista.avd.natural_sort %}
 {%             for entry in entries | arista.avd.natural_sort("ipv4_address") %}
-| vrf | {{ entry.ipv4_address }} | {{ entry.mac_address }} |
+| {{ vrf }} | {{ entry.ipv4_address }} | {{ entry.mac_address }} |
 {%             endfor %}
 {%         endfor %}
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/arp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/arp.j2
@@ -4,9 +4,29 @@
  that can be found in the LICENSE file.
 #}
 {# doc - arp #}
-{% if arp.aging.timeout_default is arista.avd.defined %}
+{% if arp.aging.timeout_default is arista.avd.defined or arp.static_entries is arista.avd.defined %}
 
 ### ARP
+{%     if arp.aging.timeout_default is arista.avd.defined %}
 
 Global ARP timeout: {{ arp.aging.timeout_default }}
+{%     endif %}
+{%     if arp.static_entries is arista.avd.defined %}
+
+#### ARP static entries
+
+| VRF | IPv4 address | MAC address |
+| --- | ------------ | ----------- |
+{%         for vrf, entries in arp.static_entries | arista.avd.default([]) | groupby("vrf", default="default") | arista.avd.natural_sort %}
+{%             for entry in entries | arista.avd.natural_sort("ipv4_address") %} 
+| vrf | {{ entry.ipv4_address }} | {{ entry.mac_address }} |
+{%             endfor %}
+{%         endfor %}
+{%     endif %}
+
+#### ARP Configuration
+
+```eos
+{%     include 'eos/arp.j2' %}
+```
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/arp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/arp.j2
@@ -18,7 +18,7 @@ Global ARP timeout: {{ arp.aging.timeout_default }}
 | VRF | IPv4 address | MAC address |
 | --- | ------------ | ----------- |
 {%         for vrf, entries in arp.static_entries | arista.avd.default([]) | groupby("vrf", default="default") | arista.avd.natural_sort %}
-{%             for entry in entries | arista.avd.natural_sort("ipv4_address") %} 
+{%             for entry in entries | arista.avd.natural_sort("ipv4_address") %}
 | vrf | {{ entry.ipv4_address }} | {{ entry.mac_address }} |
 {%             endfor %}
 {%         endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/arp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/arp.j2
@@ -9,14 +9,14 @@
 arp aging timeout default {{ arp.aging.timeout_default }}
 {% endif %}
 {% if arp.static_entries is arista.avd.defined %}
-{# HACK - remove when dropping support for ansible 2.12.6 and its jinja2 hack #}
+{# TODO - remove when dropping support for ansible 2.12.6 and its jinja2 hack #}
 {%     for entry in arp.static_entries %}
 {%         if entry.vrf is not arista.avd.defined %}
 {%             do entry.update({"vrf": "default"}) %}
 {%         endif %}
 {%     endfor %}
 {%     for vrf, entries in arp.static_entries | groupby("vrf") | arista.avd.natural_sort %}
-{# /HACK {%     for vrf, entries in arp.static_entries | arista.avd.default([]) | groupby("vrf", default="default") | arista.avd.natural_sort %} #}
+{# TODO {%     for vrf, entries in arp.static_entries | arista.avd.default([]) | groupby("vrf", default="default") | arista.avd.natural_sort %} #}
 {%         for entry in entries | arista.avd.natural_sort("ipv4_address") %}
 {%             set arp_entry_prefix = "arp" %}
 {%             if vrf != "default" %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/arp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/arp.j2
@@ -9,7 +9,7 @@
 arp aging timeout default {{ arp.aging.timeout_default }}
 {% endif %}
 {% for vrf, entries in arp.static_entries | arista.avd.default([]) | groupby("vrf", default="default") | arista.avd.natural_sort %}
-{%     for entry in entries | arista.avd.natural_sort("ipv4_address") %} 
+{%     for entry in entries | arista.avd.natural_sort("ipv4_address") %}
 {%         set arp_entry_prefix = "arp" %}
 {%         if vrf != "default" %}
 {%             set arp_entry_prefix = arp_entry_prefix ~ " vrf " ~ vrf %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/arp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/arp.j2
@@ -8,12 +8,21 @@
 !
 arp aging timeout default {{ arp.aging.timeout_default }}
 {% endif %}
-{% for vrf, entries in arp.static_entries | arista.avd.default([]) | groupby("vrf", default="default") | arista.avd.natural_sort %}
-{%     for entry in entries | arista.avd.natural_sort("ipv4_address") %}
-{%         set arp_entry_prefix = "arp" %}
-{%         if vrf != "default" %}
-{%             set arp_entry_prefix = arp_entry_prefix ~ " vrf " ~ vrf %}
+{% if arp.static_entries is arista.avd.defined %}
+{# HACK - remove when dropping support for ansible 2.12.6 and its jinja2 hack #}
+{%     for entry in arp.static_entries %}
+{%         if entry.vrf is not arista.avd.defined %}
+{%             do entry.update({"vrf": "default"}) %}
 {%         endif %}
-{{ arp_entry_prefix }} {{ entry.ipv4_address }} {{ entry.mac_address }} arpa
 {%     endfor %}
-{% endfor %}
+{%     for vrf, entries in arp.static_entries | groupby("vrf") | arista.avd.natural_sort %}
+{# /HACK {%     for vrf, entries in arp.static_entries | arista.avd.default([]) | groupby("vrf", default="default") | arista.avd.natural_sort %} #}
+{%         for entry in entries | arista.avd.natural_sort("ipv4_address") %}
+{%             set arp_entry_prefix = "arp" %}
+{%             if vrf != "default" %}
+{%                 set arp_entry_prefix = arp_entry_prefix ~ " vrf " ~ vrf %}
+{%             endif %}
+{{ arp_entry_prefix }} {{ entry.ipv4_address }} {{ entry.mac_address }} arpa
+{%         endfor %}
+{%     endfor %}
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/arp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/arp.j2
@@ -8,3 +8,12 @@
 !
 arp aging timeout default {{ arp.aging.timeout_default }}
 {% endif %}
+{% for vrf, entries in arp.static_entries | arista.avd.default([]) | groupby("vrf", default="default") | arista.avd.natural_sort %}
+{%     for entry in entries | arista.avd.natural_sort("ipv4_address") %} 
+{%         set arp_entry_prefix = "arp" %}
+{%         if vrf != "default" %}
+{%             set arp_entry_prefix = arp_entry_prefix ~ " vrf " ~ vrf %}
+{%         endif %}
+{{ arp_entry_prefix }} {{ entry.ipv4_address }} {{ entry.mac_address }} arpa
+{%     endfor %}
+{% endfor %}


### PR DESCRIPTION
## Change Summary

Implement arp static entries

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

```
type: dict
keys:
  arp:
    type: dict
    keys:
[...]
      static_entries:
        type: list
        description: Static ARP entries.
        items:
          type: dict
          keys:
            ipv4_address:
              type: str
              required: true
              description: ARP entry IPv4 address.
            vrf:
              type: str
              description: ARP entry VRF - default to "default".
            mac_address:
              type: str
              description: ARP entry MAC address.
              required: true
              pattern:  "^[0-9A-Fa-f]{1,4}\\.[0-9A-Fa-f]{1,4}\\.[0-9A-Fa-f]{1,4}$"
```

sorting is done as on EOS CLI:

```
ceos2(config)#show run | grep arp
arp aging timeout default 666
arp vrf BLAH 42.42.42.42 21:23:ca:fe:be:ef arpa
arp vrf defauls 42.42.42.42 ca:fe:ca:fe:be:ef arpa
arp 42.42.42.42 ca:fe:ca:fe:be:ef arpa
arp vrf defaulu 42.42.42.42 ca:fe:ca:fe:be:ef arpa
```

## How to test

molecule

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
