### PR TITLE
Refactor(eos_designs): Reorder BGP address family rendering for overlay module

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LER1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LER1.yml
@@ -22,10 +22,6 @@ router_bgp:
     send_community: all
     maximum_routes: 0
     remote_as: '65000'
-  address_family_ipv4:
-    peer_groups:
-    - name: MPLS-OVERLAY-PEERS
-      activate: false
   address_family_evpn:
     neighbor_default:
       encapsulation: mpls
@@ -33,6 +29,10 @@ router_bgp:
     peer_groups:
     - name: MPLS-OVERLAY-PEERS
       activate: true
+  address_family_ipv4:
+    peer_groups:
+    - name: MPLS-OVERLAY-PEERS
+      activate: false
   neighbors:
   - ip_address: 100.70.0.8
     peer_group: MPLS-OVERLAY-PEERS

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LER2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LER2.yml
@@ -22,10 +22,6 @@ router_bgp:
     send_community: all
     maximum_routes: 0
     remote_as: '65000'
-  address_family_ipv4:
-    peer_groups:
-    - name: MPLS-OVERLAY-PEERS
-      activate: false
   address_family_evpn:
     neighbor_default:
       encapsulation: mpls
@@ -33,6 +29,10 @@ router_bgp:
     peer_groups:
     - name: MPLS-OVERLAY-PEERS
       activate: true
+  address_family_ipv4:
+    peer_groups:
+    - name: MPLS-OVERLAY-PEERS
+      activate: false
   address_family_vpn_ipv4:
     neighbor_default_encapsulation_mpls_next_hop_self:
       source_interface: Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-RR1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-RR1.yml
@@ -33,12 +33,6 @@ router_bgp:
     send_community: all
     maximum_routes: 0
     remote_as: '65000'
-  address_family_ipv4:
-    peer_groups:
-    - name: MPLS-OVERLAY-PEERS
-      activate: false
-    - name: RR-OVERLAY-PEERS
-      activate: false
   address_family_evpn:
     neighbor_default:
       encapsulation: mpls
@@ -47,6 +41,12 @@ router_bgp:
       activate: true
     - name: RR-OVERLAY-PEERS
       activate: true
+  address_family_ipv4:
+    peer_groups:
+    - name: MPLS-OVERLAY-PEERS
+      activate: false
+    - name: RR-OVERLAY-PEERS
+      activate: false
   address_family_vpn_ipv4:
     peer_groups:
     - name: MPLS-OVERLAY-PEERS

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE2-LER1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE2-LER1.yml
@@ -22,10 +22,6 @@ router_bgp:
     send_community: all
     maximum_routes: 0
     remote_as: '65000'
-  address_family_ipv4:
-    peer_groups:
-    - name: MPLS-OVERLAY-PEERS
-      activate: false
   address_family_evpn:
     neighbor_default:
       encapsulation: mpls
@@ -33,6 +29,10 @@ router_bgp:
     peer_groups:
     - name: MPLS-OVERLAY-PEERS
       activate: true
+  address_family_ipv4:
+    peer_groups:
+    - name: MPLS-OVERLAY-PEERS
+      activate: false
   address_family_vpn_ipv4:
     neighbor_default_encapsulation_mpls_next_hop_self:
       source_interface: Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE2-RR1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE2-RR1.yml
@@ -33,12 +33,6 @@ router_bgp:
     send_community: all
     maximum_routes: 0
     remote_as: '65000'
-  address_family_ipv4:
-    peer_groups:
-    - name: MPLS-OVERLAY-PEERS
-      activate: false
-    - name: RR-OVERLAY-PEERS
-      activate: false
   address_family_evpn:
     neighbor_default:
       encapsulation: mpls
@@ -47,6 +41,12 @@ router_bgp:
       activate: true
     - name: RR-OVERLAY-PEERS
       activate: true
+  address_family_ipv4:
+    peer_groups:
+    - name: MPLS-OVERLAY-PEERS
+      activate: false
+    - name: RR-OVERLAY-PEERS
+      activate: false
   address_family_vpn_ipv4:
     peer_groups:
     - name: MPLS-OVERLAY-PEERS

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG-OSPF-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG-OSPF-L3LEAF1A.yml
@@ -20,10 +20,6 @@ router_bgp:
     send_community: all
     maximum_routes: 0
     ebgp_multihop: 3
