### PR TITLE
Feat(eos_designs): Custom platform_settings and node_type_keys

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-PYTHON_MODULES-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-PYTHON_MODULES-SPINE1.cfg
@@ -30,7 +30,7 @@ interface Ethernet2
    ip address 172.31.255.22/31
 !
 interface Loopback0
-   description TEST_CUSTOM_PREFIX_EVPN_Overlay_Peering_SPINE
+   description TEST_CUSTOM_PREFIX_EVPN_Overlay_Peering_CUSTOM_SPINE
    no shutdown
    ip address 192.168.255.1/32
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1A.cfg
@@ -21,7 +21,7 @@ ip name-server vrf MGMT 2001:db8::2
 !
 sflow vrf OOB destination 10.0.200.90
 sflow vrf OOB destination 192.168.200.10
-sflow vrf OOB source-interface Management1
+sflow vrf OOB source-interface Management99
 !
 snmp-server contact example@example.com
 snmp-server location EOS_DESIGNS_UNIT_TESTS DC1-BL1A
@@ -189,7 +189,7 @@ interface Loopback1
    ip address 192.168.254.14/32
    ip address 192.168.255.255/32 secondary
 !
-interface Management1
+interface Management99
    description oob_management
    no shutdown
    vrf MGMT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1B.cfg
@@ -20,7 +20,7 @@ ip name-server vrf MGMT 2001:db8::2
 !
 sflow vrf OOB destination 10.0.200.90
 sflow vrf OOB destination 192.168.200.10
-sflow vrf OOB source-interface Management1
+sflow vrf OOB source-interface Management99
 !
 snmp-server contact example@example.com
 snmp-server location EOS_DESIGNS_UNIT_TESTS DC1-BL1B
@@ -179,7 +179,7 @@ interface Loopback1
    no shutdown
    ip address 192.168.254.15/32
 !
-interface Management1
+interface Management99
    description oob_management
    no shutdown
    vrf MGMT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2A.cfg
@@ -20,7 +20,7 @@ ip name-server vrf MGMT 192.168.200.5
 ip name-server vrf MGMT 2001:db8::1
 ip name-server vrf MGMT 2001:db8::2
 !
-ntp local-interface vrf MGMT Management1
+ntp local-interface vrf MGMT Management99
 ntp server vrf MGMT 192.168.200.5 prefer
 ntp server vrf MGMT 2001:db8::3
 !
@@ -437,7 +437,7 @@ interface Loopback123
    ip address 10.1.53.0/32
    ip ospf area 1
 !
-interface Management1
+interface Management99
    description oob_management
    no shutdown
    vrf MGMT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2B.cfg
@@ -20,7 +20,7 @@ ip name-server vrf MGMT 192.168.200.5
 ip name-server vrf MGMT 2001:db8::1
 ip name-server vrf MGMT 2001:db8::2
 !
-ntp local-interface vrf MGMT Management1
+ntp local-interface vrf MGMT Management99
 ntp server vrf MGMT 192.168.200.5 prefer
 ntp server vrf MGMT 2001:db8::3
 !
@@ -402,7 +402,7 @@ interface Loopback123
    ip ospf cost 100
 
 !
-interface Management1
+interface Management99
    description oob_management
    no shutdown
    vrf MGMT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1_UNDEPLOYED_LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1_UNDEPLOYED_LEAF1A.cfg
@@ -20,18 +20,18 @@ ip name-server vrf MGMT 192.168.200.5
 ip name-server vrf MGMT 2001:db8::1
 ip name-server vrf MGMT 2001:db8::2
 !
-ntp local-interface vrf MGMT Management1
+ntp local-interface vrf MGMT Management42
 ntp server vrf MGMT 192.168.200.5 prefer
 ntp server vrf MGMT 2001:db8::3
 !
 snmp-server contact example@example.com
 snmp-server location EOS_DESIGNS_UNIT_TESTS DC1_UNDEPLOYED_LEAF1A
 !
-hardware speed-group 1 serdes 10G
+hardware speed-group 1 serdes 25G
 hardware speed-group 2 serdes 25G
-hardware speed-group 3 serdes 25G
-hardware speed-group 4 serdes 10G
-hardware speed-group 5/1 serdes 25G
+hardware speed-group 3 serdes 10G
+hardware speed-group 4 serdes 25G
+hardware speed-group 5/1 serdes 10G
 !
 spanning-tree root super
 spanning-tree mode mstp
@@ -236,7 +236,7 @@ interface Loopback100
    vrf Tenant_A_OP_Zone
    ip address 10.255.1.21/32
 !
-interface Management1
+interface Management42
    description oob_management
    no shutdown
    vrf MGMT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1_UNDEPLOYED_LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1_UNDEPLOYED_LEAF1B.cfg
@@ -20,18 +20,18 @@ ip name-server vrf MGMT 192.168.200.5
 ip name-server vrf MGMT 2001:db8::1
 ip name-server vrf MGMT 2001:db8::2
 !
-ntp local-interface vrf MGMT Management1
+ntp local-interface vrf MGMT Management42
 ntp server vrf MGMT 192.168.200.5 prefer
 ntp server vrf MGMT 2001:db8::3
 !
 snmp-server contact example@example.com
 snmp-server location EOS_DESIGNS_UNIT_TESTS DC1_UNDEPLOYED_LEAF1B
 !
-hardware speed-group 1 serdes 10G
+hardware speed-group 1 serdes 25G
 hardware speed-group 2 serdes 25G
-hardware speed-group 3 serdes 25G
-hardware speed-group 4 serdes 10G
-hardware speed-group 5/1 serdes 25G
+hardware speed-group 3 serdes 10G
+hardware speed-group 4 serdes 25G
+hardware speed-group 5/1 serdes 10G
 !
 spanning-tree root super
 spanning-tree mode mstp
@@ -236,7 +236,7 @@ interface Loopback100
    vrf Tenant_A_OP_Zone
    ip address 10.255.1.22/32
 !
-interface Management1
+interface Management42
    description oob_management
    no shutdown
    vrf MGMT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-PYTHON_MODULES-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-PYTHON_MODULES-L3LEAF1A.yml
@@ -212,7 +212,7 @@ ethernet_interfaces:
 - name: Ethernet1
   peer: CUSTOM-PYTHON_MODULES-SPINE1
   peer_interface: Ethernet1
-  peer_type: spine
+  peer_type: custom_spine
   description: TEST_CUSTOM_PREFIX_P2P_LINK_TO_CUSTOM-PYTHON_MODULES-SPINE1_Ethernet1
   shutdown: false
   mtu: 9214

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-PYTHON_MODULES-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-PYTHON_MODULES-L3LEAF1B.yml
@@ -201,7 +201,7 @@ ethernet_interfaces:
 - name: Ethernet1
   peer: CUSTOM-PYTHON_MODULES-SPINE1
   peer_interface: Ethernet2
-  peer_type: spine
+  peer_type: custom_spine
   description: TEST_CUSTOM_PREFIX_P2P_LINK_TO_CUSTOM-PYTHON_MODULES-SPINE1_Ethernet2
   shutdown: false
   mtu: 9214

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-PYTHON_MODULES-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-PYTHON_MODULES-SPINE1.yml
@@ -107,7 +107,7 @@ ethernet_interfaces:
   ip_address: 172.31.255.22/31
 loopback_interfaces:
 - name: Loopback0
-  description: TEST_CUSTOM_PREFIX_EVPN_Overlay_Peering_SPINE
+  description: TEST_CUSTOM_PREFIX_EVPN_Overlay_Peering_CUSTOM_SPINE
   shutdown: false
   ip_address: 192.168.255.1/32
 prefix_lists:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1A.yml
@@ -377,7 +377,7 @@ vrfs:
   tenant: Tenant_C
   ip_routing: true
 management_interfaces:
-- name: Management1
+- name: Management99
   description: oob_management
   shutdown: false
   vrf: MGMT
@@ -699,4 +699,4 @@ sflow:
     destinations:
     - destination: 192.168.200.10
     - destination: 10.0.200.90
-    source_interface: Management1
+    source_interface: Management99

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1B.yml
@@ -369,7 +369,7 @@ vrfs:
   tenant: Tenant_C
   ip_routing: true
 management_interfaces:
-- name: Management1
+- name: Management99
   description: oob_management
   shutdown: false
   vrf: MGMT
@@ -663,4 +663,4 @@ sflow:
     destinations:
     - destination: 192.168.200.10
     - destination: 10.0.200.90
-    source_interface: Management1
+    source_interface: Management99

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
@@ -427,7 +427,7 @@ vrfs:
   ip_routing: true
   ipv6_routing: true
 management_interfaces:
-- name: Management1
+- name: Management99
   description: oob_management
   shutdown: false
   vrf: MGMT
@@ -447,7 +447,7 @@ management_api_http:
   default_services: false
 ntp:
   local_interface:
-    name: Management1
+    name: Management99
     vrf: MGMT
   servers:
   - name: 192.168.200.5

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
@@ -427,7 +427,7 @@ vrfs:
   ip_routing: true
   ipv6_routing: true
 management_interfaces:
-- name: Management1
+- name: Management99
   description: oob_management
   shutdown: false
   vrf: MGMT
@@ -447,7 +447,7 @@ management_api_http:
   default_services: false
 ntp:
   local_interface:
-    name: Management1
+    name: Management99
     vrf: MGMT
   servers:
   - name: 192.168.200.5

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1_UNDEPLOYED_LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1_UNDEPLOYED_LEAF1A.yml
@@ -379,15 +379,15 @@ ip_routing: true
 hardware:
   speed_groups:
   - speed_group: '1'
-    serdes: 10G
+    serdes: 25G
   - speed_group: '2'
     serdes: 25G
   - speed_group: '3'
-    serdes: 25G
-  - speed_group: '4'
     serdes: 10G
-  - speed_group: 5/1
+  - speed_group: '4'
     serdes: 25G
+  - speed_group: 5/1
+    serdes: 10G
 daemon_terminattr:
   cvaddrs:
   - 192.168.200.11:9910
@@ -465,7 +465,7 @@ vrfs:
   tenant: Tenant_C
   ip_routing: true
 management_interfaces:
-- name: Management1
+- name: Management42
   description: oob_management
   shutdown: false
   vrf: MGMT
@@ -485,7 +485,7 @@ management_api_http:
   default_services: false
 ntp:
   local_interface:
-    name: Management1
+    name: Management42
     vrf: MGMT
   servers:
   - name: 192.168.200.5
@@ -1066,4 +1066,4 @@ virtual_source_nat_vrfs:
 - name: Tenant_A_OP_Zone
   ip_address: 10.255.1.21
 metadata:
-  platform: 7280R
+  platform: my_custom_platform

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1_UNDEPLOYED_LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1_UNDEPLOYED_LEAF1B.yml
@@ -379,15 +379,15 @@ ip_routing: true
 hardware:
   speed_groups:
   - speed_group: '1'
-    serdes: 10G
+    serdes: 25G
   - speed_group: '2'
     serdes: 25G
   - speed_group: '3'
-    serdes: 25G
-  - speed_group: '4'
     serdes: 10G
-  - speed_group: 5/1
+  - speed_group: '4'
     serdes: 25G
+  - speed_group: 5/1
+    serdes: 10G
 daemon_terminattr:
   cvaddrs:
   - 192.168.200.11:9910
@@ -465,7 +465,7 @@ vrfs:
   tenant: Tenant_C
   ip_routing: true
 management_interfaces:
-- name: Management1
+- name: Management42
   description: oob_management
   shutdown: false
   vrf: MGMT
