### PR TITLE
Fix(eos_cli_config_gen): l2_mtu under port_channel_interfaces

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
@@ -353,6 +353,7 @@ interface Port-Channel5
    switchport
    switchport trunk allowed vlan 110,201
    switchport mode trunk
+   l2 mtu 8000
    mlag 5
    storm-control broadcast level 1
    storm-control multicast level 1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
@@ -23,6 +23,7 @@ interface Port-Channel5
    switchport
    switchport trunk allowed vlan 110,201
    switchport mode trunk
+   l2 mtu 8000
    mlag 5
    storm-control broadcast level 1
    storm-control multicast level 1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
@@ -21,6 +21,7 @@ port_channel_interfaces:
         unit: percent
     bgp:
       session_tracker: ST2
+    l2_mtu: 8000
     eos_cli: |
       comment
       Comment created from eos_cli under port_channel_interfaces.Port-Channel5

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3A.cfg
@@ -180,6 +180,7 @@ interface Port-Channel14
    switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
+   l2 mtu 8000
    mlag 14
    spanning-tree portfast
    spanning-tree bpduguard enable
@@ -227,6 +228,7 @@ interface Port-Channel18
    switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
+   l2 mtu 8000
    port-channel lacp fallback timeout 10
    port-channel lacp fallback static
    mlag 18
@@ -244,6 +246,7 @@ interface Port-Channel19
    switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
+   l2 mtu 8000
    port-channel lacp fallback timeout 10
    port-channel lacp fallback static
    mlag 19

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3B.cfg
@@ -169,6 +169,7 @@ interface Port-Channel14
    switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
+   l2 mtu 8000
    mlag 14
    spanning-tree portfast
    spanning-tree bpduguard enable
@@ -216,6 +217,7 @@ interface Port-Channel18
    switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
+   l2 mtu 8000
    port-channel lacp fallback timeout 10
    port-channel lacp fallback static
    mlag 18
@@ -233,6 +235,7 @@ interface Port-Channel19
    switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
+   l2 mtu 8000
    port-channel lacp fallback timeout 10
    port-channel lacp fallback static
    mlag 19

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -678,6 +678,7 @@ interface Port-Channel14
    switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
+   l2 mtu 8000
    mlag 14
    spanning-tree portfast
    spanning-tree bpdufilter enable
@@ -722,6 +723,7 @@ interface Port-Channel18
    switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
+   l2 mtu 8000
    port-channel lacp fallback timeout 10
    port-channel lacp fallback static
    mlag 18
@@ -738,6 +740,7 @@ interface Port-Channel19
    switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
+   l2 mtu 8000
    port-channel lacp fallback timeout 10
    port-channel lacp fallback static
    mlag 19

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -678,6 +678,7 @@ interface Port-Channel14
    switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
+   l2 mtu 8000
    mlag 14
    spanning-tree portfast
    spanning-tree bpdufilter enable
@@ -722,6 +723,7 @@ interface Port-Channel18
    switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
+   l2 mtu 8000
    port-channel lacp fallback timeout 10
    port-channel lacp fallback static
    mlag 18
@@ -738,6 +740,7 @@ interface Port-Channel19
    switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
+   l2 mtu 8000
    port-channel lacp fallback timeout 10
    port-channel lacp fallback static
    mlag 19

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
@@ -194,6 +194,7 @@ interface Port-Channel14
    switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
+   l2 mtu 8000
    mlag 14
    spanning-tree portfast
    spanning-tree bpdufilter enable
@@ -238,6 +239,7 @@ interface Port-Channel18
    switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
+   l2 mtu 8000
    port-channel lacp fallback timeout 10
    port-channel lacp fallback static
    mlag 18
@@ -254,6 +256,7 @@ interface Port-Channel19
    switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
+   l2 mtu 8000
    port-channel lacp fallback timeout 10
    port-channel lacp fallback static
    mlag 19

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
@@ -194,6 +194,7 @@ interface Port-Channel14
    switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
+   l2 mtu 8000
    mlag 14
    spanning-tree portfast
    spanning-tree bpdufilter enable
@@ -238,6 +239,7 @@ interface Port-Channel18
    switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
+   l2 mtu 8000
    port-channel lacp fallback timeout 10
    port-channel lacp fallback static
    mlag 18
@@ -254,6 +256,7 @@ interface Port-Channel19
    switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
+   l2 mtu 8000
    port-channel lacp fallback timeout 10
    port-channel lacp fallback static
    mlag 19

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
@@ -161,6 +161,9 @@ interface {{ port_channel_interface.name }}
 {%     elif port_channel_interface.snmp_trap_link_change is arista.avd.defined(true) %}
    snmp trap link-change
 {%     endif %}
+{%     if port_channel_interface.l2_mtu is arista.avd.defined %}
+   l2 mtu {{ port_channel_interface.l2_mtu }}
+{%     endif %}
 {%     if port_channel_interface.lacp_id is arista.avd.defined %}
    lacp system-id {{ port_channel_interface.lacp_id }}
 {%     endif %}


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Fix l2_mtu under port_channel_interfaces

## Related Issue(s)

Fixes #3290 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

Feature was never implemented for port-channel interfaces, but "sneaked" in to the docs during the work on schemas. Since it was never working, the tests did not show a change at the time.

Adding the feature and a test in `eos_cli_config_gen`. Also rerunning molecule for a few scenarios for `eos_designs` where the use of `port_profiles` caused the l2_mtu to be set on the port_channel_interfaces. (This is what caused us to assume it was there when we built schemas).

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
