### PR TITLE
Fix(cvp_configlet_upload): Use correct var for tasks manipulation

### DIFF
--- a/ansible_collections/arista/avd/roles/cvp_configlet_upload/tasks/cv_collection_v3.yml
+++ b/ansible_collections/arista/avd/roles/cvp_configlet_upload/tasks/cv_collection_v3.yml
@@ -5,10 +5,12 @@
   tags: [provision, apply]
   arista.cvp.cv_configlet_v3:
     configlets: "{{ cvp_vars.cvp_configlets }}"
+  register: cvp_configlets_status
 
 - name: "Execute pending tasks on {{ inventory_hostname }}"
   tags: [apply]
   arista.cvp.cv_task_v3:
-    tasks: "{{ cvp_devices_results.tasks }}"
+    tasks: "{{ cvp_configlets_status.taskIds }}"
   when:
-    - execute_tasks | bool
+    - cvp_configlets_status.taskIds | length > 0
+    - execute_tasks|bool

--- a/ansible_collections/arista/avd/roles/cvp_configlet_upload/tasks/cv_collection_v3.yml
+++ b/ansible_collections/arista/avd/roles/cvp_configlet_upload/tasks/cv_collection_v3.yml
@@ -14,4 +14,4 @@
   when:
     - cvp_configlets_status.taskIds is arista.avd.defined
     - cvp_configlets_status.taskIds | length > 0
-    - execute_tasks|bool
+    - execute_tasks | bool

--- a/ansible_collections/arista/avd/roles/cvp_configlet_upload/tasks/cv_collection_v3.yml
+++ b/ansible_collections/arista/avd/roles/cvp_configlet_upload/tasks/cv_collection_v3.yml
@@ -12,5 +12,6 @@
   arista.cvp.cv_task_v3:
     tasks: "{{ cvp_configlets_status.taskIds }}"
   when:
+    - cvp_configlets_status.taskIds is arista.avd.defined
     - cvp_configlets_status.taskIds | length > 0
     - execute_tasks|bool


### PR DESCRIPTION
## Change Summary

Implement correct variable to retrieve list of tasks from Cloudvision when uploading configlets to CV server.

## Related Issue(s)

Fixes #3336

## Component(s) name

`arista.avd.cvp_configlet_upload`

## Proposed changes

Store CVP response in variable `cvp_configlets_status ` and if length of its `taskIds` is higher than 0, then run tasks

## How to test

Run this playbook with no error for both scenario: with and without tasks to run

```yaml
---
- name: Configuration deployment with CVP
  hosts: cv_servers
  connection: local
  gather_facts: false
  # collections:
    # - arista.avd
  tasks:
    - name: Upload configlets to support HOSTS configuration
      import_role:
        name: arista.avd.cvp_configlet_upload
      vars:
        configlet_directory: 'intended/configs'
        file_extension: 'cfg'
        configlets_cvp_prefix: 'AVD'
        execute_tasks: True
        cv_collection: v3
```

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