-  address_family_ipv4:
-    peer_groups:
-    - name: EVPN-OVERLAY-PEERS
-      activate: false
   address_family_evpn:
     peer_groups:
     - name: EVPN-OVERLAY-PEERS
@@ -33,6 +29,10 @@ router_bgp:
       threshold: 5
       enabled: true
       expiry_timeout: 10
+  address_family_ipv4:
+    peer_groups:
+    - name: EVPN-OVERLAY-PEERS
+      activate: false
   neighbors:
   - ip_address: 192.168.255.1
     peer_group: EVPN-OVERLAY-PEERS

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG-OSPF-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG-OSPF-L3LEAF1B.yml
@@ -20,10 +20,6 @@ router_bgp:
     send_community: all
     maximum_routes: 0
     ebgp_multihop: 3
-  address_family_ipv4:
-    peer_groups:
-    - name: EVPN-OVERLAY-PEERS
-      activate: false
   address_family_evpn:
     peer_groups:
     - name: EVPN-OVERLAY-PEERS
@@ -33,6 +29,10 @@ router_bgp:
       threshold: 5
       enabled: true
       expiry_timeout: 10
+  address_family_ipv4:
+    peer_groups:
+    - name: EVPN-OVERLAY-PEERS
+      activate: false
   neighbors:
   - ip_address: 192.168.255.1
     peer_group: EVPN-OVERLAY-PEERS

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-3.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-3.yml
@@ -29,12 +29,6 @@ router_bgp:
     send_community: all
     maximum_routes: 0
     description: Description for ipvpn_gateway_peers via structured_config
-  address_family_ipv4:
-    peer_groups:
-    - name: MPLS-OVERLAY-PEERS
-      activate: false
-    - name: IPVPN-GATEWAY-PEERS
-      activate: false
   address_family_evpn:
     neighbor_default:
       encapsulation: mpls
@@ -43,6 +37,12 @@ router_bgp:
     - name: MPLS-OVERLAY-PEERS
       activate: true
     domain_identifier: '65535:1'
+  address_family_ipv4:
+    peer_groups:
+    - name: MPLS-OVERLAY-PEERS
+      activate: false
+    - name: IPVPN-GATEWAY-PEERS
+      activate: false
   address_family_vpn_ipv4:
     neighbor_default_encapsulation_mpls_next_hop_self:
       source_interface: Loopback0

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-BL1A.yml
@@ -22,16 +22,16 @@ router_bgp:
     send_community: all
     maximum_routes: 0
     remote_as: '65000'
-  address_family_ipv4:
-    peer_groups:
-    - name: OVERLAY-PEERS
-      activate: false
   address_family_evpn:
     peer_groups:
     - name: OVERLAY-PEERS
       activate: true
       route_map_in: RM-EVPN-SOO-IN
       route_map_out: RM-EVPN-SOO-OUT
+  address_family_ipv4:
+    peer_groups:
+    - name: OVERLAY-PEERS
+      activate: false
   neighbors:
   - ip_address: 192.168.255.1
     peer_group: OVERLAY-PEERS

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-BL1B.yml
@@ -22,16 +22,16 @@ router_bgp:
     send_community: all
     maximum_routes: 0
     remote_as: '65000'
-  address_family_ipv4:
-    peer_groups:
-    - name: OVERLAY-PEERS
-      activate: false
   address_family_evpn:
     peer_groups:
     - name: OVERLAY-PEERS
       activate: true
       route_map_in: RM-EVPN-SOO-IN
       route_map_out: RM-EVPN-SOO-OUT
+  address_family_ipv4:
+    peer_groups:
+    - name: OVERLAY-PEERS
+      activate: false
   neighbors:
   - ip_address: 192.168.255.1
     peer_group: OVERLAY-PEERS

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF1A.yml
@@ -22,16 +22,16 @@ router_bgp:
     send_community: all
     maximum_routes: 0
     remote_as: '65000'
-  address_family_ipv4:
-    peer_groups:
-    - name: OVERLAY-PEERS
-      activate: false
   address_family_evpn:
     peer_groups:
     - name: OVERLAY-PEERS
       activate: true
       route_map_in: RM-EVPN-SOO-IN
       route_map_out: RM-EVPN-SOO-OUT
+  address_family_ipv4:
+    peer_groups:
+    - name: OVERLAY-PEERS
+      activate: false
   neighbors:
   - ip_address: 192.168.255.1
     peer_group: OVERLAY-PEERS

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -22,16 +22,16 @@ router_bgp:
     send_community: all
     maximum_routes: 0
     remote_as: '65000'
