### PR TITLE
Bump: ansible collection dependencies

### DIFF
--- a/ansible_collections/arista/avd/collections.yml
+++ b/ansible_collections/arista/avd/collections.yml
@@ -1,8 +1,8 @@
 # collection requirements leveraged by molecule etc
 collections:
   - name: arista.cvp
-    version: ">=3.6.1"
+    version: ">=3.10.1"
   - name: arista.eos
-    version: ">=6.0.1"
+    version: ">=7.0.0"
   - name: ansible.utils
-    version: ">=2.10.3"
+    version: ">=3.0.0"

--- a/ansible_collections/arista/avd/docs/release-notes/4.x.x.md
+++ b/ansible_collections/arista/avd/docs/release-notes/4.x.x.md
@@ -16,14 +16,15 @@ title: Release Notes for Ansible AVD 4.x.x
 
 ### Changes to requirements
 
-- Minimum Python version is now 3.9
-- Minimum Ansible-core version is now 2.14
-- Minimum Jinja2 version is now 3.0.0
-- Minimum PyYAML version is now 6.0.0
-- AVD now requires the minumum versions of the following Ansible collections:
-  - arista.cvp version 3.10.1 or later.
-  - arista.eos version 7.0.0 or later.
-  - ansible.utils version 3.0.0 or later.
+- Changed Python requirements:
+  - Minimum Python version 3.9
+  - Minimum `ansible-core` version 2.14
+  - Minimum `jinja2` version 3.0.0
+  - Minimum `PyYAML` version 6.0.0
+- Changed Ansible collection requirements:
+  - Minimum `arista.cvp` version 3.10.1.
+  - Minimum `arista.eos` version 7.0.0.
+  - Minimum `ansible.utils` version 3.0.0.
 
 All requirements will be enforced during each run of AVD roles.
 

--- a/ansible_collections/arista/avd/docs/release-notes/4.x.x.md
+++ b/ansible_collections/arista/avd/docs/release-notes/4.x.x.md
@@ -20,6 +20,10 @@ title: Release Notes for Ansible AVD 4.x.x
 - Minimum Ansible-core version is now 2.14
 - Minimum Jinja2 version is now 3.0.0
 - Minimum PyYAML version is now 6.0.0
+- AVD now requires the minumum versions of the following Ansible collections:
+  - arista.cvp version 3.10.1 or later.
+  - arista.eos version 7.0.0 or later.
+  - ansible.utils version 3.0.0 or later.
 
 All requirements will be enforced during each run of AVD roles.
 

--- a/ansible_collections/arista/avd/galaxy.yml
+++ b/ansible_collections/arista/avd/galaxy.yml
@@ -36,9 +36,9 @@ tags: ['arista', 'network', 'networking', 'eos', 'avd', 'cloudvision', 'cvp']
 # L(specifiers,https://python-semanticversion.readthedocs.io/en/latest/#requirement-specification). Multiple version
 # range specifiers can be set and are separated by ','
 dependencies:
-    "arista.cvp": ">=3.6.1"
-    "arista.eos": ">=6.0.1"
-    "ansible.utils": ">=2.10.3"
+    "arista.cvp": ">=3.10.1"
+    "arista.eos": ">=7.0.0"
+    "ansible.utils": ">=3.0.0"
 
 # The URL of the originating SCM repository
 repository: https://github.com/aristanetworks/ansible-avd


### PR DESCRIPTION
## Change Summary

Bump ansible dependencies version for the minimum ansible-core version of 2.14
- "arista.cvp": ">=3.10.1" -> https://github.com/aristanetworks/ansible-cvp/releases/tag/v3.10.1
- "arista.eos": ">=7.0.0" -> https://github.com/ansible-collections/arista.eos/releases/tag/v7.0.0
- "ansible.utils": ">=3.0.0" -> https://github.com/ansible-collections/ansible.utils/releases/tag/v3.0.0