### PR TITLE
Fix(eos_designs): Include ISIS interfaces in fabric docs if any device uses ISIS

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/fabric/L2LS-documentation.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/fabric/L2LS-documentation.md
@@ -10,6 +10,7 @@
   - [Point-To-Point Links Node Allocation](#point-to-point-links-node-allocation)
   - [Loopback Interfaces (BGP EVPN Peering)](#loopback-interfaces-bgp-evpn-peering)
   - [Loopback0 Interfaces Node Allocation](#loopback0-interfaces-node-allocation)
+  - [ISIS CLNS interfaces](#isis-clns-interfaces)
   - [VTEP Loopback VXLAN Tunnel Source Interfaces (VTEPs Only)](#vtep-loopback-vxlan-tunnel-source-interfaces-vteps-only)
   - [VTEP Loopback Node allocation](#vtep-loopback-node-allocation)
 
@@ -90,6 +91,12 @@
 | L2LS_ISIS | ISIS-SPINE1 | 192.168.255.1/32 |
 | L2LS_OSPF | OSPF-SPINE1 | 192.168.255.1/32 |
 | L2LS_OSPF | OSPF-SPINE2 | 192.168.255.2/32 |
+
+### ISIS CLNS interfaces
+
+| POD | Node | CLNS Address |
+| --- | ---- | ------------ |
+| L2LS_ISIS | ISIS-SPINE1 | 49.0001.0001.0000.0001.00 |
 
 ### VTEP Loopback VXLAN Tunnel Source Interfaces (VTEPs Only)
 

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/documentation/fabric-documentation.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/documentation/fabric-documentation.j2
@@ -20,6 +20,7 @@
 {% set vtep_loopback_ipv4_pools = [] %}
 {% set assigned_ip_addresses = [] %}
 {% set interfaces_done = [] %}
+{% set isis_nets = [] %}
 {% for node in groups[fabric_name] | arista.avd.natural_sort %}
 {%     set node_hostvars = hostvars[node] %}
 {%     set node_facts = avd_switch_facts[node] %}
@@ -58,6 +59,7 @@
 {%         endif %}
 {%         if node_hostvars.router_isis is arista.avd.defined and node_hostvars.router_isis.net is arista.avd.defined %}
 {%             set fabric_switch.router_isis_net = node_hostvars.router_isis.net %}
+{%             do isis_nets.append(node_hostvars.router_isis.net) %}
 {%         endif %}
 {%         do fabric_switches.append(fabric_switch) %}
 {# Populate topology_links #}
@@ -173,7 +175,7 @@
 {%     endif %}
 {% endfor %}
 
-{% if avd_switch_facts[inventory_hostname].switch.underlay_routing_protocol | arista.avd.default in ["isis", "isis-sr", "isis-ldp", "isis-sr-ldp"] %}
+{% if isis_nets %}
 ### ISIS CLNS interfaces
 
 | POD | Node | CLNS Address |


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Fix(eos_designs): Include ISIS interfaces in fabric docs if any device uses ISIS

## Related Issue(s)

Saw inconsistent results when building fabric docs with different devices selected for "run_once".

## Component(s) name

`arista.avd.eos_designs`

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Run molecule test for eos_designs-l2ls and then idempotency with --limit ISIS-SPINE1.
- Ignore the missing interfaces, but see that without this fix the ISIS interfaces appear.
- With this fix the ISIS interfaces are always included since a few devices are running ISIS. 

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
