### PR TITLE
Feat(eos_cli_config_gen): Extend platform sand for mdb profile

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/platform.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/platform.md
@@ -77,6 +77,7 @@ interface Management1
 | Hardware Only Lag | True |
 | Lag Mode | 512x32 |
 | Default Multicast Replication | ingress |
+| MDB Profile | balanced |
 
 ##### Internal Network QOS Mapping
 
@@ -104,5 +105,6 @@ platform sand lag hardware-only
 platform sand lag mode 512x32
 platform sand forwarding mode arad
 platform sand multicast replication default ingress
+platform sand mdb profile balanced
 platform sfe data-plane cpu allocation maximum 42
 ```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/platform.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/platform.cfg
@@ -33,6 +33,7 @@ platform sand lag hardware-only
 platform sand lag mode 512x32
 platform sand forwarding mode arad
 platform sand multicast replication default ingress
+platform sand mdb profile balanced
 platform sfe data-plane cpu allocation maximum 42
 !
 no enable password

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/platform.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/platform.yml
@@ -65,5 +65,7 @@ platform:
     multicast_replication:
       default: ingress
     forwarding_mode: arad
+    mdb:
+      profile: balanced
   sfe:
     data_plane_cpu_allocation_max: 42

--- a/ansible_collections/arista/avd/plugins/plugin_utils/schema/key_to_display_name.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/schema/key_to_display_name.py
@@ -101,6 +101,7 @@ WORDLIST = {
     "vrrp": "VRRP",
     "vxlan": "VxLAN",
     "ztp": "ZTP",
+    "mdb": "MDB",
 }
 
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/platform.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/platform.md
@@ -40,6 +40,8 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;forwarding_mode</samp>](## "platform.sand.forwarding_mode") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;multicast_replication</samp>](## "platform.sand.multicast_replication") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;default</samp>](## "platform.sand.multicast_replication.default") | String |  |  | Valid Values:<br>- <code>ingress</code><br>- <code>egress</code> |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mdb</samp>](## "platform.sand.mdb") | Dictionary |  |  |  | MDB Configuration |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;profile</samp>](## "platform.sand.mdb.profile") | String |  |  |  | Set MDB profile |
     | [<samp>&nbsp;&nbsp;sfe</samp>](## "platform.sfe") | Dictionary |  |  |  | Sfe (Software Forwarding Engine) settings. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;data_plane_cpu_allocation_max</samp>](## "platform.sfe.data_plane_cpu_allocation_max") | Integer |  |  | Min: 1<br>Max: 128 | Maximum number of CPUs used for data plane traffic forwarding. |
 
@@ -106,6 +108,12 @@
         forwarding_mode: <str>
         multicast_replication:
           default: <str; "ingress" | "egress">
+
+        # MDB Configuration
+        mdb:
+
+          # Set MDB profile
+          profile: <str>
 
       # Sfe (Software Forwarding Engine) settings.
       sfe:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -10632,7 +10632,7 @@
               "patternProperties": {
                 "^_.+$": {}
               },
-              "title": "Mdb"
+              "title": "MDB"
             }
           },
           "additionalProperties": false,

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -10617,6 +10617,22 @@
                 "^_.+$": {}
               },
               "title": "Multicast Replication"
+            },
+            "mdb": {
+              "type": "object",
+              "description": "MDB Configuration",
+              "properties": {
+                "profile": {
+                  "type": "string",
+                  "description": "Set MDB profile",
+                  "title": "Profile"
+                }
+              },
+              "additionalProperties": false,
+              "patternProperties": {
+                "^_.+$": {}
+              },
+              "title": "Mdb"
             }
           },
           "additionalProperties": false,

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -6221,6 +6221,13 @@ keys:
                 valid_values:
                 - ingress
                 - egress
+          mdb:
+            type: dict
+            description: MDB Configuration
+            keys:
+              profile:
+                type: str
+                description: Set MDB profile
       sfe:
         type: dict
         description: Sfe (Software Forwarding Engine) settings.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/platform.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/platform.schema.yml
@@ -167,6 +167,14 @@ keys:
               default:
                 type: str
                 valid_values: ["ingress", "egress"]
+          mdb:
+            type: dict
+            description: MDB Configuration
+            keys:
+              profile:
+                type: str
+                description: Set MDB profile
+
       sfe:
         type: dict
         description: Sfe (Software Forwarding Engine) settings.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/platform.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/platform.j2
@@ -58,6 +58,9 @@
 {%             if platform.sand.multicast_replication.default is arista.avd.defined %}
 | Default Multicast Replication | {{ platform.sand.multicast_replication.default }} |
 {%             endif %}
+{%             if platform.sand.mdb.profile is arista.avd.defined %}
+| MDB Profile | {{ platform.sand.mdb.profile }} |
+{%             endif %}
 {%             if platform.sand.qos_maps is arista.avd.defined %}
 
 ##### Internal Network QOS Mapping

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/platform.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/platform.j2
@@ -27,6 +27,9 @@ platform sand forwarding mode {{ platform.sand.forwarding_mode }}
 {%         if platform.sand.multicast_replication.default is arista.avd.defined %}
 platform sand multicast replication default {{ platform.sand.multicast_replication.default }}
 {%         endif %}
+{%         if platform.sand.mdb.profile is arista.avd.defined %}
+platform sand mdb profile {{ platform.sand.mdb.profile }}
+{%         endif %}
 {%     endif %}
 {%     if platform.sfe is arista.avd.defined %}
 {%         if platform.sfe.data_plane_cpu_allocation_max is arista.avd.defined %}


### PR DESCRIPTION
## Change Summary

Add support to specify the `platform sand mdb profile` through eso_cli_config_gen data model instead of using `eos_cli` raw commands.

## Related Issue(s)

Fixes #3342

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

- Update the schema to support the mdb profile being specified
- Update the platform eos & documentation templates to generate the line `platform sand mdb profile <profile name>`
- Update the molecule test `eos_cli_config_gen`

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

- use `molecule test -s eos_cli_config_gen`

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
