### PR TITLE
Fix(eos_designs): Inherited structured_config on multiple SVIs.

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SVI_PROFILE_NODE_1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SVI_PROFILE_NODE_1.cfg
@@ -33,6 +33,12 @@ vlan 114
 vlan 115
    name svi_profile_tests_115_description
 !
+vlan 120
+   name svi_profile_tests_120_description
+!
+vlan 121
+   name svi_profile_tests_121_description
+!
 vlan 210
    name igmp_snooping_enabled_210
 !
@@ -118,6 +124,16 @@ interface Vlan115
    no shutdown
    vrf svi_profile_tests_vrf
    ip address virtual 10.1.15.1/24
+!
+interface Vlan120
+   description set from svi_profile struct_config_on_multiple_svis
+   shutdown
+   vrf svi_profile_tests_vrf
+!
+interface Vlan121
+   description set from svi_profile struct_config_on_multiple_svis
+   shutdown
+   vrf svi_profile_tests_vrf
 !
 interface Vlan210
    description igmp_snooping_enabled_210
@@ -207,6 +223,8 @@ interface Vxlan1
    vxlan vlan 113 vni 10113
    vxlan vlan 114 vni 10114
    vxlan vlan 115 vni 10115
+   vxlan vlan 120 vni 10120
+   vxlan vlan 121 vni 10121
    vxlan vlan 210 vni 10210
    vxlan vlan 211 vni 10211
    vxlan vlan 212 vni 10212
@@ -283,6 +301,16 @@ router bgp 65001
    vlan 115
       rd 192.168.255.1:10115
       route-target both 10115:10115
+      redistribute learned
+   !
+   vlan 120
+      rd 192.168.255.1:10120
+      route-target both 10120:10120
+      redistribute learned
+   !
+   vlan 121
+      rd 192.168.255.1:10121
+      route-target both 10121:10121
       redistribute learned
    !
    vlan 210

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SVI_PROFILE_NODE_2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SVI_PROFILE_NODE_2.cfg
@@ -33,6 +33,12 @@ vlan 114
 vlan 115
    name svi_profile_tests_115_description
 !
+vlan 120
+   name svi_profile_tests_120_description
+!
+vlan 121
+   name svi_profile_tests_121_description
+!
 vlan 210
    name igmp_snooping_enabled_210
 !
@@ -118,6 +124,16 @@ interface Vlan115
    no shutdown
    vrf svi_profile_tests_vrf
    ip address virtual 10.1.15.1/24
+!
+interface Vlan120
+   description set from svi_profile struct_config_on_multiple_svis
+   shutdown
+   vrf svi_profile_tests_vrf
+!
+interface Vlan121
+   description set from svi_profile struct_config_on_multiple_svis
+   shutdown
+   vrf svi_profile_tests_vrf
 !
 interface Vlan210
    description igmp_snooping_enabled_210
@@ -207,6 +223,8 @@ interface Vxlan1
    vxlan vlan 113 vni 10113
    vxlan vlan 114 vni 10114
    vxlan vlan 115 vni 10115
+   vxlan vlan 120 vni 10120
+   vxlan vlan 121 vni 10121
    vxlan vlan 210 vni 10210
    vxlan vlan 211 vni 10211
    vxlan vlan 212 vni 10212
@@ -259,7 +277,7 @@ router bgp 65002
       rd 192.168.255.1:1
       route-target both 1:1
       redistribute learned
-      vlan 110-115,210-212,410-412,510-512
+      vlan 110-115,120-121,210-212,410-412,510-512
    !
    address-family evpn
       neighbor EVPN-OVERLAY-PEERS activate

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/SVI_PROFILE_NODE_1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/SVI_PROFILE_NODE_1.yml
@@ -101,6 +101,22 @@ router_bgp:
       - 10115:10115
     redistribute_routes:
     - learned
+  - id: 120
+    tenant: svi_profile_tests
+    rd: 192.168.255.1:10120
+    route_targets:
+      both:
+      - 10120:10120
+    redistribute_routes:
+    - learned
+  - id: 121
+    tenant: svi_profile_tests
+    rd: 192.168.255.1:10121
+    route_targets:
+      both:
+      - 10121:10121
+    redistribute_routes:
+    - learned
   - id: 210
     tenant: svi_profile_tests
     rd: 192.168.255.1:10210
@@ -253,6 +269,12 @@ vlans:
 - id: 115
   name: svi_profile_tests_115_description
   tenant: svi_profile_tests
+- id: 120
+  name: svi_profile_tests_120_description
+  tenant: svi_profile_tests
+- id: 121
+  name: svi_profile_tests_121_description
+  tenant: svi_profile_tests
 - id: 210
   name: igmp_snooping_enabled_210
   tenant: svi_profile_tests
