### PR TITLE
Feat(eos_designs): Add uplink_type at nodes level

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/override_uplink_type-d.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/override_uplink_type-d.cfg
@@ -1,0 +1,45 @@
+!RANCID-CONTENT-TYPE: arista
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname override_uplink_type-d
+!
+spanning-tree mode none
+!
+no enable password
+no aaa root
+!
+vrf instance MGMT
+!
+interface Port-Channel1
+   description OVERRIDE_UPLINK_TYPE-U_Po1
+   no shutdown
+   switchport
+   switchport trunk allowed vlan none
+   switchport mode trunk
+!
+interface Ethernet1
+   description OVERRIDE_UPLINK_TYPE-U_Ethernet1
+   no shutdown
+   channel-group 1 mode active
+!
+interface Loopback0
+   description Router_ID
+   no shutdown
+   ip address 192.168.42.2/32
+!
+ip routing
+no ip routing vrf MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/override_uplink_type-d.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/override_uplink_type-d.cfg
@@ -28,7 +28,7 @@ interface Ethernet1
    channel-group 1 mode active
 !
 interface Loopback0
-   description Router_ID
+   description EVPN_Overlay_Peering
    no shutdown
    ip address 192.168.42.2/32
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/override_uplink_type-u.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/override_uplink_type-u.cfg
@@ -28,19 +28,45 @@ interface Ethernet1
    channel-group 1 mode active
 !
 interface Loopback0
-   description Router_ID
+   description EVPN_Overlay_Peering
    no shutdown
    ip address 192.168.42.1/32
-   ip ospf area 0.0.0.0
 !
 ip routing
 no ip routing vrf MGMT
 !
-router ospf 100
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.42.0/24 eq 32
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+router bfd
+   multihop interval 300 min-rx 300 multiplier 3
+!
+router bgp 65002
    router-id 192.168.42.1
-   passive-interface default
-   max-lsa 12000
-   redistribute connected
+   maximum-paths 4 ecmp 4
+   update wait-install
+   no bgp default ipv4-unicast
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor IPv4-UNDERLAY-PEERS peer group
+   neighbor IPv4-UNDERLAY-PEERS send-community
+   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   address-family evpn
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor IPv4-UNDERLAY-PEERS activate
 !
 management api http-commands
    protocol https

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/override_uplink_type-u.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/override_uplink_type-u.cfg
@@ -1,0 +1,52 @@
+!RANCID-CONTENT-TYPE: arista
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname override_uplink_type-u
+!
+spanning-tree mode none
+!
+no enable password
+no aaa root
+!
+vrf instance MGMT
+!
+interface Port-Channel1
+   description OVERRIDE_UPLINK_TYPE-D_Po1
+   no shutdown
+   switchport
+   switchport trunk allowed vlan none
+   switchport mode trunk
+!
+interface Ethernet1
+   description OVERRIDE_UPLINK_TYPE-D_Ethernet1
+   no shutdown
+   channel-group 1 mode active
+!
+interface Loopback0
+   description Router_ID
+   no shutdown
+   ip address 192.168.42.1/32
+   ip ospf area 0.0.0.0
+!
+ip routing
+no ip routing vrf MGMT
+!
+router ospf 100
+   router-id 192.168.42.1
+   passive-interface default
+   max-lsa 12000
+   redistribute connected
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/override_uplink_type-d.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/override_uplink_type-d.yml
@@ -1,0 +1,41 @@
+hostname: override_uplink_type-d
+is_deployed: true
+service_routing_protocols_model: multi-agent
+ip_routing: true
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+spanning_tree:
+  mode: none
+vrfs:
+- name: MGMT
+  ip_routing: false
+management_api_http:
+  enable_vrfs:
+  - name: MGMT
+  enable_https: true
+ethernet_interfaces:
+- name: Ethernet1
+  peer: override_uplink_type-u
+  peer_interface: Ethernet1
+  peer_type: spine
+  description: OVERRIDE_UPLINK_TYPE-U_Ethernet1
+  shutdown: false
+  type: port-channel-member
+  channel_group:
+    id: 1
+    mode: active
+port_channel_interfaces:
+- name: Port-Channel1
+  description: OVERRIDE_UPLINK_TYPE-U_Po1
+  type: switched
+  shutdown: false
+  mode: trunk
+  vlans: none
+loopback_interfaces:
+- name: Loopback0
+  description: Router_ID
+  shutdown: false
+  ip_address: 192.168.42.2/32

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/override_uplink_type-d.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/override_uplink_type-d.yml
@@ -36,6 +36,6 @@ port_channel_interfaces:
   vlans: none
 loopback_interfaces:
 - name: Loopback0
