### PR TITLE
Fix(eos_designs): Tags not inherited from profile

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SVI_PROFILE_NODE_1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SVI_PROFILE_NODE_1.cfg
@@ -75,6 +75,9 @@ vlan 511
 vlan 512
    name ospf_enabled_512
 !
+vlan 601
+   name tag_testing
+!
 vrf instance MGMT
 !
 vrf instance svi_profile_tests_vrf
@@ -213,6 +216,12 @@ interface Vlan512
    ip ospf area 0
    ip address virtual 10.5.12.1/24
 !
+interface Vlan601
+   description tag_testing
+   no shutdown
+   vrf svi_profile_tests_vrf
+   ip address virtual 10.6.0.1/24
+!
 interface Vxlan1
    description SVI_PROFILE_NODE_1_VTEP
    vxlan source-interface Loopback1
@@ -234,6 +243,7 @@ interface Vxlan1
    vxlan vlan 510 vni 10510
    vxlan vlan 511 vni 10511
    vxlan vlan 512 vni 10512
+   vxlan vlan 601 vni 10601
    vxlan vrf svi_profile_tests_vrf vni 1
 !
 ip virtual-router mac-address 00:1c:73:00:dc:01
@@ -356,6 +366,11 @@ router bgp 65001
    vlan 512
       rd 192.168.255.1:10512
       route-target both 10512:10512
+      redistribute learned
+   !
+   vlan 601
+      rd 192.168.255.1:10601
+      route-target both 10601:10601
       redistribute learned
    !
    address-family evpn

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SVI_PROFILE_NODE_2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SVI_PROFILE_NODE_2.cfg
@@ -75,6 +75,9 @@ vlan 511
 vlan 512
    name ospf_enabled_512
 !
+vlan 601
+   name tag_testing
+!
 vrf instance MGMT
 !
 vrf instance svi_profile_tests_vrf
@@ -213,6 +216,12 @@ interface Vlan512
    ip ospf area 0
    ip address virtual 10.5.12.1/24
 !
+interface Vlan601
+   description tag_testing
+   no shutdown
+   vrf svi_profile_tests_vrf
+   ip address virtual 10.6.0.1/24
+!
 interface Vxlan1
    description SVI_PROFILE_NODE_2_VTEP
    vxlan source-interface Loopback1
@@ -234,6 +243,7 @@ interface Vxlan1
    vxlan vlan 510 vni 10510
    vxlan vlan 511 vni 10511
    vxlan vlan 512 vni 10512
+   vxlan vlan 601 vni 10601
    vxlan vrf svi_profile_tests_vrf vni 1
 !
 ip virtual-router mac-address 00:1c:73:00:dc:01
@@ -277,7 +287,7 @@ router bgp 65002
       rd 192.168.255.1:1
       route-target both 1:1
       redistribute learned
-      vlan 110-115,120-121,210-212,410-412,510-512
+      vlan 110-115,120-121,210-212,410-412,510-512,601
    !
    address-family evpn
       neighbor EVPN-OVERLAY-PEERS activate

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SVI_PROFILE_NODE_3.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SVI_PROFILE_NODE_3.cfg
@@ -1,0 +1,78 @@
+!RANCID-CONTENT-TYPE: arista
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname SVI_PROFILE_NODE_3
+!
+no enable password
+no aaa root
+!
+vrf instance MGMT
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 192.168.255.3/32
+!
+interface Loopback1
+   description VTEP_VXLAN_Tunnel_Source
+   no shutdown
+   ip address 192.168.254.3/32
+!
+interface Vxlan1
+   description SVI_PROFILE_NODE_3_VTEP
+   vxlan source-interface Loopback1
+   vxlan udp-port 4789
+!
+ip virtual-router mac-address 00:1c:73:00:dc:01
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+   seq 20 permit 192.168.254.0/24 eq 32
+!
+ip route vrf MGMT 0.0.0.0/0 10.0.0.1
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+router bfd
+   multihop interval 300 min-rx 300 multiplier 3
+!
+router bgp 65003
+   router-id 192.168.255.3
+   maximum-paths 4 ecmp 4
+   update wait-install
+   no bgp default ipv4-unicast
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor IPv4-UNDERLAY-PEERS peer group
+   neighbor IPv4-UNDERLAY-PEERS send-community
+   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   address-family evpn
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor IPv4-UNDERLAY-PEERS activate
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/SVI_PROFILE_NODE_1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/SVI_PROFILE_NODE_1.yml
@@ -189,6 +189,14 @@ router_bgp:
       - 10512:10512
     redistribute_routes:
     - learned
+  - id: 601
+    tenant: svi_profile_tests
+    rd: 192.168.255.1:10601
+    route_targets:
+      both:
+      - 10601:10601
+    redistribute_routes:
+    - learned
 static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0
@@ -310,6 +318,9 @@ vlans:
   tenant: svi_profile_tests
 - id: 512
   name: ospf_enabled_512
+  tenant: svi_profile_tests
+- id: 601
+  name: tag_testing
   tenant: svi_profile_tests
 ip_igmp_snooping:
   globally_enabled: true
@@ -452,6 +463,14 @@ vlan_interfaces:
   vrf: svi_profile_tests_vrf
   ospf_area: '0'
   ospf_network_point_to_point: false
+- name: Vlan601
+  tenant: svi_profile_tests
+  tags:
+  - tag-test
+  description: tag_testing
+  shutdown: false
+  ip_address_virtual: 10.6.0.1/24
+  vrf: svi_profile_tests_vrf
 router_ospf:
   process_ids:
   - id: 1
@@ -506,6 +525,8 @@ vxlan_interface:
         vni: 10511
       - id: 512
         vni: 10512
