### PR TITLE
Feat(eos_cli_config_gen): Adding options for path-selection lb policies

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-path-selection.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-path-selection.md
@@ -114,7 +114,7 @@ interface Management1
 
 | Policy name | Jitter (ms) | Latency (ms) | Loss Rate (%) | Path groups (priority) | Hop count lowest |
 | ----------- | ----------- | ------------ | ------------- | ---------------------- | ---------------- |
-| LB-P-1 | - | - | 17 | PG-5 (1)<br>PG-2 (42)<br>PG-4 (42)<br>PG-3 (666) | False |
+| LB-P-1 | - | - | 17 | PG-5 (1)<br>PG-2 (42)<br>PG-4 (42)<br>PG-3 (666) | True |
 | LB-P-2 | 666 | 42 | 42.42 | PG-1 (1)<br>PG-3 (1) | False |
 
 #### DPS policies
@@ -202,7 +202,7 @@ router path-selection
    path-group PG-4
    !
    load-balance policy LB-P-1
-      hop count lower
+      hop count lowest
       loss-rate 17
       path-group PG-5
       path-group PG-2 priority 42

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-path-selection.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-path-selection.md
@@ -112,10 +112,10 @@ interface Management1
 
 #### Load-balance policies
 
-| Policy name | Latency | Path group(s) |
-| ----------- | ------- | ------------- |
-| LB-P-1 | - | PG-2<br>PG-3 |
-| LB-P-2 | 42 | PG-1 |
+| Policy name | Jitter (ms) | Latency (ms) | Loss Rate (%) | Path groups (priority) | Hop count lowest |
+| ----------- | ----------- | ------------ | ------------- | ---------------------- | ---------------- |
+| LB-P-1 | - | - | 17 | PG-5 (1)<br>PG-2 (42)<br>PG-4 (42)<br>PG-3 (666) | False |
+| LB-P-2 | 666 | 42 | 42.42 | PG-1 (1)<br>PG-3 (1) | False |
 
 #### DPS policies
 
@@ -202,12 +202,19 @@ router path-selection
    path-group PG-4
    !
    load-balance policy LB-P-1
-      path-group PG-3
-      path-group PG-2
+      hop count lower
+      loss-rate 17
+      path-group PG-5
+      path-group PG-2 priority 42
+      path-group PG-4 priority 42
+      path-group PG-3 priority 666
    !
    load-balance policy LB-P-2
+      jitter 666
       latency 42
+      loss-rate 42.42
       path-group PG-1
+      path-group PG-3
    !
    policy DPS-P-1
       default-match

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-path-selection.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-path-selection.md
@@ -112,10 +112,10 @@ interface Management1
 
 #### Load-balance policies
 
-| Policy name | Path group(s) |
-| ----------- | ------------- |
-| LB-P-1 | PG-2<br>PG-3 |
-| LB-P-2 | PG-1 |
+| Policy name | Latency | Path group(s) |
+| ----------- | ------- | ------------- |
+| LB-P-1 | - | PG-2<br>PG-3 |
+| LB-P-2 | 42 | PG-1 |
 
 #### DPS policies
 
@@ -206,6 +206,7 @@ router path-selection
       path-group PG-2
    !
    load-balance policy LB-P-2
+      latency 42
       path-group PG-1
    !
    policy DPS-P-1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-path-selection.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-path-selection.md
@@ -213,7 +213,7 @@ router path-selection
       jitter 666
       latency 42
       loss-rate 42.42
-      path-group PG-1
+      path-group PG-1 priority 1
       path-group PG-3
    !
    policy DPS-P-1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-path-selection.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-path-selection.md
@@ -112,7 +112,7 @@ interface Management1
 
 #### Load-balance policies
 
-| Policy name | Jitter (ms) | Latency (ms) | Loss Rate (%) | Path groups (priority) | Hop count lowest |
+| Policy Name | Jitter (ms) | Latency (ms) | Loss Rate (%) | Path Groups (priority) | Lowest Hop Count |
 | ----------- | ----------- | ------------ | ------------- | ---------------------- | ---------------- |
 | LB-P-1 | - | - | 17 | PG-5 (1)<br>PG-2 (42)<br>PG-4 (42)<br>PG-3 (666) | True |
 | LB-P-2 | 666 | 42 | 42.42 | PG-1 (1)<br>PG-3 (1) | False |

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-path-selection.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-path-selection.cfg
@@ -66,7 +66,7 @@ router path-selection
       jitter 666
       latency 42
       loss-rate 42.42
-      path-group PG-1
+      path-group PG-1 priority 1
       path-group PG-3
    !
    policy DPS-P-1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-path-selection.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-path-selection.cfg
@@ -55,7 +55,7 @@ router path-selection
    path-group PG-4
    !
    load-balance policy LB-P-1
-      hop count lower
+      hop count lowest
       loss-rate 17
       path-group PG-5
       path-group PG-2 priority 42

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-path-selection.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-path-selection.cfg
@@ -59,6 +59,7 @@ router path-selection
       path-group PG-2
    !
    load-balance policy LB-P-2
