### PR TITLE
Feat(eos_cli_config_gen): Add hardware_offload feature to flow_tracking.sampled

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/flow-tracking-2.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/flow-tracking-2.md
@@ -41,11 +41,9 @@ interface Management1
 
 #### Flow Tracking Sampled
 
-Sample: 666
-
-Hardware offload for IPv4 traffic: enabled
-
-Hardware offload for IPv6 traffic: enabled
+| Sample Size | Minimum Sample Size | Hardware Offload for IPv4 | Hardware Offload for IPv6 |
+| ----------- | ------------------- | ------------------------- | ------------------------- |
+| 666 | default | enabled | enabled |
 
 ##### Trackers Summary
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/flow-tracking-2.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/flow-tracking-2.md
@@ -1,0 +1,72 @@
+# flow-tracking-2
+
+## Table of Contents
+
+- [Management](#management)
+  - [Management Interfaces](#management-interfaces)
+- [Monitoring](#monitoring)
+  - [Flow Tracking](#flow-tracking)
+
+## Management
+
+### Management Interfaces
+
+#### Management Interfaces Summary
+
+##### IPv4
+
+| Management Interface | description | Type | VRF | IP Address | Gateway |
+| -------------------- | ----------- | ---- | --- | ---------- | ------- |
+| Management1 | oob_management | oob | MGMT | 10.73.255.122/24 | 10.73.255.2 |
+
+##### IPv6
+
+| Management Interface | description | Type | VRF | IPv6 Address | IPv6 Gateway |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ |
+| Management1 | oob_management | oob | MGMT | - | - |
+
+#### Management Interfaces Device Configuration
+
+```eos
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+```
+
+## Monitoring
+
+### Flow Tracking
+
+#### Flow Tracking Sampled
+
+Sample: 666
+
+Hardware offload for IPv4 traffic: enabled
+
+Hardware offload for IPv6 traffic: enabled
+
+##### Trackers Summary
+
+| Tracker Name | Record Export On Inactive Timeout | Record Export On Interval | MPLS | Number of Exporters | Applied On | Table Size |
+| ------------ | --------------------------------- | ------------------------- | ---- | ------------------- | ---------- | ---------- |
+| T21 | 3666 | 5666 | True | 0 |  | - |
+
+##### Exporters Summary
+
+| Tracker Name | Exporter Name | Collector IP/Host | Collector Port | Local Interface |
+| ------------ | ------------- | ----------------- | -------------- | --------------- |
+
+#### Flow Tracking Configuration
+
+```eos
+!
+flow tracking sampled
+   sample 666
+   hardware offload ipv4 ipv6
+   tracker T21
+      record export on inactive timeout 3666
+      record export on interval 5666
+      record export mpls
+```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/flow-tracking.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/flow-tracking.md
@@ -44,11 +44,9 @@ interface Management1
 
 #### Flow Tracking Sampled
 
-Sample: 666
-
-Hardware offload for IPv4 traffic: enabled
-
-Minimum number of Samples: 2
+| Sample Size | Minimum Sample Size | Hardware Offload for IPv4 | Hardware Offload for IPv6 |
+| ----------- | ------------------- | ------------------------- | ------------------------- |
+| 666 | 2 | enabled | disabled |
 
 ##### Trackers Summary
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/flow-tracking.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/flow-tracking.md
@@ -46,6 +46,10 @@ interface Management1
 
 Sample: 666
 
+Hardware offload for IPv4 traffic: enabled
+
+Minimum number of Samples: 2
+
 ##### Trackers Summary
 
 | Tracker Name | Record Export On Inactive Timeout | Record Export On Interval | MPLS | Number of Exporters | Applied On | Table Size |
@@ -90,6 +94,8 @@ Sample: 666
 !
 flow tracking sampled
    sample 666
+   hardware offload ipv4
+   hardware offload threshold minimum 2 samples
    tracker T1
       record export on inactive timeout 3666
       record export on interval 5666

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/flow-tracking-2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/flow-tracking-2.cfg
@@ -1,0 +1,23 @@
+!RANCID-CONTENT-TYPE: arista
+!
+flow tracking sampled
+   sample 666
+   hardware offload ipv4 ipv6
+   tracker T21
+      record export on inactive timeout 3666
+      record export on interval 5666
+      record export mpls
+!
+transceiver qsfp default-mode 4x10G
+!
+hostname flow-tracking-2
+!
+no enable password
+no aaa root
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/flow-tracking.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/flow-tracking.cfg
@@ -2,6 +2,8 @@
 !
 flow tracking sampled
    sample 666
+   hardware offload ipv4
+   hardware offload threshold minimum 2 samples
    tracker T1
       record export on inactive timeout 3666
       record export on interval 5666

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/flow-tracking-2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/flow-tracking-2.yml
@@ -1,0 +1,15 @@
+---
+### Flow Tracking
+
+flow_tracking:
+  sampled:
+    sample: 666
+    hardware_offload:
+      ipv4: true
+      ipv6: true
+    trackers:
+      - name: T21
+        record_export:
+          on_inactive_timeout: 3666
+          on_interval: 5666
+          mpls: true

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/flow-tracking.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/flow-tracking.yml
@@ -4,6 +4,9 @@
 flow_tracking:
   sampled:
     sample: 666
+    hardware_offload:
+      ipv4: true
+      threshold_minimum: 2
     trackers:
       - name: T1
         record_export:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts.ini
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts.ini
@@ -27,6 +27,7 @@ ethernet-interfaces
 event-handlers
 event-monitor
 flow-tracking
+flow-tracking-2
 generate_device_documentation
 generate-default-config
 groups

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/documentation/devices/host1.md
@@ -455,7 +455,9 @@ event-handler evpn-blacklist-recovery
 
 #### Flow Tracking Sampled
 
-Sample: 666
+| Sample Size | Minimum Sample Size | Hardware Offload for IPv4 | Hardware Offload for IPv6 |
+| ----------- | ------------------- | ------------------------- | ------------------------- |
+| 666 | default | disabled | disabled |
 
 ##### Trackers Summary
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/flow-tracking.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/flow-tracking.md
@@ -10,6 +10,9 @@
     | [<samp>flow_tracking</samp>](## "flow_tracking") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;sampled</samp>](## "flow_tracking.sampled") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;sample</samp>](## "flow_tracking.sampled.sample") | Integer |  |  | Min: 1<br>Max: 4294967295 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;hardware_offload</samp>](## "flow_tracking.sampled.hardware_offload") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4</samp>](## "flow_tracking.sampled.hardware_offload.ipv4") | Boolean |  |  |  | Configure hardware offload for IPv4 traffic. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;threshold_minimum</samp>](## "flow_tracking.sampled.hardware_offload.threshold_minimum") | Integer |  |  | Min: 1<br>Max: 4294967295 | Minimum number of samples. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trackers</samp>](## "flow_tracking.sampled.trackers") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- table_size</samp>](## "flow_tracking.sampled.trackers.[].table_size") | Integer |  |  | Min: 1<br>Max: 614400 | Maximum number of entries in flow table.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;record_export</samp>](## "flow_tracking.sampled.trackers.[].record_export") | Dictionary |  |  |  |  |
@@ -50,6 +53,9 @@
     flow_tracking:
       sampled:
         sample: <int>
+        hardware_offload:
+          ipv4: <bool>
+          threshold_minimum: <int>
         trackers:
           - table_size: <int>
             record_export:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/flow-tracking.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/flow-tracking.md
@@ -12,6 +12,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;sample</samp>](## "flow_tracking.sampled.sample") | Integer |  |  | Min: 1<br>Max: 4294967295 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;hardware_offload</samp>](## "flow_tracking.sampled.hardware_offload") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4</samp>](## "flow_tracking.sampled.hardware_offload.ipv4") | Boolean |  |  |  | Configure hardware offload for IPv4 traffic. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6</samp>](## "flow_tracking.sampled.hardware_offload.ipv6") | Boolean |  |  |  | Configure hardware offload for IPv6 traffic. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;threshold_minimum</samp>](## "flow_tracking.sampled.hardware_offload.threshold_minimum") | Integer |  |  | Min: 1<br>Max: 4294967295 | Minimum number of samples. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trackers</samp>](## "flow_tracking.sampled.trackers") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- table_size</samp>](## "flow_tracking.sampled.trackers.[].table_size") | Integer |  |  | Min: 1<br>Max: 614400 | Maximum number of entries in flow table.<br> |
@@ -55,6 +56,7 @@
         sample: <int>
         hardware_offload:
           ipv4: <bool>
+          ipv6: <bool>
           threshold_minimum: <int>
         trackers:
           - table_size: <int>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -4572,6 +4572,11 @@
                   "description": "Configure hardware offload for IPv4 traffic.",
                   "title": "IPv4"
                 },
+                "ipv6": {
+                  "type": "boolean",
+                  "description": "Configure hardware offload for IPv6 traffic.",
+                  "title": "IPv6"
+                },
                 "threshold_minimum": {
                   "type": "integer",
                   "minimum": 1,

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -4564,6 +4564,28 @@
               "maximum": 4294967295,
               "title": "Sample"
             },
+            "hardware_offload": {
+              "type": "object",
+              "properties": {
+                "ipv4": {
+                  "type": "boolean",
+                  "description": "Configure hardware offload for IPv4 traffic.",
+                  "title": "IPv4"
+                },
+                "threshold_minimum": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "maximum": 4294967295,
+                  "description": "Minimum number of samples.",
+                  "title": "Threshold Minimum"
+                }
+              },
+              "additionalProperties": false,
+              "patternProperties": {
+                "^_.+$": {}
+              },
+              "title": "Hardware Offload"
+            },
             "trackers": {
               "type": "array",
               "items": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -2725,6 +2725,9 @@ keys:
               ipv4:
                 type: bool
                 description: Configure hardware offload for IPv4 traffic.
+              ipv6:
+                type: bool
+                description: Configure hardware offload for IPv6 traffic.
               threshold_minimum:
                 type: int
                 convert_types:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -2719,6 +2719,19 @@ keys:
             - str
             min: 1
             max: 4294967295
+          hardware_offload:
+            type: dict
+            keys:
+              ipv4:
+                type: bool
+                description: Configure hardware offload for IPv4 traffic.
+              threshold_minimum:
+                type: int
+                convert_types:
+                - str
+                min: 1
+                max: 4294967295
+                description: Minimum number of samples.
           trackers:
             type: list
             primary_key: name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/flow_tracking.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/flow_tracking.schema.yml
@@ -19,6 +19,21 @@ keys:
               - str
             min: 1
             max: 4294967295
+          hardware_offload:
+            type: dict
+            keys:
+              ipv4:
+                type: bool
+                description: |-
+                  Configure hardware offload for IPv4 traffic.
+              threshold_minimum:
+                type: int
+                convert_types:
+                  - str
+                min: 1
+                max: 4294967295
+                description: |-
+                  Minimum number of samples.
           trackers:
             type: list
             primary_key: name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/flow_tracking.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/flow_tracking.schema.yml
@@ -24,16 +24,17 @@ keys:
             keys:
               ipv4:
                 type: bool
-                description: |-
-                  Configure hardware offload for IPv4 traffic.
+                description: Configure hardware offload for IPv4 traffic.
+              ipv6:
+                type: bool
+                description: Configure hardware offload for IPv6 traffic.
               threshold_minimum:
                 type: int
                 convert_types:
                   - str
                 min: 1
                 max: 4294967295
-                description: |-
-                  Minimum number of samples.
+                description: Minimum number of samples.
           trackers:
             type: list
             primary_key: name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/flow-tracking.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/flow-tracking.j2
@@ -12,21 +12,19 @@
 
 #### Flow Tracking Sampled
 
-Sample: {{ flow_tracking.sampled.sample | arista.avd.default(flow_trackings[0].sample, "default") }}
-{%         if flow_tracking.sampled.hardware_offload is arista.avd.defined %}
-{%             if flow_tracking.sampled.hardware_offload.ipv4 is arista.avd.defined %}
-
-Hardware offload for IPv4 traffic: {{ 'enabled' if flow_tracking.sampled.hardware_offload.ipv4 is true else 'disabled' }}
-{%             endif %}
-{%             if flow_tracking.sampled.hardware_offload.ipv6 is arista.avd.defined %}
-
-Hardware offload for IPv6 traffic: {{ 'enabled' if flow_tracking.sampled.hardware_offload.ipv6 is true else 'disabled' }}
-{%             endif %}
-{%             if flow_tracking.sampled.hardware_offload.threshold_minimum is arista.avd.defined %}
-
-Minimum number of Samples: {{ flow_tracking.sampled.hardware_offload.threshold_minimum }}
-{%             endif %}
+| Sample Size | Minimum Sample Size | Hardware Offload for IPv4 | Hardware Offload for IPv6 |
+| ----------- | ------------------- | ------------------------- | ------------------------- |
+{%         set sample_size = flow_tracking.sampled.sample | arista.avd.default(flow_trackings[0].sample, "default") %}
+{%         set min_sample_size = flow_tracking.sampled.hardware_offload.threshold_minimum | arista.avd.default("default") %}
+{%         set hardware_offload_ipv4 = 'disabled' %}
+{%         set hardware_offload_ipv6 = 'disabled' %}
+{%         if flow_tracking.sampled.hardware_offload.ipv4 is arista.avd.defined(true) %}
+{%             set hardware_offload_ipv4 = 'enabled' %}
 {%         endif %}
+{%         if flow_tracking.sampled.hardware_offload.ipv6 is arista.avd.defined(true) %}
+{%             set hardware_offload_ipv6 = 'enabled' %}
+{%         endif %}
+| {{ sample_size }} | {{ min_sample_size }} | {{ hardware_offload_ipv4 }} | {{ hardware_offload_ipv6 }} |
 {%         if flow_tracking.sampled.trackers is arista.avd.defined or flow_trackings[0].trackers is arista.avd.defined %}
 
 ##### Trackers Summary

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/flow-tracking.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/flow-tracking.j2
@@ -18,6 +18,10 @@ Sample: {{ flow_tracking.sampled.sample | arista.avd.default(flow_trackings[0].s
 
 Hardware offload for IPv4 traffic: {{ 'enabled' if flow_tracking.sampled.hardware_offload.ipv4 is true else 'disabled' }}
 {%             endif %}
+{%             if flow_tracking.sampled.hardware_offload.ipv6 is arista.avd.defined %}
+
+Hardware offload for IPv6 traffic: {{ 'enabled' if flow_tracking.sampled.hardware_offload.ipv6 is true else 'disabled' }}
+{%             endif %}
 {%             if flow_tracking.sampled.hardware_offload.threshold_minimum is arista.avd.defined %}
 
 Minimum number of Samples: {{ flow_tracking.sampled.hardware_offload.threshold_minimum }}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/flow-tracking.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/flow-tracking.j2
@@ -13,6 +13,16 @@
 #### Flow Tracking Sampled
 
 Sample: {{ flow_tracking.sampled.sample | arista.avd.default(flow_trackings[0].sample, "default") }}
+{%         if flow_tracking.sampled.hardware_offload is arista.avd.defined %}
+{%             if flow_tracking.sampled.hardware_offload.ipv4 is arista.avd.defined %}
+
+Hardware offload for IPv4 traffic: {{ 'enabled' if flow_tracking.sampled.hardware_offload.ipv4 is true else 'disabled' }}
+{%             endif %}
+{%             if flow_tracking.sampled.hardware_offload.threshold_minimum is arista.avd.defined %}
+
+Minimum number of Samples: {{ flow_tracking.sampled.hardware_offload.threshold_minimum }}
+{%             endif %}
+{%         endif %}
 {%         if flow_tracking.sampled.trackers is arista.avd.defined or flow_trackings[0].trackers is arista.avd.defined %}
 
 ##### Trackers Summary

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/flow-tracking.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/flow-tracking.j2
@@ -12,8 +12,15 @@ flow tracking sampled
    sample {{ flow_tracking.sampled.sample }}
 {%     endif %}
 {%     if flow_tracking.sampled.hardware_offload is arista.avd.defined %}
+{%         set hardware_offload_protocols = [] %}
 {%         if flow_tracking.sampled.hardware_offload.ipv4 is arista.avd.defined(true) %}
-   hardware offload ipv4
+{%             do hardware_offload_protocols.append('ipv4') %}
+{%         endif %}
+{%         if flow_tracking.sampled.hardware_offload.ipv6 is arista.avd.defined(true) %}
+{%             do hardware_offload_protocols.append('ipv6') %}
+{%         endif %}
+{%         if hardware_offload_protocols | length > 0 %}
+   hardware offload {{ hardware_offload_protocols | join(' ') }}
 {%         endif %}
 {%         if flow_tracking.sampled.hardware_offload.threshold_minimum is arista.avd.defined %}
    hardware offload threshold minimum {{ flow_tracking.sampled.hardware_offload.threshold_minimum }} samples

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/flow-tracking.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/flow-tracking.j2
@@ -11,6 +11,14 @@ flow tracking sampled
 {%     if flow_tracking.sampled.sample is arista.avd.defined %}
    sample {{ flow_tracking.sampled.sample }}
 {%     endif %}
+{%     if flow_tracking.sampled.hardware_offload is arista.avd.defined %}
+{%         if flow_tracking.sampled.hardware_offload.ipv4 is arista.avd.defined(true) %}
+   hardware offload ipv4
+{%         endif %}
+{%         if flow_tracking.sampled.hardware_offload.threshold_minimum is arista.avd.defined %}
+   hardware offload threshold minimum {{ flow_tracking.sampled.hardware_offload.threshold_minimum }} samples
+{%         endif %}
+{%     endif %}
 {%     for tracker in flow_tracking.sampled.trackers %}
    tracker {{ tracker.name }}
 {%         if tracker.record_export.on_inactive_timeout is arista.avd.defined %}


### PR DESCRIPTION
## Change Summary

Add the hardware_offload feature to the flow_tracking sampled

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

## How to test
molecule converge -s eos_cli_config_gen -- --limit flow-tracking

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