+      - id: 601
+        vni: 10601
       vrfs:
       - name: svi_profile_tests_vrf
         vni: 1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/SVI_PROFILE_NODE_2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/SVI_PROFILE_NODE_2.yml
@@ -60,7 +60,7 @@ router_bgp:
       - '1:1'
     redistribute_routes:
     - learned
-    vlan: 110-115,120-121,210-212,410-412,510-512
+    vlan: 110-115,120-121,210-212,410-412,510-512,601
 static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0
@@ -182,6 +182,9 @@ vlans:
   tenant: svi_profile_tests
 - id: 512
   name: ospf_enabled_512
+  tenant: svi_profile_tests
+- id: 601
+  name: tag_testing
   tenant: svi_profile_tests
 ip_igmp_snooping:
   globally_enabled: true
@@ -324,6 +327,14 @@ vlan_interfaces:
   vrf: svi_profile_tests_vrf
   ospf_area: '0'
   ospf_network_point_to_point: false
+- name: Vlan601
+  tenant: svi_profile_tests
+  tags:
+  - tag-test
+  description: tag_testing
+  shutdown: false
+  ip_address_virtual: 10.6.0.1/24
+  vrf: svi_profile_tests_vrf
 router_ospf:
   process_ids:
   - id: 1
@@ -378,6 +389,8 @@ vxlan_interface:
         vni: 10511
       - id: 512
         vni: 10512
+      - id: 601
+        vni: 10601
       vrfs:
       - name: svi_profile_tests_vrf
         vni: 1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/SVI_PROFILE_NODE_3.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/SVI_PROFILE_NODE_3.yml
@@ -1,0 +1,93 @@
+hostname: SVI_PROFILE_NODE_3
+is_deployed: true
+router_bgp:
+  as: '65003'
+  router_id: 192.168.255.3
+  bgp:
+    default:
+      ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
+  updates:
+    wait_install: true
+  peer_groups:
+  - name: IPv4-UNDERLAY-PEERS
+    type: ipv4
+    maximum_routes: 12000
+    send_community: all
+  - name: EVPN-OVERLAY-PEERS
+    type: evpn
+    update_source: Loopback0
+    bfd: true
+    send_community: all
+    maximum_routes: 0
+    ebgp_multihop: 3
+  address_family_ipv4:
+    peer_groups:
+    - name: IPv4-UNDERLAY-PEERS
+      activate: true
+    - name: EVPN-OVERLAY-PEERS
+      activate: false
+  redistribute_routes:
+  - source_protocol: connected
+    route_map: RM-CONN-2-BGP
+  address_family_evpn:
+    peer_groups:
+    - name: EVPN-OVERLAY-PEERS
+      activate: true
+static_routes:
+- vrf: MGMT
+  destination_address_prefix: 0.0.0.0/0
+  gateway: 10.0.0.1
+service_routing_protocols_model: multi-agent
+ip_routing: true
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+vrfs:
+- name: MGMT
+  ip_routing: false
+management_api_http:
+  enable_vrfs:
+  - name: MGMT
+  enable_https: true
+loopback_interfaces:
+- name: Loopback0
+  description: EVPN_Overlay_Peering
+  shutdown: false
+  ip_address: 192.168.255.3/32
+- name: Loopback1
+  description: VTEP_VXLAN_Tunnel_Source
+  shutdown: false
+  ip_address: 192.168.254.3/32
+prefix_lists:
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
+route_maps:
+- name: RM-CONN-2-BGP
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    match:
+    - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+router_bfd:
+  multihop:
+    interval: 300
+    min_rx: 300
+    multiplier: 3
+ip_igmp_snooping:
+  globally_enabled: true
+ip_virtual_router_mac_address: 00:1c:73:00:dc:01
+vxlan_interface:
+  Vxlan1:
+    description: SVI_PROFILE_NODE_3_VTEP
+    vxlan:
+      udp_port: 4789
+      source_interface: Loopback1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/SVI_PROFILE_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/SVI_PROFILE_TESTS.yml
@@ -19,7 +19,11 @@ l3leaf:
     - name: SVI_PROFILE_NODE_2
       id: 1
       bgp_as: 65002
-
+    - name: SVI_PROFILE_NODE_3
+      id: 3
+      bgp_as: 65003
+      filter:
+        tags: [tag-test]
 
 #### ---- Test inheritance of svi structured_configuration ----- ###
 # Test logic for network services: vlan-interfaces
@@ -173,6 +177,11 @@ svi_profiles:
 
   - profile: ospf_enabled_child_profile_3
     parent_profile: ospf_enabled_parent_profile_2
+
+#### ---- Test profile with tag----- ###
+
+  - profile: profile_with_tag
+    tags: [tag-test]
 
 ### --- Network Services Generic base config--- ###
 
@@ -386,3 +395,12 @@ tenants:
             enabled: true
             ip_address_virtual: 10.5.12.1/24
             profile: ospf_enabled_child_profile_3
+
+#### ---- Test profile with tag----- ###
+
+          - id: 601
+            name: tag_testing
+            enabled: true
+            ip_address_virtual: 10.6.0.1/24
+            profile: profile_with_tag
+            #tags: [tag-test] - Tag set on profile

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
@@ -140,6 +140,7 @@ all:
           hosts:
             SVI_PROFILE_NODE_1:
             SVI_PROFILE_NODE_2:
+            SVI_PROFILE_NODE_3:
         RD_RT_ADMIN_SUBFIELD_TESTS:
           hosts:
             RD-RT-ADMIN-SUBFIELD-L3LEAF1:


### PR DESCRIPTION
## Change Summary

Tags not inherited from svi_profiles in network_services

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

TBD

## How to test

Updated molecule test