+      latency 42
       path-group PG-1
    !
    policy DPS-P-1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-path-selection.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-path-selection.cfg
@@ -55,12 +55,19 @@ router path-selection
    path-group PG-4
    !
    load-balance policy LB-P-1
-      path-group PG-3
-      path-group PG-2
+      hop count lower
+      loss-rate 17
+      path-group PG-5
+      path-group PG-2 priority 42
+      path-group PG-4 priority 42
+      path-group PG-3 priority 666
    !
    load-balance policy LB-P-2
+      jitter 666
       latency 42
+      loss-rate 42.42
       path-group PG-1
+      path-group PG-3
    !
    policy DPS-P-1
       default-match

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-path-selection.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-path-selection.yml
@@ -79,7 +79,7 @@ router_path_selection:
         - name: PG-1
           priority: 1
     - name: LB-P-1
-      hop_count_lowest: true
+      lowest_hop_count: true
       loss_rate: 17
       path_groups:
         # checking priority 1 comes first

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-path-selection.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-path-selection.yml
@@ -70,6 +70,7 @@ router_path_selection:
   load_balance_policies:
     # Out of order to test sorting
     - name: LB-P-2
+      latency: 42
       path_groups:
         - PG-1
     - name: LB-P-1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-path-selection.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-path-selection.yml
@@ -79,7 +79,7 @@ router_path_selection:
         - name: PG-1
           priority: 1
     - name: LB-P-1
-      hop_count_lower: true
+      hop_count_lowest: true
       loss_rate: 17
       path_groups:
         # checking priority 1 comes first

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-path-selection.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-path-selection.yml
@@ -71,12 +71,26 @@ router_path_selection:
     # Out of order to test sorting
     - name: LB-P-2
       latency: 42
+      jitter: 666
+      loss_rate: "42.42"
       path_groups:
-        - PG-1
+        # checking priority 1 comes first
+        - name: PG-3
+        - name: PG-1
+          priority: 1
     - name: LB-P-1
+      hop_count_lower: true
+      loss_rate: 17
       path_groups:
