### PR TITLE
Doc: Fix missing flow_tracking table

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/input-variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/input-variables.md
@@ -586,6 +586,12 @@ roles/eos_cli_config_gen/docs/tables/event-monitor.md
 ### Flow tracking
 
 --8<--
+roles/eos_cli_config_gen/docs/tables/flow-tracking.md
+--8<--
+
+### Flow trackings
+
+--8<--
 roles/eos_cli_config_gen/docs/tables/flow-trackings.md
 --8<--
 


### PR DESCRIPTION
## Change Summary

Fix missing new flow_tracking table in eos_cli_config_gen input variables.

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Add a table to input variables.

## How to test

Review generated documentation and ensure `flow_tracking` table is present.
https://ansible-avd--3307.org.readthedocs.build/en/3307/roles/eos_cli_config_gen/docs/input-variables.html#flow-tracking