-  address_family_ipv4:
-    peer_groups:
-    - name: OVERLAY-PEERS
-      activate: false
   address_family_evpn:
     peer_groups:
     - name: OVERLAY-PEERS
       activate: true
       route_map_in: RM-EVPN-SOO-IN
       route_map_out: RM-EVPN-SOO-OUT
+  address_family_ipv4:
+    peer_groups:
+    - name: OVERLAY-PEERS
+      activate: false
   neighbors:
   - ip_address: 192.168.255.1
     peer_group: OVERLAY-PEERS

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -22,16 +22,16 @@ router_bgp:
     send_community: all
     maximum_routes: 0
     remote_as: '65000'
-  address_family_ipv4:
-    peer_groups:
-    - name: OVERLAY-PEERS
-      activate: false
   address_family_evpn:
     peer_groups:
     - name: OVERLAY-PEERS
       activate: true
       route_map_in: RM-EVPN-SOO-IN
       route_map_out: RM-EVPN-SOO-OUT
+  address_family_ipv4:
+    peer_groups:
+    - name: OVERLAY-PEERS
+      activate: false
   neighbors:
   - ip_address: 192.168.255.1
     peer_group: OVERLAY-PEERS

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SPINE1.yml
@@ -24,14 +24,14 @@ router_bgp:
     maximum_routes: 0
     remote_as: '65000'
     route_reflector_client: true
-  address_family_ipv4:
-    peer_groups:
-    - name: OVERLAY-PEERS
-      activate: false
   address_family_evpn:
     peer_groups:
     - name: OVERLAY-PEERS
       activate: true
+  address_family_ipv4:
+    peer_groups:
+    - name: OVERLAY-PEERS
+      activate: false
   neighbors:
   - ip_address: 192.168.255.10
     peer_group: OVERLAY-PEERS

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SPINE4.yml
@@ -24,14 +24,14 @@ router_bgp:
     maximum_routes: 0
     remote_as: '65000'
     route_reflector_client: true
-  address_family_ipv4:
-    peer_groups:
-    - name: OVERLAY-PEERS
-      activate: false
   address_family_evpn:
     peer_groups:
     - name: OVERLAY-PEERS
       activate: true
+  address_family_ipv4:
+    peer_groups:
+    - name: OVERLAY-PEERS
+      activate: false
   neighbors:
   - ip_address: 192.168.255.10
     peer_group: OVERLAY-PEERS

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SVC3A.yml
@@ -22,16 +22,16 @@ router_bgp:
     send_community: all
     maximum_routes: 0
     remote_as: '65000'
-  address_family_ipv4:
-    peer_groups:
-    - name: OVERLAY-PEERS
-      activate: false
   address_family_evpn:
     peer_groups:
     - name: OVERLAY-PEERS
       activate: true
       route_map_in: RM-EVPN-SOO-IN
       route_map_out: RM-EVPN-SOO-OUT
+  address_family_ipv4:
+    peer_groups:
+    - name: OVERLAY-PEERS
+      activate: false
   neighbors:
   - ip_address: 192.168.255.1
     peer_group: OVERLAY-PEERS

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SVC3B.yml
@@ -22,16 +22,16 @@ router_bgp:
     send_community: all
     maximum_routes: 0
     remote_as: '65000'
-  address_family_ipv4:
-    peer_groups:
-    - name: OVERLAY-PEERS
-      activate: false
   address_family_evpn:
     peer_groups:
     - name: OVERLAY-PEERS
       activate: true
       route_map_in: RM-EVPN-SOO-IN
       route_map_out: RM-EVPN-SOO-OUT
+  address_family_ipv4:
+    peer_groups:
+    - name: OVERLAY-PEERS
+      activate: false
   neighbors:
   - ip_address: 192.168.255.1
     peer_group: OVERLAY-PEERS

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
@@ -22,10 +22,6 @@ router_bgp:
     send_community: all
     maximum_routes: 0
     ebgp_multihop: 3
-  address_family_ipv4:
-    peer_groups:
-    - name: EVPN-OVERLAY-PEERS
-      activate: false
   address_family_evpn:
     peer_groups:
     - name: EVPN-OVERLAY-PEERS
@@ -34,6 +30,10 @@ router_bgp:
       window: 180
       threshold: 30
       enabled: true