-  description: Router_ID
+  description: EVPN_Overlay_Peering
   shutdown: false
   ip_address: 192.168.42.2/32

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/override_uplink_type-u.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/override_uplink_type-u.yml
@@ -1,5 +1,42 @@
 hostname: override_uplink_type-u
 is_deployed: true
+router_bgp:
+  as: '65002'
+  router_id: 192.168.42.1
+  bgp:
+    default:
+      ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
+  updates:
+    wait_install: true
+  peer_groups:
+  - name: IPv4-UNDERLAY-PEERS
+    type: ipv4
+    maximum_routes: 12000
+    send_community: all
+  - name: EVPN-OVERLAY-PEERS
+    type: evpn
+    update_source: Loopback0
+    bfd: true
+    send_community: all
+    maximum_routes: 0
+    ebgp_multihop: 3
+    next_hop_unchanged: true
+  address_family_ipv4:
+    peer_groups:
+    - name: IPv4-UNDERLAY-PEERS
+      activate: true
+    - name: EVPN-OVERLAY-PEERS
+      activate: false
+  redistribute_routes:
+  - source_protocol: connected
+    route_map: RM-CONN-2-BGP
+  address_family_evpn:
+    peer_groups:
+    - name: EVPN-OVERLAY-PEERS
+      activate: true
 service_routing_protocols_model: multi-agent
 ip_routing: true
 vlan_internal_order:
@@ -36,17 +73,23 @@ port_channel_interfaces:
   vlans: none
 loopback_interfaces:
 - name: Loopback0
-  description: Router_ID
+  description: EVPN_Overlay_Peering
   shutdown: false
   ip_address: 192.168.42.1/32
-  ospf_area: 0.0.0.0
-router_ospf:
-  process_ids:
-  - id: 100
-    passive_interface_default: true
-    router_id: 192.168.42.1
-    max_lsa: 12000
-    no_passive_interfaces: []
-    bfd_enable: false
-    redistribute:
-      connected: {}
+prefix_lists:
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.42.0/24 eq 32
+route_maps:
+- name: RM-CONN-2-BGP
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    match:
+    - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+router_bfd:
+  multihop:
+    interval: 300
+    min_rx: 300
+    multiplier: 3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/override_uplink_type-u.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/override_uplink_type-u.yml
@@ -1,0 +1,52 @@
+hostname: override_uplink_type-u
+is_deployed: true
+service_routing_protocols_model: multi-agent
+ip_routing: true
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+spanning_tree:
+  mode: none
+vrfs:
+- name: MGMT
+  ip_routing: false
+management_api_http:
+  enable_vrfs:
+  - name: MGMT
+  enable_https: true
+ethernet_interfaces:
+- name: Ethernet1
+  peer: override_uplink_type-d
+  peer_interface: Ethernet1
+  peer_type: spine
+  description: OVERRIDE_UPLINK_TYPE-D_Ethernet1
+  shutdown: false
+  type: port-channel-member
+  channel_group:
+    id: 1
+    mode: active
+port_channel_interfaces:
+- name: Port-Channel1
+  description: OVERRIDE_UPLINK_TYPE-D_Po1
+  type: switched
+  shutdown: false
+  mode: trunk
+  vlans: none
+loopback_interfaces:
+- name: Loopback0
+  description: Router_ID
+  shutdown: false
+  ip_address: 192.168.42.1/32
+  ospf_area: 0.0.0.0
+router_ospf:
+  process_ids:
+  - id: 100
+    passive_interface_default: true
+    router_id: 192.168.42.1
+    max_lsa: 12000
+    no_passive_interfaces: []
+    bfd_enable: false
+    redistribute:
+      connected: {}

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/OVERRIDE_UPLINK_TYPE.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/OVERRIDE_UPLINK_TYPE.yml
@@ -1,0 +1,19 @@
+---
+# By default the uplink type should be `p2p`
+type: spine
+
+overlay_routing_protocol: none
+underlay_routing_protocol: ospf
+
+spine:
+  defaults:
+    loopback_ipv4_pool: 192.168.42.0/24
+  nodes:
+    - name: override_uplink_type-u
+      id: 1
+    - name: override_uplink_type-d
+      uplink_switches: [override_uplink_type-u]
+      uplink_switch_interfaces: [Ethernet1]
+      uplink_interfaces: [Ethernet1]
+      uplink_type: port-channel
+      id: 2

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/OVERRIDE_UPLINK_TYPE.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/OVERRIDE_UPLINK_TYPE.yml
@@ -2,14 +2,12 @@
 # By default the uplink type should be `p2p`
 type: spine
 
