### PR TITLE
CI: Molecule remove create from create_sequence

### DIFF
--- a/ansible_collections/arista/avd/molecule/dhcp_configuration/molecule.yml
+++ b/ansible_collections/arista/avd/molecule/dhcp_configuration/molecule.yml
@@ -2,7 +2,6 @@
 scenario:
   create_sequence:
     - dependency
-    - create
     - prepare
   converge_sequence:
     - dependency

--- a/ansible_collections/arista/avd/molecule/dhcp_provisioning/molecule.yml
+++ b/ansible_collections/arista/avd/molecule/dhcp_provisioning/molecule.yml
@@ -3,7 +3,6 @@
 scenario:
   create_sequence:
     - dependency
-    - create
     - prepare
   converge_sequence:
     - dependency

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/molecule.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/molecule.yml
@@ -2,7 +2,6 @@
 scenario:
   converge_sequence:
     - syntax
-    - create
     - converge
   test_sequence:
     - syntax

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/molecule.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/molecule.yml
@@ -2,7 +2,6 @@
 scenario:
   converge_sequence:
     - syntax
-    - create
     - converge
   test_sequence:
     - syntax

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_negative_unit_tests/molecule.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_negative_unit_tests/molecule.yml
@@ -2,7 +2,6 @@
 scenario:
   converge_sequence:
     - syntax
-    - create
     - converge
   test_sequence:
     - syntax

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/molecule.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/molecule.yml
@@ -2,7 +2,6 @@
 scenario:
   converge_sequence:
     - syntax
-    - create
     - converge
   test_sequence:
     - syntax

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/molecule.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/molecule.yml
@@ -2,7 +2,6 @@
 scenario:
   converge_sequence:
     - syntax
-    - create
     - converge
     - verify
   test_sequence:

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/molecule.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/molecule.yml
@@ -2,7 +2,6 @@
 scenario:
   converge_sequence:
     - syntax
-    - create
     - converge
     - verify
   test_sequence:

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/molecule.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/molecule.yml
@@ -2,7 +2,6 @@
 scenario:
   converge_sequence:
     - syntax
-    - create
     - converge
     - verify
   test_sequence:

--- a/ansible_collections/arista/avd/molecule/eos_designs_deprecated_vars/molecule.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_deprecated_vars/molecule.yml
@@ -2,7 +2,6 @@
 scenario:
   converge_sequence:
     - syntax
-    - create
     - converge
     - verify
   test_sequence:

--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/molecule.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/molecule.yml
@@ -2,7 +2,6 @@
 scenario:
   converge_sequence:
     - syntax
-    - create
     - converge
     - verify
   test_sequence:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/molecule.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/molecule.yml
@@ -2,7 +2,6 @@
 scenario:
   converge_sequence:
     - syntax
-    - create
     - converge
     - verify
   test_sequence:

--- a/ansible_collections/arista/avd/molecule/eos_validate_state/molecule.yml
+++ b/ansible_collections/arista/avd/molecule/eos_validate_state/molecule.yml
@@ -1,7 +1,6 @@
 ---
 scenario:
   converge_sequence:
-    - create
     - converge
   test_sequence:
     - create

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/molecule.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/molecule.yml
@@ -2,7 +2,6 @@
 scenario:
   converge_sequence:
     - syntax
-    - create
     - converge
     - verify
   test_sequence:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/molecule.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/molecule.yml
@@ -2,7 +2,6 @@
 scenario:
   converge_sequence:
     - syntax
-    - create
     - converge
     - verify
   test_sequence:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/molecule.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/molecule.yml
@@ -2,7 +2,6 @@
 scenario:
   converge_sequence:
     - syntax
-    - create
     - converge
     - verify
   test_sequence:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/molecule.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/molecule.yml
@@ -2,7 +2,6 @@
 scenario:
   converge_sequence:
     - syntax
-    - create
     - converge
     - verify
   test_sequence:


### PR DESCRIPTION
## Change Summary

Upgrade molecule scenarios to support running with `--limit` during development.
It doesn't impact how we run CI

