### PR TITLE
Feat(eos_validate_state): ANTA Add device_filter option to target a specific set of devices to run tests

### DIFF
--- a/ansible_collections/arista/avd/docs/plugins/Modules and action plugins/eos_validate_state_runner.md
+++ b/ansible_collections/arista/avd/docs/plugins/Modules and action plugins/eos_validate_state_runner.md
@@ -26,6 +26,7 @@ The plugin provides the following capabilities\:
     \- When using check\_mode, only generate the test catalog and generate a report to preview what would tests be run against each device
     \- Dumping the per\-device catalog to a file.
     \- Backward compatibility with existing ansible tags behavior for eos\_validate\_state to filter categories of tests.
+    \- Option to target a specific set of devices to run tests against.
 
 ## Parameters
 
@@ -37,6 +38,7 @@ The plugin provides the following capabilities\:
 | skipped_tests | list | optional | None |  | A list of dictionaries containing the categories and tests to skip<br>The keys for the dictionnary are <code>categories</code> and <code>tests</code>. |
 |     category | str | True | None |  | The name of one of the AvdTest categories. e.g., <code>AvdTestHardware</code> |
 |     tests | list | optional | None |  | A list of tests in the category. e.g, <code>VerifyRoutingProtocolModel</code> for <code>AvdTestBGP</code> |
+| device_filter | list | False | ['all'] |  | Filter to target specific devices of an Ansible inventory group for ANTA execution. Defaults to the \'all\' group.<br>It can be either a string or a list of strings. |
 
 ## Notes
 
@@ -59,6 +61,8 @@ The plugin provides the following capabilities\:
       - category: AvdTestBGP
         tests:
           - VerifyRoutingProtocolModel
+    device_filter:
+      - DC1
   register: anta_results
 ```
 

--- a/ansible_collections/arista/avd/plugins/modules/eos_validate_state_runner.py
+++ b/ansible_collections/arista/avd/plugins/modules/eos_validate_state_runner.py
@@ -25,6 +25,7 @@ description:
         - When using check_mode, only generate the test catalog and generate a report to preview what would tests be run against each device
         - Dumping the per-device catalog to a file.
         - Backward compatibility with existing ansible tags behavior for eos_validate_state to filter categories of tests.
+        - Option to target a specific set of devices to run tests against.
 options:
   logging_level:
     description: Controls the log level for the ANTA library. If unset, the Action plugin will set it to "WARNING"
@@ -56,6 +57,14 @@ options:
         type: list
         elements: str
         description: A list of tests in the category. e.g, C(VerifyRoutingProtocolModel) for C(AvdTestBGP)
+  device_filter:
+    description:
+      - Filter to target specific devices of an Ansible inventory group for ANTA execution. Defaults to the 'all' group.
+      - It can be either a string or a list of strings.
+    required: false
+    default: ['all']
+    type: list
+    elements: str
 seealso:
   - name: ANTA website
     description: ANTA documentation
@@ -75,5 +84,7 @@ EXAMPLES = r"""
       - category: AvdTestBGP
         tests:
           - VerifyRoutingProtocolModel
+    device_filter:
+      - DC1
   register: anta_results
 """

--- a/ansible_collections/arista/avd/roles/eos_validate_state/ANTA-Preview.md
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/ANTA-Preview.md
@@ -60,6 +60,12 @@
   ansible-playbook playbooks/fabric-validate.yaml --tags routing_table
   ```
 
+- To target a specific set of devices for your tests, use the `device_filter` option and provide an Ansible inventory group or a list of group that contains the devices you want to test.
+
+  ```shell
+  ansible-playbook playbooks/fabric-validate.yaml -e device_filter=DC1
+  ```
+
 - You can now run the eos_validate_state role in check_mode. This will produce a report of tests that will be performed without running the tests on your network.
 
   ```shell
@@ -185,6 +191,9 @@ skipped_tests: []
 # Logging level for the ANTA libraries
 # Default is warning
 logging_level: "WARNING"
+# Ansible groups filter to run tests against
+# Default is all
+device_filter: ["all"]
 ```
 
 ## Example Playbook
@@ -203,4 +212,7 @@ logging_level: "WARNING"
         use_anta: true
         # To save catalogs
         save_catalog: true
+        # To target and test a specific set of devices
+        device_filter:
+          - DC1
 ```

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/anta_tests.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/anta_tests.yml
@@ -10,6 +10,7 @@
   arista.avd.eos_validate_state_runner:
     logging_level: "{{ logging_level | arista.avd.default('WARNING') }}"
     skipped_tests: "{{ skipped_tests | arista.avd.default([]) }}"
+    device_filter: "{{ device_filter | arista.avd.default('all') }}"
     save_catalog: "{{ save_catalog | arista.avd.default(false) }}"
     device_catalog_output_dir: "{{ test_catalogs_dir }}"
   register: anta_results


### PR DESCRIPTION
## Change Summary

Add `device_filter` option to target a specific set of devices to run tests.

## Related Issue(s)

Fixes #3305 

## Component(s) name

`arista.avd.eos_validate_state` **ANTA**

## Proposed changes
With `device_filter`, you can provide an Ansible inventory group or a list of group as a filter to run your tests only against the devices included in those groups.

If not used, it will default to 'all' which is all the devices. ANTA will be skipped for a device that is not included in any of the provided groups.

With this functionality, the structured_config of all devices in your fabric will still be loaded in validate state, creating accurate tests for the targeted devices.


## How to test
`ansible-playbook playbooks/fabric-validate.yaml -e use_anta=True -e device_filter=DC1`

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been rebased from devel before I start
- [X] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [X] My change requires a change to the documentation and documentation have been updated accordingly.
- [X] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