@@ -485,7 +485,7 @@ management_api_http:
   default_services: false
 ntp:
   local_interface:
-    name: Management1
+    name: Management42
     vrf: MGMT
   servers:
   - name: 192.168.200.5
@@ -1066,4 +1066,4 @@ virtual_source_nat_vrfs:
 - name: Tenant_A_OP_Zone
   ip_address: 10.255.1.22
 metadata:
-  platform: 7280R
+  platform: my_custom_platform

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/AVD_LAB.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/AVD_LAB.yml
@@ -88,7 +88,7 @@ default_interfaces:
     downlink_interfaces: [ Ethernet1-30/1 ]
 
   - types: [ l3leaf ]
-    platforms: [ 7280R, 7280R2 ]
+    platforms: [ 7280R, 7280R2, my_custom_platform ]
     uplink_interfaces: [ Ethernet49-56/1 ]
     mlag_interfaces: [ Ethernet57-58/1 ]
     downlink_interfaces: [ Ethernet1-30/1 ]
@@ -104,3 +104,27 @@ default_interfaces:
     uplink_interfaces: [ Ethernet1/27-30/1 ]
     mlag_interfaces: [ Ethernet1/31-32/1 ]
     downlink_interfaces: [ Ethernet1/1-26/1 ]
+
+# Custom platform with Management42 as the management interface
+custom_platform_settings:
+  - platforms: [ my_custom_platform ]
+    management_interface: Management42
+    tcam_profile: vxlan-routing
+    lag_hardware_only: true
+    reload_delay:
+      mlag: 900
+      non_mlag: 1020
+    feature_support:
+      queue_monitor_length_notify: false
+      interface_storm_control: false
+      bgp_update_wait_for_convergence: true
+      bgp_update_wait_install: true
+
+  # Test overwriting an existing platform
+  - platforms: [ 7280R ]
+    management_interface: Management99
+    tcam_profile: vxlan-routing
+    lag_hardware_only: true
+    reload_delay:
+      mlag: 900
+      non_mlag: 1020

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CUSTOM_PYTHON_MODULES_SPINES.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CUSTOM_PYTHON_MODULES_SPINES.yml
@@ -1,9 +1,9 @@
 ---
 
-type: spine
+type: custom_spine
 
 # Spine Switches
-spine:
+custom_spine:
   defaults:
     platform: vEOS-LAB
     bgp_as: 65001

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CUSTOM_PYTHON_MODULES_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CUSTOM_PYTHON_MODULES_TESTS.yml
@@ -2,9 +2,9 @@
 
 mgmt_gateway: 192.168.200.1
 
-node_type_keys:
-  - key: spine
-    type: spine
+custom_node_type_keys:
+  - key: custom_spine
+    type: custom_spine
     default_evpn_role: server
     interface_descriptions:
       # Override default interface description with a custom python module

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_FABRIC.yml
@@ -262,6 +262,7 @@ l3leaf:
           mgmt_ip: 192.168.200.120/24
           uplink_switch_interfaces: [ Ethernet27, Ethernet27, Ethernet27, Ethernet27 ]
     - group: DC1_UNDEPLOYED_LEAF1
+      platform: my_custom_platform
       filter:
         tenants: [ Tenant_A, Tenant_B, Tenant_C ]
         tags: [ opzone, web, app, db, vmotion, nfs, wan ]
@@ -405,6 +406,12 @@ platform_speed_groups:
         speed_groups: [ 3, 2, 5/1 ]    # Unsorted order, but we should sort output correctly.
       - speed: 10G
         speed_groups: [ 1, 2, 4 ] # Duplicate speed-group 2. Since we sort on key first the result will be 25G for group 2
+  - platform: my_custom_platform
+    speeds:
+      - speed: 10G
+        speed_groups: [ 3, 2, 5/1 ]
+      - speed: 25G
+        speed_groups: [ 1, 2, 4 ]
 
 # Set Aboot password with sha512 hash
 boot:

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/input-variables.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/input-variables.md
@@ -175,7 +175,7 @@ AVD provides the capability to customize your node types, supporting a variety o
 !!! note
     The default values will be overridden if this key is defined.
     If you need to change all the existing `node_type_keys`, it is recommended to copy the defaults and modify them.
-    If you need to add custom `node_type_keys`, create them under `custom_node_type_keys` - if named identically to default `node_type_keys` entries, custom entries will replace the equivalent default entry.
+    If you need to add custom `node_type_keys`, create them under `custom_node_type_keys`; if named identically to default `node_type_keys` entries, custom entries will replace the equivalent default entry.
 
 ??? example "Default value for design `l3ls-evpn`"
 

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/input-variables.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/input-variables.md
@@ -173,7 +173,9 @@ To customize or create new node types, please refer to [node type customization]
 AVD provides the capability to customize your node types, supporting a variety of designs.
 
 !!! note
-    The default values will be overridden if defining this key, so it is recommended to copy the defaults and modify them.
+    The default values will be overridden if this key is defined.
+    If you need to change all the existing `node_type_keys`, it is recommended to copy the defaults and modify them.
+    If you need to add custom `node_type_keys`, create them under `custom_node_type_keys` - if named identically to default `node_type_keys` entries, custom entries will replace the equivalent default entry.
 
 ??? example "Default value for design `l3ls-evpn`"
 
@@ -1350,7 +1352,9 @@ Management interface is modified for specific platforms like modular platforms w
     The reload delay values should be reviewed and tuned to the specific environment.
 
 !!! note