-        - PG-3
-        - PG-2
+        # checking priority 1 comes first
+        - name: PG-5
+        - name: PG-3
+          priority: 666
+        # Checking ordering for same priority
+        - name: PG-4
+          priority: 42
+        - name: PG-2
+          priority: 42
   policies:
     # Out of order to test sorting
     - name: DPS-P-2

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-path-selection.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-path-selection.md
@@ -37,7 +37,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "router_path_selection.path_groups.[].static_peers.[].ipv4_addresses.[]") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;load_balance_policies</samp>](## "router_path_selection.load_balance_policies") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "router_path_selection.load_balance_policies.[].name") | String | Required, Unique |  |  | Load-balance policy name. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hop_count_lower</samp>](## "router_path_selection.load_balance_policies.[].hop_count_lower") | Boolean |  |  |  | Prefer paths with lowest hop-count. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hop_count_lowest</samp>](## "router_path_selection.load_balance_policies.[].hop_count_lowest") | Boolean |  |  |  | Prefer paths with lowest hop-count. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;jitter</samp>](## "router_path_selection.load_balance_policies.[].jitter") | Integer |  |  | Min: 0<br>Max: 10000 | Jitter requirement for this load balance policy in milliseconds. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;latency</samp>](## "router_path_selection.load_balance_policies.[].latency") | Integer |  |  | Min: 0<br>Max: 10000 | One way delay requirement for this load balance policy in milliseconds. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;loss_rate</samp>](## "router_path_selection.load_balance_policies.[].loss_rate") | String |  |  | Pattern: ^\d+(\.\d{1,2})?$ | Loss Rate requirement in percentage for this load balance policy.<br>Value between 0.00 and 100.00 % |
@@ -128,7 +128,7 @@
         - name: <str; required; unique>
 
           # Prefer paths with lowest hop-count.
-          hop_count_lower: <bool>
+          hop_count_lowest: <bool>
 
           # Jitter requirement for this load balance policy in milliseconds.
           jitter: <int; 0-10000>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-path-selection.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-path-selection.md
@@ -37,9 +37,13 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "router_path_selection.path_groups.[].static_peers.[].ipv4_addresses.[]") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;load_balance_policies</samp>](## "router_path_selection.load_balance_policies") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "router_path_selection.load_balance_policies.[].name") | String | Required, Unique |  |  | Load-balance policy name. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hop_count_lower</samp>](## "router_path_selection.load_balance_policies.[].hop_count_lower") | Boolean |  |  |  | Prefer paths with lowest hop-count. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;jitter</samp>](## "router_path_selection.load_balance_policies.[].jitter") | Integer |  |  | Min: 0<br>Max: 10000 | Jitter requirement for this load balance policy in milliseconds. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;latency</samp>](## "router_path_selection.load_balance_policies.[].latency") | Integer |  |  | Min: 0<br>Max: 10000 | One way delay requirement for this load balance policy in milliseconds. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;path_groups</samp>](## "router_path_selection.load_balance_policies.[].path_groups") | List, items: String |  |  |  | List of path-groups to use for this load balance policy. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "router_path_selection.load_balance_policies.[].path_groups.[]") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;loss_rate</samp>](## "router_path_selection.load_balance_policies.[].loss_rate") | String |  |  | Pattern: ^\d+(\.\d{1,2})?$ | Loss Rate requirement for this load balance policy in milliseconds. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;path_groups</samp>](## "router_path_selection.load_balance_policies.[].path_groups") | List, items: Dictionary |  |  |  | List of path-groups to use for this load balance policy. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "router_path_selection.load_balance_policies.[].path_groups.[].name") | String | Required, Unique |  |  | Path-group name |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;priority</samp>](## "router_path_selection.load_balance_policies.[].path_groups.[].priority") | Integer |  | `1` | Min: 1<br>Max: 65535 | Priority for this path-group.<br>Default is 1 and not rendred in EOS cli. |
     | [<samp>&nbsp;&nbsp;policies</samp>](## "router_path_selection.policies") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "router_path_selection.policies.[].name") | String | Required, Unique |  |  | DPS policy name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;default_match</samp>](## "router_path_selection.policies.[].default_match") | Dictionary |  |  |  |  |
@@ -123,12 +127,27 @@
           # Load-balance policy name.
         - name: <str; required; unique>
 
+          # Prefer paths with lowest hop-count.
+          hop_count_lower: <bool>
+
+          # Jitter requirement for this load balance policy in milliseconds.
+          jitter: <int; 0-10000>
+
           # One way delay requirement for this load balance policy in milliseconds.
           latency: <int; 0-10000>
 
+          # Loss Rate requirement for this load balance policy in milliseconds.
+          loss_rate: <str>
+
           # List of path-groups to use for this load balance policy.
           path_groups:
-            - <str>
+
+              # Path-group name
+            - name: <str; required; unique>
+
+              # Priority for this path-group.
+              # Default is 1 and not rendred in EOS cli.
+              priority: <int; 1-65535; default=1>
       policies:
 
           # DPS policy name.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-path-selection.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-path-selection.md
@@ -37,7 +37,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "router_path_selection.path_groups.[].static_peers.[].ipv4_addresses.[]") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;load_balance_policies</samp>](## "router_path_selection.load_balance_policies") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "router_path_selection.load_balance_policies.[].name") | String | Required, Unique |  |  | Load-balance policy name. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hop_count_lowest</samp>](## "router_path_selection.load_balance_policies.[].hop_count_lowest") | Boolean |  |  |  | Prefer paths with lowest hop-count. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;lowest_hop_count</samp>](## "router_path_selection.load_balance_policies.[].lowest_hop_count") | Boolean |  |  |  | Prefer paths with lowest hop-count. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;jitter</samp>](## "router_path_selection.load_balance_policies.[].jitter") | Integer |  |  | Min: 0<br>Max: 10000 | Jitter requirement for this load balance policy in milliseconds. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;latency</samp>](## "router_path_selection.load_balance_policies.[].latency") | Integer |  |  | Min: 0<br>Max: 10000 | One way delay requirement for this load balance policy in milliseconds. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;loss_rate</samp>](## "router_path_selection.load_balance_policies.[].loss_rate") | String |  |  | Pattern: ^\d+(\.\d{1,2})?$ | Loss Rate requirement in percentage for this load balance policy.<br>Value between 0.00 and 100.00 % |
@@ -128,7 +128,7 @@
         - name: <str; required; unique>
 
           # Prefer paths with lowest hop-count.
-          hop_count_lowest: <bool>
+          lowest_hop_count: <bool>
 
           # Jitter requirement for this load balance policy in milliseconds.
           jitter: <int; 0-10000>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-path-selection.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-path-selection.md
@@ -37,6 +37,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "router_path_selection.path_groups.[].static_peers.[].ipv4_addresses.[]") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;load_balance_policies</samp>](## "router_path_selection.load_balance_policies") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "router_path_selection.load_balance_policies.[].name") | String | Required, Unique |  |  | Load-balance policy name. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;latency</samp>](## "router_path_selection.load_balance_policies.[].latency") | Integer |  |  | Min: 0<br>Max: 10000 | One way delay requirement for this load balance policy in milliseconds. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;path_groups</samp>](## "router_path_selection.load_balance_policies.[].path_groups") | List, items: String |  |  |  | List of path-groups to use for this load balance policy. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "router_path_selection.load_balance_policies.[].path_groups.[]") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;policies</samp>](## "router_path_selection.policies") | List, items: Dictionary |  |  |  |  |
@@ -121,6 +122,9 @@
 
           # Load-balance policy name.
         - name: <str; required; unique>
+
+          # One way delay requirement for this load balance policy in milliseconds.
+          latency: <int; 0-10000>
 
           # List of path-groups to use for this load balance policy.
           path_groups:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-path-selection.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-path-selection.md
@@ -40,10 +40,10 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hop_count_lower</samp>](## "router_path_selection.load_balance_policies.[].hop_count_lower") | Boolean |  |  |  | Prefer paths with lowest hop-count. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;jitter</samp>](## "router_path_selection.load_balance_policies.[].jitter") | Integer |  |  | Min: 0<br>Max: 10000 | Jitter requirement for this load balance policy in milliseconds. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;latency</samp>](## "router_path_selection.load_balance_policies.[].latency") | Integer |  |  | Min: 0<br>Max: 10000 | One way delay requirement for this load balance policy in milliseconds. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;loss_rate</samp>](## "router_path_selection.load_balance_policies.[].loss_rate") | String |  |  | Pattern: ^\d+(\.\d{1,2})?$ | Loss Rate requirement for this load balance policy in milliseconds. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;loss_rate</samp>](## "router_path_selection.load_balance_policies.[].loss_rate") | String |  |  | Pattern: ^\d+(\.\d{1,2})?$ | Loss Rate requirement in percentage for this load balance policy.<br>Value between 0.00 and 100.00 % |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;path_groups</samp>](## "router_path_selection.load_balance_policies.[].path_groups") | List, items: Dictionary |  |  |  | List of path-groups to use for this load balance policy. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "router_path_selection.load_balance_policies.[].path_groups.[].name") | String | Required, Unique |  |  | Path-group name |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;priority</samp>](## "router_path_selection.load_balance_policies.[].path_groups.[].priority") | Integer |  | `1` | Min: 1<br>Max: 65535 | Priority for this path-group.<br>Default is 1 and not rendred in EOS cli. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;priority</samp>](## "router_path_selection.load_balance_policies.[].path_groups.[].priority") | Integer |  |  | Min: 1<br>Max: 65535 | Priority for this path-group.<br>The EOS default value is 1. |
     | [<samp>&nbsp;&nbsp;policies</samp>](## "router_path_selection.policies") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "router_path_selection.policies.[].name") | String | Required, Unique |  |  | DPS policy name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;default_match</samp>](## "router_path_selection.policies.[].default_match") | Dictionary |  |  |  |  |
@@ -136,7 +136,8 @@
           # One way delay requirement for this load balance policy in milliseconds.
           latency: <int; 0-10000>
 
-          # Loss Rate requirement for this load balance policy in milliseconds.
+          # Loss Rate requirement in percentage for this load balance policy.
+          # Value between 0.00 and 100.00 %
           loss_rate: <str>
 
           # List of path-groups to use for this load balance policy.
@@ -146,8 +147,8 @@
             - name: <str; required; unique>
 
               # Priority for this path-group.
-              # Default is 1 and not rendred in EOS cli.
-              priority: <int; 1-65535; default=1>
+              # The EOS default value is 1.
+              priority: <int; 1-65535>
       policies:
 
           # DPS policy name.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -20662,7 +20662,7 @@
               },
               "loss_rate": {
                 "type": "string",
-                "description": "Loss Rate requirement for this load balance policy in milliseconds.",
+                "description": "Loss Rate requirement in percentage for this load balance policy.\nValue between 0.00 and 100.00 %",
                 "pattern": "^\\d+(\\.\\d{1,2})?$",
                 "title": "Loss Rate"
               },
@@ -20679,10 +20679,9 @@
                     },
                     "priority": {
                       "type": "integer",
-                      "description": "Priority for this path-group.\nDefault is 1 and not rendred in EOS cli.",
+                      "description": "Priority for this path-group.\nThe EOS default value is 1.",
                       "minimum": 1,
                       "maximum": 65535,
-                      "default": 1,
                       "title": "Priority"
                     }
                   },

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -20641,6 +20641,13 @@
                 "description": "Load-balance policy name.",
                 "title": "Name"
               },
