### PR TITLE
Doc(eos_cli_config_gen): Fix table for router AVT

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/input-variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/input-variables.md
@@ -808,7 +808,7 @@ roles/eos_cli_config_gen/docs/tables/mpls.md
 ### Router adaptive virtual topology
 
 --8<--
-router-adaptive-virtual-topology.md
+roles/eos_cli_config_gen/docs/tables/router-adaptive-virtual-topology.md
 --8<--
 
 ### Router BFD


### PR DESCRIPTION
## Change Summary

Wrong path for router AVT table 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

correct path

## How to test

check docs for the PR once generate vs docs inhttps://avd.sh/en/devel/roles/eos_cli_config_gen/docs/input-variables.html?h=router+adapt#router-adaptive-virtual-topology where the table is empty

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
