### PR TITLE
Fix(eos_cli_config_gen, eos_designs): BGP VRF Prefix-lists not allowed outside of AF

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-vrf-lite.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-vrf-lite.md
@@ -225,8 +225,10 @@ router bgp 65001
    vrf RED-C1
       rd 1.0.1.1:102
       neighbor 10.1.1.0 peer group OBS_WAN
-      neighbor 10.1.1.0 prefix-list PL-BGP-DEFAULT-RED-IN-C1 in
-      neighbor 10.1.1.0 prefix-list PL-BGP-DEFAULT-RED-OUT-C1 out
+      !
+      address-family ipv4
+         neighbor 10.1.1.0 prefix-list PL-BGP-DEFAULT-RED-IN-C1 in
+         neighbor 10.1.1.0 prefix-list PL-BGP-DEFAULT-RED-OUT-C1 out
    !
    vrf YELLOW-C1
       rd 1.0.1.1:103

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-vrf-lite.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-vrf-lite.md
@@ -229,6 +229,10 @@ router bgp 65001
       address-family ipv4
          neighbor 10.1.1.0 prefix-list PL-BGP-DEFAULT-RED-IN-C1 in
          neighbor 10.1.1.0 prefix-list PL-BGP-DEFAULT-RED-OUT-C1 out
+      !
+      address-family ipv6
+         neighbor 2001:cafe:192:168::4 prefix-list PL-BGP-V6-RED-IN-C1 in
+         neighbor 2001:cafe:192:168::4 prefix-list PL-BGP-V6-RED-OUT-C1 out
    !
    vrf YELLOW-C1
       rd 1.0.1.1:103

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-vrf-lite.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-vrf-lite.cfg
@@ -105,8 +105,10 @@ router bgp 65001
    vrf RED-C1
       rd 1.0.1.1:102
       neighbor 10.1.1.0 peer group OBS_WAN
-      neighbor 10.1.1.0 prefix-list PL-BGP-DEFAULT-RED-IN-C1 in
-      neighbor 10.1.1.0 prefix-list PL-BGP-DEFAULT-RED-OUT-C1 out
+      !
+      address-family ipv4
+         neighbor 10.1.1.0 prefix-list PL-BGP-DEFAULT-RED-IN-C1 in
+         neighbor 10.1.1.0 prefix-list PL-BGP-DEFAULT-RED-OUT-C1 out
    !
    vrf YELLOW-C1
       rd 1.0.1.1:103

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-vrf-lite.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-vrf-lite.cfg
@@ -109,6 +109,10 @@ router bgp 65001
       address-family ipv4
          neighbor 10.1.1.0 prefix-list PL-BGP-DEFAULT-RED-IN-C1 in
          neighbor 10.1.1.0 prefix-list PL-BGP-DEFAULT-RED-OUT-C1 out
+      !
+      address-family ipv6
+         neighbor 2001:cafe:192:168::4 prefix-list PL-BGP-V6-RED-IN-C1 in
+         neighbor 2001:cafe:192:168::4 prefix-list PL-BGP-V6-RED-OUT-C1 out
    !
    vrf YELLOW-C1
       rd 1.0.1.1:103

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-vrf-lite.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-vrf-lite.yml
@@ -149,8 +149,11 @@ router_bgp:
       neighbors:
         - ip_address: 10.1.1.0
           peer_group: OBS_WAN
-          prefix_list_in: PL-BGP-DEFAULT-RED-IN-C1
-          prefix_list_out: PL-BGP-DEFAULT-RED-OUT-C1
+      address_family_ipv4:
+        neighbors:
+          - ip_address: 10.1.1.0
+            prefix_list_in: PL-BGP-DEFAULT-RED-IN-C1
+            prefix_list_out: PL-BGP-DEFAULT-RED-OUT-C1
     - name: YELLOW-C1
       rd: 1.0.1.1:103
       listen_ranges:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-vrf-lite.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-vrf-lite.yml
@@ -154,6 +154,11 @@ router_bgp:
           - ip_address: 10.1.1.0
             prefix_list_in: PL-BGP-DEFAULT-RED-IN-C1
             prefix_list_out: PL-BGP-DEFAULT-RED-OUT-C1
+      address_family_ipv6:
+        neighbors:
+          - ip_address: 2001:cafe:192:168::4
+            prefix_list_in: PL-BGP-V6-RED-IN-C1
+            prefix_list_out: PL-BGP-V6-RED-OUT-C1
     - name: YELLOW-C1
       rd: 1.0.1.1:103
       listen_ranges:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/documentation/devices/host1.md
@@ -1066,6 +1066,8 @@ router isis EVPN_UNDERLAY
 | 192.168.255.1 | Inherited from peer group EVPN-OVERLAY-PEERS | default | - | - | - | - | - | - | - | - |
 | 192.168.255.2 | Inherited from peer group EVPN-OVERLAY-PEERS | default | - | - | - | - | - | - | - | - |
 | 10.255.251.1 | Inherited from peer group EVPN-OVERLAY-PEERS | TENANT_A_PROJECT01 | - | - | - | - | - | - | - | - |
+| 10.2.3.4 | - | TENANT_A_PROJECT01 | - | - | - | - | - | - | - | - |
+| 10.2.3.5 | - | TENANT_A_PROJECT01 | - | - | - | - | - | - | - | - |
 
 #### BGP Neighbor Interfaces
 
@@ -1209,6 +1211,16 @@ router bgp 65101
       aggregate-address 0.0.0.0/0 as-set summary-only attribute-map RM-BGP-AGG-APPLY-SET
       redistribute connected
       redistribute static route-map RM-CONN-2-BGP
