### PR TITLE
Feat(eos_cli_config_gen): Add support for logging format rfc5424

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/logging.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/logging.md
@@ -53,7 +53,7 @@ interface Management1
 | Timestamp | traditional year timezone |
 | Hostname | hostname |
 | Sequence-numbers | false |
-| RFC5424 | true |
+| RFC5424 | True |
 
 | VRF | Source Interface |
 | --- | ---------------- |

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/logging.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/logging.md
@@ -53,6 +53,7 @@ interface Management1
 | Timestamp | traditional year timezone |
 | Hostname | hostname |
 | Sequence-numbers | false |
+| RFC5424 | true |
 
 | VRF | Source Interface |
 | --- | ---------------- |
@@ -87,6 +88,7 @@ logging vrf mgt host 30.30.30.7 100 200 protocol tcp
 logging vrf mgt host 40.40.40.7 300 400
 logging vrf vrf_with_no_source_interface host 1.2.3.4
 logging format timestamp traditional year timezone
+logging format rfc5424
 logging source-interface Loopback0
 logging vrf mgt source-interface Management0
 ```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/logging.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/logging.cfg
@@ -16,6 +16,7 @@ logging vrf mgt host 30.30.30.7 100 200 protocol tcp
 logging vrf mgt host 40.40.40.7 300 400
 logging vrf vrf_with_no_source_interface host 1.2.3.4
 logging format timestamp traditional year timezone
+logging format rfc5424
 logging source-interface Loopback0
 logging vrf mgt source-interface Management0
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/logging.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/logging.yml
@@ -9,6 +9,7 @@ logging:
     level:
   format:
     timestamp: traditional year timezone
+    rfc5424: true
   source_interface:
   vrfs:
     - name: mgt

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/logging.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/logging.md
@@ -20,6 +20,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;timestamp</samp>](## "logging.format.timestamp") | String |  |  | Valid Values:<br>- <code>high-resolution</code><br>- <code>traditional</code><br>- <code>traditional timezone</code><br>- <code>traditional year</code><br>- <code>traditional timezone year</code><br>- <code>traditional year timezone</code> | Timestamp format |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;hostname</samp>](## "logging.format.hostname") | String |  |  | Valid Values:<br>- <code>fqdn</code><br>- <code>ipv4</code> | Hostname format in syslogs. For hostname _only_, remove the line. (default EOS CLI behaviour). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;sequence_numbers</samp>](## "logging.format.sequence_numbers") | Boolean |  |  |  | Add sequence numbers to log messages<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;rfc5424</samp>](## "logging.format.rfc5424") | Boolean |  |  |  | Forward logs in RFC5424 format<br> |
     | [<samp>&nbsp;&nbsp;facility</samp>](## "logging.facility") | String |  |  | Valid Values:<br>- <code>auth</code><br>- <code>cron</code><br>- <code>daemon</code><br>- <code>kern</code><br>- <code>local0</code><br>- <code>local1</code><br>- <code>local2</code><br>- <code>local3</code><br>- <code>local4</code><br>- <code>local5</code><br>- <code>local6</code><br>- <code>local7</code><br>- <code>lpr</code><br>- <code>mail</code><br>- <code>news</code><br>- <code>sys9</code><br>- <code>sys10</code><br>- <code>sys11</code><br>- <code>sys12</code><br>- <code>sys13</code><br>- <code>sys14</code><br>- <code>syslog</code><br>- <code>user</code><br>- <code>uucp</code> |  |
     | [<samp>&nbsp;&nbsp;source_interface</samp>](## "logging.source_interface") | String |  |  |  | Source Interface Name |
     | [<samp>&nbsp;&nbsp;vrfs</samp>](## "logging.vrfs") | List, items: Dictionary |  |  |  |  |
@@ -73,6 +74,9 @@
 
         # Add sequence numbers to log messages
         sequence_numbers: <bool>
+
+        # Forward logs in RFC5424 format
+        rfc5424: <bool>
       facility: <str; "auth" | "cron" | "daemon" | "kern" | "local0" | "local1" | "local2" | "local3" | "local4" | "local5" | "local6" | "local7" | "lpr" | "mail" | "news" | "sys9" | "sys10" | "sys11" | "sys12" | "sys13" | "sys14" | "syslog" | "user" | "uucp">
 
       # Source Interface Name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -7680,6 +7680,11 @@
               "type": "boolean",
               "description": "Add sequence numbers to log messages\n",
               "title": "Sequence Numbers"
+            },
+            "rfc5424": {
+              "type": "boolean",
+              "description": "Forward logs in RFC5424 format\n",
+              "title": "RFC5424"
             }
           },
           "additionalProperties": false,

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -7684,7 +7684,7 @@
             "rfc5424": {
               "type": "boolean",
               "description": "Forward logs in RFC5424 format\n",
-              "title": "RFC5424"
+              "title": "Rfc5424"
             }
           },
           "additionalProperties": false,

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -4508,6 +4508,11 @@ keys:
             description: 'Add sequence numbers to log messages
 
               '
+          rfc5424:
+            type: bool
+            description: 'Forward logs in RFC5424 format
+
+              '
       facility:
         type: str
         valid_values:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/logging.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/logging.schema.yml
@@ -62,6 +62,10 @@ keys:
             type: bool
             description: |
               Add sequence numbers to log messages
+          rfc5424:
+            type: bool
+            description: |
+              Forward logs in RFC5424 format
       facility:
         type: str
         valid_values: ["auth", "cron", "daemon", "kern", "local0", "local1", "local2", "local3", "local4",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/logging.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/logging.j2
@@ -44,11 +44,7 @@
 {%         else %}
 | Sequence-numbers | false |
 {%         endif %}
-{%         if logging.format.rfc5424 is arista.avd.defined(true) %}
-| RFC5424 | true |
-{%         else %}
-| RFC5424 | false |
-{%         endif %}
+| RFC5424 | {{ logging.format.rfc5424 | arista.avd.default(false) }} |
 {%     endif %}
 {%     if logging.vrfs is arista.avd.defined %}
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/logging.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/logging.j2
@@ -44,6 +44,11 @@
 {%         else %}
 | Sequence-numbers | false |
 {%         endif %}
+{%         if logging.format.rfc5424 is arista.avd.defined(true) %}
+| RFC5424 | true |
+{%         else %}
+| RFC5424 | false |
+{%         endif %}
 {%     endif %}
 {%     if logging.vrfs is arista.avd.defined %}
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/logging.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/logging.j2
@@ -63,6 +63,9 @@ logging synchronous level {{ logging.synchronous.level | arista.avd.default("cri
 {%     if logging.format.timestamp is arista.avd.defined %}
 logging format timestamp {{ logging.format.timestamp }}
 {%     endif %}
+{%     if logging.format.rfc5424 is arista.avd.defined(true) %}
+logging format rfc5424
+{%     endif %}
 {%     if logging.format.hostname is arista.avd.defined('fqdn') %}
 logging format hostname fqdn
 {%     elif logging.format.hostname is arista.avd.defined('ipv4') %}
@@ -70,9 +73,6 @@ logging format hostname ipv4
 {%     endif %}
 {%     if logging.format.sequence_numbers is arista.avd.defined(true) %}
 logging format sequence-numbers
-{%     endif %}
-{%     if logging.format.rfc5424 is arista.avd.defined(true) %}
-logging format rfc5424
 {%     endif %}
 {%     if logging.facility is arista.avd.defined %}
 logging facility {{ logging.facility }}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/logging.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/logging.j2
@@ -71,6 +71,9 @@ logging format hostname ipv4
 {%     if logging.format.sequence_numbers is arista.avd.defined(true) %}
 logging format sequence-numbers
 {%     endif %}
+{%     if logging.format.rfc5424 is arista.avd.defined(true) %}
+logging format rfc5424
+{%     endif %}
 {%     if logging.facility is arista.avd.defined %}
 logging facility {{ logging.facility }}
 {%     endif %}


### PR DESCRIPTION
## Change Summary

This PR adds support for `logging format rfc5424`

## Related Issue(s)

Fixes #3365

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
This adds support for `logging format rfc5424`.
It adds the templates, documentation and schemas for this.

## How to test
I'm not sure how to run tests. I'm using vscode and the dev-container included in the repo.
I'm familiar with Makefiles from *BSD, but not while developing.

See separate comment below.

## Checklist

### User Checklist


### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
