### PR TITLE
Feat(eos_cli_config_gen): Extend sbfd for initiator measurement round-trip

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bfd.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bfd.md
@@ -53,9 +53,9 @@ interface Management1
 
 #### Router BFD SBFD Summary
 
-| Initiator Interval | Initiator Multiplier | Reflector Minimum RX | Reflector Local-Discriminator |
+| Initiator Interval | Initiator Multiplier | Initiator Round-Trip | Reflector Minimum RX | Reflector Local-Discriminator |
 | ------------------ | -------------------- | -------------------- | ----------------------------- |
-| 500 | 3 | 600 | 155.1.3.1 |
+| 500 | 3 | True | 600 | 155.1.3.1 |
 
 #### Router BFD Device Configuration
 
@@ -68,6 +68,7 @@ router bfd
    sbfd
       local-interface Loopback0 ipv4 ipv6
       initiator interval 500 multiplier 3
+      initiator measurement delay round-trip
       reflector min-rx 600
       reflector local-discriminator 155.1.3.1
-```
+initiator measurement delay round-trip```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bfd.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bfd.md
@@ -71,4 +71,4 @@ router bfd
       initiator measurement delay round-trip
       reflector min-rx 600
       reflector local-discriminator 155.1.3.1
-initiator measurement delay round-trip```
+```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bfd.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bfd.cfg
@@ -19,7 +19,8 @@ router bfd
    sbfd
       local-interface Loopback0 ipv4 ipv6
       initiator interval 500 multiplier 3
+      initiator measurement delay round-trip
       reflector min-rx 600
       reflector local-discriminator 155.1.3.1
-!
+initiator measurement delay round-trip!
 end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bfd.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bfd.cfg
@@ -22,5 +22,5 @@ router bfd
       initiator measurement delay round-trip
       reflector min-rx 600
       reflector local-discriminator 155.1.3.1
-initiator measurement delay round-trip!
+!
 end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bfd.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bfd.yml
@@ -16,6 +16,7 @@ router_bfd:
         ipv6: true
     initiator_interval: 500
     initiator_multiplier: 3
+    initiator_measurement_round_trip: true
     reflector:
       min_rx: 600
       local_discriminator: 155.1.3.1

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-bfd.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-bfd.md
@@ -23,6 +23,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6</samp>](## "router_bfd.sbfd.local_interface.protocols.ipv6") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;initiator_interval</samp>](## "router_bfd.sbfd.initiator_interval") | Integer |  |  |  | Rate in milliseconds |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;initiator_multiplier</samp>](## "router_bfd.sbfd.initiator_multiplier") | Integer |  |  | Min: 3<br>Max: 50 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;initiator_measurement_round_trip</samp>](## "router_bfd.sbfd.initiator_measurement_round_trip") | Boolean |  |  |  | Enable round-trip delay measurement |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;reflector</samp>](## "router_bfd.sbfd.reflector") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;min_rx</samp>](## "router_bfd.sbfd.reflector.min_rx") | Integer |  |  |  | Rate in milliseconds |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;local_discriminator</samp>](## "router_bfd.sbfd.reflector.local_discriminator") | String |  |  |  | IPv4 address or 32 bit integer |
@@ -58,6 +59,9 @@
         # Rate in milliseconds
         initiator_interval: <int>
         initiator_multiplier: <int; 3-50>
+
+        # Enable round-trip delay measurement
+        initiator_measurement_round_trip: <bool>
         reflector:
 
           # Rate in milliseconds

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -14029,6 +14029,11 @@
               "maximum": 50,
               "title": "Initiator Multiplier"
             },
+            "initiator_measurement_round_trip": {
+              "type": "boolean",
+              "description": "Enable round-trip delay measurement",
+              "title": "Initiator Measurement Round Trip"
+            },
             "reflector": {
               "type": "object",
               "properties": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -8269,6 +8269,9 @@ keys:
             type: int
             min: 3
             max: 50
+          initiator_measurement_round_trip:
+            type: bool
+            description: Enable round-trip delay measurement
           reflector:
             type: dict
             keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_bfd.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_bfd.schema.yml
@@ -55,6 +55,9 @@ keys:
             type: int
             min: 3
             max: 50
+          initiator_measurement_round_trip:
+            type: bool
+            description: Enable round-trip delay measurement
           reflector:
             type: dict
             keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bfd.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bfd.j2
@@ -33,13 +33,14 @@
 
 #### Router BFD SBFD Summary
 
-| Initiator Interval | Initiator Multiplier | Reflector Minimum RX | Reflector Local-Discriminator |
+| Initiator Interval | Initiator Multiplier | Initiator Round-Trip | Reflector Minimum RX | Reflector Local-Discriminator |
 | ------------------ | -------------------- | -------------------- | ----------------------------- |
 {%         set init_interval = router_bfd.sbfd.initiator_interval | arista.avd.default('-') %}
 {%         set init_multiplier = router_bfd.sbfd.initiator_multiplier | arista.avd.default('-') %}
+{%         set init_round_trip = router_bfd.sbfd.initiator_measurement_round_trip | arista.avd.default('-') %}
 {%         set ref_min_rx = router_bfd.sbfd.reflector.min_rx | arista.avd.default('-') %}
 {%         set ref_discriminator = router_bfd.sbfd.reflector.local_discriminator | arista.avd.default('-') %}
-| {{ init_interval }} | {{ init_multiplier }} | {{ ref_min_rx }} | {{ ref_discriminator }} |
+| {{ init_interval }} | {{ init_multiplier }} | {{ init_round_trip }} | {{ ref_min_rx }} | {{ ref_discriminator }} |
 {%     endif %}
 
 #### Router BFD Device Configuration

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bfd.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bfd.j2
@@ -32,6 +32,9 @@ router bfd
 {%         if router_bfd.sbfd.initiator_interval is arista.avd.defined and router_bfd.sbfd.initiator_multiplier is arista.avd.defined %}
       initiator interval {{ router_bfd.sbfd.initiator_interval }} multiplier {{ router_bfd.sbfd.initiator_multiplier }}
 {%         endif %}
+{%         if router_bfd.sbfd.initiator_measurement_round_trip is arista.avd.defined(true) %}
+      initiator measurement delay round-trip
+{%         endif %}
 {%         if router_bfd.sbfd.reflector.min_rx is arista.avd.defined %}
       reflector min-rx {{ router_bfd.sbfd.reflector.min_rx }}
 {%         endif %}
@@ -40,3 +43,4 @@ router bfd
 {%         endif %}
 {%     endif %}
 {% endif %}
+initiator measurement delay round-trip

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bfd.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bfd.j2
@@ -43,4 +43,3 @@ router bfd
 {%         endif %}
 {%     endif %}
 {% endif %}
-initiator measurement delay round-trip


### PR DESCRIPTION
## Change Summary

Add support for defining the `initiator measurement delay round-trip` through eos_cli_config_gen data model rather than raw commands using the `eos_cli` field.

## Related Issue(s)

Fixes #3343

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->


- Update the schema to support turning on `initiator measurement delay round-trip`
- Update the platform eos & documentation templates to generate the line `initiator measurement delay round-trip` as part of the sbfd config
- Update the molecule test `eos_cli_config_gen`

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

- use `molecule test -s eos_cli_config_gen`

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