+      !
+      address-family ipv4
+         neighbor 10.2.3.4 activate
+         neighbor 10.2.3.4 prefix-list PL-TEST-IN-AF4 in
+         neighbor 10.2.3.4 prefix-list PL-TEST-OUT-AF4 out
+         neighbor 10.2.3.5 activate
+         neighbor 10.2.3.5 prefix-list PL-TEST-IN in
+         neighbor 10.2.3.5 prefix-list PL-TEST-OUT out
+         neighbor 10.255.251.1 prefix-list PL-TEST-IN in
+         neighbor 10.255.251.1 prefix-list PL-TEST-OUT out
       !
       address-family ipv4
          neighbor TEST_PEER_GRP activate

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/intended/configs/host1.cfg
@@ -517,6 +517,16 @@ router bgp 65101
       redistribute static route-map RM-CONN-2-BGP
       !
       address-family ipv4
+         neighbor 10.2.3.4 activate
+         neighbor 10.2.3.4 prefix-list PL-TEST-IN-AF4 in
+         neighbor 10.2.3.4 prefix-list PL-TEST-OUT-AF4 out
+         neighbor 10.2.3.5 activate
+         neighbor 10.2.3.5 prefix-list PL-TEST-IN in
+         neighbor 10.2.3.5 prefix-list PL-TEST-OUT out
+         neighbor 10.255.251.1 prefix-list PL-TEST-IN in
+         neighbor 10.255.251.1 prefix-list PL-TEST-OUT out
+      !
+      address-family ipv4
          neighbor TEST_PEER_GRP activate
          neighbor 10.2.3.4 activate
          neighbor 10.2.3.4 route-map RM-10.2.3.4-SET-NEXT-HOP-OUT out

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/inventory/host_vars/host1/router-bgp.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/inventory/host_vars/host1/router-bgp.yml
@@ -142,6 +142,33 @@ router_bgp:
       neighbors:
         10.255.251.1:
           peer_group: EVPN-OVERLAY-PEERS
+          # prefix_list_in is deprecated in 4.5.0. To be removed in 5.0.0
+          prefix_list_in: PL-TEST-IN
+          # prefix_list_out is deprecated in 4.5.0. To be removed in 5.0.0
+          prefix_list_out: PL-TEST-OUT
+        10.2.3.4:
+          # prefix_list_in is deprecated in 4.5.0. To be removed in 5.0.0
+          # Testing overlap with address family (should be ignored)
+          prefix_list_in: PL-TEST-IN
+          # prefix_list_out is deprecated in 4.5.0. To be removed in 5.0.0
+          # Testing overlap with address family (should be ignored)
+          prefix_list_out: PL-TEST-OUT
+        10.2.3.5:
+          # prefix_list_in is deprecated in 4.5.0. To be removed in 5.0.0
+          # Testing existing in AF but not overlapping (should get configured)
+          prefix_list_in: PL-TEST-IN
+          # prefix_list_out is deprecated in 4.5.0. To be removed in 5.0.0
+          # Testing existing in AF but not overlapping (should get configured)
+          prefix_list_out: PL-TEST-OUT
+      # Part of test of overlaps from VRF neighbors. To be removed in 5.0.0
+      address_family_ipv4:
+        neighbors:
+          - ip_address: 10.2.3.4
+            activate: true
+            prefix_list_in: PL-TEST-IN-AF4
+            prefix_list_out: PL-TEST-OUT-AF4
+          - ip_address: 10.2.3.5
+            activate: true
       # Testing neighbors as dict of dict
       # Dict type is deprecated in 4.0.0. To be removed in 5.0.0
       redistribute_routes:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1A.cfg
@@ -387,9 +387,13 @@ router bgp 65104
       address-family ipv4
          neighbor 123.1.1.10 activate
          neighbor 123.1.1.11 activate
+         neighbor 123.1.1.11 prefix-list PL-TEST-IN-AF4 in
+         neighbor 123.1.1.11 prefix-list PL-TEST-OUT-AF4 out
       !
       address-family ipv6
          neighbor fd5a:fe45:8831:06c5::a activate
+         neighbor fd5a:fe45:8831:06c5::a prefix-list PL-TEST-IN-AF6 in
+         neighbor fd5a:fe45:8831:06c5::a prefix-list PL-TEST-OUT-AF6 out
          neighbor fd5a:fe45:8831:06c5::b activate
    !
    vrf Tenant_B_OP_Zone

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1B.cfg
@@ -368,9 +368,13 @@ router bgp 65105
       address-family ipv4
          neighbor 123.1.1.10 activate
          neighbor 123.1.1.11 activate
+         neighbor 123.1.1.11 prefix-list PL-TEST-IN-AF4 in
+         neighbor 123.1.1.11 prefix-list PL-TEST-OUT-AF4 out
       !
       address-family ipv6
          neighbor fd5a:fe45:8831:06c5::a activate
+         neighbor fd5a:fe45:8831:06c5::a prefix-list PL-TEST-IN-AF6 in
+         neighbor fd5a:fe45:8831:06c5::a prefix-list PL-TEST-OUT-AF6 out
          neighbor fd5a:fe45:8831:06c5::b activate
    !
    vrf Tenant_B_OP_Zone

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1A.yml
@@ -158,6 +158,8 @@ router_bgp:
         activate: true
       - ip_address: 123.1.1.11
         activate: true
+        prefix_list_in: PL-TEST-IN-AF4
+        prefix_list_out: PL-TEST-OUT-AF4
     neighbors:
     - ip_address: 123.1.1.10
       remote_as: '1234'
@@ -198,6 +200,8 @@ router_bgp:
       neighbors:
       - ip_address: fd5a:fe45:8831:06c5::a
         activate: true
+        prefix_list_in: PL-TEST-IN-AF6
+        prefix_list_out: PL-TEST-OUT-AF6
       - ip_address: fd5a:fe45:8831:06c5::b
         activate: true
     updates:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1B.yml
@@ -163,6 +163,8 @@ router_bgp:
         activate: true
       - ip_address: 123.1.1.11
         activate: true
+        prefix_list_in: PL-TEST-IN-AF4
+        prefix_list_out: PL-TEST-OUT-AF4
     neighbors:
     - ip_address: 123.1.1.10
       remote_as: '1234'