+  address_family_ipv4:
+    peer_groups:
+    - name: EVPN-OVERLAY-PEERS
+      activate: false
   neighbors:
   - ip_address: 192.168.255.1
     peer_group: EVPN-OVERLAY-PEERS

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
@@ -22,10 +22,6 @@ router_bgp:
     send_community: all
     maximum_routes: 0
     ebgp_multihop: 3
-  address_family_ipv4:
-    peer_groups:
-    - name: EVPN-OVERLAY-PEERS
-      activate: false
   address_family_evpn:
     peer_groups:
     - name: EVPN-OVERLAY-PEERS
@@ -34,6 +30,10 @@ router_bgp:
       window: 180
       threshold: 30
       enabled: true
+  address_family_ipv4:
+    peer_groups:
+    - name: EVPN-OVERLAY-PEERS
+      activate: false
   neighbors:
   - ip_address: 192.168.255.1
     peer_group: EVPN-OVERLAY-PEERS

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
@@ -22,10 +22,6 @@ router_bgp:
     send_community: all
     maximum_routes: 0
     ebgp_multihop: 3
-  address_family_ipv4:
-    peer_groups:
-    - name: EVPN-OVERLAY-PEERS
-      activate: false
   address_family_evpn:
     peer_groups:
     - name: EVPN-OVERLAY-PEERS
@@ -34,6 +30,10 @@ router_bgp:
       window: 180
       threshold: 30
       enabled: true
+  address_family_ipv4:
+    peer_groups:
+    - name: EVPN-OVERLAY-PEERS
+      activate: false
   neighbors:
   - ip_address: 192.168.255.1
     peer_group: EVPN-OVERLAY-PEERS

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -31,12 +31,6 @@ router_bgp:
     maximum_routes: 12000
     send_community: all
     route_map_in: RM-MLAG-PEER-IN
-  address_family_ipv4:
-    peer_groups:
-    - name: EVPN-OVERLAY-PEERS
-      activate: false
-    - name: MLAG-IPv4-UNDERLAY-PEER
-      activate: true
   address_family_evpn:
     peer_groups:
     - name: EVPN-OVERLAY-PEERS
@@ -45,6 +39,12 @@ router_bgp:
       window: 180
       threshold: 30
       enabled: true
+  address_family_ipv4:
+    peer_groups:
+    - name: EVPN-OVERLAY-PEERS
+      activate: false
+    - name: MLAG-IPv4-UNDERLAY-PEER
+      activate: true
   neighbors:
   - ip_address: 192.168.255.1
     peer_group: EVPN-OVERLAY-PEERS

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -31,12 +31,6 @@ router_bgp:
     maximum_routes: 12000
     send_community: all
     route_map_in: RM-MLAG-PEER-IN
-  address_family_ipv4:
-    peer_groups:
-    - name: EVPN-OVERLAY-PEERS
-      activate: false
-    - name: MLAG-IPv4-UNDERLAY-PEER
-      activate: true
   address_family_evpn:
     peer_groups:
     - name: EVPN-OVERLAY-PEERS
@@ -45,6 +39,12 @@ router_bgp:
       window: 180
       threshold: 30
       enabled: true
+  address_family_ipv4:
+    peer_groups:
+    - name: EVPN-OVERLAY-PEERS
+      activate: false
+    - name: MLAG-IPv4-UNDERLAY-PEER
+      activate: true
   neighbors:
   - ip_address: 192.168.255.1
     peer_group: EVPN-OVERLAY-PEERS

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SPINE1.yml
@@ -23,14 +23,14 @@ router_bgp:
     maximum_routes: 0
     ebgp_multihop: 3
     next_hop_unchanged: true
-  address_family_ipv4:
-    peer_groups:
-    - name: EVPN-OVERLAY-PEERS
-      activate: false
   address_family_evpn:
     peer_groups:
     - name: EVPN-OVERLAY-PEERS
       activate: true
+  address_family_ipv4:
+    peer_groups:
+    - name: EVPN-OVERLAY-PEERS
+      activate: false
   neighbors:
   - ip_address: 192.168.255.10
     peer_group: EVPN-OVERLAY-PEERS

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SPINE2.yml
@@ -23,14 +23,14 @@ router_bgp:
     maximum_routes: 0
     ebgp_multihop: 3
     next_hop_unchanged: true