-    The default values will be overridden if defining this key, so it is recommended to copy the defaults and modify them.
+    The default values will be overridden if `platform_settings` is defined.
+    If you need to replace all the default platforms, it is recommended to copy the defaults and modify them.
+    If you need to add custom platforms, create them under `custom_platform_settings`; if named identically to default `platform_settings` entries, custom entries will replace the equivalent default entry.
 
 --8<--
 roles/eos_designs/docs/tables/platform-settings.md

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/cloudvision-tags.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/cloudvision-tags.md
@@ -18,10 +18,10 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "generate_cv_tags.device_tags.[].name") | String | Required |  |  | Tag name to be assigned to generated tags. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;data_path</samp>](## "generate_cv_tags.device_tags.[].data_path") | String |  |  |  | Structured config field/key path to be used to find the value for the tag. Dot notation is supported to reference values inside dictionaries.<br>For Example: 'data_path: router_bfd.multihop.interval' would set the tag with the value of the interval for multihop bfd. If this value is not specified in the structured config, the tag is not created.<br>`data_path` is ignored if `value` is set. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;value</samp>](## "generate_cv_tags.device_tags.[].value") | String |  |  |  | Value to be assigned to the tag. |
-    | [<samp>custom_node_type_keys</samp>](## "custom_node_type_keys") | List, items: Dictionary |  |  |  | Define Custom Node Type Keys, to specify the properties of each node type in the fabric.<br>This allows for complete customization of the fabric layout and functionality.<br>`custom_node_type_keys` should be defined in top level group_var for the fabric.<br>These values will be merged with the defaults; keys named the same as a default node_type_key will override the default. |
+    | [<samp>custom_node_type_keys</samp>](## "custom_node_type_keys") | List, items: Dictionary |  | `[]` |  | Define Custom Node Type Keys, to specify the properties of each node type in the fabric.<br>This allows for complete customization of the fabric layout and functionality.<br>`custom_node_type_keys` should be defined in top level group_var for the fabric.<br>These values will be combined with the defaults; custom node type keys named the same as a<br>default node_type_key will replace the default. |
     | [<samp>&nbsp;&nbsp;-&nbsp;key</samp>](## "custom_node_type_keys.[].key") | String | Required, Unique |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;cv_tags_topology_type</samp>](## "custom_node_type_keys.[].cv_tags_topology_type") | String |  |  | Valid Values:<br>- <code>leaf</code><br>- <code>spine</code><br>- <code>core</code><br>- <code>edge</code> | PREVIEW: This key is currently not supported<br>Type that CloudVision should use when generating the Topology. |
-    | [<samp>node_type_keys</samp>](## "node_type_keys") | List, items: Dictionary |  |  |  | Define Node Type Keys, to specify the properties of each node type in the fabric.<br>This allows for complete customization of the fabric layout and functionality.<br>`node_type_keys` should be defined in top level group_var for the fabric.<br>The default values will be overridden if defining this key, so it is recommended to copy the defaults and modify them. |
+    | [<samp>node_type_keys</samp>](## "node_type_keys") | List, items: Dictionary |  |  |  | Define Node Type Keys, to specify the properties of each node type in the fabric.<br>This allows for complete customization of the fabric layout and functionality.<br>`node_type_keys` should be defined in top level group_var for the fabric.<br><br>The default values will be overridden if this key is defined.<br>If you need to change all the existing `node_type_keys`, it is recommended to copy the defaults and modify them.<br>If you need to add custom `node_type_keys`, create them under `custom_node_type_keys` - if named identically to default `node_type_keys` entries,<br>custom entries will replace the equivalent default entry. |
     | [<samp>&nbsp;&nbsp;-&nbsp;key</samp>](## "node_type_keys.[].key") | String | Required, Unique |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;cv_tags_topology_type</samp>](## "node_type_keys.[].cv_tags_topology_type") | String |  |  | Valid Values:<br>- <code>leaf</code><br>- <code>spine</code><br>- <code>core</code><br>- <code>edge</code> | PREVIEW: This key is currently not supported<br>Type that CloudVision should use when generating the Topology. |
 
@@ -70,8 +70,9 @@
     # Define Custom Node Type Keys, to specify the properties of each node type in the fabric.
     # This allows for complete customization of the fabric layout and functionality.
     # `custom_node_type_keys` should be defined in top level group_var for the fabric.
-    # These values will be merged with the defaults; keys named the same as a default node_type_key will override the default.
-    custom_node_type_keys:
+    # These values will be combined with the defaults; custom node type keys named the same as a
+    # default node_type_key will replace the default.
+    custom_node_type_keys: # default=[]
       - key: <str; required; unique>
 
         # PREVIEW: This key is currently not supported
@@ -81,7 +82,11 @@
     # Define Node Type Keys, to specify the properties of each node type in the fabric.
     # This allows for complete customization of the fabric layout and functionality.
     # `node_type_keys` should be defined in top level group_var for the fabric.
-    # The default values will be overridden if defining this key, so it is recommended to copy the defaults and modify them.
+    #
+    # The default values will be overridden if this key is defined.
+    # If you need to change all the existing `node_type_keys`, it is recommended to copy the defaults and modify them.
+    # If you need to add custom `node_type_keys`, create them under `custom_node_type_keys` - if named identically to default `node_type_keys` entries,
+    # custom entries will replace the equivalent default entry.
     node_type_keys:
       - key: <str; required; unique>
 

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/cloudvision-tags.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/cloudvision-tags.md
@@ -18,7 +18,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "generate_cv_tags.device_tags.[].name") | String | Required |  |  | Tag name to be assigned to generated tags. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;data_path</samp>](## "generate_cv_tags.device_tags.[].data_path") | String |  |  |  | Structured config field/key path to be used to find the value for the tag. Dot notation is supported to reference values inside dictionaries.<br>For Example: 'data_path: router_bfd.multihop.interval' would set the tag with the value of the interval for multihop bfd. If this value is not specified in the structured config, the tag is not created.<br>`data_path` is ignored if `value` is set. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;value</samp>](## "generate_cv_tags.device_tags.[].value") | String |  |  |  | Value to be assigned to the tag. |
-    | [<samp>custom_node_type_keys</samp>](## "custom_node_type_keys") | List, items: Dictionary |  | `[]` |  | Define Custom Node Type Keys, to specify the properties of each node type in the fabric.<br>This allows for complete customization of the fabric layout and functionality.<br>`custom_node_type_keys` should be defined in top level group_var for the fabric.<br>These values will be combined with the defaults; custom node type keys named the same as a<br>default node_type_key will replace the default. |
+    | [<samp>custom_node_type_keys</samp>](## "custom_node_type_keys") | List, items: Dictionary |  |  |  | Define Custom Node Type Keys, to specify the properties of each node type in the fabric.<br>This allows for complete customization of the fabric layout and functionality.<br>`custom_node_type_keys` should be defined in top level group_var for the fabric.<br>These values will be combined with the defaults; custom node type keys named the same as a<br>default node_type_key will replace the default. |
     | [<samp>&nbsp;&nbsp;-&nbsp;key</samp>](## "custom_node_type_keys.[].key") | String | Required, Unique |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;cv_tags_topology_type</samp>](## "custom_node_type_keys.[].cv_tags_topology_type") | String |  |  | Valid Values:<br>- <code>leaf</code><br>- <code>spine</code><br>- <code>core</code><br>- <code>edge</code> | PREVIEW: This key is currently not supported<br>Type that CloudVision should use when generating the Topology. |
     | [<samp>node_type_keys</samp>](## "node_type_keys") | List, items: Dictionary |  |  |  | Define Node Type Keys, to specify the properties of each node type in the fabric.<br>This allows for complete customization of the fabric layout and functionality.<br>`node_type_keys` should be defined in top level group_var for the fabric.<br><br>The default values will be overridden if this key is defined.<br>If you need to change all the existing `node_type_keys`, it is recommended to copy the defaults and modify them.<br>If you need to add custom `node_type_keys`, create them under `custom_node_type_keys` - if named identically to default `node_type_keys` entries,<br>custom entries will replace the equivalent default entry. |
@@ -72,7 +72,7 @@
     # `custom_node_type_keys` should be defined in top level group_var for the fabric.
     # These values will be combined with the defaults; custom node type keys named the same as a
     # default node_type_key will replace the default.
-    custom_node_type_keys: # default=[]
+    custom_node_type_keys:
       - key: <str; required; unique>
 
         # PREVIEW: This key is currently not supported

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/cloudvision-tags.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/cloudvision-tags.md
@@ -18,7 +18,10 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "generate_cv_tags.device_tags.[].name") | String | Required |  |  | Tag name to be assigned to generated tags. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;data_path</samp>](## "generate_cv_tags.device_tags.[].data_path") | String |  |  |  | Structured config field/key path to be used to find the value for the tag. Dot notation is supported to reference values inside dictionaries.<br>For Example: 'data_path: router_bfd.multihop.interval' would set the tag with the value of the interval for multihop bfd. If this value is not specified in the structured config, the tag is not created.<br>`data_path` is ignored if `value` is set. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;value</samp>](## "generate_cv_tags.device_tags.[].value") | String |  |  |  | Value to be assigned to the tag. |
-    | [<samp>node_type_keys</samp>](## "node_type_keys") | List, items: Dictionary |  |  |  | Define Node Type Keys, to specify the properties of each node type in the fabric.<br>This allows for complete customization of the fabric layout and functionality.<br>`node_type_keys` should be defined in top level group_var for the fabric.<br>The default values will be overridden if defining this key, so it is recommended to copy the defaults and modify them.<br> |
+    | [<samp>custom_node_type_keys</samp>](## "custom_node_type_keys") | List, items: Dictionary |  |  |  | Define Custom Node Type Keys, to specify the properties of each node type in the fabric.<br>This allows for complete customization of the fabric layout and functionality.<br>`custom_node_type_keys` should be defined in top level group_var for the fabric.<br>These values will be merged with the defaults; keys named the same as a default node_type_key will override the default. |
+    | [<samp>&nbsp;&nbsp;-&nbsp;key</samp>](## "custom_node_type_keys.[].key") | String | Required, Unique |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;cv_tags_topology_type</samp>](## "custom_node_type_keys.[].cv_tags_topology_type") | String |  |  | Valid Values:<br>- <code>leaf</code><br>- <code>spine</code><br>- <code>core</code><br>- <code>edge</code> | PREVIEW: This key is currently not supported<br>Type that CloudVision should use when generating the Topology. |
+    | [<samp>node_type_keys</samp>](## "node_type_keys") | List, items: Dictionary |  |  |  | Define Node Type Keys, to specify the properties of each node type in the fabric.<br>This allows for complete customization of the fabric layout and functionality.<br>`node_type_keys` should be defined in top level group_var for the fabric.<br>The default values will be overridden if defining this key, so it is recommended to copy the defaults and modify them. |
     | [<samp>&nbsp;&nbsp;-&nbsp;key</samp>](## "node_type_keys.[].key") | String | Required, Unique |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;cv_tags_topology_type</samp>](## "node_type_keys.[].cv_tags_topology_type") | String |  |  | Valid Values:<br>- <code>leaf</code><br>- <code>spine</code><br>- <code>core</code><br>- <code>edge</code> | PREVIEW: This key is currently not supported<br>Type that CloudVision should use when generating the Topology. |
 
@@ -63,6 +66,17 @@
 
           # Value to be assigned to the tag.
           value: <str>
+
+    # Define Custom Node Type Keys, to specify the properties of each node type in the fabric.
+    # This allows for complete customization of the fabric layout and functionality.
+    # `custom_node_type_keys` should be defined in top level group_var for the fabric.
+    # These values will be merged with the defaults; keys named the same as a default node_type_key will override the default.
+    custom_node_type_keys:
+      - key: <str; required; unique>
+
+        # PREVIEW: This key is currently not supported
+        # Type that CloudVision should use when generating the Topology.
+        cv_tags_topology_type: <str; "leaf" | "spine" | "core" | "edge">
 
     # Define Node Type Keys, to specify the properties of each node type in the fabric.
     # This allows for complete customization of the fabric layout and functionality.

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/node-type-keys.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/node-type-keys.md
@@ -7,7 +7,7 @@
 
     | Variable | Type | Required | Default | Value Restrictions | Description |
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
-    | [<samp>custom_node_type_keys</samp>](## "custom_node_type_keys") | List, items: Dictionary |  | `[]` |  | Define Custom Node Type Keys, to specify the properties of each node type in the fabric.<br>This allows for complete customization of the fabric layout and functionality.<br>`custom_node_type_keys` should be defined in top level group_var for the fabric.<br>These values will be combined with the defaults; custom node type keys named the same as a<br>default node_type_key will replace the default. |
+    | [<samp>custom_node_type_keys</samp>](## "custom_node_type_keys") | List, items: Dictionary |  |  |  | Define Custom Node Type Keys, to specify the properties of each node type in the fabric.<br>This allows for complete customization of the fabric layout and functionality.<br>`custom_node_type_keys` should be defined in top level group_var for the fabric.<br>These values will be combined with the defaults; custom node type keys named the same as a<br>default node_type_key will replace the default. |
     | [<samp>&nbsp;&nbsp;-&nbsp;key</samp>](## "custom_node_type_keys.[].key") | String | Required, Unique |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;type</samp>](## "custom_node_type_keys.[].type") | String |  |  |  | Type value matching this node_type_key. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;connected_endpoints</samp>](## "custom_node_type_keys.[].connected_endpoints") | Boolean |  | `False` |  | Are endpoints connected to this node type. |
@@ -114,7 +114,7 @@
     # `custom_node_type_keys` should be defined in top level group_var for the fabric.
     # These values will be combined with the defaults; custom node type keys named the same as a
     # default node_type_key will replace the default.
-    custom_node_type_keys: # default=[]
+    custom_node_type_keys:
       - key: <str; required; unique>
 
         # Type value matching this node_type_key.

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/node-type-keys.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/node-type-keys.md
@@ -7,7 +7,56 @@
 
     | Variable | Type | Required | Default | Value Restrictions | Description |
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
-    | [<samp>node_type_keys</samp>](## "node_type_keys") | List, items: Dictionary |  |  |  | Define Node Type Keys, to specify the properties of each node type in the fabric.<br>This allows for complete customization of the fabric layout and functionality.<br>`node_type_keys` should be defined in top level group_var for the fabric.<br>The default values will be overridden if defining this key, so it is recommended to copy the defaults and modify them.<br> |
+    | [<samp>custom_node_type_keys</samp>](## "custom_node_type_keys") | List, items: Dictionary |  |  |  | Define Custom Node Type Keys, to specify the properties of each node type in the fabric.<br>This allows for complete customization of the fabric layout and functionality.<br>`custom_node_type_keys` should be defined in top level group_var for the fabric.<br>These values will be merged with the defaults; keys named the same as a default node_type_key will override the default. |
+    | [<samp>&nbsp;&nbsp;-&nbsp;key</samp>](## "custom_node_type_keys.[].key") | String | Required, Unique |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;type</samp>](## "custom_node_type_keys.[].type") | String |  |  |  | Type value matching this node_type_key. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;connected_endpoints</samp>](## "custom_node_type_keys.[].connected_endpoints") | Boolean |  | `False` |  | Are endpoints connected to this node type. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;default_evpn_role</samp>](## "custom_node_type_keys.[].default_evpn_role") | String |  | `none` | Valid Values:<br>- <code>none</code><br>- <code>client</code><br>- <code>server</code> | Default evpn_role. Can be overridden in topology vars. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;default_ptp_priority1</samp>](## "custom_node_type_keys.[].default_ptp_priority1") | Integer |  | `127` | Min: 0<br>Max: 255 | Default PTP priority 1 |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;default_underlay_routing_protocol</samp>](## "custom_node_type_keys.[].default_underlay_routing_protocol") | String |  | `ebgp` | Value is converted to lower case.<br>Valid Values:<br>- <code>ebgp</code><br>- <code>ospf</code><br>- <code>ospf-ldp</code><br>- <code>isis</code><br>- <code>isis-sr</code><br>- <code>isis-ldp</code><br>- <code>isis-sr-ldp</code><br>- <code>none</code> | Set the default underlay routing_protocol.<br>Can be overridden by setting "underlay_routing_protocol" host/group_vars.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;default_overlay_routing_protocol</samp>](## "custom_node_type_keys.[].default_overlay_routing_protocol") | String |  | `ebgp` | Value is converted to lower case.<br>Valid Values:<br>- <code>ebgp</code><br>- <code>ibgp</code><br>- <code>her</code><br>- <code>cvx</code><br>- <code>none</code> | Set the default overlay routing_protocol.<br>Can be overridden by setting "overlay_routing_protocol" host/group_vars.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;default_mpls_overlay_role</samp>](## "custom_node_type_keys.[].default_mpls_overlay_role") | String |  |  | Valid Values:<br>- <code>client</code><br>- <code>server</code><br>- <code>none</code> | Set the default mpls overlay role.<br>Acting role in overlay control plane.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;default_overlay_address_families</samp>](## "custom_node_type_keys.[].default_overlay_address_families") | List, items: String |  |  |  | Set the default overlay address families.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "custom_node_type_keys.[].default_overlay_address_families.[]") | String |  |  | Value is converted to lower case.<br>Valid Values:<br>- <code>evpn</code><br>- <code>vpn-ipv4</code><br>- <code>vpn-ipv6</code> |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;default_evpn_encapsulation</samp>](## "custom_node_type_keys.[].default_evpn_encapsulation") | String |  |  | Value is converted to lower case.<br>Valid Values:<br>- <code>mpls</code><br>- <code>vxlan</code> | Set the default evpn encapsulation.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;default_wan_role</samp>](## "custom_node_type_keys.[].default_wan_role") | String |  |  | Valid Values:<br>- <code>client</code><br>- <code>server</code> | Set the default WAN role.<br><br>This is used both for AutoVPN and Pathfinder designs.<br>That means if `wan_mode` root key is set to `autovpn` or `cv-pathfinder`.<br>`server` indicates that the router is a route-reflector.<br><br>Only supported if `overlay_routing_protocol` is set to `ibgp`.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;default_flow_tracker_type</samp>](## "custom_node_type_keys.[].default_flow_tracker_type") | String |  | `sampled` | Valid Values:<br>- <code>sampled</code><br>- <code>hardware</code> | Set the default flow tracker type. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mlag_support</samp>](## "custom_node_type_keys.[].mlag_support") | Boolean |  | `False` |  | Can this node type support mlag. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;network_services</samp>](## "custom_node_type_keys.[].network_services") | Dictionary |  |  |  | Will network services be deployed on this node type. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;l1</samp>](## "custom_node_type_keys.[].network_services.l1") | Boolean |  | `False` |  | ?? |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;l2</samp>](## "custom_node_type_keys.[].network_services.l2") | Boolean |  | `False` |  | Vlans |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;l3</samp>](## "custom_node_type_keys.[].network_services.l3") | Boolean |  | `False` |  | VRFs, SVIs (if l2 is true).<br>Only supported with underlay_router.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;underlay_router</samp>](## "custom_node_type_keys.[].underlay_router") | Boolean |  | `True` |  | Is this node type a L3 device. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;uplink_type</samp>](## "custom_node_type_keys.[].uplink_type") | String |  | `p2p` | Valid Values:<br>- <code>p2p</code><br>- <code>port-channel</code><br>- <code>p2p-vrfs</code><br>- <code>lan</code> | `uplink_type` must be `p2p`, `p2p-vrfs` or `lan` if `vtep` or `underlay_router` is true.<br><br>For `p2p-vrfs`, the uplinks are configured as L3 interfaces with a subinterface for each VRF<br>in `network_services` present on both the uplink and the downlink switch.<br>The subinterface ID is the `vrf_id`.<br>'underlay_router' and 'network_services.l3' must be set to true.<br>VRF `default` is always configured on the physical interface using the underlay routing protocol.<br>All subinterfaces use the same IP address as the physical interface.<br>Multicast is not supported.<br>Only BGP is supported for subinterfaces.<br><br>For `lan`, a single uplink interface is supported and will be configured as an L3 Interface with<br>subinterfaces for each SVI defined under the VRFs in `network_services` as long as the uplink switch also<br>has the VLAN permitted by tag/tenant filtering. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vtep</samp>](## "custom_node_type_keys.[].vtep") | Boolean |  | `False` |  | Is this switch an EVPN VTEP. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mpls_lsr</samp>](## "custom_node_type_keys.[].mpls_lsr") | Boolean |  | `False` |  | Is this switch an MPLS LSR. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_addressing</samp>](## "custom_node_type_keys.[].ip_addressing") | Dictionary |  |  |  | Override ip_addressing templates. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;python_module</samp>](## "custom_node_type_keys.[].ip_addressing.python_module") | String |  |  |  | Custom Python Module to import for IP addressing. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;python_class_name</samp>](## "custom_node_type_keys.[].ip_addressing.python_class_name") | String |  |  |  | Name of Custom Python Class to import for IP addressing. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;router_id</samp>](## "custom_node_type_keys.[].ip_addressing.router_id") | String |  |  |  | Path to Custom J2 template. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;router_id_ipv6</samp>](## "custom_node_type_keys.[].ip_addressing.router_id_ipv6") | String |  |  |  | Path to Custom J2 template. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_ip_primary</samp>](## "custom_node_type_keys.[].ip_addressing.mlag_ip_primary") | String |  |  |  | Path to Custom J2 template. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_ip_secondary</samp>](## "custom_node_type_keys.[].ip_addressing.mlag_ip_secondary") | String |  |  |  | Path to Custom J2 template. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_l3_ip_primary</samp>](## "custom_node_type_keys.[].ip_addressing.mlag_l3_ip_primary") | String |  |  |  | Path to Custom J2 template. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_l3_ip_secondary</samp>](## "custom_node_type_keys.[].ip_addressing.mlag_l3_ip_secondary") | String |  |  |  | Path to Custom J2 template. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_ibgp_peering_ip_primary</samp>](## "custom_node_type_keys.[].ip_addressing.mlag_ibgp_peering_ip_primary") | String |  |  |  | Path to Custom J2 template. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_ibgp_peering_ip_secondary</samp>](## "custom_node_type_keys.[].ip_addressing.mlag_ibgp_peering_ip_secondary") | String |  |  |  | Path to Custom J2 template. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;p2p_uplinks_ip</samp>](## "custom_node_type_keys.[].ip_addressing.p2p_uplinks_ip") | String |  |  |  | Path to Custom J2 template. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;p2p_uplinks_peer_ip</samp>](## "custom_node_type_keys.[].ip_addressing.p2p_uplinks_peer_ip") | String |  |  |  | Path to Custom J2 template. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vtep_ip_mlag</samp>](## "custom_node_type_keys.[].ip_addressing.vtep_ip_mlag") | String |  |  |  | Path to Custom J2 template. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vtep_ip</samp>](## "custom_node_type_keys.[].ip_addressing.vtep_ip") | String |  |  |  | Path to Custom J2 template. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;interface_descriptions</samp>](## "custom_node_type_keys.[].interface_descriptions") | Dictionary |  |  |  | Override interface_descriptions templates.<br>If description templates use Jinja2, they have to strip whitespaces using {%- -%} on any code blocks.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;python_module</samp>](## "custom_node_type_keys.[].interface_descriptions.python_module") | String |  |  |  | Custom Python Module to import for interface descriptions. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;python_class_name</samp>](## "custom_node_type_keys.[].interface_descriptions.python_class_name") | String |  |  |  | Name of Custom Python Class to import for interface descriptions. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;underlay_ethernet_interfaces</samp>](## "custom_node_type_keys.[].interface_descriptions.underlay_ethernet_interfaces") | String |  |  |  | Path to Custom J2 template. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;underlay_port_channel_interfaces</samp>](## "custom_node_type_keys.[].interface_descriptions.underlay_port_channel_interfaces") | String |  |  |  | Path to Custom J2 template. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_ethernet_interfaces</samp>](## "custom_node_type_keys.[].interface_descriptions.mlag_ethernet_interfaces") | String |  |  |  | Path to Custom J2 template. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_port_channel_interfaces</samp>](## "custom_node_type_keys.[].interface_descriptions.mlag_port_channel_interfaces") | String |  |  |  | Path to Custom J2 template. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;connected_endpoints_ethernet_interfaces</samp>](## "custom_node_type_keys.[].interface_descriptions.connected_endpoints_ethernet_interfaces") | String |  |  |  | Path to Custom J2 template. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;connected_endpoints_port_channel_interfaces</samp>](## "custom_node_type_keys.[].interface_descriptions.connected_endpoints_port_channel_interfaces") | String |  |  |  | Path to Custom J2 template. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;overlay_loopback_interface</samp>](## "custom_node_type_keys.[].interface_descriptions.overlay_loopback_interface") | String |  |  |  | Path to Custom J2 template. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vtep_loopback_interface</samp>](## "custom_node_type_keys.[].interface_descriptions.vtep_loopback_interface") | String |  |  |  | Path to Custom J2 template. |
+    | [<samp>node_type_keys</samp>](## "node_type_keys") | List, items: Dictionary |  |  |  | Define Node Type Keys, to specify the properties of each node type in the fabric.<br>This allows for complete customization of the fabric layout and functionality.<br>`node_type_keys` should be defined in top level group_var for the fabric.<br>The default values will be overridden if defining this key, so it is recommended to copy the defaults and modify them. |
     | [<samp>&nbsp;&nbsp;-&nbsp;key</samp>](## "node_type_keys.[].key") | String | Required, Unique |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;type</samp>](## "node_type_keys.[].type") | String |  |  |  | Type value matching this node_type_key. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;connected_endpoints</samp>](## "node_type_keys.[].connected_endpoints") | Boolean |  | `False` |  | Are endpoints connected to this node type. |
@@ -60,6 +109,176 @@
 === "YAML"
 
     ```yaml
+    # Define Custom Node Type Keys, to specify the properties of each node type in the fabric.
+    # This allows for complete customization of the fabric layout and functionality.
+    # `custom_node_type_keys` should be defined in top level group_var for the fabric.
+    # These values will be merged with the defaults; keys named the same as a default node_type_key will override the default.
+    custom_node_type_keys:
+      - key: <str; required; unique>
+
+        # Type value matching this node_type_key.
+        type: <str>
+
+        # Are endpoints connected to this node type.
+        connected_endpoints: <bool; default=False>
+
+        # Default evpn_role. Can be overridden in topology vars.
+        default_evpn_role: <str; "none" | "client" | "server"; default="none">
+
+        # Default PTP priority 1
+        default_ptp_priority1: <int; 0-255; default=127>
+
+        # Set the default underlay routing_protocol.
+        # Can be overridden by setting "underlay_routing_protocol" host/group_vars.
+        default_underlay_routing_protocol: <str; "ebgp" | "ospf" | "ospf-ldp" | "isis" | "isis-sr" | "isis-ldp" | "isis-sr-ldp" | "none"; default="ebgp">
+
+        # Set the default overlay routing_protocol.
+        # Can be overridden by setting "overlay_routing_protocol" host/group_vars.
+        default_overlay_routing_protocol: <str; "ebgp" | "ibgp" | "her" | "cvx" | "none"; default="ebgp">
+
+        # Set the default mpls overlay role.
+        # Acting role in overlay control plane.
+        default_mpls_overlay_role: <str; "client" | "server" | "none">
+
+        # Set the default overlay address families.
+        default_overlay_address_families:
+          - <str; "evpn" | "vpn-ipv4" | "vpn-ipv6">
+
+        # Set the default evpn encapsulation.
+        default_evpn_encapsulation: <str; "mpls" | "vxlan">
+
+        # Set the default WAN role.
+        #
+        # This is used both for AutoVPN and Pathfinder designs.
+        # That means if `wan_mode` root key is set to `autovpn` or `cv-pathfinder`.
+        # `server` indicates that the router is a route-reflector.
+        #
+        # Only supported if `overlay_routing_protocol` is set to `ibgp`.
+        default_wan_role: <str; "client" | "server">
+
+        # Set the default flow tracker type.
+        default_flow_tracker_type: <str; "sampled" | "hardware"; default="sampled">
+
+        # Can this node type support mlag.
+        mlag_support: <bool; default=False>
+
+        # Will network services be deployed on this node type.
+        network_services:
+
+          # ??
+          l1: <bool; default=False>
+
+          # Vlans
+          l2: <bool; default=False>
+
+          # VRFs, SVIs (if l2 is true).
+          # Only supported with underlay_router.
+          l3: <bool; default=False>
+
+        # Is this node type a L3 device.
+        underlay_router: <bool; default=True>
+
+        # `uplink_type` must be `p2p`, `p2p-vrfs` or `lan` if `vtep` or `underlay_router` is true.
+        #
+        # For `p2p-vrfs`, the uplinks are configured as L3 interfaces with a subinterface for each VRF
+        # in `network_services` present on both the uplink and the downlink switch.
+        # The subinterface ID is the `vrf_id`.
+        # 'underlay_router' and 'network_services.l3' must be set to true.
+        # VRF `default` is always configured on the physical interface using the underlay routing protocol.
+        # All subinterfaces use the same IP address as the physical interface.
+        # Multicast is not supported.
+        # Only BGP is supported for subinterfaces.
+        #
+        # For `lan`, a single uplink interface is supported and will be configured as an L3 Interface with
+        # subinterfaces for each SVI defined under the VRFs in `network_services` as long as the uplink switch also
+        # has the VLAN permitted by tag/tenant filtering.
+        uplink_type: <str; "p2p" | "port-channel" | "p2p-vrfs" | "lan"; default="p2p">
+
+        # Is this switch an EVPN VTEP.
+        vtep: <bool; default=False>
+
+        # Is this switch an MPLS LSR.
+        mpls_lsr: <bool; default=False>
+
+        # Override ip_addressing templates.
+        ip_addressing:
+
+          # Custom Python Module to import for IP addressing.
+          python_module: <str>
+
+          # Name of Custom Python Class to import for IP addressing.
+          python_class_name: <str>
+
+          # Path to Custom J2 template.
+          router_id: <str>
+
+          # Path to Custom J2 template.
+          router_id_ipv6: <str>
+
+          # Path to Custom J2 template.
+          mlag_ip_primary: <str>
+
+          # Path to Custom J2 template.
+          mlag_ip_secondary: <str>
+
+          # Path to Custom J2 template.
+          mlag_l3_ip_primary: <str>
+
+          # Path to Custom J2 template.
+          mlag_l3_ip_secondary: <str>
+
+          # Path to Custom J2 template.
+          mlag_ibgp_peering_ip_primary: <str>
+
+          # Path to Custom J2 template.
+          mlag_ibgp_peering_ip_secondary: <str>
+
+          # Path to Custom J2 template.
+          p2p_uplinks_ip: <str>
+
+          # Path to Custom J2 template.
+          p2p_uplinks_peer_ip: <str>
+
+          # Path to Custom J2 template.
+          vtep_ip_mlag: <str>
+
+          # Path to Custom J2 template.
+          vtep_ip: <str>
+
+        # Override interface_descriptions templates.
+        # If description templates use Jinja2, they have to strip whitespaces using {%- -%} on any code blocks.
+        interface_descriptions:
+
+          # Custom Python Module to import for interface descriptions.
+          python_module: <str>
+
+          # Name of Custom Python Class to import for interface descriptions.
+          python_class_name: <str>
+
+          # Path to Custom J2 template.
+          underlay_ethernet_interfaces: <str>
+
+          # Path to Custom J2 template.
+          underlay_port_channel_interfaces: <str>
+
+          # Path to Custom J2 template.
+          mlag_ethernet_interfaces: <str>
+
+          # Path to Custom J2 template.
+          mlag_port_channel_interfaces: <str>
+
+          # Path to Custom J2 template.
+          connected_endpoints_ethernet_interfaces: <str>
+
+          # Path to Custom J2 template.
+          connected_endpoints_port_channel_interfaces: <str>
+
+          # Path to Custom J2 template.
+          overlay_loopback_interface: <str>
+
+          # Path to Custom J2 template.
+          vtep_loopback_interface: <str>
+
     # Define Node Type Keys, to specify the properties of each node type in the fabric.
     # This allows for complete customization of the fabric layout and functionality.
     # `node_type_keys` should be defined in top level group_var for the fabric.

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/node-type-keys.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/node-type-keys.md
@@ -7,7 +7,7 @@
 
     | Variable | Type | Required | Default | Value Restrictions | Description |
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
-    | [<samp>custom_node_type_keys</samp>](## "custom_node_type_keys") | List, items: Dictionary |  |  |  | Define Custom Node Type Keys, to specify the properties of each node type in the fabric.<br>This allows for complete customization of the fabric layout and functionality.<br>`custom_node_type_keys` should be defined in top level group_var for the fabric.<br>These values will be merged with the defaults; keys named the same as a default node_type_key will override the default. |
+    | [<samp>custom_node_type_keys</samp>](## "custom_node_type_keys") | List, items: Dictionary |  | `[]` |  | Define Custom Node Type Keys, to specify the properties of each node type in the fabric.<br>This allows for complete customization of the fabric layout and functionality.<br>`custom_node_type_keys` should be defined in top level group_var for the fabric.<br>These values will be combined with the defaults; custom node type keys named the same as a<br>default node_type_key will replace the default. |
     | [<samp>&nbsp;&nbsp;-&nbsp;key</samp>](## "custom_node_type_keys.[].key") | String | Required, Unique |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;type</samp>](## "custom_node_type_keys.[].type") | String |  |  |  | Type value matching this node_type_key. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;connected_endpoints</samp>](## "custom_node_type_keys.[].connected_endpoints") | Boolean |  | `False` |  | Are endpoints connected to this node type. |
@@ -56,7 +56,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;connected_endpoints_port_channel_interfaces</samp>](## "custom_node_type_keys.[].interface_descriptions.connected_endpoints_port_channel_interfaces") | String |  |  |  | Path to Custom J2 template. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;overlay_loopback_interface</samp>](## "custom_node_type_keys.[].interface_descriptions.overlay_loopback_interface") | String |  |  |  | Path to Custom J2 template. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vtep_loopback_interface</samp>](## "custom_node_type_keys.[].interface_descriptions.vtep_loopback_interface") | String |  |  |  | Path to Custom J2 template. |
-    | [<samp>node_type_keys</samp>](## "node_type_keys") | List, items: Dictionary |  |  |  | Define Node Type Keys, to specify the properties of each node type in the fabric.<br>This allows for complete customization of the fabric layout and functionality.<br>`node_type_keys` should be defined in top level group_var for the fabric.<br>The default values will be overridden if defining this key, so it is recommended to copy the defaults and modify them. |
+    | [<samp>node_type_keys</samp>](## "node_type_keys") | List, items: Dictionary |  |  |  | Define Node Type Keys, to specify the properties of each node type in the fabric.<br>This allows for complete customization of the fabric layout and functionality.<br>`node_type_keys` should be defined in top level group_var for the fabric.<br><br>The default values will be overridden if this key is defined.<br>If you need to change all the existing `node_type_keys`, it is recommended to copy the defaults and modify them.<br>If you need to add custom `node_type_keys`, create them under `custom_node_type_keys` - if named identically to default `node_type_keys` entries,<br>custom entries will replace the equivalent default entry. |
     | [<samp>&nbsp;&nbsp;-&nbsp;key</samp>](## "node_type_keys.[].key") | String | Required, Unique |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;type</samp>](## "node_type_keys.[].type") | String |  |  |  | Type value matching this node_type_key. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;connected_endpoints</samp>](## "node_type_keys.[].connected_endpoints") | Boolean |  | `False` |  | Are endpoints connected to this node type. |
@@ -112,8 +112,9 @@
     # Define Custom Node Type Keys, to specify the properties of each node type in the fabric.
     # This allows for complete customization of the fabric layout and functionality.
     # `custom_node_type_keys` should be defined in top level group_var for the fabric.
-    # These values will be merged with the defaults; keys named the same as a default node_type_key will override the default.
-    custom_node_type_keys:
+    # These values will be combined with the defaults; custom node type keys named the same as a
+    # default node_type_key will replace the default.
+    custom_node_type_keys: # default=[]
       - key: <str; required; unique>
 
         # Type value matching this node_type_key.
@@ -282,7 +283,11 @@
     # Define Node Type Keys, to specify the properties of each node type in the fabric.
     # This allows for complete customization of the fabric layout and functionality.
     # `node_type_keys` should be defined in top level group_var for the fabric.
-    # The default values will be overridden if defining this key, so it is recommended to copy the defaults and modify them.
+    #
+    # The default values will be overridden if this key is defined.
+    # If you need to change all the existing `node_type_keys`, it is recommended to copy the defaults and modify them.
+    # If you need to add custom `node_type_keys`, create them under `custom_node_type_keys` - if named identically to default `node_type_keys` entries,
+    # custom entries will replace the equivalent default entry.
     node_type_keys:
       - key: <str; required; unique>
 

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/platform-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/platform-settings.md
@@ -7,6 +7,25 @@
 
     | Variable | Type | Required | Default | Value Restrictions | Description |
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
+    | [<samp>custom_platform_settings</samp>](## "custom_platform_settings") | List, items: Dictionary |  | See (+) on YAML tab |  |  |
+    | [<samp>&nbsp;&nbsp;-&nbsp;platforms</samp>](## "custom_platform_settings.[].platforms") | List, items: String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "custom_platform_settings.[].platforms.[]") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trident_forwarding_table_partition</samp>](## "custom_platform_settings.[].trident_forwarding_table_partition") | String |  |  |  | Only applied when evpn_multicast is true. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;reload_delay</samp>](## "custom_platform_settings.[].reload_delay") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag</samp>](## "custom_platform_settings.[].reload_delay.mlag") | Integer |  |  | Min: 0<br>Max: 86400 | In seconds. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;non_mlag</samp>](## "custom_platform_settings.[].reload_delay.non_mlag") | Integer |  |  | Min: 0<br>Max: 86400 | In seconds. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;tcam_profile</samp>](## "custom_platform_settings.[].tcam_profile") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;lag_hardware_only</samp>](## "custom_platform_settings.[].lag_hardware_only") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;default_interface_mtu</samp>](## "custom_platform_settings.[].default_interface_mtu") | Integer |  |  | Min: 68<br>Max: 65535 | Default interface MTU configured on EOS under "interface defaults".<br>Takes precedence over the root key "default_interface_mtu".<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;feature_support</samp>](## "custom_platform_settings.[].feature_support") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;queue_monitor_length_notify</samp>](## "custom_platform_settings.[].feature_support.queue_monitor_length_notify") | Boolean |  | `True` |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interface_storm_control</samp>](## "custom_platform_settings.[].feature_support.interface_storm_control") | Boolean |  | `True` |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;poe</samp>](## "custom_platform_settings.[].feature_support.poe") | Boolean |  | `False` |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;per_interface_mtu</samp>](## "custom_platform_settings.[].feature_support.per_interface_mtu") | Boolean |  | `True` |  | Support for configuration of per interface MTU for p2p links, MLAG SVIs and Network Services.<br>Effectively this means that all settings regarding interface MTU will be ignored if this is false.<br>Platforms without support for per interface MTU can use a single default interface MTU setting. Set this via "default_interface_mtu"<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bgp_update_wait_install</samp>](## "custom_platform_settings.[].feature_support.bgp_update_wait_install") | Boolean |  | `True` |  | Disables FIB updates and route advertisement when the BGP instance is initiated until the BGP convergence state is reached.<br>Can be overridden by setting "bgp_update_wait_install" host/group_vars.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bgp_update_wait_for_convergence</samp>](## "custom_platform_settings.[].feature_support.bgp_update_wait_for_convergence") | Boolean |  | `True` |  | Do not advertise reachability to a prefix until that prefix has been installed in hardware.<br>This will eliminate any temporary black holes due to a BGP speaker advertising reachability to a prefix that may not yet be installed into the forwarding plane.<br>Can be overridden by setting "bgp_update_wait_for_convergence" host/group_vars.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;management_interface</samp>](## "custom_platform_settings.[].management_interface") | String |  | `Management1` |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;raw_eos_cli</samp>](## "custom_platform_settings.[].raw_eos_cli") | String |  |  |  | EOS CLI rendered directly on the root level of the final EOS configuration. |
     | [<samp>platform_settings</samp>](## "platform_settings") | List, items: Dictionary |  | See (+) on YAML tab |  |  |
     | [<samp>&nbsp;&nbsp;-&nbsp;platforms</samp>](## "platform_settings.[].platforms") | List, items: String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "platform_settings.[].platforms.[]") | String |  |  |  |  |
@@ -42,7 +61,48 @@
 === "YAML"
 
     ```yaml
-    platform_settings: # (1)!
+    custom_platform_settings: # (1)!
+      - platforms:
+          - <str>
+
+        # Only applied when evpn_multicast is true.
+        trident_forwarding_table_partition: <str>
+        reload_delay:
+
+          # In seconds.
+          mlag: <int; 0-86400>
+
+          # In seconds.
+          non_mlag: <int; 0-86400>
+        tcam_profile: <str>
+        lag_hardware_only: <bool>
+
+        # Default interface MTU configured on EOS under "interface defaults".
+        # Takes precedence over the root key "default_interface_mtu".
+        default_interface_mtu: <int; 68-65535>
+        feature_support:
+          queue_monitor_length_notify: <bool; default=True>
+          interface_storm_control: <bool; default=True>
+          poe: <bool; default=False>
+
+          # Support for configuration of per interface MTU for p2p links, MLAG SVIs and Network Services.
+          # Effectively this means that all settings regarding interface MTU will be ignored if this is false.
+          # Platforms without support for per interface MTU can use a single default interface MTU setting. Set this via "default_interface_mtu"
+          per_interface_mtu: <bool; default=True>
+
+          # Disables FIB updates and route advertisement when the BGP instance is initiated until the BGP convergence state is reached.
+          # Can be overridden by setting "bgp_update_wait_install" host/group_vars.
+          bgp_update_wait_install: <bool; default=True>
+
+          # Do not advertise reachability to a prefix until that prefix has been installed in hardware.
+          # This will eliminate any temporary black holes due to a BGP speaker advertising reachability to a prefix that may not yet be installed into the forwarding plane.
+          # Can be overridden by setting "bgp_update_wait_for_convergence" host/group_vars.
+          bgp_update_wait_for_convergence: <bool; default=True>
+        management_interface: <str; default="Management1">
+
+        # EOS CLI rendered directly on the root level of the final EOS configuration.
+        raw_eos_cli: <str>
+    platform_settings: # (2)!
       - platforms:
           - <str>
 
@@ -112,6 +172,141 @@
     ```
 
     1. Default Value
+
+        ```yaml
+        custom_platform_settings:
+        - feature_support:
+            queue_monitor_length_notify: false
+          platforms:
+          - default
+          reload_delay:
+            mlag: 300
+            non_mlag: 330
+        - feature_support:
+            queue_monitor_length_notify: false
+          platforms:
+          - 7050X3
+          reload_delay:
+            mlag: 300
+            non_mlag: 330
+          trident_forwarding_table_partition: flexible exact-match 16384 l2-shared 98304 l3-shared
+            131072
+        - feature_support:
+            poe: true
+            queue_monitor_length_notify: false
+          platforms:
+          - 720XP
+          reload_delay:
+            mlag: 300
+            non_mlag: 330
+          trident_forwarding_table_partition: flexible exact-match 16384 l2-shared 98304 l3-shared
+            131072
+        - feature_support:
+            poe: true
+            queue_monitor_length_notify: false
+          management_interface: Management0
+          platforms:
+          - '750'
+          - '755'
+          - '758'
+          reload_delay:
+            mlag: 300
+            non_mlag: 330
+        - feature_support:
+            poe: true
+            queue_monitor_length_notify: false
+          platforms:
+          - 720DP
+          - 722XP
+          - 710P
+          reload_delay:
+            mlag: 300
+            non_mlag: 330
+        - lag_hardware_only: true
+          platforms:
+          - 7280R
+          - 7280R2
+          - 7020R
+          reload_delay:
+            mlag: 900
+            non_mlag: 1020
+          tcam_profile: vxlan-routing
+        - platforms:
+          - 7280R3
+          reload_delay:
+            mlag: 900
+            non_mlag: 1020
+        - lag_hardware_only: true
+          management_interface: Management0
+          platforms:
+          - 7500R
+          - 7500R2
+          reload_delay:
+            mlag: 900
+            non_mlag: 1020
+          tcam_profile: vxlan-routing
+        - management_interface: Management0
+          platforms:
+          - 7500R3
+          - 7800R3
+          reload_delay:
+            mlag: 900
+            non_mlag: 1020
+        - feature_support:
+            bgp_update_wait_for_convergence: true
+            bgp_update_wait_install: false
+            interface_storm_control: true
+            queue_monitor_length_notify: false
+          management_interface: Management1/1
+          platforms:
+          - 7358X4
+          reload_delay:
+            mlag: 300
+            non_mlag: 330
+        - management_interface: Management0
+          platforms:
+          - 7368X4
+          reload_delay:
+            mlag: 300
+            non_mlag: 330
+        - management_interface: Management0
+          platforms:
+          - 7300X3
+          reload_delay:
+            mlag: 1200
+            non_mlag: 1320
+          trident_forwarding_table_partition: flexible exact-match 16384 l2-shared 98304 l3-shared
+            131072
+        - feature_support:
+            bgp_update_wait_for_convergence: false
+            bgp_update_wait_install: false
+            interface_storm_control: false
+            queue_monitor_length_notify: false
+          platforms:
+          - VEOS
+          - VEOS-LAB
+          - vEOS
+          - vEOS-lab
+          reload_delay:
+            mlag: 300
+            non_mlag: 330
+        - feature_support:
+            bgp_update_wait_for_convergence: false
+            bgp_update_wait_install: false
+            interface_storm_control: false
+            queue_monitor_length_notify: false
+          management_interface: Management0
+          platforms:
+          - CEOS
+          - cEOS
+          - ceos
+          - cEOSLab
+          reload_delay:
+            mlag: 300
+            non_mlag: 330
+        ```
+
+    2. Default Value
 
         ```yaml
         platform_settings:

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/platform-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/platform-settings.md
@@ -25,6 +25,12 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bgp_update_wait_install</samp>](## "custom_platform_settings.[].feature_support.bgp_update_wait_install") | Boolean |  | `True` |  | Disables FIB updates and route advertisement when the BGP instance is initiated until the BGP convergence state is reached.<br>Can be overridden by setting "bgp_update_wait_install" host/group_vars.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bgp_update_wait_for_convergence</samp>](## "custom_platform_settings.[].feature_support.bgp_update_wait_for_convergence") | Boolean |  | `True` |  | Do not advertise reachability to a prefix until that prefix has been installed in hardware.<br>This will eliminate any temporary black holes due to a BGP speaker advertising reachability to a prefix that may not yet be installed into the forwarding plane.<br>Can be overridden by setting "bgp_update_wait_for_convergence" host/group_vars.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;management_interface</samp>](## "custom_platform_settings.[].management_interface") | String |  | `Management1` |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;security_entropy_sources</samp>](## "custom_platform_settings.[].security_entropy_sources") | Dictionary |  |  |  | Entropy source improves the randomness of the numbers used to generate MACsec's cryptographic keys. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hardware</samp>](## "custom_platform_settings.[].security_entropy_sources.hardware") | Boolean |  |  |  | Use a hardware based source. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;haveged</samp>](## "custom_platform_settings.[].security_entropy_sources.haveged") | Boolean |  |  |  | Use the HAVEGE algorithm. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;cpu_jitter</samp>](## "custom_platform_settings.[].security_entropy_sources.cpu_jitter") | Boolean |  |  |  | Use the Jitter RNG algorithm of a CPU based source. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hardware_exclusive</samp>](## "custom_platform_settings.[].security_entropy_sources.hardware_exclusive") | Boolean |  |  |  | Only use entropy from the hardware source. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;structured_config</samp>](## "custom_platform_settings.[].structured_config") | Dictionary |  |  |  | Custom structured config for eos_cli_config_gen. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;raw_eos_cli</samp>](## "custom_platform_settings.[].raw_eos_cli") | String |  |  |  | EOS CLI rendered directly on the root level of the final EOS configuration. |
     | [<samp>platform_settings</samp>](## "platform_settings") | List, items: Dictionary |  | See (+) on YAML tab |  |  |
     | [<samp>&nbsp;&nbsp;-&nbsp;platforms</samp>](## "platform_settings.[].platforms") | List, items: String |  |  |  |  |
@@ -99,6 +105,24 @@
           # Can be overridden by setting "bgp_update_wait_for_convergence" host/group_vars.
           bgp_update_wait_for_convergence: <bool; default=True>
         management_interface: <str; default="Management1">
+
+        # Entropy source improves the randomness of the numbers used to generate MACsec's cryptographic keys.
+        security_entropy_sources:
+
+          # Use a hardware based source.
+          hardware: <bool>
+
+          # Use the HAVEGE algorithm.
+          haveged: <bool>
+
+          # Use the Jitter RNG algorithm of a CPU based source.
+          cpu_jitter: <bool>
+
+          # Only use entropy from the hardware source.
+          hardware_exclusive: <bool>
+
+        # Custom structured config for eos_cli_config_gen.
+        structured_config: <dict>
 
         # EOS CLI rendered directly on the root level of the final EOS configuration.
         raw_eos_cli: <str>
@@ -199,8 +223,8 @@
           reload_delay:
             mlag: 300
             non_mlag: 330
-          trident_forwarding_table_partition: flexible exact-match 16384 l2-shared 98304 l3-shared
-            131072
+          trident_forwarding_table_partition: flexible exact-match 16000 l2-shared 18000 l3-shared
+            22000
         - feature_support:
             poe: true
             queue_monitor_length_notify: false
@@ -219,6 +243,14 @@
           - 720DP
           - 722XP
           - 710P
+          reload_delay:
+            mlag: 300
+            non_mlag: 330
+        - feature_support:
+            per_interface_mtu: false
+            queue_monitor_length_notify: false
+          platforms:
+          - 7010TX
           reload_delay:
             mlag: 300
             non_mlag: 330
@@ -304,6 +336,26 @@
           reload_delay:
             mlag: 300
             non_mlag: 330
+        - feature_support:
+            bgp_update_wait_for_convergence: true
+            bgp_update_wait_install: false
+            interface_storm_control: false
+            queue_monitor_length_notify: false
+          management_interface: Management1/1
+          platforms:
+          - AWE-5310
+          - AWE-5510
+          - AWE-7250R
+          - AWE-7230R
+        - feature_support:
+            bgp_update_wait_for_convergence: true
+            bgp_update_wait_install: false
+            interface_storm_control: false
+            poe: true
+            queue_monitor_length_notify: false
+          management_interface: Management1
+          platforms:
+          - AWE-7220R
         ```
 
     2. Default Value

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/platform-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/platform-settings.md
@@ -7,7 +7,7 @@
 
     | Variable | Type | Required | Default | Value Restrictions | Description |
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
-    | [<samp>custom_platform_settings</samp>](## "custom_platform_settings") | List, items: Dictionary |  | See (+) on YAML tab |  | Custom Platform settings to override the default `platform_settings`. This list will be prepended to the list of `platform_settings`. The first entry containing `platforms` matching the `platform` node setting will be chosen. If no matches are found, the first entry containing a platform `default` will be chosen. |
+    | [<samp>custom_platform_settings</samp>](## "custom_platform_settings") | List, items: Dictionary |  |  |  | Custom Platform settings to override the default `platform_settings`. This list will be prepended to the list of `platform_settings`. The first entry containing `platforms` matching the `platform` node setting will be chosen. If no matches are found, the first entry containing a platform `default` will be chosen. |
     | [<samp>&nbsp;&nbsp;-&nbsp;platforms</samp>](## "custom_platform_settings.[].platforms") | List, items: String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "custom_platform_settings.[].platforms.[]") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trident_forwarding_table_partition</samp>](## "custom_platform_settings.[].trident_forwarding_table_partition") | String |  |  |  | Only applied when evpn_multicast is true. |
@@ -68,7 +68,7 @@
 
     ```yaml
     # Custom Platform settings to override the default `platform_settings`. This list will be prepended to the list of `platform_settings`. The first entry containing `platforms` matching the `platform` node setting will be chosen. If no matches are found, the first entry containing a platform `default` will be chosen.
-    custom_platform_settings: # (1)!
+    custom_platform_settings:
       - platforms:
           - <str>
 
@@ -129,7 +129,7 @@
         raw_eos_cli: <str>
 
     # Platform settings. The first entry containing `platforms` matching the `platform` node setting will be chosen. If no matches are found, the first entry containing a platform `default` will be chosen. The default values will be overridden if `platform_settings` is defined. If you need to replace all the default platforms, it is recommended to copy the defaults and modify them. If you need to add custom platforms, create them under `custom_platform_settings`. Entries under `custom_platform_settings` will be matched before the equivalent entries from `platform_settings`.
-    platform_settings: # (2)!
+    platform_settings: # (1)!
       - platforms:
           - <str>
 
@@ -199,169 +199,6 @@
     ```
 
     1. Default Value
-
-        ```yaml
-        custom_platform_settings:
-        - feature_support:
-            queue_monitor_length_notify: false
-          platforms:
-          - default
-          reload_delay:
-            mlag: 300
-            non_mlag: 330
-        - feature_support:
-            queue_monitor_length_notify: false
-          platforms:
-          - 7050X3
-          reload_delay:
-            mlag: 300
-            non_mlag: 330
-          trident_forwarding_table_partition: flexible exact-match 16384 l2-shared 98304 l3-shared
-            131072
-        - feature_support:
-            poe: true
-            queue_monitor_length_notify: false
-          platforms:
-          - 720XP
-          reload_delay:
-            mlag: 300
-            non_mlag: 330
-          trident_forwarding_table_partition: flexible exact-match 16000 l2-shared 18000 l3-shared
-            22000
-        - feature_support:
-            poe: true
-            queue_monitor_length_notify: false
-          management_interface: Management0
-          platforms:
-          - '750'
-          - '755'
-          - '758'
-          reload_delay:
-            mlag: 300
-            non_mlag: 330
-        - feature_support:
-            poe: true
-            queue_monitor_length_notify: false
-          platforms:
-          - 720DP
-          - 722XP
-          - 710P
-          reload_delay:
-            mlag: 300
-            non_mlag: 330
-        - feature_support:
-            per_interface_mtu: false
-            queue_monitor_length_notify: false
-          platforms:
-          - 7010TX
-          reload_delay:
-            mlag: 300
-            non_mlag: 330
-        - lag_hardware_only: true
-          platforms:
-          - 7280R
-          - 7280R2
-          - 7020R
-          reload_delay:
-            mlag: 900
-            non_mlag: 1020
-          tcam_profile: vxlan-routing
-        - platforms:
-          - 7280R3
-          reload_delay:
-            mlag: 900
-            non_mlag: 1020
-        - lag_hardware_only: true
-          management_interface: Management0
-          platforms:
-          - 7500R
-          - 7500R2
-          reload_delay:
-            mlag: 900
-            non_mlag: 1020
-          tcam_profile: vxlan-routing
-        - management_interface: Management0
-          platforms:
-          - 7500R3
-          - 7800R3
-          reload_delay:
-            mlag: 900
-            non_mlag: 1020
-        - feature_support:
-            bgp_update_wait_for_convergence: true
-            bgp_update_wait_install: false
-            interface_storm_control: true
-            queue_monitor_length_notify: false
-          management_interface: Management1/1
-          platforms:
-          - 7358X4
-          reload_delay:
-            mlag: 300
-            non_mlag: 330
-        - management_interface: Management0
-          platforms:
-          - 7368X4
-          reload_delay:
-            mlag: 300
-            non_mlag: 330
-        - management_interface: Management0
-          platforms:
-          - 7300X3
-          reload_delay:
-            mlag: 1200
-            non_mlag: 1320
-          trident_forwarding_table_partition: flexible exact-match 16384 l2-shared 98304 l3-shared
-            131072
-        - feature_support:
-            bgp_update_wait_for_convergence: false
-            bgp_update_wait_install: false
-            interface_storm_control: false
-            queue_monitor_length_notify: false
-          platforms:
-          - VEOS
-          - VEOS-LAB
-          - vEOS
-          - vEOS-lab
-          reload_delay:
-            mlag: 300
-            non_mlag: 330
-        - feature_support:
-            bgp_update_wait_for_convergence: false
-            bgp_update_wait_install: false
-            interface_storm_control: false
-            queue_monitor_length_notify: false
-          management_interface: Management0
-          platforms:
-          - CEOS
-          - cEOS
-          - ceos
-          - cEOSLab
-          reload_delay:
-            mlag: 300
-            non_mlag: 330
-        - feature_support:
-            bgp_update_wait_for_convergence: true
-            bgp_update_wait_install: false
-            interface_storm_control: false
-            queue_monitor_length_notify: false
-          management_interface: Management1/1
-          platforms:
-          - AWE-5310
-          - AWE-5510
-          - AWE-7250R
-          - AWE-7230R
-        - feature_support:
-            bgp_update_wait_for_convergence: true
-            bgp_update_wait_install: false
-            interface_storm_control: false
-            poe: true
-            queue_monitor_length_notify: false
-          management_interface: Management1
-          platforms:
-          - AWE-7220R
-        ```
-
-    2. Default Value
 
         ```yaml
         platform_settings:

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/platform-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/platform-settings.md
@@ -7,7 +7,7 @@
 
     | Variable | Type | Required | Default | Value Restrictions | Description |
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
-    | [<samp>custom_platform_settings</samp>](## "custom_platform_settings") | List, items: Dictionary |  | See (+) on YAML tab |  |  |
+    | [<samp>custom_platform_settings</samp>](## "custom_platform_settings") | List, items: Dictionary |  | See (+) on YAML tab |  | Custom Platform settings to override the default `platform_settings`. This list will be prepended to the list of `platform_settings`. The first entry containing `platforms` matching the `platform` node setting will be chosen. If no matches are found, the first entry containing a platform `default` will be chosen. |
     | [<samp>&nbsp;&nbsp;-&nbsp;platforms</samp>](## "custom_platform_settings.[].platforms") | List, items: String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "custom_platform_settings.[].platforms.[]") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trident_forwarding_table_partition</samp>](## "custom_platform_settings.[].trident_forwarding_table_partition") | String |  |  |  | Only applied when evpn_multicast is true. |
@@ -32,7 +32,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hardware_exclusive</samp>](## "custom_platform_settings.[].security_entropy_sources.hardware_exclusive") | Boolean |  |  |  | Only use entropy from the hardware source. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;structured_config</samp>](## "custom_platform_settings.[].structured_config") | Dictionary |  |  |  | Custom structured config for eos_cli_config_gen. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;raw_eos_cli</samp>](## "custom_platform_settings.[].raw_eos_cli") | String |  |  |  | EOS CLI rendered directly on the root level of the final EOS configuration. |
-    | [<samp>platform_settings</samp>](## "platform_settings") | List, items: Dictionary |  | See (+) on YAML tab |  |  |
+    | [<samp>platform_settings</samp>](## "platform_settings") | List, items: Dictionary |  | See (+) on YAML tab |  | Platform settings. The first entry containing `platforms` matching the `platform` node setting will be chosen. If no matches are found, the first entry containing a platform `default` will be chosen. The default values will be overridden if `platform_settings` is defined. If you need to replace all the default platforms, it is recommended to copy the defaults and modify them. If you need to add custom platforms, create them under `custom_platform_settings`. Entries under `custom_platform_settings` will be matched before the equivalent entries from `platform_settings`. |
     | [<samp>&nbsp;&nbsp;-&nbsp;platforms</samp>](## "platform_settings.[].platforms") | List, items: String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "platform_settings.[].platforms.[]") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trident_forwarding_table_partition</samp>](## "platform_settings.[].trident_forwarding_table_partition") | String |  |  |  | Only applied when evpn_multicast is true. |
@@ -67,6 +67,7 @@
 === "YAML"
 
     ```yaml
+    # Custom Platform settings to override the default `platform_settings`. This list will be prepended to the list of `platform_settings`. The first entry containing `platforms` matching the `platform` node setting will be chosen. If no matches are found, the first entry containing a platform `default` will be chosen.
     custom_platform_settings: # (1)!
       - platforms:
           - <str>
@@ -126,6 +127,8 @@
 
         # EOS CLI rendered directly on the root level of the final EOS configuration.
         raw_eos_cli: <str>
+
+    # Platform settings. The first entry containing `platforms` matching the `platform` node setting will be chosen. If no matches are found, the first entry containing a platform `default` will be chosen. The default values will be overridden if `platform_settings` is defined. If you need to replace all the default platforms, it is recommended to copy the defaults and modify them. If you need to add custom platforms, create them under `custom_platform_settings`. Entries under `custom_platform_settings` will be matched before the equivalent entries from `platform_settings`.
     platform_settings: # (2)!
       - platforms:
           - <str>

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
@@ -2108,8 +2108,24 @@ keys:
 
 
       This may introduce breaking changes to your configuration.'
+  custom_node_type_keys:
+    $ref: eos_designs#/keys/node_type_keys
+    type: list
+    documentation_options:
+      table: node-type-keys
+    description: 'Define Custom Node Type Keys, to specify the properties of each
+      node type in the fabric.
+
+      This allows for complete customization of the fabric layout and functionality.
+
+      `custom_node_type_keys` should be defined in top level group_var for the fabric.
+
+      These values will be merged with the defaults; keys named the same as a default
+      node_type_key will override the default.'
   node_type_keys:
     type: list
+    documentation_options:
+      table: node-type-keys
     description: 'Define Node Type Keys, to specify the properties of each node type
       in the fabric.
 
@@ -2118,9 +2134,7 @@ keys:
       `node_type_keys` should be defined in top level group_var for the fabric.
 
       The default values will be overridden if defining this key, so it is recommended
-      to copy the defaults and modify them.
-
-      '
+      to copy the defaults and modify them.'
     primary_key: key
     items:
       type: dict
@@ -2828,6 +2842,12 @@ keys:
       table: fabric-settings
     description: QOS Profile assigned on all infrastructure links.
     type: str
+  custom_platform_settings:
+    $ref: eos_designs#/keys/platform_settings
+    display_name: Custom Platform Settings
+    documentation_options:
+      table: platform-settings
+    type: list
   platform_settings:
     documentation_options:
       table: platform-settings

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
@@ -2110,7 +2110,7 @@ keys:
       This may introduce breaking changes to your configuration.'
   custom_node_type_keys:
     $ref: eos_designs#/keys/node_type_keys
-    default: []
+    default: null
     type: list
     documentation_options:
       table: node-type-keys
@@ -2855,7 +2855,7 @@ keys:
     type: str
   custom_platform_settings:
     $ref: eos_designs#/keys/platform_settings
-    default: []
+    default: null
     documentation_options:
       table: platform-settings
     description: Custom Platform settings to override the default `platform_settings`.

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
@@ -2110,6 +2110,7 @@ keys:
       This may introduce breaking changes to your configuration.'
   custom_node_type_keys:
     $ref: eos_designs#/keys/node_type_keys
+    default: []
     type: list
     documentation_options:
       table: node-type-keys
@@ -2120,8 +2121,10 @@ keys:
 
       `custom_node_type_keys` should be defined in top level group_var for the fabric.
 
-      These values will be merged with the defaults; keys named the same as a default
-      node_type_key will override the default.'
+      These values will be combined with the defaults; custom node type keys named
+      the same as a
+
+      default node_type_key will replace the default.'
   node_type_keys:
     type: list
     documentation_options:
@@ -2133,8 +2136,16 @@ keys:
 
       `node_type_keys` should be defined in top level group_var for the fabric.
 
-      The default values will be overridden if defining this key, so it is recommended
-      to copy the defaults and modify them.'
+
+      The default values will be overridden if this key is defined.
+
+      If you need to change all the existing `node_type_keys`, it is recommended to
+      copy the defaults and modify them.
+
+      If you need to add custom `node_type_keys`, create them under `custom_node_type_keys`
+      - if named identically to default `node_type_keys` entries,
+
+      custom entries will replace the equivalent default entry.'
     primary_key: key
     items:
       type: dict
@@ -2844,14 +2855,27 @@ keys:
     type: str
   custom_platform_settings:
     $ref: eos_designs#/keys/platform_settings
-    display_name: Custom Platform Settings
+    default: []
     documentation_options:
       table: platform-settings
+    description: Custom Platform settings to override the default `platform_settings`.
+      This list will be prepended to the list of `platform_settings`. The first entry
+      containing `platforms` matching the `platform` node setting will be chosen.
+      If no matches are found, the first entry containing a platform `default` will
+      be chosen.
     type: list
   platform_settings:
+    type: list
     documentation_options:
       table: platform-settings
-    type: list
+    description: Platform settings. The first entry containing `platforms` matching
+      the `platform` node setting will be chosen. If no matches are found, the first
+      entry containing a platform `default` will be chosen. The default values will
+      be overridden if `platform_settings` is defined. If you need to replace all
+      the default platforms, it is recommended to copy the defaults and modify them.
+      If you need to add custom platforms, create them under `custom_platform_settings`.
+      Entries under `custom_platform_settings` will be matched before the equivalent
+      entries from `platform_settings`.
     items:
       type: dict
       keys:

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/node_type_keys.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/node_type_keys.schema.yml
@@ -6,9 +6,21 @@
 # Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
 type: dict
 keys:
+  custom_node_type_keys:
+    $ref: eos_designs#/keys/node_type_keys
+    type: list
+    documentation_options:
+      table: node-type-keys
+    description: |-
+      Define Custom Node Type Keys, to specify the properties of each node type in the fabric.
+      This allows for complete customization of the fabric layout and functionality.
+      `custom_node_type_keys` should be defined in top level group_var for the fabric.
+      These values will be merged with the defaults; keys named the same as a default node_type_key will override the default.
   node_type_keys:
     type: list
-    description: |
+    documentation_options:
+      table: node-type-keys
+    description: |-
       Define Node Type Keys, to specify the properties of each node type in the fabric.
       This allows for complete customization of the fabric layout and functionality.
       `node_type_keys` should be defined in top level group_var for the fabric.

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/node_type_keys.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/node_type_keys.schema.yml
@@ -8,7 +8,7 @@ type: dict
 keys:
   custom_node_type_keys:
     $ref: eos_designs#/keys/node_type_keys
-    default: []
+    default: null
     type: list
     documentation_options:
       table: node-type-keys

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/node_type_keys.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/node_type_keys.schema.yml
@@ -8,6 +8,7 @@ type: dict
 keys:
   custom_node_type_keys:
     $ref: eos_designs#/keys/node_type_keys
+    default: []
     type: list
     documentation_options:
       table: node-type-keys
@@ -15,7 +16,8 @@ keys:
       Define Custom Node Type Keys, to specify the properties of each node type in the fabric.
       This allows for complete customization of the fabric layout and functionality.
       `custom_node_type_keys` should be defined in top level group_var for the fabric.
-      These values will be merged with the defaults; keys named the same as a default node_type_key will override the default.
+      These values will be combined with the defaults; custom node type keys named the same as a
+      default node_type_key will replace the default.
   node_type_keys:
     type: list
     documentation_options:
@@ -24,7 +26,12 @@ keys:
       Define Node Type Keys, to specify the properties of each node type in the fabric.
       This allows for complete customization of the fabric layout and functionality.
       `node_type_keys` should be defined in top level group_var for the fabric.
-      The default values will be overridden if defining this key, so it is recommended to copy the defaults and modify them.
+
+      The default values will be overridden if this key is defined.
+      If you need to change all the existing `node_type_keys`, it is recommended to copy the defaults and modify them.
+      If you need to add custom `node_type_keys`, create them under `custom_node_type_keys` - if named identically to default `node_type_keys` entries,
+      custom entries will replace the equivalent default entry.
+
     primary_key: key
     items:
       type: dict

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/platform_settings.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/platform_settings.schema.yml
@@ -8,14 +8,27 @@ type: dict
 keys:
   custom_platform_settings:
     $ref: eos_designs#/keys/platform_settings
-    display_name: Custom Platform Settings
+    default: []
     documentation_options:
       table: platform-settings
+    description:
+      Custom Platform settings to override the default `platform_settings`.
+      This list will be prepended to the list of `platform_settings`.
+      The first entry containing `platforms` matching the `platform` node setting will be chosen.
+      If no matches are found, the first entry containing a platform `default` will be chosen.
     type: list
   platform_settings:
+    type: list
     documentation_options:
       table: platform-settings
-    type: list
+    description:
+      Platform settings.
+      The first entry containing `platforms` matching the `platform` node setting will be chosen.
+      If no matches are found, the first entry containing a platform `default` will be chosen.
+      The default values will be overridden if `platform_settings` is defined.
+      If you need to replace all the default platforms, it is recommended to copy the defaults and modify them.
+      If you need to add custom platforms, create them under `custom_platform_settings`.
+      Entries under `custom_platform_settings` will be matched before the equivalent entries from `platform_settings`.
     items:
       type: dict
       keys:

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/platform_settings.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/platform_settings.schema.yml
@@ -6,6 +6,12 @@
 # Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
 type: dict
 keys:
+  custom_platform_settings:
+    $ref: eos_designs#/keys/platform_settings
+    display_name: Custom Platform Settings
+    documentation_options:
+      table: platform-settings
+    type: list
   platform_settings:
     documentation_options:
       table: platform-settings

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/platform_settings.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/platform_settings.schema.yml
@@ -8,7 +8,7 @@ type: dict
 keys:
   custom_platform_settings:
     $ref: eos_designs#/keys/platform_settings
-    default: []
+    default: null
     documentation_options:
       table: platform-settings
     description:

--- a/python-avd/pyavd/_eos_designs/shared_utils/node_type_keys.py
+++ b/python-avd/pyavd/_eos_designs/shared_utils/node_type_keys.py
@@ -7,7 +7,7 @@ from functools import cached_property
 from typing import TYPE_CHECKING
 
 from pyavd._errors import AristaAvdMissingVariableError
-from pyavd._utils import get
+from pyavd._utils import get, replace_or_append_item
 
 if TYPE_CHECKING:
     from . import SharedUtils
@@ -176,7 +176,14 @@ class NodeTypeKeysMixin:
         """NOTE: This method is called _before_ any schema validation, since we need to resolve node_type_keys dynamically."""
         design_type = get(self.hostvars, "design.type", default="l3ls-evpn")
         default_node_type_keys_for_our_design = get(DEFAULT_NODE_TYPE_KEYS, design_type)
-        return get(self.hostvars, "node_type_keys", default=default_node_type_keys_for_our_design)
+
+        node_type_keys = get(self.hostvars, "node_type_keys", default=default_node_type_keys_for_our_design)
+        custom_node_type_keys = get(self.hostvars, "custom_node_type_keys", default=[])
+
+        for node_type_key in custom_node_type_keys:
+            replace_or_append_item(node_type_keys, "key", node_type_key)
+
+        return node_type_keys
 
     @cached_property
     def node_type_key_data(self: SharedUtils) -> dict:

--- a/python-avd/pyavd/_eos_designs/shared_utils/node_type_keys.py
+++ b/python-avd/pyavd/_eos_designs/shared_utils/node_type_keys.py
@@ -177,7 +177,8 @@ class NodeTypeKeysMixin:
         design_type = get(self.hostvars, "design.type", default="l3ls-evpn")
         default_node_type_keys_for_our_design = get(DEFAULT_NODE_TYPE_KEYS, design_type)
 
-        node_type_keys = get(self.hostvars, "node_type_keys", default=default_node_type_keys_for_our_design)
+        # Using list() to force a copy of node_type_keys so we don't modify the default when we apply custom_node_type_keys
+        node_type_keys = list(get(self.hostvars, "node_type_keys", default=default_node_type_keys_for_our_design))
         custom_node_type_keys = get(self.hostvars, "custom_node_type_keys", default=[])
 
         for node_type_key in custom_node_type_keys:

--- a/python-avd/pyavd/_eos_designs/shared_utils/platform.py
+++ b/python-avd/pyavd/_eos_designs/shared_utils/platform.py
@@ -199,7 +199,8 @@ class PlatformMixin:
 
     @cached_property
     def platform_settings(self: SharedUtils) -> dict:
-        platform_settings = get(self.hostvars, "platform_settings", default=DEFAULT_PLATFORM_SETTINGS)
+        custom_platform_settings = get(self.hostvars, "custom_platform_settings", default=[])
+        platform_settings = custom_platform_settings + get(self.hostvars, "platform_settings", default=DEFAULT_PLATFORM_SETTINGS)
 
         # First look for a matching platform setting specifying our platform
         for platform_setting in platform_settings:

--- a/python-avd/scripts/export_test_vars.yml
+++ b/python-avd/scripts/export_test_vars.yml
@@ -63,7 +63,7 @@
         # Variables required to run Molecule test data outside Ansible without getting "undefined" errors.
         playbook_dir: "playbook_dir"
         switch:
-          mgmt_interface: Management1
+          mgmt_interface: Management99
           mgmt_vrf: MGMT
           id: 6
 
@@ -76,6 +76,6 @@
         # Variables required to run Molecule test data outside Ansible without getting "undefined" errors.
         playbook_dir: "playbook_dir"
         switch:
-          mgmt_interface: Management1
+          mgmt_interface: Management99
           mgmt_vrf: MGMT
           id: 6


### PR DESCRIPTION
## Change Summary

Allow use of `custom_platform_settings` and `custom_node_type_keys` to allow replacement of already-defined keys/platforms, or addition of new keys/platforms while retaining the default settings.

## Related Issue(s)

Fixes #3152 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
Allows you to:
* Specify new platform settings and node_type_keys in addition to the AVD-defined defaults without having to copy/paste these into your inventory.
* Redefine AVD-defined default node_type_keys and platform_settings without having to redefine every single one.

No changes to the data model - just use:
* `custom_platform_settings` instead of `platform_settings`.
* `custom_node_type_keys` instead of `node_type_keys`.

## How to test
Molecule tests updated to cover these new options.  Problems encountered included AVD complaining about duplicate `node_type_keys` - this was fixed through use of `replace_or_append_item()`.

This can be tested in your own repo by defining a `custom_platform_settings` and/or `custom_node_type_keys` at a high level in your repo's hierarchy.  Defaults can be copied from the AVD docs and amended as required.

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been rebased from devel before I start
- [X] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [X] My change requires a change to the documentation and documentation have been updated accordingly.
- [X] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