@@ -203,6 +205,8 @@ router_bgp:
       neighbors:
       - ip_address: fd5a:fe45:8831:06c5::a
         activate: true
+        prefix_list_in: PL-TEST-IN-AF6
+        prefix_list_out: PL-TEST-OUT-AF6
       - ip_address: fd5a:fe45:8831:06c5::b
         activate: true
     updates:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_A.yml
@@ -182,6 +182,8 @@ tenant_a:
             nodes: [DC1-BL1A, DC1-BL1B]
             route_map_in: RM-123-1-1-11-IN
             route_map_out: RM-123-1-1-11-OUT
+            prefix_list_in: PL-TEST-IN-AF4
+            prefix_list_out: PL-TEST-OUT-AF4
             local_as: 123
             bfd: true
           - ip_address: fd5a:fe45:8831:06c5::a
@@ -189,6 +191,8 @@ tenant_a:
             send_community: all
             nodes: [DC1-BL1A, DC1-BL1B]
             set_ipv6_next_hop: fd5a:fe45:8831:06c5::1
+            prefix_list_in: PL-TEST-IN-AF6
+            prefix_list_out: PL-TEST-OUT-AF6
           - ip_address: fd5a:fe45:8831:06c5::b
             remote_as: 12345
             nodes: [DC1-BL1A, DC1-BL1B]

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-bgp.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-bgp.md
@@ -629,6 +629,8 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;activate</samp>](## "router_bgp.vrfs.[].address_family_ipv6.neighbors.[].activate") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map_in</samp>](## "router_bgp.vrfs.[].address_family_ipv6.neighbors.[].route_map_in") | String |  |  |  | Inbound route-map name |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map_out</samp>](## "router_bgp.vrfs.[].address_family_ipv6.neighbors.[].route_map_out") | String |  |  |  | Outbound route-map name |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;prefix_list_in</samp>](## "router_bgp.vrfs.[].address_family_ipv6.neighbors.[].prefix_list_in") | String |  |  |  | Inbound prefix-list name |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;prefix_list_out</samp>](## "router_bgp.vrfs.[].address_family_ipv6.neighbors.[].prefix_list_out") | String |  |  |  | Outbound prefix-list name |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;networks</samp>](## "router_bgp.vrfs.[].address_family_ipv6.networks") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;prefix</samp>](## "router_bgp.vrfs.[].address_family_ipv6.networks.[].prefix") | String | Required, Unique |  |  | IPv6 prefix "A:B:C:D:E:F:G:H/I" |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "router_bgp.vrfs.[].address_family_ipv6.networks.[].route_map") | String |  |  |  |  |
@@ -1756,6 +1758,12 @@
 
                 # Outbound route-map name
                 route_map_out: <str>
+
+                # Inbound prefix-list name
+                prefix_list_in: <str>
+
+                # Outbound prefix-list name
+                prefix_list_out: <str>
             networks:
 
                 # IPv6 prefix "A:B:C:D:E:F:G:H/I"

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-bgp.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-bgp.md
@@ -561,8 +561,8 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;update_source</samp>](## "router_bgp.vrfs.[].neighbors.[].update_source") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map_in</samp>](## "router_bgp.vrfs.[].neighbors.[].route_map_in") | String |  |  |  | Inbound route-map name |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map_out</samp>](## "router_bgp.vrfs.[].neighbors.[].route_map_out") | String |  |  |  | Outbound route-map name |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;prefix_list_in</samp>](## "router_bgp.vrfs.[].neighbors.[].prefix_list_in") | String |  |  |  | Inbound prefix-list name |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;prefix_list_out</samp>](## "router_bgp.vrfs.[].neighbors.[].prefix_list_out") | String |  |  |  | Outbound prefix-list name |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;prefix_list_in</samp>](## "router_bgp.vrfs.[].neighbors.[].prefix_list_in") <span style="color:red">deprecated</span> | String |  |  |  | Inbound prefix-list name<span style="color:red">This key is deprecated. Support will be removed in AVD version 5.0.0. Use <samp>router_bgp.vrfs[].address_family_ipv4.neighbors[].prefix_list_in</samp> instead.</span> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;prefix_list_out</samp>](## "router_bgp.vrfs.[].neighbors.[].prefix_list_out") <span style="color:red">deprecated</span> | String |  |  |  | Outbound prefix-list name<span style="color:red">This key is deprecated. Support will be removed in AVD version 5.0.0. Use <samp>router_bgp.vrfs[].address_family_ipv4.neighbors[].prefix_list_out</samp> instead.</span> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;neighbor_interfaces</samp>](## "router_bgp.vrfs.[].neighbor_interfaces") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "router_bgp.vrfs.[].neighbor_interfaces.[].name") | String | Required, Unique |  |  | Interface name |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;remote_as</samp>](## "router_bgp.vrfs.[].neighbor_interfaces.[].remote_as") | String |  |  |  | BGP AS <1-4294967295> or AS number in asdot notation "<1-65535>.<0-65535>" |
@@ -600,6 +600,8 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;activate</samp>](## "router_bgp.vrfs.[].address_family_ipv4.neighbors.[].activate") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map_in</samp>](## "router_bgp.vrfs.[].address_family_ipv4.neighbors.[].route_map_in") | String |  |  |  | Inbound route-map name |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map_out</samp>](## "router_bgp.vrfs.[].address_family_ipv4.neighbors.[].route_map_out") | String |  |  |  | Outbound route-map name |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;prefix_list_in</samp>](## "router_bgp.vrfs.[].address_family_ipv4.neighbors.[].prefix_list_in") | String |  |  |  | Inbound prefix-list name |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;prefix_list_out</samp>](## "router_bgp.vrfs.[].address_family_ipv4.neighbors.[].prefix_list_out") | String |  |  |  | Outbound prefix-list name |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;next_hop</samp>](## "router_bgp.vrfs.[].address_family_ipv4.neighbors.[].next_hop") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;address_family_ipv6</samp>](## "router_bgp.vrfs.[].address_family_ipv4.neighbors.[].next_hop.address_family_ipv6") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "router_bgp.vrfs.[].address_family_ipv4.neighbors.[].next_hop.address_family_ipv6.enabled") | Boolean | Required |  |  |  |
@@ -676,7 +678,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;neighbors</samp>](## "router_bgp.vrfs.[].address_family_flow_spec_ipv6.neighbors") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;ip_address</samp>](## "router_bgp.vrfs.[].address_family_flow_spec_ipv6.neighbors.[].ip_address") | String | Required, Unique |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;activate</samp>](## "router_bgp.vrfs.[].address_family_flow_spec_ipv6.neighbors.[].activate") | Boolean |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;address_families</samp>](## "router_bgp.vrfs.[].address_families") <span style="color:red">deprecated</span> | List, items: Dictionary |  |  |  | <span style="color:red">This key is deprecated. Support will be removed in AVD version v5.0.0. Use <samp>address_family_*</samp> instead.</span> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;address_families</samp>](## "router_bgp.vrfs.[].address_families") <span style="color:red">deprecated</span> | List, items: Dictionary |  |  |  | <span style="color:red">This key is deprecated. Support will be removed in AVD version 5.0.0. Use <samp>address_family_*</samp> instead.</span> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;address_family</samp>](## "router_bgp.vrfs.[].address_families.[].address_family") | String | Required, Unique |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bgp</samp>](## "router_bgp.vrfs.[].address_families.[].bgp") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;missing_policy</samp>](## "router_bgp.vrfs.[].address_families.[].bgp.missing_policy") | Dictionary |  |  |  |  |
@@ -1646,9 +1648,15 @@
               route_map_out: <str>
 
               # Inbound prefix-list name
+              # This key is deprecated.
+              # Support will be removed in AVD version 5.0.0.
+              # Use <samp>router_bgp.vrfs[].address_family_ipv4.neighbors[].prefix_list_in</samp> instead.
               prefix_list_in: <str>
 
               # Outbound prefix-list name
+              # This key is deprecated.
+              # Support will be removed in AVD version 5.0.0.
+              # Use <samp>router_bgp.vrfs[].address_family_ipv4.neighbors[].prefix_list_out</samp> instead.
               prefix_list_out: <str>
           neighbor_interfaces:
 
@@ -1705,6 +1713,12 @@
 
                 # Outbound route-map name
                 route_map_out: <str>
+
+                # Inbound prefix-list name
+                prefix_list_in: <str>
+
+                # Outbound prefix-list name
+                prefix_list_out: <str>
                 next_hop:
                   address_family_ipv6:
                     enabled: <bool; required>
@@ -1806,7 +1820,7 @@
               - ip_address: <str; required; unique>
                 activate: <bool>
           # This key is deprecated.
-          # Support will be removed in AVD version v5.0.0.
+          # Support will be removed in AVD version 5.0.0.
           # Use <samp>address_family_*</samp> instead.
           address_families:
             - address_family: <str; required; unique>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-bgp.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-bgp.md
@@ -561,8 +561,8 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;update_source</samp>](## "router_bgp.vrfs.[].neighbors.[].update_source") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map_in</samp>](## "router_bgp.vrfs.[].neighbors.[].route_map_in") | String |  |  |  | Inbound route-map name |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map_out</samp>](## "router_bgp.vrfs.[].neighbors.[].route_map_out") | String |  |  |  | Outbound route-map name |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;prefix_list_in</samp>](## "router_bgp.vrfs.[].neighbors.[].prefix_list_in") <span style="color:red">deprecated</span> | String |  |  |  | Inbound prefix-list name<span style="color:red">This key is deprecated. Support will be removed in AVD version 5.0.0. Use <samp>router_bgp.vrfs[].address_family_ipv4.neighbors[].prefix_list_in</samp> instead.</span> |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;prefix_list_out</samp>](## "router_bgp.vrfs.[].neighbors.[].prefix_list_out") <span style="color:red">deprecated</span> | String |  |  |  | Outbound prefix-list name<span style="color:red">This key is deprecated. Support will be removed in AVD version 5.0.0. Use <samp>router_bgp.vrfs[].address_family_ipv4.neighbors[].prefix_list_out</samp> instead.</span> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;prefix_list_in</samp>](## "router_bgp.vrfs.[].neighbors.[].prefix_list_in") <span style="color:red">deprecated</span> | String |  |  |  | Inbound prefix-list name<span style="color:red">This key is deprecated. Support will be removed in AVD version 5.0.0. Use <samp>router_bgp.vrfs[].address_family_ipv4.neighbors[].prefix_list_in or router_bgp.vrfs[].address_family_ipv6.neighbors[].prefix_list_in</samp> instead.</span> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;prefix_list_out</samp>](## "router_bgp.vrfs.[].neighbors.[].prefix_list_out") <span style="color:red">deprecated</span> | String |  |  |  | Outbound prefix-list name<span style="color:red">This key is deprecated. Support will be removed in AVD version 5.0.0. Use <samp>router_bgp.vrfs[].address_family_ipv4.neighbors[].prefix_list_out or router_bgp.vrfs[].address_family_ipv6.neighbors[].prefix_list_out</samp> instead.</span> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;neighbor_interfaces</samp>](## "router_bgp.vrfs.[].neighbor_interfaces") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "router_bgp.vrfs.[].neighbor_interfaces.[].name") | String | Required, Unique |  |  | Interface name |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;remote_as</samp>](## "router_bgp.vrfs.[].neighbor_interfaces.[].remote_as") | String |  |  |  | BGP AS <1-4294967295> or AS number in asdot notation "<1-65535>.<0-65535>" |
@@ -1652,13 +1652,13 @@
               # Inbound prefix-list name
               # This key is deprecated.
               # Support will be removed in AVD version 5.0.0.
-              # Use <samp>router_bgp.vrfs[].address_family_ipv4.neighbors[].prefix_list_in</samp> instead.
+              # Use <samp>router_bgp.vrfs[].address_family_ipv4.neighbors[].prefix_list_in or router_bgp.vrfs[].address_family_ipv6.neighbors[].prefix_list_in</samp> instead.
               prefix_list_in: <str>
 
               # Outbound prefix-list name
               # This key is deprecated.
               # Support will be removed in AVD version 5.0.0.
-              # Use <samp>router_bgp.vrfs[].address_family_ipv4.neighbors[].prefix_list_out</samp> instead.
+              # Use <samp>router_bgp.vrfs[].address_family_ipv4.neighbors[].prefix_list_out or router_bgp.vrfs[].address_family_ipv6.neighbors[].prefix_list_out</samp> instead.
               prefix_list_out: <str>
           neighbor_interfaces:
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -17753,13 +17753,13 @@
                     },
                     "prefix_list_in": {
                       "type": "string",
-                      "description": "Inbound prefix-list name\nThis key is deprecated. Support will be removed in AVD version 5.0.0. Use <samp>router_bgp.vrfs[].address_family_ipv4.neighbors[].prefix_list_in</samp> instead.",
+                      "description": "Inbound prefix-list name\nThis key is deprecated. Support will be removed in AVD version 5.0.0. Use <samp>router_bgp.vrfs[].address_family_ipv4.neighbors[].prefix_list_in or router_bgp.vrfs[].address_family_ipv6.neighbors[].prefix_list_in</samp> instead.",
                       "deprecated": true,
                       "title": "Prefix List In"
                     },
                     "prefix_list_out": {
                       "type": "string",
-                      "description": "Outbound prefix-list name\nThis key is deprecated. Support will be removed in AVD version 5.0.0. Use <samp>router_bgp.vrfs[].address_family_ipv4.neighbors[].prefix_list_out</samp> instead.",
+                      "description": "Outbound prefix-list name\nThis key is deprecated. Support will be removed in AVD version 5.0.0. Use <samp>router_bgp.vrfs[].address_family_ipv4.neighbors[].prefix_list_out or router_bgp.vrfs[].address_family_ipv6.neighbors[].prefix_list_out</samp> instead.",
                       "deprecated": true,
                       "title": "Prefix List Out"
                     }

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -18210,6 +18210,16 @@
                           "type": "string",
                           "description": "Outbound route-map name",
                           "title": "Route Map Out"
