### PR TITLE
Doc: Fix missing tables in eos_cli_config_gen

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/input-variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/input-variables.md
@@ -281,6 +281,12 @@ roles/eos_cli_config_gen/docs/tables/traffic-policies.md
 
 ## Interfaces
 
+### DPS interfaces
+
+--8<--
+roles/eos_cli_config_gen/docs/tables/dps-interfaces.md
+--8<--
+
 ### Errdisable
 
 --8<--
@@ -429,6 +435,12 @@ roles/eos_cli_config_gen/docs/tables/dns-domain.md
 roles/eos_cli_config_gen/docs/tables/domain-list.md
 --8<--
 
+### Hostname
+
+--8<--
+roles/eos_cli_config_gen/docs/tables/hostname.md
+--8<--
+
 ### IP domain lookup
 
 --8<--
@@ -543,6 +555,12 @@ roles/eos_cli_config_gen/docs/tables/cvx.md
 
 --8<--
 roles/eos_cli_config_gen/docs/tables/eos-cli.md
+--8<--
+
+### Is deployed
+
+--8<--
+roles/eos_cli_config_gen/docs/tables/is-deployed.md
 --8<--
 
 ### Management CVX
@@ -682,6 +700,12 @@ roles/eos_cli_config_gen/docs/tables/router-pim-sparse-mode.md
 --8<--
 
 ## Quality of Service
+
+### Priority flow control
+
+--8<--
+roles/eos_cli_config_gen/docs/tables/priority-flow-control.md
+--8<--
 
 ### QoS
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/input-variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/input-variables.md
@@ -851,6 +851,7 @@ roles/eos_cli_config_gen/docs/tables/router-path-selection.md
 
 --8<--
 roles/eos_cli_config_gen/docs/tables/router-service-insertion.md
+--8<--
 
 ### Router traffic engineering
 


### PR DESCRIPTION
## Change Summary

Add missing tables in eos_cli_config_gen input variables:
  - dps-interfaces
  - hostname
  - is-deployed
  - priority-flow-control

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Add a tables to input variables.

## How to test

Review eos_cli_config_gen input-variable documentation:
  - dps-interfaces: https://ansible-avd--3308.org.readthedocs.build/en/3308/roles/eos_cli_config_gen/docs/input-variables.html#dps-interfaces
  - hostname: https://ansible-avd--3308.org.readthedocs.build/en/3308/roles/eos_cli_config_gen/docs/input-variables.html#hostname
  - is-deployed: https://ansible-avd--3308.org.readthedocs.build/en/3308/roles/eos_cli_config_gen/docs/input-variables.html#is-deployed
  - priority-flow-control: https://ansible-avd--3308.org.readthedocs.build/en/3308/roles/eos_cli_config_gen/docs/input-variables.html#priority-flow-control