-overlay_routing_protocol: none
-underlay_routing_protocol: ospf
-
 spine:
   defaults:
     loopback_ipv4_pool: 192.168.42.0/24
   nodes:
     - name: override_uplink_type-u
+      bgp_as: 65002
       id: 1
     - name: override_uplink_type-d
       uplink_switches: [override_uplink_type-u]

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
@@ -28,6 +28,10 @@ all:
             default_interface_mtu_hostvars:
             default_interface_mtu_platform:
             evpn-to-ipvpn-gateway:
+        OVERRIDE_UPLINK_TYPE:
+          hosts:
+            override_uplink_type-d:
+            override_uplink_type-u:
         CORE_UNIT_TESTS:
           hosts:
             core-1-isis-sr-ldp:

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/node_type.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/node_type.py
@@ -68,9 +68,11 @@ class NodeTypeMixin:
     def uplink_type(self: SharedUtils) -> str:
         """
         uplink_type set based on
+        <node_type_key>.nodes.[].uplink_type and
         node_type_keys.<node_type_key>.uplink_type
         """
-        return get(self.node_type_key_data, "uplink_type", default="p2p")
+        default_uplink_type = get(self.node_type_key_data, "uplink_type", default="p2p")
+        return get(self.switch_data_combined, "uplink_type", default=default_uplink_type)
 
     @cached_property
     def network_services_l1(self: SharedUtils) -> bool:

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/node-type-keys.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/node-type-keys.md
@@ -25,7 +25,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;l2</samp>](## "node_type_keys.[].network_services.l2") | Boolean |  | `False` |  | Vlans |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;l3</samp>](## "node_type_keys.[].network_services.l3") | Boolean |  | `False` |  | VRFs, SVIs (if l2 is true).<br>Only supported with underlay_router.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;underlay_router</samp>](## "node_type_keys.[].underlay_router") | Boolean |  | `True` |  | Is this node type a L3 device. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;uplink_type</samp>](## "node_type_keys.[].uplink_type") | String |  | `p2p` | Valid Values:<br>- <code>p2p</code><br>- <code>port-channel</code> | Uplinks must be p2p if "vtep" or "underlay_router" is true. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;uplink_type</samp>](## "node_type_keys.[].uplink_type") | String |  | `p2p` | Valid Values:<br>- <code>p2p</code><br>- <code>port-channel</code> | `uplink_type` must be "p2p" if `vtep` or `underlay_router` is true. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vtep</samp>](## "node_type_keys.[].vtep") | Boolean |  | `False` |  | Is this switch an EVPN VTEP. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mpls_lsr</samp>](## "node_type_keys.[].mpls_lsr") | Boolean |  | `False` |  | Is this switch an MPLS LSR. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_addressing</samp>](## "node_type_keys.[].ip_addressing") | Dictionary |  |  |  | Override ip_addressing templates. |
@@ -115,7 +115,7 @@
         # Is this node type a L3 device.
         underlay_router: <bool; default=True>
 
-        # Uplinks must be p2p if "vtep" or "underlay_router" is true.
+        # `uplink_type` must be "p2p" if `vtep` or `underlay_router` is true.
         uplink_type: <str; "p2p" | "port-channel"; default="p2p">
 
         # Is this switch an EVPN VTEP.

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/node-type-uplink-configuration.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/node-type-uplink-configuration.md
@@ -15,7 +15,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "<node_type_keys.key>.defaults.link_tracking.groups.[].name") | String |  |  |  | Tracking group name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;recovery_delay</samp>](## "<node_type_keys.key>.defaults.link_tracking.groups.[].recovery_delay") | Integer |  |  | Min: 0<br>Max: 3600 | default -> platform_settings_mlag_reload_delay -> 300. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;links_minimum</samp>](## "<node_type_keys.key>.defaults.link_tracking.groups.[].links_minimum") | Integer |  |  | Min: 1<br>Max: 100000 |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;uplink_type</samp>](## "<node_type_keys.key>.defaults.uplink_type") | String |  | `p2p` | Valid Values:<br>- <code>p2p</code><br>- <code>port-channel</code> | Override the default `uplink_type` set at the `node_type_key` level.<br>Uplinks must be p2p if "vtep" or "underlay_router" is true. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;uplink_type</samp>](## "<node_type_keys.key>.defaults.uplink_type") | String |  | `p2p` | Valid Values:<br>- <code>p2p</code><br>- <code>port-channel</code> | Override the default `uplink_type` set at the `node_type_key` level.<br>`uplink_type` must be "p2p" if `vtep` or `underlay_router` is true for the `node_type_key` definition. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;uplink_ipv4_pool</samp>](## "<node_type_keys.key>.defaults.uplink_ipv4_pool") | String |  |  | Format: ipv4_cidr | IPv4 subnet to use to connect to uplink switches. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;uplink_interfaces</samp>](## "<node_type_keys.key>.defaults.uplink_interfaces") | List, items: String |  |  |  | Local uplink interfaces<br>Each list item supports range syntax that can be expanded into a list of interfaces.<br>If uplink_interfaces is not defined, platform-specific defaults (defined under default_interfaces) will be used instead.<br>Please note that default_interfaces are not defined by default, you should define these yourself.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<node_type_keys.key>.defaults.uplink_interfaces.[]") | String |  |  | Pattern: Ethernet[\d/]+ |  |
@@ -47,7 +47,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].link_tracking.groups.[].name") | String |  |  |  | Tracking group name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;recovery_delay</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].link_tracking.groups.[].recovery_delay") | Integer |  |  | Min: 0<br>Max: 3600 | default -> platform_settings_mlag_reload_delay -> 300. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;links_minimum</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].link_tracking.groups.[].links_minimum") | Integer |  |  | Min: 1<br>Max: 100000 |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;uplink_type</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].uplink_type") | String |  | `p2p` | Valid Values:<br>- <code>p2p</code><br>- <code>port-channel</code> | Override the default `uplink_type` set at the `node_type_key` level.<br>Uplinks must be p2p if "vtep" or "underlay_router" is true. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;uplink_type</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].uplink_type") | String |  | `p2p` | Valid Values:<br>- <code>p2p</code><br>- <code>port-channel</code> | Override the default `uplink_type` set at the `node_type_key` level.<br>`uplink_type` must be "p2p" if `vtep` or `underlay_router` is true for the `node_type_key` definition. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;uplink_ipv4_pool</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].uplink_ipv4_pool") | String |  |  | Format: ipv4_cidr | IPv4 subnet to use to connect to uplink switches. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;uplink_interfaces</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].uplink_interfaces") | List, items: String |  |  |  | Local uplink interfaces<br>Each list item supports range syntax that can be expanded into a list of interfaces.<br>If uplink_interfaces is not defined, platform-specific defaults (defined under default_interfaces) will be used instead.<br>Please note that default_interfaces are not defined by default, you should define these yourself.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].uplink_interfaces.[]") | String |  |  | Pattern: Ethernet[\d/]+ |  |
@@ -75,7 +75,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "<node_type_keys.key>.node_groups.[].link_tracking.groups.[].name") | String |  |  |  | Tracking group name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;recovery_delay</samp>](## "<node_type_keys.key>.node_groups.[].link_tracking.groups.[].recovery_delay") | Integer |  |  | Min: 0<br>Max: 3600 | default -> platform_settings_mlag_reload_delay -> 300. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;links_minimum</samp>](## "<node_type_keys.key>.node_groups.[].link_tracking.groups.[].links_minimum") | Integer |  |  | Min: 1<br>Max: 100000 |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;uplink_type</samp>](## "<node_type_keys.key>.node_groups.[].uplink_type") | String |  | `p2p` | Valid Values:<br>- <code>p2p</code><br>- <code>port-channel</code> | Override the default `uplink_type` set at the `node_type_key` level.<br>Uplinks must be p2p if "vtep" or "underlay_router" is true. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;uplink_type</samp>](## "<node_type_keys.key>.node_groups.[].uplink_type") | String |  | `p2p` | Valid Values:<br>- <code>p2p</code><br>- <code>port-channel</code> | Override the default `uplink_type` set at the `node_type_key` level.<br>`uplink_type` must be "p2p" if `vtep` or `underlay_router` is true for the `node_type_key` definition. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;uplink_ipv4_pool</samp>](## "<node_type_keys.key>.node_groups.[].uplink_ipv4_pool") | String |  |  | Format: ipv4_cidr | IPv4 subnet to use to connect to uplink switches. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;uplink_interfaces</samp>](## "<node_type_keys.key>.node_groups.[].uplink_interfaces") | List, items: String |  |  |  | Local uplink interfaces<br>Each list item supports range syntax that can be expanded into a list of interfaces.<br>If uplink_interfaces is not defined, platform-specific defaults (defined under default_interfaces) will be used instead.<br>Please note that default_interfaces are not defined by default, you should define these yourself.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<node_type_keys.key>.node_groups.[].uplink_interfaces.[]") | String |  |  | Pattern: Ethernet[\d/]+ |  |
@@ -105,7 +105,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "<node_type_keys.key>.nodes.[].link_tracking.groups.[].name") | String |  |  |  | Tracking group name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;recovery_delay</samp>](## "<node_type_keys.key>.nodes.[].link_tracking.groups.[].recovery_delay") | Integer |  |  | Min: 0<br>Max: 3600 | default -> platform_settings_mlag_reload_delay -> 300. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;links_minimum</samp>](## "<node_type_keys.key>.nodes.[].link_tracking.groups.[].links_minimum") | Integer |  |  | Min: 1<br>Max: 100000 |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;uplink_type</samp>](## "<node_type_keys.key>.nodes.[].uplink_type") | String |  | `p2p` | Valid Values:<br>- <code>p2p</code><br>- <code>port-channel</code> | Override the default `uplink_type` set at the `node_type_key` level.<br>Uplinks must be p2p if "vtep" or "underlay_router" is true. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;uplink_type</samp>](## "<node_type_keys.key>.nodes.[].uplink_type") | String |  | `p2p` | Valid Values:<br>- <code>p2p</code><br>- <code>port-channel</code> | Override the default `uplink_type` set at the `node_type_key` level.<br>`uplink_type` must be "p2p" if `vtep` or `underlay_router` is true for the `node_type_key` definition. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;uplink_ipv4_pool</samp>](## "<node_type_keys.key>.nodes.[].uplink_ipv4_pool") | String |  |  | Format: ipv4_cidr | IPv4 subnet to use to connect to uplink switches. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;uplink_interfaces</samp>](## "<node_type_keys.key>.nodes.[].uplink_interfaces") | List, items: String |  |  |  | Local uplink interfaces<br>Each list item supports range syntax that can be expanded into a list of interfaces.<br>If uplink_interfaces is not defined, platform-specific defaults (defined under default_interfaces) will be used instead.<br>Please note that default_interfaces are not defined by default, you should define these yourself.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<node_type_keys.key>.nodes.[].uplink_interfaces.[]") | String |  |  | Pattern: Ethernet[\d/]+ |  |
@@ -154,7 +154,7 @@
               links_minimum: <int; 1-100000>
 
         # Override the default `uplink_type` set at the `node_type_key` level.
-        # Uplinks must be p2p if "vtep" or "underlay_router" is true.
+        # `uplink_type` must be "p2p" if `vtep` or `underlay_router` is true for the `node_type_key` definition.
         uplink_type: <str; "p2p" | "port-channel"; default="p2p">
 
         # IPv4 subnet to use to connect to uplink switches.
@@ -277,7 +277,7 @@
                     links_minimum: <int; 1-100000>
 
               # Override the default `uplink_type` set at the `node_type_key` level.
-              # Uplinks must be p2p if "vtep" or "underlay_router" is true.
+              # `uplink_type` must be "p2p" if `vtep` or `underlay_router` is true for the `node_type_key` definition.
               uplink_type: <str; "p2p" | "port-channel"; default="p2p">
 
               # IPv4 subnet to use to connect to uplink switches.
@@ -387,7 +387,7 @@
                 links_minimum: <int; 1-100000>
 
           # Override the default `uplink_type` set at the `node_type_key` level.
-          # Uplinks must be p2p if "vtep" or "underlay_router" is true.
+          # `uplink_type` must be "p2p" if `vtep` or `underlay_router` is true for the `node_type_key` definition.
           uplink_type: <str; "p2p" | "port-channel"; default="p2p">
 
           # IPv4 subnet to use to connect to uplink switches.
@@ -503,7 +503,7 @@
                 links_minimum: <int; 1-100000>
 
           # Override the default `uplink_type` set at the `node_type_key` level.
-          # Uplinks must be p2p if "vtep" or "underlay_router" is true.
+          # `uplink_type` must be "p2p" if `vtep` or `underlay_router` is true for the `node_type_key` definition.
           uplink_type: <str; "p2p" | "port-channel"; default="p2p">
 
           # IPv4 subnet to use to connect to uplink switches.

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/node-type-uplink-configuration.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/node-type-uplink-configuration.md
@@ -15,6 +15,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "<node_type_keys.key>.defaults.link_tracking.groups.[].name") | String |  |  |  | Tracking group name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;recovery_delay</samp>](## "<node_type_keys.key>.defaults.link_tracking.groups.[].recovery_delay") | Integer |  |  | Min: 0<br>Max: 3600 | default -> platform_settings_mlag_reload_delay -> 300. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;links_minimum</samp>](## "<node_type_keys.key>.defaults.link_tracking.groups.[].links_minimum") | Integer |  |  | Min: 1<br>Max: 100000 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;uplink_type</samp>](## "<node_type_keys.key>.defaults.uplink_type") | String |  | `p2p` | Valid Values:<br>- <code>p2p</code><br>- <code>port-channel</code> | Override the default `uplink_type` set at the `node_type_key` level.<br>Uplinks must be p2p if "vtep" or "underlay_router" is true. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;uplink_ipv4_pool</samp>](## "<node_type_keys.key>.defaults.uplink_ipv4_pool") | String |  |  | Format: ipv4_cidr | IPv4 subnet to use to connect to uplink switches. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;uplink_interfaces</samp>](## "<node_type_keys.key>.defaults.uplink_interfaces") | List, items: String |  |  |  | Local uplink interfaces<br>Each list item supports range syntax that can be expanded into a list of interfaces.<br>If uplink_interfaces is not defined, platform-specific defaults (defined under default_interfaces) will be used instead.<br>Please note that default_interfaces are not defined by default, you should define these yourself.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<node_type_keys.key>.defaults.uplink_interfaces.[]") | String |  |  | Pattern: Ethernet[\d/]+ |  |
@@ -46,6 +47,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].link_tracking.groups.[].name") | String |  |  |  | Tracking group name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;recovery_delay</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].link_tracking.groups.[].recovery_delay") | Integer |  |  | Min: 0<br>Max: 3600 | default -> platform_settings_mlag_reload_delay -> 300. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;links_minimum</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].link_tracking.groups.[].links_minimum") | Integer |  |  | Min: 1<br>Max: 100000 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;uplink_type</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].uplink_type") | String |  | `p2p` | Valid Values:<br>- <code>p2p</code><br>- <code>port-channel</code> | Override the default `uplink_type` set at the `node_type_key` level.<br>Uplinks must be p2p if "vtep" or "underlay_router" is true. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;uplink_ipv4_pool</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].uplink_ipv4_pool") | String |  |  | Format: ipv4_cidr | IPv4 subnet to use to connect to uplink switches. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;uplink_interfaces</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].uplink_interfaces") | List, items: String |  |  |  | Local uplink interfaces<br>Each list item supports range syntax that can be expanded into a list of interfaces.<br>If uplink_interfaces is not defined, platform-specific defaults (defined under default_interfaces) will be used instead.<br>Please note that default_interfaces are not defined by default, you should define these yourself.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].uplink_interfaces.[]") | String |  |  | Pattern: Ethernet[\d/]+ |  |
@@ -73,6 +75,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "<node_type_keys.key>.node_groups.[].link_tracking.groups.[].name") | String |  |  |  | Tracking group name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;recovery_delay</samp>](## "<node_type_keys.key>.node_groups.[].link_tracking.groups.[].recovery_delay") | Integer |  |  | Min: 0<br>Max: 3600 | default -> platform_settings_mlag_reload_delay -> 300. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;links_minimum</samp>](## "<node_type_keys.key>.node_groups.[].link_tracking.groups.[].links_minimum") | Integer |  |  | Min: 1<br>Max: 100000 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;uplink_type</samp>](## "<node_type_keys.key>.node_groups.[].uplink_type") | String |  | `p2p` | Valid Values:<br>- <code>p2p</code><br>- <code>port-channel</code> | Override the default `uplink_type` set at the `node_type_key` level.<br>Uplinks must be p2p if "vtep" or "underlay_router" is true. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;uplink_ipv4_pool</samp>](## "<node_type_keys.key>.node_groups.[].uplink_ipv4_pool") | String |  |  | Format: ipv4_cidr | IPv4 subnet to use to connect to uplink switches. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;uplink_interfaces</samp>](## "<node_type_keys.key>.node_groups.[].uplink_interfaces") | List, items: String |  |  |  | Local uplink interfaces<br>Each list item supports range syntax that can be expanded into a list of interfaces.<br>If uplink_interfaces is not defined, platform-specific defaults (defined under default_interfaces) will be used instead.<br>Please note that default_interfaces are not defined by default, you should define these yourself.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<node_type_keys.key>.node_groups.[].uplink_interfaces.[]") | String |  |  | Pattern: Ethernet[\d/]+ |  |
@@ -102,6 +105,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "<node_type_keys.key>.nodes.[].link_tracking.groups.[].name") | String |  |  |  | Tracking group name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;recovery_delay</samp>](## "<node_type_keys.key>.nodes.[].link_tracking.groups.[].recovery_delay") | Integer |  |  | Min: 0<br>Max: 3600 | default -> platform_settings_mlag_reload_delay -> 300. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;links_minimum</samp>](## "<node_type_keys.key>.nodes.[].link_tracking.groups.[].links_minimum") | Integer |  |  | Min: 1<br>Max: 100000 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;uplink_type</samp>](## "<node_type_keys.key>.nodes.[].uplink_type") | String |  | `p2p` | Valid Values:<br>- <code>p2p</code><br>- <code>port-channel</code> | Override the default `uplink_type` set at the `node_type_key` level.<br>Uplinks must be p2p if "vtep" or "underlay_router" is true. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;uplink_ipv4_pool</samp>](## "<node_type_keys.key>.nodes.[].uplink_ipv4_pool") | String |  |  | Format: ipv4_cidr | IPv4 subnet to use to connect to uplink switches. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;uplink_interfaces</samp>](## "<node_type_keys.key>.nodes.[].uplink_interfaces") | List, items: String |  |  |  | Local uplink interfaces<br>Each list item supports range syntax that can be expanded into a list of interfaces.<br>If uplink_interfaces is not defined, platform-specific defaults (defined under default_interfaces) will be used instead.<br>Please note that default_interfaces are not defined by default, you should define these yourself.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<node_type_keys.key>.nodes.[].uplink_interfaces.[]") | String |  |  | Pattern: Ethernet[\d/]+ |  |
@@ -148,6 +152,10 @@
               # default -> platform_settings_mlag_reload_delay -> 300.
               recovery_delay: <int; 0-3600>
               links_minimum: <int; 1-100000>
+
+        # Override the default `uplink_type` set at the `node_type_key` level.
+        # Uplinks must be p2p if "vtep" or "underlay_router" is true.
+        uplink_type: <str; "p2p" | "port-channel"; default="p2p">
 
         # IPv4 subnet to use to connect to uplink switches.
         uplink_ipv4_pool: <str>
@@ -268,6 +276,10 @@
                     recovery_delay: <int; 0-3600>
                     links_minimum: <int; 1-100000>
 
+              # Override the default `uplink_type` set at the `node_type_key` level.
+              # Uplinks must be p2p if "vtep" or "underlay_router" is true.
+              uplink_type: <str; "p2p" | "port-channel"; default="p2p">
+
               # IPv4 subnet to use to connect to uplink switches.
               uplink_ipv4_pool: <str>
 
@@ -373,6 +385,10 @@
                 # default -> platform_settings_mlag_reload_delay -> 300.
                 recovery_delay: <int; 0-3600>
                 links_minimum: <int; 1-100000>
+
+          # Override the default `uplink_type` set at the `node_type_key` level.
+          # Uplinks must be p2p if "vtep" or "underlay_router" is true.
+          uplink_type: <str; "p2p" | "port-channel"; default="p2p">
 
           # IPv4 subnet to use to connect to uplink switches.
           uplink_ipv4_pool: <str>
@@ -485,6 +501,10 @@
                 # default -> platform_settings_mlag_reload_delay -> 300.
                 recovery_delay: <int; 0-3600>
                 links_minimum: <int; 1-100000>
+
+          # Override the default `uplink_type` set at the `node_type_key` level.
+          # Uplinks must be p2p if "vtep" or "underlay_router" is true.
+          uplink_type: <str; "p2p" | "port-channel"; default="p2p">
 
           # IPv4 subnet to use to connect to uplink switches.
           uplink_ipv4_pool: <str>

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -9583,7 +9583,7 @@
               "port-channel"
             ],
             "default": "p2p",