+                        },
+                        "prefix_list_in": {
+                          "type": "string",
+                          "description": "Inbound prefix-list name",
+                          "title": "Prefix List In"
+                        },
+                        "prefix_list_out": {
+                          "type": "string",
+                          "description": "Outbound prefix-list name",
+                          "title": "Prefix List Out"
                         }
                       },
                       "additionalProperties": false,

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -17753,12 +17753,14 @@
                     },
                     "prefix_list_in": {
                       "type": "string",
-                      "description": "Inbound prefix-list name",
+                      "description": "Inbound prefix-list name\nThis key is deprecated. Support will be removed in AVD version 5.0.0. Use <samp>router_bgp.vrfs[].address_family_ipv4.neighbors[].prefix_list_in</samp> instead.",
+                      "deprecated": true,
                       "title": "Prefix List In"
                     },
                     "prefix_list_out": {
                       "type": "string",
-                      "description": "Outbound prefix-list name",
+                      "description": "Outbound prefix-list name\nThis key is deprecated. Support will be removed in AVD version 5.0.0. Use <samp>router_bgp.vrfs[].address_family_ipv4.neighbors[].prefix_list_out</samp> instead.",
+                      "deprecated": true,
                       "title": "Prefix List Out"
                     }
                   },
@@ -18002,6 +18004,16 @@
                           "type": "string",
                           "description": "Outbound route-map name",
                           "title": "Route Map Out"