@@ -335,6 +357,16 @@ vlan_interfaces:
   description: set from structured_config on svi_parent_profile.structured_config
   shutdown: false
   ip_address_virtual: 10.1.15.1/24
+  vrf: svi_profile_tests_vrf
+- name: Vlan120
+  tenant: svi_profile_tests
+  description: set from svi_profile struct_config_on_multiple_svis
+  shutdown: true
+  vrf: svi_profile_tests_vrf
+- name: Vlan121
+  tenant: svi_profile_tests
+  description: set from svi_profile struct_config_on_multiple_svis
+  shutdown: true
   vrf: svi_profile_tests_vrf
 - name: Vlan210
   tenant: svi_profile_tests
@@ -452,6 +484,10 @@ vxlan_interface:
         vni: 10114
       - id: 115
         vni: 10115
+      - id: 120
+        vni: 10120
+      - id: 121
+        vni: 10121
       - id: 210
         vni: 10210
       - id: 211

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/SVI_PROFILE_NODE_2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/SVI_PROFILE_NODE_2.yml
@@ -60,7 +60,7 @@ router_bgp:
       - '1:1'
     redistribute_routes:
     - learned
-    vlan: 110-115,210-212,410-412,510-512
+    vlan: 110-115,120-121,210-212,410-412,510-512
 static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0
@@ -140,6 +140,12 @@ vlans:
   tenant: svi_profile_tests
 - id: 115
   name: svi_profile_tests_115_description
+  tenant: svi_profile_tests
+- id: 120
+  name: svi_profile_tests_120_description
+  tenant: svi_profile_tests
+- id: 121
+  name: svi_profile_tests_121_description
   tenant: svi_profile_tests
 - id: 210
   name: igmp_snooping_enabled_210
@@ -223,6 +229,16 @@ vlan_interfaces:
   description: set from structured_config on svi_parent_profile.structured_config
   shutdown: false
   ip_address_virtual: 10.1.15.1/24
+  vrf: svi_profile_tests_vrf
+- name: Vlan120
+  tenant: svi_profile_tests
+  description: set from svi_profile struct_config_on_multiple_svis
+  shutdown: true
+  vrf: svi_profile_tests_vrf
+- name: Vlan121
+  tenant: svi_profile_tests
+  description: set from svi_profile struct_config_on_multiple_svis
+  shutdown: true
   vrf: svi_profile_tests_vrf
 - name: Vlan210
   tenant: svi_profile_tests
@@ -340,6 +356,10 @@ vxlan_interface:
         vni: 10114
       - id: 115
         vni: 10115
+      - id: 120
+        vni: 10120
+      - id: 121
+        vni: 10121
       - id: 210
         vni: 10210
       - id: 211

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/SVI_PROFILE_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/SVI_PROFILE_TESTS.yml
@@ -71,6 +71,10 @@ svi_profiles:
   - profile: struct_config_child_profile_4
     parent_profile: struct_config_parent_profile_2
 
+  - profile: struct_config_on_multiple_svis
+    structured_config:
+      description: "set from svi_profile struct_config_on_multiple_svis"
+
 #### ---- Test inheritance of svi igmp_snooping_enabled ----- ###
 # Tests logic for network services: ip igmp snooping
 # Precedence order:
@@ -251,6 +255,15 @@ tenants:
             enabled: true
             ip_address_virtual: 10.1.15.1/24
             profile: struct_config_child_profile_4
+
+          # Expected results:
+          # - description: set from svi_profile struct_config_on_multiple_svis
+          - id: 120
+            name: svi_profile_tests_120_description
+            profile: struct_config_on_multiple_svis
+          - id: 121
+            name: svi_profile_tests_121_description
+            profile: struct_config_on_multiple_svis
 
 #### ---- Test inheritance of svi igmp_snooping_enabled ----- ###
 # Tests logic for network services: ip igmp snooping

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/custom_structured_configuration/avdstructuredconfig.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/custom_structured_configuration/avdstructuredconfig.py
@@ -45,8 +45,7 @@ class AvdStructuredConfigCustomStructuredConfiguration(AvdFacts):
                 continue
 
             struct_cfg = item.pop("struct_cfg")
-            struct_cfg[primary_key] = item[primary_key]
-            struct_cfgs.append(struct_cfg)
+            struct_cfgs.append({primary_key: item[primary_key], **struct_cfg})
 
         return struct_cfgs
 


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Fix inherited structured_config on multiple SVIs.

## Related Issue(s)

When using structured config from `svi_profiles` the value of `structured_config` was only applied to the last item.

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

Fix unpacking of structured config to avoid changing the original dict.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Added a test case to molecule and confirmed the issue. Fixed and confirmed it was solved.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
