### PR TITLE
Feat(eos_cli_config_gen): Extend CLI model for ip_security

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-security.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-security.md
@@ -54,7 +54,7 @@ interface Management1
 | ----------- | ------------- | -------------- | ------------ |
 | SA-1 | - |  aes128 | 14 |
 | SA-2 | - |  aes128 | 14 |
-| SA-3 | null |  null | 17 |
+| SA-3 | disabled |  disabled | 17 |
 
 ### IPSec profiles
 
@@ -92,7 +92,6 @@ ip security
       pfs dh-group 14
    !
    sa policy SA-3
-      esp encryption null
       pfs dh-group 17
    !
    profile Profile-1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-security.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-security.md
@@ -92,6 +92,8 @@ ip security
       pfs dh-group 14
    !
    sa policy SA-3
+      esp integrity null
+      esp encryption null
       pfs dh-group 17
    !
    profile Profile-1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-security.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-security.md
@@ -68,6 +68,9 @@ ip security
    !
    ike policy IKE-1
       local-id 192.168.100.1
+      ike-lifetime 24
+      encryption aes256
+      dh-group 20
    !
    ike policy IKE-2
    !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-security.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-security.md
@@ -6,6 +6,7 @@
   - [Management Interfaces](#management-interfaces)
 - [IP Security](#ip-security)
   - [IKE policies](#ike-policies)
+  - [Security Association policies](#security-association-policies)
   - [IPSec profiles](#ipsec-profiles)
   - [Key controller](#key-controller)
   - [IP Security Configuration](#ip-security-configuration)
@@ -42,10 +43,18 @@ interface Management1
 
 ### IKE policies
 
-| Policy name | Local ID |
-| ----------- | -------- |
-| IKE-1 | 192.168.100.1 |
-| IKE-2 | - |
+| Policy name | IKE lifetime | Encryption | DH group | Local ID |
+| ----------- | ------------ | ---------- | -------- | -------- |
+| IKE-1 | 24 | aes256 | 20 | 192.168.100.1 |
+| IKE-2 | - | - | - | - |
+
+### Security Association policies
+
+| Policy name | ESP Integrity | ESP Encryption | PFS DH Group |
+| ----------- | ------------- | -------------- | ------------ |
+| SA-1 | - |  aes128 | 14 |
+| SA-2 | - |  aes128 | 14 |
+| SA-3 | null |  null | 17 |
 
 ### IPSec profiles
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-security.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-security.md
@@ -52,9 +52,9 @@ interface Management1
 
 | Policy name | ESP Integrity | ESP Encryption | PFS DH Group |
 | ----------- | ------------- | -------------- | ------------ |
-| SA-1 | - |  aes128 | 14 |
-| SA-2 | - |  aes128 | 14 |
-| SA-3 | disabled |  disabled | 17 |
+| SA-1 | - | aes128 | 14 |
+| SA-2 | - | aes128 | 14 |
+| SA-3 | disabled | disabled | 17 |
 
 ### IPSec profiles
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ip-security.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ip-security.cfg
@@ -11,6 +11,9 @@ ip security
    !
    ike policy IKE-1
       local-id 192.168.100.1
+      ike-lifetime 24
+      encryption aes256
+      dh-group 20
    !
    ike policy IKE-2
    !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ip-security.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ip-security.cfg
@@ -26,6 +26,8 @@ ip security
       pfs dh-group 14
    !
    sa policy SA-3
+      esp integrity null
+      esp encryption null
       pfs dh-group 17
    !
    profile Profile-1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ip-security.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ip-security.cfg
@@ -26,7 +26,6 @@ ip security
       pfs dh-group 14
    !
    sa policy SA-3
-      esp encryption null
       pfs dh-group 17
    !
    profile Profile-1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ip-security.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ip-security.yml
@@ -18,8 +18,8 @@ ip_security:
       pfs_dh_group: 14
     - name: SA-3
       esp:
-        integrity: "disabled"
-        encryption: "disabled"
+        integrity: disabled
+        encryption: disabled
       pfs_dh_group: 17
   profiles:
     - name: Profile-1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ip-security.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ip-security.yml
@@ -18,8 +18,8 @@ ip_security:
       pfs_dh_group: 14
     - name: SA-3
       esp:
-        integrity: "null"
-        encryption: "null"
+        integrity: "disabled"
+        encryption: "disabled"
       pfs_dh_group: 17
   profiles:
     - name: Profile-1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ip-security.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ip-security.yml
@@ -3,6 +3,9 @@ ip_security:
   ike_policies:
     - name: IKE-1
       local_id: 192.168.100.1
+      ike_lifetime: 24
+      encryption: aes256
+      dh_group: 20
     - name: IKE-2
   sa_policies:
     - name: SA-1

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ip-security.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ip-security.md
@@ -12,13 +12,13 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "ip_security.ike_policies.[].name") | String | Required, Unique |  |  | Policy name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;local_id</samp>](## "ip_security.ike_policies.[].local_id") | String |  |  |  | Local IKE Identification.<br>Can be an IPv4 or an IPv6 address.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ike_lifetime</samp>](## "ip_security.ike_policies.[].ike_lifetime") | Integer |  |  | Min: 1<br>Max: 24 | IKE lifetime in hours.<br> |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;encryption</samp>](## "ip_security.ike_policies.[].encryption") | String |  |  | Valid Values:<br>- null<br>- 3des<br>- aes128<br>- aes256 | Local IKE Identification.<br>Can be an IPv4 or an IPv6 address.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;encryption</samp>](## "ip_security.ike_policies.[].encryption") | String |  |  | Valid Values:<br>- disabled<br>- 3des<br>- aes128<br>- aes256 | Local IKE Identification.<br>Can be an IPv4 or an IPv6 address.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dh_group</samp>](## "ip_security.ike_policies.[].dh_group") | Integer |  |  | Valid Values:<br>- 1<br>- 2<br>- 5<br>- 14<br>- 15<br>- 16<br>- 17<br>- 20<br>- 21<br>- 24 | Diffie-Hellman group for the key exchange.<br> |
     | [<samp>&nbsp;&nbsp;sa_policies</samp>](## "ip_security.sa_policies") | List, items: Dictionary |  |  |  | Security Association policies. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "ip_security.sa_policies.[].name") | String | Required, Unique |  |  | Name of the SA policy. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "ip_security.sa_policies.[].name") | String | Required, Unique |  |  | Name of the SA policy. The "null" value is deprecated and will be removed on AVD 5.0.0 |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;esp</samp>](## "ip_security.sa_policies.[].esp") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;integrity</samp>](## "ip_security.sa_policies.[].esp.integrity") | String |  |  | Valid Values:<br>- null<br>- sha1<br>- sha256 |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;encryption</samp>](## "ip_security.sa_policies.[].esp.encryption") | String |  |  | Valid Values:<br>- null<br>- aes128<br>- aes128gcm128<br>- aes128gcm64<br>- aes256<br>- aes256gcm256 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;integrity</samp>](## "ip_security.sa_policies.[].esp.integrity") | String |  |  | Valid Values:<br>- disabled<br>- sha1<br>- sha256<br>- null |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;encryption</samp>](## "ip_security.sa_policies.[].esp.encryption") | String |  |  | Valid Values:<br>- disabled<br>- aes128<br>- aes128gcm128<br>- aes128gcm64<br>- aes256<br>- aes256gcm256<br>- null |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;pfs_dh_group</samp>](## "ip_security.sa_policies.[].pfs_dh_group") | Integer |  |  | Valid Values:<br>- 1<br>- 2<br>- 5<br>- 14<br>- 15<br>- 16<br>- 17<br>- 20<br>- 21<br>- 24 |  |
     | [<samp>&nbsp;&nbsp;profiles</samp>](## "ip_security.profiles") | List, items: Dictionary |  |  |  | IPSec profiles. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "ip_security.profiles.[].name") | String | Required, Unique |  |  | Name of the IPsec profile. |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ip-security.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ip-security.md
@@ -11,11 +11,11 @@
     | [<samp>&nbsp;&nbsp;ike_policies</samp>](## "ip_security.ike_policies") | List, items: Dictionary |  |  |  | Internet Security Association and Key Mgmt Protocol. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "ip_security.ike_policies.[].name") | String | Required, Unique |  |  | Policy name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;local_id</samp>](## "ip_security.ike_policies.[].local_id") | String |  |  |  | Local IKE Identification.<br>Can be an IPv4 or an IPv6 address.<br> |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ike_lifetime</samp>](## "ip_security.ike_policies.[].ike_lifetime") | Integer |  |  | Min: 1<br>Max: 24 | IKE lifetime in hours.<br> |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;encryption</samp>](## "ip_security.ike_policies.[].encryption") | String |  |  | Valid Values:<br>- disabled<br>- 3des<br>- aes128<br>- aes256 | Local IKE Identification.<br>Can be an IPv4 or an IPv6 address.<br> |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dh_group</samp>](## "ip_security.ike_policies.[].dh_group") | Integer |  |  | Valid Values:<br>- 1<br>- 2<br>- 5<br>- 14<br>- 15<br>- 16<br>- 17<br>- 20<br>- 21<br>- 24 | Diffie-Hellman group for the key exchange.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ike_lifetime</samp>](## "ip_security.ike_policies.[].ike_lifetime") | Integer |  |  | Min: 1<br>Max: 24 | IKE lifetime in hours. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;encryption</samp>](## "ip_security.ike_policies.[].encryption") | String |  |  | Valid Values:<br>- disabled<br>- 3des<br>- aes128<br>- aes256 | Local IKE Identification.<br>Can be an IPv4 or an IPv6 address. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dh_group</samp>](## "ip_security.ike_policies.[].dh_group") | Integer |  |  | Valid Values:<br>- 1<br>- 2<br>- 5<br>- 14<br>- 15<br>- 16<br>- 17<br>- 20<br>- 21<br>- 24 | Diffie-Hellman group for the key exchange. |
     | [<samp>&nbsp;&nbsp;sa_policies</samp>](## "ip_security.sa_policies") | List, items: Dictionary |  |  |  | Security Association policies. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "ip_security.sa_policies.[].name") | String | Required, Unique |  |  | Name of the SA policy. The "null" value is deprecated and will be removed on AVD 5.0.0 |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "ip_security.sa_policies.[].name") | String | Required, Unique |  |  | Name of the SA policy. The "null" value is deprecated and will be removed in AVD 5.0.0 |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;esp</samp>](## "ip_security.sa_policies.[].esp") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;integrity</samp>](## "ip_security.sa_policies.[].esp.integrity") | String |  |  | Valid Values:<br>- disabled<br>- sha1<br>- sha256<br>- null |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;encryption</samp>](## "ip_security.sa_policies.[].esp.encryption") | String |  |  | Valid Values:<br>- disabled<br>- aes128<br>- aes128gcm128<br>- aes128gcm64<br>- aes256<br>- aes256gcm256<br>- null |  |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ip-security.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ip-security.md
@@ -12,7 +12,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "ip_security.ike_policies.[].name") | String | Required, Unique |  |  | Policy name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;local_id</samp>](## "ip_security.ike_policies.[].local_id") | String |  |  |  | Local IKE Identification.<br>Can be an IPv4 or an IPv6 address.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ike_lifetime</samp>](## "ip_security.ike_policies.[].ike_lifetime") | Integer |  |  | Min: 1<br>Max: 24 | IKE lifetime in hours. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;encryption</samp>](## "ip_security.ike_policies.[].encryption") | String |  |  | Valid Values:<br>- disabled<br>- 3des<br>- aes128<br>- aes256 | Local IKE Identification.<br>Can be an IPv4 or an IPv6 address. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;encryption</samp>](## "ip_security.ike_policies.[].encryption") | String |  |  | Valid Values:<br>- 3des<br>- aes128<br>- aes256 | IKE encryption algorithm. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dh_group</samp>](## "ip_security.ike_policies.[].dh_group") | Integer |  |  | Valid Values:<br>- 1<br>- 2<br>- 5<br>- 14<br>- 15<br>- 16<br>- 17<br>- 20<br>- 21<br>- 24 | Diffie-Hellman group for the key exchange. |
     | [<samp>&nbsp;&nbsp;sa_policies</samp>](## "ip_security.sa_policies") | List, items: Dictionary |  |  |  | Security Association policies. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "ip_security.sa_policies.[].name") | String | Required, Unique |  |  | Name of the SA policy. The "null" value is deprecated and will be removed in AVD 5.0.0 |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ip-security.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ip-security.md
@@ -11,6 +11,9 @@
     | [<samp>&nbsp;&nbsp;ike_policies</samp>](## "ip_security.ike_policies") | List, items: Dictionary |  |  |  | Internet Security Association and Key Mgmt Protocol. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "ip_security.ike_policies.[].name") | String | Required, Unique |  |  | Policy name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;local_id</samp>](## "ip_security.ike_policies.[].local_id") | String |  |  |  | Local IKE Identification.<br>Can be an IPv4 or an IPv6 address.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ike_lifetime</samp>](## "ip_security.ike_policies.[].ike_lifetime") | Integer |  |  | Min: 1<br>Max: 24 | IKE lifetime in hours.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;encryption</samp>](## "ip_security.ike_policies.[].encryption") | String |  |  | Valid Values:<br>- null<br>- 3des<br>- aes128<br>- aes256 | Local IKE Identification.<br>Can be an IPv4 or an IPv6 address.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dh_group</samp>](## "ip_security.ike_policies.[].dh_group") | Integer |  |  | Valid Values:<br>- 1<br>- 2<br>- 5<br>- 14<br>- 15<br>- 16<br>- 17<br>- 20<br>- 21<br>- 24 | Diffie-Hellman group for the key exchange.<br> |
     | [<samp>&nbsp;&nbsp;sa_policies</samp>](## "ip_security.sa_policies") | List, items: Dictionary |  |  |  | Security Association policies. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;- name</samp>](## "ip_security.sa_policies.[].name") | String | Required, Unique |  |  | Name of the SA policy. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;esp</samp>](## "ip_security.sa_policies.[].esp") | Dictionary |  |  |  |  |
@@ -38,6 +41,9 @@
       ike_policies:
         - name: <str>
           local_id: <str>
+          ike_lifetime: <int>
+          encryption: <str>
+          dh_group: <int>
       sa_policies:
         - name: <str>
           esp:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -6602,7 +6602,7 @@
                 "type": "integer",
                 "minimum": 1,
                 "maximum": 24,
-                "description": "IKE lifetime in hours.\n",
+                "description": "IKE lifetime in hours.",
                 "title": "Ike Lifetime"
               },
               "encryption": {
@@ -6613,7 +6613,7 @@
                   "aes128",
                   "aes256"
                 ],
-                "description": "Local IKE Identification.\nCan be an IPv4 or an IPv6 address.\n",
+                "description": "Local IKE Identification.\nCan be an IPv4 or an IPv6 address.",
                 "title": "Encryption"
               },
               "dh_group": {
@@ -6630,7 +6630,7 @@
                   21,
                   24
                 ],
-                "description": "Diffie-Hellman group for the key exchange.\n",
+                "description": "Diffie-Hellman group for the key exchange.",
                 "title": "Dh Group"
               }
             },
@@ -6652,7 +6652,7 @@
             "properties": {
               "name": {
                 "type": "string",
-                "description": "Name of the SA policy. The \"null\" value is deprecated and will be removed on AVD 5.0.0",
+                "description": "Name of the SA policy. The \"null\" value is deprecated and will be removed in AVD 5.0.0",
                 "title": "Name"
               },
               "esp": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -6608,7 +6608,7 @@
               "encryption": {
                 "type": "string",
                 "enum": [
-                  "null",
+                  "disabled",
                   "3des",
                   "aes128",
                   "aes256"
@@ -6652,7 +6652,7 @@
             "properties": {
               "name": {
                 "type": "string",
-                "description": "Name of the SA policy.",
+                "description": "Name of the SA policy. The \"null\" value is deprecated and will be removed on AVD 5.0.0",
                 "title": "Name"
               },
               "esp": {
@@ -6661,21 +6661,23 @@
                   "integrity": {
                     "type": "string",
                     "enum": [
-                      "null",
+                      "disabled",
                       "sha1",
-                      "sha256"
+                      "sha256",
+                      "null"
                     ],
                     "title": "Integrity"
                   },
                   "encryption": {
                     "type": "string",
                     "enum": [
-                      "null",
+                      "disabled",
                       "aes128",
                       "aes128gcm128",
                       "aes128gcm64",
                       "aes256",
-                      "aes256gcm256"
+                      "aes256gcm256",
+                      "null"
                     ],
                     "title": "Encryption"
                   }

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -6608,12 +6608,11 @@
               "encryption": {
                 "type": "string",
                 "enum": [
-                  "disabled",
                   "3des",
                   "aes128",
                   "aes256"
                 ],
-                "description": "Local IKE Identification.\nCan be an IPv4 or an IPv6 address.",
+                "description": "IKE encryption algorithm.",
                 "title": "Encryption"
               },
               "dh_group": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -6597,6 +6597,41 @@
                 "type": "string",
                 "description": "Local IKE Identification.\nCan be an IPv4 or an IPv6 address.\n",
                 "title": "Local ID"
+              },
+              "ike_lifetime": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 24,
+                "description": "IKE lifetime in hours.\n",
+                "title": "Ike Lifetime"
+              },
+              "encryption": {
+                "type": "string",
+                "enum": [
+                  "null",
+                  "3des",
+                  "aes128",
+                  "aes256"
+                ],
+                "description": "Local IKE Identification.\nCan be an IPv4 or an IPv6 address.\n",
+                "title": "Encryption"
+              },
+              "dh_group": {
+                "type": "integer",
+                "enum": [
+                  1,
+                  2,
+                  5,
+                  14,
+                  15,
+                  16,
+                  17,
+                  20,
+                  21,
+                  24
+                ],
+                "description": "Diffie-Hellman group for the key exchange.\n",
+                "title": "Dh Group"
               }
             },
             "additionalProperties": false,

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -3801,7 +3801,7 @@ keys:
             encryption:
               type: str
               valid_values:
-              - 'null'
+              - disabled
               - 3des
               - aes128
               - aes256
@@ -3837,25 +3837,28 @@ keys:
           keys:
             name:
               type: str
-              description: Name of the SA policy.
+              description: Name of the SA policy. The "null" value is deprecated and
+                will be removed on AVD 5.0.0
             esp:
               type: dict
               keys:
                 integrity:
                   type: str
                   valid_values:
-                  - 'null'
+                  - disabled
                   - sha1
                   - sha256
+                  - 'null'
                 encryption:
                   type: str
                   valid_values:
-                  - 'null'
+                  - disabled
                   - aes128
                   - aes128gcm128
                   - aes128gcm64
                   - aes256
                   - aes256gcm256
+                  - 'null'
             pfs_dh_group:
               type: int
               convert_types:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -3789,6 +3789,45 @@ keys:
                 Can be an IPv4 or an IPv6 address.
 
                 '
+            ike_lifetime:
+              type: int
+              convert_types:
+              - str
+              min: 1
+              max: 24
+              description: 'IKE lifetime in hours.
+
+                '
+            encryption:
+              type: str
+              valid_values:
+              - 'null'
+              - 3des
+              - aes128
+              - aes256
+              description: 'Local IKE Identification.
+
+                Can be an IPv4 or an IPv6 address.
+
+                '
+            dh_group:
+              type: int
+              convert_types:
+              - str
+              valid_values:
+              - 1
+              - 2
+              - 5
+              - 14
+              - 15
+              - 16
+              - 17
+              - 20
+              - 21
+              - 24
+              description: 'Diffie-Hellman group for the key exchange.
+
+                '
       sa_policies:
         type: list
         description: Security Association policies.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -3795,9 +3795,7 @@ keys:
               - str
               min: 1
               max: 24
-              description: 'IKE lifetime in hours.
-
-                '
+              description: IKE lifetime in hours.
             encryption:
               type: str
               valid_values:
@@ -3807,9 +3805,7 @@ keys:
               - aes256
               description: 'Local IKE Identification.
 
-                Can be an IPv4 or an IPv6 address.
-
-                '
+                Can be an IPv4 or an IPv6 address.'
             dh_group:
               type: int
               convert_types:
@@ -3825,9 +3821,7 @@ keys:
               - 20
               - 21
               - 24
-              description: 'Diffie-Hellman group for the key exchange.
-
-                '
+              description: Diffie-Hellman group for the key exchange.
       sa_policies:
         type: list
         description: Security Association policies.
@@ -3838,7 +3832,7 @@ keys:
             name:
               type: str
               description: Name of the SA policy. The "null" value is deprecated and
-                will be removed on AVD 5.0.0
+                will be removed in AVD 5.0.0
             esp:
               type: dict
               keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -3799,13 +3799,10 @@ keys:
             encryption:
               type: str
               valid_values:
-              - disabled
               - 3des
               - aes128
               - aes256
-              description: 'Local IKE Identification.
-
-                Can be an IPv4 or an IPv6 address.'
+              description: IKE encryption algorithm.
             dh_group:
               type: int
               convert_types:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ip_security.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ip_security.schema.yml
@@ -30,8 +30,7 @@ keys:
                 - str
               min: 1
               max: 24
-              description: |
-                IKE lifetime in hours.
+              description: IKE lifetime in hours.
             encryption:
               type: str
               valid_values:
@@ -39,7 +38,7 @@ keys:
                 - 3des
                 - aes128
                 - aes256
-              description: |
+              description: |-
                 Local IKE Identification.
                 Can be an IPv4 or an IPv6 address.
             dh_group:
@@ -47,8 +46,7 @@ keys:
               convert_types:
                 - str
               valid_values: [1, 2, 5, 14, 15, 16, 17, 20, 21, 24]
-              description: |
-                Diffie-Hellman group for the key exchange.
+              description: Diffie-Hellman group for the key exchange.
       sa_policies:
         type: list
         description: Security Association policies.
@@ -58,7 +56,7 @@ keys:
           keys:
             name:
               type: str
-              description: Name of the SA policy. The "null" value is deprecated and will be removed on AVD 5.0.0
+              description: Name of the SA policy. The "null" value is deprecated and will be removed in AVD 5.0.0
             esp:
               type: dict
               keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ip_security.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ip_security.schema.yml
@@ -34,13 +34,10 @@ keys:
             encryption:
               type: str
               valid_values:
-                - disabled
                 - 3des
                 - aes128
                 - aes256
-              description: |-
-                Local IKE Identification.
-                Can be an IPv4 or an IPv6 address.
+              description: IKE encryption algorithm.
             dh_group:
               type: int
               convert_types:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ip_security.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ip_security.schema.yml
@@ -35,7 +35,7 @@ keys:
             encryption:
               type: str
               valid_values:
-                - "null"
+                - disabled
                 - 3des
                 - aes128
                 - aes256
@@ -58,25 +58,27 @@ keys:
           keys:
             name:
               type: str
-              description: Name of the SA policy.
+              description: Name of the SA policy. The "null" value is deprecated and will be removed on AVD 5.0.0
             esp:
               type: dict
               keys:
                 integrity:
                   type: str
                   valid_values:
-                    - "null"
+                    - disabled
                     - sha1
                     - sha256
+                    - "null"  # TODO: AVD 5.0.0
                 encryption:
                   type: str
                   valid_values:
-                    - "null"
+                    - disabled
                     - aes128
                     - aes128gcm128
                     - aes128gcm64
                     - aes256
                     - aes256gcm256
+                    - "null"  # TODO: AVD 5.0.0
             pfs_dh_group:
               type: int
               convert_types:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ip_security.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ip_security.schema.yml
@@ -24,6 +24,31 @@ keys:
               description: |
                 Local IKE Identification.
                 Can be an IPv4 or an IPv6 address.
+            ike_lifetime:
+              type: int
+              convert_types:
+                - str
+              min: 1
+              max: 24
+              description: |
+                IKE lifetime in hours.
+            encryption:
+              type: str
+              valid_values:
+                - "null"
+                - 3des
+                - aes128
+                - aes256
+              description: |
+                Local IKE Identification.
+                Can be an IPv4 or an IPv6 address.
+            dh_group:
+              type: int
+              convert_types:
+                - str
+              valid_values: [1, 2, 5, 14, 15, 16, 17, 20, 21, 24]
+              description: |
+                Diffie-Hellman group for the key exchange.
       sa_policies:
         type: list
         description: Security Association policies.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ip-security.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ip-security.j2
@@ -11,13 +11,13 @@
 
 ### IKE policies
 
-| Policy name | Local ID |
-| ----------- | -------- |
+| Policy name | IKE lifetime | Encryption | DH group | Local ID |
+| ----------- | ------------ | ---------- | -------- | -------- |
 {%         for ike_policy in ip_security.ike_policies | arista.avd.default([]) %}
-| {{ ike_policy.name }} | {{ ike_policy.local_id | arista.avd.default("-") }} |
+| {{ ike_policy.name }} | {{ ike_policy.ike_lifetime | arista.avd.default("-") }} | {{ ike_policy.encryption | arista.avd.default("-") }} | {{ ike_policy.dh_group | arista.avd.default("-") }} | {{ ike_policy.local_id | arista.avd.default("-") }} |
 {%         endfor %}
 {%     endif %}
-{%     if ip_security.ike_policie is arista.avd.defined %}
+{%     if ip_security.sa_policies is arista.avd.defined %}
 
 ### Security Association policies
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ip-security.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ip-security.j2
@@ -7,55 +7,55 @@
 {% if ip_security is arista.avd.defined %}
 
 ## IP Security
-{%     if ip_security.ike_policies is arista.avd.defined %}
+{%   if ip_security.ike_policies is arista.avd.defined %}
 
 ### IKE policies
 
 | Policy name | IKE lifetime | Encryption | DH group | Local ID |
 | ----------- | ------------ | ---------- | -------- | -------- |
-{%         for ike_policy in ip_security.ike_policies | arista.avd.default([]) %}
+{%       for ike_policy in ip_security.ike_policies | arista.avd.default([]) %}
 | {{ ike_policy.name }} | {{ ike_policy.ike_lifetime | arista.avd.default("-") }} | {{ ike_policy.encryption | arista.avd.default("-") }} | {{ ike_policy.dh_group | arista.avd.default("-") }} | {{ ike_policy.local_id | arista.avd.default("-") }} |
-{%         endfor %}
-{%     endif %}
-{%     if ip_security.sa_policies is arista.avd.defined %}
+{%       endfor %}
+{%   endif %}
+{%   if ip_security.sa_policies is arista.avd.defined %}
 
 ### Security Association policies
 
 | Policy name | ESP Integrity | ESP Encryption | PFS DH Group |
 | ----------- | ------------- | -------------- | ------------ |
-{%         for sa_policy in ip_security.sa_policies | arista.avd.default([]) %}
-| {{ sa_policy.name }} | {{ sa_policy.esp.integrity | arista.avd.default("-") }} |  {{ sa_policy.esp.encryption | arista.avd.default("-") }} | {{ sa_policy.pfs_dh_group | arista.avd.default("-") }} |
-{%         endfor %}
-{%     endif %}
-{%     if ip_security.profiles is arista.avd.defined %}
+{%       for sa_policy in ip_security.sa_policies | arista.avd.default([]) %}
+| {{ sa_policy.name }} | {{ sa_policy.esp.integrity | arista.avd.default("-") }} | {{ sa_policy.esp.encryption | arista.avd.default("-") }} | {{ sa_policy.pfs_dh_group | arista.avd.default("-") }} |
+{%       endfor %}
+{%   endif %}
+{%   if ip_security.profiles is arista.avd.defined %}
 
 ### IPSec profiles
 
 | Profile name | IKE policy | SA policy | Connection | DPD Interval | DPD Time | DPD action | Mode |
 | ------------ | ---------- | ----------| ---------- | ------------ | -------- | ---------- | ---- |
-{%         for profile in ip_security.profiles | arista.avd.default([]) %}
-{%             set ike_policy = profile.ike_policy | arista.avd.default("-") %}
-{%             set sa_policy = profile.sa_policy | arista.avd.default("-") %}
-{%             set connection = profile.connection | arista.avd.default("-") %}
-{%             set dpd_interval = profile.dpd_interval | arista.avd.default("-") %}
-{%             set dpd_time = profile.dpd_time | arista.avd.default("-") %}
-{%             set dpd_action = profile.dpd_action | arista.avd.default("-") %}
-{%             set mode = profile.mode | arista.avd.default("-") %}
+{%       for profile in ip_security.profiles | arista.avd.default([]) %}
+{%           set ike_policy = profile.ike_policy | arista.avd.default("-") %}
+{%           set sa_policy = profile.sa_policy | arista.avd.default("-") %}
+{%           set connection = profile.connection | arista.avd.default("-") %}
+{%           set dpd_interval = profile.dpd_interval | arista.avd.default("-") %}
+{%           set dpd_time = profile.dpd_time | arista.avd.default("-") %}
+{%           set dpd_action = profile.dpd_action | arista.avd.default("-") %}
+{%           set mode = profile.mode | arista.avd.default("-") %}
 | {{ profile.name }} | {{ ike_policy }} | {{ sa_policy }} | {{ connection }} | {{ dpd_interval }} | {{ dpd_time }} | {{ dpd_action }} | {{ mode }} |
-{%         endfor %}
-{%     endif %}
-{%     if ip_security.key_controller is arista.avd.defined %}
+{%       endfor %}
+{%   endif %}
+{%   if ip_security.key_controller is arista.avd.defined %}
 
 ### Key controller
 
 | Profile name |
 | ------------ |
 | {{ ip_security.key_controller.profile | arista.avd.default("-") }} |
-{%     endif %}
+{%   endif %}
 
 ### IP Security Configuration
 
 ```eos
-{%     include 'eos/ip-security.j2' %}
+{%   include 'eos/ip-security.j2' %}
 ```
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ip-security.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ip-security.j2
@@ -7,55 +7,55 @@
 {% if ip_security is arista.avd.defined %}
 
 ## IP Security
-{%   if ip_security.ike_policies is arista.avd.defined %}
+{%     if ip_security.ike_policies is arista.avd.defined %}
 
 ### IKE policies
 
 | Policy name | IKE lifetime | Encryption | DH group | Local ID |
 | ----------- | ------------ | ---------- | -------- | -------- |
-{%       for ike_policy in ip_security.ike_policies | arista.avd.default([]) %}
+{%         for ike_policy in ip_security.ike_policies | arista.avd.default([]) %}
 | {{ ike_policy.name }} | {{ ike_policy.ike_lifetime | arista.avd.default("-") }} | {{ ike_policy.encryption | arista.avd.default("-") }} | {{ ike_policy.dh_group | arista.avd.default("-") }} | {{ ike_policy.local_id | arista.avd.default("-") }} |
-{%       endfor %}
-{%   endif %}
-{%   if ip_security.sa_policies is arista.avd.defined %}
+{%         endfor %}
+{%     endif %}
+{%     if ip_security.sa_policies is arista.avd.defined %}
 
 ### Security Association policies
 
 | Policy name | ESP Integrity | ESP Encryption | PFS DH Group |
 | ----------- | ------------- | -------------- | ------------ |
-{%       for sa_policy in ip_security.sa_policies | arista.avd.default([]) %}
+{%         for sa_policy in ip_security.sa_policies | arista.avd.default([]) %}
 | {{ sa_policy.name }} | {{ sa_policy.esp.integrity | arista.avd.default("-") }} | {{ sa_policy.esp.encryption | arista.avd.default("-") }} | {{ sa_policy.pfs_dh_group | arista.avd.default("-") }} |
-{%       endfor %}
-{%   endif %}
-{%   if ip_security.profiles is arista.avd.defined %}
+{%         endfor %}
+{%     endif %}
+{%     if ip_security.profiles is arista.avd.defined %}
 
 ### IPSec profiles
 
 | Profile name | IKE policy | SA policy | Connection | DPD Interval | DPD Time | DPD action | Mode |
 | ------------ | ---------- | ----------| ---------- | ------------ | -------- | ---------- | ---- |
-{%       for profile in ip_security.profiles | arista.avd.default([]) %}
-{%           set ike_policy = profile.ike_policy | arista.avd.default("-") %}
-{%           set sa_policy = profile.sa_policy | arista.avd.default("-") %}
-{%           set connection = profile.connection | arista.avd.default("-") %}
-{%           set dpd_interval = profile.dpd_interval | arista.avd.default("-") %}
-{%           set dpd_time = profile.dpd_time | arista.avd.default("-") %}
-{%           set dpd_action = profile.dpd_action | arista.avd.default("-") %}
-{%           set mode = profile.mode | arista.avd.default("-") %}
+{%         for profile in ip_security.profiles | arista.avd.default([]) %}
+{%             set ike_policy = profile.ike_policy | arista.avd.default("-") %}
+{%             set sa_policy = profile.sa_policy | arista.avd.default("-") %}
+{%             set connection = profile.connection | arista.avd.default("-") %}
+{%             set dpd_interval = profile.dpd_interval | arista.avd.default("-") %}
+{%             set dpd_time = profile.dpd_time | arista.avd.default("-") %}
+{%             set dpd_action = profile.dpd_action | arista.avd.default("-") %}
+{%             set mode = profile.mode | arista.avd.default("-") %}
 | {{ profile.name }} | {{ ike_policy }} | {{ sa_policy }} | {{ connection }} | {{ dpd_interval }} | {{ dpd_time }} | {{ dpd_action }} | {{ mode }} |
-{%       endfor %}
-{%   endif %}
-{%   if ip_security.key_controller is arista.avd.defined %}
+{%         endfor %}
+{%     endif %}
+{%     if ip_security.key_controller is arista.avd.defined %}
 
 ### Key controller
 
 | Profile name |
 | ------------ |
 | {{ ip_security.key_controller.profile | arista.avd.default("-") }} |
-{%   endif %}
+{%     endif %}
 
 ### IP Security Configuration
 
 ```eos
-{%   include 'eos/ip-security.j2' %}
+{%     include 'eos/ip-security.j2' %}
 ```
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ip-security.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ip-security.j2
@@ -16,7 +16,7 @@ ip security
 {%         if ike_policy.ike_lifetime is arista.avd.defined %}
       ike-lifetime {{ ike_policy.ike_lifetime }}
 {%         endif %}
-{%         if ike_policy.encryption is arista.avd.defined and ike_policy.encryption != "disabled" %}
+{%         if ike_policy.encryption is arista.avd.defined %}
       encryption {{ ike_policy.encryption }}
 {%         endif %}
 {%         if ike_policy.dh_group is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ip-security.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ip-security.j2
@@ -16,7 +16,7 @@ ip security
 {%         if ike_policy.ike_lifetime is arista.avd.defined %}
       ike-lifetime {{ ike_policy.ike_lifetime }}
 {%         endif %}
-{%         if ike_policy.encryption is arista.avd.defined %}
+{%         if ike_policy.encryption is arista.avd.defined and ike_policy.encryption != "disabled" %}
       encryption {{ ike_policy.encryption }}
 {%         endif %}
 {%         if ike_policy.dh_group is arista.avd.defined %}
@@ -26,10 +26,10 @@ ip security
 {%     for sa_policy in ip_security.sa_policies | arista.avd.default([]) %}
    !
    sa policy {{ sa_policy.name }}
-{%         if sa_policy.esp.intergrity is arista.avd.defined %}
+{%         if sa_policy.esp.intergrity is arista.avd.defined and sa_policy.esp.intergrity != "disabled" %}
       esp intergrity {{ sa_policy.esp.intergrity }}
 {%         endif %}
-{%         if sa_policy.esp.encryption is arista.avd.defined %}
+{%         if sa_policy.esp.encryption is arista.avd.defined and sa_policy.esp.encryption != "disabled" %}
       esp encryption {{ sa_policy.esp.encryption }}
 {%         endif %}
 {%         if sa_policy.pfs_dh_group is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ip-security.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ip-security.j2
@@ -13,6 +13,15 @@ ip security
 {%         if ike_policy.local_id is arista.avd.defined %}
       local-id {{ ike_policy.local_id }}
 {%         endif %}
+{%         if ike_policy.ike_lifetime is arista.avd.defined %}
+      ike-lifetime {{ ike_policy.ike_lifetime }}
+{%         endif %}
+{%         if ike_policy.encryption is arista.avd.defined %}
+      encryption {{ ike_policy.encryption }}
+{%         endif %}
+{%         if ike_policy.dh_group is arista.avd.defined %}
+      dh-group {{ ike_policy.dh_group }}
+{%         endif %}
 {%     endfor %}
 {%     for sa_policy in ip_security.sa_policies | arista.avd.default([]) %}
    !

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ip-security.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ip-security.j2
@@ -26,11 +26,19 @@ ip security
 {%     for sa_policy in ip_security.sa_policies | arista.avd.default([]) %}
    !
    sa policy {{ sa_policy.name }}
-{%         if sa_policy.esp.intergrity is arista.avd.defined and sa_policy.esp.intergrity != "disabled" %}
-      esp intergrity {{ sa_policy.esp.intergrity }}
+{%         if sa_policy.esp.integrity is arista.avd.defined %}
+{%             if sa_policy.esp.integrity == "disabled" %}
+      esp integrity null
+{%             else %}
+      esp integrity {{ sa_policy.esp.integrity }}
+{%             endif %}
 {%         endif %}
-{%         if sa_policy.esp.encryption is arista.avd.defined and sa_policy.esp.encryption != "disabled" %}
+{%         if sa_policy.esp.encryption is arista.avd.defined %}
+{%             if sa_policy.esp.encryption == "disabled" %}
+      esp encryption null
+{%             else %}
       esp encryption {{ sa_policy.esp.encryption }}
+{%             endif %}
 {%         endif %}
 {%         if sa_policy.pfs_dh_group is arista.avd.defined %}
       pfs dh-group {{ sa_policy.pfs_dh_group }}


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Adds CLI support for the following:

* IKE policies
   * IKE lifetime
   * encryption
   * DH group

See related issue

## Related Issue(s)

Fixes #3310

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->
Extend Jinja2 template for `ip_security` to support extra CLI options for IKE profiles

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
See molecule tests

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