-            "description": "Uplinks must be p2p if \"vtep\" or \"underlay_router\" is true.",
+            "description": "`uplink_type` must be \"p2p\" if `vtep` or `underlay_router` is true.",
             "title": "Uplink Type"
           },
           "vtep": {

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
@@ -5386,6 +5386,15 @@ $defs:
             description: Custom structured config for eos_cli_config_gen.
             type: dict
             $ref: eos_cli_config_gen#/
+          uplink_type:
+            documentation_options:
+              table: node-type-uplink-configuration
+            type: str
+            $ref: eos_designs#/keys/node_type_keys/items/keys/uplink_type
+            description: 'Override the default `uplink_type` set at the `node_type_key`
+              level.
+
+              Uplinks must be p2p if "vtep" or "underlay_router" is true.'
           uplink_ipv4_pool:
             documentation_options:
               table: node-type-uplink-configuration

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
@@ -1460,7 +1460,8 @@ keys:
           - p2p
           - port-channel
           default: p2p
-          description: Uplinks must be p2p if "vtep" or "underlay_router" is true.
+          description: '`uplink_type` must be "p2p" if `vtep` or `underlay_router`
+            is true.'
         vtep:
           type: bool
           default: false
@@ -5394,7 +5395,8 @@ $defs:
             description: 'Override the default `uplink_type` set at the `node_type_key`
               level.
 
-              Uplinks must be p2p if "vtep" or "underlay_router" is true.'
+              `uplink_type` must be "p2p" if `vtep` or `underlay_router` is true for
+              the `node_type_key` definition.'
           uplink_ipv4_pool:
             documentation_options:
               table: node-type-uplink-configuration

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/defs_node_type.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/defs_node_type.schema.yml
@@ -164,7 +164,7 @@ $defs:
             $ref: "eos_designs#/keys/node_type_keys/items/keys/uplink_type"
             description: |-
               Override the default `uplink_type` set at the `node_type_key` level.
-              Uplinks must be p2p if "vtep" or "underlay_router" is true.
+              `uplink_type` must be "p2p" if `vtep` or `underlay_router` is true for the `node_type_key` definition.
           uplink_ipv4_pool:
             documentation_options:
               table: node-type-uplink-configuration

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/defs_node_type.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/defs_node_type.schema.yml
@@ -157,6 +157,14 @@ $defs:
             description: Custom structured config for eos_cli_config_gen.
             type: dict
             $ref: "eos_cli_config_gen#/"
+          uplink_type:
+            documentation_options:
+              table: node-type-uplink-configuration
+            type: str
+            $ref: "eos_designs#/keys/node_type_keys/items/keys/uplink_type"
+            description: |-
+              Override the default `uplink_type` set at the `node_type_key` level.
+              Uplinks must be p2p if "vtep" or "underlay_router" is true.
           uplink_ipv4_pool:
             documentation_options:
               table: node-type-uplink-configuration

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/node_type_keys.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/node_type_keys.schema.yml
@@ -134,7 +134,8 @@ keys:
             - "p2p"
             - "port-channel"
           default: "p2p"
-          description: Uplinks must be p2p if "vtep" or "underlay_router" is true.
+          description: |-
+            `uplink_type` must be "p2p" if `vtep` or `underlay_router` is true.
         vtep:
           type: bool
           default: false


### PR DESCRIPTION
## Change Summary

Add the possibility to overwrite the uplink_type at the node level

the usecase is to be able to have a default uplink_type for a given node_type but be able to overwrite it at the nodes level

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

Added `uplink_type` via a ref in the node_type schema and make it having better preference in the shared_utils plugin

## How to test
molecule

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