+              "latency": {
+                "type": "integer",
+                "description": "One way delay requirement for this load balance policy in milliseconds.",
+                "minimum": 0,
+                "maximum": 10000,
+                "title": "Latency"
+              },
               "path_groups": {
                 "type": "array",
                 "description": "List of path-groups to use for this load balance policy.",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -20641,10 +20641,10 @@
                 "description": "Load-balance policy name.",
                 "title": "Name"
               },
-              "hop_count_lowest": {
+              "lowest_hop_count": {
                 "type": "boolean",
                 "description": "Prefer paths with lowest hop-count.",
-                "title": "Hop Count Lowest"
+                "title": "Lowest Hop Count"
               },
               "jitter": {
                 "type": "integer",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -20641,10 +20641,10 @@
                 "description": "Load-balance policy name.",
                 "title": "Name"
               },
-              "hop_count_lower": {
+              "hop_count_lowest": {
                 "type": "boolean",
                 "description": "Prefer paths with lowest hop-count.",
-                "title": "Hop Count Lower"
+                "title": "Hop Count Lowest"
               },
               "jitter": {
                 "type": "integer",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -20641,6 +20641,18 @@
                 "description": "Load-balance policy name.",
                 "title": "Name"
               },
+              "hop_count_lower": {
+                "type": "boolean",
+                "description": "Prefer paths with lowest hop-count.",
+                "title": "Hop Count Lower"
+              },
+              "jitter": {
+                "type": "integer",
+                "description": "Jitter requirement for this load balance policy in milliseconds.",
+                "minimum": 0,
+                "maximum": 10000,
+                "title": "Jitter"
+              },
               "latency": {
                 "type": "integer",
                 "description": "One way delay requirement for this load balance policy in milliseconds.",
@@ -20648,11 +20660,39 @@
                 "maximum": 10000,
                 "title": "Latency"
               },
+              "loss_rate": {
+                "type": "string",
+                "description": "Loss Rate requirement for this load balance policy in milliseconds.",
+                "pattern": "^\\d+(\\.\\d{1,2})?$",
+                "title": "Loss Rate"
+              },
               "path_groups": {
                 "type": "array",
                 "description": "List of path-groups to use for this load balance policy.",
                 "items": {
-                  "type": "string"
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "description": "Path-group name",
+                      "title": "Name"
+                    },
+                    "priority": {
+                      "type": "integer",
+                      "description": "Priority for this path-group.\nDefault is 1 and not rendred in EOS cli.",
+                      "minimum": 1,
+                      "maximum": 65535,
+                      "default": 1,
+                      "title": "Priority"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "patternProperties": {
+                    "^_.+$": {}
+                  },
+                  "required": [
+                    "name"
+                  ]
                 },
                 "title": "Path Groups"
               }

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -11824,6 +11824,16 @@ keys:
             name:
               type: str
               description: Load-balance policy name.
+            hop_count_lower:
+              type: bool
+              description: Prefer paths with lowest hop-count.
+            jitter:
+              type: int
+              description: Jitter requirement for this load balance policy in milliseconds.
+              convert_types:
+              - str
+              min: 0
+              max: 10000
             latency:
               type: int
               description: One way delay requirement for this load balance policy
@@ -11832,11 +11842,33 @@ keys:
               - str
               min: 0
               max: 10000
+            loss_rate:
+              type: str
+              description: Loss Rate requirement for this load balance policy in milliseconds.
+              convert_types:
+              - int
+              - float
+              pattern: ^\d+(\.\d{1,2})?$
             path_groups:
               type: list
+              primary_key: name
               description: List of path-groups to use for this load balance policy.
               items:
-                type: str
+                type: dict
+                keys:
+                  name:
+                    type: str
+                    description: Path-group name
+                  priority:
+                    type: int
+                    description: 'Priority for this path-group.
+
+                      Default is 1 and not rendred in EOS cli.'
+                    convert_types:
+                    - str
+                    min: 1
+                    max: 65535
+                    default: 1
       policies:
         type: list
         primary_key: name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -11824,6 +11824,14 @@ keys:
             name:
               type: str
               description: Load-balance policy name.
+            latency:
+              type: int
+              description: One way delay requirement for this load balance policy
+                in milliseconds.
+              convert_types:
+              - str
+              min: 0
+              max: 10000
             path_groups:
               type: list
               description: List of path-groups to use for this load balance policy.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -11824,7 +11824,7 @@ keys:
             name:
               type: str
               description: Load-balance policy name.
-            hop_count_lowest:
+            lowest_hop_count:
               type: bool
               description: Prefer paths with lowest hop-count.
             jitter:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -11824,7 +11824,7 @@ keys:
             name:
               type: str
               description: Load-balance policy name.
-            hop_count_lower:
+            hop_count_lowest:
               type: bool
               description: Prefer paths with lowest hop-count.
             jitter:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -11844,7 +11844,10 @@ keys:
               max: 10000
             loss_rate:
               type: str
-              description: Loss Rate requirement for this load balance policy in milliseconds.
+              description: 'Loss Rate requirement in percentage for this load balance
+                policy.
+
+                Value between 0.00 and 100.00 %'
               convert_types:
               - int
               - float
@@ -11863,12 +11866,11 @@ keys:
                     type: int
                     description: 'Priority for this path-group.
 
-                      Default is 1 and not rendred in EOS cli.'
+                      The EOS default value is 1.'
                     convert_types:
                     - str
                     min: 1
                     max: 65535
-                    default: 1
       policies:
         type: list
         primary_key: name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_path_selection.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_path_selection.schema.yml
@@ -143,7 +143,9 @@ keys:
               max: 10000
             loss_rate:
               type: str
-              description: Loss Rate requirement for this load balance policy in milliseconds.
+              description: |-
+                Loss Rate requirement in percentage for this load balance policy.
+                Value between 0.00 and 100.00 %
               convert_types:
                 - int
                 - float
@@ -162,12 +164,11 @@ keys:
                     type: int
                     description: |-
                       Priority for this path-group.
-                      Default is 1 and not rendred in EOS cli.
+                      The EOS default value is 1.
                     convert_types:
                       - str
                     min: 1
                     max: 65535
-                    default: 1
       policies:
         type: list
         primary_key: name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_path_selection.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_path_selection.schema.yml
@@ -124,7 +124,7 @@ keys:
             name:
               type: str
               description: Load-balance policy name.
-            hop_count_lower:
+            hop_count_lowest:
               type: bool
               description: Prefer paths with lowest hop-count.
             jitter:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_path_selection.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_path_selection.schema.yml
@@ -124,6 +124,16 @@ keys:
             name:
               type: str
               description: Load-balance policy name.
+            hop_count_lower:
+              type: bool
+              description: Prefer paths with lowest hop-count.
+            jitter:
+              type: int
+              description: Jitter requirement for this load balance policy in milliseconds.
+              convert_types:
+                - str
+              min: 0
+              max: 10000
             latency:
               type: int
               description: One way delay requirement for this load balance policy in milliseconds.
@@ -131,11 +141,33 @@ keys:
                 - str
               min: 0
               max: 10000
+            loss_rate:
+              type: str
+              description: Loss Rate requirement for this load balance policy in milliseconds.
+              convert_types:
+                - int
+                - float
+              pattern: "^\\d+(\\.\\d{1,2})?$"
             path_groups:
               type: list
+              primary_key: name
               description: List of path-groups to use for this load balance policy.
               items:
-                type: str
+                type: dict
+                keys:
+                  name:
+                    type: str
+                    description: Path-group name
+                  priority:
+                    type: int
+                    description: |-
+                      Priority for this path-group.
+                      Default is 1 and not rendred in EOS cli.
+                    convert_types:
+                      - str
+                    min: 1
+                    max: 65535
+                    default: 1
       policies:
         type: list
         primary_key: name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_path_selection.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_path_selection.schema.yml
@@ -124,6 +124,13 @@ keys:
             name:
               type: str
               description: Load-balance policy name.
+            latency:
+              type: int
+              description: One way delay requirement for this load balance policy in milliseconds.
+              convert_types:
+                - str
+              min: 0
+              max: 10000
             path_groups:
               type: list
               description: List of path-groups to use for this load balance policy.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_path_selection.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_path_selection.schema.yml
@@ -124,7 +124,7 @@ keys:
             name:
               type: str
               description: Load-balance policy name.
-            hop_count_lowest:
+            lowest_hop_count:
               type: bool
               description: Prefer paths with lowest hop-count.
             jitter:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-path-selection.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-path-selection.j2
@@ -87,11 +87,9 @@
 {%             set path_groups_list = [] %}
 {# TODO remove inplace update once Ansible 2.13 is dropped and use groupby default instead #}
 {%             for path_group in load_balance_policy.path_groups | arista.avd.default([]) %}
-{%                 if path_group.priority is not arista.avd.defined %}
-{%                     do path_group.update({"priority": 1}) %}
-{%                 endif %}
+{%                 do path_group.update({"_priority": path_group.priority | arista.avd.default(1)}) %}
 {%             endfor %}
-{%             for priority, entries in load_balance_policy.path_groups | groupby("priority") %}
+{%             for priority, entries in load_balance_policy.path_groups | groupby("_priority") %}
 {%                 for entry in entries | arista.avd.natural_sort("name") %}
 {%                     do path_groups_list.append(entry.name ~ " (" ~ priority ~ ")") %}
 {%                 endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-path-selection.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-path-selection.j2
@@ -77,7 +77,7 @@
 
 #### Load-balance policies
 
-| Policy name | Jitter (ms) | Latency (ms) | Loss Rate (%) | Path groups (priority) | Hop count lowest |
+| Policy Name | Jitter (ms) | Latency (ms) | Loss Rate (%) | Path Groups (priority) | Hop Count Lowest |
 | ----------- | ----------- | ------------ | ------------- | ---------------------- | ---------------- |
 {%         for load_balance_policy in router_path_selection.load_balance_policies | arista.avd.natural_sort('name') %}
 {%             set hop_count_lowest = load_balance_policy.hop_count_lowest | arista.avd.default(false) %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-path-selection.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-path-selection.j2
@@ -77,10 +77,10 @@
 
 #### Load-balance policies
 
-| Policy Name | Jitter (ms) | Latency (ms) | Loss Rate (%) | Path Groups (priority) | Hop Count Lowest |
+| Policy Name | Jitter (ms) | Latency (ms) | Loss Rate (%) | Path Groups (priority) | Lowest Hop Count |
 | ----------- | ----------- | ------------ | ------------- | ---------------------- | ---------------- |
 {%         for load_balance_policy in router_path_selection.load_balance_policies | arista.avd.natural_sort('name') %}
-{%             set hop_count_lowest = load_balance_policy.hop_count_lowest | arista.avd.default(false) %}
+{%             set lowest_hop_count = load_balance_policy.lowest_hop_count | arista.avd.default(false) %}
 {%             set jitter = load_balance_policy.jitter | arista.avd.default("-") %}
 {%             set latency = load_balance_policy.latency | arista.avd.default("-") %}
 {%             set loss_rate = load_balance_policy.loss_rate | arista.avd.default("-") %}
@@ -94,7 +94,7 @@
 {%                     do path_groups_list.append(entry.name ~ " (" ~ priority ~ ")") %}
 {%                 endfor %}
 {%             endfor %}
-| {{ load_balance_policy.name }} | {{ jitter }} | {{ latency }} | {{ loss_rate }} | {{ path_groups_list | join("<br>") }} | {{ hop_count_lowest }} |
+| {{ load_balance_policy.name }} | {{ jitter }} | {{ latency }} | {{ loss_rate }} | {{ path_groups_list | join("<br>") }} | {{ lowest_hop_count }} |
 {%         endfor %}
 {%     endif %}
 {%     if router_path_selection.policies is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-path-selection.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-path-selection.j2
@@ -77,10 +77,26 @@
 
 #### Load-balance policies
 
-| Policy name | Latency | Path group(s) |
-| ----------- | ------- | ------------- |
+| Policy name | Jitter (ms) | Latency (ms) | Loss Rate (%) | Path groups (priority) | Hop count lowest |
+| ----------- | ----------- | ------------ | ------------- | ---------------------- | ---------------- |
 {%         for load_balance_policy in router_path_selection.load_balance_policies | arista.avd.natural_sort('name') %}
-| {{ load_balance_policy.name }} | {{ load_balance_policy.latency | arista.avd.default("-") }} | {{ load_balance_policy.path_groups | arista.avd.natural_sort() | join("<br>") }} |
+{%             set hop_count_lowest = load_balance_policy.hop_count_lowest | arista.avd.default(false) %}
+{%             set jitter = load_balance_policy.jitter | arista.avd.default("-") %}
+{%             set latency = load_balance_policy.latency | arista.avd.default("-") %}
+{%             set loss_rate = load_balance_policy.loss_rate | arista.avd.default("-") %}
+{%             set path_groups_list = [] %}
+{# TODO remove inplace update once Ansible 2.13 is dropped and use groupby default instead #}
+{%             for path_group in load_balance_policy.path_groups | arista.avd.default([]) %}
+{%                 if path_group.priority is not arista.avd.defined %}
+{%                     do path_group.update({"priority": 1}) %}
+{%                 endif %}
+{%             endfor %}
+{%             for priority, entries in load_balance_policy.path_groups | groupby("priority") %}
+{%                 for entry in entries | arista.avd.natural_sort("name") %}
+{%                     do path_groups_list.append(entry.name ~ " (" ~ priority ~ ")") %}
+{%                 endfor %}
+{%             endfor %}
+| {{ load_balance_policy.name }} | {{ jitter }} | {{ latency }} | {{ loss_rate }} | {{ path_groups_list | join("<br>") }} | {{ hop_count_lowest }} |
 {%         endfor %}
 {%     endif %}
 {%     if router_path_selection.policies is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-path-selection.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-path-selection.j2
@@ -77,10 +77,10 @@
 
 #### Load-balance policies
 
-| Policy name | Path group(s) |
-| ----------- | ------------- |
+| Policy name | Latency | Path group(s) |
+| ----------- | ------- | ------------- |
 {%         for load_balance_policy in router_path_selection.load_balance_policies | arista.avd.natural_sort('name') %}
-| {{ load_balance_policy.name }} | {{ load_balance_policy.path_groups | arista.avd.natural_sort() | join("<br>") }} |
+| {{ load_balance_policy.name }} | {{ load_balance_policy.latency | arista.avd.default("-") }} | {{ load_balance_policy.path_groups | arista.avd.natural_sort() | join("<br>") }} |
 {%         endfor %}
 {%     endif %}
 {%     if router_path_selection.policies is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-path-selection.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-path-selection.j2
@@ -78,6 +78,9 @@ router path-selection
 {%     for load_balance_policy in router_path_selection.load_balance_policies | arista.avd.natural_sort('name') %}
    !
    load-balance policy {{ load_balance_policy.name }}
+{%         if load_balance_policy.latency is arista.avd.defined %}
+      latency {{ load_balance_policy.latency }}
+{%         endif %}
 {%         for path_group_name in load_balance_policy.path_groups | arista.avd.default([]) %}
       path-group {{ path_group_name }}
 {%         endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-path-selection.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-path-selection.j2
@@ -78,11 +78,32 @@ router path-selection
 {%     for load_balance_policy in router_path_selection.load_balance_policies | arista.avd.natural_sort('name') %}
    !
    load-balance policy {{ load_balance_policy.name }}
+{%         if load_balance_policy.hop_count_lower is arista.avd.defined(true) %}
+      hop count lower
+{%         endif %}
+{%         if load_balance_policy.jitter is arista.avd.defined %}
+      jitter {{ load_balance_policy.jitter }}
+{%         endif %}
 {%         if load_balance_policy.latency is arista.avd.defined %}
       latency {{ load_balance_policy.latency }}
 {%         endif %}
-{%         for path_group_name in load_balance_policy.path_groups | arista.avd.default([]) %}
-      path-group {{ path_group_name }}
+{%         if load_balance_policy.loss_rate is arista.avd.defined %}
+      loss-rate {{ load_balance_policy.loss_rate }}
+{%         endif %}
+{# TODO remove inplace update once Ansible 2.13 is dropped and use groupby default instead #}
+{%         for path_group in load_balance_policy.path_groups | arista.avd.default([]) %}
+{%             if path_group.priority is not arista.avd.defined %}
+{%                 do path_group.update({"priority": 1}) %}
+{%             endif %}
+{%         endfor %}
+{%         for priority, entries in load_balance_policy.path_groups | groupby("priority") %}
+{%             for entry in entries | arista.avd.natural_sort("name") %}
+{%                 set path_group_cli = "path-group " ~ entry.name %}
+{%                 if priority != 1 %}
+{%                     set path_group_cli = path_group_cli ~ " priority " ~ priority %}
+{%                 endif %}
+      {{ path_group_cli }}
+{%             endfor %}
 {%         endfor %}
 {%     endfor %}
 {#   DPS policies #}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-path-selection.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-path-selection.j2
@@ -78,8 +78,8 @@ router path-selection
 {%     for load_balance_policy in router_path_selection.load_balance_policies | arista.avd.natural_sort('name') %}
    !
    load-balance policy {{ load_balance_policy.name }}
-{%         if load_balance_policy.hop_count_lower is arista.avd.defined(true) %}
-      hop count lower
+{%         if load_balance_policy.hop_count_lowest is arista.avd.defined(true) %}
+      hop count lowest
 {%         endif %}
 {%         if load_balance_policy.jitter is arista.avd.defined %}
       jitter {{ load_balance_policy.jitter }}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-path-selection.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-path-selection.j2
@@ -92,15 +92,13 @@ router path-selection
 {%         endif %}
 {# TODO remove inplace update once Ansible 2.13 is dropped and use groupby default instead #}
 {%         for path_group in load_balance_policy.path_groups | arista.avd.default([]) %}
-{%             if path_group.priority is not arista.avd.defined %}
-{%                 do path_group.update({"priority": 1}) %}
-{%             endif %}
+{%             do path_group.update({"_priority": path_group.priority | arista.avd.default(1)}) %}
 {%         endfor %}
-{%         for priority, entries in load_balance_policy.path_groups | groupby("priority") %}
+{%         for priority, entries in load_balance_policy.path_groups | groupby("_priority") %}
 {%             for entry in entries | arista.avd.natural_sort("name") %}
 {%                 set path_group_cli = "path-group " ~ entry.name %}
-{%                 if priority != 1 %}
-{%                     set path_group_cli = path_group_cli ~ " priority " ~ priority %}
+{%                 if entry.priority is arista.avd.defined %}
+{%                     set path_group_cli = path_group_cli ~ " priority " ~ entry.priority %}
 {%                 endif %}
       {{ path_group_cli }}
 {%             endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-path-selection.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-path-selection.j2
@@ -78,7 +78,7 @@ router path-selection
 {%     for load_balance_policy in router_path_selection.load_balance_policies | arista.avd.natural_sort('name') %}
    !
    load-balance policy {{ load_balance_policy.name }}
-{%         if load_balance_policy.hop_count_lowest is arista.avd.defined(true) %}
+{%         if load_balance_policy.lowest_hop_count is arista.avd.defined(true) %}
       hop count lowest
 {%         endif %}
 {%         if load_balance_policy.jitter is arista.avd.defined %}


### PR DESCRIPTION
## Change Summary

Adding new options to `router_path_selection.load_balancing_policies`

**NOTE** - updating the schema for `path_groups` but it is ok as we have not released it yet (except in a dev release)

```diff
       load_balance_policies:
         - name: <str>
+          hop_count_lower: <bool>
+          jitter: <int>
           latency: <int>
+          loss_rate: <str>
           path_groups:
-            - <str>
+            - name: <str>
+              priority: <int>
```

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

cf schema update.

**NOTE:** The sorting of path-groups is done per priority and then per alphabetical order. When no priority is given by the user in the schema, the priority is `1` and when priority is set to 1 in CLI it is not rendered (Cf below)

For now because of Ansible version 2.13 and its overwriting of Jinja2 groupby filter that does not support default, a cumbersome injection of priority `1` is made when it is not set to allow for a proper sorting.

```
router path-selection
   load-balance policy DEMO
      no latency
      no jitter
      loss-rate 42.42
      path-group BLAH priority 42
host1(config-load-balance-policy-DEMO)#path-group BLEH priority 12
host1(config-load-balance-policy-DEMO)#show active
router path-selection
   load-balance policy DEMO
      loss-rate 42.42
      path-group BLEH priority 12
      path-group BLAH priority 42
host1(config-load-balance-policy-DEMO)#path-group BLUH pr 1
host1(config-load-balance-policy-DEMO)#show active
router path-selection
   load-balance policy DEMO
      loss-rate 42.42
      path-group BLIH
      path-group BLUH
      path-group BLEH priority 12
      path-group BLAH priority 42
```

## How to test

molecule

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
