### PR TITLE
CI: Add .gitattributes for PR reviews and clean .gitignore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,8 @@
 # Collapsing generated schemas from PR diff by default
 ansible-avd/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml  linguist-generated=true
-ansible-avd/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.jsonschema.json  linguist-generated=true
+ansible-avd/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json  linguist-generated=true
 ansible-avd/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml  linguist-generated=true
-ansible-avd/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.jsonschema.json  linguist-generated=true
+ansible-avd/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json  linguist-generated=true
 
 # Collapsing generated tables from PR diff by default
 ansible-avd/ansible_collections/arista/avd/roles/eos_cli_config_gen/tables/*  linguist-generated=true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,21 @@
+# Collapsing generated schemas from PR diff by default
+ansible-avd/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml  linguist-generated=true
+ansible-avd/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.jsonschema.json  linguist-generated=true
+ansible-avd/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml  linguist-generated=true
+ansible-avd/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.jsonschema.json  linguist-generated=true
+
+# Collapsing generated tables from PR diff by default
+ansible-avd/ansible_collections/arista/avd/roles/eos_cli_config_gen/tables/*  linguist-generated=true
+ansible-avd/ansible_collections/arista/avd/roles/eos_designs/tables/*  linguist-generated=true
+
+# Collapsing generated plugins doc from PR diff by default
+ansible-avd/ansible_collections/arista/avd/docs/plugins/*  linguist-generated=true
+
+# debatable maybe only for some scenarios ?
+# Collapsing molecule diffs by default for docs / structured_configs
+ansible-avd/ansible_collections/arista/avd/molecule/*/documentation/*  linguist-generated=true
+
+# Excluding docs from stats for linguist
+ansible-avd/ansible_collections/arista/avd/roles/*/docs/*  linguist-documentation
+ansible-avd/ansible_collections/arista/avd/docs/*  linguist-documentation
+ansible-avd/ansible_collections/arista/avd/docs/*  linguist-documentation

--- a/.gitattributes
+++ b/.gitattributes
@@ -5,8 +5,8 @@
 /ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json  linguist-generated=true
 
 # Collapsing generated tables from PR diff by default
-/ansible_collections/arista/avd/roles/eos_cli_config_gen/tables/*  linguist-generated=true
-/ansible_collections/arista/avd/roles/eos_designs/tables/*  linguist-generated=true
+/ansible_collections/arista/avd/roles/eos_cli_config_gen/tables/*  linguist-generated=true -merge -diff
+/ansible_collections/arista/avd/roles/eos_designs/tables/*  linguist-generated=true -merge -diff
 
 # Collapsing generated plugins doc from PR diff by default
 /ansible_collections/arista/avd/docs/plugins/*  linguist-generated=true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,21 +1,21 @@
 # Collapsing generated schemas from PR diff by default
-ansible-avd/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml  linguist-generated=true
-ansible-avd/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json  linguist-generated=true
-ansible-avd/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml  linguist-generated=true
-ansible-avd/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json  linguist-generated=true
+/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml  linguist-generated=true
+/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json  linguist-generated=true
+/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml  linguist-generated=true
+/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json  linguist-generated=true
 
 # Collapsing generated tables from PR diff by default
-ansible-avd/ansible_collections/arista/avd/roles/eos_cli_config_gen/tables/*  linguist-generated=true
-ansible-avd/ansible_collections/arista/avd/roles/eos_designs/tables/*  linguist-generated=true
+/ansible_collections/arista/avd/roles/eos_cli_config_gen/tables/*  linguist-generated=true
+/ansible_collections/arista/avd/roles/eos_designs/tables/*  linguist-generated=true
 
 # Collapsing generated plugins doc from PR diff by default
-ansible-avd/ansible_collections/arista/avd/docs/plugins/*  linguist-generated=true
+/ansible_collections/arista/avd/docs/plugins/*  linguist-generated=true
 
 # debatable maybe only for some scenarios ?
 # Collapsing molecule diffs by default for docs / structured_configs
-ansible-avd/ansible_collections/arista/avd/molecule/*/documentation/*  linguist-generated=true
+/ansible_collections/arista/avd/molecule/*/documentation/*  linguist-generated=true
 
 # Excluding docs from stats for linguist
-ansible-avd/ansible_collections/arista/avd/roles/*/docs/*  linguist-documentation
-ansible-avd/ansible_collections/arista/avd/docs/*  linguist-documentation
-ansible-avd/ansible_collections/arista/avd/docs/*  linguist-documentation
+/ansible_collections/arista/avd/roles/*/docs/*  linguist-documentation
+/ansible_collections/arista/avd/docs/*  linguist-documentation
+/ansible_collections/arista/avd/docs/*  linguist-documentation

--- a/.gitattributes
+++ b/.gitattributes
@@ -17,4 +17,3 @@
 # Excluding docs from stats for linguist
 /ansible_collections/arista/avd/roles/*/docs/*  linguist-documentation
 /ansible_collections/arista/avd/docs/*  linguist-documentation
-/ansible_collections/arista/avd/docs/*  linguist-documentation

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,8 @@
 # Collapsing generated schemas from PR diff by default
-/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml  linguist-generated=true
-/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json  linguist-generated=true
-/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml  linguist-generated=true
-/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json  linguist-generated=true
+/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml  linguist-generated=true -merge -diff
+/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json  linguist-generated=true  -merge -diff
+/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml  linguist-generated=true  -merge -diff
+/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json  linguist-generated=true  -merge -diff
 
 # Collapsing generated tables from PR diff by default
 /ansible_collections/arista/avd/roles/eos_cli_config_gen/tables/*  linguist-generated=true -merge -diff
@@ -12,8 +12,7 @@
 /ansible_collections/arista/avd/docs/plugins/*  linguist-generated=true
 
 # debatable maybe only for some scenarios ?
-# Collapsing molecule diffs by default for docs / structured_configs
-/ansible_collections/arista/avd/molecule/*/documentation/*  linguist-generated=true
+# /ansible_collections/arista/avd/molecule/*/documentation/*  linguist-generated=true
 
 # Excluding docs from stats for linguist
 /ansible_collections/arista/avd/roles/*/docs/*  linguist-documentation

--- a/.gitignore
+++ b/.gitignore
@@ -1,138 +1,42 @@
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
+*.py-e
 *$py.class
 .j2cache/
-
-# C extensions
-*.so
-
-# Distribution / packaging
-.Python
-build/
-develop-eggs/
-dist/
-downloads/
-eggs/
-.eggs/
-lib/
-lib64/
-parts/
-sdist/
-var/
-wheels/
-*.egg-info/
-.installed.cfg
-*.egg
-MANIFEST
-
-# PyInstaller
-#  Usually these files are written by a python script from a template
-#  before PyInstaller builds the exe, so as to inject date/other infos into it.
-*.manifest
-*.spec
-
-# Installer logs
-pip-log.txt
-pip-delete-this-directory.txt
-
-# Unit test / coverage reports
-htmlcov/
-.tox/
-.coverage
-.coverage.*
-.cache
-nosetests.xml
-coverage.xml
-*.cover
-.hypothesis/
-.pytest_cache/
-
-# Translations
-*.mo
-*.pot
-
-# Ansible builder
-*context/
-*_build/
-Containerfile
-
-# Django stuff:
 *.log
-local_settings.py
-db.sqlite3
 
-# Flask stuff:
-instance/
-.webassets-cache
+# pyavd ignores
+python-avd/build/
+python-avd/dist/
+python-avd/vendor/
+python-avd/tests/artifacts/
+python-avd/pyavd.egg-info/
+python-avd/.tox/
+python-avd/.coverage
+python-avd/.mypy_cache/
 
-# Scrapy stuff:
-.scrapy
-
-# Sphinx documentation
-docs/_build/
-
-# PyBuilder
-target/
-
-# Jupyter Notebook
-.ipynb_checkpoints
-
-# pyenv
-.python-version
-
-# celery beat schedule file
-celerybeat-schedule
-
-# SageMath parsed files
-*.sage.py
-
-# Environments
-.env
-.venv
-env/
-venv/
-ENV/
-env.bak/
-venv.bak/
-
-# Spyder project settings
-.spyderproject
-.spyproject
-
-# Rope project settings
-.ropeproject
-
-# mkdocs documentation
+# top level installers
+/*.tar.gz
+## Ansible galaxy-importer
+/importer_result.json
+# mkdocs
 /site
 
-# mypy
-.mypy_cache/
+#  ansible_collections/arista/avd/tests ignores
+ansible_collections/arista/avd/tests/.mypy_cache/
 
-.vscode/*
+# molecule
+
+
+
+## Development
+# pyenv
+.python-version
+#.vscode/*
+.vscode/launch.json
 */.vscode/*
 **/.vscode/*
 
-# Installation path for CVP example
-examples/evpn-l3ls-cvp-deployment/collections
-
-# DS_Store
+## DS_Store
 *.DS_Store
-
-# mkdocs process
-ansible_collections/arista/avd/docs/_build/*.rst
-ansible_collections/arista/avd/docs/media/*
-ansible_collections/arista/avd/docs/contributing.md
-ansible_collections/arista/avd/docs/*.rst
-
-# Molecule AVD build folders
-ansible_collections/arista/avd/molecule/*/config_backup
-
-# Examples config-backup folder
-ansible_collections/arista/avd/examples/*/config_backup
-
-# Ignore TAR GZ files
-*.tar.gz
-
-# Ansible galaxy-importer
-importer_result.json

--- a/.gitignore
+++ b/.gitignore
@@ -20,23 +20,22 @@ python-avd/.mypy_cache/
 /*.tar.gz
 ## Ansible galaxy-importer
 /importer_result.json
+## ansible-builder
+/_build
+
 # mkdocs
 /site
 
-#  ansible_collections/arista/avd/tests ignores
+# ansible_collections/arista/avd/tests ignores
 ansible_collections/arista/avd/tests/.mypy_cache/
 
-# molecule
-
-
-
-## Development
-# pyenv
+# Development
+## pyenv
 .python-version
-#.vscode/*
+## .vscode/*
 .vscode/launch.json
 */.vscode/*
 **/.vscode/*
 
-## DS_Store
+# OSX
 *.DS_Store


### PR DESCRIPTION
## Change Summary

* Trim .gitignore
* add .gitattribute to toggle by default some automatically generated files for PRs

**NOTE** couple of commits will demonstrate the behavior

## Component(s) name

`ci`


## How to test

will try a couple of dummy commit to see it working

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