+                        },
+                        "prefix_list_in": {
+                          "type": "string",
+                          "description": "Inbound prefix-list name",
+                          "title": "Prefix List In"
+                        },
+                        "prefix_list_out": {
+                          "type": "string",
+                          "description": "Outbound prefix-list name",
+                          "title": "Prefix List Out"
                         },
                         "next_hop": {
                           "type": "object",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -10549,6 +10549,12 @@ keys:
                       route_map_out:
                         type: str
                         description: Outbound route-map name
+                      prefix_list_in:
+                        type: str
+                        description: Inbound prefix-list name
+                      prefix_list_out:
+                        type: str
+                        description: Outbound prefix-list name
                 networks:
                   type: list
                   primary_key: prefix

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -10305,9 +10305,17 @@ keys:
                   prefix_list_in:
                     type: str
                     description: Inbound prefix-list name
+                    deprecation:
+                      warning: true
+                      new_key: router_bgp.vrfs[].address_family_ipv4.neighbors[].prefix_list_in
+                      remove_in_version: 5.0.0
                   prefix_list_out:
                     type: str
                     description: Outbound prefix-list name
+                    deprecation:
+                      warning: true
+                      new_key: router_bgp.vrfs[].address_family_ipv4.neighbors[].prefix_list_out
+                      remove_in_version: 5.0.0
             neighbor_interfaces:
               type: list
               primary_key: name
@@ -10440,6 +10448,12 @@ keys:
                       route_map_out:
                         type: str
                         description: Outbound route-map name
+                      prefix_list_in:
+                        type: str
+                        description: Inbound prefix-list name
+                      prefix_list_out:
+                        type: str
+                        description: Outbound prefix-list name
                       next_hop:
                         type: dict
                         keys:
@@ -10736,7 +10750,7 @@ keys:
               deprecation:
                 warning: true
                 new_key: address_family_*
-                remove_in_version: v5.0.0
+                remove_in_version: 5.0.0
               items:
                 type: dict
                 keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -10308,6 +10308,7 @@ keys:
                     deprecation:
                       warning: true
                       new_key: router_bgp.vrfs[].address_family_ipv4.neighbors[].prefix_list_in
+                        or router_bgp.vrfs[].address_family_ipv6.neighbors[].prefix_list_in
                       remove_in_version: 5.0.0
                   prefix_list_out:
                     type: str
@@ -10315,6 +10316,7 @@ keys:
                     deprecation:
                       warning: true
                       new_key: router_bgp.vrfs[].address_family_ipv4.neighbors[].prefix_list_out
+                        or router_bgp.vrfs[].address_family_ipv6.neighbors[].prefix_list_out
                       remove_in_version: 5.0.0
             neighbor_interfaces:
               type: list

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_bgp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_bgp.schema.yml
@@ -1963,14 +1963,14 @@ keys:
                     description: Inbound prefix-list name
                     deprecation:
                       warning: true
-                      new_key: "router_bgp.vrfs[].address_family_ipv4.neighbors[].prefix_list_in"
+                      new_key: "router_bgp.vrfs[].address_family_ipv4.neighbors[].prefix_list_in or router_bgp.vrfs[].address_family_ipv6.neighbors[].prefix_list_in"
                       remove_in_version: 5.0.0
                   prefix_list_out:
                     type: str
                     description: Outbound prefix-list name
                     deprecation:
                       warning: true
-                      new_key: "router_bgp.vrfs[].address_family_ipv4.neighbors[].prefix_list_out"
+                      new_key: "router_bgp.vrfs[].address_family_ipv4.neighbors[].prefix_list_out or router_bgp.vrfs[].address_family_ipv6.neighbors[].prefix_list_out"
                       remove_in_version: 5.0.0
             neighbor_interfaces:
               type: list

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_bgp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_bgp.schema.yml
@@ -2204,6 +2204,12 @@ keys:
                       route_map_out:
                         type: str
                         description: Outbound route-map name
+                      prefix_list_in:
+                        type: str
+                        description: Inbound prefix-list name
+                      prefix_list_out:
+                        type: str
+                        description: Outbound prefix-list name
                 networks:
                   type: list
                   primary_key: prefix

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_bgp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_bgp.schema.yml
@@ -1961,9 +1961,17 @@ keys:
                   prefix_list_in:
                     type: str
                     description: Inbound prefix-list name
+                    deprecation:
+                      warning: true
+                      new_key: "router_bgp.vrfs[].address_family_ipv4.neighbors[].prefix_list_in"
+                      remove_in_version: 5.0.0
                   prefix_list_out:
                     type: str
                     description: Outbound prefix-list name
+                    deprecation:
+                      warning: true
+                      new_key: "router_bgp.vrfs[].address_family_ipv4.neighbors[].prefix_list_out"
+                      remove_in_version: 5.0.0
             neighbor_interfaces:
               type: list
               primary_key: name
@@ -2095,6 +2103,12 @@ keys:
                       route_map_out:
                         type: str
                         description: Outbound route-map name
+                      prefix_list_in:
+                        type: str
+                        description: Inbound prefix-list name
+                      prefix_list_out:
+                        type: str
+                        description: Outbound prefix-list name
                       next_hop:
                         type: dict
                         keys:
@@ -2391,7 +2405,7 @@ keys:
               deprecation:
                 warning: true
                 new_key: address_family_*
-                remove_in_version: v5.0.0
+                remove_in_version: 5.0.0
               items:
                 type: dict
                 keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -1573,6 +1573,12 @@ router bgp {{ router_bgp.as }}
 {%                 if neighbor.route_map_out is arista.avd.defined %}
          neighbor {{ neighbor.ip_address }} route-map {{ neighbor.route_map_out }} out
 {%                 endif %}
+{%                 if neighbor.prefix_list_in is arista.avd.defined %}
+         neighbor {{ neighbor.ip_address }} prefix-list {{ neighbor.prefix_list_in }} in
+{%                 endif %}
+{%                 if neighbor.prefix_list_out is arista.avd.defined %}
+         neighbor {{ neighbor.ip_address }} prefix-list {{ neighbor.prefix_list_out }} out
+{%                 endif %}
 {%             endfor %}
 {%             for network in vrf.address_family_ipv6.networks | arista.avd.natural_sort('prefix') %}
 {%                 set network_cli = "network " ~ network.prefix %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -1210,6 +1210,12 @@ router bgp {{ router_bgp.as }}
       neighbor interface {{ neighbor_interface.name }} peer-group {{ neighbor_interface.peer_group }} peer-filter {{ neighbor_interface.peer_filter }}
 {%             endif %}
 {%         endfor %}
+{# TODO: AVD5.0 remove tmp_vrf_neighbor_prefix_list_in and tmp_vrf_neighbor_prefix_list_out #}
+{# Special temporary variables set under vrf neighbors but read under vrf address_family_ipv4 #}
+{# This is required to move the deprecated vrfs[].neighbors[].ip_prefix_list_in/out to #}
+{# vrfs[].address_family_ipv4.neighbors[].ip_prefix_list_in/out #}
+{%         set tmp_vrf_neighbor_prefix_list_in = {} %}
+{%         set tmp_vrf_neighbor_prefix_list_out = {} %}
 {%         for neighbor in vrf.neighbors | arista.avd.natural_sort('ip_address') %}
 {%             if neighbor.remote_as is arista.avd.defined %}
       neighbor {{ neighbor.ip_address }} remote-as {{ neighbor.remote_as }}
@@ -1336,11 +1342,15 @@ router bgp {{ router_bgp.as }}
 {%             if neighbor.route_map_in is arista.avd.defined %}
       neighbor {{ neighbor.ip_address }} route-map {{ neighbor.route_map_in }} in
 {%             endif %}
+{#             TODO: AVD5.0 remove tmp_vrf_neighbor_prefix_list_in and tmp_vrf_neighbor_prefix_list_out #}
+{#             Special temporary variables set under vrf neighbors but read under vrf address_family_ipv4 #}
+{#             This is required to move the deprecated vrfs[].neighbors[].ip_prefix_list_in/out to #}
+{#             vrfs[].address_family_ipv4.neighbors[].ip_prefix_list_in/out #}
 {%             if neighbor.prefix_list_in is arista.avd.defined %}
-      neighbor {{ neighbor.ip_address }} prefix-list {{ neighbor.prefix_list_in }} in
+{%                 do tmp_vrf_neighbor_prefix_list_in.update({neighbor.ip_address: neighbor.prefix_list_in}) %}
 {%             endif %}
 {%             if neighbor.prefix_list_out is arista.avd.defined %}
-      neighbor {{ neighbor.ip_address }} prefix-list {{ neighbor.prefix_list_out }} out
+{%                 do tmp_vrf_neighbor_prefix_list_out.update({neighbor.ip_address: neighbor.prefix_list_out}) %}
 {%             endif %}
 {%         endfor %}
 {%         for network in vrf.networks | arista.avd.natural_sort('prefix') %}
@@ -1411,7 +1421,8 @@ router bgp {{ router_bgp.as }}
 {%                 endif %}
 {%             endfor %}
 {%         endif %}
-{%         if vrf.address_family_ipv4 is arista.avd.defined %}
+{#         TODO: AVD5.0 remove tmp_vrf_neighbor_prefix_list_in and tmp_vrf_neighbor_prefix_list_out #}
+{%         if vrf.address_family_ipv4 is arista.avd.defined or tmp_vrf_neighbor_prefix_list_in or tmp_vrf_neighbor_prefix_list_out %}
       !
       address-family ipv4
 {%             if vrf.address_family_ipv4.bgp.missing_policy.direction_in_action is arista.avd.defined %}
@@ -1449,6 +1460,23 @@ router bgp {{ router_bgp.as }}
 {%                 if neighbor.route_map_out is arista.avd.defined %}
          neighbor {{ neighbor.ip_address }} route-map {{ neighbor.route_map_out }} out
 {%                 endif %}
+{#                 TODO: AVD5.0 remove tmp_vrf_neighbor_prefix_list_in and tmp_vrf_neighbor_prefix_list_out #}
+{%                 if neighbor.prefix_list_in is arista.avd.defined %}
+         neighbor {{ neighbor.ip_address }} prefix-list {{ neighbor.prefix_list_in }} in
+{%                     if tmp_vrf_neighbor_prefix_list_in[neighbor.ip_address] is arista.avd.defined %}
+{%                         do tmp_vrf_neighbor_prefix_list_in.pop(neighbor.ip_address) %}
+{%                     endif %}
+{%                 elif tmp_vrf_neighbor_prefix_list_in[neighbor.ip_address] is arista.avd.defined %}
+         neighbor {{ neighbor.ip_address }} prefix-list {{ tmp_vrf_neighbor_prefix_list_in.pop(neighbor.ip_address) }} in
+{%                 endif %}
+{%                 if neighbor.prefix_list_out is arista.avd.defined %}
+         neighbor {{ neighbor.ip_address }} prefix-list {{ neighbor.prefix_list_out }} out
+{%                     if tmp_vrf_neighbor_prefix_list_out[neighbor.ip_address] is arista.avd.defined %}
+{%                         do tmp_vrf_neighbor_prefix_list_out.pop(neighbor.ip_address) %}
+{%                     endif %}
+{%                 elif tmp_vrf_neighbor_prefix_list_out[neighbor.ip_address] is arista.avd.defined %}
+         neighbor {{ neighbor.ip_address }} prefix-list {{ tmp_vrf_neighbor_prefix_list_out.pop(neighbor.ip_address) }} out
+{%                 endif %}
 {%                 if neighbor.next_hop.address_family_ipv6.enabled is arista.avd.defined %}
 {%                     if neighbor.next_hop.address_family_ipv6.enabled is arista.avd.defined(true) %}
 {%                         set ipv6_originate_cli = "neighbor " ~ neighbor.ip_address ~ " next-hop address-family ipv6" %}
@@ -1460,6 +1488,13 @@ router bgp {{ router_bgp.as }}
 {%                     endif %}
          {{ ipv6_originate_cli }}
 {%                 endif %}
+{%             endfor %}
+{#             TODO: AVD5.0 remove tmp_vrf_neighbor_prefix_list_in and tmp_vrf_neighbor_prefix_list_out #}
+{%             for tmp_neighbor_ip in tmp_vrf_neighbor_prefix_list_in | arista.avd.natural_sort %}
+         neighbor {{ tmp_neighbor_ip }} prefix-list {{ tmp_vrf_neighbor_prefix_list_in[tmp_neighbor_ip] }} in
+{%             endfor %}
+{%             for tmp_neighbor_ip in tmp_vrf_neighbor_prefix_list_out | arista.avd.natural_sort %}
+         neighbor {{ tmp_neighbor_ip }} prefix-list {{ tmp_vrf_neighbor_prefix_list_out[tmp_neighbor_ip] }} out
 {%             endfor %}
 {%             for network in vrf.address_family_ipv4.networks | arista.avd.natural_sort('prefix') %}
 {%                 set network_cli = "network " ~ network.prefix %}

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-bgp-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-bgp-settings.md
@@ -82,8 +82,8 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;set_ipv6_next_hop</samp>](## "<network_services_keys.name>.[].vrfs.[].bgp_peers.[].set_ipv6_next_hop") | String |  |  |  | IPv6_address<br>Next hop settings can be either ipv4 or ipv6 for one neighbor, this will be applied by a uniquely generated route-map per neighbor.<br>Next hop takes precedence over route_map_out.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map_out</samp>](## "<network_services_keys.name>.[].vrfs.[].bgp_peers.[].route_map_out") | String |  |  |  | Route-map name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map_in</samp>](## "<network_services_keys.name>.[].vrfs.[].bgp_peers.[].route_map_in") | String |  |  |  | Route-map name. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;prefix_list_in</samp>](## "<network_services_keys.name>.[].vrfs.[].bgp_peers.[].prefix_list_in") | String |  |  |  | Prefix list name. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;prefix_list_out</samp>](## "<network_services_keys.name>.[].vrfs.[].bgp_peers.[].prefix_list_out") | String |  |  |  | Prefix list name. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;prefix_list_in</samp>](## "<network_services_keys.name>.[].vrfs.[].bgp_peers.[].prefix_list_in") | String |  |  |  | Inbound prefix list name.<br>The prefix-list will be associated under the IPv4 or IPv6 address family based on the IP address. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;prefix_list_out</samp>](## "<network_services_keys.name>.[].vrfs.[].bgp_peers.[].prefix_list_out") | String |  |  |  | Outbound prefix list name.<br>The prefix-list will be associated under the IPv4 or IPv6 address family based on the IP address. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;local_as</samp>](## "<network_services_keys.name>.[].vrfs.[].bgp_peers.[].local_as") | String |  |  |  | Local BGP ASN.<br>eg. "65001.1200".<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;weight</samp>](## "<network_services_keys.name>.[].vrfs.[].bgp_peers.[].weight") | Integer |  |  | Min: 0<br>Max: 65535 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bfd</samp>](## "<network_services_keys.name>.[].vrfs.[].bgp_peers.[].bfd") | Boolean |  |  |  |  |
@@ -329,10 +329,12 @@
                 # Route-map name.
                 route_map_in: <str>
 
-                # Prefix list name.
+                # Inbound prefix list name.
+                # The prefix-list will be associated under the IPv4 or IPv6 address family based on the IP address.
                 prefix_list_in: <str>
 
-                # Prefix list name.
+                # Outbound prefix list name.
+                # The prefix-list will be associated under the IPv4 or IPv6 address family based on the IP address.
                 prefix_list_out: <str>
 
                 # Local BGP ASN.

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/router_bgp.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/router_bgp.py
@@ -244,6 +244,10 @@ class RouterBgpMixin(UtilsMixin):
                             )
 
                 for bgp_peer in vrf["bgp_peers"]:
+                    # Below we pop various keys that are not supported by the eos_cli_config_gen schema.
+                    # The rest of the keys are relayed directly to eos_cli_config_gen.
+                    # 'ip_address' is popped even though it is supported. It will be added again later
+                    # to ensure it comes first in the generated dict.
                     peer_ip = bgp_peer.pop("ip_address")
                     address_family = f"address_family_ipv{ipaddress.ip_address(peer_ip).version}"
                     neighbor = strip_empties_from_dict(

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/router_bgp.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/router_bgp.py
@@ -246,7 +246,14 @@ class RouterBgpMixin(UtilsMixin):
                 for bgp_peer in vrf["bgp_peers"]:
                     peer_ip = bgp_peer.pop("ip_address")
                     address_family = f"address_family_ipv{ipaddress.ip_address(peer_ip).version}"
-                    neighbor = {"ip_address": peer_ip, "activate": True}
+                    neighbor = strip_empties_from_dict(
+                        {
+                            "ip_address": peer_ip,
+                            "activate": True,
+                            "prefix_list_in": bgp_peer.pop("prefix_list_in", None),
+                            "prefix_list_out": bgp_peer.pop("prefix_list_out", None),
+                        }
+                    )
                     bgp_vrf.setdefault(address_family, {}).setdefault("neighbors", []).append(neighbor)
 
                     if bgp_peer.get("set_ipv4_next_hop") is not None or bgp_peer.get("set_ipv6_next_hop") is not None:

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
@@ -4836,10 +4836,16 @@ $defs:
                       description: Route-map name.
                     prefix_list_in:
                       type: str
-                      description: Prefix list name.
+                      description: 'Inbound prefix list name.
+
+                        The prefix-list will be associated under the IPv4 or IPv6
+                        address family based on the IP address.'
                     prefix_list_out:
                       type: str
-                      description: Prefix list name.
+                      description: 'Outbound prefix list name.
+
+                        The prefix-list will be associated under the IPv4 or IPv6
+                        address family based on the IP address.'
                     local_as:
                       type: str
                       convert_types:

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/defs_network_services.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/defs_network_services.schema.yml
@@ -856,10 +856,14 @@ $defs:
                       description: Route-map name.
                     prefix_list_in:
                       type: str
-                      description: Prefix list name.
+                      description: |-
+                        Inbound prefix list name.
+                        The prefix-list will be associated under the IPv4 or IPv6 address family based on the IP address.
                     prefix_list_out:
                       type: str
-                      description: Prefix list name.
+                      description: |-
+                        Outbound prefix list name.
+                        The prefix-list will be associated under the IPv4 or IPv6 address family based on the IP address.
                     local_as:
                       type: str
                       convert_types:


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Fix BGP VRF Prefix-lists not allowed outside of AF

## Related Issue(s)

Fixes #3348

## Component(s) name

`arista.avd.<role-name>`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

- Deprecate `router_bgp.vrfs[].neighbors[].prefix_list_in` in favor of `router_bgp.vrfs[].address_family_ipv4.neighbors[].prefix_list_in`.
- Deprecate `router_bgp.vrfs[].neighbors[].prefix_list_out` in favor of `router_bgp.vrfs[].address_family_ipv4.neighbors[].prefix_list_out`.
- Adding support for ipv6 prefix-list in/out under VRFs.
- Updating eos_designs to not produce the wrong config and handle both v4 and v6.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

- Updated molecule scenario `eos_cli_config_gen` to use the new model. Added to `eos_cli_config_gen_deprecated_vars` to test old model plus various combinations.
- Updated molecule `eos_designs_unit_tests` to cover v4 and v6 prefix-lists.
## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
