### PR TITLE
Fix(eos_config_deploy_cvp): share tags from parent to dependent tasks.

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v3/present.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v3/present.yml
@@ -17,7 +17,7 @@
   arista.cvp.cv_task_v3:
     tasks: "{{ cvp_configlets_status.taskIds }}"
   when:
-    - cvp_configlets_status.taskIds | length > 0
+    - (cvp_configlets_status is defined) and (cvp_configlets_status.taskIds | length > 0)
     - execute_tasks|bool
 
 - name: "Building Containers topology on {{ inventory_hostname }}"
@@ -29,11 +29,11 @@
   register: cvp_container_results
 
 - name: "Execute pending tasks on {{ inventory_hostname }}"
-  tags: [apply, containers, provision]
+  tags: [apply]
   arista.cvp.cv_task_v3:
     tasks: "{{ cvp_container_results.taskIds }}"
   when:
-    - cvp_container_results.taskIds | length > 0
+    - (cvp_container_results is defined) and (cvp_container_results.taskIds | length > 0)
     - execute_tasks|bool
 
 - name: "Configure devices on {{ inventory_hostname }}"
@@ -51,5 +51,5 @@
   arista.cvp.cv_task_v3:
     tasks: "{{ cvp_devices_results.taskIds }}"
   when:
-    - cvp_devices_results.taskIds | length > 0
+    - (cvp_devices_results is defined) and (cvp_devices_results.taskIds | length > 0)
     - execute_tasks|bool

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v3/present.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v3/present.yml
@@ -29,7 +29,7 @@
   register: cvp_container_results
 
 - name: "Execute pending tasks on {{ inventory_hostname }}"
-  tags: [apply]
+  tags: [apply, containers, provision]
   arista.cvp.cv_task_v3:
     tasks: "{{ cvp_container_results.taskIds }}"
   when:

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v3/present.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v3/present.yml
@@ -17,8 +17,9 @@
   arista.cvp.cv_task_v3:
     tasks: "{{ cvp_configlets_status.taskIds }}"
   when:
-    - (cvp_configlets_status is defined) and (cvp_configlets_status.taskIds | length > 0)
-    - execute_tasks|bool
+    - cvp_configlets_status.taskIds is arista.avd.defined
+    - cvp_configlets_status.taskIds | length > 0
+    - execute_tasks | bool
 
 - name: "Building Containers topology on {{ inventory_hostname }}"
   tags: [provision, containers]
@@ -33,8 +34,9 @@
   arista.cvp.cv_task_v3:
     tasks: "{{ cvp_container_results.taskIds }}"
   when:
-    - (cvp_container_results is defined) and (cvp_container_results.taskIds | length > 0)
-    - execute_tasks|bool
+    - cvp_container_results.taskIds is arista.avd.defined
+    - cvp_container_results.taskIds | length > 0
+    - execute_tasks | bool
 
 - name: "Configure devices on {{ inventory_hostname }}"
   tags: [provision, apply]
@@ -51,5 +53,6 @@
   arista.cvp.cv_task_v3:
     tasks: "{{ cvp_devices_results.taskIds }}"
   when:
-    - (cvp_devices_results is defined) and (cvp_devices_results.taskIds | length > 0)
-    - execute_tasks|bool
+    - cvp_devices_results.taskIds is arista.avd.defined
+    - cvp_devices_results.taskIds | length > 0
+    - execute_tasks | bool


### PR DESCRIPTION
## Change Summary

share tags from parent to dependent tasks

## Related Issue(s)

Fixes #3260 

## Component(s) name

`arista.avd.eos_config_deploy_cvp`

## Proposed changes
`arista.cvp.cv_task_v3` depends upon `arista.cvp.cv_container_v3`'s `cvp_container_results`, but doesn't share the `containers` tag. If the `containers` tag is skipped, `arista.cvp.cv_task_v3` will fail due to missing `cvp_container_results`.

## How to test
The following [documented/suggested](https://avd.arista.com/4.4/roles/eos_config_deploy_cvp/index.html?h=skip+tags#run-module-with-different-tags) command`ansible-playbook playbook.to.deploy.with.cvp.yml --skip-tags "containers"` should not fail with the error documented in the attached issue: #3260 However, it's also clear that if `--skip-tags provision` is used it will similarly fail. So using `--skip-tags` with either/both `provision` and `containers` successfully would indicate this issue has been fixed.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
