### PR TITLE
Fix(eos_cli_config_gen): correct logging event storm-control unter interface ethernet

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
@@ -401,7 +401,7 @@ interface Ethernet6
    logging event link-status
    logging event congestion-drops
    logging event spanning-tree
-   logging event storm-control
+   logging event storm-control discards
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
    switchport
@@ -482,7 +482,7 @@ interface Ethernet13
    no logging event link-status
    no logging event congestion-drops
    no logging event spanning-tree
-   no logging event storm-control
+   no logging event storm-control discards
    switchport trunk native vlan 100
    switchport phone vlan 70
    switchport phone trunk untagged
@@ -849,7 +849,7 @@ interface Ethernet61
    no logging event link-status
    no logging event congestion-drops
    no logging event spanning-tree
-   no logging event storm-control
+   no logging event storm-control discards
    switchport trunk native vlan 100
    switchport phone vlan 70
    switchport phone trunk untagged phone
@@ -861,7 +861,7 @@ interface Ethernet62
    no logging event link-status
    no logging event congestion-drops
    no logging event spanning-tree
-   no logging event storm-control
+   no logging event storm-control discards
    switchport trunk native vlan 100
    switchport phone vlan 70
    switchport phone trunk tagged phone

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
@@ -103,7 +103,7 @@ interface Ethernet6
    logging event link-status
    logging event congestion-drops
    logging event spanning-tree
-   logging event storm-control
+   logging event storm-control discards
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
    switchport
@@ -184,7 +184,7 @@ interface Ethernet13
    no logging event link-status
    no logging event congestion-drops
    no logging event spanning-tree
-   no logging event storm-control
+   no logging event storm-control discards
    switchport trunk native vlan 100
    switchport phone vlan 70
    switchport phone trunk untagged
@@ -551,7 +551,7 @@ interface Ethernet61
    no logging event link-status
    no logging event congestion-drops
    no logging event spanning-tree
-   no logging event storm-control
+   no logging event storm-control discards
    switchport trunk native vlan 100
    switchport phone vlan 70
    switchport phone trunk untagged phone
@@ -563,7 +563,7 @@ interface Ethernet62
    no logging event link-status
    no logging event congestion-drops
    no logging event spanning-tree
-   no logging event storm-control
+   no logging event storm-control discards
    switchport trunk native vlan 100
    switchport phone vlan 70
    switchport phone trunk tagged phone

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
@@ -157,7 +157,7 @@ ethernet_interfaces:
         link_status: true
         congestion_drops: true
         spanning_tree: true
-        storm_control: true
+        storm_control_discards: true
     peer: SRV-POD02
     peer_interface: Eth1
     peer_type: server
@@ -270,7 +270,7 @@ ethernet_interfaces:
         link_status: false
         congestion_drops: false
         spanning_tree: false
-        storm_control: false
+        storm_control_discards: false
     description: interface_in_mode_access_with_voice
     type: switched
     native_vlan: 100
@@ -832,7 +832,7 @@ ethernet_interfaces:
         link_status: false
         congestion_drops: false
         spanning_tree: false
-        storm_control: false
+        storm_control_discards: false
     description: interface_in_mode_access_with_voice
     type: switched
     native_vlan: 100
@@ -847,7 +847,7 @@ ethernet_interfaces:
         link_status: false
         congestion_drops: false
         spanning_tree: false
-        storm_control: false
+        storm_control_discards: false
     description: interface_in_mode_access_with_voice
     type: switched
     native_vlan: 100

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ethernet-interfaces.md
@@ -225,7 +225,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;link_status</samp>](## "ethernet_interfaces.[].logging.event.link_status") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;congestion_drops</samp>](## "ethernet_interfaces.[].logging.event.congestion_drops") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;spanning_tree</samp>](## "ethernet_interfaces.[].logging.event.spanning_tree") | Boolean |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;storm_control</samp>](## "ethernet_interfaces.[].logging.event.storm_control") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;storm_control_discards</samp>](## "ethernet_interfaces.[].logging.event.storm_control_discards") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;lldp</samp>](## "ethernet_interfaces.[].lldp") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;transmit</samp>](## "ethernet_interfaces.[].lldp.transmit") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;receive</samp>](## "ethernet_interfaces.[].lldp.receive") | Boolean |  |  |  |  |
@@ -566,7 +566,7 @@
             link_status: <bool>
             congestion_drops: <bool>
             spanning_tree: <bool>
-            storm_control: <bool>
+            storm_control_discards: <bool>
         lldp:
           transmit: <bool>
           receive: <bool>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -3386,9 +3386,9 @@
                     "type": "boolean",
                     "title": "Spanning Tree"
                   },
-                  "storm_control": {
+                  "storm_control_discards": {
                     "type": "boolean",
-                    "title": "Storm Control"
+                    "title": "Storm Control Discards"
                   }
                 },
                 "additionalProperties": false,

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -2029,7 +2029,7 @@ keys:
                   type: bool
                 spanning_tree:
                   type: bool
-                storm_control:
+                storm_control_discards:
                   type: bool
         lldp:
           type: dict

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ethernet_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ethernet_interfaces.schema.yml
@@ -665,7 +665,7 @@ keys:
                   type: bool
                 spanning_tree:
                   type: bool
-                storm_control:
+                storm_control_discards:
                   type: bool
         lldp:
           type: dict

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -41,10 +41,10 @@ interface {{ ethernet_interface.name }}
 {%         elif ethernet_interface.logging.event.spanning_tree is arista.avd.defined(false) %}
    no logging event spanning-tree
 {%         endif %}
-{%         if ethernet_interface.logging.event.storm_control is arista.avd.defined(true) %}
-   logging event storm-control
-{%         elif ethernet_interface.logging.event.storm_control is arista.avd.defined(false) %}
-   no logging event storm-control
+{%         if ethernet_interface.logging.event.storm_control_discards is arista.avd.defined(true) %}
+   logging event storm-control discards
+{%         elif ethernet_interface.logging.event.storm_control_discards is arista.avd.defined(false) %}
+   no logging event storm-control discards
 {%         endif %}
 {%     endif %}
 {%     if ethernet_interface.flowcontrol.received is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -8273,9 +8273,9 @@
                         "type": "boolean",
                         "title": "Spanning Tree"
                       },
-                      "storm_control": {
+                      "storm_control_discards": {
                         "type": "boolean",
-                        "title": "Storm Control"
+                        "title": "Storm Control Discards"
                       }
                     },
                     "additionalProperties": false,
@@ -13857,9 +13857,9 @@
                         "type": "boolean",
                         "title": "Spanning Tree"
                       },
-                      "storm_control": {
+                      "storm_control_discards": {
                         "type": "boolean",
-                        "title": "Storm Control"
+                        "title": "Storm Control Discards"
                       }
                     },
                     "additionalProperties": false,


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
fix the current `logging event storm-control` under ethernet interfaces and add the mandatory keyword `discards`,

## Related Issue(s)

Fixes #3299

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->
```
ethernet_interfaces:
  - name: Ethernet<nr>
    logging:
      event:
        storm_control_discards: <bool>
```


## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

```
ethernet_interfaces:
  - name: Ethernet5
    logging:
      event:
        storm_control_discards: true
```
renders the follwing cli config:
```
interface Ethernet5
   logging event storm-control discards
```

which fits the cli:
```
access(config-if-Et5)#logging event storm-control ?
  discards  Discards due to storm control

access(config-if-Et5)#logging event storm-control discards ?
  use-global  Use the global configuration
  <cr>
```

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