-  address_family_ipv4:
-    peer_groups:
-    - name: EVPN-OVERLAY-PEERS
-      activate: false
   address_family_evpn:
     peer_groups:
     - name: EVPN-OVERLAY-PEERS
       activate: true
+  address_family_ipv4:
+    peer_groups:
+    - name: EVPN-OVERLAY-PEERS
+      activate: false
   neighbors:
   - ip_address: 192.168.255.10
     peer_group: EVPN-OVERLAY-PEERS

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SPINE3.yml
@@ -23,14 +23,14 @@ router_bgp:
     maximum_routes: 0
     ebgp_multihop: 3
     next_hop_unchanged: true
-  address_family_ipv4:
-    peer_groups:
-    - name: EVPN-OVERLAY-PEERS
-      activate: false
   address_family_evpn:
     peer_groups:
     - name: EVPN-OVERLAY-PEERS
       activate: true
+  address_family_ipv4:
+    peer_groups:
+    - name: EVPN-OVERLAY-PEERS
+      activate: false
   neighbors:
   - ip_address: 192.168.255.10
     peer_group: EVPN-OVERLAY-PEERS

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SPINE4.yml
@@ -23,14 +23,14 @@ router_bgp:
     maximum_routes: 0
     ebgp_multihop: 3
     next_hop_unchanged: true
-  address_family_ipv4:
-    peer_groups:
-    - name: EVPN-OVERLAY-PEERS
-      activate: false
   address_family_evpn:
     peer_groups:
     - name: EVPN-OVERLAY-PEERS
       activate: true
+  address_family_ipv4:
+    peer_groups:
+    - name: EVPN-OVERLAY-PEERS
+      activate: false
   neighbors:
   - ip_address: 192.168.255.10
     peer_group: EVPN-OVERLAY-PEERS

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -31,12 +31,6 @@ router_bgp:
     maximum_routes: 12000
     send_community: all
     route_map_in: RM-MLAG-PEER-IN
-  address_family_ipv4:
-    peer_groups:
-    - name: EVPN-OVERLAY-PEERS
-      activate: false
-    - name: MLAG-IPv4-UNDERLAY-PEER
-      activate: true
   address_family_evpn:
     peer_groups:
     - name: EVPN-OVERLAY-PEERS
@@ -45,6 +39,12 @@ router_bgp:
       window: 180
       threshold: 30
       enabled: true
+  address_family_ipv4:
+    peer_groups:
+    - name: EVPN-OVERLAY-PEERS
+      activate: false
+    - name: MLAG-IPv4-UNDERLAY-PEER
+      activate: true
   neighbors:
   - ip_address: 192.168.255.1
     peer_group: EVPN-OVERLAY-PEERS

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -31,12 +31,6 @@ router_bgp:
     maximum_routes: 12000
     send_community: all
     route_map_in: RM-MLAG-PEER-IN
-  address_family_ipv4:
-    peer_groups:
-    - name: EVPN-OVERLAY-PEERS
-      activate: false
-    - name: MLAG-IPv4-UNDERLAY-PEER
-      activate: true
   address_family_evpn:
     peer_groups:
     - name: EVPN-OVERLAY-PEERS
@@ -45,6 +39,12 @@ router_bgp:
       window: 180
       threshold: 30
       enabled: true
+  address_family_ipv4:
+    peer_groups:
+    - name: EVPN-OVERLAY-PEERS
+      activate: false
+    - name: MLAG-IPv4-UNDERLAY-PEER
+      activate: true
   neighbors:
   - ip_address: 192.168.255.1
     peer_group: EVPN-OVERLAY-PEERS

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/overlay/router_bgp.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/overlay/router_bgp.py
@@ -30,8 +30,8 @@ class RouterBgpMixin(UtilsMixin):
         router_bgp = {
             "bgp_cluster_id": self._bgp_cluster_id(),
             "peer_groups": self._peer_groups(),
-            "address_family_ipv4": self._address_family_ipv4(),
             "address_family_evpn": self._address_family_evpn(),
+            "address_family_ipv4": self._address_family_ipv4(),
             "address_family_rtc": self._address_family_rtc(),
             "bgp": self._bgp_overlay_dpath(),
             "address_family_vpn_ipv4": self._address_family_vpn_ipvx(4),


### PR DESCRIPTION
## Change Summary

AF evpn is rendered before AF ipv4 in router_bgp so fixing this

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

switched two lines of code - cf rendering difference in one molecule scenario

## How to test

check molecule

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
