### PR TITLE
Feat(eos_designs): Add support for l3_edge l3_interfaces

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/l3_edge_l3_interfaces_bgp.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/l3_edge_l3_interfaces_bgp.cfg
@@ -1,0 +1,98 @@
+!RANCID-CONTENT-TYPE: arista
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname l3_edge_l3_interfaces_bgp
+!
+spanning-tree mode none
+!
+no enable password
+no aaa root
+!
+vrf instance MGMT
+!
+interface Ethernet1
+   description TODO
+   no shutdown
+   no switchport
+   ip address 192.168.1.2/31
+!
+interface Ethernet2
+   description Custom description on l3_edge_l3_interfaces_bgp eth2
+   no shutdown
+   no switchport
+   ip address 192.168.2.2/31
+!
+interface Ethernet3
+   description TODO
+   no shutdown
+   no switchport
+   vrf TEST
+   ip address 192.168.3.2/31
+!
+interface Ethernet4
+   description TODO
+   no shutdown
+   no switchport
+!
+interface Ethernet4.42
+   description TODO
+   encapsulation dot1q vlan 42
+   vrf TEST
+!
+interface Ethernet4.100
+   description TODO
+   encapsulation dot1q vlan 100
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 1.2.3.1/32
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 1.2.3.4/24 eq 32
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+router bgp 65000
+   router-id 1.2.3.1
+   maximum-paths 4 ecmp 4
+   update wait-install
+   no bgp default ipv4-unicast
+   neighbor IPv4-UNDERLAY-PEERS peer group
+   neighbor IPv4-UNDERLAY-PEERS send-community
+   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   neighbor 192.168.1.3 remote-as 65000
+   neighbor 192.168.1.3 description peer1
+   neighbor 192.168.2.3 remote-as 65000
+   neighbor 192.168.2.3 description peer2
+   neighbor 192.168.3.3 remote-as 65000
+   neighbor 192.168.3.3 description peer3
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   address-family ipv4
+      neighbor IPv4-UNDERLAY-PEERS activate
+      neighbor 192.168.1.3 activate
+      neighbor 192.168.2.3 activate
+   !
+   vrf TEST
+      !
+      address-family ipv4
+         neighbor 192.168.3.3 activate
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/l3_edge_l3_interfaces_no_bgp.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/l3_edge_l3_interfaces_no_bgp.cfg
@@ -1,0 +1,77 @@
+!RANCID-CONTENT-TYPE: arista
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname l3_edge_l3_interfaces_no_bgp
+!
+spanning-tree mode none
+!
+no enable password
+no aaa root
+!
+vrf instance MGMT
+!
+interface Ethernet1
+   description TODO
+   no shutdown
+   no switchport
+   ip address 192.168.1.2/31
+!
+interface Ethernet2
+   description TODO
+   no shutdown
+   no switchport
+   ip address 192.168.0.2/31
+!
+interface Ethernet3
+   description TODO
+   no shutdown
+   no switchport
+   vrf TEST
+   ip address 192.168.3.2/31
+!
+interface Ethernet4
+   description Custom description on l3_edge_l3_interfaces_no_bgp eth4
+   no shutdown
+   no switchport
+   ip address dhcp
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 1.2.3.1/32
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 1.2.3.4/24 eq 32
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+router bgp 65000
+   router-id 1.2.3.1
+   maximum-paths 4 ecmp 4
+   update wait-install
+   no bgp default ipv4-unicast
+   neighbor IPv4-UNDERLAY-PEERS peer group
+   neighbor IPv4-UNDERLAY-PEERS send-community
+   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   address-family ipv4
+      neighbor IPv4-UNDERLAY-PEERS activate
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/l3_edge_l3_interfaces_bgp.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/l3_edge_l3_interfaces_bgp.yml
@@ -1,0 +1,118 @@
+hostname: l3_edge_l3_interfaces_bgp
+is_deployed: true
+router_bgp:
+  as: '65000'
+  router_id: 1.2.3.1
+  bgp:
+    default:
+      ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
+  updates:
+    wait_install: true
+  peer_groups:
+  - name: IPv4-UNDERLAY-PEERS
+    type: ipv4
+    maximum_routes: 12000
+    send_community: all
+  address_family_ipv4:
+    peer_groups:
+    - name: IPv4-UNDERLAY-PEERS
+      activate: true
+    neighbors:
+    - ip_address: 192.168.1.3
+      activate: true
+    - ip_address: 192.168.2.3
+      activate: true
+  redistribute_routes:
+  - source_protocol: connected
+    route_map: RM-CONN-2-BGP
+  vrfs:
+  - name: TEST
+    address_family_ipv4:
+      neighbors:
+      - ip_address: 192.168.3.3
+        activate: true
+  neighbors:
+  - ip_address: 192.168.1.3
+    remote_as: '65000'
+    peer: peer1
+    description: peer1
+  - ip_address: 192.168.2.3
+    remote_as: '65000'
+    peer: peer2
+    description: peer2
+  - ip_address: 192.168.3.3
+    remote_as: '65000'
+    peer: peer3
+    description: peer3
+service_routing_protocols_model: multi-agent
+ip_routing: true
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+spanning_tree:
+  mode: none
+vrfs:
+- name: MGMT
+  ip_routing: false
+management_api_http:
+  enable_vrfs:
+  - name: MGMT
+  enable_https: true
+loopback_interfaces:
+- name: Loopback0
+  description: EVPN_Overlay_Peering
+  shutdown: false
+  ip_address: 1.2.3.1/32
+prefix_lists:
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 1.2.3.4/24 eq 32
+route_maps:
+- name: RM-CONN-2-BGP
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    match:
+    - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+ethernet_interfaces:
+- name: Ethernet1
+  peer_type: l3_interface
+  ip_address: 192.168.1.2/31
+  shutdown: false
+  type: routed
+  description: TODO
+- name: Ethernet2
+  peer_type: l3_interface
+  ip_address: 192.168.2.2/31
+  shutdown: false
+  type: routed
+  description: Custom description on l3_edge_l3_interfaces_bgp eth2
+- name: Ethernet3
+  peer_type: l3_interface
+  vrf: TEST
+  ip_address: 192.168.3.2/31
+  shutdown: false
+  type: routed
+  description: TODO
+- name: Ethernet4
+  peer_type: l3_interface
+  shutdown: false
+  type: routed
+  description: TODO
+- name: Ethernet4.42
+  peer_type: l3_subinterface
+  vrf: TEST
+  type: l3dot1q
+  encapsulation_dot1q_vlan: 42
+  description: TODO
+- name: Ethernet4.100
+  peer_type: l3_subinterface
+  type: l3dot1q
+  encapsulation_dot1q_vlan: 100
+  description: TODO

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/l3_edge_l3_interfaces_no_bgp.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/l3_edge_l3_interfaces_no_bgp.yml
@@ -1,0 +1,84 @@
+hostname: l3_edge_l3_interfaces_no_bgp
+is_deployed: true
+router_bgp:
+  as: '65000'
+  router_id: 1.2.3.1
+  bgp:
+    default:
+      ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
+  updates:
+    wait_install: true
+  peer_groups:
+  - name: IPv4-UNDERLAY-PEERS
+    type: ipv4
+    maximum_routes: 12000
+    send_community: all
+  address_family_ipv4:
+    peer_groups:
+    - name: IPv4-UNDERLAY-PEERS
+      activate: true
+  redistribute_routes:
+  - source_protocol: connected
+    route_map: RM-CONN-2-BGP
+service_routing_protocols_model: multi-agent
+ip_routing: true
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+spanning_tree:
+  mode: none
+vrfs:
+- name: MGMT
+  ip_routing: false
+management_api_http:
+  enable_vrfs:
+  - name: MGMT
+  enable_https: true
+loopback_interfaces:
+- name: Loopback0
+  description: EVPN_Overlay_Peering
+  shutdown: false
+  ip_address: 1.2.3.1/32
+prefix_lists:
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 1.2.3.4/24 eq 32
+route_maps:
+- name: RM-CONN-2-BGP
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    match:
+    - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+ethernet_interfaces:
+- name: Ethernet1
+  peer_type: l3_interface
+  ip_address: 192.168.1.2/31
+  shutdown: false
+  type: routed
+  description: TODO
+- name: Ethernet2
+  peer_type: l3_interface
+  ip_address: 192.168.0.2/31
+  shutdown: false
+  type: routed
+  description: TODO
+- name: Ethernet3
+  peer_type: l3_interface
+  vrf: TEST
+  ip_address: 192.168.3.2/31
+  shutdown: false
+  type: routed
+  description: TODO
+- name: Ethernet4
+  peer_type: l3_interface
+  ip_address: dhcp
+  shutdown: false
+  type: routed
+  description: Custom description on l3_edge_l3_interfaces_no_bgp eth4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/l3_edge_l3_interfaces_bgp.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/l3_edge_l3_interfaces_bgp.yml
@@ -6,9 +6,6 @@ spine:
       evpn_role: "none"
       loopback_ipv4_pool: 1.2.3.4/24
       bgp_as: 65000
-      filter:
-        always_include_vrfs_in_tenants: [TenantA]
-
 
 tenants:
   - name: TenantA

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/l3_edge_l3_interfaces_bgp.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/l3_edge_l3_interfaces_bgp.yml
@@ -1,0 +1,71 @@
+type: spine
+spine:
+  nodes:
+    - name: l3_edge_l3_interfaces_bgp
+      id: 1
+      evpn_role: "none"
+      loopback_ipv4_pool: 1.2.3.4/24
+      bgp_as: 65000
+      filter:
+        always_include_vrfs_in_tenants: [TenantA]
+
+
+tenants:
+  - name: TenantA
+    vrfs:
+      - name: TEST
+        vrf_id: 101
+      - name: default
+        vrf_id: 100
+
+l3_edge:
+  l3_interfaces_profiles:
+    - name: profile1
+      speed: "forced 10000full"
+      bfd: true
+      qos_profile: TEST-QOS-PROFILE
+      structured_config:
+        service_policy:
+          qos:
+            input: TEST_POLICY
+      raw_eos_cli: |
+        ! TEST RAW_EOS_CLI
+  l3_interfaces:
+      # Settings set via profile
+    - node: l3_edge_l3_interfaces_bgp
+      peer: peer1
+      interface: Ethernet1
+      ip: 192.168.1.2/31
+      peer_ip: 192.168.1.3/31
+      profile: profile1
+      bgp_as: 65000
+
+      # IPv6 enabled
+      # Descriptions set manually
+    - node: l3_edge_l3_interfaces_bgp
+      description: Custom description on l3_edge_l3_interfaces_bgp eth2
+      peer: peer2
+      interface: Ethernet2
+      ip: 192.168.2.2/31
+      peer_ip: 192.168.2.3/31
+      bgp_as: 65000
+      ipv6_enable: true
+
+      # VRF
+    - node: l3_edge_l3_interfaces_bgp
+      peer: peer3
+      interface: Ethernet3
+      ip: 192.168.3.2/31
+      peer_ip: 192.168.3.3/31
+      vrf: "TEST"
+      bgp_as: 65000
+
+      # subinterfaces
+    - node: l3_edge_l3_interfaces_bgp
+      peer: peer4
+      interface: Ethernet4
+      subinterfaces:
+        # override subinterface_id
+        - vrf: TEST
+          subinterface_id: 42
+        - vrf: default

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/l3_edge_l3_interfaces_no_bgp.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/l3_edge_l3_interfaces_no_bgp.yml
@@ -1,0 +1,59 @@
+type: spine
+spine:
+  nodes:
+    - name: l3_edge_l3_interfaces_no_bgp
+      id: 1
+      evpn_role: "none"
+      loopback_ipv4_pool: 1.2.3.4/24
+      bgp_as: 65000
+      filter:
+        always_include_vrfs_in_tenants: [TenantA]
+
+
+tenants:
+  - name: TenantA
+    vrfs:
+      - name: TEST
+      - name: default
+
+l3_edge:
+  l3_interfaces_profiles:
+    - name: profile1
+      speed: "forced 10000full"
+      bfd: true
+      qos_profile: TEST-QOS-PROFILE
+      structured_config:
+        service_policy:
+          qos:
+            input: TEST_POLICY
+      raw_eos_cli: |
+        ! TEST RAW_EOS_CLI
+  l3_interfaces:
+      # Settings set via profile
+    - node: l3_edge_l3_interfaces_no_bgp
+      peer: peer1
+      interface: Ethernet1
+      ip: 192.168.1.2/31
+      profile: profile1
+
+      # IP set manually and ipv6_enabled.
+    - node: l3_edge_l3_interfaces_no_bgp
+      peer: peer2
+      interface: Ethernet2
+      ip: 192.168.0.2/31
+      ipv6_enable: true
+
+      # IP set manually and VRF
+    - node: l3_edge_l3_interfaces_no_bgp
+      peer: peer3
+      interface: Ethernet3
+      ip: 192.168.3.2/31
+      vrf: "TEST"
+
+      # P2P link with underlay routing and IP set via ip_pool and id.
+      # Descriptions set manually
+    - node: l3_edge_l3_interfaces_no_bgp
+      peer: peer4
+      interface: Ethernet4
+      ip: dhcp
+      description: "Custom description on l3_edge_l3_interfaces_no_bgp eth4"

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/l3_edge_l3_interfaces_no_bgp.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/l3_edge_l3_interfaces_no_bgp.yml
@@ -6,9 +6,6 @@ spine:
       evpn_role: "none"
       loopback_ipv4_pool: 1.2.3.4/24
       bgp_as: 65000
-      filter:
-        always_include_vrfs_in_tenants: [TenantA]
-
 
 tenants:
   - name: TenantA

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
@@ -261,6 +261,8 @@ all:
             l3_edge_bgp:
             l3_edge_ospf:
             l3_edge_isis:
+            l3_edge_l3_interfaces_no_bgp:
+            l3_edge_l3_interfaces_bgp:
         UPLINK_NATIVE_VLAN_TESTS:
           hosts:
             uplink-native-vlan-grandparent:

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/filtered_tenants.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/filtered_tenants.py
@@ -1,0 +1,303 @@
+# Copyright (c) 2023 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the LICENSE file.
+from __future__ import annotations
+
+from functools import cached_property
+from typing import TYPE_CHECKING
+
+from ansible_collections.arista.avd.plugins.filter.convert_dicts import convert_dicts
+from ansible_collections.arista.avd.plugins.filter.default import default
+from ansible_collections.arista.avd.plugins.filter.natural_sort import natural_sort
+from ansible_collections.arista.avd.plugins.filter.range_expand import range_expand
+from ansible_collections.arista.avd.plugins.plugin_utils.errors import AristaAvdError
+from ansible_collections.arista.avd.plugins.plugin_utils.merge import merge
+from ansible_collections.arista.avd.plugins.plugin_utils.utils import get, get_item, unique
+
+if TYPE_CHECKING:
+    from .shared_utils import SharedUtils
+
+
+class FilteredTenantsMixin:
+    """
+    Mixin Class providing a subset of SharedUtils
+    Class should only be used as Mixin to the SharedUtils class
+    Using type-hint on self to get proper type-hints on attributes across all Mixins.
+    """
+
+    @cached_property
+    def filtered_tenants(self: SharedUtils) -> list[dict]:
+        """
+        Return sorted tenants list from all network_services_keys and filtered based on switch.filter_tenants
+        Keys of Tenant data model will be converted to lists.
+        All sub data models like vrfs and l2vlans are also converted and filtered.
+        """
+        filtered_tenants = []
+        filter_tenants = self.filter_tenants
+        for network_services_key in self.network_services_keys:
+            tenants = convert_dicts(get(self.hostvars, network_services_key["name"]), "name")
+            for tenant in tenants:
+                if tenant["name"] in filter_tenants or "all" in filter_tenants:
+                    tenant["l2vlans"] = self.filtered_l2vlans(tenant)
+                    tenant["vrfs"] = self.filtered_vrfs(tenant)
+                    filtered_tenants.append(tenant)
+
+        return natural_sort(filtered_tenants, "name")
+
+    def filtered_l2vlans(self: SharedUtils, tenant: dict) -> list[dict]:
+        """
+        Return sorted and filtered l2vlan list from given tenant.
+        Filtering based on l2vlan tags.
+        """
+        if "l2vlans" not in tenant:
+            return []
+
+        l2vlans: list[dict] = natural_sort(convert_dicts(tenant["l2vlans"], "id"), "id")
+        l2vlans = [
+            l2vlan
+            for l2vlan in l2vlans
+            if self.is_accepted_vlan(l2vlan) and ("all" in self.filter_tags or set(l2vlan.get("tags", ["all"])).intersection(self.filter_tags))
+        ]
+        # Set tenant key on all l2vlans
+        for l2vlan in l2vlans:
+            l2vlan.update({"tenant": tenant["name"]})
+
+        return l2vlans
+
+    def is_accepted_vlan(self: SharedUtils, vlan: dict) -> bool:
+        # sourcery skip: assign-if-exp, boolean-if-exp-identity, reintroduce-else
+        """
+        Check if vlan is in accepted_vlans list
+        If filter.only_vlans_in_use is True also check if vlan id or trunk group is assigned to connected endpoint
+        """
+        vlan_id = int(vlan["id"])
+
+        if vlan_id not in self.accepted_vlans:
+            return False
+
+        if not self.filter_only_vlans_in_use:
+            # No further filtering
+            return True
+
+        if vlan_id in self.endpoint_vlans:
+            return True
+
+        # Picking this up from facts so this would fail if accessed when shared_utils is run before facts
+        # TODO see if this can be optimized
+        endpoint_trunk_groups = set(get(self.hostvars, "switch.endpoint_trunk_groups", default=[]))
+        if self.enable_trunk_groups and vlan.get("trunk_groups") and endpoint_trunk_groups.intersection(vlan["trunk_groups"]):
+            return True
+
+        return False
+
+    @cached_property
+    def accepted_vlans(self: SharedUtils) -> list[int]:
+        """
+        switch.vlans is a string representing a vlan range (ex. "1-200")
+        For l2 switches return intersection of switch.vlans and switch.vlans from uplink switches
+        For anything else return the expanded switch.vlans
+        """
+        switch_vlans = get(self.hostvars, "switch.vlans")
+        if not switch_vlans:
+            return []
+        switch_vlans_list = range_expand(switch_vlans)
+        accepted_vlans = [int(vlan) for vlan in switch_vlans_list]
+        if self.uplink_type != "port-channel":
+            return accepted_vlans
+
+        uplink_switches = unique(self.uplink_switches)
+        uplink_switches = [uplink_switch for uplink_switch in uplink_switches if uplink_switch in self.all_fabric_devices]
+        for uplink_switch in uplink_switches:
+            uplink_switch_facts = self.get_peer_facts(uplink_switch, required=True)
+            uplink_switch_vlans = uplink_switch_facts.get("vlans", [])
+            uplink_switch_vlans_list = range_expand(uplink_switch_vlans)
+            uplink_switch_vlans_list = [int(vlan) for vlan in uplink_switch_vlans_list]
+            accepted_vlans = [vlan for vlan in accepted_vlans if vlan in uplink_switch_vlans_list]
+
+        return accepted_vlans
+
+    def filtered_vrfs(self: SharedUtils, tenant: dict) -> list[dict]:
+        """
+        Return sorted and filtered vrf list from given tenant.
+        Filtering based on svi tags, l3interfaces and filter.always_include_vrfs_in_tenants.
+        Keys of VRF data model will be converted to lists.
+        """
+        filtered_vrfs = []
+
+        always_include_vrfs_in_tenants = get(self.switch_data_combined, "filter.always_include_vrfs_in_tenants", default=[])
+
+        vrfs: list[dict] = natural_sort(convert_dicts(tenant.get("vrfs", []), "name"), "name")
+        for vrf in vrfs:
+            # Storing tenant on VRF for use by child objects like SVIs
+            vrf["tenant"] = tenant["name"]
+            bgp_peers = natural_sort(convert_dicts(vrf.get("bgp_peers"), "ip_address"), "ip_address")
+            vrf["bgp_peers"] = [bgp_peer for bgp_peer in bgp_peers if self.hostname in bgp_peer.get("nodes", [])]
+            vrf["static_routes"] = [route for route in get(vrf, "static_routes", default=[]) if self.hostname in get(route, "nodes", default=[self.hostname])]
+            vrf["ipv6_static_routes"] = [
+                route for route in get(vrf, "ipv6_static_routes", default=[]) if self.hostname in get(route, "nodes", default=[self.hostname])
+            ]
+            vrf["svis"] = self.filtered_svis(vrf)
+            vrf["l3_interfaces"] = [
+                l3_interface
+                for l3_interface in get(vrf, "l3_interfaces", default=[])
+                if (
+                    self.hostname in get(l3_interface, "nodes", default=[])
+                    and l3_interface.get("ip_addresses") is not None
+                    and l3_interface.get("interfaces") is not None
+                )
+            ]
+
+            if self.vtep is True:
+                evpn_l3_multicast_enabled = default(get(vrf, "evpn_l3_multicast.enabled"), get(tenant, "evpn_l3_multicast.enabled"))
+                if evpn_l3_multicast_enabled is True and self.evpn_multicast is not True:
+                    raise AristaAvdError(
+                        f"'evpn_l3_multicast: true' under VRF {vrf['name']} or Tenant {tenant['name']}; this requires 'evpn_multicast' to also be set to true."
+                    )
+
+                if self.evpn_multicast:
+                    vrf["_evpn_l3_multicast_enabled"] = evpn_l3_multicast_enabled
+
+                    rps = []
+                    for rp_entry in default(get(vrf, "pim_rp_addresses"), get(tenant, "pim_rp_addresses"), []):
+                        if self.hostname in get(rp_entry, "nodes", default=[self.hostname]):
+                            for rp_ip in get(
+                                rp_entry,
+                                "rps",
+                                required=True,
+                                org_key=f"pim_rp_addresses.rps under VRF '{vrf['name']}' in Tenant '{tenant['name']}'",
+                            ):
+                                rp_address = {"address": rp_ip}
+                                if (rp_groups := get(rp_entry, "groups")) is not None:
+                                    if (acl := rp_entry.get("access_list_name")) is not None:
+                                        rp_address["access_lists"] = [acl]
+                                    else:
+                                        rp_address["groups"] = rp_groups
+
+                                rps.append(rp_address)
+
+                    if rps:
+                        vrf["_pim_rp_addresses"] = rps
+
+                    for evpn_peg in default(get(vrf, "evpn_l3_multicast.evpn_peg"), get(tenant, "evpn_l3_multicast.evpn_peg"), []):
+                        if self.hostname in evpn_peg.get("nodes", [self.hostname]) and rps:
+                            vrf["_evpn_l3_multicast_evpn_peg_transit"] = evpn_peg.get("transit")
+                            break
+
+            if vrf["svis"] or vrf["l3_interfaces"] or "all" in always_include_vrfs_in_tenants or tenant["name"] in always_include_vrfs_in_tenants:
+                filtered_vrfs.append(vrf)
+
+            vrf["additional_route_targets"] = [
+                rt
+                for rt in get(vrf, "additional_route_targets", default=[])
+                if (
+                    self.hostname in get(rt, "nodes", default=[self.hostname])
+                    and rt.get("address_family") is not None
+                    and rt.get("route_target") is not None
+                    and rt.get("type") in ["import", "export"]
+                )
+            ]
+
+        return filtered_vrfs
+
+    @cached_property
+    def svi_profiles(self: SharedUtils) -> list[dict]:
+        """
+        Return list of svi_profiles
+
+        The key "nodes" is filtered to only contain one item with the relevant dict from "nodes" or {}
+        """
+        svi_profiles = convert_dicts(get(self.hostvars, "svi_profiles", default=[]), "profile")
+        for svi_profile in svi_profiles:
+            svi_profile["nodes"] = convert_dicts(svi_profile.get("nodes", []), "node")
+            svi_profile["nodes"] = [get_item(svi_profile["nodes"], "node", self.hostname, default={})]
+
+        return svi_profiles
+
+    def get_merged_svi_config(self: SharedUtils, svi: dict) -> list[dict]:
+        """
+        Return structured config for one svi after inheritance
+
+        Handle inheritance of node config as svi_profiles in two levels:
+
+        First variables will be merged
+        svi > svi_profile > svi_parent_profile --> svi_cfg
+        &
+        svi.nodes.<hostname> > svi_profile.nodes.<hostname> > svi_parent_profile.nodes.<hostname> --> svi_node_cfg
+
+        Then svi is updated with the result of merging svi_node_cfg over svi_cfg
+        svi_node_cfg > svi_cfg --> svi
+        """
+        svi_profile = {"nodes": [{}]}
+        svi_parent_profile = {"nodes": [{}]}
+
+        svi["nodes"] = convert_dicts(svi.get("nodes", []), "node")
+        svi["nodes"] = [get_item(svi["nodes"], "node", self.hostname, default={})]
+
+        if (svi_profile_name := svi.get("profile")) is not None:
+            svi_profile = get_item(self.svi_profiles, "profile", svi_profile_name, default={})
+
+        if (svi_parent_profile_name := svi_profile.get("parent_profile")) is not None:
+            svi_parent_profile = get_item(self.svi_profiles, "profile", svi_parent_profile_name, default={})
+
+        # deepmerge all levels of config - later vars override previous.
+        # Using destructive_merge=False to avoid having references to profiles and other data.
+        # Instead it will be doing deep copies inside merge.
+        merged_svi = merge(
+            svi_parent_profile,
+            svi_profile,
+            svi,
+            svi_parent_profile["nodes"][0],
+            svi_profile["nodes"][0],
+            svi["nodes"][0],
+            list_merge="replace",
+            destructive_merge=False,
+        )
+
+        # Override structured configs since we don't want to deep-merge those
+        merged_svi["structured_config"] = default(
+            svi["nodes"][0].get("structured_config"),
+            svi_profile["nodes"][0].get("structured_config"),
+            svi_parent_profile["nodes"][0].get("structured_config"),
+            svi.get("structured_config"),
+            svi_profile.get("structured_config"),
+            svi_parent_profile.get("structured_config"),
+        )
+
+        # Override bgp.structured configs since we don't want to deep-merge those
+        merged_svi.setdefault("bgp", {})["structured_config"] = default(
+            get(svi["nodes"][0], "bgp.structured_config"),
+            get(svi_profile["nodes"][0], "bgp.structured_config"),
+            get(svi_parent_profile["nodes"][0], "bgp.structured_config"),
+            get(svi, "bgp.structured_config"),
+            get(svi_profile, "bgp.structured_config"),
+            get(svi_parent_profile, "bgp.structured_config"),
+        )
+        return merged_svi
+
+    def filtered_svis(self: SharedUtils, vrf: dict) -> list[dict]:
+        """
+        Return sorted and filtered svi list from given tenant vrf.
+        Filtering based on accepted vlans since eos_designs_facts already
+        filtered that on tags and trunk_groups.
+        """
+        svis: list[dict] = natural_sort(convert_dicts(vrf.get("svis", []), "id"), "id")
+        svis = [svi for svi in svis if self.is_accepted_vlan(svi)]
+
+        # Handle svi_profile inheritance
+        svis = [self.get_merged_svi_config(svi) for svi in svis]
+
+        # Perform filtering on tags after merge of profiles, to support tags being set inside profiles.
+        svis = [svi for svi in svis if "all" in self.filter_tags or set(svi.get("tags", ["all"])).intersection(self.filter_tags)]
+
+        # Set tenant key on all SVIs
+        for svi in svis:
+            svi.update({"tenant": vrf["tenant"]})
+
+        return svis
+
+    @cached_property
+    def endpoint_vlans(self) -> list:
+        endpoint_vlans = get(self.hostvars, "switch.endpoint_vlans", default="")
+        if not endpoint_vlans:
+            return []
+        return [int(id) for id in range_expand(endpoint_vlans)]

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/misc.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/misc.py
@@ -254,3 +254,7 @@ class MiscMixin:
     def default_interface_mtu(self: SharedUtils) -> int | None:
         default_default_interface_mtu = get(self.hostvars, "default_interface_mtu")
         return get(self.platform_settings, "default_interface_mtu", default=default_default_interface_mtu)
+
+    @cached_property
+    def evpn_multicast(self) -> bool:
+        return get(self.hostvars, "switch.evpn_multicast") is True

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/misc.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/misc.py
@@ -68,10 +68,6 @@ class MiscMixin:
         return filter_tags
 
     @cached_property
-    def filter_tenants(self: SharedUtils) -> list:
-        return get(self.switch_data_combined, "filter.tenants", default=["all"])
-
-    @cached_property
     def igmp_snooping_enabled(self: SharedUtils) -> bool:
         default_igmp_snooping_enabled = get(self.hostvars, "default_igmp_snooping_enabled", default=True)
         return get(self.switch_data_combined, "igmp_snooping_enabled", default=default_igmp_snooping_enabled) is True

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/shared_utils.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/shared_utils.py
@@ -4,6 +4,7 @@
 from .bgp_peer_groups import BgpPeerGroupsMixin
 from .connected_endpoints_keys import ConnectedEndpointsKeysMixin
 from .cv_topology import CvTopology
+from .filtered_tenants import FilteredTenantsMixin
 from .inband_management import InbandManagementMixin
 from .interface_descriptions import InterfaceDescriptionsMixin
 from .ip_addressing import IpAddressingMixin
@@ -25,6 +26,7 @@ from .utils import UtilsMixin
 class SharedUtils(
     BgpPeerGroupsMixin,
     ConnectedEndpointsKeysMixin,
+    FilteredTenantsMixin,
     InbandManagementMixin,
     InterfaceDescriptionsMixin,
     IpAddressingMixin,

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/core-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/core-interfaces.md
@@ -13,7 +13,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_pool</samp>](## "core_interfaces.p2p_links_ip_pools.[].ipv4_pool") | String |  |  |  | IPv4 address/Mask. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;prefix_size</samp>](## "core_interfaces.p2p_links_ip_pools.[].prefix_size") | Integer |  | `31` | Min: 8<br>Max: 31 | Subnet mask size. |
     | [<samp>&nbsp;&nbsp;p2p_links_profiles</samp>](## "core_interfaces.p2p_links_profiles") | List, items: Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "core_interfaces.p2p_links_profiles.[].name") | String | Required, Unique |  |  | P2P profile name. Any variable supported under p2p_links can be inherited from a profile. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "core_interfaces.p2p_links_profiles.[].name") | String | Required, Unique |  |  | P2P profile name. Any variable supported under `p2p_links` can be inherited from a profile. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;id</samp>](## "core_interfaces.p2p_links_profiles.[].id") | Integer |  |  |  | Unique id per subnet_summary. Used to calculate ip addresses.<br>Required with ip_pool. ID starting from 1.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;speed</samp>](## "core_interfaces.p2p_links_profiles.[].speed") | String |  |  |  | Speed should be set in the format `<interface_speed>` or `forced <interface_speed>` or `auto <interface_speed>`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ip_pool</samp>](## "core_interfaces.p2p_links_profiles.[].ip_pool") | String |  |  |  | P2P pool name. IP Pool defined under p2p_links_ip_pools. A /31 will be taken from the pool per P2P link. |
@@ -92,6 +92,53 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "core_interfaces.p2p_links.[].port_channel.nodes_child_interfaces.[].interfaces.[]") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;raw_eos_cli</samp>](## "core_interfaces.p2p_links.[].raw_eos_cli") | String |  |  |  | EOS CLI rendered directly on the point-to-point interface in the final EOS configuration. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;structured_config</samp>](## "core_interfaces.p2p_links.[].structured_config") | Dictionary |  |  |  | Custom structured config for interfaces<br>Note! The content of this dictionary is _not_ validated by the schema, since it can be either ethernet_interfaces or port_channel_interfaces. |
+    | [<samp>&nbsp;&nbsp;l3_interfaces_profiles</samp>](## "core_interfaces.l3_interfaces_profiles") | List, items: Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "core_interfaces.l3_interfaces_profiles.[].name") | String | Required, Unique |  |  | L3 interface profile name. Any variable supported under `l3_interfaces` can be inherited from a profile. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;speed</samp>](## "core_interfaces.l3_interfaces_profiles.[].speed") | String |  |  |  | Speed should be set in the format `<interface_speed>` or `forced <interface_speed>` or `auto <interface_speed>`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "core_interfaces.l3_interfaces_profiles.[].vrf") | String |  |  |  | VRF to configure on the interface. (default VRF if not set). |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ip</samp>](## "core_interfaces.l3_interfaces_profiles.[].ip") | String |  |  |  | Node IPv4 address/Mask or dhcp. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dhcp_client_accept_default_route</samp>](## "core_interfaces.l3_interfaces_profiles.[].dhcp_client_accept_default_route") | Boolean |  |  |  | Supported if `ip` is `dhcp`.<br>Accepts default route from DHCP, default False. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_enable</samp>](## "core_interfaces.l3_interfaces_profiles.[].ipv6_enable") | Boolean |  | `False` |  | Allows turning on ipv6 for the interface or profile. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interface</samp>](## "core_interfaces.l3_interfaces_profiles.[].interface") | String |  |  |  | Must be an Ethernet interface like 'Ethernet2'. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;peer</samp>](## "core_interfaces.l3_interfaces_profiles.[].peer") | String |  |  |  | The peer device name. Used for description and documentation |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;peer_interface</samp>](## "core_interfaces.l3_interfaces_profiles.[].peer_interface") | String |  |  |  | The peer device interface. Used for description and documentation |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;peer_ip</samp>](## "core_interfaces.l3_interfaces_profiles.[].peer_ip") | String |  |  |  | The peer device IP. Used for description and documentation |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bgp_as</samp>](## "core_interfaces.l3_interfaces_profiles.[].bgp_as") | String |  |  |  | AS numbers for BGP.<br>Required with bgp peering.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;peer_bgp_as</samp>](## "core_interfaces.l3_interfaces_profiles.[].peer_bgp_as") | String |  |  |  | AS numbers for BGP for the remote peer.<br>If not provided, `bgp_as` is used.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;description</samp>](## "core_interfaces.l3_interfaces_profiles.[].description") | String |  |  |  | Interface description. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bfd</samp>](## "core_interfaces.l3_interfaces_profiles.[].bfd") | Boolean |  | `False` |  | Enable BFD (only considered for BGP). |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;qos_profile</samp>](## "core_interfaces.l3_interfaces_profiles.[].qos_profile") | String |  |  |  | QOS service profile. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;subinterfaces</samp>](## "core_interfaces.l3_interfaces_profiles.[].subinterfaces") | List, items: Dictionary |  |  |  | Configure subinterfaces, each in their own VRF under the interface. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;vrf</samp>](## "core_interfaces.l3_interfaces_profiles.[].subinterfaces.[].vrf") | String | Required, Unique |  |  | Name of the VRF to configure for this subinterface<br>The VRF MUST exist in `network_services` |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;subinterface_id</samp>](## "core_interfaces.l3_interfaces_profiles.[].subinterfaces.[].subinterface_id") | Integer |  |  |  | Optional ID to overwrite the default one used from the VRF.<br>`vrf_id` is used otherwise. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;description</samp>](## "core_interfaces.l3_interfaces_profiles.[].subinterfaces.[].description") | String |  |  |  | Optional description for the subinterface. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;structured_config</samp>](## "core_interfaces.l3_interfaces_profiles.[].subinterfaces.[].structured_config") | Dictionary |  |  |  | Custom structured config for the subinterface.<br>Note! The content of this dictionary is _not_ validated by the schema, since it can be either ethernet_interfaces or port_channel_interfaces. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;raw_eos_cli</samp>](## "core_interfaces.l3_interfaces_profiles.[].raw_eos_cli") | String |  |  |  | EOS CLI rendered directly on the interface in the final EOS configuration. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;structured_config</samp>](## "core_interfaces.l3_interfaces_profiles.[].structured_config") | Dictionary |  |  |  | Custom structured config for interfaces |
+    | [<samp>&nbsp;&nbsp;l3_interfaces</samp>](## "core_interfaces.l3_interfaces") | List, items: Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;node</samp>](## "core_interfaces.l3_interfaces.[].node") | String |  |  |  | Device on which the interface should be configured. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;profile</samp>](## "core_interfaces.l3_interfaces.[].profile") | String |  |  |  | L3 interface profile name. Profile defined under l3_interfaces_profiles. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;speed</samp>](## "core_interfaces.l3_interfaces.[].speed") | String |  |  |  | Speed should be set in the format `<interface_speed>` or `forced <interface_speed>` or `auto <interface_speed>`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "core_interfaces.l3_interfaces.[].vrf") | String |  |  |  | VRF to configure on the interface. (default VRF if not set). |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ip</samp>](## "core_interfaces.l3_interfaces.[].ip") | String |  |  |  | Node IPv4 address/Mask or dhcp. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dhcp_client_accept_default_route</samp>](## "core_interfaces.l3_interfaces.[].dhcp_client_accept_default_route") | Boolean |  |  |  | Supported if `ip` is `dhcp`.<br>Accepts default route from DHCP, default False. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_enable</samp>](## "core_interfaces.l3_interfaces.[].ipv6_enable") | Boolean |  | `False` |  | Allows turning on ipv6 for the interface or profile. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interface</samp>](## "core_interfaces.l3_interfaces.[].interface") | String |  |  |  | Must be an Ethernet interface like 'Ethernet2'. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;peer</samp>](## "core_interfaces.l3_interfaces.[].peer") | String |  |  |  | The peer device name. Used for description and documentation |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;peer_interface</samp>](## "core_interfaces.l3_interfaces.[].peer_interface") | String |  |  |  | The peer device interface. Used for description and documentation |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;peer_ip</samp>](## "core_interfaces.l3_interfaces.[].peer_ip") | String |  |  |  | The peer device IP. Used for description and documentation |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bgp_as</samp>](## "core_interfaces.l3_interfaces.[].bgp_as") | String |  |  |  | AS numbers for BGP.<br>Required with bgp peering.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;peer_bgp_as</samp>](## "core_interfaces.l3_interfaces.[].peer_bgp_as") | String |  |  |  | AS numbers for BGP for the remote peer.<br>If not provided, `bgp_as` is used.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;description</samp>](## "core_interfaces.l3_interfaces.[].description") | String |  |  |  | Interface description. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bfd</samp>](## "core_interfaces.l3_interfaces.[].bfd") | Boolean |  | `False` |  | Enable BFD (only considered for BGP). |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;qos_profile</samp>](## "core_interfaces.l3_interfaces.[].qos_profile") | String |  |  |  | QOS service profile. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;subinterfaces</samp>](## "core_interfaces.l3_interfaces.[].subinterfaces") | List, items: Dictionary |  |  |  | Configure subinterfaces, each in their own VRF under the interface. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;vrf</samp>](## "core_interfaces.l3_interfaces.[].subinterfaces.[].vrf") | String | Required, Unique |  |  | Name of the VRF to configure for this subinterface<br>The VRF MUST exist in `network_services` |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;subinterface_id</samp>](## "core_interfaces.l3_interfaces.[].subinterfaces.[].subinterface_id") | Integer |  |  |  | Optional ID to overwrite the default one used from the VRF.<br>`vrf_id` is used otherwise. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;description</samp>](## "core_interfaces.l3_interfaces.[].subinterfaces.[].description") | String |  |  |  | Optional description for the subinterface. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;structured_config</samp>](## "core_interfaces.l3_interfaces.[].subinterfaces.[].structured_config") | Dictionary |  |  |  | Custom structured config for the subinterface.<br>Note! The content of this dictionary is _not_ validated by the schema, since it can be either ethernet_interfaces or port_channel_interfaces. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;raw_eos_cli</samp>](## "core_interfaces.l3_interfaces.[].raw_eos_cli") | String |  |  |  | EOS CLI rendered directly on the interface in the final EOS configuration. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;structured_config</samp>](## "core_interfaces.l3_interfaces.[].structured_config") | Dictionary |  |  |  | Custom structured config for interfaces |
 
 === "YAML"
 
@@ -109,7 +156,7 @@
           prefix_size: <int; 8-31; default=31>
       p2p_links_profiles:
 
-          # P2P profile name. Any variable supported under p2p_links can be inherited from a profile.
+          # P2P profile name. Any variable supported under `p2p_links` can be inherited from a profile.
         - name: <str; required; unique>
 
           # Unique id per subnet_summary. Used to calculate ip addresses.
@@ -316,5 +363,154 @@
 
           # Custom structured config for interfaces
           # Note! The content of this dictionary is _not_ validated by the schema, since it can be either ethernet_interfaces or port_channel_interfaces.
+          structured_config: <dict>
+      l3_interfaces_profiles:
+
+          # L3 interface profile name. Any variable supported under `l3_interfaces` can be inherited from a profile.
+        - name: <str; required; unique>
+
+          # Speed should be set in the format `<interface_speed>` or `forced <interface_speed>` or `auto <interface_speed>`.
+          speed: <str>
+
+          # VRF to configure on the interface. (default VRF if not set).
+          vrf: <str>
+
+          # Node IPv4 address/Mask or dhcp.
+          ip: <str>
+
+          # Supported if `ip` is `dhcp`.
+          # Accepts default route from DHCP, default False.
+          dhcp_client_accept_default_route: <bool>
+
+          # Allows turning on ipv6 for the interface or profile.
+          ipv6_enable: <bool; default=False>
+
+          # Must be an Ethernet interface like 'Ethernet2'.
+          interface: <str>
+
+          # The peer device name. Used for description and documentation
+          peer: <str>
+
+          # The peer device interface. Used for description and documentation
+          peer_interface: <str>
+
+          # The peer device IP. Used for description and documentation
+          peer_ip: <str>
+
+          # AS numbers for BGP.
+          # Required with bgp peering.
+          bgp_as: <str>
+
+          # AS numbers for BGP for the remote peer.
+          # If not provided, `bgp_as` is used.
+          peer_bgp_as: <str>
+
+          # Interface description.
+          description: <str>
+
+          # Enable BFD (only considered for BGP).
+          bfd: <bool; default=False>
+
+          # QOS service profile.
+          qos_profile: <str>
+
+          # Configure subinterfaces, each in their own VRF under the interface.
+          subinterfaces:
+
+              # Name of the VRF to configure for this subinterface
+              # The VRF MUST exist in `network_services`
+            - vrf: <str; required; unique>
+
+              # Optional ID to overwrite the default one used from the VRF.
+              # `vrf_id` is used otherwise.
+              subinterface_id: <int>
+
+              # Optional description for the subinterface.
+              description: <str>
+
+              # Custom structured config for the subinterface.
+              # Note! The content of this dictionary is _not_ validated by the schema, since it can be either ethernet_interfaces or port_channel_interfaces.
+              structured_config: <dict>
+
+          # EOS CLI rendered directly on the interface in the final EOS configuration.
+          raw_eos_cli: <str>
+
+          # Custom structured config for interfaces
+          structured_config: <dict>
+      l3_interfaces:
+
+          # Device on which the interface should be configured.
+        - node: <str>
+
+          # L3 interface profile name. Profile defined under l3_interfaces_profiles.
+          profile: <str>
+
+          # Speed should be set in the format `<interface_speed>` or `forced <interface_speed>` or `auto <interface_speed>`.
+          speed: <str>
+
+          # VRF to configure on the interface. (default VRF if not set).
+          vrf: <str>
+
+          # Node IPv4 address/Mask or dhcp.
+          ip: <str>
+
+          # Supported if `ip` is `dhcp`.
+          # Accepts default route from DHCP, default False.
+          dhcp_client_accept_default_route: <bool>
+
+          # Allows turning on ipv6 for the interface or profile.
+          ipv6_enable: <bool; default=False>
+
+          # Must be an Ethernet interface like 'Ethernet2'.
+          interface: <str>
+
+          # The peer device name. Used for description and documentation
+          peer: <str>
+
+          # The peer device interface. Used for description and documentation
+          peer_interface: <str>
+
+          # The peer device IP. Used for description and documentation
+          peer_ip: <str>
+
+          # AS numbers for BGP.
+          # Required with bgp peering.
+          bgp_as: <str>
+
+          # AS numbers for BGP for the remote peer.
+          # If not provided, `bgp_as` is used.
+          peer_bgp_as: <str>
+
+          # Interface description.
+          description: <str>
+
+          # Enable BFD (only considered for BGP).
+          bfd: <bool; default=False>
+
+          # QOS service profile.
+          qos_profile: <str>
+
+          # Configure subinterfaces, each in their own VRF under the interface.
+          subinterfaces:
+
+              # Name of the VRF to configure for this subinterface
+              # The VRF MUST exist in `network_services`
+            - vrf: <str; required; unique>
+
+              # Optional ID to overwrite the default one used from the VRF.
+              # `vrf_id` is used otherwise.
+              subinterface_id: <int>
+
+              # Optional description for the subinterface.
+              description: <str>
+
+              # Custom structured config for the subinterface.
+              # Note! The content of this dictionary is _not_ validated by the schema, since it can be either ethernet_interfaces or port_channel_interfaces.
+              structured_config: <dict>
+
+          # EOS CLI rendered directly on the interface in the final EOS configuration.
+          raw_eos_cli: <str>
+
+          # Custom structured config for interfaces
           structured_config: <dict>
     ```

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/l3-edge.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/l3-edge.md
@@ -13,7 +13,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_pool</samp>](## "l3_edge.p2p_links_ip_pools.[].ipv4_pool") | String |  |  |  | IPv4 address/Mask. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;prefix_size</samp>](## "l3_edge.p2p_links_ip_pools.[].prefix_size") | Integer |  | `31` | Min: 8<br>Max: 31 | Subnet mask size. |
     | [<samp>&nbsp;&nbsp;p2p_links_profiles</samp>](## "l3_edge.p2p_links_profiles") | List, items: Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "l3_edge.p2p_links_profiles.[].name") | String | Required, Unique |  |  | P2P profile name. Any variable supported under p2p_links can be inherited from a profile. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "l3_edge.p2p_links_profiles.[].name") | String | Required, Unique |  |  | P2P profile name. Any variable supported under `p2p_links` can be inherited from a profile. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;id</samp>](## "l3_edge.p2p_links_profiles.[].id") | Integer |  |  |  | Unique id per subnet_summary. Used to calculate ip addresses.<br>Required with ip_pool. ID starting from 1.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;speed</samp>](## "l3_edge.p2p_links_profiles.[].speed") | String |  |  |  | Speed should be set in the format `<interface_speed>` or `forced <interface_speed>` or `auto <interface_speed>`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ip_pool</samp>](## "l3_edge.p2p_links_profiles.[].ip_pool") | String |  |  |  | P2P pool name. IP Pool defined under p2p_links_ip_pools. A /31 will be taken from the pool per P2P link. |
@@ -92,6 +92,53 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "l3_edge.p2p_links.[].port_channel.nodes_child_interfaces.[].interfaces.[]") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;raw_eos_cli</samp>](## "l3_edge.p2p_links.[].raw_eos_cli") | String |  |  |  | EOS CLI rendered directly on the point-to-point interface in the final EOS configuration. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;structured_config</samp>](## "l3_edge.p2p_links.[].structured_config") | Dictionary |  |  |  | Custom structured config for interfaces<br>Note! The content of this dictionary is _not_ validated by the schema, since it can be either ethernet_interfaces or port_channel_interfaces. |
+    | [<samp>&nbsp;&nbsp;l3_interfaces_profiles</samp>](## "l3_edge.l3_interfaces_profiles") | List, items: Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "l3_edge.l3_interfaces_profiles.[].name") | String | Required, Unique |  |  | L3 interface profile name. Any variable supported under `l3_interfaces` can be inherited from a profile. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;speed</samp>](## "l3_edge.l3_interfaces_profiles.[].speed") | String |  |  |  | Speed should be set in the format `<interface_speed>` or `forced <interface_speed>` or `auto <interface_speed>`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "l3_edge.l3_interfaces_profiles.[].vrf") | String |  |  |  | VRF to configure on the interface. (default VRF if not set). |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ip</samp>](## "l3_edge.l3_interfaces_profiles.[].ip") | String |  |  |  | Node IPv4 address/Mask or dhcp. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dhcp_client_accept_default_route</samp>](## "l3_edge.l3_interfaces_profiles.[].dhcp_client_accept_default_route") | Boolean |  |  |  | Supported if `ip` is `dhcp`.<br>Accepts default route from DHCP, default False. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_enable</samp>](## "l3_edge.l3_interfaces_profiles.[].ipv6_enable") | Boolean |  | `False` |  | Allows turning on ipv6 for the interface or profile. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interface</samp>](## "l3_edge.l3_interfaces_profiles.[].interface") | String |  |  |  | Must be an Ethernet interface like 'Ethernet2'. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;peer</samp>](## "l3_edge.l3_interfaces_profiles.[].peer") | String |  |  |  | The peer device name. Used for description and documentation |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;peer_interface</samp>](## "l3_edge.l3_interfaces_profiles.[].peer_interface") | String |  |  |  | The peer device interface. Used for description and documentation |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;peer_ip</samp>](## "l3_edge.l3_interfaces_profiles.[].peer_ip") | String |  |  |  | The peer device IP. Used for description and documentation |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bgp_as</samp>](## "l3_edge.l3_interfaces_profiles.[].bgp_as") | String |  |  |  | AS numbers for BGP.<br>Required with bgp peering.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;peer_bgp_as</samp>](## "l3_edge.l3_interfaces_profiles.[].peer_bgp_as") | String |  |  |  | AS numbers for BGP for the remote peer.<br>If not provided, `bgp_as` is used.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;description</samp>](## "l3_edge.l3_interfaces_profiles.[].description") | String |  |  |  | Interface description. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bfd</samp>](## "l3_edge.l3_interfaces_profiles.[].bfd") | Boolean |  | `False` |  | Enable BFD (only considered for BGP). |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;qos_profile</samp>](## "l3_edge.l3_interfaces_profiles.[].qos_profile") | String |  |  |  | QOS service profile. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;subinterfaces</samp>](## "l3_edge.l3_interfaces_profiles.[].subinterfaces") | List, items: Dictionary |  |  |  | Configure subinterfaces, each in their own VRF under the interface. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;vrf</samp>](## "l3_edge.l3_interfaces_profiles.[].subinterfaces.[].vrf") | String | Required, Unique |  |  | Name of the VRF to configure for this subinterface<br>The VRF MUST exist in `network_services` |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;subinterface_id</samp>](## "l3_edge.l3_interfaces_profiles.[].subinterfaces.[].subinterface_id") | Integer |  |  |  | Optional ID to overwrite the default one used from the VRF.<br>`vrf_id` is used otherwise. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;description</samp>](## "l3_edge.l3_interfaces_profiles.[].subinterfaces.[].description") | String |  |  |  | Optional description for the subinterface. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;structured_config</samp>](## "l3_edge.l3_interfaces_profiles.[].subinterfaces.[].structured_config") | Dictionary |  |  |  | Custom structured config for the subinterface.<br>Note! The content of this dictionary is _not_ validated by the schema, since it can be either ethernet_interfaces or port_channel_interfaces. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;raw_eos_cli</samp>](## "l3_edge.l3_interfaces_profiles.[].raw_eos_cli") | String |  |  |  | EOS CLI rendered directly on the interface in the final EOS configuration. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;structured_config</samp>](## "l3_edge.l3_interfaces_profiles.[].structured_config") | Dictionary |  |  |  | Custom structured config for interfaces |
+    | [<samp>&nbsp;&nbsp;l3_interfaces</samp>](## "l3_edge.l3_interfaces") | List, items: Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;node</samp>](## "l3_edge.l3_interfaces.[].node") | String |  |  |  | Device on which the interface should be configured. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;profile</samp>](## "l3_edge.l3_interfaces.[].profile") | String |  |  |  | L3 interface profile name. Profile defined under l3_interfaces_profiles. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;speed</samp>](## "l3_edge.l3_interfaces.[].speed") | String |  |  |  | Speed should be set in the format `<interface_speed>` or `forced <interface_speed>` or `auto <interface_speed>`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "l3_edge.l3_interfaces.[].vrf") | String |  |  |  | VRF to configure on the interface. (default VRF if not set). |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ip</samp>](## "l3_edge.l3_interfaces.[].ip") | String |  |  |  | Node IPv4 address/Mask or dhcp. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dhcp_client_accept_default_route</samp>](## "l3_edge.l3_interfaces.[].dhcp_client_accept_default_route") | Boolean |  |  |  | Supported if `ip` is `dhcp`.<br>Accepts default route from DHCP, default False. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_enable</samp>](## "l3_edge.l3_interfaces.[].ipv6_enable") | Boolean |  | `False` |  | Allows turning on ipv6 for the interface or profile. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interface</samp>](## "l3_edge.l3_interfaces.[].interface") | String |  |  |  | Must be an Ethernet interface like 'Ethernet2'. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;peer</samp>](## "l3_edge.l3_interfaces.[].peer") | String |  |  |  | The peer device name. Used for description and documentation |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;peer_interface</samp>](## "l3_edge.l3_interfaces.[].peer_interface") | String |  |  |  | The peer device interface. Used for description and documentation |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;peer_ip</samp>](## "l3_edge.l3_interfaces.[].peer_ip") | String |  |  |  | The peer device IP. Used for description and documentation |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bgp_as</samp>](## "l3_edge.l3_interfaces.[].bgp_as") | String |  |  |  | AS numbers for BGP.<br>Required with bgp peering.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;peer_bgp_as</samp>](## "l3_edge.l3_interfaces.[].peer_bgp_as") | String |  |  |  | AS numbers for BGP for the remote peer.<br>If not provided, `bgp_as` is used.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;description</samp>](## "l3_edge.l3_interfaces.[].description") | String |  |  |  | Interface description. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bfd</samp>](## "l3_edge.l3_interfaces.[].bfd") | Boolean |  | `False` |  | Enable BFD (only considered for BGP). |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;qos_profile</samp>](## "l3_edge.l3_interfaces.[].qos_profile") | String |  |  |  | QOS service profile. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;subinterfaces</samp>](## "l3_edge.l3_interfaces.[].subinterfaces") | List, items: Dictionary |  |  |  | Configure subinterfaces, each in their own VRF under the interface. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;vrf</samp>](## "l3_edge.l3_interfaces.[].subinterfaces.[].vrf") | String | Required, Unique |  |  | Name of the VRF to configure for this subinterface<br>The VRF MUST exist in `network_services` |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;subinterface_id</samp>](## "l3_edge.l3_interfaces.[].subinterfaces.[].subinterface_id") | Integer |  |  |  | Optional ID to overwrite the default one used from the VRF.<br>`vrf_id` is used otherwise. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;description</samp>](## "l3_edge.l3_interfaces.[].subinterfaces.[].description") | String |  |  |  | Optional description for the subinterface. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;structured_config</samp>](## "l3_edge.l3_interfaces.[].subinterfaces.[].structured_config") | Dictionary |  |  |  | Custom structured config for the subinterface.<br>Note! The content of this dictionary is _not_ validated by the schema, since it can be either ethernet_interfaces or port_channel_interfaces. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;raw_eos_cli</samp>](## "l3_edge.l3_interfaces.[].raw_eos_cli") | String |  |  |  | EOS CLI rendered directly on the interface in the final EOS configuration. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;structured_config</samp>](## "l3_edge.l3_interfaces.[].structured_config") | Dictionary |  |  |  | Custom structured config for interfaces |
 
 === "YAML"
 
@@ -109,7 +156,7 @@
           prefix_size: <int; 8-31; default=31>
       p2p_links_profiles:
 
-          # P2P profile name. Any variable supported under p2p_links can be inherited from a profile.
+          # P2P profile name. Any variable supported under `p2p_links` can be inherited from a profile.
         - name: <str; required; unique>
 
           # Unique id per subnet_summary. Used to calculate ip addresses.
@@ -316,5 +363,154 @@
 
           # Custom structured config for interfaces
           # Note! The content of this dictionary is _not_ validated by the schema, since it can be either ethernet_interfaces or port_channel_interfaces.
+          structured_config: <dict>
+      l3_interfaces_profiles:
+
+          # L3 interface profile name. Any variable supported under `l3_interfaces` can be inherited from a profile.
+        - name: <str; required; unique>
+
+          # Speed should be set in the format `<interface_speed>` or `forced <interface_speed>` or `auto <interface_speed>`.
+          speed: <str>
+
+          # VRF to configure on the interface. (default VRF if not set).
+          vrf: <str>
+
+          # Node IPv4 address/Mask or dhcp.
+          ip: <str>
+
+          # Supported if `ip` is `dhcp`.
+          # Accepts default route from DHCP, default False.
+          dhcp_client_accept_default_route: <bool>
+
+          # Allows turning on ipv6 for the interface or profile.
+          ipv6_enable: <bool; default=False>
+
+          # Must be an Ethernet interface like 'Ethernet2'.
+          interface: <str>
+
+          # The peer device name. Used for description and documentation
+          peer: <str>
+
+          # The peer device interface. Used for description and documentation
+          peer_interface: <str>
+
+          # The peer device IP. Used for description and documentation
+          peer_ip: <str>
+
+          # AS numbers for BGP.
+          # Required with bgp peering.
+          bgp_as: <str>
+
+          # AS numbers for BGP for the remote peer.
+          # If not provided, `bgp_as` is used.
+          peer_bgp_as: <str>
+
+          # Interface description.
+          description: <str>
+
+          # Enable BFD (only considered for BGP).
+          bfd: <bool; default=False>
+
+          # QOS service profile.
+          qos_profile: <str>
+
+          # Configure subinterfaces, each in their own VRF under the interface.
+          subinterfaces:
+
+              # Name of the VRF to configure for this subinterface
+              # The VRF MUST exist in `network_services`
+            - vrf: <str; required; unique>
+
+              # Optional ID to overwrite the default one used from the VRF.
+              # `vrf_id` is used otherwise.
+              subinterface_id: <int>
+
+              # Optional description for the subinterface.
+              description: <str>
+
+              # Custom structured config for the subinterface.
+              # Note! The content of this dictionary is _not_ validated by the schema, since it can be either ethernet_interfaces or port_channel_interfaces.
+              structured_config: <dict>
+
+          # EOS CLI rendered directly on the interface in the final EOS configuration.
+          raw_eos_cli: <str>
+
+          # Custom structured config for interfaces
+          structured_config: <dict>
+      l3_interfaces:
+
+          # Device on which the interface should be configured.
+        - node: <str>
+
+          # L3 interface profile name. Profile defined under l3_interfaces_profiles.
+          profile: <str>
+
+          # Speed should be set in the format `<interface_speed>` or `forced <interface_speed>` or `auto <interface_speed>`.
+          speed: <str>
+
+          # VRF to configure on the interface. (default VRF if not set).
+          vrf: <str>
+
+          # Node IPv4 address/Mask or dhcp.
+          ip: <str>
+
+          # Supported if `ip` is `dhcp`.
+          # Accepts default route from DHCP, default False.
+          dhcp_client_accept_default_route: <bool>
+
+          # Allows turning on ipv6 for the interface or profile.
+          ipv6_enable: <bool; default=False>
+
+          # Must be an Ethernet interface like 'Ethernet2'.
+          interface: <str>
+
+          # The peer device name. Used for description and documentation
+          peer: <str>
+
+          # The peer device interface. Used for description and documentation
+          peer_interface: <str>
+
+          # The peer device IP. Used for description and documentation
+          peer_ip: <str>
+
+          # AS numbers for BGP.
+          # Required with bgp peering.
+          bgp_as: <str>
+
+          # AS numbers for BGP for the remote peer.
+          # If not provided, `bgp_as` is used.
+          peer_bgp_as: <str>
+
+          # Interface description.
+          description: <str>
+
+          # Enable BFD (only considered for BGP).
+          bfd: <bool; default=False>
+
+          # QOS service profile.
+          qos_profile: <str>
+
+          # Configure subinterfaces, each in their own VRF under the interface.
+          subinterfaces:
+
+              # Name of the VRF to configure for this subinterface
+              # The VRF MUST exist in `network_services`
+            - vrf: <str; required; unique>
+
+              # Optional ID to overwrite the default one used from the VRF.
+              # `vrf_id` is used otherwise.
+              subinterface_id: <int>
+
+              # Optional description for the subinterface.
+              description: <str>
+
+              # Custom structured config for the subinterface.
+              # Note! The content of this dictionary is _not_ validated by the schema, since it can be either ethernet_interfaces or port_channel_interfaces.
+              structured_config: <dict>
+
+          # EOS CLI rendered directly on the interface in the final EOS configuration.
+          raw_eos_cli: <str>
+
+          # Custom structured config for interfaces
           structured_config: <dict>
     ```

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/core_interfaces_and_l3_edge/ethernet_interfaces.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/core_interfaces_and_l3_edge/ethernet_interfaces.py
@@ -56,6 +56,34 @@ class EthernetInterfacesMixin(UtilsMixin):
                     context_keys=["name", "peer", "peer_interface"],
                 )
 
+        for l3_interface in self._filtered_l3_interfaces:
+            # Ethernet interface
+            ethernet_interface = self._get_l3_interface_cfg(l3_interface)
+
+            # Remove None values
+            ethernet_interface = {key: value for key, value in ethernet_interface.items() if value is not None}
+
+            append_if_not_duplicate(
+                list_of_dicts=ethernet_interfaces,
+                primary_key="name",
+                new_dict=ethernet_interface,
+                context=f"Ethernet Interfaces defined under {self.data_model} l3_interfaces",
+                context_keys=["name", "peer", "peer_interface"],
+            )
+
+            if (subinterfaces := l3_interface.get("subinterfaces")) is not None:
+                for subinterface_dict in subinterfaces:
+                    # Technically could pass only the VRF name here but more convenient access
+                    subinterface = self._get_l3_subinterface_cfg(l3_interface, subinterface_dict)
+
+                    append_if_not_duplicate(
+                        list_of_dicts=ethernet_interfaces,
+                        primary_key="name",
+                        new_dict=subinterface,
+                        context=f"Ethernet Sub interfaces defined under {self.data_model} l3_interfaces",
+                        context_keys=["name", "peer", "peer_interface"],
+                    )
+
         if ethernet_interfaces:
             return ethernet_interfaces
 

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/core_interfaces_and_l3_edge/router_bgp.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/core_interfaces_and_l3_edge/router_bgp.py
@@ -3,6 +3,7 @@
 # that can be found in the LICENSE file.
 from __future__ import annotations
 
+import ipaddress
 from functools import cached_property
 
 from ansible_collections.arista.avd.plugins.plugin_utils.errors import AristaAvdMissingVariableError
@@ -21,12 +22,31 @@ class RouterBgpMixin(UtilsMixin):
         """
         Return structured config for router_bgp
         """
-
-        if not self.shared_utils.underlay_bgp:
-            return None
-
+        router_bgp = {}
         neighbors = []
         neighbor_interfaces = []
+
+        self._router_bgp_p2p_links(neighbors, neighbor_interfaces)
+        self._router_bgp_l3_interfaces(router_bgp, neighbors)
+
+        if neighbors:
+            router_bgp["neighbors"] = neighbors
+
+        if neighbor_interfaces:
+            router_bgp["neighbor_interfaces"] = neighbor_interfaces
+
+        if router_bgp:
+            return router_bgp
+
+        return None
+
+    def _router_bgp_p2p_links(self, neighbors: list, neighbor_interfaces: list) -> None:
+        """
+        In place update of neighbor and / or neighbor_interfaces
+        """
+        if not self.shared_utils.underlay_bgp:
+            return
+
         for p2p_link in self._filtered_p2p_links:
             if not (p2p_link.get("include_in_underlay_protocol", True) is True):
                 continue
@@ -58,15 +78,55 @@ class RouterBgpMixin(UtilsMixin):
             neighbor = {key: value for key, value in neighbor.items() if value is not None}
 
             neighbors.append({"ip_address": p2p_link["data"]["peer_ip"].split("/")[0], **neighbor})
+        return
 
-        router_bgp = {}
-        if neighbors:
-            router_bgp["neighbors"] = neighbors
+    def _router_bgp_l3_interfaces(self, router_bgp: dict, neighbors: list) -> None:
+        """
+        In place update of router_bgp / neighbors
+        """
+        # Review
+        for l3_interface in self._filtered_l3_interfaces:
+            local_as = l3_interface.get("bgp_as")
+            remote_as = l3_interface.get("peer_bgp_as")
+            if local_as is None and remote_as is None:
+                # No BGP config for this interface
+                continue
+            # One or the other is set
+            neighbor_as = local_as if remote_as is None else remote_as
 
-        if neighbor_interfaces:
-            router_bgp["neighbor_interfaces"] = neighbor_interfaces
+            neighbor = {
+                "remote_as": neighbor_as,
+                "peer": l3_interface["peer"],
+                "description": f"{l3_interface['peer']}",
+            }
 
-        if router_bgp:
-            return router_bgp
+            # Regular BGP Neighbors
+            if l3_interface.get("peer_ip") is None:
+                raise AristaAvdMissingVariableError("l3_edge.l3_interfaces.[].peer_ip")
+            peer_ip = l3_interface["peer_ip"].split("/")[0]
 
-        return None
+            neighbor["bfd"] = l3_interface.get("bfd")
+
+            if local_as != self.shared_utils.bgp_as:
+                neighbor["local_as"] = local_as
+
+            # Remove None values
+            neighbor = {key: value for key, value in neighbor.items() if value is not None}
+
+            neighbors.append({"ip_address": peer_ip, **neighbor})
+
+            address_family = f"address_family_ipv{ipaddress.ip_address(peer_ip).version}"
+            af_neighbor = {
+                "ip_address": peer_ip,
+                "activate": True,
+            }
+
+            if (vrf := l3_interface.get("vrf")) is not None:
+                bgp_vrf = {"name": vrf}
+                bgp_vrf.setdefault(address_family, {}).setdefault("neighbors", []).append(af_neighbor)
+                router_bgp.setdefault("vrfs", []).append(bgp_vrf)
+            else:
+                router_bgp.setdefault(address_family, {}).setdefault("neighbors", []).append(af_neighbor)
+
+            # TODO handle subinterfaces with BGP
+        return

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/core_interfaces_and_l3_edge/utils.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/core_interfaces_and_l3_edge/utils.py
@@ -10,7 +10,7 @@ from itertools import islice
 
 from ansible_collections.arista.avd.plugins.filter.convert_dicts import convert_dicts
 from ansible_collections.arista.avd.plugins.plugin_utils.eos_designs_shared_utils import SharedUtils
-from ansible_collections.arista.avd.plugins.plugin_utils.errors import AristaAvdMissingVariableError
+from ansible_collections.arista.avd.plugins.plugin_utils.errors import AristaAvdError, AristaAvdMissingVariableError
 from ansible_collections.arista.avd.plugins.plugin_utils.merge import merge
 from ansible_collections.arista.avd.plugins.plugin_utils.utils import default, get, get_item
 
@@ -38,6 +38,10 @@ class UtilsMixin:
         return get(self._hostvars, f"{self.data_model}.p2p_links", default=[])
 
     @cached_property
+    def _p2p_links_sflow(self) -> bool | None:
+        return get(self._hostvars, f"fabric_sflow.{self.data_model}")
+
+    @cached_property
     def _filtered_p2p_links(self) -> list:
         """
         Returns a filtered list of p2p_links, which only contains links with our hostname.
@@ -50,7 +54,7 @@ class UtilsMixin:
 
         # Apply p2p_profiles if set. Silently ignoring missing profile.
         if self._p2p_links_profiles:
-            p2p_links = [self._apply_p2p_profile(p2p_link) for p2p_link in p2p_links]
+            p2p_links = [self._apply_profile("p2p_links", p2p_link) for p2p_link in p2p_links]
 
         # Filter to only include p2p_links with our hostname under "nodes"
         p2p_links = [p2p_link for p2p_link in p2p_links if self.shared_utils.hostname in p2p_link.get("nodes", [])]
@@ -65,16 +69,26 @@ class UtilsMixin:
 
         return p2p_links
 
-    def _apply_p2p_profile(self, p2p_link: dict) -> dict:
-        if "profile" not in p2p_link:
+    def _apply_profile(self, type: str, target_dict: dict) -> dict:
+        """
+        Apply a profile to
+        """
+        if "profile" not in target_dict:
             # Nothing to do
-            return p2p_link
+            return target_dict
 
-        # Silently ignoring missing profile.
-        profile = get_item(self._p2p_links_profiles, "name", p2p_link["profile"], default={})
-        p2p_link = merge(profile, p2p_link, list_merge="replace", destructive_merge=False)
-        p2p_link.pop("name", None)
-        return p2p_link
+        # Silently ignoring missing profile and wrong types.
+        if type == "l3_interfaces":
+            profile = get_item(self._l3_interfaces_profiles, "name", target_dict["profile"], default={})
+        elif type == "p2p_links":
+            profile = get_item(self._p2p_links_profiles, "name", target_dict["profile"], default={})
+        else:
+            return target_dict
+
+        target_dict = merge(profile, target_dict, list_merge="replace", destructive_merge=False)
+        target_dict.pop("name", None)
+
+        return target_dict
 
     def _resolve_p2p_ips(self, p2p_link: dict) -> dict:
         if "ip" in p2p_link:
@@ -161,13 +175,13 @@ class UtilsMixin:
                 required=True,
                 var_name=f"{peer} under {self.data_model}.p2p_links.[].port_channel.nodes_child_interfaces",
             )["interfaces"]
-            id = int("".join(re.findall(r"\d", member_interfaces[0])))
+            pc_id = int("".join(re.findall(r"\d", member_interfaces[0])))
             peer_id = int("".join(re.findall(r"\d", peer_member_interfaces[0])))
             data.update(
                 {
-                    "interface": f"Port-Channel{id}",
+                    "interface": f"Port-Channel{pc_id}",
                     "peer_interface": f"Port-Channel{peer_id}",
-                    "port_channel_id": id,
+                    "port_channel_id": pc_id,
                     "port_channel_members": [
                         {
                             "interface": interface,
@@ -316,6 +330,123 @@ class UtilsMixin:
             },
         }
 
+    # l3_interfaces here
     @cached_property
-    def _p2p_links_sflow(self) -> bool | None:
+    def _l3_interfaces_profiles(self) -> list:
+        return get(self._hostvars, f"{self.data_model}.l3_interfaces_profiles", default=[])
+
+    @cached_property
+    def _l3_interfaces(self) -> list:
+        return get(self._hostvars, f"{self.data_model}.l3_interfaces", default=[])
+
+    @cached_property
+    def _l3_interfaces_sflow(self) -> bool | None:
         return get(self._hostvars, f"fabric_sflow.{self.data_model}")
+
+    @cached_property
+    def _filtered_l3_interfaces(self) -> list:
+        """
+        Returns a filtered list of l3_interfaces, which only contains interfaces with our hostname.
+        For each interface any referenced profiles are applied and IP addresses are resolved
+        from pools or subnets.
+        """
+        if not (l3_interfaces := self._l3_interfaces):
+            return []
+
+        # Apply p2p_profiles if set. Silently ignoring missing profile.
+        if self._l3_interfaces_profiles:
+            l3_interfaces = [self._apply_profile("l3_interface", l3_interface) for l3_interface in l3_interfaces]
+
+        # Filter to only include l3_interfaces with our hostname under "nodes"
+        l3_interfaces = [l3_interface for l3_interface in l3_interfaces if self.shared_utils.hostname == get(l3_interface, "node", required=True)]
+        if not l3_interfaces:
+            return []
+
+        # Update data to match current p2p_link
+        # This is a bit shady
+        for l3_interface in l3_interfaces:
+            l3_interface["peer_bgp_as"] = l3_interface.get("peer_bgp_as") or l3_interface.get("bgp_as")
+
+        return l3_interfaces
+
+    @cached_property
+    def _valid_vrfs(self) -> list[dict]:
+        """
+        Return all the valid VRF on this device based on network_services configuration
+        """
+        # TODO check as we could end up with duplicates here
+        return [vrf for tenant in self.shared_utils.filtered_tenants for vrf in tenant.get("vrfs", [])]
+
+    def _get_l3_interface_cfg(self, l3_interface: dict) -> dict | None:
+        """
+        TODO
+        only physical interfaces, not sub interfaces
+        """
+        if l3_interface["node"] != self.shared_utils.hostname:
+            return None
+
+        interface_name = l3_interface["interface"]
+        interface_description = l3_interface.get("description") or "TODO"
+        interface_vrf = l3_interface.get("vrf") or "default"
+
+        if interface_vrf and get_item(self._valid_vrfs, "name", interface_vrf) is None:
+            raise AristaAvdError("TODO invalid VRF")
+
+        # TODO extra stuff for DHCP for ip_address
+        interface = {
+            "name": interface_name,
+            "peer_type": "l3_interface",
+            "vrf": interface_vrf if interface_vrf != "default" else None,
+            "ip_address": l3_interface.get("ip"),
+            "shutdown": not l3_interface.get("enabled", True),
+            "type": "routed",
+            "description": interface_description,
+            "service_profile": l3_interface.get("qos_profile"),
+            "eos_cli": l3_interface.get("raw_eos_cli"),
+            "struct_cfg": l3_interface.get("structured_config"),
+        }
+
+        # TODO handle OSPF
+
+        # Strip None values from vlan before adding to list
+        interface = {key: value for key, value in interface.items() if value is not None}
+
+        return interface
+
+    def _get_l3_subinterface_cfg(self, l3_interface: dict, subinterface_dict: dict) -> dict | None:
+        """
+        Return a subinterface structured config.
+        """
+        if l3_interface["node"] != self.shared_utils.hostname:
+            return None
+
+        subif_vrf = get(subinterface_dict, "vrf", required=True)
+        if (vrf_dict := get_item(self._valid_vrfs, "name", subif_vrf)) is None:
+            raise AristaAvdError("TODO invalid VRF for subif")
+
+        subif_id = subinterface_dict.get("subinterface_id") or vrf_dict.get("vrf_vni") or vrf_dict.get("vrf_id")
+
+        interface_name = f"{l3_interface['interface']}.{subif_id}"
+        interface_description = subinterface_dict.get("description") or l3_interface.get("description") or "TODO"
+
+        interface = {
+            "name": interface_name,
+            "peer_type": "l3_subinterface",
+            "vrf": subif_vrf if subif_vrf != "default" else None,
+            "ip_address": l3_interface.get("ip"),
+            "type": "l3dot1q",
+            "encapsulation_dot1q_vlan": subif_id,
+            "description": interface_description,
+            "eos_cli": l3_interface.get("raw_eos_cli"),
+            "struct_cfg": l3_interface.get("structured_config"),
+        }
+
+        if l3_interface.get("dhcp_client_accept_default_route", False):
+            interface["dhcp_client_accept_default_route"] = True
+
+        # TODO handle OSPF
+
+        # Strip None values from vlan before adding to list
+        interface = {key: value for key, value in interface.items() if value is not None}
+
+        return interface

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/eos_cli.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/eos_cli.py
@@ -29,7 +29,7 @@ class EosCliMixin(UtilsMixin):
         if (eos_cli := get(self._hostvars, "eos_cli")) is not None:
             eos_clis.append(eos_cli)
 
-        for tenant in self._filtered_tenants:
+        for tenant in self.shared_utils.filtered_tenants:
             for vrf in tenant["vrfs"]:
                 if (eos_cli := vrf.get("raw_eos_cli")) is not None:
                     eos_clis.append(eos_cli)

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/ethernet_interfaces.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/ethernet_interfaces.py
@@ -35,9 +35,9 @@ class EthernetInterfacesMixin(UtilsMixin):
         subif_parent_interface_names = set()
 
         if self.shared_utils.network_services_l3:
-            for tenant in self._filtered_tenants:
+            for tenant in self.shared_utils.filtered_tenants:
                 for vrf in tenant["vrfs"]:
-                    # The l3_interfaces has already been filtered in _filtered_tenants
+                    # The l3_interfaces has already been filtered in filtered_tenants
                     # to only contain entries with our hostname
                     for l3_interface in vrf["l3_interfaces"]:
                         nodes_length = len(l3_interface["nodes"])
@@ -146,7 +146,7 @@ class EthernetInterfacesMixin(UtilsMixin):
                             )
 
         if self.shared_utils.network_services_l1:
-            for tenant in self._filtered_tenants:
+            for tenant in self.shared_utils.filtered_tenants:
                 if "point_to_point_services" not in tenant:
                     continue
 

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/ip_igmp_snooping.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/ip_igmp_snooping.py
@@ -32,7 +32,7 @@ class IpIgmpSnoopingMixin(UtilsMixin):
             return ip_igmp_snooping
 
         vlans = []
-        for tenant in self._filtered_tenants:
+        for tenant in self.shared_utils.filtered_tenants:
             for vrf in tenant["vrfs"]:
                 for svi in vrf["svis"]:
                     if vlan := self._ip_igmp_snooping_vlan(svi, tenant):

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/ipv6_static_routes.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/ipv6_static_routes.py
@@ -28,7 +28,7 @@ class Ipv6StaticRoutesMixin(UtilsMixin):
             return None
 
         ipv6_static_routes = []
-        for tenant in self._filtered_tenants:
+        for tenant in self.shared_utils.filtered_tenants:
             for vrf in tenant["vrfs"]:
                 for static_route in vrf["ipv6_static_routes"]:
                     static_route["vrf"] = vrf["name"]

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/loopback_interfaces.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/loopback_interfaces.py
@@ -29,7 +29,7 @@ class LoopbackInterfacesMixin(UtilsMixin):
             return None
 
         loopback_interfaces = []
-        for tenant in self._filtered_tenants:
+        for tenant in self.shared_utils.filtered_tenants:
             for vrf in tenant["vrfs"]:
                 if (loopback := get(vrf, "vtep_diagnostic.loopback")) is None:
                     continue

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/patch_panel.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/patch_panel.py
@@ -28,7 +28,7 @@ class PatchPanelMixin(UtilsMixin):
             return None
 
         patches = []
-        for tenant in self._filtered_tenants:
+        for tenant in self.shared_utils.filtered_tenants:
             if "point_to_point_services" not in tenant:
                 continue
 

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/port_channel_interfaces.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/port_channel_interfaces.py
@@ -36,7 +36,7 @@ class PortChannelInterfacesMixin(UtilsMixin):
         port_channel_interfaces = []
         subif_parent_interfaces = []
 
-        for tenant in self._filtered_tenants:
+        for tenant in self.shared_utils.filtered_tenants:
             if "point_to_point_services" not in tenant:
                 continue
 

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/prefix_lists.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/prefix_lists.py
@@ -76,7 +76,7 @@ class PrefixListsMixin(UtilsMixin):
         Return sorted list of MLAG peerings for VRFs where MLAG iBGP peering should not be redistributed
         """
         mlag_prefixes = set()
-        for tenant in self._filtered_tenants:
+        for tenant in self.shared_utils.filtered_tenants:
             for vrf in tenant["vrfs"]:
                 if self._mlag_ibgp_peering_vlan_vrf(vrf, tenant) is None:
                     continue

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/route_maps.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/route_maps.py
@@ -31,9 +31,9 @@ class RouteMapsMixin(UtilsMixin):
 
         route_maps = []
 
-        for tenant in self._filtered_tenants:
+        for tenant in self.shared_utils.filtered_tenants:
             for vrf in tenant["vrfs"]:
-                # BGP Peers are already filtered in _filtered_tenants
+                # BGP Peers are already filtered in filtered_tenants
                 #  so we only have entries with our hostname in them.
                 for bgp_peer in vrf["bgp_peers"]:
                     ipv4_next_hop = bgp_peer.get("set_ipv4_next_hop")

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/router_bgp.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/router_bgp.py
@@ -68,9 +68,9 @@ class RouterBgpMixin(UtilsMixin):
 
         peer_groups = []
         peer_peergroups = set()
-        for tenant in self._filtered_tenants:
+        for tenant in self.shared_utils.filtered_tenants:
             for vrf in tenant["vrfs"]:
-                # bgp_peers is already filtered in _filtered_tenants to only contain entries with our hostname
+                # bgp_peers is already filtered in filtered_tenants to only contain entries with our hostname
                 if not (vrf["bgp_peers"] or vrf.get("bgp_peer_groups")):
                     continue
 
@@ -134,7 +134,7 @@ class RouterBgpMixin(UtilsMixin):
 
         vrfs = []
 
-        for tenant in self._filtered_tenants:
+        for tenant in self.shared_utils.filtered_tenants:
             for vrf in tenant["vrfs"]:
                 vrf_address_families = [af for af in vrf.get("address_families", ["evpn"]) if af in self.shared_utils.overlay_address_families]
                 if not vrf_address_families:
@@ -322,7 +322,7 @@ class RouterBgpMixin(UtilsMixin):
             return None
 
         vlans = []
-        for tenant in self._filtered_tenants:
+        for tenant in self.shared_utils.filtered_tenants:
             for vrf in tenant["vrfs"]:
                 for svi in vrf["svis"]:
                     if (vlan := self._router_bgp_vlans_vlan(svi, tenant, vrf)) is not None:
@@ -382,7 +382,7 @@ class RouterBgpMixin(UtilsMixin):
             bgp_vlan["route_targets"]["import_export_evpn_domains"] = [{"domain": "remote", "route_target": vlan_rt}]
 
         vlan_evpn_l2_multicast_enabled = default(get(vlan, "evpn_l2_multicast.enabled"), get(tenant, "evpn_l2_multicast.enabled"))
-        if vlan_evpn_l2_multicast_enabled is True and self._evpn_multicast is not True:
+        if vlan_evpn_l2_multicast_enabled is True and self.shared_utils.evpn_multicast is not True:
             raise AristaAvdError(
                 f"'evpn_l2_multicast: true' under VLAN {vlan['id']}({vlan['name']}) or Tenant {tenant['name']}; this requires 'evpn_multicast' to also be set"
                 " to true."
@@ -419,7 +419,7 @@ class RouterBgpMixin(UtilsMixin):
             return None
 
         bundles = []
-        for tenant in self._filtered_tenants:
+        for tenant in self.shared_utils.filtered_tenants:
             for vrf in tenant["vrfs"]:
                 if (bundle := self._router_bgp_vlan_aware_bundles_vrf(vrf, tenant)) is not None:
                     append_if_not_duplicate(
@@ -743,7 +743,7 @@ class RouterBgpMixin(UtilsMixin):
             return None
 
         vpws = []
-        for tenant in self._filtered_tenants:
+        for tenant in self.shared_utils.filtered_tenants:
             if "point_to_point_services" not in tenant:
                 continue
 

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/router_multicast.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/router_multicast.py
@@ -27,7 +27,7 @@ class RouterMulticastMixin(UtilsMixin):
             return None
 
         vrfs = []
-        for tenant in self._filtered_tenants:
+        for tenant in self.shared_utils.filtered_tenants:
             for vrf in tenant["vrfs"]:
                 if get(vrf, "_evpn_l3_multicast_enabled"):
                     vrf_config = {"name": vrf["name"], "ipv4": {"routing": True}}

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/router_ospf.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/router_ospf.py
@@ -30,7 +30,7 @@ class RouterOspfMixin(UtilsMixin):
             return None
 
         ospf_processes = []
-        for tenant in self._filtered_tenants:
+        for tenant in self.shared_utils.filtered_tenants:
             for vrf in tenant["vrfs"]:
                 if get(vrf, "ospf.enabled") is not True:
                     continue

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/router_pim_sparse_mode.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/router_pim_sparse_mode.py
@@ -27,7 +27,7 @@ class RouterPimSparseModeMixin(UtilsMixin):
             return None
 
         vrfs = []
-        for tenant in self._filtered_tenants:
+        for tenant in self.shared_utils.filtered_tenants:
             for vrf in tenant["vrfs"]:
                 if vrf_rps := get(vrf, "_pim_rp_addresses"):
                     vrf_config = {

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/standard_access_lists.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/standard_access_lists.py
@@ -28,7 +28,7 @@ class StandardAccessListsMixin(UtilsMixin):
             return None
 
         standard_access_lists = []
-        for tenant in self._filtered_tenants:
+        for tenant in self.shared_utils.filtered_tenants:
             for vrf in tenant["vrfs"]:
                 for rp_entry in default(get(vrf, "pim_rp_addresses"), get(tenant, "pim_rp_addresses"), []):
                     if self.shared_utils.hostname in get(rp_entry, "nodes", default=[self.shared_utils.hostname]):

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/static_routes.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/static_routes.py
@@ -29,9 +29,9 @@ class StaticRoutesMixin(UtilsMixin):
             return None
 
         static_routes = []
-        for tenant in self._filtered_tenants:
+        for tenant in self.shared_utils.filtered_tenants:
             for vrf in tenant["vrfs"]:
-                # Static routes are already filtered inside _filtered_tenants
+                # Static routes are already filtered inside filtered_tenants
                 for static_route in vrf["static_routes"]:
                     static_route["vrf"] = vrf["name"]
                     static_route.pop("nodes", None)

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/struct_cfgs.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/struct_cfgs.py
@@ -29,7 +29,7 @@ class StructCfgsMixin(UtilsMixin):
             return None
 
         vrf_struct_cfgs = []
-        for tenant in self._filtered_tenants:
+        for tenant in self.shared_utils.filtered_tenants:
             for vrf in tenant["vrfs"]:
                 if (structured_config := vrf.get("structured_config")) is not None:
                     # Inserting VRF into structured_config to perform duplication checks

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/vlan_interfaces.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/vlan_interfaces.py
@@ -30,7 +30,7 @@ class VlanInterfacesMixin(UtilsMixin):
             return None
 
         vlan_interfaces = []
-        for tenant in self._filtered_tenants:
+        for tenant in self.shared_utils.filtered_tenants:
             for vrf in tenant["vrfs"]:
                 for svi in vrf["svis"]:
                     vlan_interface = self._get_vlan_interface_config_for_svi(svi, vrf)

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/vlans.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/vlans.py
@@ -32,7 +32,7 @@ class VlansMixin(UtilsMixin):
             return None
 
         vlans = []
-        for tenant in self._filtered_tenants:
+        for tenant in self.shared_utils.filtered_tenants:
             for vrf in tenant["vrfs"]:
                 for svi in vrf["svis"]:
                     vlan = self._get_vlan_config(svi)

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/vrfs.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/vrfs.py
@@ -31,7 +31,7 @@ class VrfsMixin(UtilsMixin):
             return None
 
         vrfs = []
-        for tenant in self._filtered_tenants:
+        for tenant in self.shared_utils.filtered_tenants:
             for vrf in tenant["vrfs"]:
                 vrf_name = vrf["name"]
                 if vrf_name == "default":
@@ -73,7 +73,7 @@ class VrfsMixin(UtilsMixin):
         """
         Return bool if IPv6 is configured in the given VRF.
 
-        Expects a VRF definition coming from _filtered_tenants, where all keys have been set and filtered
+        Expects a VRF definition coming from filtered_tenants, where all keys have been set and filtered
         """
         for svi in vrf["svis"]:
             if svi.get("ipv6_address_virtual") is not None:

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/vxlan_interface.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/vxlan_interface.py
@@ -22,7 +22,6 @@ class VxlanInterfaceMixin(UtilsMixin):
 
     # Set type hints for Attributes of the main class as needed
     _hostvars: dict
-    _filtered_tenants: list[dict]
 
     @cached_property
     def vxlan_interface(self) -> dict | None:
@@ -59,7 +58,7 @@ class VxlanInterfaceMixin(UtilsMixin):
         vrfs = []
         # vnis is a list of dicts only used for duplication checks across multiple types of objects all having "vni" as a key.
         vnis = []
-        for tenant in self._filtered_tenants:
+        for tenant in self.shared_utils.filtered_tenants:
             for vrf in tenant["vrfs"]:
                 for svi in vrf["svis"]:
                     if vlan := self._get_vxlan_interface_config_for_vlan(svi, tenant):
@@ -262,4 +261,4 @@ class VxlanInterfaceMixin(UtilsMixin):
 
     @cached_property
     def _multi_vtep(self) -> bool:
-        return self.shared_utils.mlag is True and self._evpn_multicast is True
+        return self.shared_utils.mlag is True and self.shared_utils.evpn_multicast is True

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -2431,7 +2431,7 @@
             "properties": {
               "name": {
                 "type": "string",
-                "description": "P2P profile name. Any variable supported under p2p_links can be inherited from a profile.",
+                "description": "P2P profile name. Any variable supported under `p2p_links` can be inherited from a profile.",
                 "title": "Name"
               },
               "id": {
@@ -2893,6 +2893,10580 @@
             }
           },
           "title": "P2P Links"
+        },
+        "l3_interfaces_profiles": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "L3 interface profile name. Any variable supported under `l3_interfaces` can be inherited from a profile.",
+                "title": "Name"
+              },
+              "speed": {
+                "type": "string",
+                "description": "Speed should be set in the format `<interface_speed>` or `forced <interface_speed>` or `auto <interface_speed>`.",
+                "title": "Speed"
+              },
+              "vrf": {
+                "type": "string",
+                "description": "VRF to configure on the interface. (default VRF if not set).",
+                "title": "VRF"
+              },
+              "ip": {
+                "type": "string",
+                "description": "Node IPv4 address/Mask or dhcp.",
+                "title": "IP"
+              },
+              "dhcp_client_accept_default_route": {
+                "type": "boolean",
+                "description": "Supported if `ip` is `dhcp`.\nAccepts default route from DHCP, default False.",
+                "title": "DHCP Client Accept Default Route"
+              },
+              "ipv6_enable": {
+                "type": "boolean",
+                "default": false,
+                "description": "Allows turning on ipv6 for the interface or profile.",
+                "title": "IPv6 Enable"
+              },
+              "interface": {
+                "type": "string",
+                "description": "Must be an Ethernet interface like 'Ethernet2'.",
+                "title": "Interface"
+              },
+              "peer": {
+                "type": "string",
+                "description": "The peer device name. Used for description and documentation",
+                "title": "Peer"
+              },
+              "peer_interface": {
+                "type": "string",
+                "description": "The peer device interface. Used for description and documentation",
+                "title": "Peer Interface"
+              },
+              "peer_ip": {
+                "type": "string",
+                "description": "The peer device IP. Used for description and documentation",
+                "title": "Peer IP"
+              },
+              "bgp_as": {
+                "type": "string",
+                "description": "AS numbers for BGP.\nRequired with bgp peering.\n",
+                "title": "BGP As"
+              },
+              "peer_bgp_as": {
+                "type": "string",
+                "description": "AS numbers for BGP for the remote peer.\nIf not provided, `bgp_as` is used.\n",
+                "title": "Peer BGP As"
+              },
+              "description": {
+                "type": "string",
+                "description": "Interface description.",
+                "title": "Description"
+              },
+              "bfd": {
+                "type": "boolean",
+                "default": false,
+                "description": "Enable BFD (only considered for BGP).",
+                "title": "BFD"
+              },
+              "qos_profile": {
+                "type": "string",
+                "description": "QOS service profile.",
+                "title": "QOS Profile"
+              },
+              "subinterfaces": {
+                "type": "array",
+                "description": "Configure subinterfaces, each in their own VRF under the interface.",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "vrf": {
+                      "type": "string",
+                      "description": "Name of the VRF to configure for this subinterface\nThe VRF MUST exist in `network_services`",
+                      "title": "VRF"
+                    },
+                    "subinterface_id": {
+                      "type": "integer",
+                      "description": "Optional ID to overwrite the default one used from the VRF.\n`vrf_id` is used otherwise.",
+                      "title": "Subinterface ID"
+                    },
+                    "description": {
+                      "type": "string",
+                      "description": "Optional description for the subinterface.",
+                      "title": "Description"
+                    },
+                    "structured_config": {
+                      "type": "object",
+                      "description": "Custom structured config for the subinterface.\nNote! The content of this dictionary is _not_ validated by the schema, since it can be either ethernet_interfaces or port_channel_interfaces.",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "title": "Name"
+                        },
+                        "description": {
+                          "type": "string",
+                          "title": "Description"
+                        },
+                        "shutdown": {
+                          "type": "boolean",
+                          "title": "Shutdown"
+                        },
+                        "load_interval": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "maximum": 600,
+                          "description": "Interval in seconds for updating interface counters\"",
+                          "title": "Load Interval"
+                        },
+                        "speed": {
+                          "type": "string",
+                          "description": "Speed should be set in the format `<interface_speed>` or `forced <interface_speed>` or `auto <interface_speed>`.",
+                          "title": "Speed"
+                        },
+                        "mtu": {
+                          "type": "integer",
+                          "minimum": 68,
+                          "maximum": 65535,
+                          "title": "MTU"
+                        },
+                        "l2_mtu": {
+                          "type": "integer",
+                          "minimum": 68,
+                          "maximum": 65535,
+                          "description": "\"l2_mtu\" should only be defined for platforms supporting the \"l2 mtu\" CLI\n",
+                          "title": "L2 MTU"
+                        },
+                        "l2_mru": {
+                          "type": "integer",
+                          "minimum": 68,
+                          "maximum": 65535,
+                          "description": "\"l2_mru\" should only be defined for platforms supporting the \"l2 mru\" CLI\n",
+                          "title": "L2 MRU"
+                        },
+                        "vlans": {
+                          "type": "string",
+                          "description": "List of switchport vlans as string\nFor a trunk port this would be a range like \"1-200,300\"\nFor an access port this would be a single vlan \"123\"\n",
+                          "title": "VLANs"
+                        },
+                        "native_vlan": {
+                          "type": "integer",
+                          "title": "Native VLAN"
+                        },
+                        "native_vlan_tag": {
+                          "type": "boolean",
+                          "description": "If setting both native_vlan and native_vlan_tag, native_vlan_tag takes precedence",
+                          "title": "Native VLAN Tag"
+                        },
+                        "mode": {
+                          "type": "string",
+                          "enum": [
+                            "access",
+                            "dot1q-tunnel",
+                            "trunk",
+                            "trunk phone"
+                          ],
+                          "title": "Mode"
+                        },
+                        "phone": {
+                          "type": "object",
+                          "properties": {
+                            "trunk": {
+                              "type": "string",
+                              "enum": [
+                                "tagged",
+                                "tagged phone",
+                                "untagged",
+                                "untagged phone"
+                              ],
+                              "title": "Trunk"
+                            },
+                            "vlan": {
+                              "type": "integer",
+                              "minimum": 1,
+                              "maximum": 4094,
+                              "title": "VLAN"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Phone"
+                        },
+                        "l2_protocol": {
+                          "type": "object",
+                          "properties": {
+                            "encapsulation_dot1q_vlan": {
+                              "type": "integer",
+                              "description": "Vlan tag to configure on sub-interface",
+                              "title": "Encapsulation Dot1Q VLAN"
+                            },
+                            "forwarding_profile": {
+                              "type": "string",
+                              "description": "L2 protocol forwarding profile",
+                              "title": "Forwarding Profile"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "L2 Protocol"
+                        },
+                        "trunk_groups": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "title": "Trunk Groups"
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "routed",
+                            "switched",
+                            "l3dot1q",
+                            "l2dot1q",
+                            "port-channel-member"
+                          ],
+                          "description": "l3dot1q and l2dot1q are used for sub-interfaces. The parent interface should be defined as routed.\nInterface will not be listed in device documentation, unless \"type\" is set.\n",
+                          "title": "Type"
+                        },
+                        "snmp_trap_link_change": {
+                          "type": "boolean",
+                          "title": "Snmp Trap Link Change"
+                        },
+                        "address_locking": {
+                          "type": "object",
+                          "properties": {
+                            "ipv4": {
+                              "type": "boolean",
+                              "description": "Enable address locking for IPv4",
+                              "title": "IPv4"
+                            },
+                            "ipv6": {
+                              "type": "boolean",
+                              "description": "Enable address locking for IPv6",
+                              "title": "IPv6"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Address Locking"
+                        },
+                        "flowcontrol": {
+                          "type": "object",
+                          "properties": {
+                            "received": {
+                              "type": "string",
+                              "enum": [
+                                "desired",
+                                "on",
+                                "off"
+                              ],
+                              "title": "Received"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Flowcontrol"
+                        },
+                        "vrf": {
+                          "type": "string",
+                          "description": "VRF name",
+                          "title": "VRF"
+                        },
+                        "flow_tracker": {
+                          "type": "object",
+                          "properties": {
+                            "sampled": {
+                              "type": "string",
+                              "description": "Sampled flow tracker name.",
+                              "title": "Sampled"
+                            },
+                            "hardware": {
+                              "type": "string",
+                              "description": "Hardware flow tracker name.",
+                              "title": "Hardware"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Flow Tracker"
+                        },
+                        "error_correction_encoding": {
+                          "type": "object",
+                          "properties": {
+                            "enabled": {
+                              "type": "boolean",
+                              "default": true,
+                              "title": "Enabled"
+                            },
+                            "fire_code": {
+                              "type": "boolean",
+                              "title": "Fire Code"
+                            },
+                            "reed_solomon": {
+                              "type": "boolean",
+                              "title": "Reed Solomon"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Error Correction Encoding"
+                        },
+                        "link_tracking_groups": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "string",
+                                "description": "Group name",
+                                "title": "Name"
+                              },
+                              "direction": {
+                                "type": "string",
+                                "enum": [
+                                  "upstream",
+                                  "downstream"
+                                ],
+                                "title": "Direction"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            },
+                            "required": [
+                              "name"
+                            ]
+                          },
+                          "title": "Link Tracking Groups"
+                        },
+                        "evpn_ethernet_segment": {
+                          "type": "object",
+                          "properties": {
+                            "identifier": {
+                              "type": "string",
+                              "description": "EVPN Ethernet Segment Identifier (Type 1 format)",
+                              "title": "Identifier"
+                            },
+                            "redundancy": {
+                              "type": "string",
+                              "enum": [
+                                "all-active",
+                                "single-active"
+                              ],
+                              "title": "Redundancy"
+                            },
+                            "designated_forwarder_election": {
+                              "type": "object",
+                              "properties": {
+                                "algorithm": {
+                                  "type": "string",
+                                  "enum": [
+                                    "modulus",
+                                    "preference"
+                                  ],
+                                  "title": "Algorithm"
+                                },
+                                "preference_value": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "maximum": 65535,
+                                  "description": "Preference_value is only used when \"algorithm\" is \"preference\"",
+                                  "title": "Preference Value"
+                                },
+                                "dont_preempt": {
+                                  "type": "boolean",
+                                  "description": "Dont_preempt is only used when \"algorithm\" is \"preference\"",
+                                  "title": "Dont Preempt"
+                                },
+                                "hold_time": {
+                                  "type": "integer",
+                                  "title": "Hold Time"
+                                },
+                                "subsequent_hold_time": {
+                                  "type": "integer",
+                                  "title": "Subsequent Hold Time"
+                                },
+                                "candidate_reachability_required": {
+                                  "type": "boolean",
+                                  "title": "Candidate Reachability Required"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Designated Forwarder Election"
+                            },
+                            "mpls": {
+                              "type": "object",
+                              "properties": {
+                                "shared_index": {
+                                  "type": "integer",
+                                  "minimum": 1,
+                                  "maximum": 1024,
+                                  "title": "Shared Index"
+                                },
+                                "tunnel_flood_filter_time": {
+                                  "type": "integer",
+                                  "title": "Tunnel Flood Filter Time"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "MPLS"
+                            },
+                            "route_target": {
+                              "type": "string",
+                              "description": "EVPN Route Target for ESI with format xx:xx:xx:xx:xx:xx",
+                              "title": "Route Target"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "EVPN Ethernet Segment"
+                        },
+                        "encapsulation_dot1q_vlan": {
+                          "type": "integer",
+                          "description": "VLAN tag to configure on sub-interface",
+                          "title": "Encapsulation Dot1Q VLAN"
+                        },
+                        "encapsulation_vlan": {
+                          "type": "object",
+                          "properties": {
+                            "client": {
+                              "type": "object",
+                              "properties": {
+                                "dot1q": {
+                                  "type": "object",
+                                  "properties": {
+                                    "vlan": {
+                                      "type": "integer",
+                                      "description": "Client VLAN ID",
+                                      "title": "VLAN"
+                                    },
+                                    "outer": {
+                                      "type": "integer",
+                                      "description": "Client Outer VLAN ID",
+                                      "title": "Outer"
+                                    },
+                                    "inner": {
+                                      "type": "integer",
+                                      "description": "Client Inner VLAN ID",
+                                      "title": "Inner"
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "patternProperties": {
+                                    "^_.+$": {}
+                                  },
+                                  "title": "Dot1Q"
+                                },
+                                "unmatched": {
+                                  "type": "boolean",
+                                  "title": "Unmatched"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Client"
+                            },
+                            "network": {
+                              "type": "object",
+                              "description": "Network encapsulations are all optional and skipped if using client unmatched",
+                              "properties": {
+                                "dot1q": {
+                                  "type": "object",
+                                  "properties": {
+                                    "vlan": {
+                                      "type": "integer",
+                                      "description": "Network VLAN ID",
+                                      "title": "VLAN"
+                                    },
+                                    "outer": {
+                                      "type": "integer",
+                                      "description": "Network outer VLAN ID",
+                                      "title": "Outer"
+                                    },
+                                    "inner": {
+                                      "type": "integer",
+                                      "description": "Network inner VLAN ID",
+                                      "title": "Inner"
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "patternProperties": {
+                                    "^_.+$": {}
+                                  },
+                                  "title": "Dot1Q"
+                                },
+                                "client": {
+                                  "type": "boolean",
+                                  "title": "Client"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Network"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Encapsulation VLAN"
+                        },
+                        "vlan_id": {
+                          "type": "integer",
+                          "minimum": 1,
+                          "maximum": 4094,
+                          "title": "VLAN ID"
+                        },
+                        "ip_address": {
+                          "type": "string",
+                          "description": "IPv4 address/mask or \"dhcp\"",
+                          "title": "IP Address"
+                        },
+                        "ip_address_secondaries": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "title": "IP Address Secondaries"
+                        },
+                        "dhcp_client_accept_default_route": {
+                          "type": "boolean",
+                          "description": "Install default-route obtained via DHCP",
+                          "title": "DHCP Client Accept Default Route"
+                        },
+                        "dhcp_server_ipv4": {
+                          "type": "boolean",
+                          "description": "Enable IPv4 DHCP server.",
+                          "title": "DHCP Server IPv4"
+                        },
+                        "dhcp_server_ipv6": {
+                          "type": "boolean",
+                          "description": "Enable IPv6 DHCP server.",
+                          "title": "DHCP Server IPv6"
+                        },
+                        "ip_helpers": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "ip_helper": {
+                                "type": "string",
+                                "title": "IP Helper"
+                              },
+                              "source_interface": {
+                                "type": "string",
+                                "description": "Source interface name",
+                                "title": "Source Interface"
+                              },
+                              "vrf": {
+                                "type": "string",
+                                "description": "VRF name",
+                                "title": "VRF"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            },
+                            "required": [
+                              "ip_helper"
+                            ]
+                          },
+                          "title": "IP Helpers"
+                        },
+                        "ip_nat": {
+                          "type": "object",
+                          "properties": {
+                            "service_profile": {
+                              "type": "string",
+                              "description": "NAT interface profile.",
+                              "title": "Service Profile"
+                            },
+                            "destination": {
+                              "type": "object",
+                              "properties": {
+                                "dynamic": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "access_list": {
+                                        "type": "string",
+                                        "title": "Access List"
+                                      },
+                                      "comment": {
+                                        "type": "string",
+                                        "title": "Comment"
+                                      },
+                                      "pool_name": {
+                                        "type": "string",
+                                        "title": "Pool Name"
+                                      },
+                                      "priority": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "maximum": 4294967295,
+                                        "title": "Priority"
+                                      }
+                                    },
+                                    "required": [
+                                      "pool_name",
+                                      "access_list"
+                                    ],
+                                    "additionalProperties": false,
+                                    "patternProperties": {
+                                      "^_.+$": {}
+                                    }
+                                  },
+                                  "title": "Dynamic"
+                                },
+                                "static": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "access_list": {
+                                        "type": "string",
+                                        "description": "'access_list' and 'group' are mutual exclusive",
+                                        "title": "Access List"
+                                      },
+                                      "comment": {
+                                        "type": "string",
+                                        "title": "Comment"
+                                      },
+                                      "direction": {
+                                        "type": "string",
+                                        "enum": [
+                                          "egress",
+                                          "ingress"
+                                        ],
+                                        "description": "Egress or ingress can be the default. This depends on source/destination, EOS version, and hardware platform.\nEOS might remove this keyword in the configuration. So, check the configuration on targeted HW/SW.\n",
+                                        "title": "Direction"
+                                      },
+                                      "group": {
+                                        "type": "integer",
+                                        "minimum": 1,
+                                        "maximum": 65535,
+                                        "description": "'access_list' and 'group' are mutual exclusive",
+                                        "title": "Group"
+                                      },
+                                      "original_ip": {
+                                        "type": "string",
+                                        "description": "IPv4 address",
+                                        "title": "Original IP"
+                                      },
+                                      "original_port": {
+                                        "type": "integer",
+                                        "minimum": 1,
+                                        "maximum": 65535,
+                                        "title": "Original Port"
+                                      },
+                                      "priority": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "maximum": 4294967295,
+                                        "title": "Priority"
+                                      },
+                                      "protocol": {
+                                        "type": "string",
+                                        "enum": [
+                                          "udp",
+                                          "tcp"
+                                        ],
+                                        "title": "Protocol"
+                                      },
+                                      "translated_ip": {
+                                        "type": "string",
+                                        "description": "IPv4 address",
+                                        "title": "Translated IP"
+                                      },
+                                      "translated_port": {
+                                        "type": "integer",
+                                        "minimum": 1,
+                                        "maximum": 65535,
+                                        "description": "requires 'original_port'",
+                                        "title": "Translated Port"
+                                      }
+                                    },
+                                    "required": [
+                                      "translated_ip",
+                                      "original_ip"
+                                    ],
+                                    "additionalProperties": false,
+                                    "patternProperties": {
+                                      "^_.+$": {}
+                                    }
+                                  },
+                                  "title": "Static"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Destination"
+                            },
+                            "source": {
+                              "type": "object",
+                              "properties": {
+                                "dynamic": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "access_list": {
+                                        "type": "string",
+                                        "title": "Access List"
+                                      },
+                                      "comment": {
+                                        "type": "string",
+                                        "title": "Comment"
+                                      },
+                                      "nat_type": {
+                                        "type": "string",
+                                        "enum": [
+                                          "overload",
+                                          "pool",
+                                          "pool-address-only",
+                                          "pool-full-cone"
+                                        ],
+                                        "title": "Nat Type"
+                                      },
+                                      "pool_name": {
+                                        "type": "string",
+                                        "description": "required if 'nat_type' is pool, pool-address-only or pool-full-cone\nignored if 'nat_type' is overload\n",
+                                        "title": "Pool Name"
+                                      },
+                                      "priority": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "maximum": 4294967295,
+                                        "title": "Priority"
+                                      }
+                                    },
+                                    "required": [
+                                      "nat_type",
+                                      "access_list"
+                                    ],
+                                    "additionalProperties": false,
+                                    "patternProperties": {
+                                      "^_.+$": {}
+                                    }
+                                  },
+                                  "title": "Dynamic"
+                                },
+                                "static": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "access_list": {
+                                        "type": "string",
+                                        "description": "'access_list' and 'group' are mutual exclusive",
+                                        "title": "Access List"
+                                      },
+                                      "comment": {
+                                        "type": "string",
+                                        "title": "Comment"
+                                      },
+                                      "direction": {
+                                        "type": "string",
+                                        "enum": [
+                                          "egress",
+                                          "ingress"
+                                        ],
+                                        "description": "Egress or ingress can be the default. This depends on source/destination, EOS version, and hardware platform.\nEOS might remove this keyword in the configuration. So, check the configuration on targeted HW/SW.\n",
+                                        "title": "Direction"
+                                      },
+                                      "group": {
+                                        "type": "integer",
+                                        "minimum": 1,
+                                        "maximum": 65535,
+                                        "description": "'access_list' and 'group' are mutual exclusive",
+                                        "title": "Group"
+                                      },
+                                      "original_ip": {
+                                        "type": "string",
+                                        "description": "IPv4 address",
+                                        "title": "Original IP"
+                                      },
+                                      "original_port": {
+                                        "type": "integer",
+                                        "minimum": 1,
+                                        "maximum": 65535,
+                                        "title": "Original Port"
+                                      },
+                                      "priority": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "maximum": 4294967295,
+                                        "title": "Priority"
+                                      },
+                                      "protocol": {
+                                        "type": "string",
+                                        "enum": [
+                                          "udp",
+                                          "tcp"
+                                        ],
+                                        "title": "Protocol"
+                                      },
+                                      "translated_ip": {
+                                        "type": "string",
+                                        "description": "IPv4 address",
+                                        "title": "Translated IP"
+                                      },
+                                      "translated_port": {
+                                        "type": "integer",
+                                        "minimum": 1,
+                                        "maximum": 65535,
+                                        "description": "requires 'original_port'",
+                                        "title": "Translated Port"
+                                      }
+                                    },
+                                    "required": [
+                                      "translated_ip",
+                                      "original_ip"
+                                    ],
+                                    "additionalProperties": false,
+                                    "patternProperties": {
+                                      "^_.+$": {}
+                                    }
+                                  },
+                                  "title": "Static"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Source"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "IP Nat"
+                        },
+                        "ipv6_enable": {
+                          "type": "boolean",
+                          "title": "IPv6 Enable"
+                        },
+                        "ipv6_address": {
+                          "type": "string",
+                          "title": "IPv6 Address"
+                        },
+                        "ipv6_address_link_local": {
+                          "type": "string",
+                          "description": "Link local IPv6 address/mask",
+                          "title": "IPv6 Address Link Local"
+                        },
+                        "ipv6_nd_ra_disabled": {
+                          "type": "boolean",
+                          "title": "IPv6 ND RA Disabled"
+                        },
+                        "ipv6_nd_managed_config_flag": {
+                          "type": "boolean",
+                          "title": "IPv6 ND Managed Config Flag"
+                        },
+                        "ipv6_nd_prefixes": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "ipv6_prefix": {
+                                "type": "string",
+                                "title": "IPv6 Prefix"
+                              },
+                              "valid_lifetime": {
+                                "type": "string",
+                                "description": "Infinite or lifetime in seconds",
+                                "title": "Valid Lifetime"
+                              },
+                              "preferred_lifetime": {
+                                "type": "string",
+                                "description": "Infinite or lifetime in seconds",
+                                "title": "Preferred Lifetime"
+                              },
+                              "no_autoconfig_flag": {
+                                "type": "boolean",
+                                "title": "No Autoconfig Flag"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            },
+                            "required": [
+                              "ipv6_prefix"
+                            ]
+                          },
+                          "title": "IPv6 ND Prefixes"
+                        },
+                        "ipv6_dhcp_relay_destinations": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "address": {
+                                "type": "string",
+                                "description": "DHCP server's IPv6 address",
+                                "title": "Address"
+                              },
+                              "vrf": {
+                                "type": "string",
+                                "title": "VRF"
+                              },
+                              "local_interface": {
+                                "type": "string",
+                                "description": "Local interface to communicate with DHCP server - mutually exclusive to source_address",
+                                "title": "Local Interface"
+                              },
+                              "source_address": {
+                                "type": "string",
+                                "description": "Source IPv6 address to communicate with DHCP server - mutually exclusive to local_interface",
+                                "title": "Source Address"
+                              },
+                              "link_address": {
+                                "type": "string",
+                                "description": "Override the default link address specified in the relayed DHCP packet",
+                                "title": "Link Address"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            },
+                            "required": [
+                              "address"
+                            ]
+                          },
+                          "title": "IPv6 DHCP Relay Destinations"
+                        },
+                        "access_group_in": {
+                          "type": "string",
+                          "description": "Access list name",
+                          "title": "Access Group In"
+                        },
+                        "access_group_out": {
+                          "type": "string",
+                          "description": "Access list name",
+                          "title": "Access Group Out"
+                        },
+                        "ipv6_access_group_in": {
+                          "type": "string",
+                          "description": "IPv6 access list name",
+                          "title": "IPv6 Access Group In"
+                        },
+                        "ipv6_access_group_out": {
+                          "type": "string",
+                          "description": "IPv6 access list name",
+                          "title": "IPv6 Access Group Out"
+                        },
+                        "mac_access_group_in": {
+                          "type": "string",
+                          "description": "MAC access list name",
+                          "title": "MAC Access Group In"
+                        },
+                        "mac_access_group_out": {
+                          "type": "string",
+                          "description": "MAC access list name",
+                          "title": "MAC Access Group Out"
+                        },
+                        "multicast": {
+                          "type": "object",
+                          "description": "Boundaries can be either 1 ACL or a list of multicast IP address_range(s)/prefix but not combination of both",
+                          "properties": {
+                            "ipv4": {
+                              "type": "object",
+                              "properties": {
+                                "boundaries": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "boundary": {
+                                        "type": "string",
+                                        "description": "ACL name or multicast IP subnet",
+                                        "title": "Boundary"
+                                      },
+                                      "out": {
+                                        "type": "boolean",
+                                        "title": "Out"
+                                      }
+                                    },
+                                    "additionalProperties": false,
+                                    "patternProperties": {
+                                      "^_.+$": {}
+                                    }
+                                  },
+                                  "title": "Boundaries"
+                                },
+                                "static": {
+                                  "type": "boolean",
+                                  "title": "Static"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "IPv4"
+                            },
+                            "ipv6": {
+                              "type": "object",
+                              "properties": {
+                                "boundaries": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "boundary": {
+                                        "type": "string",
+                                        "description": "ACL name or multicast IP subnet",
+                                        "title": "Boundary"
+                                      }
+                                    },
+                                    "additionalProperties": false,
+                                    "patternProperties": {
+                                      "^_.+$": {}
+                                    }
+                                  },
+                                  "title": "Boundaries"
+                                },
+                                "static": {
+                                  "type": "boolean",
+                                  "title": "Static"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "IPv6"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Multicast"
+                        },
+                        "ospf_network_point_to_point": {
+                          "type": "boolean",
+                          "title": "OSPF Network Point To Point"
+                        },
+                        "ospf_area": {
+                          "type": "string",
+                          "title": "OSPF Area"
+                        },
+                        "ospf_cost": {
+                          "type": "integer",
+                          "title": "OSPF Cost"
+                        },
+                        "ospf_authentication": {
+                          "type": "string",
+                          "enum": [
+                            "none",
+                            "simple",
+                            "message-digest"
+                          ],
+                          "title": "OSPF Authentication"
+                        },
+                        "ospf_authentication_key": {
+                          "type": "string",
+                          "description": "Encrypted password - only type 7 supported",
+                          "title": "OSPF Authentication Key"
+                        },
+                        "ospf_message_digest_keys": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "integer",
+                                "title": "ID"
+                              },
+                              "hash_algorithm": {
+                                "type": "string",
+                                "enum": [
+                                  "md5",
+                                  "sha1",
+                                  "sha256",
+                                  "sha384",
+                                  "sha512"
+                                ],
+                                "title": "Hash Algorithm"
+                              },
+                              "key": {
+                                "type": "string",
+                                "description": "Encrypted password - only type 7 supported",
+                                "title": "Key"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            },
+                            "required": [
+                              "id"
+                            ]
+                          },
+                          "title": "OSPF Message Digest Keys"
+                        },
+                        "pim": {
+                          "type": "object",
+                          "properties": {
+                            "ipv4": {
+                              "type": "object",
+                              "properties": {
+                                "dr_priority": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "maximum": 429467295,
+                                  "title": "DR Priority"
+                                },
+                                "sparse_mode": {
+                                  "type": "boolean",
+                                  "title": "Sparse Mode"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "IPv4"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "PIM"
+                        },
+                        "mac_security": {
+                          "type": "object",
+                          "properties": {
+                            "profile": {
+                              "type": "string",
+                              "title": "Profile"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "MAC Security"
+                        },
+                        "channel_group": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "integer",
+                              "title": "ID"
+                            },
+                            "mode": {
+                              "type": "string",
+                              "enum": [
+                                "on",
+                                "active",
+                                "passive"
+                              ],
+                              "title": "Mode"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Channel Group"
+                        },
+                        "isis_enable": {
+                          "type": "string",
+                          "description": "ISIS instance",
+                          "title": "ISIS Enable"
+                        },
+                        "isis_passive": {
+                          "type": "boolean",
+                          "title": "ISIS Passive"
+                        },
+                        "isis_metric": {
+                          "type": "integer",
+                          "title": "ISIS Metric"
+                        },
+                        "isis_network_point_to_point": {
+                          "type": "boolean",
+                          "title": "ISIS Network Point To Point"
+                        },
+                        "isis_circuit_type": {
+                          "type": "string",
+                          "enum": [
+                            "level-1-2",
+                            "level-1",
+                            "level-2"
+                          ],
+                          "title": "ISIS Circuit Type"
+                        },
+                        "isis_hello_padding": {
+                          "type": "boolean",
+                          "title": "ISIS Hello Padding"
+                        },
+                        "isis_authentication_mode": {
+                          "type": "string",
+                          "enum": [
+                            "text",
+                            "md5"
+                          ],
+                          "title": "ISIS Authentication Mode"
+                        },
+                        "isis_authentication_key": {
+                          "type": "string",
+                          "description": "Type-7 encrypted password",
+                          "title": "ISIS Authentication Key"
+                        },
+                        "poe": {
+                          "type": "object",
+                          "properties": {
+                            "disabled": {
+                              "type": "boolean",
+                              "description": "Disable PoE on a POE capable port. PoE is enabled on all ports that support it by default in EOS.",
+                              "default": false,
+                              "title": "Disabled"
+                            },
+                            "priority": {
+                              "type": "string",
+                              "enum": [
+                                "critical",
+                                "high",
+                                "medium",
+                                "low"
+                              ],
+                              "description": "Prioritize a port's power in the event that one of the switch's power supplies loses power",
+                              "title": "Priority"
+                            },
+                            "reboot": {
+                              "description": "Set the PoE power behavior for a PoE port when the system is rebooted",
+                              "type": "object",
+                              "properties": {
+                                "action": {
+                                  "type": "string",
+                                  "enum": [
+                                    "maintain",
+                                    "power-off"
+                                  ],
+                                  "description": "PoE action for interface",
+                                  "title": "Action"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Reboot"
+                            },
+                            "link_down": {
+                              "description": "Set the PoE power behavior for a PoE port when the port goes down",
+                              "type": "object",
+                              "properties": {
+                                "action": {
+                                  "type": "string",
+                                  "enum": [
+                                    "maintain",
+                                    "power-off"
+                                  ],
+                                  "description": "PoE action for interface",
+                                  "title": "Action"
+                                },
+                                "power_off_delay": {
+                                  "type": "integer",
+                                  "minimum": 1,
+                                  "maximum": 86400,
+                                  "description": "Number of seconds to delay shutting the power off after a link down event occurs. Default value is 5 seconds in EOS.",
+                                  "title": "Power Off Delay"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Link Down"
+                            },
+                            "shutdown": {
+                              "description": "Set the PoE power behavior for a PoE port when the port is admin down",
+                              "type": "object",
+                              "properties": {
+                                "action": {
+                                  "type": "string",
+                                  "enum": [
+                                    "maintain",
+                                    "power-off"
+                                  ],
+                                  "description": "PoE action for interface",
+                                  "title": "Action"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Shutdown"
+                            },
+                            "limit": {
+                              "type": "object",
+                              "description": "Override the hardware-negotiated power limit using either wattage or a power class. Note that if using a power class, AVD will automatically convert the class value to the wattage value corresponding to that power class.",
+                              "properties": {
+                                "class": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "maximum": 8,
+                                  "title": "Class"
+                                },
+                                "watts": {
+                                  "type": "string",
+                                  "title": "Watts"
+                                },
+                                "fixed": {
+                                  "type": "boolean",
+                                  "description": "Set to ignore hardware classification",
+                                  "title": "Fixed"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Limit"
+                            },
+                            "negotiation_lldp": {
+                              "type": "boolean",
+                              "description": "Disable to prevent port from negotiating power with powered devices over LLDP. Enabled by default in EOS.",
+                              "title": "Negotiation LLDP"
+                            },
+                            "legacy_detect": {
+                              "type": "boolean",
+                              "description": "Allow a subset of legacy devices to work with the PoE switch. Disabled by default in EOS because it can cause false positive detections.",
+                              "title": "Legacy Detect"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "PoE"
+                        },
+                        "ptp": {
+                          "type": "object",
+                          "properties": {
+                            "enable": {
+                              "type": "boolean",
+                              "title": "Enable"
+                            },
+                            "announce": {
+                              "type": "object",
+                              "properties": {
+                                "interval": {
+                                  "type": "integer",
+                                  "title": "Interval"
+                                },
+                                "timeout": {
+                                  "type": "integer",
+                                  "title": "Timeout"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Announce"
+                            },
+                            "delay_req": {
+                              "type": "integer",
+                              "title": "Delay Req"
+                            },
+                            "delay_mechanism": {
+                              "type": "string",
+                              "enum": [
+                                "e2e",
+                                "p2p"
+                              ],
+                              "title": "Delay Mechanism"
+                            },
+                            "sync_message": {
+                              "type": "object",
+                              "properties": {
+                                "interval": {
+                                  "type": "integer",
+                                  "title": "Interval"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Sync Message"
+                            },
+                            "role": {
+                              "type": "string",
+                              "enum": [
+                                "master",
+                                "dynamic"
+                              ],
+                              "title": "Role"
+                            },
+                            "vlan": {
+                              "type": "string",
+                              "description": "VLAN can be 'all' or list of vlans as string",
+                              "title": "VLAN"
+                            },
+                            "transport": {
+                              "type": "string",
+                              "enum": [
+                                "ipv4",
+                                "ipv6",
+                                "layer2"
+                              ],
+                              "title": "Transport"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "PTP"
+                        },
+                        "profile": {
+                          "type": "string",
+                          "description": "Interface profile",
+                          "title": "Profile"
+                        },
+                        "storm_control": {
+                          "type": "object",
+                          "properties": {
+                            "all": {
+                              "type": "object",
+                              "properties": {
+                                "level": {
+                                  "type": "string",
+                                  "description": "Configure maximum storm-control level",
+                                  "title": "Level"
+                                },
+                                "unit": {
+                                  "type": "string",
+                                  "default": "percent",
+                                  "enum": [
+                                    "percent",
+                                    "pps"
+                                  ],
+                                  "description": "Optional field and is hardware dependent",
+                                  "title": "Unit"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "All"
+                            },
+                            "broadcast": {
+                              "type": "object",
+                              "properties": {
+                                "level": {
+                                  "type": "string",
+                                  "description": "Configure maximum storm-control level",
+                                  "title": "Level"
+                                },
+                                "unit": {
+                                  "type": "string",
+                                  "default": "percent",
+                                  "enum": [
+                                    "percent",
+                                    "pps"
+                                  ],
+                                  "description": "Optional field and is hardware dependent",
+                                  "title": "Unit"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Broadcast"
+                            },
+                            "multicast": {
+                              "type": "object",
+                              "properties": {
+                                "level": {
+                                  "type": "string",
+                                  "description": "Configure maximum storm-control level",
+                                  "title": "Level"
+                                },
+                                "unit": {
+                                  "type": "string",
+                                  "default": "percent",
+                                  "enum": [
+                                    "percent",
+                                    "pps"
+                                  ],
+                                  "description": "Optional field and is hardware dependent",
+                                  "title": "Unit"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Multicast"
+                            },
+                            "unknown_unicast": {
+                              "type": "object",
+                              "properties": {
+                                "level": {
+                                  "type": "string",
+                                  "description": "Configure maximum storm-control level",
+                                  "title": "Level"
+                                },
+                                "unit": {
+                                  "type": "string",
+                                  "default": "percent",
+                                  "enum": [
+                                    "percent",
+                                    "pps"
+                                  ],
+                                  "description": "Optional field and is hardware dependent",
+                                  "title": "Unit"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Unknown Unicast"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Storm Control"
+                        },
+                        "logging": {
+                          "type": "object",
+                          "properties": {
+                            "event": {
+                              "type": "object",
+                              "properties": {
+                                "link_status": {
+                                  "type": "boolean",
+                                  "title": "Link Status"
+                                },
+                                "congestion_drops": {
+                                  "type": "boolean",
+                                  "title": "Congestion Drops"
+                                },
+                                "spanning_tree": {
+                                  "type": "boolean",
+                                  "title": "Spanning Tree"
+                                },
+                                "storm_control_discards": {
+                                  "type": "boolean",
+                                  "title": "Storm Control Discards"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Event"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Logging"
+                        },
+                        "lldp": {
+                          "type": "object",
+                          "properties": {
+                            "transmit": {
+                              "type": "boolean",
+                              "title": "Transmit"
+                            },
+                            "receive": {
+                              "type": "boolean",
+                              "title": "Receive"
+                            },
+                            "ztp_vlan": {
+                              "type": "integer",
+                              "description": "ZTP vlan number",
+                              "title": "ZTP VLAN"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "LLDP"
+                        },
+                        "trunk_private_vlan_secondary": {
+                          "type": "boolean",
+                          "title": "Trunk Private VLAN Secondary"
+                        },
+                        "pvlan_mapping": {
+                          "type": "string",
+                          "description": "List of vlans as string",
+                          "title": "PVLAN Mapping"
+                        },
+                        "vlan_translations": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "from": {
+                                "type": "string",
+                                "description": "List of vlans as string (only one vlan if direction is \"both\")",
+                                "title": "From"
+                              },
+                              "to": {
+                                "type": "integer",
+                                "description": "VLAN ID",
+                                "title": "To"
+                              },
+                              "direction": {
+                                "type": "string",
+                                "enum": [
+                                  "in",
+                                  "out",
+                                  "both"
+                                ],
+                                "default": "both",
+                                "title": "Direction"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            }
+                          },
+                          "title": "VLAN Translations"
+                        },
+                        "dot1x": {
+                          "type": "object",
+                          "properties": {
+                            "port_control": {
+                              "type": "string",
+                              "enum": [
+                                "auto",
+                                "force-authorized",
+                                "force-unauthorized"
+                              ],
+                              "title": "Port Control"
+                            },
+                            "port_control_force_authorized_phone": {
+                              "type": "boolean",
+                              "title": "Port Control Force Authorized Phone"
+                            },
+                            "reauthentication": {
+                              "type": "boolean",
+                              "title": "Reauthentication"
+                            },
+                            "pae": {
+                              "type": "object",
+                              "properties": {
+                                "mode": {
+                                  "type": "string",
+                                  "enum": [
+                                    "authenticator"
+                                  ],
+                                  "title": "Mode"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "PAE"
+                            },
+                            "authentication_failure": {
+                              "type": "object",
+                              "properties": {
+                                "action": {
+                                  "type": "string",
+                                  "enum": [
+                                    "allow",
+                                    "drop"
+                                  ],
+                                  "title": "Action"
+                                },
+                                "allow_vlan": {
+                                  "type": "integer",
+                                  "minimum": 1,
+                                  "maximum": 4094,
+                                  "title": "Allow VLAN"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Authentication Failure"
+                            },
+                            "host_mode": {
+                              "type": "object",
+                              "properties": {
+                                "mode": {
+                                  "type": "string",
+                                  "enum": [
+                                    "multi-host",
+                                    "single-host"
+                                  ],
+                                  "title": "Mode"
+                                },
+                                "multi_host_authenticated": {
+                                  "type": "boolean",
+                                  "title": "Multi Host Authenticated"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Host Mode"
+                            },
+                            "mac_based_authentication": {
+                              "type": "object",
+                              "properties": {
+                                "enabled": {
+                                  "type": "boolean",
+                                  "title": "Enabled"
+                                },
+                                "always": {
+                                  "type": "boolean",
+                                  "title": "Always"
+                                },
+                                "host_mode_common": {
+                                  "type": "boolean",
+                                  "title": "Host Mode Common"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "MAC Based Authentication"
+                            },
+                            "timeout": {
+                              "type": "object",
+                              "properties": {
+                                "idle_host": {
+                                  "type": "integer",
+                                  "minimum": 10,
+                                  "maximum": 65535,
+                                  "title": "Idle Host"
+                                },
+                                "quiet_period": {
+                                  "type": "integer",
+                                  "minimum": 1,
+                                  "maximum": 65535,
+                                  "title": "Quiet Period"
+                                },
+                                "reauth_period": {
+                                  "type": "string",
+                                  "description": "Value can be 60-4294967295 or 'server'",
+                                  "title": "Reauth Period"
+                                },
+                                "reauth_timeout_ignore": {
+                                  "type": "boolean",
+                                  "title": "Reauth Timeout Ignore"
+                                },
+                                "tx_period": {
+                                  "type": "integer",
+                                  "minimum": 1,
+                                  "maximum": 65535,
+                                  "title": "TX Period"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Timeout"
+                            },
+                            "reauthorization_request_limit": {
+                              "type": "integer",
+                              "minimum": 1,
+                              "maximum": 10,
+                              "title": "Reauthorization Request Limit"
+                            },
+                            "unauthorized": {
+                              "type": "object",
+                              "properties": {
+                                "access_vlan_membership_egress": {
+                                  "type": "boolean",
+                                  "title": "Access VLAN Membership Egress"
+                                },
+                                "native_vlan_membership_egress": {
+                                  "type": "boolean",
+                                  "title": "Native VLAN Membership Egress"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Unauthorized"
+                            },
+                            "eapol": {
+                              "type": "object",
+                              "properties": {
+                                "disabled": {
+                                  "type": "boolean",
+                                  "title": "Disabled"
+                                },
+                                "authentication_failure_fallback_mba": {
+                                  "type": "object",
+                                  "properties": {
+                                    "enabled": {
+                                      "type": "boolean",
+                                      "title": "Enabled"
+                                    },
+                                    "timeout": {
+                                      "type": "integer",
+                                      "minimum": 0,
+                                      "maximum": 65535,
+                                      "title": "Timeout"
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "patternProperties": {
+                                    "^_.+$": {}
+                                  },
+                                  "title": "Authentication Failure Fallback Mba"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Eapol"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "dot1x"
+                        },
+                        "service_profile": {
+                          "type": "string",
+                          "description": "QOS profile",
+                          "title": "Service Profile"
+                        },
+                        "shape": {
+                          "type": "object",
+                          "properties": {
+                            "rate": {
+                              "type": "string",
+                              "description": "Rate in kbps, pps or percent\nSupported options are platform dependent\nExamples:\n- \"5000 kbps\"\n- \"1000 pps\"\n- \"20 percent\"\n",
+                              "title": "Rate"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Shape"
+                        },
+                        "qos": {
+                          "type": "object",
+                          "properties": {
+                            "trust": {
+                              "type": "string",
+                              "enum": [
+                                "dscp",
+                                "cos",
+                                "disabled"
+                              ],
+                              "title": "Trust"
+                            },
+                            "dscp": {
+                              "type": "integer",
+                              "description": "DSCP value",
+                              "title": "DSCP"
+                            },
+                            "cos": {
+                              "type": "integer",
+                              "description": "COS value",
+                              "title": "COS"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "QOS"
+                        },
+                        "spanning_tree_bpdufilter": {
+                          "type": "string",
+                          "enum": [
+                            "enabled",
+                            "disabled",
+                            "True",
+                            "False",
+                            "true",
+                            "false"
+                          ],
+                          "title": "Spanning Tree Bpdufilter"
+                        },
+                        "spanning_tree_bpduguard": {
+                          "type": "string",
+                          "enum": [
+                            "enabled",
+                            "disabled",
+                            "True",
+                            "False",
+                            "true",
+                            "false"
+                          ],
+                          "title": "Spanning Tree Bpduguard"
+                        },
+                        "spanning_tree_guard": {
+                          "type": "string",
+                          "enum": [
+                            "loop",
+                            "root",
+                            "disabled"
+                          ],
+                          "title": "Spanning Tree Guard"
+                        },
+                        "spanning_tree_portfast": {
+                          "type": "string",
+                          "enum": [
+                            "edge",
+                            "network"
+                          ],
+                          "title": "Spanning Tree Portfast"
+                        },
+                        "vmtracer": {
+                          "type": "boolean",
+                          "title": "VMTracer"
+                        },
+                        "priority_flow_control": {
+                          "type": "object",
+                          "properties": {
+                            "enabled": {
+                              "type": "boolean",
+                              "title": "Enabled"
+                            },
+                            "priorities": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "priority": {
+                                    "type": "integer",
+                                    "minimum": 0,
+                                    "maximum": 7,
+                                    "title": "Priority"
+                                  },
+                                  "no_drop": {
+                                    "type": "boolean",
+                                    "title": "No Drop"
+                                  }
+                                },
+                                "additionalProperties": false,
+                                "patternProperties": {
+                                  "^_.+$": {}
+                                },
+                                "required": [
+                                  "priority"
+                                ]
+                              },
+                              "title": "Priorities"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Priority Flow Control"
+                        },
+                        "bfd": {
+                          "type": "object",
+                          "properties": {
+                            "echo": {
+                              "type": "boolean",
+                              "title": "Echo"
+                            },
+                            "interval": {
+                              "type": "integer",
+                              "description": "Interval in milliseconds",
+                              "title": "Interval"
+                            },
+                            "min_rx": {
+                              "type": "integer",
+                              "description": "Rate in milliseconds",
+                              "title": "Min RX"
+                            },
+                            "multiplier": {
+                              "type": "integer",
+                              "minimum": 3,
+                              "maximum": 50,
+                              "title": "Multiplier"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "BFD"
+                        },
+                        "service_policy": {
+                          "type": "object",
+                          "properties": {
+                            "pbr": {
+                              "type": "object",
+                              "properties": {
+                                "input": {
+                                  "type": "string",
+                                  "description": "Policy Based Routing Policy-map name",
+                                  "title": "Input"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "PBR"
+                            },
+                            "qos": {
+                              "type": "object",
+                              "properties": {
+                                "input": {
+                                  "type": "string",
+                                  "description": "Quality of Service Policy-map name",
+                                  "title": "Input"
+                                }
+                              },
+                              "required": [
+                                "input"
+                              ],
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "QOS"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Service Policy"
+                        },
+                        "mpls": {
+                          "type": "object",
+                          "properties": {
+                            "ip": {
+                              "type": "boolean",
+                              "title": "IP"
+                            },
+                            "ldp": {
+                              "type": "object",
+                              "properties": {
+                                "interface": {
+                                  "type": "boolean",
+                                  "title": "Interface"
+                                },
+                                "igp_sync": {
+                                  "type": "boolean",
+                                  "title": "IGP Sync"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "LDP"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "MPLS"
+                        },
+                        "lacp_timer": {
+                          "type": "object",
+                          "properties": {
+                            "mode": {
+                              "type": "string",
+                              "enum": [
+                                "fast",
+                                "normal"
+                              ],
+                              "title": "Mode"
+                            },
+                            "multiplier": {
+                              "type": "integer",
+                              "minimum": 3,
+                              "maximum": 3000,
+                              "title": "Multiplier"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "LACP Timer"
+                        },
+                        "lacp_port_priority": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "maximum": 65535,
+                          "title": "LACP Port Priority"
+                        },
+                        "transceiver": {
+                          "type": "object",
+                          "properties": {
+                            "media": {
+                              "type": "object",
+                              "properties": {
+                                "override": {
+                                  "type": "string",
+                                  "description": "Transceiver type",
+                                  "title": "Override"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Media"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Transceiver"
+                        },
+                        "ip_proxy_arp": {
+                          "type": "boolean",
+                          "title": "IP Proxy ARP"
+                        },
+                        "traffic_policy": {
+                          "type": "object",
+                          "properties": {
+                            "input": {
+                              "type": "string",
+                              "description": "Ingress traffic policy",
+                              "title": "Input"
+                            },
+                            "output": {
+                              "type": "string",
+                              "description": "Egress traffic policy",
+                              "title": "Output"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Traffic Policy"
+                        },
+                        "bgp": {
+                          "type": "object",
+                          "properties": {
+                            "session_tracker": {
+                              "type": "string",
+                              "description": "Name of session tracker",
+                              "title": "Session Tracker"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "BGP"
+                        },
+                        "peer": {
+                          "type": "string",
+                          "description": "Key only used for documentation or validation purposes",
+                          "title": "Peer"
+                        },
+                        "peer_interface": {
+                          "type": "string",
+                          "description": "Key only used for documentation or validation purposes",
+                          "title": "Peer Interface"
+                        },
+                        "peer_type": {
+                          "type": "string",
+                          "description": "Key only used for documentation or validation purposes",
+                          "title": "Peer Type"
+                        },
+                        "sflow": {
+                          "type": "object",
+                          "properties": {
+                            "enable": {
+                              "type": "boolean",
+                              "title": "Enable"
+                            },
+                            "egress": {
+                              "type": "object",
+                              "properties": {
+                                "enable": {
+                                  "type": "boolean",
+                                  "title": "Enable"
+                                },
+                                "unmodified_enable": {
+                                  "type": "boolean",
+                                  "title": "Unmodified Enable"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Egress"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Sflow"
+                        },
+                        "port_profile": {
+                          "type": "string",
+                          "description": "Key only used for documentation or validation purposes",
+                          "title": "Port Profile"
+                        },
+                        "uc_tx_queues": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "integer",
+                                "description": "TX-Queue ID",
+                                "title": "ID"
+                              },
+                              "random_detect": {
+                                "type": "object",
+                                "properties": {
+                                  "ecn": {
+                                    "description": "Explicit Congestion Notification",
+                                    "type": "object",
+                                    "properties": {
+                                      "count": {
+                                        "type": "boolean",
+                                        "description": "Enable counter for random-detect ECNs",
+                                        "title": "Count"
+                                      },
+                                      "threshold": {
+                                        "type": "object",
+                                        "properties": {
+                                          "units": {
+                                            "type": "string",
+                                            "enum": [
+                                              "segments",
+                                              "bytes",
+                                              "kbytes",
+                                              "mbytes",
+                                              "milliseconds"
+                                            ],
+                                            "description": "Indicate the units to be used for the threshold values",
+                                            "title": "Units"
+                                          },
+                                          "min": {
+                                            "type": "integer",
+                                            "minimum": 1,
+                                            "maximum": 256000000,
+                                            "description": "Set the random-detect ECN minimum-threshold",
+                                            "title": "Min"
+                                          },
+                                          "max": {
+                                            "type": "integer",
+                                            "minimum": 1,
+                                            "maximum": 256000000,
+                                            "description": "Set the random-detect ECN maximum-threshold",
+                                            "title": "Max"
+                                          },
+                                          "max_probability": {
+                                            "type": "integer",
+                                            "minimum": 1,
+                                            "maximum": 100,
+                                            "description": "Set the random-detect ECN max-mark-probability",
+                                            "title": "Max Probability"
+                                          },
+                                          "weight": {
+                                            "type": "integer",
+                                            "minimum": 0,
+                                            "maximum": 15,
+                                            "description": "Set the random-detect ECN weight",
+                                            "title": "Weight"
+                                          }
+                                        },
+                                        "required": [
+                                          "units",
+                                          "min",
+                                          "max"
+                                        ],
+                                        "additionalProperties": false,
+                                        "patternProperties": {
+                                          "^_.+$": {}
+                                        },
+                                        "title": "Threshold"
+                                      }
+                                    },
+                                    "additionalProperties": false,
+                                    "patternProperties": {
+                                      "^_.+$": {}
+                                    },
+                                    "title": "Ecn"
+                                  }
+                                },
+                                "additionalProperties": false,
+                                "patternProperties": {
+                                  "^_.+$": {}
+                                },
+                                "title": "Random Detect"
+                              }
+                            },
+                            "required": [
+                              "id"
+                            ],
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            }
+                          },
+                          "title": "Uc TX Queues"
+                        },
+                        "tx_queues": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "integer",
+                                "description": "TX-Queue ID",
+                                "title": "ID"
+                              },
+                              "random_detect": {
+                                "type": "object",
+                                "properties": {
+                                  "ecn": {
+                                    "description": "Explicit Congestion Notification",
+                                    "type": "object",
+                                    "properties": {
+                                      "count": {
+                                        "type": "boolean",
+                                        "description": "Enable counter for random-detect ECNs",
+                                        "title": "Count"
+                                      },
+                                      "threshold": {
+                                        "type": "object",
+                                        "properties": {
+                                          "units": {
+                                            "type": "string",
+                                            "enum": [
+                                              "segments",
+                                              "bytes",
+                                              "kbytes",
+                                              "mbytes",
+                                              "milliseconds"
+                                            ],
+                                            "description": "Indicate the units to be used for the threshold values",
+                                            "title": "Units"
+                                          },
+                                          "min": {
+                                            "type": "integer",
+                                            "minimum": 1,
+                                            "maximum": 256000000,
+                                            "description": "Set the random-detect ECN minimum-threshold",
+                                            "title": "Min"
+                                          },
+                                          "max": {
+                                            "type": "integer",
+                                            "minimum": 1,
+                                            "maximum": 256000000,
+                                            "description": "Set the random-detect ECN maximum-threshold",
+                                            "title": "Max"
+                                          },
+                                          "max_probability": {
+                                            "type": "integer",
+                                            "minimum": 1,
+                                            "maximum": 100,
+                                            "description": "Set the random-detect ECN max-mark-probability",
+                                            "title": "Max Probability"
+                                          },
+                                          "weight": {
+                                            "type": "integer",
+                                            "minimum": 0,
+                                            "maximum": 15,
+                                            "description": "Set the random-detect ECN weight",
+                                            "title": "Weight"
+                                          }
+                                        },
+                                        "required": [
+                                          "units",
+                                          "max",
+                                          "max_probability"
+                                        ],
+                                        "additionalProperties": false,
+                                        "patternProperties": {
+                                          "^_.+$": {}
+                                        },
+                                        "title": "Threshold"
+                                      }
+                                    },
+                                    "additionalProperties": false,
+                                    "patternProperties": {
+                                      "^_.+$": {}
+                                    },
+                                    "title": "Ecn"
+                                  }
+                                },
+                                "additionalProperties": false,
+                                "patternProperties": {
+                                  "^_.+$": {}
+                                },
+                                "title": "Random Detect"
+                              }
+                            },
+                            "required": [
+                              "id"
+                            ],
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            }
+                          },
+                          "title": "TX Queues"
+                        },
+                        "vrrp_ids": {
+                          "type": "array",
+                          "description": "VRRP model.",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "integer",
+                                "description": "VRID",
+                                "title": "ID"
+                              },
+                              "priority_level": {
+                                "type": "integer",
+                                "description": "Instance priority",
+                                "minimum": 1,
+                                "maximum": 254,
+                                "title": "Priority Level"
+                              },
+                              "advertisement": {
+                                "type": "object",
+                                "properties": {
+                                  "interval": {
+                                    "type": "integer",
+                                    "description": "Interval in seconds",
+                                    "minimum": 1,
+                                    "maximum": 255,
+                                    "title": "Interval"
+                                  }
+                                },
+                                "additionalProperties": false,
+                                "patternProperties": {
+                                  "^_.+$": {}
+                                },
+                                "title": "Advertisement"
+                              },
+                              "preempt": {
+                                "type": "object",
+                                "properties": {
+                                  "enabled": {
+                                    "type": "boolean",
+                                    "title": "Enabled"
+                                  },
+                                  "delay": {
+                                    "type": "object",
+                                    "properties": {
+                                      "minimum": {
+                                        "type": "integer",
+                                        "description": "Minimum preempt delay in seconds",
+                                        "minimum": 0,
+                                        "maximum": 3600,
+                                        "title": "Minimum"
+                                      },
+                                      "reload": {
+                                        "type": "integer",
+                                        "description": "Reload preempt delay in seconds",
+                                        "minimum": 0,
+                                        "maximum": 3600,
+                                        "title": "Reload"
+                                      }
+                                    },
+                                    "additionalProperties": false,
+                                    "patternProperties": {
+                                      "^_.+$": {}
+                                    },
+                                    "title": "Delay"
+                                  }
+                                },
+                                "required": [
+                                  "enabled"
+                                ],
+                                "additionalProperties": false,
+                                "patternProperties": {
+                                  "^_.+$": {}
+                                },
+                                "title": "Preempt"
+                              },
+                              "timers": {
+                                "type": "object",
+                                "properties": {
+                                  "delay": {
+                                    "type": "object",
+                                    "properties": {
+                                      "reload": {
+                                        "type": "integer",
+                                        "description": "Delay after reload in seconds.",
+                                        "minimum": 0,
+                                        "maximum": 3600,
+                                        "title": "Reload"
+                                      }
+                                    },
+                                    "additionalProperties": false,
+                                    "patternProperties": {
+                                      "^_.+$": {}
+                                    },
+                                    "title": "Delay"
+                                  }
+                                },
+                                "additionalProperties": false,
+                                "patternProperties": {
+                                  "^_.+$": {}
+                                },
+                                "title": "Timers"
+                              },
+                              "tracked_object": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string",
+                                      "description": "Tracked object name",
+                                      "title": "Name"
+                                    },
+                                    "decrement": {
+                                      "type": "integer",
+                                      "minimum": 1,
+                                      "maximum": 254,
+                                      "description": "Decrement VRRP priority by 1-254",
+                                      "title": "Decrement"
+                                    },
+                                    "shutdown": {
+                                      "type": "boolean",
+                                      "title": "Shutdown"
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "patternProperties": {
+                                    "^_.+$": {}
+                                  },
+                                  "required": [
+                                    "name"
+                                  ]
+                                },
+                                "title": "Tracked Object"
+                              },
+                              "ipv4": {
+                                "type": "object",
+                                "properties": {
+                                  "address": {
+                                    "type": "string",
+                                    "description": "Virtual IPv4 address",
+                                    "title": "Address"
+                                  },
+                                  "version": {
+                                    "type": "integer",
+                                    "enum": [
+                                      2,
+                                      3
+                                    ],
+                                    "title": "Version"
+                                  }
+                                },
+                                "required": [
+                                  "address"
+                                ],
+                                "additionalProperties": false,
+                                "patternProperties": {
+                                  "^_.+$": {}
+                                },
+                                "title": "IPv4"
+                              },
+                              "ipv6": {
+                                "type": "object",
+                                "properties": {
+                                  "address": {
+                                    "type": "string",
+                                    "description": "Virtual IPv6 address",
+                                    "title": "Address"
+                                  }
+                                },
+                                "required": [
+                                  "address"
+                                ],
+                                "additionalProperties": false,
+                                "patternProperties": {
+                                  "^_.+$": {}
+                                },
+                                "title": "IPv6"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            },
+                            "required": [
+                              "id"
+                            ]
+                          },
+                          "title": "VRRP IDs"
+                        },
+                        "eos_cli": {
+                          "type": "string",
+                          "description": "Multiline EOS CLI rendered directly on the ethernet interface in the final EOS configuration",
+                          "title": "EOS CLI"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      },
+                      "title": "Structured Config"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "patternProperties": {
+                    "^_.+$": {}
+                  },
+                  "required": [
+                    "vrf"
+                  ]
+                },
+                "title": "Subinterfaces"
+              },
+              "raw_eos_cli": {
+                "type": "string",
+                "description": "EOS CLI rendered directly on the interface in the final EOS configuration.",
+                "title": "Raw EOS CLI"
+              },
+              "structured_config": {
+                "type": "object",
+                "description": "Custom structured config for interfaces",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "title": "Name"
+                  },
+                  "description": {
+                    "type": "string",
+                    "title": "Description"
+                  },
+                  "shutdown": {
+                    "type": "boolean",
+                    "title": "Shutdown"
+                  },
+                  "load_interval": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 600,
+                    "description": "Interval in seconds for updating interface counters\"",
+                    "title": "Load Interval"
+                  },
+                  "speed": {
+                    "type": "string",
+                    "description": "Speed should be set in the format `<interface_speed>` or `forced <interface_speed>` or `auto <interface_speed>`.",
+                    "title": "Speed"
+                  },
+                  "mtu": {
+                    "type": "integer",
+                    "minimum": 68,
+                    "maximum": 65535,
+                    "title": "MTU"
+                  },
+                  "l2_mtu": {
+                    "type": "integer",
+                    "minimum": 68,
+                    "maximum": 65535,
+                    "description": "\"l2_mtu\" should only be defined for platforms supporting the \"l2 mtu\" CLI\n",
+                    "title": "L2 MTU"
+                  },
+                  "l2_mru": {
+                    "type": "integer",
+                    "minimum": 68,
+                    "maximum": 65535,
+                    "description": "\"l2_mru\" should only be defined for platforms supporting the \"l2 mru\" CLI\n",
+                    "title": "L2 MRU"
+                  },
+                  "vlans": {
+                    "type": "string",
+                    "description": "List of switchport vlans as string\nFor a trunk port this would be a range like \"1-200,300\"\nFor an access port this would be a single vlan \"123\"\n",
+                    "title": "VLANs"
+                  },
+                  "native_vlan": {
+                    "type": "integer",
+                    "title": "Native VLAN"
+                  },
+                  "native_vlan_tag": {
+                    "type": "boolean",
+                    "description": "If setting both native_vlan and native_vlan_tag, native_vlan_tag takes precedence",
+                    "title": "Native VLAN Tag"
+                  },
+                  "mode": {
+                    "type": "string",
+                    "enum": [
+                      "access",
+                      "dot1q-tunnel",
+                      "trunk",
+                      "trunk phone"
+                    ],
+                    "title": "Mode"
+                  },
+                  "phone": {
+                    "type": "object",
+                    "properties": {
+                      "trunk": {
+                        "type": "string",
+                        "enum": [
+                          "tagged",
+                          "tagged phone",
+                          "untagged",
+                          "untagged phone"
+                        ],
+                        "title": "Trunk"
+                      },
+                      "vlan": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 4094,
+                        "title": "VLAN"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Phone"
+                  },
+                  "l2_protocol": {
+                    "type": "object",
+                    "properties": {
+                      "encapsulation_dot1q_vlan": {
+                        "type": "integer",
+                        "description": "Vlan tag to configure on sub-interface",
+                        "title": "Encapsulation Dot1Q VLAN"
+                      },
+                      "forwarding_profile": {
+                        "type": "string",
+                        "description": "L2 protocol forwarding profile",
+                        "title": "Forwarding Profile"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "L2 Protocol"
+                  },
+                  "trunk_groups": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Trunk Groups"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "routed",
+                      "switched",
+                      "l3dot1q",
+                      "l2dot1q",
+                      "port-channel-member"
+                    ],
+                    "description": "l3dot1q and l2dot1q are used for sub-interfaces. The parent interface should be defined as routed.\nInterface will not be listed in device documentation, unless \"type\" is set.\n",
+                    "title": "Type"
+                  },
+                  "snmp_trap_link_change": {
+                    "type": "boolean",
+                    "title": "Snmp Trap Link Change"
+                  },
+                  "address_locking": {
+                    "type": "object",
+                    "properties": {
+                      "ipv4": {
+                        "type": "boolean",
+                        "description": "Enable address locking for IPv4",
+                        "title": "IPv4"
+                      },
+                      "ipv6": {
+                        "type": "boolean",
+                        "description": "Enable address locking for IPv6",
+                        "title": "IPv6"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Address Locking"
+                  },
+                  "flowcontrol": {
+                    "type": "object",
+                    "properties": {
+                      "received": {
+                        "type": "string",
+                        "enum": [
+                          "desired",
+                          "on",
+                          "off"
+                        ],
+                        "title": "Received"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Flowcontrol"
+                  },
+                  "vrf": {
+                    "type": "string",
+                    "description": "VRF name",
+                    "title": "VRF"
+                  },
+                  "flow_tracker": {
+                    "type": "object",
+                    "properties": {
+                      "sampled": {
+                        "type": "string",
+                        "description": "Sampled flow tracker name.",
+                        "title": "Sampled"
+                      },
+                      "hardware": {
+                        "type": "string",
+                        "description": "Hardware flow tracker name.",
+                        "title": "Hardware"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Flow Tracker"
+                  },
+                  "error_correction_encoding": {
+                    "type": "object",
+                    "properties": {
+                      "enabled": {
+                        "type": "boolean",
+                        "default": true,
+                        "title": "Enabled"
+                      },
+                      "fire_code": {
+                        "type": "boolean",
+                        "title": "Fire Code"
+                      },
+                      "reed_solomon": {
+                        "type": "boolean",
+                        "title": "Reed Solomon"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Error Correction Encoding"
+                  },
+                  "link_tracking_groups": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "description": "Group name",
+                          "title": "Name"
+                        },
+                        "direction": {
+                          "type": "string",
+                          "enum": [
+                            "upstream",
+                            "downstream"
+                          ],
+                          "title": "Direction"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      },
+                      "required": [
+                        "name"
+                      ]
+                    },
+                    "title": "Link Tracking Groups"
+                  },
+                  "evpn_ethernet_segment": {
+                    "type": "object",
+                    "properties": {
+                      "identifier": {
+                        "type": "string",
+                        "description": "EVPN Ethernet Segment Identifier (Type 1 format)",
+                        "title": "Identifier"
+                      },
+                      "redundancy": {
+                        "type": "string",
+                        "enum": [
+                          "all-active",
+                          "single-active"
+                        ],
+                        "title": "Redundancy"
+                      },
+                      "designated_forwarder_election": {
+                        "type": "object",
+                        "properties": {
+                          "algorithm": {
+                            "type": "string",
+                            "enum": [
+                              "modulus",
+                              "preference"
+                            ],
+                            "title": "Algorithm"
+                          },
+                          "preference_value": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 65535,
+                            "description": "Preference_value is only used when \"algorithm\" is \"preference\"",
+                            "title": "Preference Value"
+                          },
+                          "dont_preempt": {
+                            "type": "boolean",
+                            "description": "Dont_preempt is only used when \"algorithm\" is \"preference\"",
+                            "title": "Dont Preempt"
+                          },
+                          "hold_time": {
+                            "type": "integer",
+                            "title": "Hold Time"
+                          },
+                          "subsequent_hold_time": {
+                            "type": "integer",
+                            "title": "Subsequent Hold Time"
+                          },
+                          "candidate_reachability_required": {
+                            "type": "boolean",
+                            "title": "Candidate Reachability Required"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Designated Forwarder Election"
+                      },
+                      "mpls": {
+                        "type": "object",
+                        "properties": {
+                          "shared_index": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 1024,
+                            "title": "Shared Index"
+                          },
+                          "tunnel_flood_filter_time": {
+                            "type": "integer",
+                            "title": "Tunnel Flood Filter Time"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "MPLS"
+                      },
+                      "route_target": {
+                        "type": "string",
+                        "description": "EVPN Route Target for ESI with format xx:xx:xx:xx:xx:xx",
+                        "title": "Route Target"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "EVPN Ethernet Segment"
+                  },
+                  "encapsulation_dot1q_vlan": {
+                    "type": "integer",
+                    "description": "VLAN tag to configure on sub-interface",
+                    "title": "Encapsulation Dot1Q VLAN"
+                  },
+                  "encapsulation_vlan": {
+                    "type": "object",
+                    "properties": {
+                      "client": {
+                        "type": "object",
+                        "properties": {
+                          "dot1q": {
+                            "type": "object",
+                            "properties": {
+                              "vlan": {
+                                "type": "integer",
+                                "description": "Client VLAN ID",
+                                "title": "VLAN"
+                              },
+                              "outer": {
+                                "type": "integer",
+                                "description": "Client Outer VLAN ID",
+                                "title": "Outer"
+                              },
+                              "inner": {
+                                "type": "integer",
+                                "description": "Client Inner VLAN ID",
+                                "title": "Inner"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            },
+                            "title": "Dot1Q"
+                          },
+                          "unmatched": {
+                            "type": "boolean",
+                            "title": "Unmatched"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Client"
+                      },
+                      "network": {
+                        "type": "object",
+                        "description": "Network encapsulations are all optional and skipped if using client unmatched",
+                        "properties": {
+                          "dot1q": {
+                            "type": "object",
+                            "properties": {
+                              "vlan": {
+                                "type": "integer",
+                                "description": "Network VLAN ID",
+                                "title": "VLAN"
+                              },
+                              "outer": {
+                                "type": "integer",
+                                "description": "Network outer VLAN ID",
+                                "title": "Outer"
+                              },
+                              "inner": {
+                                "type": "integer",
+                                "description": "Network inner VLAN ID",
+                                "title": "Inner"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            },
+                            "title": "Dot1Q"
+                          },
+                          "client": {
+                            "type": "boolean",
+                            "title": "Client"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Network"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Encapsulation VLAN"
+                  },
+                  "vlan_id": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 4094,
+                    "title": "VLAN ID"
+                  },
+                  "ip_address": {
+                    "type": "string",
+                    "description": "IPv4 address/mask or \"dhcp\"",
+                    "title": "IP Address"
+                  },
+                  "ip_address_secondaries": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "IP Address Secondaries"
+                  },
+                  "dhcp_client_accept_default_route": {
+                    "type": "boolean",
+                    "description": "Install default-route obtained via DHCP",
+                    "title": "DHCP Client Accept Default Route"
+                  },
+                  "dhcp_server_ipv4": {
+                    "type": "boolean",
+                    "description": "Enable IPv4 DHCP server.",
+                    "title": "DHCP Server IPv4"
+                  },
+                  "dhcp_server_ipv6": {
+                    "type": "boolean",
+                    "description": "Enable IPv6 DHCP server.",
+                    "title": "DHCP Server IPv6"
+                  },
+                  "ip_helpers": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "ip_helper": {
+                          "type": "string",
+                          "title": "IP Helper"
+                        },
+                        "source_interface": {
+                          "type": "string",
+                          "description": "Source interface name",
+                          "title": "Source Interface"
+                        },
+                        "vrf": {
+                          "type": "string",
+                          "description": "VRF name",
+                          "title": "VRF"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      },
+                      "required": [
+                        "ip_helper"
+                      ]
+                    },
+                    "title": "IP Helpers"
+                  },
+                  "ip_nat": {
+                    "type": "object",
+                    "properties": {
+                      "service_profile": {
+                        "type": "string",
+                        "description": "NAT interface profile.",
+                        "title": "Service Profile"
+                      },
+                      "destination": {
+                        "type": "object",
+                        "properties": {
+                          "dynamic": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "access_list": {
+                                  "type": "string",
+                                  "title": "Access List"
+                                },
+                                "comment": {
+                                  "type": "string",
+                                  "title": "Comment"
+                                },
+                                "pool_name": {
+                                  "type": "string",
+                                  "title": "Pool Name"
+                                },
+                                "priority": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "maximum": 4294967295,
+                                  "title": "Priority"
+                                }
+                              },
+                              "required": [
+                                "pool_name",
+                                "access_list"
+                              ],
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              }
+                            },
+                            "title": "Dynamic"
+                          },
+                          "static": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "access_list": {
+                                  "type": "string",
+                                  "description": "'access_list' and 'group' are mutual exclusive",
+                                  "title": "Access List"
+                                },
+                                "comment": {
+                                  "type": "string",
+                                  "title": "Comment"
+                                },
+                                "direction": {
+                                  "type": "string",
+                                  "enum": [
+                                    "egress",
+                                    "ingress"
+                                  ],
+                                  "description": "Egress or ingress can be the default. This depends on source/destination, EOS version, and hardware platform.\nEOS might remove this keyword in the configuration. So, check the configuration on targeted HW/SW.\n",
+                                  "title": "Direction"
+                                },
+                                "group": {
+                                  "type": "integer",
+                                  "minimum": 1,
+                                  "maximum": 65535,
+                                  "description": "'access_list' and 'group' are mutual exclusive",
+                                  "title": "Group"
+                                },
+                                "original_ip": {
+                                  "type": "string",
+                                  "description": "IPv4 address",
+                                  "title": "Original IP"
+                                },
+                                "original_port": {
+                                  "type": "integer",
+                                  "minimum": 1,
+                                  "maximum": 65535,
+                                  "title": "Original Port"
+                                },
+                                "priority": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "maximum": 4294967295,
+                                  "title": "Priority"
+                                },
+                                "protocol": {
+                                  "type": "string",
+                                  "enum": [
+                                    "udp",
+                                    "tcp"
+                                  ],
+                                  "title": "Protocol"
+                                },
+                                "translated_ip": {
+                                  "type": "string",
+                                  "description": "IPv4 address",
+                                  "title": "Translated IP"
+                                },
+                                "translated_port": {
+                                  "type": "integer",
+                                  "minimum": 1,
+                                  "maximum": 65535,
+                                  "description": "requires 'original_port'",
+                                  "title": "Translated Port"
+                                }
+                              },
+                              "required": [
+                                "translated_ip",
+                                "original_ip"
+                              ],
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              }
+                            },
+                            "title": "Static"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Destination"
+                      },
+                      "source": {
+                        "type": "object",
+                        "properties": {
+                          "dynamic": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "access_list": {
+                                  "type": "string",
+                                  "title": "Access List"
+                                },
+                                "comment": {
+                                  "type": "string",
+                                  "title": "Comment"
+                                },
+                                "nat_type": {
+                                  "type": "string",
+                                  "enum": [
+                                    "overload",
+                                    "pool",
+                                    "pool-address-only",
+                                    "pool-full-cone"
+                                  ],
+                                  "title": "Nat Type"
+                                },
+                                "pool_name": {
+                                  "type": "string",
+                                  "description": "required if 'nat_type' is pool, pool-address-only or pool-full-cone\nignored if 'nat_type' is overload\n",
+                                  "title": "Pool Name"
+                                },
+                                "priority": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "maximum": 4294967295,
+                                  "title": "Priority"
+                                }
+                              },
+                              "required": [
+                                "nat_type",
+                                "access_list"
+                              ],
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              }
+                            },
+                            "title": "Dynamic"
+                          },
+                          "static": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "access_list": {
+                                  "type": "string",
+                                  "description": "'access_list' and 'group' are mutual exclusive",
+                                  "title": "Access List"
+                                },
+                                "comment": {
+                                  "type": "string",
+                                  "title": "Comment"
+                                },
+                                "direction": {
+                                  "type": "string",
+                                  "enum": [
+                                    "egress",
+                                    "ingress"
+                                  ],
+                                  "description": "Egress or ingress can be the default. This depends on source/destination, EOS version, and hardware platform.\nEOS might remove this keyword in the configuration. So, check the configuration on targeted HW/SW.\n",
+                                  "title": "Direction"
+                                },
+                                "group": {
+                                  "type": "integer",
+                                  "minimum": 1,
+                                  "maximum": 65535,
+                                  "description": "'access_list' and 'group' are mutual exclusive",
+                                  "title": "Group"
+                                },
+                                "original_ip": {
+                                  "type": "string",
+                                  "description": "IPv4 address",
+                                  "title": "Original IP"
+                                },
+                                "original_port": {
+                                  "type": "integer",
+                                  "minimum": 1,
+                                  "maximum": 65535,
+                                  "title": "Original Port"
+                                },
+                                "priority": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "maximum": 4294967295,
+                                  "title": "Priority"
+                                },
+                                "protocol": {
+                                  "type": "string",
+                                  "enum": [
+                                    "udp",
+                                    "tcp"
+                                  ],
+                                  "title": "Protocol"
+                                },
+                                "translated_ip": {
+                                  "type": "string",
+                                  "description": "IPv4 address",
+                                  "title": "Translated IP"
+                                },
+                                "translated_port": {
+                                  "type": "integer",
+                                  "minimum": 1,
+                                  "maximum": 65535,
+                                  "description": "requires 'original_port'",
+                                  "title": "Translated Port"
+                                }
+                              },
+                              "required": [
+                                "translated_ip",
+                                "original_ip"
+                              ],
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              }
+                            },
+                            "title": "Static"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Source"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "IP Nat"
+                  },
+                  "ipv6_enable": {
+                    "type": "boolean",
+                    "title": "IPv6 Enable"
+                  },
+                  "ipv6_address": {
+                    "type": "string",
+                    "title": "IPv6 Address"
+                  },
+                  "ipv6_address_link_local": {
+                    "type": "string",
+                    "description": "Link local IPv6 address/mask",
+                    "title": "IPv6 Address Link Local"
+                  },
+                  "ipv6_nd_ra_disabled": {
+                    "type": "boolean",
+                    "title": "IPv6 ND RA Disabled"
+                  },
+                  "ipv6_nd_managed_config_flag": {
+                    "type": "boolean",
+                    "title": "IPv6 ND Managed Config Flag"
+                  },
+                  "ipv6_nd_prefixes": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "ipv6_prefix": {
+                          "type": "string",
+                          "title": "IPv6 Prefix"
+                        },
+                        "valid_lifetime": {
+                          "type": "string",
+                          "description": "Infinite or lifetime in seconds",
+                          "title": "Valid Lifetime"
+                        },
+                        "preferred_lifetime": {
+                          "type": "string",
+                          "description": "Infinite or lifetime in seconds",
+                          "title": "Preferred Lifetime"
+                        },
+                        "no_autoconfig_flag": {
+                          "type": "boolean",
+                          "title": "No Autoconfig Flag"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      },
+                      "required": [
+                        "ipv6_prefix"
+                      ]
+                    },
+                    "title": "IPv6 ND Prefixes"
+                  },
+                  "ipv6_dhcp_relay_destinations": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "address": {
+                          "type": "string",
+                          "description": "DHCP server's IPv6 address",
+                          "title": "Address"
+                        },
+                        "vrf": {
+                          "type": "string",
+                          "title": "VRF"
+                        },
+                        "local_interface": {
+                          "type": "string",
+                          "description": "Local interface to communicate with DHCP server - mutually exclusive to source_address",
+                          "title": "Local Interface"
+                        },
+                        "source_address": {
+                          "type": "string",
+                          "description": "Source IPv6 address to communicate with DHCP server - mutually exclusive to local_interface",
+                          "title": "Source Address"
+                        },
+                        "link_address": {
+                          "type": "string",
+                          "description": "Override the default link address specified in the relayed DHCP packet",
+                          "title": "Link Address"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      },
+                      "required": [
+                        "address"
+                      ]
+                    },
+                    "title": "IPv6 DHCP Relay Destinations"
+                  },
+                  "access_group_in": {
+                    "type": "string",
+                    "description": "Access list name",
+                    "title": "Access Group In"
+                  },
+                  "access_group_out": {
+                    "type": "string",
+                    "description": "Access list name",
+                    "title": "Access Group Out"
+                  },
+                  "ipv6_access_group_in": {
+                    "type": "string",
+                    "description": "IPv6 access list name",
+                    "title": "IPv6 Access Group In"
+                  },
+                  "ipv6_access_group_out": {
+                    "type": "string",
+                    "description": "IPv6 access list name",
+                    "title": "IPv6 Access Group Out"
+                  },
+                  "mac_access_group_in": {
+                    "type": "string",
+                    "description": "MAC access list name",
+                    "title": "MAC Access Group In"
+                  },
+                  "mac_access_group_out": {
+                    "type": "string",
+                    "description": "MAC access list name",
+                    "title": "MAC Access Group Out"
+                  },
+                  "multicast": {
+                    "type": "object",
+                    "description": "Boundaries can be either 1 ACL or a list of multicast IP address_range(s)/prefix but not combination of both",
+                    "properties": {
+                      "ipv4": {
+                        "type": "object",
+                        "properties": {
+                          "boundaries": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "boundary": {
+                                  "type": "string",
+                                  "description": "ACL name or multicast IP subnet",
+                                  "title": "Boundary"
+                                },
+                                "out": {
+                                  "type": "boolean",
+                                  "title": "Out"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              }
+                            },
+                            "title": "Boundaries"
+                          },
+                          "static": {
+                            "type": "boolean",
+                            "title": "Static"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "IPv4"
+                      },
+                      "ipv6": {
+                        "type": "object",
+                        "properties": {
+                          "boundaries": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "boundary": {
+                                  "type": "string",
+                                  "description": "ACL name or multicast IP subnet",
+                                  "title": "Boundary"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              }
+                            },
+                            "title": "Boundaries"
+                          },
+                          "static": {
+                            "type": "boolean",
+                            "title": "Static"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "IPv6"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Multicast"
+                  },
+                  "ospf_network_point_to_point": {
+                    "type": "boolean",
+                    "title": "OSPF Network Point To Point"
+                  },
+                  "ospf_area": {
+                    "type": "string",
+                    "title": "OSPF Area"
+                  },
+                  "ospf_cost": {
+                    "type": "integer",
+                    "title": "OSPF Cost"
+                  },
+                  "ospf_authentication": {
+                    "type": "string",
+                    "enum": [
+                      "none",
+                      "simple",
+                      "message-digest"
+                    ],
+                    "title": "OSPF Authentication"
+                  },
+                  "ospf_authentication_key": {
+                    "type": "string",
+                    "description": "Encrypted password - only type 7 supported",
+                    "title": "OSPF Authentication Key"
+                  },
+                  "ospf_message_digest_keys": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "title": "ID"
+                        },
+                        "hash_algorithm": {
+                          "type": "string",
+                          "enum": [
+                            "md5",
+                            "sha1",
+                            "sha256",
+                            "sha384",
+                            "sha512"
+                          ],
+                          "title": "Hash Algorithm"
+                        },
+                        "key": {
+                          "type": "string",
+                          "description": "Encrypted password - only type 7 supported",
+                          "title": "Key"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      },
+                      "required": [
+                        "id"
+                      ]
+                    },
+                    "title": "OSPF Message Digest Keys"
+                  },
+                  "pim": {
+                    "type": "object",
+                    "properties": {
+                      "ipv4": {
+                        "type": "object",
+                        "properties": {
+                          "dr_priority": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 429467295,
+                            "title": "DR Priority"
+                          },
+                          "sparse_mode": {
+                            "type": "boolean",
+                            "title": "Sparse Mode"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "IPv4"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "PIM"
+                  },
+                  "mac_security": {
+                    "type": "object",
+                    "properties": {
+                      "profile": {
+                        "type": "string",
+                        "title": "Profile"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "MAC Security"
+                  },
+                  "channel_group": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "integer",
+                        "title": "ID"
+                      },
+                      "mode": {
+                        "type": "string",
+                        "enum": [
+                          "on",
+                          "active",
+                          "passive"
+                        ],
+                        "title": "Mode"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Channel Group"
+                  },
+                  "isis_enable": {
+                    "type": "string",
+                    "description": "ISIS instance",
+                    "title": "ISIS Enable"
+                  },
+                  "isis_passive": {
+                    "type": "boolean",
+                    "title": "ISIS Passive"
+                  },
+                  "isis_metric": {
+                    "type": "integer",
+                    "title": "ISIS Metric"
+                  },
+                  "isis_network_point_to_point": {
+                    "type": "boolean",
+                    "title": "ISIS Network Point To Point"
+                  },
+                  "isis_circuit_type": {
+                    "type": "string",
+                    "enum": [
+                      "level-1-2",
+                      "level-1",
+                      "level-2"
+                    ],
+                    "title": "ISIS Circuit Type"
+                  },
+                  "isis_hello_padding": {
+                    "type": "boolean",
+                    "title": "ISIS Hello Padding"
+                  },
+                  "isis_authentication_mode": {
+                    "type": "string",
+                    "enum": [
+                      "text",
+                      "md5"
+                    ],
+                    "title": "ISIS Authentication Mode"
+                  },
+                  "isis_authentication_key": {
+                    "type": "string",
+                    "description": "Type-7 encrypted password",
+                    "title": "ISIS Authentication Key"
+                  },
+                  "poe": {
+                    "type": "object",
+                    "properties": {
+                      "disabled": {
+                        "type": "boolean",
+                        "description": "Disable PoE on a POE capable port. PoE is enabled on all ports that support it by default in EOS.",
+                        "default": false,
+                        "title": "Disabled"
+                      },
+                      "priority": {
+                        "type": "string",
+                        "enum": [
+                          "critical",
+                          "high",
+                          "medium",
+                          "low"
+                        ],
+                        "description": "Prioritize a port's power in the event that one of the switch's power supplies loses power",
+                        "title": "Priority"
+                      },
+                      "reboot": {
+                        "description": "Set the PoE power behavior for a PoE port when the system is rebooted",
+                        "type": "object",
+                        "properties": {
+                          "action": {
+                            "type": "string",
+                            "enum": [
+                              "maintain",
+                              "power-off"
+                            ],
+                            "description": "PoE action for interface",
+                            "title": "Action"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Reboot"
+                      },
+                      "link_down": {
+                        "description": "Set the PoE power behavior for a PoE port when the port goes down",
+                        "type": "object",
+                        "properties": {
+                          "action": {
+                            "type": "string",
+                            "enum": [
+                              "maintain",
+                              "power-off"
+                            ],
+                            "description": "PoE action for interface",
+                            "title": "Action"
+                          },
+                          "power_off_delay": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 86400,
+                            "description": "Number of seconds to delay shutting the power off after a link down event occurs. Default value is 5 seconds in EOS.",
+                            "title": "Power Off Delay"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Link Down"
+                      },
+                      "shutdown": {
+                        "description": "Set the PoE power behavior for a PoE port when the port is admin down",
+                        "type": "object",
+                        "properties": {
+                          "action": {
+                            "type": "string",
+                            "enum": [
+                              "maintain",
+                              "power-off"
+                            ],
+                            "description": "PoE action for interface",
+                            "title": "Action"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Shutdown"
+                      },
+                      "limit": {
+                        "type": "object",
+                        "description": "Override the hardware-negotiated power limit using either wattage or a power class. Note that if using a power class, AVD will automatically convert the class value to the wattage value corresponding to that power class.",
+                        "properties": {
+                          "class": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 8,
+                            "title": "Class"
+                          },
+                          "watts": {
+                            "type": "string",
+                            "title": "Watts"
+                          },
+                          "fixed": {
+                            "type": "boolean",
+                            "description": "Set to ignore hardware classification",
+                            "title": "Fixed"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Limit"
+                      },
+                      "negotiation_lldp": {
+                        "type": "boolean",
+                        "description": "Disable to prevent port from negotiating power with powered devices over LLDP. Enabled by default in EOS.",
+                        "title": "Negotiation LLDP"
+                      },
+                      "legacy_detect": {
+                        "type": "boolean",
+                        "description": "Allow a subset of legacy devices to work with the PoE switch. Disabled by default in EOS because it can cause false positive detections.",
+                        "title": "Legacy Detect"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "PoE"
+                  },
+                  "ptp": {
+                    "type": "object",
+                    "properties": {
+                      "enable": {
+                        "type": "boolean",
+                        "title": "Enable"
+                      },
+                      "announce": {
+                        "type": "object",
+                        "properties": {
+                          "interval": {
+                            "type": "integer",
+                            "title": "Interval"
+                          },
+                          "timeout": {
+                            "type": "integer",
+                            "title": "Timeout"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Announce"
+                      },
+                      "delay_req": {
+                        "type": "integer",
+                        "title": "Delay Req"
+                      },
+                      "delay_mechanism": {
+                        "type": "string",
+                        "enum": [
+                          "e2e",
+                          "p2p"
+                        ],
+                        "title": "Delay Mechanism"
+                      },
+                      "sync_message": {
+                        "type": "object",
+                        "properties": {
+                          "interval": {
+                            "type": "integer",
+                            "title": "Interval"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Sync Message"
+                      },
+                      "role": {
+                        "type": "string",
+                        "enum": [
+                          "master",
+                          "dynamic"
+                        ],
+                        "title": "Role"
+                      },
+                      "vlan": {
+                        "type": "string",
+                        "description": "VLAN can be 'all' or list of vlans as string",
+                        "title": "VLAN"
+                      },
+                      "transport": {
+                        "type": "string",
+                        "enum": [
+                          "ipv4",
+                          "ipv6",
+                          "layer2"
+                        ],
+                        "title": "Transport"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "PTP"
+                  },
+                  "profile": {
+                    "type": "string",
+                    "description": "Interface profile",
+                    "title": "Profile"
+                  },
+                  "storm_control": {
+                    "type": "object",
+                    "properties": {
+                      "all": {
+                        "type": "object",
+                        "properties": {
+                          "level": {
+                            "type": "string",
+                            "description": "Configure maximum storm-control level",
+                            "title": "Level"
+                          },
+                          "unit": {
+                            "type": "string",
+                            "default": "percent",
+                            "enum": [
+                              "percent",
+                              "pps"
+                            ],
+                            "description": "Optional field and is hardware dependent",
+                            "title": "Unit"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "All"
+                      },
+                      "broadcast": {
+                        "type": "object",
+                        "properties": {
+                          "level": {
+                            "type": "string",
+                            "description": "Configure maximum storm-control level",
+                            "title": "Level"
+                          },
+                          "unit": {
+                            "type": "string",
+                            "default": "percent",
+                            "enum": [
+                              "percent",
+                              "pps"
+                            ],
+                            "description": "Optional field and is hardware dependent",
+                            "title": "Unit"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Broadcast"
+                      },
+                      "multicast": {
+                        "type": "object",
+                        "properties": {
+                          "level": {
+                            "type": "string",
+                            "description": "Configure maximum storm-control level",
+                            "title": "Level"
+                          },
+                          "unit": {
+                            "type": "string",
+                            "default": "percent",
+                            "enum": [
+                              "percent",
+                              "pps"
+                            ],
+                            "description": "Optional field and is hardware dependent",
+                            "title": "Unit"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Multicast"
+                      },
+                      "unknown_unicast": {
+                        "type": "object",
+                        "properties": {
+                          "level": {
+                            "type": "string",
+                            "description": "Configure maximum storm-control level",
+                            "title": "Level"
+                          },
+                          "unit": {
+                            "type": "string",
+                            "default": "percent",
+                            "enum": [
+                              "percent",
+                              "pps"
+                            ],
+                            "description": "Optional field and is hardware dependent",
+                            "title": "Unit"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Unknown Unicast"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Storm Control"
+                  },
+                  "logging": {
+                    "type": "object",
+                    "properties": {
+                      "event": {
+                        "type": "object",
+                        "properties": {
+                          "link_status": {
+                            "type": "boolean",
+                            "title": "Link Status"
+                          },
+                          "congestion_drops": {
+                            "type": "boolean",
+                            "title": "Congestion Drops"
+                          },
+                          "spanning_tree": {
+                            "type": "boolean",
+                            "title": "Spanning Tree"
+                          },
+                          "storm_control_discards": {
+                            "type": "boolean",
+                            "title": "Storm Control Discards"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Event"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Logging"
+                  },
+                  "lldp": {
+                    "type": "object",
+                    "properties": {
+                      "transmit": {
+                        "type": "boolean",
+                        "title": "Transmit"
+                      },
+                      "receive": {
+                        "type": "boolean",
+                        "title": "Receive"
+                      },
+                      "ztp_vlan": {
+                        "type": "integer",
+                        "description": "ZTP vlan number",
+                        "title": "ZTP VLAN"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "LLDP"
+                  },
+                  "trunk_private_vlan_secondary": {
+                    "type": "boolean",
+                    "title": "Trunk Private VLAN Secondary"
+                  },
+                  "pvlan_mapping": {
+                    "type": "string",
+                    "description": "List of vlans as string",
+                    "title": "PVLAN Mapping"
+                  },
+                  "vlan_translations": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "from": {
+                          "type": "string",
+                          "description": "List of vlans as string (only one vlan if direction is \"both\")",
+                          "title": "From"
+                        },
+                        "to": {
+                          "type": "integer",
+                          "description": "VLAN ID",
+                          "title": "To"
+                        },
+                        "direction": {
+                          "type": "string",
+                          "enum": [
+                            "in",
+                            "out",
+                            "both"
+                          ],
+                          "default": "both",
+                          "title": "Direction"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      }
+                    },
+                    "title": "VLAN Translations"
+                  },
+                  "dot1x": {
+                    "type": "object",
+                    "properties": {
+                      "port_control": {
+                        "type": "string",
+                        "enum": [
+                          "auto",
+                          "force-authorized",
+                          "force-unauthorized"
+                        ],
+                        "title": "Port Control"
+                      },
+                      "port_control_force_authorized_phone": {
+                        "type": "boolean",
+                        "title": "Port Control Force Authorized Phone"
+                      },
+                      "reauthentication": {
+                        "type": "boolean",
+                        "title": "Reauthentication"
+                      },
+                      "pae": {
+                        "type": "object",
+                        "properties": {
+                          "mode": {
+                            "type": "string",
+                            "enum": [
+                              "authenticator"
+                            ],
+                            "title": "Mode"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "PAE"
+                      },
+                      "authentication_failure": {
+                        "type": "object",
+                        "properties": {
+                          "action": {
+                            "type": "string",
+                            "enum": [
+                              "allow",
+                              "drop"
+                            ],
+                            "title": "Action"
+                          },
+                          "allow_vlan": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 4094,
+                            "title": "Allow VLAN"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Authentication Failure"
+                      },
+                      "host_mode": {
+                        "type": "object",
+                        "properties": {
+                          "mode": {
+                            "type": "string",
+                            "enum": [
+                              "multi-host",
+                              "single-host"
+                            ],
+                            "title": "Mode"
+                          },
+                          "multi_host_authenticated": {
+                            "type": "boolean",
+                            "title": "Multi Host Authenticated"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Host Mode"
+                      },
+                      "mac_based_authentication": {
+                        "type": "object",
+                        "properties": {
+                          "enabled": {
+                            "type": "boolean",
+                            "title": "Enabled"
+                          },
+                          "always": {
+                            "type": "boolean",
+                            "title": "Always"
+                          },
+                          "host_mode_common": {
+                            "type": "boolean",
+                            "title": "Host Mode Common"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "MAC Based Authentication"
+                      },
+                      "timeout": {
+                        "type": "object",
+                        "properties": {
+                          "idle_host": {
+                            "type": "integer",
+                            "minimum": 10,
+                            "maximum": 65535,
+                            "title": "Idle Host"
+                          },
+                          "quiet_period": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 65535,
+                            "title": "Quiet Period"
+                          },
+                          "reauth_period": {
+                            "type": "string",
+                            "description": "Value can be 60-4294967295 or 'server'",
+                            "title": "Reauth Period"
+                          },
+                          "reauth_timeout_ignore": {
+                            "type": "boolean",
+                            "title": "Reauth Timeout Ignore"
+                          },
+                          "tx_period": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 65535,
+                            "title": "TX Period"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Timeout"
+                      },
+                      "reauthorization_request_limit": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 10,
+                        "title": "Reauthorization Request Limit"
+                      },
+                      "unauthorized": {
+                        "type": "object",
+                        "properties": {
+                          "access_vlan_membership_egress": {
+                            "type": "boolean",
+                            "title": "Access VLAN Membership Egress"
+                          },
+                          "native_vlan_membership_egress": {
+                            "type": "boolean",
+                            "title": "Native VLAN Membership Egress"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Unauthorized"
+                      },
+                      "eapol": {
+                        "type": "object",
+                        "properties": {
+                          "disabled": {
+                            "type": "boolean",
+                            "title": "Disabled"
+                          },
+                          "authentication_failure_fallback_mba": {
+                            "type": "object",
+                            "properties": {
+                              "enabled": {
+                                "type": "boolean",
+                                "title": "Enabled"
+                              },
+                              "timeout": {
+                                "type": "integer",
+                                "minimum": 0,
+                                "maximum": 65535,
+                                "title": "Timeout"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            },
+                            "title": "Authentication Failure Fallback Mba"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Eapol"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "dot1x"
+                  },
+                  "service_profile": {
+                    "type": "string",
+                    "description": "QOS profile",
+                    "title": "Service Profile"
+                  },
+                  "shape": {
+                    "type": "object",
+                    "properties": {
+                      "rate": {
+                        "type": "string",
+                        "description": "Rate in kbps, pps or percent\nSupported options are platform dependent\nExamples:\n- \"5000 kbps\"\n- \"1000 pps\"\n- \"20 percent\"\n",
+                        "title": "Rate"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Shape"
+                  },
+                  "qos": {
+                    "type": "object",
+                    "properties": {
+                      "trust": {
+                        "type": "string",
+                        "enum": [
+                          "dscp",
+                          "cos",
+                          "disabled"
+                        ],
+                        "title": "Trust"
+                      },
+                      "dscp": {
+                        "type": "integer",
+                        "description": "DSCP value",
+                        "title": "DSCP"
+                      },
+                      "cos": {
+                        "type": "integer",
+                        "description": "COS value",
+                        "title": "COS"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "QOS"
+                  },
+                  "spanning_tree_bpdufilter": {
+                    "type": "string",
+                    "enum": [
+                      "enabled",
+                      "disabled",
+                      "True",
+                      "False",
+                      "true",
+                      "false"
+                    ],
+                    "title": "Spanning Tree Bpdufilter"
+                  },
+                  "spanning_tree_bpduguard": {
+                    "type": "string",
+                    "enum": [
+                      "enabled",
+                      "disabled",
+                      "True",
+                      "False",
+                      "true",
+                      "false"
+                    ],
+                    "title": "Spanning Tree Bpduguard"
+                  },
+                  "spanning_tree_guard": {
+                    "type": "string",
+                    "enum": [
+                      "loop",
+                      "root",
+                      "disabled"
+                    ],
+                    "title": "Spanning Tree Guard"
+                  },
+                  "spanning_tree_portfast": {
+                    "type": "string",
+                    "enum": [
+                      "edge",
+                      "network"
+                    ],
+                    "title": "Spanning Tree Portfast"
+                  },
+                  "vmtracer": {
+                    "type": "boolean",
+                    "title": "VMTracer"
+                  },
+                  "priority_flow_control": {
+                    "type": "object",
+                    "properties": {
+                      "enabled": {
+                        "type": "boolean",
+                        "title": "Enabled"
+                      },
+                      "priorities": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "priority": {
+                              "type": "integer",
+                              "minimum": 0,
+                              "maximum": 7,
+                              "title": "Priority"
+                            },
+                            "no_drop": {
+                              "type": "boolean",
+                              "title": "No Drop"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "required": [
+                            "priority"
+                          ]
+                        },
+                        "title": "Priorities"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Priority Flow Control"
+                  },
+                  "bfd": {
+                    "type": "object",
+                    "properties": {
+                      "echo": {
+                        "type": "boolean",
+                        "title": "Echo"
+                      },
+                      "interval": {
+                        "type": "integer",
+                        "description": "Interval in milliseconds",
+                        "title": "Interval"
+                      },
+                      "min_rx": {
+                        "type": "integer",
+                        "description": "Rate in milliseconds",
+                        "title": "Min RX"
+                      },
+                      "multiplier": {
+                        "type": "integer",
+                        "minimum": 3,
+                        "maximum": 50,
+                        "title": "Multiplier"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "BFD"
+                  },
+                  "service_policy": {
+                    "type": "object",
+                    "properties": {
+                      "pbr": {
+                        "type": "object",
+                        "properties": {
+                          "input": {
+                            "type": "string",
+                            "description": "Policy Based Routing Policy-map name",
+                            "title": "Input"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "PBR"
+                      },
+                      "qos": {
+                        "type": "object",
+                        "properties": {
+                          "input": {
+                            "type": "string",
+                            "description": "Quality of Service Policy-map name",
+                            "title": "Input"
+                          }
+                        },
+                        "required": [
+                          "input"
+                        ],
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "QOS"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Service Policy"
+                  },
+                  "mpls": {
+                    "type": "object",
+                    "properties": {
+                      "ip": {
+                        "type": "boolean",
+                        "title": "IP"
+                      },
+                      "ldp": {
+                        "type": "object",
+                        "properties": {
+                          "interface": {
+                            "type": "boolean",
+                            "title": "Interface"
+                          },
+                          "igp_sync": {
+                            "type": "boolean",
+                            "title": "IGP Sync"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "LDP"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "MPLS"
+                  },
+                  "lacp_timer": {
+                    "type": "object",
+                    "properties": {
+                      "mode": {
+                        "type": "string",
+                        "enum": [
+                          "fast",
+                          "normal"
+                        ],
+                        "title": "Mode"
+                      },
+                      "multiplier": {
+                        "type": "integer",
+                        "minimum": 3,
+                        "maximum": 3000,
+                        "title": "Multiplier"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "LACP Timer"
+                  },
+                  "lacp_port_priority": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 65535,
+                    "title": "LACP Port Priority"
+                  },
+                  "transceiver": {
+                    "type": "object",
+                    "properties": {
+                      "media": {
+                        "type": "object",
+                        "properties": {
+                          "override": {
+                            "type": "string",
+                            "description": "Transceiver type",
+                            "title": "Override"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Media"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Transceiver"
+                  },
+                  "ip_proxy_arp": {
+                    "type": "boolean",
+                    "title": "IP Proxy ARP"
+                  },
+                  "traffic_policy": {
+                    "type": "object",
+                    "properties": {
+                      "input": {
+                        "type": "string",
+                        "description": "Ingress traffic policy",
+                        "title": "Input"
+                      },
+                      "output": {
+                        "type": "string",
+                        "description": "Egress traffic policy",
+                        "title": "Output"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Traffic Policy"
+                  },
+                  "bgp": {
+                    "type": "object",
+                    "properties": {
+                      "session_tracker": {
+                        "type": "string",
+                        "description": "Name of session tracker",
+                        "title": "Session Tracker"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "BGP"
+                  },
+                  "peer": {
+                    "type": "string",
+                    "description": "Key only used for documentation or validation purposes",
+                    "title": "Peer"
+                  },
+                  "peer_interface": {
+                    "type": "string",
+                    "description": "Key only used for documentation or validation purposes",
+                    "title": "Peer Interface"
+                  },
+                  "peer_type": {
+                    "type": "string",
+                    "description": "Key only used for documentation or validation purposes",
+                    "title": "Peer Type"
+                  },
+                  "sflow": {
+                    "type": "object",
+                    "properties": {
+                      "enable": {
+                        "type": "boolean",
+                        "title": "Enable"
+                      },
+                      "egress": {
+                        "type": "object",
+                        "properties": {
+                          "enable": {
+                            "type": "boolean",
+                            "title": "Enable"
+                          },
+                          "unmodified_enable": {
+                            "type": "boolean",
+                            "title": "Unmodified Enable"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Egress"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Sflow"
+                  },
+                  "port_profile": {
+                    "type": "string",
+                    "description": "Key only used for documentation or validation purposes",
+                    "title": "Port Profile"
+                  },
+                  "uc_tx_queues": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "description": "TX-Queue ID",
+                          "title": "ID"
+                        },
+                        "random_detect": {
+                          "type": "object",
+                          "properties": {
+                            "ecn": {
+                              "description": "Explicit Congestion Notification",
+                              "type": "object",
+                              "properties": {
+                                "count": {
+                                  "type": "boolean",
+                                  "description": "Enable counter for random-detect ECNs",
+                                  "title": "Count"
+                                },
+                                "threshold": {
+                                  "type": "object",
+                                  "properties": {
+                                    "units": {
+                                      "type": "string",
+                                      "enum": [
+                                        "segments",
+                                        "bytes",
+                                        "kbytes",
+                                        "mbytes",
+                                        "milliseconds"
+                                      ],
+                                      "description": "Indicate the units to be used for the threshold values",
+                                      "title": "Units"
+                                    },
+                                    "min": {
+                                      "type": "integer",
+                                      "minimum": 1,
+                                      "maximum": 256000000,
+                                      "description": "Set the random-detect ECN minimum-threshold",
+                                      "title": "Min"
+                                    },
+                                    "max": {
+                                      "type": "integer",
+                                      "minimum": 1,
+                                      "maximum": 256000000,
+                                      "description": "Set the random-detect ECN maximum-threshold",
+                                      "title": "Max"
+                                    },
+                                    "max_probability": {
+                                      "type": "integer",
+                                      "minimum": 1,
+                                      "maximum": 100,
+                                      "description": "Set the random-detect ECN max-mark-probability",
+                                      "title": "Max Probability"
+                                    },
+                                    "weight": {
+                                      "type": "integer",
+                                      "minimum": 0,
+                                      "maximum": 15,
+                                      "description": "Set the random-detect ECN weight",
+                                      "title": "Weight"
+                                    }
+                                  },
+                                  "required": [
+                                    "units",
+                                    "min",
+                                    "max"
+                                  ],
+                                  "additionalProperties": false,
+                                  "patternProperties": {
+                                    "^_.+$": {}
+                                  },
+                                  "title": "Threshold"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Ecn"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Random Detect"
+                        }
+                      },
+                      "required": [
+                        "id"
+                      ],
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      }
+                    },
+                    "title": "Uc TX Queues"
+                  },
+                  "tx_queues": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "description": "TX-Queue ID",
+                          "title": "ID"
+                        },
+                        "random_detect": {
+                          "type": "object",
+                          "properties": {
+                            "ecn": {
+                              "description": "Explicit Congestion Notification",
+                              "type": "object",
+                              "properties": {
+                                "count": {
+                                  "type": "boolean",
+                                  "description": "Enable counter for random-detect ECNs",
+                                  "title": "Count"
+                                },
+                                "threshold": {
+                                  "type": "object",
+                                  "properties": {
+                                    "units": {
+                                      "type": "string",
+                                      "enum": [
+                                        "segments",
+                                        "bytes",
+                                        "kbytes",
+                                        "mbytes",
+                                        "milliseconds"
+                                      ],
+                                      "description": "Indicate the units to be used for the threshold values",
+                                      "title": "Units"
+                                    },
+                                    "min": {
+                                      "type": "integer",
+                                      "minimum": 1,
+                                      "maximum": 256000000,
+                                      "description": "Set the random-detect ECN minimum-threshold",
+                                      "title": "Min"
+                                    },
+                                    "max": {
+                                      "type": "integer",
+                                      "minimum": 1,
+                                      "maximum": 256000000,
+                                      "description": "Set the random-detect ECN maximum-threshold",
+                                      "title": "Max"
+                                    },
+                                    "max_probability": {
+                                      "type": "integer",
+                                      "minimum": 1,
+                                      "maximum": 100,
+                                      "description": "Set the random-detect ECN max-mark-probability",
+                                      "title": "Max Probability"
+                                    },
+                                    "weight": {
+                                      "type": "integer",
+                                      "minimum": 0,
+                                      "maximum": 15,
+                                      "description": "Set the random-detect ECN weight",
+                                      "title": "Weight"
+                                    }
+                                  },
+                                  "required": [
+                                    "units",
+                                    "max",
+                                    "max_probability"
+                                  ],
+                                  "additionalProperties": false,
+                                  "patternProperties": {
+                                    "^_.+$": {}
+                                  },
+                                  "title": "Threshold"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Ecn"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Random Detect"
+                        }
+                      },
+                      "required": [
+                        "id"
+                      ],
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      }
+                    },
+                    "title": "TX Queues"
+                  },
+                  "vrrp_ids": {
+                    "type": "array",
+                    "description": "VRRP model.",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "description": "VRID",
+                          "title": "ID"
+                        },
+                        "priority_level": {
+                          "type": "integer",
+                          "description": "Instance priority",
+                          "minimum": 1,
+                          "maximum": 254,
+                          "title": "Priority Level"
+                        },
+                        "advertisement": {
+                          "type": "object",
+                          "properties": {
+                            "interval": {
+                              "type": "integer",
+                              "description": "Interval in seconds",
+                              "minimum": 1,
+                              "maximum": 255,
+                              "title": "Interval"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Advertisement"
+                        },
+                        "preempt": {
+                          "type": "object",
+                          "properties": {
+                            "enabled": {
+                              "type": "boolean",
+                              "title": "Enabled"
+                            },
+                            "delay": {
+                              "type": "object",
+                              "properties": {
+                                "minimum": {
+                                  "type": "integer",
+                                  "description": "Minimum preempt delay in seconds",
+                                  "minimum": 0,
+                                  "maximum": 3600,
+                                  "title": "Minimum"
+                                },
+                                "reload": {
+                                  "type": "integer",
+                                  "description": "Reload preempt delay in seconds",
+                                  "minimum": 0,
+                                  "maximum": 3600,
+                                  "title": "Reload"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Delay"
+                            }
+                          },
+                          "required": [
+                            "enabled"
+                          ],
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Preempt"
+                        },
+                        "timers": {
+                          "type": "object",
+                          "properties": {
+                            "delay": {
+                              "type": "object",
+                              "properties": {
+                                "reload": {
+                                  "type": "integer",
+                                  "description": "Delay after reload in seconds.",
+                                  "minimum": 0,
+                                  "maximum": 3600,
+                                  "title": "Reload"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Delay"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Timers"
+                        },
+                        "tracked_object": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "string",
+                                "description": "Tracked object name",
+                                "title": "Name"
+                              },
+                              "decrement": {
+                                "type": "integer",
+                                "minimum": 1,
+                                "maximum": 254,
+                                "description": "Decrement VRRP priority by 1-254",
+                                "title": "Decrement"
+                              },
+                              "shutdown": {
+                                "type": "boolean",
+                                "title": "Shutdown"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            },
+                            "required": [
+                              "name"
+                            ]
+                          },
+                          "title": "Tracked Object"
+                        },
+                        "ipv4": {
+                          "type": "object",
+                          "properties": {
+                            "address": {
+                              "type": "string",
+                              "description": "Virtual IPv4 address",
+                              "title": "Address"
+                            },
+                            "version": {
+                              "type": "integer",
+                              "enum": [
+                                2,
+                                3
+                              ],
+                              "title": "Version"
+                            }
+                          },
+                          "required": [
+                            "address"
+                          ],
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "IPv4"
+                        },
+                        "ipv6": {
+                          "type": "object",
+                          "properties": {
+                            "address": {
+                              "type": "string",
+                              "description": "Virtual IPv6 address",
+                              "title": "Address"
+                            }
+                          },
+                          "required": [
+                            "address"
+                          ],
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "IPv6"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      },
+                      "required": [
+                        "id"
+                      ]
+                    },
+                    "title": "VRRP IDs"
+                  },
+                  "eos_cli": {
+                    "type": "string",
+                    "description": "Multiline EOS CLI rendered directly on the ethernet interface in the final EOS configuration",
+                    "title": "EOS CLI"
+                  }
+                },
+                "additionalProperties": false,
+                "patternProperties": {
+                  "^_.+$": {}
+                },
+                "title": "Structured Config"
+              }
+            },
+            "additionalProperties": false,
+            "patternProperties": {
+              "^_.+$": {}
+            },
+            "required": [
+              "name"
+            ]
+          },
+          "title": "L3 Interfaces Profiles"
+        },
+        "l3_interfaces": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "node": {
+                "type": "string",
+                "description": "Device on which the interface should be configured.",
+                "title": "Node"
+              },
+              "profile": {
+                "type": "string",
+                "description": "L3 interface profile name. Profile defined under l3_interfaces_profiles.",
+                "title": "Profile"
+              },
+              "speed": {
+                "type": "string",
+                "description": "Speed should be set in the format `<interface_speed>` or `forced <interface_speed>` or `auto <interface_speed>`.",
+                "title": "Speed"
+              },
+              "vrf": {
+                "type": "string",
+                "description": "VRF to configure on the interface. (default VRF if not set).",
+                "title": "VRF"
+              },
+              "ip": {
+                "type": "string",
+                "description": "Node IPv4 address/Mask or dhcp.",
+                "title": "IP"
+              },
+              "dhcp_client_accept_default_route": {
+                "type": "boolean",
+                "description": "Supported if `ip` is `dhcp`.\nAccepts default route from DHCP, default False.",
+                "title": "DHCP Client Accept Default Route"
+              },
+              "ipv6_enable": {
+                "type": "boolean",
+                "default": false,
+                "description": "Allows turning on ipv6 for the interface or profile.",
+                "title": "IPv6 Enable"
+              },
+              "interface": {
+                "type": "string",
+                "description": "Must be an Ethernet interface like 'Ethernet2'.",
+                "title": "Interface"
+              },
+              "peer": {
+                "type": "string",
+                "description": "The peer device name. Used for description and documentation",
+                "title": "Peer"
+              },
+              "peer_interface": {
+                "type": "string",
+                "description": "The peer device interface. Used for description and documentation",
+                "title": "Peer Interface"
+              },
+              "peer_ip": {
+                "type": "string",
+                "description": "The peer device IP. Used for description and documentation",
+                "title": "Peer IP"
+              },
+              "bgp_as": {
+                "type": "string",
+                "description": "AS numbers for BGP.\nRequired with bgp peering.\n",
+                "title": "BGP As"
+              },
+              "peer_bgp_as": {
+                "type": "string",
+                "description": "AS numbers for BGP for the remote peer.\nIf not provided, `bgp_as` is used.\n",
+                "title": "Peer BGP As"
+              },
+              "description": {
+                "type": "string",
+                "description": "Interface description.",
+                "title": "Description"
+              },
+              "bfd": {
+                "type": "boolean",
+                "default": false,
+                "description": "Enable BFD (only considered for BGP).",
+                "title": "BFD"
+              },
+              "qos_profile": {
+                "type": "string",
+                "description": "QOS service profile.",
+                "title": "QOS Profile"
+              },
+              "subinterfaces": {
+                "type": "array",
+                "description": "Configure subinterfaces, each in their own VRF under the interface.",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "vrf": {
+                      "type": "string",
+                      "description": "Name of the VRF to configure for this subinterface\nThe VRF MUST exist in `network_services`",
+                      "title": "VRF"
+                    },
+                    "subinterface_id": {
+                      "type": "integer",
+                      "description": "Optional ID to overwrite the default one used from the VRF.\n`vrf_id` is used otherwise.",
+                      "title": "Subinterface ID"
+                    },
+                    "description": {
+                      "type": "string",
+                      "description": "Optional description for the subinterface.",
+                      "title": "Description"
+                    },
+                    "structured_config": {
+                      "type": "object",
+                      "description": "Custom structured config for the subinterface.\nNote! The content of this dictionary is _not_ validated by the schema, since it can be either ethernet_interfaces or port_channel_interfaces.",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "title": "Name"
+                        },
+                        "description": {
+                          "type": "string",
+                          "title": "Description"
+                        },
+                        "shutdown": {
+                          "type": "boolean",
+                          "title": "Shutdown"
+                        },
+                        "load_interval": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "maximum": 600,
+                          "description": "Interval in seconds for updating interface counters\"",
+                          "title": "Load Interval"
+                        },
+                        "speed": {
+                          "type": "string",
+                          "description": "Speed should be set in the format `<interface_speed>` or `forced <interface_speed>` or `auto <interface_speed>`.",
+                          "title": "Speed"
+                        },
+                        "mtu": {
+                          "type": "integer",
+                          "minimum": 68,
+                          "maximum": 65535,
+                          "title": "MTU"
+                        },
+                        "l2_mtu": {
+                          "type": "integer",
+                          "minimum": 68,
+                          "maximum": 65535,
+                          "description": "\"l2_mtu\" should only be defined for platforms supporting the \"l2 mtu\" CLI\n",
+                          "title": "L2 MTU"
+                        },
+                        "l2_mru": {
+                          "type": "integer",
+                          "minimum": 68,
+                          "maximum": 65535,
+                          "description": "\"l2_mru\" should only be defined for platforms supporting the \"l2 mru\" CLI\n",
+                          "title": "L2 MRU"
+                        },
+                        "vlans": {
+                          "type": "string",
+                          "description": "List of switchport vlans as string\nFor a trunk port this would be a range like \"1-200,300\"\nFor an access port this would be a single vlan \"123\"\n",
+                          "title": "VLANs"
+                        },
+                        "native_vlan": {
+                          "type": "integer",
+                          "title": "Native VLAN"
+                        },
+                        "native_vlan_tag": {
+                          "type": "boolean",
+                          "description": "If setting both native_vlan and native_vlan_tag, native_vlan_tag takes precedence",
+                          "title": "Native VLAN Tag"
+                        },
+                        "mode": {
+                          "type": "string",
+                          "enum": [
+                            "access",
+                            "dot1q-tunnel",
+                            "trunk",
+                            "trunk phone"
+                          ],
+                          "title": "Mode"
+                        },
+                        "phone": {
+                          "type": "object",
+                          "properties": {
+                            "trunk": {
+                              "type": "string",
+                              "enum": [
+                                "tagged",
+                                "tagged phone",
+                                "untagged",
+                                "untagged phone"
+                              ],
+                              "title": "Trunk"
+                            },
+                            "vlan": {
+                              "type": "integer",
+                              "minimum": 1,
+                              "maximum": 4094,
+                              "title": "VLAN"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Phone"
+                        },
+                        "l2_protocol": {
+                          "type": "object",
+                          "properties": {
+                            "encapsulation_dot1q_vlan": {
+                              "type": "integer",
+                              "description": "Vlan tag to configure on sub-interface",
+                              "title": "Encapsulation Dot1Q VLAN"
+                            },
+                            "forwarding_profile": {
+                              "type": "string",
+                              "description": "L2 protocol forwarding profile",
+                              "title": "Forwarding Profile"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "L2 Protocol"
+                        },
+                        "trunk_groups": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "title": "Trunk Groups"
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "routed",
+                            "switched",
+                            "l3dot1q",
+                            "l2dot1q",
+                            "port-channel-member"
+                          ],
+                          "description": "l3dot1q and l2dot1q are used for sub-interfaces. The parent interface should be defined as routed.\nInterface will not be listed in device documentation, unless \"type\" is set.\n",
+                          "title": "Type"
+                        },
+                        "snmp_trap_link_change": {
+                          "type": "boolean",
+                          "title": "Snmp Trap Link Change"
+                        },
+                        "address_locking": {
+                          "type": "object",
+                          "properties": {
+                            "ipv4": {
+                              "type": "boolean",
+                              "description": "Enable address locking for IPv4",
+                              "title": "IPv4"
+                            },
+                            "ipv6": {
+                              "type": "boolean",
+                              "description": "Enable address locking for IPv6",
+                              "title": "IPv6"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Address Locking"
+                        },
+                        "flowcontrol": {
+                          "type": "object",
+                          "properties": {
+                            "received": {
+                              "type": "string",
+                              "enum": [
+                                "desired",
+                                "on",
+                                "off"
+                              ],
+                              "title": "Received"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Flowcontrol"
+                        },
+                        "vrf": {
+                          "type": "string",
+                          "description": "VRF name",
+                          "title": "VRF"
+                        },
+                        "flow_tracker": {
+                          "type": "object",
+                          "properties": {
+                            "sampled": {
+                              "type": "string",
+                              "description": "Sampled flow tracker name.",
+                              "title": "Sampled"
+                            },
+                            "hardware": {
+                              "type": "string",
+                              "description": "Hardware flow tracker name.",
+                              "title": "Hardware"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Flow Tracker"
+                        },
+                        "error_correction_encoding": {
+                          "type": "object",
+                          "properties": {
+                            "enabled": {
+                              "type": "boolean",
+                              "default": true,
+                              "title": "Enabled"
+                            },
+                            "fire_code": {
+                              "type": "boolean",
+                              "title": "Fire Code"
+                            },
+                            "reed_solomon": {
+                              "type": "boolean",
+                              "title": "Reed Solomon"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Error Correction Encoding"
+                        },
+                        "link_tracking_groups": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "string",
+                                "description": "Group name",
+                                "title": "Name"
+                              },
+                              "direction": {
+                                "type": "string",
+                                "enum": [
+                                  "upstream",
+                                  "downstream"
+                                ],
+                                "title": "Direction"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            },
+                            "required": [
+                              "name"
+                            ]
+                          },
+                          "title": "Link Tracking Groups"
+                        },
+                        "evpn_ethernet_segment": {
+                          "type": "object",
+                          "properties": {
+                            "identifier": {
+                              "type": "string",
+                              "description": "EVPN Ethernet Segment Identifier (Type 1 format)",
+                              "title": "Identifier"
+                            },
+                            "redundancy": {
+                              "type": "string",
+                              "enum": [
+                                "all-active",
+                                "single-active"
+                              ],
+                              "title": "Redundancy"
+                            },
+                            "designated_forwarder_election": {
+                              "type": "object",
+                              "properties": {
+                                "algorithm": {
+                                  "type": "string",
+                                  "enum": [
+                                    "modulus",
+                                    "preference"
+                                  ],
+                                  "title": "Algorithm"
+                                },
+                                "preference_value": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "maximum": 65535,
+                                  "description": "Preference_value is only used when \"algorithm\" is \"preference\"",
+                                  "title": "Preference Value"
+                                },
+                                "dont_preempt": {
+                                  "type": "boolean",
+                                  "description": "Dont_preempt is only used when \"algorithm\" is \"preference\"",
+                                  "title": "Dont Preempt"
+                                },
+                                "hold_time": {
+                                  "type": "integer",
+                                  "title": "Hold Time"
+                                },
+                                "subsequent_hold_time": {
+                                  "type": "integer",
+                                  "title": "Subsequent Hold Time"
+                                },
+                                "candidate_reachability_required": {
+                                  "type": "boolean",
+                                  "title": "Candidate Reachability Required"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Designated Forwarder Election"
+                            },
+                            "mpls": {
+                              "type": "object",
+                              "properties": {
+                                "shared_index": {
+                                  "type": "integer",
+                                  "minimum": 1,
+                                  "maximum": 1024,
+                                  "title": "Shared Index"
+                                },
+                                "tunnel_flood_filter_time": {
+                                  "type": "integer",
+                                  "title": "Tunnel Flood Filter Time"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "MPLS"
+                            },
+                            "route_target": {
+                              "type": "string",
+                              "description": "EVPN Route Target for ESI with format xx:xx:xx:xx:xx:xx",
+                              "title": "Route Target"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "EVPN Ethernet Segment"
+                        },
+                        "encapsulation_dot1q_vlan": {
+                          "type": "integer",
+                          "description": "VLAN tag to configure on sub-interface",
+                          "title": "Encapsulation Dot1Q VLAN"
+                        },
+                        "encapsulation_vlan": {
+                          "type": "object",
+                          "properties": {
+                            "client": {
+                              "type": "object",
+                              "properties": {
+                                "dot1q": {
+                                  "type": "object",
+                                  "properties": {
+                                    "vlan": {
+                                      "type": "integer",
+                                      "description": "Client VLAN ID",
+                                      "title": "VLAN"
+                                    },
+                                    "outer": {
+                                      "type": "integer",
+                                      "description": "Client Outer VLAN ID",
+                                      "title": "Outer"
+                                    },
+                                    "inner": {
+                                      "type": "integer",
+                                      "description": "Client Inner VLAN ID",
+                                      "title": "Inner"
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "patternProperties": {
+                                    "^_.+$": {}
+                                  },
+                                  "title": "Dot1Q"
+                                },
+                                "unmatched": {
+                                  "type": "boolean",
+                                  "title": "Unmatched"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Client"
+                            },
+                            "network": {
+                              "type": "object",
+                              "description": "Network encapsulations are all optional and skipped if using client unmatched",
+                              "properties": {
+                                "dot1q": {
+                                  "type": "object",
+                                  "properties": {
+                                    "vlan": {
+                                      "type": "integer",
+                                      "description": "Network VLAN ID",
+                                      "title": "VLAN"
+                                    },
+                                    "outer": {
+                                      "type": "integer",
+                                      "description": "Network outer VLAN ID",
+                                      "title": "Outer"
+                                    },
+                                    "inner": {
+                                      "type": "integer",
+                                      "description": "Network inner VLAN ID",
+                                      "title": "Inner"
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "patternProperties": {
+                                    "^_.+$": {}
+                                  },
+                                  "title": "Dot1Q"
+                                },
+                                "client": {
+                                  "type": "boolean",
+                                  "title": "Client"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Network"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Encapsulation VLAN"
+                        },
+                        "vlan_id": {
+                          "type": "integer",
+                          "minimum": 1,
+                          "maximum": 4094,
+                          "title": "VLAN ID"
+                        },
+                        "ip_address": {
+                          "type": "string",
+                          "description": "IPv4 address/mask or \"dhcp\"",
+                          "title": "IP Address"
+                        },
+                        "ip_address_secondaries": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "title": "IP Address Secondaries"
+                        },
+                        "dhcp_client_accept_default_route": {
+                          "type": "boolean",
+                          "description": "Install default-route obtained via DHCP",
+                          "title": "DHCP Client Accept Default Route"
+                        },
+                        "dhcp_server_ipv4": {
+                          "type": "boolean",
+                          "description": "Enable IPv4 DHCP server.",
+                          "title": "DHCP Server IPv4"
+                        },
+                        "dhcp_server_ipv6": {
+                          "type": "boolean",
+                          "description": "Enable IPv6 DHCP server.",
+                          "title": "DHCP Server IPv6"
+                        },
+                        "ip_helpers": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "ip_helper": {
+                                "type": "string",
+                                "title": "IP Helper"
+                              },
+                              "source_interface": {
+                                "type": "string",
+                                "description": "Source interface name",
+                                "title": "Source Interface"
+                              },
+                              "vrf": {
+                                "type": "string",
+                                "description": "VRF name",
+                                "title": "VRF"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            },
+                            "required": [
+                              "ip_helper"
+                            ]
+                          },
+                          "title": "IP Helpers"
+                        },
+                        "ip_nat": {
+                          "type": "object",
+                          "properties": {
+                            "service_profile": {
+                              "type": "string",
+                              "description": "NAT interface profile.",
+                              "title": "Service Profile"
+                            },
+                            "destination": {
+                              "type": "object",
+                              "properties": {
+                                "dynamic": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "access_list": {
+                                        "type": "string",
+                                        "title": "Access List"
+                                      },
+                                      "comment": {
+                                        "type": "string",
+                                        "title": "Comment"
+                                      },
+                                      "pool_name": {
+                                        "type": "string",
+                                        "title": "Pool Name"
+                                      },
+                                      "priority": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "maximum": 4294967295,
+                                        "title": "Priority"
+                                      }
+                                    },
+                                    "required": [
+                                      "pool_name",
+                                      "access_list"
+                                    ],
+                                    "additionalProperties": false,
+                                    "patternProperties": {
+                                      "^_.+$": {}
+                                    }
+                                  },
+                                  "title": "Dynamic"
+                                },
+                                "static": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "access_list": {
+                                        "type": "string",
+                                        "description": "'access_list' and 'group' are mutual exclusive",
+                                        "title": "Access List"
+                                      },
+                                      "comment": {
+                                        "type": "string",
+                                        "title": "Comment"
+                                      },
+                                      "direction": {
+                                        "type": "string",
+                                        "enum": [
+                                          "egress",
+                                          "ingress"
+                                        ],
+                                        "description": "Egress or ingress can be the default. This depends on source/destination, EOS version, and hardware platform.\nEOS might remove this keyword in the configuration. So, check the configuration on targeted HW/SW.\n",
+                                        "title": "Direction"
+                                      },
+                                      "group": {
+                                        "type": "integer",
+                                        "minimum": 1,
+                                        "maximum": 65535,
+                                        "description": "'access_list' and 'group' are mutual exclusive",
+                                        "title": "Group"
+                                      },
+                                      "original_ip": {
+                                        "type": "string",
+                                        "description": "IPv4 address",
+                                        "title": "Original IP"
+                                      },
+                                      "original_port": {
+                                        "type": "integer",
+                                        "minimum": 1,
+                                        "maximum": 65535,
+                                        "title": "Original Port"
+                                      },
+                                      "priority": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "maximum": 4294967295,
+                                        "title": "Priority"
+                                      },
+                                      "protocol": {
+                                        "type": "string",
+                                        "enum": [
+                                          "udp",
+                                          "tcp"
+                                        ],
+                                        "title": "Protocol"
+                                      },
+                                      "translated_ip": {
+                                        "type": "string",
+                                        "description": "IPv4 address",
+                                        "title": "Translated IP"
+                                      },
+                                      "translated_port": {
+                                        "type": "integer",
+                                        "minimum": 1,
+                                        "maximum": 65535,
+                                        "description": "requires 'original_port'",
+                                        "title": "Translated Port"
+                                      }
+                                    },
+                                    "required": [
+                                      "translated_ip",
+                                      "original_ip"
+                                    ],
+                                    "additionalProperties": false,
+                                    "patternProperties": {
+                                      "^_.+$": {}
+                                    }
+                                  },
+                                  "title": "Static"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Destination"
+                            },
+                            "source": {
+                              "type": "object",
+                              "properties": {
+                                "dynamic": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "access_list": {
+                                        "type": "string",
+                                        "title": "Access List"
+                                      },
+                                      "comment": {
+                                        "type": "string",
+                                        "title": "Comment"
+                                      },
+                                      "nat_type": {
+                                        "type": "string",
+                                        "enum": [
+                                          "overload",
+                                          "pool",
+                                          "pool-address-only",
+                                          "pool-full-cone"
+                                        ],
+                                        "title": "Nat Type"
+                                      },
+                                      "pool_name": {
+                                        "type": "string",
+                                        "description": "required if 'nat_type' is pool, pool-address-only or pool-full-cone\nignored if 'nat_type' is overload\n",
+                                        "title": "Pool Name"
+                                      },
+                                      "priority": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "maximum": 4294967295,
+                                        "title": "Priority"
+                                      }
+                                    },
+                                    "required": [
+                                      "nat_type",
+                                      "access_list"
+                                    ],
+                                    "additionalProperties": false,
+                                    "patternProperties": {
+                                      "^_.+$": {}
+                                    }
+                                  },
+                                  "title": "Dynamic"
+                                },
+                                "static": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "access_list": {
+                                        "type": "string",
+                                        "description": "'access_list' and 'group' are mutual exclusive",
+                                        "title": "Access List"
+                                      },
+                                      "comment": {
+                                        "type": "string",
+                                        "title": "Comment"
+                                      },
+                                      "direction": {
+                                        "type": "string",
+                                        "enum": [
+                                          "egress",
+                                          "ingress"
+                                        ],
+                                        "description": "Egress or ingress can be the default. This depends on source/destination, EOS version, and hardware platform.\nEOS might remove this keyword in the configuration. So, check the configuration on targeted HW/SW.\n",
+                                        "title": "Direction"
+                                      },
+                                      "group": {
+                                        "type": "integer",
+                                        "minimum": 1,
+                                        "maximum": 65535,
+                                        "description": "'access_list' and 'group' are mutual exclusive",
+                                        "title": "Group"
+                                      },
+                                      "original_ip": {
+                                        "type": "string",
+                                        "description": "IPv4 address",
+                                        "title": "Original IP"
+                                      },
+                                      "original_port": {
+                                        "type": "integer",
+                                        "minimum": 1,
+                                        "maximum": 65535,
+                                        "title": "Original Port"
+                                      },
+                                      "priority": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "maximum": 4294967295,
+                                        "title": "Priority"
+                                      },
+                                      "protocol": {
+                                        "type": "string",
+                                        "enum": [
+                                          "udp",
+                                          "tcp"
+                                        ],
+                                        "title": "Protocol"
+                                      },
+                                      "translated_ip": {
+                                        "type": "string",
+                                        "description": "IPv4 address",
+                                        "title": "Translated IP"
+                                      },
+                                      "translated_port": {
+                                        "type": "integer",
+                                        "minimum": 1,
+                                        "maximum": 65535,
+                                        "description": "requires 'original_port'",
+                                        "title": "Translated Port"
+                                      }
+                                    },
+                                    "required": [
+                                      "translated_ip",
+                                      "original_ip"
+                                    ],
+                                    "additionalProperties": false,
+                                    "patternProperties": {
+                                      "^_.+$": {}
+                                    }
+                                  },
+                                  "title": "Static"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Source"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "IP Nat"
+                        },
+                        "ipv6_enable": {
+                          "type": "boolean",
+                          "title": "IPv6 Enable"
+                        },
+                        "ipv6_address": {
+                          "type": "string",
+                          "title": "IPv6 Address"
+                        },
+                        "ipv6_address_link_local": {
+                          "type": "string",
+                          "description": "Link local IPv6 address/mask",
+                          "title": "IPv6 Address Link Local"
+                        },
+                        "ipv6_nd_ra_disabled": {
+                          "type": "boolean",
+                          "title": "IPv6 ND RA Disabled"
+                        },
+                        "ipv6_nd_managed_config_flag": {
+                          "type": "boolean",
+                          "title": "IPv6 ND Managed Config Flag"
+                        },
+                        "ipv6_nd_prefixes": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "ipv6_prefix": {
+                                "type": "string",
+                                "title": "IPv6 Prefix"
+                              },
+                              "valid_lifetime": {
+                                "type": "string",
+                                "description": "Infinite or lifetime in seconds",
+                                "title": "Valid Lifetime"
+                              },
+                              "preferred_lifetime": {
+                                "type": "string",
+                                "description": "Infinite or lifetime in seconds",
+                                "title": "Preferred Lifetime"
+                              },
+                              "no_autoconfig_flag": {
+                                "type": "boolean",
+                                "title": "No Autoconfig Flag"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            },
+                            "required": [
+                              "ipv6_prefix"
+                            ]
+                          },
+                          "title": "IPv6 ND Prefixes"
+                        },
+                        "ipv6_dhcp_relay_destinations": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "address": {
+                                "type": "string",
+                                "description": "DHCP server's IPv6 address",
+                                "title": "Address"
+                              },
+                              "vrf": {
+                                "type": "string",
+                                "title": "VRF"
+                              },
+                              "local_interface": {
+                                "type": "string",
+                                "description": "Local interface to communicate with DHCP server - mutually exclusive to source_address",
+                                "title": "Local Interface"
+                              },
+                              "source_address": {
+                                "type": "string",
+                                "description": "Source IPv6 address to communicate with DHCP server - mutually exclusive to local_interface",
+                                "title": "Source Address"
+                              },
+                              "link_address": {
+                                "type": "string",
+                                "description": "Override the default link address specified in the relayed DHCP packet",
+                                "title": "Link Address"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            },
+                            "required": [
+                              "address"
+                            ]
+                          },
+                          "title": "IPv6 DHCP Relay Destinations"
+                        },
+                        "access_group_in": {
+                          "type": "string",
+                          "description": "Access list name",
+                          "title": "Access Group In"
+                        },
+                        "access_group_out": {
+                          "type": "string",
+                          "description": "Access list name",
+                          "title": "Access Group Out"
+                        },
+                        "ipv6_access_group_in": {
+                          "type": "string",
+                          "description": "IPv6 access list name",
+                          "title": "IPv6 Access Group In"
+                        },
+                        "ipv6_access_group_out": {
+                          "type": "string",
+                          "description": "IPv6 access list name",
+                          "title": "IPv6 Access Group Out"
+                        },
+                        "mac_access_group_in": {
+                          "type": "string",
+                          "description": "MAC access list name",
+                          "title": "MAC Access Group In"
+                        },
+                        "mac_access_group_out": {
+                          "type": "string",
+                          "description": "MAC access list name",
+                          "title": "MAC Access Group Out"
+                        },
+                        "multicast": {
+                          "type": "object",
+                          "description": "Boundaries can be either 1 ACL or a list of multicast IP address_range(s)/prefix but not combination of both",
+                          "properties": {
+                            "ipv4": {
+                              "type": "object",
+                              "properties": {
+                                "boundaries": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "boundary": {
+                                        "type": "string",
+                                        "description": "ACL name or multicast IP subnet",
+                                        "title": "Boundary"
+                                      },
+                                      "out": {
+                                        "type": "boolean",
+                                        "title": "Out"
+                                      }
+                                    },
+                                    "additionalProperties": false,
+                                    "patternProperties": {
+                                      "^_.+$": {}
+                                    }
+                                  },
+                                  "title": "Boundaries"
+                                },
+                                "static": {
+                                  "type": "boolean",
+                                  "title": "Static"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "IPv4"
+                            },
+                            "ipv6": {
+                              "type": "object",
+                              "properties": {
+                                "boundaries": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "boundary": {
+                                        "type": "string",
+                                        "description": "ACL name or multicast IP subnet",
+                                        "title": "Boundary"
+                                      }
+                                    },
+                                    "additionalProperties": false,
+                                    "patternProperties": {
+                                      "^_.+$": {}
+                                    }
+                                  },
+                                  "title": "Boundaries"
+                                },
+                                "static": {
+                                  "type": "boolean",
+                                  "title": "Static"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "IPv6"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Multicast"
+                        },
+                        "ospf_network_point_to_point": {
+                          "type": "boolean",
+                          "title": "OSPF Network Point To Point"
+                        },
+                        "ospf_area": {
+                          "type": "string",
+                          "title": "OSPF Area"
+                        },
+                        "ospf_cost": {
+                          "type": "integer",
+                          "title": "OSPF Cost"
+                        },
+                        "ospf_authentication": {
+                          "type": "string",
+                          "enum": [
+                            "none",
+                            "simple",
+                            "message-digest"
+                          ],
+                          "title": "OSPF Authentication"
+                        },
+                        "ospf_authentication_key": {
+                          "type": "string",
+                          "description": "Encrypted password - only type 7 supported",
+                          "title": "OSPF Authentication Key"
+                        },
+                        "ospf_message_digest_keys": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "integer",
+                                "title": "ID"
+                              },
+                              "hash_algorithm": {
+                                "type": "string",
+                                "enum": [
+                                  "md5",
+                                  "sha1",
+                                  "sha256",
+                                  "sha384",
+                                  "sha512"
+                                ],
+                                "title": "Hash Algorithm"
+                              },
+                              "key": {
+                                "type": "string",
+                                "description": "Encrypted password - only type 7 supported",
+                                "title": "Key"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            },
+                            "required": [
+                              "id"
+                            ]
+                          },
+                          "title": "OSPF Message Digest Keys"
+                        },
+                        "pim": {
+                          "type": "object",
+                          "properties": {
+                            "ipv4": {
+                              "type": "object",
+                              "properties": {
+                                "dr_priority": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "maximum": 429467295,
+                                  "title": "DR Priority"
+                                },
+                                "sparse_mode": {
+                                  "type": "boolean",
+                                  "title": "Sparse Mode"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "IPv4"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "PIM"
+                        },
+                        "mac_security": {
+                          "type": "object",
+                          "properties": {
+                            "profile": {
+                              "type": "string",
+                              "title": "Profile"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "MAC Security"
+                        },
+                        "channel_group": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "integer",
+                              "title": "ID"
+                            },
+                            "mode": {
+                              "type": "string",
+                              "enum": [
+                                "on",
+                                "active",
+                                "passive"
+                              ],
+                              "title": "Mode"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Channel Group"
+                        },
+                        "isis_enable": {
+                          "type": "string",
+                          "description": "ISIS instance",
+                          "title": "ISIS Enable"
+                        },
+                        "isis_passive": {
+                          "type": "boolean",
+                          "title": "ISIS Passive"
+                        },
+                        "isis_metric": {
+                          "type": "integer",
+                          "title": "ISIS Metric"
+                        },
+                        "isis_network_point_to_point": {
+                          "type": "boolean",
+                          "title": "ISIS Network Point To Point"
+                        },
+                        "isis_circuit_type": {
+                          "type": "string",
+                          "enum": [
+                            "level-1-2",
+                            "level-1",
+                            "level-2"
+                          ],
+                          "title": "ISIS Circuit Type"
+                        },
+                        "isis_hello_padding": {
+                          "type": "boolean",
+                          "title": "ISIS Hello Padding"
+                        },
+                        "isis_authentication_mode": {
+                          "type": "string",
+                          "enum": [
+                            "text",
+                            "md5"
+                          ],
+                          "title": "ISIS Authentication Mode"
+                        },
+                        "isis_authentication_key": {
+                          "type": "string",
+                          "description": "Type-7 encrypted password",
+                          "title": "ISIS Authentication Key"
+                        },
+                        "poe": {
+                          "type": "object",
+                          "properties": {
+                            "disabled": {
+                              "type": "boolean",
+                              "description": "Disable PoE on a POE capable port. PoE is enabled on all ports that support it by default in EOS.",
+                              "default": false,
+                              "title": "Disabled"
+                            },
+                            "priority": {
+                              "type": "string",
+                              "enum": [
+                                "critical",
+                                "high",
+                                "medium",
+                                "low"
+                              ],
+                              "description": "Prioritize a port's power in the event that one of the switch's power supplies loses power",
+                              "title": "Priority"
+                            },
+                            "reboot": {
+                              "description": "Set the PoE power behavior for a PoE port when the system is rebooted",
+                              "type": "object",
+                              "properties": {
+                                "action": {
+                                  "type": "string",
+                                  "enum": [
+                                    "maintain",
+                                    "power-off"
+                                  ],
+                                  "description": "PoE action for interface",
+                                  "title": "Action"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Reboot"
+                            },
+                            "link_down": {
+                              "description": "Set the PoE power behavior for a PoE port when the port goes down",
+                              "type": "object",
+                              "properties": {
+                                "action": {
+                                  "type": "string",
+                                  "enum": [
+                                    "maintain",
+                                    "power-off"
+                                  ],
+                                  "description": "PoE action for interface",
+                                  "title": "Action"
+                                },
+                                "power_off_delay": {
+                                  "type": "integer",
+                                  "minimum": 1,
+                                  "maximum": 86400,
+                                  "description": "Number of seconds to delay shutting the power off after a link down event occurs. Default value is 5 seconds in EOS.",
+                                  "title": "Power Off Delay"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Link Down"
+                            },
+                            "shutdown": {
+                              "description": "Set the PoE power behavior for a PoE port when the port is admin down",
+                              "type": "object",
+                              "properties": {
+                                "action": {
+                                  "type": "string",
+                                  "enum": [
+                                    "maintain",
+                                    "power-off"
+                                  ],
+                                  "description": "PoE action for interface",
+                                  "title": "Action"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Shutdown"
+                            },
+                            "limit": {
+                              "type": "object",
+                              "description": "Override the hardware-negotiated power limit using either wattage or a power class. Note that if using a power class, AVD will automatically convert the class value to the wattage value corresponding to that power class.",
+                              "properties": {
+                                "class": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "maximum": 8,
+                                  "title": "Class"
+                                },
+                                "watts": {
+                                  "type": "string",
+                                  "title": "Watts"
+                                },
+                                "fixed": {
+                                  "type": "boolean",
+                                  "description": "Set to ignore hardware classification",
+                                  "title": "Fixed"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Limit"
+                            },
+                            "negotiation_lldp": {
+                              "type": "boolean",
+                              "description": "Disable to prevent port from negotiating power with powered devices over LLDP. Enabled by default in EOS.",
+                              "title": "Negotiation LLDP"
+                            },
+                            "legacy_detect": {
+                              "type": "boolean",
+                              "description": "Allow a subset of legacy devices to work with the PoE switch. Disabled by default in EOS because it can cause false positive detections.",
+                              "title": "Legacy Detect"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "PoE"
+                        },
+                        "ptp": {
+                          "type": "object",
+                          "properties": {
+                            "enable": {
+                              "type": "boolean",
+                              "title": "Enable"
+                            },
+                            "announce": {
+                              "type": "object",
+                              "properties": {
+                                "interval": {
+                                  "type": "integer",
+                                  "title": "Interval"
+                                },
+                                "timeout": {
+                                  "type": "integer",
+                                  "title": "Timeout"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Announce"
+                            },
+                            "delay_req": {
+                              "type": "integer",
+                              "title": "Delay Req"
+                            },
+                            "delay_mechanism": {
+                              "type": "string",
+                              "enum": [
+                                "e2e",
+                                "p2p"
+                              ],
+                              "title": "Delay Mechanism"
+                            },
+                            "sync_message": {
+                              "type": "object",
+                              "properties": {
+                                "interval": {
+                                  "type": "integer",
+                                  "title": "Interval"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Sync Message"
+                            },
+                            "role": {
+                              "type": "string",
+                              "enum": [
+                                "master",
+                                "dynamic"
+                              ],
+                              "title": "Role"
+                            },
+                            "vlan": {
+                              "type": "string",
+                              "description": "VLAN can be 'all' or list of vlans as string",
+                              "title": "VLAN"
+                            },
+                            "transport": {
+                              "type": "string",
+                              "enum": [
+                                "ipv4",
+                                "ipv6",
+                                "layer2"
+                              ],
+                              "title": "Transport"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "PTP"
+                        },
+                        "profile": {
+                          "type": "string",
+                          "description": "Interface profile",
+                          "title": "Profile"
+                        },
+                        "storm_control": {
+                          "type": "object",
+                          "properties": {
+                            "all": {
+                              "type": "object",
+                              "properties": {
+                                "level": {
+                                  "type": "string",
+                                  "description": "Configure maximum storm-control level",
+                                  "title": "Level"
+                                },
+                                "unit": {
+                                  "type": "string",
+                                  "default": "percent",
+                                  "enum": [
+                                    "percent",
+                                    "pps"
+                                  ],
+                                  "description": "Optional field and is hardware dependent",
+                                  "title": "Unit"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "All"
+                            },
+                            "broadcast": {
+                              "type": "object",
+                              "properties": {
+                                "level": {
+                                  "type": "string",
+                                  "description": "Configure maximum storm-control level",
+                                  "title": "Level"
+                                },
+                                "unit": {
+                                  "type": "string",
+                                  "default": "percent",
+                                  "enum": [
+                                    "percent",
+                                    "pps"
+                                  ],
+                                  "description": "Optional field and is hardware dependent",
+                                  "title": "Unit"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Broadcast"
+                            },
+                            "multicast": {
+                              "type": "object",
+                              "properties": {
+                                "level": {
+                                  "type": "string",
+                                  "description": "Configure maximum storm-control level",
+                                  "title": "Level"
+                                },
+                                "unit": {
+                                  "type": "string",
+                                  "default": "percent",
+                                  "enum": [
+                                    "percent",
+                                    "pps"
+                                  ],
+                                  "description": "Optional field and is hardware dependent",
+                                  "title": "Unit"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Multicast"
+                            },
+                            "unknown_unicast": {
+                              "type": "object",
+                              "properties": {
+                                "level": {
+                                  "type": "string",
+                                  "description": "Configure maximum storm-control level",
+                                  "title": "Level"
+                                },
+                                "unit": {
+                                  "type": "string",
+                                  "default": "percent",
+                                  "enum": [
+                                    "percent",
+                                    "pps"
+                                  ],
+                                  "description": "Optional field and is hardware dependent",
+                                  "title": "Unit"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Unknown Unicast"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Storm Control"
+                        },
+                        "logging": {
+                          "type": "object",
+                          "properties": {
+                            "event": {
+                              "type": "object",
+                              "properties": {
+                                "link_status": {
+                                  "type": "boolean",
+                                  "title": "Link Status"
+                                },
+                                "congestion_drops": {
+                                  "type": "boolean",
+                                  "title": "Congestion Drops"
+                                },
+                                "spanning_tree": {
+                                  "type": "boolean",
+                                  "title": "Spanning Tree"
+                                },
+                                "storm_control_discards": {
+                                  "type": "boolean",
+                                  "title": "Storm Control Discards"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Event"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Logging"
+                        },
+                        "lldp": {
+                          "type": "object",
+                          "properties": {
+                            "transmit": {
+                              "type": "boolean",
+                              "title": "Transmit"
+                            },
+                            "receive": {
+                              "type": "boolean",
+                              "title": "Receive"
+                            },
+                            "ztp_vlan": {
+                              "type": "integer",
+                              "description": "ZTP vlan number",
+                              "title": "ZTP VLAN"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "LLDP"
+                        },
+                        "trunk_private_vlan_secondary": {
+                          "type": "boolean",
+                          "title": "Trunk Private VLAN Secondary"
+                        },
+                        "pvlan_mapping": {
+                          "type": "string",
+                          "description": "List of vlans as string",
+                          "title": "PVLAN Mapping"
+                        },
+                        "vlan_translations": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "from": {
+                                "type": "string",
+                                "description": "List of vlans as string (only one vlan if direction is \"both\")",
+                                "title": "From"
+                              },
+                              "to": {
+                                "type": "integer",
+                                "description": "VLAN ID",
+                                "title": "To"
+                              },
+                              "direction": {
+                                "type": "string",
+                                "enum": [
+                                  "in",
+                                  "out",
+                                  "both"
+                                ],
+                                "default": "both",
+                                "title": "Direction"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            }
+                          },
+                          "title": "VLAN Translations"
+                        },
+                        "dot1x": {
+                          "type": "object",
+                          "properties": {
+                            "port_control": {
+                              "type": "string",
+                              "enum": [
+                                "auto",
+                                "force-authorized",
+                                "force-unauthorized"
+                              ],
+                              "title": "Port Control"
+                            },
+                            "port_control_force_authorized_phone": {
+                              "type": "boolean",
+                              "title": "Port Control Force Authorized Phone"
+                            },
+                            "reauthentication": {
+                              "type": "boolean",
+                              "title": "Reauthentication"
+                            },
+                            "pae": {
+                              "type": "object",
+                              "properties": {
+                                "mode": {
+                                  "type": "string",
+                                  "enum": [
+                                    "authenticator"
+                                  ],
+                                  "title": "Mode"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "PAE"
+                            },
+                            "authentication_failure": {
+                              "type": "object",
+                              "properties": {
+                                "action": {
+                                  "type": "string",
+                                  "enum": [
+                                    "allow",
+                                    "drop"
+                                  ],
+                                  "title": "Action"
+                                },
+                                "allow_vlan": {
+                                  "type": "integer",
+                                  "minimum": 1,
+                                  "maximum": 4094,
+                                  "title": "Allow VLAN"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Authentication Failure"
+                            },
+                            "host_mode": {
+                              "type": "object",
+                              "properties": {
+                                "mode": {
+                                  "type": "string",
+                                  "enum": [
+                                    "multi-host",
+                                    "single-host"
+                                  ],
+                                  "title": "Mode"
+                                },
+                                "multi_host_authenticated": {
+                                  "type": "boolean",
+                                  "title": "Multi Host Authenticated"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Host Mode"
+                            },
+                            "mac_based_authentication": {
+                              "type": "object",
+                              "properties": {
+                                "enabled": {
+                                  "type": "boolean",
+                                  "title": "Enabled"
+                                },
+                                "always": {
+                                  "type": "boolean",
+                                  "title": "Always"
+                                },
+                                "host_mode_common": {
+                                  "type": "boolean",
+                                  "title": "Host Mode Common"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "MAC Based Authentication"
+                            },
+                            "timeout": {
+                              "type": "object",
+                              "properties": {
+                                "idle_host": {
+                                  "type": "integer",
+                                  "minimum": 10,
+                                  "maximum": 65535,
+                                  "title": "Idle Host"
+                                },
+                                "quiet_period": {
+                                  "type": "integer",
+                                  "minimum": 1,
+                                  "maximum": 65535,
+                                  "title": "Quiet Period"
+                                },
+                                "reauth_period": {
+                                  "type": "string",
+                                  "description": "Value can be 60-4294967295 or 'server'",
+                                  "title": "Reauth Period"
+                                },
+                                "reauth_timeout_ignore": {
+                                  "type": "boolean",
+                                  "title": "Reauth Timeout Ignore"
+                                },
+                                "tx_period": {
+                                  "type": "integer",
+                                  "minimum": 1,
+                                  "maximum": 65535,
+                                  "title": "TX Period"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Timeout"
+                            },
+                            "reauthorization_request_limit": {
+                              "type": "integer",
+                              "minimum": 1,
+                              "maximum": 10,
+                              "title": "Reauthorization Request Limit"
+                            },
+                            "unauthorized": {
+                              "type": "object",
+                              "properties": {
+                                "access_vlan_membership_egress": {
+                                  "type": "boolean",
+                                  "title": "Access VLAN Membership Egress"
+                                },
+                                "native_vlan_membership_egress": {
+                                  "type": "boolean",
+                                  "title": "Native VLAN Membership Egress"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Unauthorized"
+                            },
+                            "eapol": {
+                              "type": "object",
+                              "properties": {
+                                "disabled": {
+                                  "type": "boolean",
+                                  "title": "Disabled"
+                                },
+                                "authentication_failure_fallback_mba": {
+                                  "type": "object",
+                                  "properties": {
+                                    "enabled": {
+                                      "type": "boolean",
+                                      "title": "Enabled"
+                                    },
+                                    "timeout": {
+                                      "type": "integer",
+                                      "minimum": 0,
+                                      "maximum": 65535,
+                                      "title": "Timeout"
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "patternProperties": {
+                                    "^_.+$": {}
+                                  },
+                                  "title": "Authentication Failure Fallback Mba"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Eapol"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "dot1x"
+                        },
+                        "service_profile": {
+                          "type": "string",
+                          "description": "QOS profile",
+                          "title": "Service Profile"
+                        },
+                        "shape": {
+                          "type": "object",
+                          "properties": {
+                            "rate": {
+                              "type": "string",
+                              "description": "Rate in kbps, pps or percent\nSupported options are platform dependent\nExamples:\n- \"5000 kbps\"\n- \"1000 pps\"\n- \"20 percent\"\n",
+                              "title": "Rate"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Shape"
+                        },
+                        "qos": {
+                          "type": "object",
+                          "properties": {
+                            "trust": {
+                              "type": "string",
+                              "enum": [
+                                "dscp",
+                                "cos",
+                                "disabled"
+                              ],
+                              "title": "Trust"
+                            },
+                            "dscp": {
+                              "type": "integer",
+                              "description": "DSCP value",
+                              "title": "DSCP"
+                            },
+                            "cos": {
+                              "type": "integer",
+                              "description": "COS value",
+                              "title": "COS"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "QOS"
+                        },
+                        "spanning_tree_bpdufilter": {
+                          "type": "string",
+                          "enum": [
+                            "enabled",
+                            "disabled",
+                            "True",
+                            "False",
+                            "true",
+                            "false"
+                          ],
+                          "title": "Spanning Tree Bpdufilter"
+                        },
+                        "spanning_tree_bpduguard": {
+                          "type": "string",
+                          "enum": [
+                            "enabled",
+                            "disabled",
+                            "True",
+                            "False",
+                            "true",
+                            "false"
+                          ],
+                          "title": "Spanning Tree Bpduguard"
+                        },
+                        "spanning_tree_guard": {
+                          "type": "string",
+                          "enum": [
+                            "loop",
+                            "root",
+                            "disabled"
+                          ],
+                          "title": "Spanning Tree Guard"
+                        },
+                        "spanning_tree_portfast": {
+                          "type": "string",
+                          "enum": [
+                            "edge",
+                            "network"
+                          ],
+                          "title": "Spanning Tree Portfast"
+                        },
+                        "vmtracer": {
+                          "type": "boolean",
+                          "title": "VMTracer"
+                        },
+                        "priority_flow_control": {
+                          "type": "object",
+                          "properties": {
+                            "enabled": {
+                              "type": "boolean",
+                              "title": "Enabled"
+                            },
+                            "priorities": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "priority": {
+                                    "type": "integer",
+                                    "minimum": 0,
+                                    "maximum": 7,
+                                    "title": "Priority"
+                                  },
+                                  "no_drop": {
+                                    "type": "boolean",
+                                    "title": "No Drop"
+                                  }
+                                },
+                                "additionalProperties": false,
+                                "patternProperties": {
+                                  "^_.+$": {}
+                                },
+                                "required": [
+                                  "priority"
+                                ]
+                              },
+                              "title": "Priorities"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Priority Flow Control"
+                        },
+                        "bfd": {
+                          "type": "object",
+                          "properties": {
+                            "echo": {
+                              "type": "boolean",
+                              "title": "Echo"
+                            },
+                            "interval": {
+                              "type": "integer",
+                              "description": "Interval in milliseconds",
+                              "title": "Interval"
+                            },
+                            "min_rx": {
+                              "type": "integer",
+                              "description": "Rate in milliseconds",
+                              "title": "Min RX"
+                            },
+                            "multiplier": {
+                              "type": "integer",
+                              "minimum": 3,
+                              "maximum": 50,
+                              "title": "Multiplier"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "BFD"
+                        },
+                        "service_policy": {
+                          "type": "object",
+                          "properties": {
+                            "pbr": {
+                              "type": "object",
+                              "properties": {
+                                "input": {
+                                  "type": "string",
+                                  "description": "Policy Based Routing Policy-map name",
+                                  "title": "Input"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "PBR"
+                            },
+                            "qos": {
+                              "type": "object",
+                              "properties": {
+                                "input": {
+                                  "type": "string",
+                                  "description": "Quality of Service Policy-map name",
+                                  "title": "Input"
+                                }
+                              },
+                              "required": [
+                                "input"
+                              ],
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "QOS"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Service Policy"
+                        },
+                        "mpls": {
+                          "type": "object",
+                          "properties": {
+                            "ip": {
+                              "type": "boolean",
+                              "title": "IP"
+                            },
+                            "ldp": {
+                              "type": "object",
+                              "properties": {
+                                "interface": {
+                                  "type": "boolean",
+                                  "title": "Interface"
+                                },
+                                "igp_sync": {
+                                  "type": "boolean",
+                                  "title": "IGP Sync"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "LDP"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "MPLS"
+                        },
+                        "lacp_timer": {
+                          "type": "object",
+                          "properties": {
+                            "mode": {
+                              "type": "string",
+                              "enum": [
+                                "fast",
+                                "normal"
+                              ],
+                              "title": "Mode"
+                            },
+                            "multiplier": {
+                              "type": "integer",
+                              "minimum": 3,
+                              "maximum": 3000,
+                              "title": "Multiplier"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "LACP Timer"
+                        },
+                        "lacp_port_priority": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "maximum": 65535,
+                          "title": "LACP Port Priority"
+                        },
+                        "transceiver": {
+                          "type": "object",
+                          "properties": {
+                            "media": {
+                              "type": "object",
+                              "properties": {
+                                "override": {
+                                  "type": "string",
+                                  "description": "Transceiver type",
+                                  "title": "Override"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Media"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Transceiver"
+                        },
+                        "ip_proxy_arp": {
+                          "type": "boolean",
+                          "title": "IP Proxy ARP"
+                        },
+                        "traffic_policy": {
+                          "type": "object",
+                          "properties": {
+                            "input": {
+                              "type": "string",
+                              "description": "Ingress traffic policy",
+                              "title": "Input"
+                            },
+                            "output": {
+                              "type": "string",
+                              "description": "Egress traffic policy",
+                              "title": "Output"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Traffic Policy"
+                        },
+                        "bgp": {
+                          "type": "object",
+                          "properties": {
+                            "session_tracker": {
+                              "type": "string",
+                              "description": "Name of session tracker",
+                              "title": "Session Tracker"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "BGP"
+                        },
+                        "peer": {
+                          "type": "string",
+                          "description": "Key only used for documentation or validation purposes",
+                          "title": "Peer"
+                        },
+                        "peer_interface": {
+                          "type": "string",
+                          "description": "Key only used for documentation or validation purposes",
+                          "title": "Peer Interface"
+                        },
+                        "peer_type": {
+                          "type": "string",
+                          "description": "Key only used for documentation or validation purposes",
+                          "title": "Peer Type"
+                        },
+                        "sflow": {
+                          "type": "object",
+                          "properties": {
+                            "enable": {
+                              "type": "boolean",
+                              "title": "Enable"
+                            },
+                            "egress": {
+                              "type": "object",
+                              "properties": {
+                                "enable": {
+                                  "type": "boolean",
+                                  "title": "Enable"
+                                },
+                                "unmodified_enable": {
+                                  "type": "boolean",
+                                  "title": "Unmodified Enable"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Egress"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Sflow"
+                        },
+                        "port_profile": {
+                          "type": "string",
+                          "description": "Key only used for documentation or validation purposes",
+                          "title": "Port Profile"
+                        },
+                        "uc_tx_queues": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "integer",
+                                "description": "TX-Queue ID",
+                                "title": "ID"
+                              },
+                              "random_detect": {
+                                "type": "object",
+                                "properties": {
+                                  "ecn": {
+                                    "description": "Explicit Congestion Notification",
+                                    "type": "object",
+                                    "properties": {
+                                      "count": {
+                                        "type": "boolean",
+                                        "description": "Enable counter for random-detect ECNs",
+                                        "title": "Count"
+                                      },
+                                      "threshold": {
+                                        "type": "object",
+                                        "properties": {
+                                          "units": {
+                                            "type": "string",
+                                            "enum": [
+                                              "segments",
+                                              "bytes",
+                                              "kbytes",
+                                              "mbytes",
+                                              "milliseconds"
+                                            ],
+                                            "description": "Indicate the units to be used for the threshold values",
+                                            "title": "Units"
+                                          },
+                                          "min": {
+                                            "type": "integer",
+                                            "minimum": 1,
+                                            "maximum": 256000000,
+                                            "description": "Set the random-detect ECN minimum-threshold",
+                                            "title": "Min"
+                                          },
+                                          "max": {
+                                            "type": "integer",
+                                            "minimum": 1,
+                                            "maximum": 256000000,
+                                            "description": "Set the random-detect ECN maximum-threshold",
+                                            "title": "Max"
+                                          },
+                                          "max_probability": {
+                                            "type": "integer",
+                                            "minimum": 1,
+                                            "maximum": 100,
+                                            "description": "Set the random-detect ECN max-mark-probability",
+                                            "title": "Max Probability"
+                                          },
+                                          "weight": {
+                                            "type": "integer",
+                                            "minimum": 0,
+                                            "maximum": 15,
+                                            "description": "Set the random-detect ECN weight",
+                                            "title": "Weight"
+                                          }
+                                        },
+                                        "required": [
+                                          "units",
+                                          "min",
+                                          "max"
+                                        ],
+                                        "additionalProperties": false,
+                                        "patternProperties": {
+                                          "^_.+$": {}
+                                        },
+                                        "title": "Threshold"
+                                      }
+                                    },
+                                    "additionalProperties": false,
+                                    "patternProperties": {
+                                      "^_.+$": {}
+                                    },
+                                    "title": "Ecn"
+                                  }
+                                },
+                                "additionalProperties": false,
+                                "patternProperties": {
+                                  "^_.+$": {}
+                                },
+                                "title": "Random Detect"
+                              }
+                            },
+                            "required": [
+                              "id"
+                            ],
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            }
+                          },
+                          "title": "Uc TX Queues"
+                        },
+                        "tx_queues": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "integer",
+                                "description": "TX-Queue ID",
+                                "title": "ID"
+                              },
+                              "random_detect": {
+                                "type": "object",
+                                "properties": {
+                                  "ecn": {
+                                    "description": "Explicit Congestion Notification",
+                                    "type": "object",
+                                    "properties": {
+                                      "count": {
+                                        "type": "boolean",
+                                        "description": "Enable counter for random-detect ECNs",
+                                        "title": "Count"
+                                      },
+                                      "threshold": {
+                                        "type": "object",
+                                        "properties": {
+                                          "units": {
+                                            "type": "string",
+                                            "enum": [
+                                              "segments",
+                                              "bytes",
+                                              "kbytes",
+                                              "mbytes",
+                                              "milliseconds"
+                                            ],
+                                            "description": "Indicate the units to be used for the threshold values",
+                                            "title": "Units"
+                                          },
+                                          "min": {
+                                            "type": "integer",
+                                            "minimum": 1,
+                                            "maximum": 256000000,
+                                            "description": "Set the random-detect ECN minimum-threshold",
+                                            "title": "Min"
+                                          },
+                                          "max": {
+                                            "type": "integer",
+                                            "minimum": 1,
+                                            "maximum": 256000000,
+                                            "description": "Set the random-detect ECN maximum-threshold",
+                                            "title": "Max"
+                                          },
+                                          "max_probability": {
+                                            "type": "integer",
+                                            "minimum": 1,
+                                            "maximum": 100,
+                                            "description": "Set the random-detect ECN max-mark-probability",
+                                            "title": "Max Probability"
+                                          },
+                                          "weight": {
+                                            "type": "integer",
+                                            "minimum": 0,
+                                            "maximum": 15,
+                                            "description": "Set the random-detect ECN weight",
+                                            "title": "Weight"
+                                          }
+                                        },
+                                        "required": [
+                                          "units",
+                                          "max",
+                                          "max_probability"
+                                        ],
+                                        "additionalProperties": false,
+                                        "patternProperties": {
+                                          "^_.+$": {}
+                                        },
+                                        "title": "Threshold"
+                                      }
+                                    },
+                                    "additionalProperties": false,
+                                    "patternProperties": {
+                                      "^_.+$": {}
+                                    },
+                                    "title": "Ecn"
+                                  }
+                                },
+                                "additionalProperties": false,
+                                "patternProperties": {
+                                  "^_.+$": {}
+                                },
+                                "title": "Random Detect"
+                              }
+                            },
+                            "required": [
+                              "id"
+                            ],
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            }
+                          },
+                          "title": "TX Queues"
+                        },
+                        "vrrp_ids": {
+                          "type": "array",
+                          "description": "VRRP model.",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "integer",
+                                "description": "VRID",
+                                "title": "ID"
+                              },
+                              "priority_level": {
+                                "type": "integer",
+                                "description": "Instance priority",
+                                "minimum": 1,
+                                "maximum": 254,
+                                "title": "Priority Level"
+                              },
+                              "advertisement": {
+                                "type": "object",
+                                "properties": {
+                                  "interval": {
+                                    "type": "integer",
+                                    "description": "Interval in seconds",
+                                    "minimum": 1,
+                                    "maximum": 255,
+                                    "title": "Interval"
+                                  }
+                                },
+                                "additionalProperties": false,
+                                "patternProperties": {
+                                  "^_.+$": {}
+                                },
+                                "title": "Advertisement"
+                              },
+                              "preempt": {
+                                "type": "object",
+                                "properties": {
+                                  "enabled": {
+                                    "type": "boolean",
+                                    "title": "Enabled"
+                                  },
+                                  "delay": {
+                                    "type": "object",
+                                    "properties": {
+                                      "minimum": {
+                                        "type": "integer",
+                                        "description": "Minimum preempt delay in seconds",
+                                        "minimum": 0,
+                                        "maximum": 3600,
+                                        "title": "Minimum"
+                                      },
+                                      "reload": {
+                                        "type": "integer",
+                                        "description": "Reload preempt delay in seconds",
+                                        "minimum": 0,
+                                        "maximum": 3600,
+                                        "title": "Reload"
+                                      }
+                                    },
+                                    "additionalProperties": false,
+                                    "patternProperties": {
+                                      "^_.+$": {}
+                                    },
+                                    "title": "Delay"
+                                  }
+                                },
+                                "required": [
+                                  "enabled"
+                                ],
+                                "additionalProperties": false,
+                                "patternProperties": {
+                                  "^_.+$": {}
+                                },
+                                "title": "Preempt"
+                              },
+                              "timers": {
+                                "type": "object",
+                                "properties": {
+                                  "delay": {
+                                    "type": "object",
+                                    "properties": {
+                                      "reload": {
+                                        "type": "integer",
+                                        "description": "Delay after reload in seconds.",
+                                        "minimum": 0,
+                                        "maximum": 3600,
+                                        "title": "Reload"
+                                      }
+                                    },
+                                    "additionalProperties": false,
+                                    "patternProperties": {
+                                      "^_.+$": {}
+                                    },
+                                    "title": "Delay"
+                                  }
+                                },
+                                "additionalProperties": false,
+                                "patternProperties": {
+                                  "^_.+$": {}
+                                },
+                                "title": "Timers"
+                              },
+                              "tracked_object": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string",
+                                      "description": "Tracked object name",
+                                      "title": "Name"
+                                    },
+                                    "decrement": {
+                                      "type": "integer",
+                                      "minimum": 1,
+                                      "maximum": 254,
+                                      "description": "Decrement VRRP priority by 1-254",
+                                      "title": "Decrement"
+                                    },
+                                    "shutdown": {
+                                      "type": "boolean",
+                                      "title": "Shutdown"
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "patternProperties": {
+                                    "^_.+$": {}
+                                  },
+                                  "required": [
+                                    "name"
+                                  ]
+                                },
+                                "title": "Tracked Object"
+                              },
+                              "ipv4": {
+                                "type": "object",
+                                "properties": {
+                                  "address": {
+                                    "type": "string",
+                                    "description": "Virtual IPv4 address",
+                                    "title": "Address"
+                                  },
+                                  "version": {
+                                    "type": "integer",
+                                    "enum": [
+                                      2,
+                                      3
+                                    ],
+                                    "title": "Version"
+                                  }
+                                },
+                                "required": [
+                                  "address"
+                                ],
+                                "additionalProperties": false,
+                                "patternProperties": {
+                                  "^_.+$": {}
+                                },
+                                "title": "IPv4"
+                              },
+                              "ipv6": {
+                                "type": "object",
+                                "properties": {
+                                  "address": {
+                                    "type": "string",
+                                    "description": "Virtual IPv6 address",
+                                    "title": "Address"
+                                  }
+                                },
+                                "required": [
+                                  "address"
+                                ],
+                                "additionalProperties": false,
+                                "patternProperties": {
+                                  "^_.+$": {}
+                                },
+                                "title": "IPv6"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            },
+                            "required": [
+                              "id"
+                            ]
+                          },
+                          "title": "VRRP IDs"
+                        },
+                        "eos_cli": {
+                          "type": "string",
+                          "description": "Multiline EOS CLI rendered directly on the ethernet interface in the final EOS configuration",
+                          "title": "EOS CLI"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      },
+                      "title": "Structured Config"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "patternProperties": {
+                    "^_.+$": {}
+                  },
+                  "required": [
+                    "vrf"
+                  ]
+                },
+                "title": "Subinterfaces"
+              },
+              "raw_eos_cli": {
+                "type": "string",
+                "description": "EOS CLI rendered directly on the interface in the final EOS configuration.",
+                "title": "Raw EOS CLI"
+              },
+              "structured_config": {
+                "type": "object",
+                "description": "Custom structured config for interfaces",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "title": "Name"
+                  },
+                  "description": {
+                    "type": "string",
+                    "title": "Description"
+                  },
+                  "shutdown": {
+                    "type": "boolean",
+                    "title": "Shutdown"
+                  },
+                  "load_interval": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 600,
+                    "description": "Interval in seconds for updating interface counters\"",
+                    "title": "Load Interval"
+                  },
+                  "speed": {
+                    "type": "string",
+                    "description": "Speed should be set in the format `<interface_speed>` or `forced <interface_speed>` or `auto <interface_speed>`.",
+                    "title": "Speed"
+                  },
+                  "mtu": {
+                    "type": "integer",
+                    "minimum": 68,
+                    "maximum": 65535,
+                    "title": "MTU"
+                  },
+                  "l2_mtu": {
+                    "type": "integer",
+                    "minimum": 68,
+                    "maximum": 65535,
+                    "description": "\"l2_mtu\" should only be defined for platforms supporting the \"l2 mtu\" CLI\n",
+                    "title": "L2 MTU"
+                  },
+                  "l2_mru": {
+                    "type": "integer",
+                    "minimum": 68,
+                    "maximum": 65535,
+                    "description": "\"l2_mru\" should only be defined for platforms supporting the \"l2 mru\" CLI\n",
+                    "title": "L2 MRU"
+                  },
+                  "vlans": {
+                    "type": "string",
+                    "description": "List of switchport vlans as string\nFor a trunk port this would be a range like \"1-200,300\"\nFor an access port this would be a single vlan \"123\"\n",
+                    "title": "VLANs"
+                  },
+                  "native_vlan": {
+                    "type": "integer",
+                    "title": "Native VLAN"
+                  },
+                  "native_vlan_tag": {
+                    "type": "boolean",
+                    "description": "If setting both native_vlan and native_vlan_tag, native_vlan_tag takes precedence",
+                    "title": "Native VLAN Tag"
+                  },
+                  "mode": {
+                    "type": "string",
+                    "enum": [
+                      "access",
+                      "dot1q-tunnel",
+                      "trunk",
+                      "trunk phone"
+                    ],
+                    "title": "Mode"
+                  },
+                  "phone": {
+                    "type": "object",
+                    "properties": {
+                      "trunk": {
+                        "type": "string",
+                        "enum": [
+                          "tagged",
+                          "tagged phone",
+                          "untagged",
+                          "untagged phone"
+                        ],
+                        "title": "Trunk"
+                      },
+                      "vlan": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 4094,
+                        "title": "VLAN"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Phone"
+                  },
+                  "l2_protocol": {
+                    "type": "object",
+                    "properties": {
+                      "encapsulation_dot1q_vlan": {
+                        "type": "integer",
+                        "description": "Vlan tag to configure on sub-interface",
+                        "title": "Encapsulation Dot1Q VLAN"
+                      },
+                      "forwarding_profile": {
+                        "type": "string",
+                        "description": "L2 protocol forwarding profile",
+                        "title": "Forwarding Profile"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "L2 Protocol"
+                  },
+                  "trunk_groups": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Trunk Groups"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "routed",
+                      "switched",
+                      "l3dot1q",
+                      "l2dot1q",
+                      "port-channel-member"
+                    ],
+                    "description": "l3dot1q and l2dot1q are used for sub-interfaces. The parent interface should be defined as routed.\nInterface will not be listed in device documentation, unless \"type\" is set.\n",
+                    "title": "Type"
+                  },
+                  "snmp_trap_link_change": {
+                    "type": "boolean",
+                    "title": "Snmp Trap Link Change"
+                  },
+                  "address_locking": {
+                    "type": "object",
+                    "properties": {
+                      "ipv4": {
+                        "type": "boolean",
+                        "description": "Enable address locking for IPv4",
+                        "title": "IPv4"
+                      },
+                      "ipv6": {
+                        "type": "boolean",
+                        "description": "Enable address locking for IPv6",
+                        "title": "IPv6"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Address Locking"
+                  },
+                  "flowcontrol": {
+                    "type": "object",
+                    "properties": {
+                      "received": {
+                        "type": "string",
+                        "enum": [
+                          "desired",
+                          "on",
+                          "off"
+                        ],
+                        "title": "Received"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Flowcontrol"
+                  },
+                  "vrf": {
+                    "type": "string",
+                    "description": "VRF name",
+                    "title": "VRF"
+                  },
+                  "flow_tracker": {
+                    "type": "object",
+                    "properties": {
+                      "sampled": {
+                        "type": "string",
+                        "description": "Sampled flow tracker name.",
+                        "title": "Sampled"
+                      },
+                      "hardware": {
+                        "type": "string",
+                        "description": "Hardware flow tracker name.",
+                        "title": "Hardware"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Flow Tracker"
+                  },
+                  "error_correction_encoding": {
+                    "type": "object",
+                    "properties": {
+                      "enabled": {
+                        "type": "boolean",
+                        "default": true,
+                        "title": "Enabled"
+                      },
+                      "fire_code": {
+                        "type": "boolean",
+                        "title": "Fire Code"
+                      },
+                      "reed_solomon": {
+                        "type": "boolean",
+                        "title": "Reed Solomon"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Error Correction Encoding"
+                  },
+                  "link_tracking_groups": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "description": "Group name",
+                          "title": "Name"
+                        },
+                        "direction": {
+                          "type": "string",
+                          "enum": [
+                            "upstream",
+                            "downstream"
+                          ],
+                          "title": "Direction"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      },
+                      "required": [
+                        "name"
+                      ]
+                    },
+                    "title": "Link Tracking Groups"
+                  },
+                  "evpn_ethernet_segment": {
+                    "type": "object",
+                    "properties": {
+                      "identifier": {
+                        "type": "string",
+                        "description": "EVPN Ethernet Segment Identifier (Type 1 format)",
+                        "title": "Identifier"
+                      },
+                      "redundancy": {
+                        "type": "string",
+                        "enum": [
+                          "all-active",
+                          "single-active"
+                        ],
+                        "title": "Redundancy"
+                      },
+                      "designated_forwarder_election": {
+                        "type": "object",
+                        "properties": {
+                          "algorithm": {
+                            "type": "string",
+                            "enum": [
+                              "modulus",
+                              "preference"
+                            ],
+                            "title": "Algorithm"
+                          },
+                          "preference_value": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 65535,
+                            "description": "Preference_value is only used when \"algorithm\" is \"preference\"",
+                            "title": "Preference Value"
+                          },
+                          "dont_preempt": {
+                            "type": "boolean",
+                            "description": "Dont_preempt is only used when \"algorithm\" is \"preference\"",
+                            "title": "Dont Preempt"
+                          },
+                          "hold_time": {
+                            "type": "integer",
+                            "title": "Hold Time"
+                          },
+                          "subsequent_hold_time": {
+                            "type": "integer",
+                            "title": "Subsequent Hold Time"
+                          },
+                          "candidate_reachability_required": {
+                            "type": "boolean",
+                            "title": "Candidate Reachability Required"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Designated Forwarder Election"
+                      },
+                      "mpls": {
+                        "type": "object",
+                        "properties": {
+                          "shared_index": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 1024,
+                            "title": "Shared Index"
+                          },
+                          "tunnel_flood_filter_time": {
+                            "type": "integer",
+                            "title": "Tunnel Flood Filter Time"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "MPLS"
+                      },
+                      "route_target": {
+                        "type": "string",
+                        "description": "EVPN Route Target for ESI with format xx:xx:xx:xx:xx:xx",
+                        "title": "Route Target"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "EVPN Ethernet Segment"
+                  },
+                  "encapsulation_dot1q_vlan": {
+                    "type": "integer",
+                    "description": "VLAN tag to configure on sub-interface",
+                    "title": "Encapsulation Dot1Q VLAN"
+                  },
+                  "encapsulation_vlan": {
+                    "type": "object",
+                    "properties": {
+                      "client": {
+                        "type": "object",
+                        "properties": {
+                          "dot1q": {
+                            "type": "object",
+                            "properties": {
+                              "vlan": {
+                                "type": "integer",
+                                "description": "Client VLAN ID",
+                                "title": "VLAN"
+                              },
+                              "outer": {
+                                "type": "integer",
+                                "description": "Client Outer VLAN ID",
+                                "title": "Outer"
+                              },
+                              "inner": {
+                                "type": "integer",
+                                "description": "Client Inner VLAN ID",
+                                "title": "Inner"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            },
+                            "title": "Dot1Q"
+                          },
+                          "unmatched": {
+                            "type": "boolean",
+                            "title": "Unmatched"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Client"
+                      },
+                      "network": {
+                        "type": "object",
+                        "description": "Network encapsulations are all optional and skipped if using client unmatched",
+                        "properties": {
+                          "dot1q": {
+                            "type": "object",
+                            "properties": {
+                              "vlan": {
+                                "type": "integer",
+                                "description": "Network VLAN ID",
+                                "title": "VLAN"
+                              },
+                              "outer": {
+                                "type": "integer",
+                                "description": "Network outer VLAN ID",
+                                "title": "Outer"
+                              },
+                              "inner": {
+                                "type": "integer",
+                                "description": "Network inner VLAN ID",
+                                "title": "Inner"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            },
+                            "title": "Dot1Q"
+                          },
+                          "client": {
+                            "type": "boolean",
+                            "title": "Client"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Network"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Encapsulation VLAN"
+                  },
+                  "vlan_id": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 4094,
+                    "title": "VLAN ID"
+                  },
+                  "ip_address": {
+                    "type": "string",
+                    "description": "IPv4 address/mask or \"dhcp\"",
+                    "title": "IP Address"
+                  },
+                  "ip_address_secondaries": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "IP Address Secondaries"
+                  },
+                  "dhcp_client_accept_default_route": {
+                    "type": "boolean",
+                    "description": "Install default-route obtained via DHCP",
+                    "title": "DHCP Client Accept Default Route"
+                  },
+                  "dhcp_server_ipv4": {
+                    "type": "boolean",
+                    "description": "Enable IPv4 DHCP server.",
+                    "title": "DHCP Server IPv4"
+                  },
+                  "dhcp_server_ipv6": {
+                    "type": "boolean",
+                    "description": "Enable IPv6 DHCP server.",
+                    "title": "DHCP Server IPv6"
+                  },
+                  "ip_helpers": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "ip_helper": {
+                          "type": "string",
+                          "title": "IP Helper"
+                        },
+                        "source_interface": {
+                          "type": "string",
+                          "description": "Source interface name",
+                          "title": "Source Interface"
+                        },
+                        "vrf": {
+                          "type": "string",
+                          "description": "VRF name",
+                          "title": "VRF"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      },
+                      "required": [
+                        "ip_helper"
+                      ]
+                    },
+                    "title": "IP Helpers"
+                  },
+                  "ip_nat": {
+                    "type": "object",
+                    "properties": {
+                      "service_profile": {
+                        "type": "string",
+                        "description": "NAT interface profile.",
+                        "title": "Service Profile"
+                      },
+                      "destination": {
+                        "type": "object",
+                        "properties": {
+                          "dynamic": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "access_list": {
+                                  "type": "string",
+                                  "title": "Access List"
+                                },
+                                "comment": {
+                                  "type": "string",
+                                  "title": "Comment"
+                                },
+                                "pool_name": {
+                                  "type": "string",
+                                  "title": "Pool Name"
+                                },
+                                "priority": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "maximum": 4294967295,
+                                  "title": "Priority"
+                                }
+                              },
+                              "required": [
+                                "pool_name",
+                                "access_list"
+                              ],
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              }
+                            },
+                            "title": "Dynamic"
+                          },
+                          "static": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "access_list": {
+                                  "type": "string",
+                                  "description": "'access_list' and 'group' are mutual exclusive",
+                                  "title": "Access List"
+                                },
+                                "comment": {
+                                  "type": "string",
+                                  "title": "Comment"
+                                },
+                                "direction": {
+                                  "type": "string",
+                                  "enum": [
+                                    "egress",
+                                    "ingress"
+                                  ],
+                                  "description": "Egress or ingress can be the default. This depends on source/destination, EOS version, and hardware platform.\nEOS might remove this keyword in the configuration. So, check the configuration on targeted HW/SW.\n",
+                                  "title": "Direction"
+                                },
+                                "group": {
+                                  "type": "integer",
+                                  "minimum": 1,
+                                  "maximum": 65535,
+                                  "description": "'access_list' and 'group' are mutual exclusive",
+                                  "title": "Group"
+                                },
+                                "original_ip": {
+                                  "type": "string",
+                                  "description": "IPv4 address",
+                                  "title": "Original IP"
+                                },
+                                "original_port": {
+                                  "type": "integer",
+                                  "minimum": 1,
+                                  "maximum": 65535,
+                                  "title": "Original Port"
+                                },
+                                "priority": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "maximum": 4294967295,
+                                  "title": "Priority"
+                                },
+                                "protocol": {
+                                  "type": "string",
+                                  "enum": [
+                                    "udp",
+                                    "tcp"
+                                  ],
+                                  "title": "Protocol"
+                                },
+                                "translated_ip": {
+                                  "type": "string",
+                                  "description": "IPv4 address",
+                                  "title": "Translated IP"
+                                },
+                                "translated_port": {
+                                  "type": "integer",
+                                  "minimum": 1,
+                                  "maximum": 65535,
+                                  "description": "requires 'original_port'",
+                                  "title": "Translated Port"
+                                }
+                              },
+                              "required": [
+                                "translated_ip",
+                                "original_ip"
+                              ],
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              }
+                            },
+                            "title": "Static"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Destination"
+                      },
+                      "source": {
+                        "type": "object",
+                        "properties": {
+                          "dynamic": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "access_list": {
+                                  "type": "string",
+                                  "title": "Access List"
+                                },
+                                "comment": {
+                                  "type": "string",
+                                  "title": "Comment"
+                                },
+                                "nat_type": {
+                                  "type": "string",
+                                  "enum": [
+                                    "overload",
+                                    "pool",
+                                    "pool-address-only",
+                                    "pool-full-cone"
+                                  ],
+                                  "title": "Nat Type"
+                                },
+                                "pool_name": {
+                                  "type": "string",
+                                  "description": "required if 'nat_type' is pool, pool-address-only or pool-full-cone\nignored if 'nat_type' is overload\n",
+                                  "title": "Pool Name"
+                                },
+                                "priority": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "maximum": 4294967295,
+                                  "title": "Priority"
+                                }
+                              },
+                              "required": [
+                                "nat_type",
+                                "access_list"
+                              ],
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              }
+                            },
+                            "title": "Dynamic"
+                          },
+                          "static": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "access_list": {
+                                  "type": "string",
+                                  "description": "'access_list' and 'group' are mutual exclusive",
+                                  "title": "Access List"
+                                },
+                                "comment": {
+                                  "type": "string",
+                                  "title": "Comment"
+                                },
+                                "direction": {
+                                  "type": "string",
+                                  "enum": [
+                                    "egress",
+                                    "ingress"
+                                  ],
+                                  "description": "Egress or ingress can be the default. This depends on source/destination, EOS version, and hardware platform.\nEOS might remove this keyword in the configuration. So, check the configuration on targeted HW/SW.\n",
+                                  "title": "Direction"
+                                },
+                                "group": {
+                                  "type": "integer",
+                                  "minimum": 1,
+                                  "maximum": 65535,
+                                  "description": "'access_list' and 'group' are mutual exclusive",
+                                  "title": "Group"
+                                },
+                                "original_ip": {
+                                  "type": "string",
+                                  "description": "IPv4 address",
+                                  "title": "Original IP"
+                                },
+                                "original_port": {
+                                  "type": "integer",
+                                  "minimum": 1,
+                                  "maximum": 65535,
+                                  "title": "Original Port"
+                                },
+                                "priority": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "maximum": 4294967295,
+                                  "title": "Priority"
+                                },
+                                "protocol": {
+                                  "type": "string",
+                                  "enum": [
+                                    "udp",
+                                    "tcp"
+                                  ],
+                                  "title": "Protocol"
+                                },
+                                "translated_ip": {
+                                  "type": "string",
+                                  "description": "IPv4 address",
+                                  "title": "Translated IP"
+                                },
+                                "translated_port": {
+                                  "type": "integer",
+                                  "minimum": 1,
+                                  "maximum": 65535,
+                                  "description": "requires 'original_port'",
+                                  "title": "Translated Port"
+                                }
+                              },
+                              "required": [
+                                "translated_ip",
+                                "original_ip"
+                              ],
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              }
+                            },
+                            "title": "Static"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Source"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "IP Nat"
+                  },
+                  "ipv6_enable": {
+                    "type": "boolean",
+                    "title": "IPv6 Enable"
+                  },
+                  "ipv6_address": {
+                    "type": "string",
+                    "title": "IPv6 Address"
+                  },
+                  "ipv6_address_link_local": {
+                    "type": "string",
+                    "description": "Link local IPv6 address/mask",
+                    "title": "IPv6 Address Link Local"
+                  },
+                  "ipv6_nd_ra_disabled": {
+                    "type": "boolean",
+                    "title": "IPv6 ND RA Disabled"
+                  },
+                  "ipv6_nd_managed_config_flag": {
+                    "type": "boolean",
+                    "title": "IPv6 ND Managed Config Flag"
+                  },
+                  "ipv6_nd_prefixes": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "ipv6_prefix": {
+                          "type": "string",
+                          "title": "IPv6 Prefix"
+                        },
+                        "valid_lifetime": {
+                          "type": "string",
+                          "description": "Infinite or lifetime in seconds",
+                          "title": "Valid Lifetime"
+                        },
+                        "preferred_lifetime": {
+                          "type": "string",
+                          "description": "Infinite or lifetime in seconds",
+                          "title": "Preferred Lifetime"
+                        },
+                        "no_autoconfig_flag": {
+                          "type": "boolean",
+                          "title": "No Autoconfig Flag"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      },
+                      "required": [
+                        "ipv6_prefix"
+                      ]
+                    },
+                    "title": "IPv6 ND Prefixes"
+                  },
+                  "ipv6_dhcp_relay_destinations": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "address": {
+                          "type": "string",
+                          "description": "DHCP server's IPv6 address",
+                          "title": "Address"
+                        },
+                        "vrf": {
+                          "type": "string",
+                          "title": "VRF"
+                        },
+                        "local_interface": {
+                          "type": "string",
+                          "description": "Local interface to communicate with DHCP server - mutually exclusive to source_address",
+                          "title": "Local Interface"
+                        },
+                        "source_address": {
+                          "type": "string",
+                          "description": "Source IPv6 address to communicate with DHCP server - mutually exclusive to local_interface",
+                          "title": "Source Address"
+                        },
+                        "link_address": {
+                          "type": "string",
+                          "description": "Override the default link address specified in the relayed DHCP packet",
+                          "title": "Link Address"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      },
+                      "required": [
+                        "address"
+                      ]
+                    },
+                    "title": "IPv6 DHCP Relay Destinations"
+                  },
+                  "access_group_in": {
+                    "type": "string",
+                    "description": "Access list name",
+                    "title": "Access Group In"
+                  },
+                  "access_group_out": {
+                    "type": "string",
+                    "description": "Access list name",
+                    "title": "Access Group Out"
+                  },
+                  "ipv6_access_group_in": {
+                    "type": "string",
+                    "description": "IPv6 access list name",
+                    "title": "IPv6 Access Group In"
+                  },
+                  "ipv6_access_group_out": {
+                    "type": "string",
+                    "description": "IPv6 access list name",
+                    "title": "IPv6 Access Group Out"
+                  },
+                  "mac_access_group_in": {
+                    "type": "string",
+                    "description": "MAC access list name",
+                    "title": "MAC Access Group In"
+                  },
+                  "mac_access_group_out": {
+                    "type": "string",
+                    "description": "MAC access list name",
+                    "title": "MAC Access Group Out"
+                  },
+                  "multicast": {
+                    "type": "object",
+                    "description": "Boundaries can be either 1 ACL or a list of multicast IP address_range(s)/prefix but not combination of both",
+                    "properties": {
+                      "ipv4": {
+                        "type": "object",
+                        "properties": {
+                          "boundaries": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "boundary": {
+                                  "type": "string",
+                                  "description": "ACL name or multicast IP subnet",
+                                  "title": "Boundary"
+                                },
+                                "out": {
+                                  "type": "boolean",
+                                  "title": "Out"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              }
+                            },
+                            "title": "Boundaries"
+                          },
+                          "static": {
+                            "type": "boolean",
+                            "title": "Static"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "IPv4"
+                      },
+                      "ipv6": {
+                        "type": "object",
+                        "properties": {
+                          "boundaries": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "boundary": {
+                                  "type": "string",
+                                  "description": "ACL name or multicast IP subnet",
+                                  "title": "Boundary"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              }
+                            },
+                            "title": "Boundaries"
+                          },
+                          "static": {
+                            "type": "boolean",
+                            "title": "Static"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "IPv6"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Multicast"
+                  },
+                  "ospf_network_point_to_point": {
+                    "type": "boolean",
+                    "title": "OSPF Network Point To Point"
+                  },
+                  "ospf_area": {
+                    "type": "string",
+                    "title": "OSPF Area"
+                  },
+                  "ospf_cost": {
+                    "type": "integer",
+                    "title": "OSPF Cost"
+                  },
+                  "ospf_authentication": {
+                    "type": "string",
+                    "enum": [
+                      "none",
+                      "simple",
+                      "message-digest"
+                    ],
+                    "title": "OSPF Authentication"
+                  },
+                  "ospf_authentication_key": {
+                    "type": "string",
+                    "description": "Encrypted password - only type 7 supported",
+                    "title": "OSPF Authentication Key"
+                  },
+                  "ospf_message_digest_keys": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "title": "ID"
+                        },
+                        "hash_algorithm": {
+                          "type": "string",
+                          "enum": [
+                            "md5",
+                            "sha1",
+                            "sha256",
+                            "sha384",
+                            "sha512"
+                          ],
+                          "title": "Hash Algorithm"
+                        },
+                        "key": {
+                          "type": "string",
+                          "description": "Encrypted password - only type 7 supported",
+                          "title": "Key"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      },
+                      "required": [
+                        "id"
+                      ]
+                    },
+                    "title": "OSPF Message Digest Keys"
+                  },
+                  "pim": {
+                    "type": "object",
+                    "properties": {
+                      "ipv4": {
+                        "type": "object",
+                        "properties": {
+                          "dr_priority": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 429467295,
+                            "title": "DR Priority"
+                          },
+                          "sparse_mode": {
+                            "type": "boolean",
+                            "title": "Sparse Mode"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "IPv4"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "PIM"
+                  },
+                  "mac_security": {
+                    "type": "object",
+                    "properties": {
+                      "profile": {
+                        "type": "string",
+                        "title": "Profile"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "MAC Security"
+                  },
+                  "channel_group": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "integer",
+                        "title": "ID"
+                      },
+                      "mode": {
+                        "type": "string",
+                        "enum": [
+                          "on",
+                          "active",
+                          "passive"
+                        ],
+                        "title": "Mode"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Channel Group"
+                  },
+                  "isis_enable": {
+                    "type": "string",
+                    "description": "ISIS instance",
+                    "title": "ISIS Enable"
+                  },
+                  "isis_passive": {
+                    "type": "boolean",
+                    "title": "ISIS Passive"
+                  },
+                  "isis_metric": {
+                    "type": "integer",
+                    "title": "ISIS Metric"
+                  },
+                  "isis_network_point_to_point": {
+                    "type": "boolean",
+                    "title": "ISIS Network Point To Point"
+                  },
+                  "isis_circuit_type": {
+                    "type": "string",
+                    "enum": [
+                      "level-1-2",
+                      "level-1",
+                      "level-2"
+                    ],
+                    "title": "ISIS Circuit Type"
+                  },
+                  "isis_hello_padding": {
+                    "type": "boolean",
+                    "title": "ISIS Hello Padding"
+                  },
+                  "isis_authentication_mode": {
+                    "type": "string",
+                    "enum": [
+                      "text",
+                      "md5"
+                    ],
+                    "title": "ISIS Authentication Mode"
+                  },
+                  "isis_authentication_key": {
+                    "type": "string",
+                    "description": "Type-7 encrypted password",
+                    "title": "ISIS Authentication Key"
+                  },
+                  "poe": {
+                    "type": "object",
+                    "properties": {
+                      "disabled": {
+                        "type": "boolean",
+                        "description": "Disable PoE on a POE capable port. PoE is enabled on all ports that support it by default in EOS.",
+                        "default": false,
+                        "title": "Disabled"
+                      },
+                      "priority": {
+                        "type": "string",
+                        "enum": [
+                          "critical",
+                          "high",
+                          "medium",
+                          "low"
+                        ],
+                        "description": "Prioritize a port's power in the event that one of the switch's power supplies loses power",
+                        "title": "Priority"
+                      },
+                      "reboot": {
+                        "description": "Set the PoE power behavior for a PoE port when the system is rebooted",
+                        "type": "object",
+                        "properties": {
+                          "action": {
+                            "type": "string",
+                            "enum": [
+                              "maintain",
+                              "power-off"
+                            ],
+                            "description": "PoE action for interface",
+                            "title": "Action"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Reboot"
+                      },
+                      "link_down": {
+                        "description": "Set the PoE power behavior for a PoE port when the port goes down",
+                        "type": "object",
+                        "properties": {
+                          "action": {
+                            "type": "string",
+                            "enum": [
+                              "maintain",
+                              "power-off"
+                            ],
+                            "description": "PoE action for interface",
+                            "title": "Action"
+                          },
+                          "power_off_delay": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 86400,
+                            "description": "Number of seconds to delay shutting the power off after a link down event occurs. Default value is 5 seconds in EOS.",
+                            "title": "Power Off Delay"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Link Down"
+                      },
+                      "shutdown": {
+                        "description": "Set the PoE power behavior for a PoE port when the port is admin down",
+                        "type": "object",
+                        "properties": {
+                          "action": {
+                            "type": "string",
+                            "enum": [
+                              "maintain",
+                              "power-off"
+                            ],
+                            "description": "PoE action for interface",
+                            "title": "Action"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Shutdown"
+                      },
+                      "limit": {
+                        "type": "object",
+                        "description": "Override the hardware-negotiated power limit using either wattage or a power class. Note that if using a power class, AVD will automatically convert the class value to the wattage value corresponding to that power class.",
+                        "properties": {
+                          "class": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 8,
+                            "title": "Class"
+                          },
+                          "watts": {
+                            "type": "string",
+                            "title": "Watts"
+                          },
+                          "fixed": {
+                            "type": "boolean",
+                            "description": "Set to ignore hardware classification",
+                            "title": "Fixed"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Limit"
+                      },
+                      "negotiation_lldp": {
+                        "type": "boolean",
+                        "description": "Disable to prevent port from negotiating power with powered devices over LLDP. Enabled by default in EOS.",
+                        "title": "Negotiation LLDP"
+                      },
+                      "legacy_detect": {
+                        "type": "boolean",
+                        "description": "Allow a subset of legacy devices to work with the PoE switch. Disabled by default in EOS because it can cause false positive detections.",
+                        "title": "Legacy Detect"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "PoE"
+                  },
+                  "ptp": {
+                    "type": "object",
+                    "properties": {
+                      "enable": {
+                        "type": "boolean",
+                        "title": "Enable"
+                      },
+                      "announce": {
+                        "type": "object",
+                        "properties": {
+                          "interval": {
+                            "type": "integer",
+                            "title": "Interval"
+                          },
+                          "timeout": {
+                            "type": "integer",
+                            "title": "Timeout"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Announce"
+                      },
+                      "delay_req": {
+                        "type": "integer",
+                        "title": "Delay Req"
+                      },
+                      "delay_mechanism": {
+                        "type": "string",
+                        "enum": [
+                          "e2e",
+                          "p2p"
+                        ],
+                        "title": "Delay Mechanism"
+                      },
+                      "sync_message": {
+                        "type": "object",
+                        "properties": {
+                          "interval": {
+                            "type": "integer",
+                            "title": "Interval"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Sync Message"
+                      },
+                      "role": {
+                        "type": "string",
+                        "enum": [
+                          "master",
+                          "dynamic"
+                        ],
+                        "title": "Role"
+                      },
+                      "vlan": {
+                        "type": "string",
+                        "description": "VLAN can be 'all' or list of vlans as string",
+                        "title": "VLAN"
+                      },
+                      "transport": {
+                        "type": "string",
+                        "enum": [
+                          "ipv4",
+                          "ipv6",
+                          "layer2"
+                        ],
+                        "title": "Transport"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "PTP"
+                  },
+                  "profile": {
+                    "type": "string",
+                    "description": "Interface profile",
+                    "title": "Profile"
+                  },
+                  "storm_control": {
+                    "type": "object",
+                    "properties": {
+                      "all": {
+                        "type": "object",
+                        "properties": {
+                          "level": {
+                            "type": "string",
+                            "description": "Configure maximum storm-control level",
+                            "title": "Level"
+                          },
+                          "unit": {
+                            "type": "string",
+                            "default": "percent",
+                            "enum": [
+                              "percent",
+                              "pps"
+                            ],
+                            "description": "Optional field and is hardware dependent",
+                            "title": "Unit"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "All"
+                      },
+                      "broadcast": {
+                        "type": "object",
+                        "properties": {
+                          "level": {
+                            "type": "string",
+                            "description": "Configure maximum storm-control level",
+                            "title": "Level"
+                          },
+                          "unit": {
+                            "type": "string",
+                            "default": "percent",
+                            "enum": [
+                              "percent",
+                              "pps"
+                            ],
+                            "description": "Optional field and is hardware dependent",
+                            "title": "Unit"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Broadcast"
+                      },
+                      "multicast": {
+                        "type": "object",
+                        "properties": {
+                          "level": {
+                            "type": "string",
+                            "description": "Configure maximum storm-control level",
+                            "title": "Level"
+                          },
+                          "unit": {
+                            "type": "string",
+                            "default": "percent",
+                            "enum": [
+                              "percent",
+                              "pps"
+                            ],
+                            "description": "Optional field and is hardware dependent",
+                            "title": "Unit"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Multicast"
+                      },
+                      "unknown_unicast": {
+                        "type": "object",
+                        "properties": {
+                          "level": {
+                            "type": "string",
+                            "description": "Configure maximum storm-control level",
+                            "title": "Level"
+                          },
+                          "unit": {
+                            "type": "string",
+                            "default": "percent",
+                            "enum": [
+                              "percent",
+                              "pps"
+                            ],
+                            "description": "Optional field and is hardware dependent",
+                            "title": "Unit"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Unknown Unicast"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Storm Control"
+                  },
+                  "logging": {
+                    "type": "object",
+                    "properties": {
+                      "event": {
+                        "type": "object",
+                        "properties": {
+                          "link_status": {
+                            "type": "boolean",
+                            "title": "Link Status"
+                          },
+                          "congestion_drops": {
+                            "type": "boolean",
+                            "title": "Congestion Drops"
+                          },
+                          "spanning_tree": {
+                            "type": "boolean",
+                            "title": "Spanning Tree"
+                          },
+                          "storm_control_discards": {
+                            "type": "boolean",
+                            "title": "Storm Control Discards"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Event"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Logging"
+                  },
+                  "lldp": {
+                    "type": "object",
+                    "properties": {
+                      "transmit": {
+                        "type": "boolean",
+                        "title": "Transmit"
+                      },
+                      "receive": {
+                        "type": "boolean",
+                        "title": "Receive"
+                      },
+                      "ztp_vlan": {
+                        "type": "integer",
+                        "description": "ZTP vlan number",
+                        "title": "ZTP VLAN"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "LLDP"
+                  },
+                  "trunk_private_vlan_secondary": {
+                    "type": "boolean",
+                    "title": "Trunk Private VLAN Secondary"
+                  },
+                  "pvlan_mapping": {
+                    "type": "string",
+                    "description": "List of vlans as string",
+                    "title": "PVLAN Mapping"
+                  },
+                  "vlan_translations": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "from": {
+                          "type": "string",
+                          "description": "List of vlans as string (only one vlan if direction is \"both\")",
+                          "title": "From"
+                        },
+                        "to": {
+                          "type": "integer",
+                          "description": "VLAN ID",
+                          "title": "To"
+                        },
+                        "direction": {
+                          "type": "string",
+                          "enum": [
+                            "in",
+                            "out",
+                            "both"
+                          ],
+                          "default": "both",
+                          "title": "Direction"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      }
+                    },
+                    "title": "VLAN Translations"
+                  },
+                  "dot1x": {
+                    "type": "object",
+                    "properties": {
+                      "port_control": {
+                        "type": "string",
+                        "enum": [
+                          "auto",
+                          "force-authorized",
+                          "force-unauthorized"
+                        ],
+                        "title": "Port Control"
+                      },
+                      "port_control_force_authorized_phone": {
+                        "type": "boolean",
+                        "title": "Port Control Force Authorized Phone"
+                      },
+                      "reauthentication": {
+                        "type": "boolean",
+                        "title": "Reauthentication"
+                      },
+                      "pae": {
+                        "type": "object",
+                        "properties": {
+                          "mode": {
+                            "type": "string",
+                            "enum": [
+                              "authenticator"
+                            ],
+                            "title": "Mode"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "PAE"
+                      },
+                      "authentication_failure": {
+                        "type": "object",
+                        "properties": {
+                          "action": {
+                            "type": "string",
+                            "enum": [
+                              "allow",
+                              "drop"
+                            ],
+                            "title": "Action"
+                          },
+                          "allow_vlan": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 4094,
+                            "title": "Allow VLAN"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Authentication Failure"
+                      },
+                      "host_mode": {
+                        "type": "object",
+                        "properties": {
+                          "mode": {
+                            "type": "string",
+                            "enum": [
+                              "multi-host",
+                              "single-host"
+                            ],
+                            "title": "Mode"
+                          },
+                          "multi_host_authenticated": {
+                            "type": "boolean",
+                            "title": "Multi Host Authenticated"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Host Mode"
+                      },
+                      "mac_based_authentication": {
+                        "type": "object",
+                        "properties": {
+                          "enabled": {
+                            "type": "boolean",
+                            "title": "Enabled"
+                          },
+                          "always": {
+                            "type": "boolean",
+                            "title": "Always"
+                          },
+                          "host_mode_common": {
+                            "type": "boolean",
+                            "title": "Host Mode Common"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "MAC Based Authentication"
+                      },
+                      "timeout": {
+                        "type": "object",
+                        "properties": {
+                          "idle_host": {
+                            "type": "integer",
+                            "minimum": 10,
+                            "maximum": 65535,
+                            "title": "Idle Host"
+                          },
+                          "quiet_period": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 65535,
+                            "title": "Quiet Period"
+                          },
+                          "reauth_period": {
+                            "type": "string",
+                            "description": "Value can be 60-4294967295 or 'server'",
+                            "title": "Reauth Period"
+                          },
+                          "reauth_timeout_ignore": {
+                            "type": "boolean",
+                            "title": "Reauth Timeout Ignore"
+                          },
+                          "tx_period": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 65535,
+                            "title": "TX Period"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Timeout"
+                      },
+                      "reauthorization_request_limit": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 10,
+                        "title": "Reauthorization Request Limit"
+                      },
+                      "unauthorized": {
+                        "type": "object",
+                        "properties": {
+                          "access_vlan_membership_egress": {
+                            "type": "boolean",
+                            "title": "Access VLAN Membership Egress"
+                          },
+                          "native_vlan_membership_egress": {
+                            "type": "boolean",
+                            "title": "Native VLAN Membership Egress"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Unauthorized"
+                      },
+                      "eapol": {
+                        "type": "object",
+                        "properties": {
+                          "disabled": {
+                            "type": "boolean",
+                            "title": "Disabled"
+                          },
+                          "authentication_failure_fallback_mba": {
+                            "type": "object",
+                            "properties": {
+                              "enabled": {
+                                "type": "boolean",
+                                "title": "Enabled"
+                              },
+                              "timeout": {
+                                "type": "integer",
+                                "minimum": 0,
+                                "maximum": 65535,
+                                "title": "Timeout"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            },
+                            "title": "Authentication Failure Fallback Mba"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Eapol"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "dot1x"
+                  },
+                  "service_profile": {
+                    "type": "string",
+                    "description": "QOS profile",
+                    "title": "Service Profile"
+                  },
+                  "shape": {
+                    "type": "object",
+                    "properties": {
+                      "rate": {
+                        "type": "string",
+                        "description": "Rate in kbps, pps or percent\nSupported options are platform dependent\nExamples:\n- \"5000 kbps\"\n- \"1000 pps\"\n- \"20 percent\"\n",
+                        "title": "Rate"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Shape"
+                  },
+                  "qos": {
+                    "type": "object",
+                    "properties": {
+                      "trust": {
+                        "type": "string",
+                        "enum": [
+                          "dscp",
+                          "cos",
+                          "disabled"
+                        ],
+                        "title": "Trust"
+                      },
+                      "dscp": {
+                        "type": "integer",
+                        "description": "DSCP value",
+                        "title": "DSCP"
+                      },
+                      "cos": {
+                        "type": "integer",
+                        "description": "COS value",
+                        "title": "COS"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "QOS"
+                  },
+                  "spanning_tree_bpdufilter": {
+                    "type": "string",
+                    "enum": [
+                      "enabled",
+                      "disabled",
+                      "True",
+                      "False",
+                      "true",
+                      "false"
+                    ],
+                    "title": "Spanning Tree Bpdufilter"
+                  },
+                  "spanning_tree_bpduguard": {
+                    "type": "string",
+                    "enum": [
+                      "enabled",
+                      "disabled",
+                      "True",
+                      "False",
+                      "true",
+                      "false"
+                    ],
+                    "title": "Spanning Tree Bpduguard"
+                  },
+                  "spanning_tree_guard": {
+                    "type": "string",
+                    "enum": [
+                      "loop",
+                      "root",
+                      "disabled"
+                    ],
+                    "title": "Spanning Tree Guard"
+                  },
+                  "spanning_tree_portfast": {
+                    "type": "string",
+                    "enum": [
+                      "edge",
+                      "network"
+                    ],
+                    "title": "Spanning Tree Portfast"
+                  },
+                  "vmtracer": {
+                    "type": "boolean",
+                    "title": "VMTracer"
+                  },
+                  "priority_flow_control": {
+                    "type": "object",
+                    "properties": {
+                      "enabled": {
+                        "type": "boolean",
+                        "title": "Enabled"
+                      },
+                      "priorities": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "priority": {
+                              "type": "integer",
+                              "minimum": 0,
+                              "maximum": 7,
+                              "title": "Priority"
+                            },
+                            "no_drop": {
+                              "type": "boolean",
+                              "title": "No Drop"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "required": [
+                            "priority"
+                          ]
+                        },
+                        "title": "Priorities"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Priority Flow Control"
+                  },
+                  "bfd": {
+                    "type": "object",
+                    "properties": {
+                      "echo": {
+                        "type": "boolean",
+                        "title": "Echo"
+                      },
+                      "interval": {
+                        "type": "integer",
+                        "description": "Interval in milliseconds",
+                        "title": "Interval"
+                      },
+                      "min_rx": {
+                        "type": "integer",
+                        "description": "Rate in milliseconds",
+                        "title": "Min RX"
+                      },
+                      "multiplier": {
+                        "type": "integer",
+                        "minimum": 3,
+                        "maximum": 50,
+                        "title": "Multiplier"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "BFD"
+                  },
+                  "service_policy": {
+                    "type": "object",
+                    "properties": {
+                      "pbr": {
+                        "type": "object",
+                        "properties": {
+                          "input": {
+                            "type": "string",
+                            "description": "Policy Based Routing Policy-map name",
+                            "title": "Input"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "PBR"
+                      },
+                      "qos": {
+                        "type": "object",
+                        "properties": {
+                          "input": {
+                            "type": "string",
+                            "description": "Quality of Service Policy-map name",
+                            "title": "Input"
+                          }
+                        },
+                        "required": [
+                          "input"
+                        ],
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "QOS"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Service Policy"
+                  },
+                  "mpls": {
+                    "type": "object",
+                    "properties": {
+                      "ip": {
+                        "type": "boolean",
+                        "title": "IP"
+                      },
+                      "ldp": {
+                        "type": "object",
+                        "properties": {
+                          "interface": {
+                            "type": "boolean",
+                            "title": "Interface"
+                          },
+                          "igp_sync": {
+                            "type": "boolean",
+                            "title": "IGP Sync"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "LDP"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "MPLS"
+                  },
+                  "lacp_timer": {
+                    "type": "object",
+                    "properties": {
+                      "mode": {
+                        "type": "string",
+                        "enum": [
+                          "fast",
+                          "normal"
+                        ],
+                        "title": "Mode"
+                      },
+                      "multiplier": {
+                        "type": "integer",
+                        "minimum": 3,
+                        "maximum": 3000,
+                        "title": "Multiplier"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "LACP Timer"
+                  },
+                  "lacp_port_priority": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 65535,
+                    "title": "LACP Port Priority"
+                  },
+                  "transceiver": {
+                    "type": "object",
+                    "properties": {
+                      "media": {
+                        "type": "object",
+                        "properties": {
+                          "override": {
+                            "type": "string",
+                            "description": "Transceiver type",
+                            "title": "Override"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Media"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Transceiver"
+                  },
+                  "ip_proxy_arp": {
+                    "type": "boolean",
+                    "title": "IP Proxy ARP"
+                  },
+                  "traffic_policy": {
+                    "type": "object",
+                    "properties": {
+                      "input": {
+                        "type": "string",
+                        "description": "Ingress traffic policy",
+                        "title": "Input"
+                      },
+                      "output": {
+                        "type": "string",
+                        "description": "Egress traffic policy",
+                        "title": "Output"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Traffic Policy"
+                  },
+                  "bgp": {
+                    "type": "object",
+                    "properties": {
+                      "session_tracker": {
+                        "type": "string",
+                        "description": "Name of session tracker",
+                        "title": "Session Tracker"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "BGP"
+                  },
+                  "peer": {
+                    "type": "string",
+                    "description": "Key only used for documentation or validation purposes",
+                    "title": "Peer"
+                  },
+                  "peer_interface": {
+                    "type": "string",
+                    "description": "Key only used for documentation or validation purposes",
+                    "title": "Peer Interface"
+                  },
+                  "peer_type": {
+                    "type": "string",
+                    "description": "Key only used for documentation or validation purposes",
+                    "title": "Peer Type"
+                  },
+                  "sflow": {
+                    "type": "object",
+                    "properties": {
+                      "enable": {
+                        "type": "boolean",
+                        "title": "Enable"
+                      },
+                      "egress": {
+                        "type": "object",
+                        "properties": {
+                          "enable": {
+                            "type": "boolean",
+                            "title": "Enable"
+                          },
+                          "unmodified_enable": {
+                            "type": "boolean",
+                            "title": "Unmodified Enable"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Egress"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Sflow"
+                  },
+                  "port_profile": {
+                    "type": "string",
+                    "description": "Key only used for documentation or validation purposes",
+                    "title": "Port Profile"
+                  },
+                  "uc_tx_queues": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "description": "TX-Queue ID",
+                          "title": "ID"
+                        },
+                        "random_detect": {
+                          "type": "object",
+                          "properties": {
+                            "ecn": {
+                              "description": "Explicit Congestion Notification",
+                              "type": "object",
+                              "properties": {
+                                "count": {
+                                  "type": "boolean",
+                                  "description": "Enable counter for random-detect ECNs",
+                                  "title": "Count"
+                                },
+                                "threshold": {
+                                  "type": "object",
+                                  "properties": {
+                                    "units": {
+                                      "type": "string",
+                                      "enum": [
+                                        "segments",
+                                        "bytes",
+                                        "kbytes",
+                                        "mbytes",
+                                        "milliseconds"
+                                      ],
+                                      "description": "Indicate the units to be used for the threshold values",
+                                      "title": "Units"
+                                    },
+                                    "min": {
+                                      "type": "integer",
+                                      "minimum": 1,
+                                      "maximum": 256000000,
+                                      "description": "Set the random-detect ECN minimum-threshold",
+                                      "title": "Min"
+                                    },
+                                    "max": {
+                                      "type": "integer",
+                                      "minimum": 1,
+                                      "maximum": 256000000,
+                                      "description": "Set the random-detect ECN maximum-threshold",
+                                      "title": "Max"
+                                    },
+                                    "max_probability": {
+                                      "type": "integer",
+                                      "minimum": 1,
+                                      "maximum": 100,
+                                      "description": "Set the random-detect ECN max-mark-probability",
+                                      "title": "Max Probability"
+                                    },
+                                    "weight": {
+                                      "type": "integer",
+                                      "minimum": 0,
+                                      "maximum": 15,
+                                      "description": "Set the random-detect ECN weight",
+                                      "title": "Weight"
+                                    }
+                                  },
+                                  "required": [
+                                    "units",
+                                    "min",
+                                    "max"
+                                  ],
+                                  "additionalProperties": false,
+                                  "patternProperties": {
+                                    "^_.+$": {}
+                                  },
+                                  "title": "Threshold"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Ecn"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Random Detect"
+                        }
+                      },
+                      "required": [
+                        "id"
+                      ],
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      }
+                    },
+                    "title": "Uc TX Queues"
+                  },
+                  "tx_queues": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "description": "TX-Queue ID",
+                          "title": "ID"
+                        },
+                        "random_detect": {
+                          "type": "object",
+                          "properties": {
+                            "ecn": {
+                              "description": "Explicit Congestion Notification",
+                              "type": "object",
+                              "properties": {
+                                "count": {
+                                  "type": "boolean",
+                                  "description": "Enable counter for random-detect ECNs",
+                                  "title": "Count"
+                                },
+                                "threshold": {
+                                  "type": "object",
+                                  "properties": {
+                                    "units": {
+                                      "type": "string",
+                                      "enum": [
+                                        "segments",
+                                        "bytes",
+                                        "kbytes",
+                                        "mbytes",
+                                        "milliseconds"
+                                      ],
+                                      "description": "Indicate the units to be used for the threshold values",
+                                      "title": "Units"
+                                    },
+                                    "min": {
+                                      "type": "integer",
+                                      "minimum": 1,
+                                      "maximum": 256000000,
+                                      "description": "Set the random-detect ECN minimum-threshold",
+                                      "title": "Min"
+                                    },
+                                    "max": {
+                                      "type": "integer",
+                                      "minimum": 1,
+                                      "maximum": 256000000,
+                                      "description": "Set the random-detect ECN maximum-threshold",
+                                      "title": "Max"
+                                    },
+                                    "max_probability": {
+                                      "type": "integer",
+                                      "minimum": 1,
+                                      "maximum": 100,
+                                      "description": "Set the random-detect ECN max-mark-probability",
+                                      "title": "Max Probability"
+                                    },
+                                    "weight": {
+                                      "type": "integer",
+                                      "minimum": 0,
+                                      "maximum": 15,
+                                      "description": "Set the random-detect ECN weight",
+                                      "title": "Weight"
+                                    }
+                                  },
+                                  "required": [
+                                    "units",
+                                    "max",
+                                    "max_probability"
+                                  ],
+                                  "additionalProperties": false,
+                                  "patternProperties": {
+                                    "^_.+$": {}
+                                  },
+                                  "title": "Threshold"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Ecn"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Random Detect"
+                        }
+                      },
+                      "required": [
+                        "id"
+                      ],
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      }
+                    },
+                    "title": "TX Queues"
+                  },
+                  "vrrp_ids": {
+                    "type": "array",
+                    "description": "VRRP model.",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "description": "VRID",
+                          "title": "ID"
+                        },
+                        "priority_level": {
+                          "type": "integer",
+                          "description": "Instance priority",
+                          "minimum": 1,
+                          "maximum": 254,
+                          "title": "Priority Level"
+                        },
+                        "advertisement": {
+                          "type": "object",
+                          "properties": {
+                            "interval": {
+                              "type": "integer",
+                              "description": "Interval in seconds",
+                              "minimum": 1,
+                              "maximum": 255,
+                              "title": "Interval"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Advertisement"
+                        },
+                        "preempt": {
+                          "type": "object",
+                          "properties": {
+                            "enabled": {
+                              "type": "boolean",
+                              "title": "Enabled"
+                            },
+                            "delay": {
+                              "type": "object",
+                              "properties": {
+                                "minimum": {
+                                  "type": "integer",
+                                  "description": "Minimum preempt delay in seconds",
+                                  "minimum": 0,
+                                  "maximum": 3600,
+                                  "title": "Minimum"
+                                },
+                                "reload": {
+                                  "type": "integer",
+                                  "description": "Reload preempt delay in seconds",
+                                  "minimum": 0,
+                                  "maximum": 3600,
+                                  "title": "Reload"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Delay"
+                            }
+                          },
+                          "required": [
+                            "enabled"
+                          ],
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Preempt"
+                        },
+                        "timers": {
+                          "type": "object",
+                          "properties": {
+                            "delay": {
+                              "type": "object",
+                              "properties": {
+                                "reload": {
+                                  "type": "integer",
+                                  "description": "Delay after reload in seconds.",
+                                  "minimum": 0,
+                                  "maximum": 3600,
+                                  "title": "Reload"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Delay"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Timers"
+                        },
+                        "tracked_object": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "string",
+                                "description": "Tracked object name",
+                                "title": "Name"
+                              },
+                              "decrement": {
+                                "type": "integer",
+                                "minimum": 1,
+                                "maximum": 254,
+                                "description": "Decrement VRRP priority by 1-254",
+                                "title": "Decrement"
+                              },
+                              "shutdown": {
+                                "type": "boolean",
+                                "title": "Shutdown"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            },
+                            "required": [
+                              "name"
+                            ]
+                          },
+                          "title": "Tracked Object"
+                        },
+                        "ipv4": {
+                          "type": "object",
+                          "properties": {
+                            "address": {
+                              "type": "string",
+                              "description": "Virtual IPv4 address",
+                              "title": "Address"
+                            },
+                            "version": {
+                              "type": "integer",
+                              "enum": [
+                                2,
+                                3
+                              ],
+                              "title": "Version"
+                            }
+                          },
+                          "required": [
+                            "address"
+                          ],
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "IPv4"
+                        },
+                        "ipv6": {
+                          "type": "object",
+                          "properties": {
+                            "address": {
+                              "type": "string",
+                              "description": "Virtual IPv6 address",
+                              "title": "Address"
+                            }
+                          },
+                          "required": [
+                            "address"
+                          ],
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "IPv6"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      },
+                      "required": [
+                        "id"
+                      ]
+                    },
+                    "title": "VRRP IDs"
+                  },
+                  "eos_cli": {
+                    "type": "string",
+                    "description": "Multiline EOS CLI rendered directly on the ethernet interface in the final EOS configuration",
+                    "title": "EOS CLI"
+                  }
+                },
+                "additionalProperties": false,
+                "patternProperties": {
+                  "^_.+$": {}
+                },
+                "title": "Structured Config"
+              }
+            },
+            "additionalProperties": false,
+            "patternProperties": {
+              "^_.+$": {}
+            }
+          },
+          "title": "L3 Interfaces"
         }
       },
       "additionalProperties": false,
@@ -3751,7 +14325,7 @@
             "properties": {
               "name": {
                 "type": "string",
-                "description": "P2P profile name. Any variable supported under p2p_links can be inherited from a profile.",
+                "description": "P2P profile name. Any variable supported under `p2p_links` can be inherited from a profile.",
                 "title": "Name"
               },
               "id": {
@@ -4213,6 +14787,10580 @@
             }
           },
           "title": "P2P Links"
+        },
+        "l3_interfaces_profiles": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "L3 interface profile name. Any variable supported under `l3_interfaces` can be inherited from a profile.",
+                "title": "Name"
+              },
+              "speed": {
+                "type": "string",
+                "description": "Speed should be set in the format `<interface_speed>` or `forced <interface_speed>` or `auto <interface_speed>`.",
+                "title": "Speed"
+              },
+              "vrf": {
+                "type": "string",
+                "description": "VRF to configure on the interface. (default VRF if not set).",
+                "title": "VRF"
+              },
+              "ip": {
+                "type": "string",
+                "description": "Node IPv4 address/Mask or dhcp.",
+                "title": "IP"
+              },
+              "dhcp_client_accept_default_route": {
+                "type": "boolean",
+                "description": "Supported if `ip` is `dhcp`.\nAccepts default route from DHCP, default False.",
+                "title": "DHCP Client Accept Default Route"
+              },
+              "ipv6_enable": {
+                "type": "boolean",
+                "default": false,
+                "description": "Allows turning on ipv6 for the interface or profile.",
+                "title": "IPv6 Enable"
+              },
+              "interface": {
+                "type": "string",
+                "description": "Must be an Ethernet interface like 'Ethernet2'.",
+                "title": "Interface"
+              },
+              "peer": {
+                "type": "string",
+                "description": "The peer device name. Used for description and documentation",
+                "title": "Peer"
+              },
+              "peer_interface": {
+                "type": "string",
+                "description": "The peer device interface. Used for description and documentation",
+                "title": "Peer Interface"
+              },
+              "peer_ip": {
+                "type": "string",
+                "description": "The peer device IP. Used for description and documentation",
+                "title": "Peer IP"
+              },
+              "bgp_as": {
+                "type": "string",
+                "description": "AS numbers for BGP.\nRequired with bgp peering.\n",
+                "title": "BGP As"
+              },
+              "peer_bgp_as": {
+                "type": "string",
+                "description": "AS numbers for BGP for the remote peer.\nIf not provided, `bgp_as` is used.\n",
+                "title": "Peer BGP As"
+              },
+              "description": {
+                "type": "string",
+                "description": "Interface description.",
+                "title": "Description"
+              },
+              "bfd": {
+                "type": "boolean",
+                "default": false,
+                "description": "Enable BFD (only considered for BGP).",
+                "title": "BFD"
+              },
+              "qos_profile": {
+                "type": "string",
+                "description": "QOS service profile.",
+                "title": "QOS Profile"
+              },
+              "subinterfaces": {
+                "type": "array",
+                "description": "Configure subinterfaces, each in their own VRF under the interface.",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "vrf": {
+                      "type": "string",
+                      "description": "Name of the VRF to configure for this subinterface\nThe VRF MUST exist in `network_services`",
+                      "title": "VRF"
+                    },
+                    "subinterface_id": {
+                      "type": "integer",
+                      "description": "Optional ID to overwrite the default one used from the VRF.\n`vrf_id` is used otherwise.",
+                      "title": "Subinterface ID"
+                    },
+                    "description": {
+                      "type": "string",
+                      "description": "Optional description for the subinterface.",
+                      "title": "Description"
+                    },
+                    "structured_config": {
+                      "type": "object",
+                      "description": "Custom structured config for the subinterface.\nNote! The content of this dictionary is _not_ validated by the schema, since it can be either ethernet_interfaces or port_channel_interfaces.",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "title": "Name"
+                        },
+                        "description": {
+                          "type": "string",
+                          "title": "Description"
+                        },
+                        "shutdown": {
+                          "type": "boolean",
+                          "title": "Shutdown"
+                        },
+                        "load_interval": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "maximum": 600,
+                          "description": "Interval in seconds for updating interface counters\"",
+                          "title": "Load Interval"
+                        },
+                        "speed": {
+                          "type": "string",
+                          "description": "Speed should be set in the format `<interface_speed>` or `forced <interface_speed>` or `auto <interface_speed>`.",
+                          "title": "Speed"
+                        },
+                        "mtu": {
+                          "type": "integer",
+                          "minimum": 68,
+                          "maximum": 65535,
+                          "title": "MTU"
+                        },
+                        "l2_mtu": {
+                          "type": "integer",
+                          "minimum": 68,
+                          "maximum": 65535,
+                          "description": "\"l2_mtu\" should only be defined for platforms supporting the \"l2 mtu\" CLI\n",
+                          "title": "L2 MTU"
+                        },
+                        "l2_mru": {
+                          "type": "integer",
+                          "minimum": 68,
+                          "maximum": 65535,
+                          "description": "\"l2_mru\" should only be defined for platforms supporting the \"l2 mru\" CLI\n",
+                          "title": "L2 MRU"
+                        },
+                        "vlans": {
+                          "type": "string",
+                          "description": "List of switchport vlans as string\nFor a trunk port this would be a range like \"1-200,300\"\nFor an access port this would be a single vlan \"123\"\n",
+                          "title": "VLANs"
+                        },
+                        "native_vlan": {
+                          "type": "integer",
+                          "title": "Native VLAN"
+                        },
+                        "native_vlan_tag": {
+                          "type": "boolean",
+                          "description": "If setting both native_vlan and native_vlan_tag, native_vlan_tag takes precedence",
+                          "title": "Native VLAN Tag"
+                        },
+                        "mode": {
+                          "type": "string",
+                          "enum": [
+                            "access",
+                            "dot1q-tunnel",
+                            "trunk",
+                            "trunk phone"
+                          ],
+                          "title": "Mode"
+                        },
+                        "phone": {
+                          "type": "object",
+                          "properties": {
+                            "trunk": {
+                              "type": "string",
+                              "enum": [
+                                "tagged",
+                                "tagged phone",
+                                "untagged",
+                                "untagged phone"
+                              ],
+                              "title": "Trunk"
+                            },
+                            "vlan": {
+                              "type": "integer",
+                              "minimum": 1,
+                              "maximum": 4094,
+                              "title": "VLAN"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Phone"
+                        },
+                        "l2_protocol": {
+                          "type": "object",
+                          "properties": {
+                            "encapsulation_dot1q_vlan": {
+                              "type": "integer",
+                              "description": "Vlan tag to configure on sub-interface",
+                              "title": "Encapsulation Dot1Q VLAN"
+                            },
+                            "forwarding_profile": {
+                              "type": "string",
+                              "description": "L2 protocol forwarding profile",
+                              "title": "Forwarding Profile"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "L2 Protocol"
+                        },
+                        "trunk_groups": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "title": "Trunk Groups"
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "routed",
+                            "switched",
+                            "l3dot1q",
+                            "l2dot1q",
+                            "port-channel-member"
+                          ],
+                          "description": "l3dot1q and l2dot1q are used for sub-interfaces. The parent interface should be defined as routed.\nInterface will not be listed in device documentation, unless \"type\" is set.\n",
+                          "title": "Type"
+                        },
+                        "snmp_trap_link_change": {
+                          "type": "boolean",
+                          "title": "Snmp Trap Link Change"
+                        },
+                        "address_locking": {
+                          "type": "object",
+                          "properties": {
+                            "ipv4": {
+                              "type": "boolean",
+                              "description": "Enable address locking for IPv4",
+                              "title": "IPv4"
+                            },
+                            "ipv6": {
+                              "type": "boolean",
+                              "description": "Enable address locking for IPv6",
+                              "title": "IPv6"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Address Locking"
+                        },
+                        "flowcontrol": {
+                          "type": "object",
+                          "properties": {
+                            "received": {
+                              "type": "string",
+                              "enum": [
+                                "desired",
+                                "on",
+                                "off"
+                              ],
+                              "title": "Received"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Flowcontrol"
+                        },
+                        "vrf": {
+                          "type": "string",
+                          "description": "VRF name",
+                          "title": "VRF"
+                        },
+                        "flow_tracker": {
+                          "type": "object",
+                          "properties": {
+                            "sampled": {
+                              "type": "string",
+                              "description": "Sampled flow tracker name.",
+                              "title": "Sampled"
+                            },
+                            "hardware": {
+                              "type": "string",
+                              "description": "Hardware flow tracker name.",
+                              "title": "Hardware"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Flow Tracker"
+                        },
+                        "error_correction_encoding": {
+                          "type": "object",
+                          "properties": {
+                            "enabled": {
+                              "type": "boolean",
+                              "default": true,
+                              "title": "Enabled"
+                            },
+                            "fire_code": {
+                              "type": "boolean",
+                              "title": "Fire Code"
+                            },
+                            "reed_solomon": {
+                              "type": "boolean",
+                              "title": "Reed Solomon"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Error Correction Encoding"
+                        },
+                        "link_tracking_groups": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "string",
+                                "description": "Group name",
+                                "title": "Name"
+                              },
+                              "direction": {
+                                "type": "string",
+                                "enum": [
+                                  "upstream",
+                                  "downstream"
+                                ],
+                                "title": "Direction"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            },
+                            "required": [
+                              "name"
+                            ]
+                          },
+                          "title": "Link Tracking Groups"
+                        },
+                        "evpn_ethernet_segment": {
+                          "type": "object",
+                          "properties": {
+                            "identifier": {
+                              "type": "string",
+                              "description": "EVPN Ethernet Segment Identifier (Type 1 format)",
+                              "title": "Identifier"
+                            },
+                            "redundancy": {
+                              "type": "string",
+                              "enum": [
+                                "all-active",
+                                "single-active"
+                              ],
+                              "title": "Redundancy"
+                            },
+                            "designated_forwarder_election": {
+                              "type": "object",
+                              "properties": {
+                                "algorithm": {
+                                  "type": "string",
+                                  "enum": [
+                                    "modulus",
+                                    "preference"
+                                  ],
+                                  "title": "Algorithm"
+                                },
+                                "preference_value": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "maximum": 65535,
+                                  "description": "Preference_value is only used when \"algorithm\" is \"preference\"",
+                                  "title": "Preference Value"
+                                },
+                                "dont_preempt": {
+                                  "type": "boolean",
+                                  "description": "Dont_preempt is only used when \"algorithm\" is \"preference\"",
+                                  "title": "Dont Preempt"
+                                },
+                                "hold_time": {
+                                  "type": "integer",
+                                  "title": "Hold Time"
+                                },
+                                "subsequent_hold_time": {
+                                  "type": "integer",
+                                  "title": "Subsequent Hold Time"
+                                },
+                                "candidate_reachability_required": {
+                                  "type": "boolean",
+                                  "title": "Candidate Reachability Required"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Designated Forwarder Election"
+                            },
+                            "mpls": {
+                              "type": "object",
+                              "properties": {
+                                "shared_index": {
+                                  "type": "integer",
+                                  "minimum": 1,
+                                  "maximum": 1024,
+                                  "title": "Shared Index"
+                                },
+                                "tunnel_flood_filter_time": {
+                                  "type": "integer",
+                                  "title": "Tunnel Flood Filter Time"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "MPLS"
+                            },
+                            "route_target": {
+                              "type": "string",
+                              "description": "EVPN Route Target for ESI with format xx:xx:xx:xx:xx:xx",
+                              "title": "Route Target"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "EVPN Ethernet Segment"
+                        },
+                        "encapsulation_dot1q_vlan": {
+                          "type": "integer",
+                          "description": "VLAN tag to configure on sub-interface",
+                          "title": "Encapsulation Dot1Q VLAN"
+                        },
+                        "encapsulation_vlan": {
+                          "type": "object",
+                          "properties": {
+                            "client": {
+                              "type": "object",
+                              "properties": {
+                                "dot1q": {
+                                  "type": "object",
+                                  "properties": {
+                                    "vlan": {
+                                      "type": "integer",
+                                      "description": "Client VLAN ID",
+                                      "title": "VLAN"
+                                    },
+                                    "outer": {
+                                      "type": "integer",
+                                      "description": "Client Outer VLAN ID",
+                                      "title": "Outer"
+                                    },
+                                    "inner": {
+                                      "type": "integer",
+                                      "description": "Client Inner VLAN ID",
+                                      "title": "Inner"
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "patternProperties": {
+                                    "^_.+$": {}
+                                  },
+                                  "title": "Dot1Q"
+                                },
+                                "unmatched": {
+                                  "type": "boolean",
+                                  "title": "Unmatched"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Client"
+                            },
+                            "network": {
+                              "type": "object",
+                              "description": "Network encapsulations are all optional and skipped if using client unmatched",
+                              "properties": {
+                                "dot1q": {
+                                  "type": "object",
+                                  "properties": {
+                                    "vlan": {
+                                      "type": "integer",
+                                      "description": "Network VLAN ID",
+                                      "title": "VLAN"
+                                    },
+                                    "outer": {
+                                      "type": "integer",
+                                      "description": "Network outer VLAN ID",
+                                      "title": "Outer"
+                                    },
+                                    "inner": {
+                                      "type": "integer",
+                                      "description": "Network inner VLAN ID",
+                                      "title": "Inner"
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "patternProperties": {
+                                    "^_.+$": {}
+                                  },
+                                  "title": "Dot1Q"
+                                },
+                                "client": {
+                                  "type": "boolean",
+                                  "title": "Client"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Network"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Encapsulation VLAN"
+                        },
+                        "vlan_id": {
+                          "type": "integer",
+                          "minimum": 1,
+                          "maximum": 4094,
+                          "title": "VLAN ID"
+                        },
+                        "ip_address": {
+                          "type": "string",
+                          "description": "IPv4 address/mask or \"dhcp\"",
+                          "title": "IP Address"
+                        },
+                        "ip_address_secondaries": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "title": "IP Address Secondaries"
+                        },
+                        "dhcp_client_accept_default_route": {
+                          "type": "boolean",
+                          "description": "Install default-route obtained via DHCP",
+                          "title": "DHCP Client Accept Default Route"
+                        },
+                        "dhcp_server_ipv4": {
+                          "type": "boolean",
+                          "description": "Enable IPv4 DHCP server.",
+                          "title": "DHCP Server IPv4"
+                        },
+                        "dhcp_server_ipv6": {
+                          "type": "boolean",
+                          "description": "Enable IPv6 DHCP server.",
+                          "title": "DHCP Server IPv6"
+                        },
+                        "ip_helpers": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "ip_helper": {
+                                "type": "string",
+                                "title": "IP Helper"
+                              },
+                              "source_interface": {
+                                "type": "string",
+                                "description": "Source interface name",
+                                "title": "Source Interface"
+                              },
+                              "vrf": {
+                                "type": "string",
+                                "description": "VRF name",
+                                "title": "VRF"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            },
+                            "required": [
+                              "ip_helper"
+                            ]
+                          },
+                          "title": "IP Helpers"
+                        },
+                        "ip_nat": {
+                          "type": "object",
+                          "properties": {
+                            "service_profile": {
+                              "type": "string",
+                              "description": "NAT interface profile.",
+                              "title": "Service Profile"
+                            },
+                            "destination": {
+                              "type": "object",
+                              "properties": {
+                                "dynamic": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "access_list": {
+                                        "type": "string",
+                                        "title": "Access List"
+                                      },
+                                      "comment": {
+                                        "type": "string",
+                                        "title": "Comment"
+                                      },
+                                      "pool_name": {
+                                        "type": "string",
+                                        "title": "Pool Name"
+                                      },
+                                      "priority": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "maximum": 4294967295,
+                                        "title": "Priority"
+                                      }
+                                    },
+                                    "required": [
+                                      "pool_name",
+                                      "access_list"
+                                    ],
+                                    "additionalProperties": false,
+                                    "patternProperties": {
+                                      "^_.+$": {}
+                                    }
+                                  },
+                                  "title": "Dynamic"
+                                },
+                                "static": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "access_list": {
+                                        "type": "string",
+                                        "description": "'access_list' and 'group' are mutual exclusive",
+                                        "title": "Access List"
+                                      },
+                                      "comment": {
+                                        "type": "string",
+                                        "title": "Comment"
+                                      },
+                                      "direction": {
+                                        "type": "string",
+                                        "enum": [
+                                          "egress",
+                                          "ingress"
+                                        ],
+                                        "description": "Egress or ingress can be the default. This depends on source/destination, EOS version, and hardware platform.\nEOS might remove this keyword in the configuration. So, check the configuration on targeted HW/SW.\n",
+                                        "title": "Direction"
+                                      },
+                                      "group": {
+                                        "type": "integer",
+                                        "minimum": 1,
+                                        "maximum": 65535,
+                                        "description": "'access_list' and 'group' are mutual exclusive",
+                                        "title": "Group"
+                                      },
+                                      "original_ip": {
+                                        "type": "string",
+                                        "description": "IPv4 address",
+                                        "title": "Original IP"
+                                      },
+                                      "original_port": {
+                                        "type": "integer",
+                                        "minimum": 1,
+                                        "maximum": 65535,
+                                        "title": "Original Port"
+                                      },
+                                      "priority": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "maximum": 4294967295,
+                                        "title": "Priority"
+                                      },
+                                      "protocol": {
+                                        "type": "string",
+                                        "enum": [
+                                          "udp",
+                                          "tcp"
+                                        ],
+                                        "title": "Protocol"
+                                      },
+                                      "translated_ip": {
+                                        "type": "string",
+                                        "description": "IPv4 address",
+                                        "title": "Translated IP"
+                                      },
+                                      "translated_port": {
+                                        "type": "integer",
+                                        "minimum": 1,
+                                        "maximum": 65535,
+                                        "description": "requires 'original_port'",
+                                        "title": "Translated Port"
+                                      }
+                                    },
+                                    "required": [
+                                      "translated_ip",
+                                      "original_ip"
+                                    ],
+                                    "additionalProperties": false,
+                                    "patternProperties": {
+                                      "^_.+$": {}
+                                    }
+                                  },
+                                  "title": "Static"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Destination"
+                            },
+                            "source": {
+                              "type": "object",
+                              "properties": {
+                                "dynamic": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "access_list": {
+                                        "type": "string",
+                                        "title": "Access List"
+                                      },
+                                      "comment": {
+                                        "type": "string",
+                                        "title": "Comment"
+                                      },
+                                      "nat_type": {
+                                        "type": "string",
+                                        "enum": [
+                                          "overload",
+                                          "pool",
+                                          "pool-address-only",
+                                          "pool-full-cone"
+                                        ],
+                                        "title": "Nat Type"
+                                      },
+                                      "pool_name": {
+                                        "type": "string",
+                                        "description": "required if 'nat_type' is pool, pool-address-only or pool-full-cone\nignored if 'nat_type' is overload\n",
+                                        "title": "Pool Name"
+                                      },
+                                      "priority": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "maximum": 4294967295,
+                                        "title": "Priority"
+                                      }
+                                    },
+                                    "required": [
+                                      "nat_type",
+                                      "access_list"
+                                    ],
+                                    "additionalProperties": false,
+                                    "patternProperties": {
+                                      "^_.+$": {}
+                                    }
+                                  },
+                                  "title": "Dynamic"
+                                },
+                                "static": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "access_list": {
+                                        "type": "string",
+                                        "description": "'access_list' and 'group' are mutual exclusive",
+                                        "title": "Access List"
+                                      },
+                                      "comment": {
+                                        "type": "string",
+                                        "title": "Comment"
+                                      },
+                                      "direction": {
+                                        "type": "string",
+                                        "enum": [
+                                          "egress",
+                                          "ingress"
+                                        ],
+                                        "description": "Egress or ingress can be the default. This depends on source/destination, EOS version, and hardware platform.\nEOS might remove this keyword in the configuration. So, check the configuration on targeted HW/SW.\n",
+                                        "title": "Direction"
+                                      },
+                                      "group": {
+                                        "type": "integer",
+                                        "minimum": 1,
+                                        "maximum": 65535,
+                                        "description": "'access_list' and 'group' are mutual exclusive",
+                                        "title": "Group"
+                                      },
+                                      "original_ip": {
+                                        "type": "string",
+                                        "description": "IPv4 address",
+                                        "title": "Original IP"
+                                      },
+                                      "original_port": {
+                                        "type": "integer",
+                                        "minimum": 1,
+                                        "maximum": 65535,
+                                        "title": "Original Port"
+                                      },
+                                      "priority": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "maximum": 4294967295,
+                                        "title": "Priority"
+                                      },
+                                      "protocol": {
+                                        "type": "string",
+                                        "enum": [
+                                          "udp",
+                                          "tcp"
+                                        ],
+                                        "title": "Protocol"
+                                      },
+                                      "translated_ip": {
+                                        "type": "string",
+                                        "description": "IPv4 address",
+                                        "title": "Translated IP"
+                                      },
+                                      "translated_port": {
+                                        "type": "integer",
+                                        "minimum": 1,
+                                        "maximum": 65535,
+                                        "description": "requires 'original_port'",
+                                        "title": "Translated Port"
+                                      }
+                                    },
+                                    "required": [
+                                      "translated_ip",
+                                      "original_ip"
+                                    ],
+                                    "additionalProperties": false,
+                                    "patternProperties": {
+                                      "^_.+$": {}
+                                    }
+                                  },
+                                  "title": "Static"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Source"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "IP Nat"
+                        },
+                        "ipv6_enable": {
+                          "type": "boolean",
+                          "title": "IPv6 Enable"
+                        },
+                        "ipv6_address": {
+                          "type": "string",
+                          "title": "IPv6 Address"
+                        },
+                        "ipv6_address_link_local": {
+                          "type": "string",
+                          "description": "Link local IPv6 address/mask",
+                          "title": "IPv6 Address Link Local"
+                        },
+                        "ipv6_nd_ra_disabled": {
+                          "type": "boolean",
+                          "title": "IPv6 ND RA Disabled"
+                        },
+                        "ipv6_nd_managed_config_flag": {
+                          "type": "boolean",
+                          "title": "IPv6 ND Managed Config Flag"
+                        },
+                        "ipv6_nd_prefixes": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "ipv6_prefix": {
+                                "type": "string",
+                                "title": "IPv6 Prefix"
+                              },
+                              "valid_lifetime": {
+                                "type": "string",
+                                "description": "Infinite or lifetime in seconds",
+                                "title": "Valid Lifetime"
+                              },
+                              "preferred_lifetime": {
+                                "type": "string",
+                                "description": "Infinite or lifetime in seconds",
+                                "title": "Preferred Lifetime"
+                              },
+                              "no_autoconfig_flag": {
+                                "type": "boolean",
+                                "title": "No Autoconfig Flag"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            },
+                            "required": [
+                              "ipv6_prefix"
+                            ]
+                          },
+                          "title": "IPv6 ND Prefixes"
+                        },
+                        "ipv6_dhcp_relay_destinations": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "address": {
+                                "type": "string",
+                                "description": "DHCP server's IPv6 address",
+                                "title": "Address"
+                              },
+                              "vrf": {
+                                "type": "string",
+                                "title": "VRF"
+                              },
+                              "local_interface": {
+                                "type": "string",
+                                "description": "Local interface to communicate with DHCP server - mutually exclusive to source_address",
+                                "title": "Local Interface"
+                              },
+                              "source_address": {
+                                "type": "string",
+                                "description": "Source IPv6 address to communicate with DHCP server - mutually exclusive to local_interface",
+                                "title": "Source Address"
+                              },
+                              "link_address": {
+                                "type": "string",
+                                "description": "Override the default link address specified in the relayed DHCP packet",
+                                "title": "Link Address"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            },
+                            "required": [
+                              "address"
+                            ]
+                          },
+                          "title": "IPv6 DHCP Relay Destinations"
+                        },
+                        "access_group_in": {
+                          "type": "string",
+                          "description": "Access list name",
+                          "title": "Access Group In"
+                        },
+                        "access_group_out": {
+                          "type": "string",
+                          "description": "Access list name",
+                          "title": "Access Group Out"
+                        },
+                        "ipv6_access_group_in": {
+                          "type": "string",
+                          "description": "IPv6 access list name",
+                          "title": "IPv6 Access Group In"
+                        },
+                        "ipv6_access_group_out": {
+                          "type": "string",
+                          "description": "IPv6 access list name",
+                          "title": "IPv6 Access Group Out"
+                        },
+                        "mac_access_group_in": {
+                          "type": "string",
+                          "description": "MAC access list name",
+                          "title": "MAC Access Group In"
+                        },
+                        "mac_access_group_out": {
+                          "type": "string",
+                          "description": "MAC access list name",
+                          "title": "MAC Access Group Out"
+                        },
+                        "multicast": {
+                          "type": "object",
+                          "description": "Boundaries can be either 1 ACL or a list of multicast IP address_range(s)/prefix but not combination of both",
+                          "properties": {
+                            "ipv4": {
+                              "type": "object",
+                              "properties": {
+                                "boundaries": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "boundary": {
+                                        "type": "string",
+                                        "description": "ACL name or multicast IP subnet",
+                                        "title": "Boundary"
+                                      },
+                                      "out": {
+                                        "type": "boolean",
+                                        "title": "Out"
+                                      }
+                                    },
+                                    "additionalProperties": false,
+                                    "patternProperties": {
+                                      "^_.+$": {}
+                                    }
+                                  },
+                                  "title": "Boundaries"
+                                },
+                                "static": {
+                                  "type": "boolean",
+                                  "title": "Static"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "IPv4"
+                            },
+                            "ipv6": {
+                              "type": "object",
+                              "properties": {
+                                "boundaries": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "boundary": {
+                                        "type": "string",
+                                        "description": "ACL name or multicast IP subnet",
+                                        "title": "Boundary"
+                                      }
+                                    },
+                                    "additionalProperties": false,
+                                    "patternProperties": {
+                                      "^_.+$": {}
+                                    }
+                                  },
+                                  "title": "Boundaries"
+                                },
+                                "static": {
+                                  "type": "boolean",
+                                  "title": "Static"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "IPv6"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Multicast"
+                        },
+                        "ospf_network_point_to_point": {
+                          "type": "boolean",
+                          "title": "OSPF Network Point To Point"
+                        },
+                        "ospf_area": {
+                          "type": "string",
+                          "title": "OSPF Area"
+                        },
+                        "ospf_cost": {
+                          "type": "integer",
+                          "title": "OSPF Cost"
+                        },
+                        "ospf_authentication": {
+                          "type": "string",
+                          "enum": [
+                            "none",
+                            "simple",
+                            "message-digest"
+                          ],
+                          "title": "OSPF Authentication"
+                        },
+                        "ospf_authentication_key": {
+                          "type": "string",
+                          "description": "Encrypted password - only type 7 supported",
+                          "title": "OSPF Authentication Key"
+                        },
+                        "ospf_message_digest_keys": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "integer",
+                                "title": "ID"
+                              },
+                              "hash_algorithm": {
+                                "type": "string",
+                                "enum": [
+                                  "md5",
+                                  "sha1",
+                                  "sha256",
+                                  "sha384",
+                                  "sha512"
+                                ],
+                                "title": "Hash Algorithm"
+                              },
+                              "key": {
+                                "type": "string",
+                                "description": "Encrypted password - only type 7 supported",
+                                "title": "Key"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            },
+                            "required": [
+                              "id"
+                            ]
+                          },
+                          "title": "OSPF Message Digest Keys"
+                        },
+                        "pim": {
+                          "type": "object",
+                          "properties": {
+                            "ipv4": {
+                              "type": "object",
+                              "properties": {
+                                "dr_priority": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "maximum": 429467295,
+                                  "title": "DR Priority"
+                                },
+                                "sparse_mode": {
+                                  "type": "boolean",
+                                  "title": "Sparse Mode"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "IPv4"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "PIM"
+                        },
+                        "mac_security": {
+                          "type": "object",
+                          "properties": {
+                            "profile": {
+                              "type": "string",
+                              "title": "Profile"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "MAC Security"
+                        },
+                        "channel_group": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "integer",
+                              "title": "ID"
+                            },
+                            "mode": {
+                              "type": "string",
+                              "enum": [
+                                "on",
+                                "active",
+                                "passive"
+                              ],
+                              "title": "Mode"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Channel Group"
+                        },
+                        "isis_enable": {
+                          "type": "string",
+                          "description": "ISIS instance",
+                          "title": "ISIS Enable"
+                        },
+                        "isis_passive": {
+                          "type": "boolean",
+                          "title": "ISIS Passive"
+                        },
+                        "isis_metric": {
+                          "type": "integer",
+                          "title": "ISIS Metric"
+                        },
+                        "isis_network_point_to_point": {
+                          "type": "boolean",
+                          "title": "ISIS Network Point To Point"
+                        },
+                        "isis_circuit_type": {
+                          "type": "string",
+                          "enum": [
+                            "level-1-2",
+                            "level-1",
+                            "level-2"
+                          ],
+                          "title": "ISIS Circuit Type"
+                        },
+                        "isis_hello_padding": {
+                          "type": "boolean",
+                          "title": "ISIS Hello Padding"
+                        },
+                        "isis_authentication_mode": {
+                          "type": "string",
+                          "enum": [
+                            "text",
+                            "md5"
+                          ],
+                          "title": "ISIS Authentication Mode"
+                        },
+                        "isis_authentication_key": {
+                          "type": "string",
+                          "description": "Type-7 encrypted password",
+                          "title": "ISIS Authentication Key"
+                        },
+                        "poe": {
+                          "type": "object",
+                          "properties": {
+                            "disabled": {
+                              "type": "boolean",
+                              "description": "Disable PoE on a POE capable port. PoE is enabled on all ports that support it by default in EOS.",
+                              "default": false,
+                              "title": "Disabled"
+                            },
+                            "priority": {
+                              "type": "string",
+                              "enum": [
+                                "critical",
+                                "high",
+                                "medium",
+                                "low"
+                              ],
+                              "description": "Prioritize a port's power in the event that one of the switch's power supplies loses power",
+                              "title": "Priority"
+                            },
+                            "reboot": {
+                              "description": "Set the PoE power behavior for a PoE port when the system is rebooted",
+                              "type": "object",
+                              "properties": {
+                                "action": {
+                                  "type": "string",
+                                  "enum": [
+                                    "maintain",
+                                    "power-off"
+                                  ],
+                                  "description": "PoE action for interface",
+                                  "title": "Action"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Reboot"
+                            },
+                            "link_down": {
+                              "description": "Set the PoE power behavior for a PoE port when the port goes down",
+                              "type": "object",
+                              "properties": {
+                                "action": {
+                                  "type": "string",
+                                  "enum": [
+                                    "maintain",
+                                    "power-off"
+                                  ],
+                                  "description": "PoE action for interface",
+                                  "title": "Action"
+                                },
+                                "power_off_delay": {
+                                  "type": "integer",
+                                  "minimum": 1,
+                                  "maximum": 86400,
+                                  "description": "Number of seconds to delay shutting the power off after a link down event occurs. Default value is 5 seconds in EOS.",
+                                  "title": "Power Off Delay"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Link Down"
+                            },
+                            "shutdown": {
+                              "description": "Set the PoE power behavior for a PoE port when the port is admin down",
+                              "type": "object",
+                              "properties": {
+                                "action": {
+                                  "type": "string",
+                                  "enum": [
+                                    "maintain",
+                                    "power-off"
+                                  ],
+                                  "description": "PoE action for interface",
+                                  "title": "Action"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Shutdown"
+                            },
+                            "limit": {
+                              "type": "object",
+                              "description": "Override the hardware-negotiated power limit using either wattage or a power class. Note that if using a power class, AVD will automatically convert the class value to the wattage value corresponding to that power class.",
+                              "properties": {
+                                "class": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "maximum": 8,
+                                  "title": "Class"
+                                },
+                                "watts": {
+                                  "type": "string",
+                                  "title": "Watts"
+                                },
+                                "fixed": {
+                                  "type": "boolean",
+                                  "description": "Set to ignore hardware classification",
+                                  "title": "Fixed"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Limit"
+                            },
+                            "negotiation_lldp": {
+                              "type": "boolean",
+                              "description": "Disable to prevent port from negotiating power with powered devices over LLDP. Enabled by default in EOS.",
+                              "title": "Negotiation LLDP"
+                            },
+                            "legacy_detect": {
+                              "type": "boolean",
+                              "description": "Allow a subset of legacy devices to work with the PoE switch. Disabled by default in EOS because it can cause false positive detections.",
+                              "title": "Legacy Detect"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "PoE"
+                        },
+                        "ptp": {
+                          "type": "object",
+                          "properties": {
+                            "enable": {
+                              "type": "boolean",
+                              "title": "Enable"
+                            },
+                            "announce": {
+                              "type": "object",
+                              "properties": {
+                                "interval": {
+                                  "type": "integer",
+                                  "title": "Interval"
+                                },
+                                "timeout": {
+                                  "type": "integer",
+                                  "title": "Timeout"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Announce"
+                            },
+                            "delay_req": {
+                              "type": "integer",
+                              "title": "Delay Req"
+                            },
+                            "delay_mechanism": {
+                              "type": "string",
+                              "enum": [
+                                "e2e",
+                                "p2p"
+                              ],
+                              "title": "Delay Mechanism"
+                            },
+                            "sync_message": {
+                              "type": "object",
+                              "properties": {
+                                "interval": {
+                                  "type": "integer",
+                                  "title": "Interval"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Sync Message"
+                            },
+                            "role": {
+                              "type": "string",
+                              "enum": [
+                                "master",
+                                "dynamic"
+                              ],
+                              "title": "Role"
+                            },
+                            "vlan": {
+                              "type": "string",
+                              "description": "VLAN can be 'all' or list of vlans as string",
+                              "title": "VLAN"
+                            },
+                            "transport": {
+                              "type": "string",
+                              "enum": [
+                                "ipv4",
+                                "ipv6",
+                                "layer2"
+                              ],
+                              "title": "Transport"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "PTP"
+                        },
+                        "profile": {
+                          "type": "string",
+                          "description": "Interface profile",
+                          "title": "Profile"
+                        },
+                        "storm_control": {
+                          "type": "object",
+                          "properties": {
+                            "all": {
+                              "type": "object",
+                              "properties": {
+                                "level": {
+                                  "type": "string",
+                                  "description": "Configure maximum storm-control level",
+                                  "title": "Level"
+                                },
+                                "unit": {
+                                  "type": "string",
+                                  "default": "percent",
+                                  "enum": [
+                                    "percent",
+                                    "pps"
+                                  ],
+                                  "description": "Optional field and is hardware dependent",
+                                  "title": "Unit"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "All"
+                            },
+                            "broadcast": {
+                              "type": "object",
+                              "properties": {
+                                "level": {
+                                  "type": "string",
+                                  "description": "Configure maximum storm-control level",
+                                  "title": "Level"
+                                },
+                                "unit": {
+                                  "type": "string",
+                                  "default": "percent",
+                                  "enum": [
+                                    "percent",
+                                    "pps"
+                                  ],
+                                  "description": "Optional field and is hardware dependent",
+                                  "title": "Unit"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Broadcast"
+                            },
+                            "multicast": {
+                              "type": "object",
+                              "properties": {
+                                "level": {
+                                  "type": "string",
+                                  "description": "Configure maximum storm-control level",
+                                  "title": "Level"
+                                },
+                                "unit": {
+                                  "type": "string",
+                                  "default": "percent",
+                                  "enum": [
+                                    "percent",
+                                    "pps"
+                                  ],
+                                  "description": "Optional field and is hardware dependent",
+                                  "title": "Unit"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Multicast"
+                            },
+                            "unknown_unicast": {
+                              "type": "object",
+                              "properties": {
+                                "level": {
+                                  "type": "string",
+                                  "description": "Configure maximum storm-control level",
+                                  "title": "Level"
+                                },
+                                "unit": {
+                                  "type": "string",
+                                  "default": "percent",
+                                  "enum": [
+                                    "percent",
+                                    "pps"
+                                  ],
+                                  "description": "Optional field and is hardware dependent",
+                                  "title": "Unit"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Unknown Unicast"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Storm Control"
+                        },
+                        "logging": {
+                          "type": "object",
+                          "properties": {
+                            "event": {
+                              "type": "object",
+                              "properties": {
+                                "link_status": {
+                                  "type": "boolean",
+                                  "title": "Link Status"
+                                },
+                                "congestion_drops": {
+                                  "type": "boolean",
+                                  "title": "Congestion Drops"
+                                },
+                                "spanning_tree": {
+                                  "type": "boolean",
+                                  "title": "Spanning Tree"
+                                },
+                                "storm_control_discards": {
+                                  "type": "boolean",
+                                  "title": "Storm Control Discards"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Event"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Logging"
+                        },
+                        "lldp": {
+                          "type": "object",
+                          "properties": {
+                            "transmit": {
+                              "type": "boolean",
+                              "title": "Transmit"
+                            },
+                            "receive": {
+                              "type": "boolean",
+                              "title": "Receive"
+                            },
+                            "ztp_vlan": {
+                              "type": "integer",
+                              "description": "ZTP vlan number",
+                              "title": "ZTP VLAN"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "LLDP"
+                        },
+                        "trunk_private_vlan_secondary": {
+                          "type": "boolean",
+                          "title": "Trunk Private VLAN Secondary"
+                        },
+                        "pvlan_mapping": {
+                          "type": "string",
+                          "description": "List of vlans as string",
+                          "title": "PVLAN Mapping"
+                        },
+                        "vlan_translations": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "from": {
+                                "type": "string",
+                                "description": "List of vlans as string (only one vlan if direction is \"both\")",
+                                "title": "From"
+                              },
+                              "to": {
+                                "type": "integer",
+                                "description": "VLAN ID",
+                                "title": "To"
+                              },
+                              "direction": {
+                                "type": "string",
+                                "enum": [
+                                  "in",
+                                  "out",
+                                  "both"
+                                ],
+                                "default": "both",
+                                "title": "Direction"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            }
+                          },
+                          "title": "VLAN Translations"
+                        },
+                        "dot1x": {
+                          "type": "object",
+                          "properties": {
+                            "port_control": {
+                              "type": "string",
+                              "enum": [
+                                "auto",
+                                "force-authorized",
+                                "force-unauthorized"
+                              ],
+                              "title": "Port Control"
+                            },
+                            "port_control_force_authorized_phone": {
+                              "type": "boolean",
+                              "title": "Port Control Force Authorized Phone"
+                            },
+                            "reauthentication": {
+                              "type": "boolean",
+                              "title": "Reauthentication"
+                            },
+                            "pae": {
+                              "type": "object",
+                              "properties": {
+                                "mode": {
+                                  "type": "string",
+                                  "enum": [
+                                    "authenticator"
+                                  ],
+                                  "title": "Mode"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "PAE"
+                            },
+                            "authentication_failure": {
+                              "type": "object",
+                              "properties": {
+                                "action": {
+                                  "type": "string",
+                                  "enum": [
+                                    "allow",
+                                    "drop"
+                                  ],
+                                  "title": "Action"
+                                },
+                                "allow_vlan": {
+                                  "type": "integer",
+                                  "minimum": 1,
+                                  "maximum": 4094,
+                                  "title": "Allow VLAN"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Authentication Failure"
+                            },
+                            "host_mode": {
+                              "type": "object",
+                              "properties": {
+                                "mode": {
+                                  "type": "string",
+                                  "enum": [
+                                    "multi-host",
+                                    "single-host"
+                                  ],
+                                  "title": "Mode"
+                                },
+                                "multi_host_authenticated": {
+                                  "type": "boolean",
+                                  "title": "Multi Host Authenticated"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Host Mode"
+                            },
+                            "mac_based_authentication": {
+                              "type": "object",
+                              "properties": {
+                                "enabled": {
+                                  "type": "boolean",
+                                  "title": "Enabled"
+                                },
+                                "always": {
+                                  "type": "boolean",
+                                  "title": "Always"
+                                },
+                                "host_mode_common": {
+                                  "type": "boolean",
+                                  "title": "Host Mode Common"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "MAC Based Authentication"
+                            },
+                            "timeout": {
+                              "type": "object",
+                              "properties": {
+                                "idle_host": {
+                                  "type": "integer",
+                                  "minimum": 10,
+                                  "maximum": 65535,
+                                  "title": "Idle Host"
+                                },
+                                "quiet_period": {
+                                  "type": "integer",
+                                  "minimum": 1,
+                                  "maximum": 65535,
+                                  "title": "Quiet Period"
+                                },
+                                "reauth_period": {
+                                  "type": "string",
+                                  "description": "Value can be 60-4294967295 or 'server'",
+                                  "title": "Reauth Period"
+                                },
+                                "reauth_timeout_ignore": {
+                                  "type": "boolean",
+                                  "title": "Reauth Timeout Ignore"
+                                },
+                                "tx_period": {
+                                  "type": "integer",
+                                  "minimum": 1,
+                                  "maximum": 65535,
+                                  "title": "TX Period"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Timeout"
+                            },
+                            "reauthorization_request_limit": {
+                              "type": "integer",
+                              "minimum": 1,
+                              "maximum": 10,
+                              "title": "Reauthorization Request Limit"
+                            },
+                            "unauthorized": {
+                              "type": "object",
+                              "properties": {
+                                "access_vlan_membership_egress": {
+                                  "type": "boolean",
+                                  "title": "Access VLAN Membership Egress"
+                                },
+                                "native_vlan_membership_egress": {
+                                  "type": "boolean",
+                                  "title": "Native VLAN Membership Egress"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Unauthorized"
+                            },
+                            "eapol": {
+                              "type": "object",
+                              "properties": {
+                                "disabled": {
+                                  "type": "boolean",
+                                  "title": "Disabled"
+                                },
+                                "authentication_failure_fallback_mba": {
+                                  "type": "object",
+                                  "properties": {
+                                    "enabled": {
+                                      "type": "boolean",
+                                      "title": "Enabled"
+                                    },
+                                    "timeout": {
+                                      "type": "integer",
+                                      "minimum": 0,
+                                      "maximum": 65535,
+                                      "title": "Timeout"
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "patternProperties": {
+                                    "^_.+$": {}
+                                  },
+                                  "title": "Authentication Failure Fallback Mba"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Eapol"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "dot1x"
+                        },
+                        "service_profile": {
+                          "type": "string",
+                          "description": "QOS profile",
+                          "title": "Service Profile"
+                        },
+                        "shape": {
+                          "type": "object",
+                          "properties": {
+                            "rate": {
+                              "type": "string",
+                              "description": "Rate in kbps, pps or percent\nSupported options are platform dependent\nExamples:\n- \"5000 kbps\"\n- \"1000 pps\"\n- \"20 percent\"\n",
+                              "title": "Rate"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Shape"
+                        },
+                        "qos": {
+                          "type": "object",
+                          "properties": {
+                            "trust": {
+                              "type": "string",
+                              "enum": [
+                                "dscp",
+                                "cos",
+                                "disabled"
+                              ],
+                              "title": "Trust"
+                            },
+                            "dscp": {
+                              "type": "integer",
+                              "description": "DSCP value",
+                              "title": "DSCP"
+                            },
+                            "cos": {
+                              "type": "integer",
+                              "description": "COS value",
+                              "title": "COS"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "QOS"
+                        },
+                        "spanning_tree_bpdufilter": {
+                          "type": "string",
+                          "enum": [
+                            "enabled",
+                            "disabled",
+                            "True",
+                            "False",
+                            "true",
+                            "false"
+                          ],
+                          "title": "Spanning Tree Bpdufilter"
+                        },
+                        "spanning_tree_bpduguard": {
+                          "type": "string",
+                          "enum": [
+                            "enabled",
+                            "disabled",
+                            "True",
+                            "False",
+                            "true",
+                            "false"
+                          ],
+                          "title": "Spanning Tree Bpduguard"
+                        },
+                        "spanning_tree_guard": {
+                          "type": "string",
+                          "enum": [
+                            "loop",
+                            "root",
+                            "disabled"
+                          ],
+                          "title": "Spanning Tree Guard"
+                        },
+                        "spanning_tree_portfast": {
+                          "type": "string",
+                          "enum": [
+                            "edge",
+                            "network"
+                          ],
+                          "title": "Spanning Tree Portfast"
+                        },
+                        "vmtracer": {
+                          "type": "boolean",
+                          "title": "VMTracer"
+                        },
+                        "priority_flow_control": {
+                          "type": "object",
+                          "properties": {
+                            "enabled": {
+                              "type": "boolean",
+                              "title": "Enabled"
+                            },
+                            "priorities": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "priority": {
+                                    "type": "integer",
+                                    "minimum": 0,
+                                    "maximum": 7,
+                                    "title": "Priority"
+                                  },
+                                  "no_drop": {
+                                    "type": "boolean",
+                                    "title": "No Drop"
+                                  }
+                                },
+                                "additionalProperties": false,
+                                "patternProperties": {
+                                  "^_.+$": {}
+                                },
+                                "required": [
+                                  "priority"
+                                ]
+                              },
+                              "title": "Priorities"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Priority Flow Control"
+                        },
+                        "bfd": {
+                          "type": "object",
+                          "properties": {
+                            "echo": {
+                              "type": "boolean",
+                              "title": "Echo"
+                            },
+                            "interval": {
+                              "type": "integer",
+                              "description": "Interval in milliseconds",
+                              "title": "Interval"
+                            },
+                            "min_rx": {
+                              "type": "integer",
+                              "description": "Rate in milliseconds",
+                              "title": "Min RX"
+                            },
+                            "multiplier": {
+                              "type": "integer",
+                              "minimum": 3,
+                              "maximum": 50,
+                              "title": "Multiplier"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "BFD"
+                        },
+                        "service_policy": {
+                          "type": "object",
+                          "properties": {
+                            "pbr": {
+                              "type": "object",
+                              "properties": {
+                                "input": {
+                                  "type": "string",
+                                  "description": "Policy Based Routing Policy-map name",
+                                  "title": "Input"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "PBR"
+                            },
+                            "qos": {
+                              "type": "object",
+                              "properties": {
+                                "input": {
+                                  "type": "string",
+                                  "description": "Quality of Service Policy-map name",
+                                  "title": "Input"
+                                }
+                              },
+                              "required": [
+                                "input"
+                              ],
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "QOS"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Service Policy"
+                        },
+                        "mpls": {
+                          "type": "object",
+                          "properties": {
+                            "ip": {
+                              "type": "boolean",
+                              "title": "IP"
+                            },
+                            "ldp": {
+                              "type": "object",
+                              "properties": {
+                                "interface": {
+                                  "type": "boolean",
+                                  "title": "Interface"
+                                },
+                                "igp_sync": {
+                                  "type": "boolean",
+                                  "title": "IGP Sync"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "LDP"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "MPLS"
+                        },
+                        "lacp_timer": {
+                          "type": "object",
+                          "properties": {
+                            "mode": {
+                              "type": "string",
+                              "enum": [
+                                "fast",
+                                "normal"
+                              ],
+                              "title": "Mode"
+                            },
+                            "multiplier": {
+                              "type": "integer",
+                              "minimum": 3,
+                              "maximum": 3000,
+                              "title": "Multiplier"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "LACP Timer"
+                        },
+                        "lacp_port_priority": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "maximum": 65535,
+                          "title": "LACP Port Priority"
+                        },
+                        "transceiver": {
+                          "type": "object",
+                          "properties": {
+                            "media": {
+                              "type": "object",
+                              "properties": {
+                                "override": {
+                                  "type": "string",
+                                  "description": "Transceiver type",
+                                  "title": "Override"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Media"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Transceiver"
+                        },
+                        "ip_proxy_arp": {
+                          "type": "boolean",
+                          "title": "IP Proxy ARP"
+                        },
+                        "traffic_policy": {
+                          "type": "object",
+                          "properties": {
+                            "input": {
+                              "type": "string",
+                              "description": "Ingress traffic policy",
+                              "title": "Input"
+                            },
+                            "output": {
+                              "type": "string",
+                              "description": "Egress traffic policy",
+                              "title": "Output"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Traffic Policy"
+                        },
+                        "bgp": {
+                          "type": "object",
+                          "properties": {
+                            "session_tracker": {
+                              "type": "string",
+                              "description": "Name of session tracker",
+                              "title": "Session Tracker"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "BGP"
+                        },
+                        "peer": {
+                          "type": "string",
+                          "description": "Key only used for documentation or validation purposes",
+                          "title": "Peer"
+                        },
+                        "peer_interface": {
+                          "type": "string",
+                          "description": "Key only used for documentation or validation purposes",
+                          "title": "Peer Interface"
+                        },
+                        "peer_type": {
+                          "type": "string",
+                          "description": "Key only used for documentation or validation purposes",
+                          "title": "Peer Type"
+                        },
+                        "sflow": {
+                          "type": "object",
+                          "properties": {
+                            "enable": {
+                              "type": "boolean",
+                              "title": "Enable"
+                            },
+                            "egress": {
+                              "type": "object",
+                              "properties": {
+                                "enable": {
+                                  "type": "boolean",
+                                  "title": "Enable"
+                                },
+                                "unmodified_enable": {
+                                  "type": "boolean",
+                                  "title": "Unmodified Enable"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Egress"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Sflow"
+                        },
+                        "port_profile": {
+                          "type": "string",
+                          "description": "Key only used for documentation or validation purposes",
+                          "title": "Port Profile"
+                        },
+                        "uc_tx_queues": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "integer",
+                                "description": "TX-Queue ID",
+                                "title": "ID"
+                              },
+                              "random_detect": {
+                                "type": "object",
+                                "properties": {
+                                  "ecn": {
+                                    "description": "Explicit Congestion Notification",
+                                    "type": "object",
+                                    "properties": {
+                                      "count": {
+                                        "type": "boolean",
+                                        "description": "Enable counter for random-detect ECNs",
+                                        "title": "Count"
+                                      },
+                                      "threshold": {
+                                        "type": "object",
+                                        "properties": {
+                                          "units": {
+                                            "type": "string",
+                                            "enum": [
+                                              "segments",
+                                              "bytes",
+                                              "kbytes",
+                                              "mbytes",
+                                              "milliseconds"
+                                            ],
+                                            "description": "Indicate the units to be used for the threshold values",
+                                            "title": "Units"
+                                          },
+                                          "min": {
+                                            "type": "integer",
+                                            "minimum": 1,
+                                            "maximum": 256000000,
+                                            "description": "Set the random-detect ECN minimum-threshold",
+                                            "title": "Min"
+                                          },
+                                          "max": {
+                                            "type": "integer",
+                                            "minimum": 1,
+                                            "maximum": 256000000,
+                                            "description": "Set the random-detect ECN maximum-threshold",
+                                            "title": "Max"
+                                          },
+                                          "max_probability": {
+                                            "type": "integer",
+                                            "minimum": 1,
+                                            "maximum": 100,
+                                            "description": "Set the random-detect ECN max-mark-probability",
+                                            "title": "Max Probability"
+                                          },
+                                          "weight": {
+                                            "type": "integer",
+                                            "minimum": 0,
+                                            "maximum": 15,
+                                            "description": "Set the random-detect ECN weight",
+                                            "title": "Weight"
+                                          }
+                                        },
+                                        "required": [
+                                          "units",
+                                          "min",
+                                          "max"
+                                        ],
+                                        "additionalProperties": false,
+                                        "patternProperties": {
+                                          "^_.+$": {}
+                                        },
+                                        "title": "Threshold"
+                                      }
+                                    },
+                                    "additionalProperties": false,
+                                    "patternProperties": {
+                                      "^_.+$": {}
+                                    },
+                                    "title": "Ecn"
+                                  }
+                                },
+                                "additionalProperties": false,
+                                "patternProperties": {
+                                  "^_.+$": {}
+                                },
+                                "title": "Random Detect"
+                              }
+                            },
+                            "required": [
+                              "id"
+                            ],
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            }
+                          },
+                          "title": "Uc TX Queues"
+                        },
+                        "tx_queues": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "integer",
+                                "description": "TX-Queue ID",
+                                "title": "ID"
+                              },
+                              "random_detect": {
+                                "type": "object",
+                                "properties": {
+                                  "ecn": {
+                                    "description": "Explicit Congestion Notification",
+                                    "type": "object",
+                                    "properties": {
+                                      "count": {
+                                        "type": "boolean",
+                                        "description": "Enable counter for random-detect ECNs",
+                                        "title": "Count"
+                                      },
+                                      "threshold": {
+                                        "type": "object",
+                                        "properties": {
+                                          "units": {
+                                            "type": "string",
+                                            "enum": [
+                                              "segments",
+                                              "bytes",
+                                              "kbytes",
+                                              "mbytes",
+                                              "milliseconds"
+                                            ],
+                                            "description": "Indicate the units to be used for the threshold values",
+                                            "title": "Units"
+                                          },
+                                          "min": {
+                                            "type": "integer",
+                                            "minimum": 1,
+                                            "maximum": 256000000,
+                                            "description": "Set the random-detect ECN minimum-threshold",
+                                            "title": "Min"
+                                          },
+                                          "max": {
+                                            "type": "integer",
+                                            "minimum": 1,
+                                            "maximum": 256000000,
+                                            "description": "Set the random-detect ECN maximum-threshold",
+                                            "title": "Max"
+                                          },
+                                          "max_probability": {
+                                            "type": "integer",
+                                            "minimum": 1,
+                                            "maximum": 100,
+                                            "description": "Set the random-detect ECN max-mark-probability",
+                                            "title": "Max Probability"
+                                          },
+                                          "weight": {
+                                            "type": "integer",
+                                            "minimum": 0,
+                                            "maximum": 15,
+                                            "description": "Set the random-detect ECN weight",
+                                            "title": "Weight"
+                                          }
+                                        },
+                                        "required": [
+                                          "units",
+                                          "max",
+                                          "max_probability"
+                                        ],
+                                        "additionalProperties": false,
+                                        "patternProperties": {
+                                          "^_.+$": {}
+                                        },
+                                        "title": "Threshold"
+                                      }
+                                    },
+                                    "additionalProperties": false,
+                                    "patternProperties": {
+                                      "^_.+$": {}
+                                    },
+                                    "title": "Ecn"
+                                  }
+                                },
+                                "additionalProperties": false,
+                                "patternProperties": {
+                                  "^_.+$": {}
+                                },
+                                "title": "Random Detect"
+                              }
+                            },
+                            "required": [
+                              "id"
+                            ],
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            }
+                          },
+                          "title": "TX Queues"
+                        },
+                        "vrrp_ids": {
+                          "type": "array",
+                          "description": "VRRP model.",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "integer",
+                                "description": "VRID",
+                                "title": "ID"
+                              },
+                              "priority_level": {
+                                "type": "integer",
+                                "description": "Instance priority",
+                                "minimum": 1,
+                                "maximum": 254,
+                                "title": "Priority Level"
+                              },
+                              "advertisement": {
+                                "type": "object",
+                                "properties": {
+                                  "interval": {
+                                    "type": "integer",
+                                    "description": "Interval in seconds",
+                                    "minimum": 1,
+                                    "maximum": 255,
+                                    "title": "Interval"
+                                  }
+                                },
+                                "additionalProperties": false,
+                                "patternProperties": {
+                                  "^_.+$": {}
+                                },
+                                "title": "Advertisement"
+                              },
+                              "preempt": {
+                                "type": "object",
+                                "properties": {
+                                  "enabled": {
+                                    "type": "boolean",
+                                    "title": "Enabled"
+                                  },
+                                  "delay": {
+                                    "type": "object",
+                                    "properties": {
+                                      "minimum": {
+                                        "type": "integer",
+                                        "description": "Minimum preempt delay in seconds",
+                                        "minimum": 0,
+                                        "maximum": 3600,
+                                        "title": "Minimum"
+                                      },
+                                      "reload": {
+                                        "type": "integer",
+                                        "description": "Reload preempt delay in seconds",
+                                        "minimum": 0,
+                                        "maximum": 3600,
+                                        "title": "Reload"
+                                      }
+                                    },
+                                    "additionalProperties": false,
+                                    "patternProperties": {
+                                      "^_.+$": {}
+                                    },
+                                    "title": "Delay"
+                                  }
+                                },
+                                "required": [
+                                  "enabled"
+                                ],
+                                "additionalProperties": false,
+                                "patternProperties": {
+                                  "^_.+$": {}
+                                },
+                                "title": "Preempt"
+                              },
+                              "timers": {
+                                "type": "object",
+                                "properties": {
+                                  "delay": {
+                                    "type": "object",
+                                    "properties": {
+                                      "reload": {
+                                        "type": "integer",
+                                        "description": "Delay after reload in seconds.",
+                                        "minimum": 0,
+                                        "maximum": 3600,
+                                        "title": "Reload"
+                                      }
+                                    },
+                                    "additionalProperties": false,
+                                    "patternProperties": {
+                                      "^_.+$": {}
+                                    },
+                                    "title": "Delay"
+                                  }
+                                },
+                                "additionalProperties": false,
+                                "patternProperties": {
+                                  "^_.+$": {}
+                                },
+                                "title": "Timers"
+                              },
+                              "tracked_object": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string",
+                                      "description": "Tracked object name",
+                                      "title": "Name"
+                                    },
+                                    "decrement": {
+                                      "type": "integer",
+                                      "minimum": 1,
+                                      "maximum": 254,
+                                      "description": "Decrement VRRP priority by 1-254",
+                                      "title": "Decrement"
+                                    },
+                                    "shutdown": {
+                                      "type": "boolean",
+                                      "title": "Shutdown"
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "patternProperties": {
+                                    "^_.+$": {}
+                                  },
+                                  "required": [
+                                    "name"
+                                  ]
+                                },
+                                "title": "Tracked Object"
+                              },
+                              "ipv4": {
+                                "type": "object",
+                                "properties": {
+                                  "address": {
+                                    "type": "string",
+                                    "description": "Virtual IPv4 address",
+                                    "title": "Address"
+                                  },
+                                  "version": {
+                                    "type": "integer",
+                                    "enum": [
+                                      2,
+                                      3
+                                    ],
+                                    "title": "Version"
+                                  }
+                                },
+                                "required": [
+                                  "address"
+                                ],
+                                "additionalProperties": false,
+                                "patternProperties": {
+                                  "^_.+$": {}
+                                },
+                                "title": "IPv4"
+                              },
+                              "ipv6": {
+                                "type": "object",
+                                "properties": {
+                                  "address": {
+                                    "type": "string",
+                                    "description": "Virtual IPv6 address",
+                                    "title": "Address"
+                                  }
+                                },
+                                "required": [
+                                  "address"
+                                ],
+                                "additionalProperties": false,
+                                "patternProperties": {
+                                  "^_.+$": {}
+                                },
+                                "title": "IPv6"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            },
+                            "required": [
+                              "id"
+                            ]
+                          },
+                          "title": "VRRP IDs"
+                        },
+                        "eos_cli": {
+                          "type": "string",
+                          "description": "Multiline EOS CLI rendered directly on the ethernet interface in the final EOS configuration",
+                          "title": "EOS CLI"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      },
+                      "title": "Structured Config"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "patternProperties": {
+                    "^_.+$": {}
+                  },
+                  "required": [
+                    "vrf"
+                  ]
+                },
+                "title": "Subinterfaces"
+              },
+              "raw_eos_cli": {
+                "type": "string",
+                "description": "EOS CLI rendered directly on the interface in the final EOS configuration.",
+                "title": "Raw EOS CLI"
+              },
+              "structured_config": {
+                "type": "object",
+                "description": "Custom structured config for interfaces",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "title": "Name"
+                  },
+                  "description": {
+                    "type": "string",
+                    "title": "Description"
+                  },
+                  "shutdown": {
+                    "type": "boolean",
+                    "title": "Shutdown"
+                  },
+                  "load_interval": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 600,
+                    "description": "Interval in seconds for updating interface counters\"",
+                    "title": "Load Interval"
+                  },
+                  "speed": {
+                    "type": "string",
+                    "description": "Speed should be set in the format `<interface_speed>` or `forced <interface_speed>` or `auto <interface_speed>`.",
+                    "title": "Speed"
+                  },
+                  "mtu": {
+                    "type": "integer",
+                    "minimum": 68,
+                    "maximum": 65535,
+                    "title": "MTU"
+                  },
+                  "l2_mtu": {
+                    "type": "integer",
+                    "minimum": 68,
+                    "maximum": 65535,
+                    "description": "\"l2_mtu\" should only be defined for platforms supporting the \"l2 mtu\" CLI\n",
+                    "title": "L2 MTU"
+                  },
+                  "l2_mru": {
+                    "type": "integer",
+                    "minimum": 68,
+                    "maximum": 65535,
+                    "description": "\"l2_mru\" should only be defined for platforms supporting the \"l2 mru\" CLI\n",
+                    "title": "L2 MRU"
+                  },
+                  "vlans": {
+                    "type": "string",
+                    "description": "List of switchport vlans as string\nFor a trunk port this would be a range like \"1-200,300\"\nFor an access port this would be a single vlan \"123\"\n",
+                    "title": "VLANs"
+                  },
+                  "native_vlan": {
+                    "type": "integer",
+                    "title": "Native VLAN"
+                  },
+                  "native_vlan_tag": {
+                    "type": "boolean",
+                    "description": "If setting both native_vlan and native_vlan_tag, native_vlan_tag takes precedence",
+                    "title": "Native VLAN Tag"
+                  },
+                  "mode": {
+                    "type": "string",
+                    "enum": [
+                      "access",
+                      "dot1q-tunnel",
+                      "trunk",
+                      "trunk phone"
+                    ],
+                    "title": "Mode"
+                  },
+                  "phone": {
+                    "type": "object",
+                    "properties": {
+                      "trunk": {
+                        "type": "string",
+                        "enum": [
+                          "tagged",
+                          "tagged phone",
+                          "untagged",
+                          "untagged phone"
+                        ],
+                        "title": "Trunk"
+                      },
+                      "vlan": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 4094,
+                        "title": "VLAN"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Phone"
+                  },
+                  "l2_protocol": {
+                    "type": "object",
+                    "properties": {
+                      "encapsulation_dot1q_vlan": {
+                        "type": "integer",
+                        "description": "Vlan tag to configure on sub-interface",
+                        "title": "Encapsulation Dot1Q VLAN"
+                      },
+                      "forwarding_profile": {
+                        "type": "string",
+                        "description": "L2 protocol forwarding profile",
+                        "title": "Forwarding Profile"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "L2 Protocol"
+                  },
+                  "trunk_groups": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Trunk Groups"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "routed",
+                      "switched",
+                      "l3dot1q",
+                      "l2dot1q",
+                      "port-channel-member"
+                    ],
+                    "description": "l3dot1q and l2dot1q are used for sub-interfaces. The parent interface should be defined as routed.\nInterface will not be listed in device documentation, unless \"type\" is set.\n",
+                    "title": "Type"
+                  },
+                  "snmp_trap_link_change": {
+                    "type": "boolean",
+                    "title": "Snmp Trap Link Change"
+                  },
+                  "address_locking": {
+                    "type": "object",
+                    "properties": {
+                      "ipv4": {
+                        "type": "boolean",
+                        "description": "Enable address locking for IPv4",
+                        "title": "IPv4"
+                      },
+                      "ipv6": {
+                        "type": "boolean",
+                        "description": "Enable address locking for IPv6",
+                        "title": "IPv6"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Address Locking"
+                  },
+                  "flowcontrol": {
+                    "type": "object",
+                    "properties": {
+                      "received": {
+                        "type": "string",
+                        "enum": [
+                          "desired",
+                          "on",
+                          "off"
+                        ],
+                        "title": "Received"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Flowcontrol"
+                  },
+                  "vrf": {
+                    "type": "string",
+                    "description": "VRF name",
+                    "title": "VRF"
+                  },
+                  "flow_tracker": {
+                    "type": "object",
+                    "properties": {
+                      "sampled": {
+                        "type": "string",
+                        "description": "Sampled flow tracker name.",
+                        "title": "Sampled"
+                      },
+                      "hardware": {
+                        "type": "string",
+                        "description": "Hardware flow tracker name.",
+                        "title": "Hardware"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Flow Tracker"
+                  },
+                  "error_correction_encoding": {
+                    "type": "object",
+                    "properties": {
+                      "enabled": {
+                        "type": "boolean",
+                        "default": true,
+                        "title": "Enabled"
+                      },
+                      "fire_code": {
+                        "type": "boolean",
+                        "title": "Fire Code"
+                      },
+                      "reed_solomon": {
+                        "type": "boolean",
+                        "title": "Reed Solomon"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Error Correction Encoding"
+                  },
+                  "link_tracking_groups": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "description": "Group name",
+                          "title": "Name"
+                        },
+                        "direction": {
+                          "type": "string",
+                          "enum": [
+                            "upstream",
+                            "downstream"
+                          ],
+                          "title": "Direction"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      },
+                      "required": [
+                        "name"
+                      ]
+                    },
+                    "title": "Link Tracking Groups"
+                  },
+                  "evpn_ethernet_segment": {
+                    "type": "object",
+                    "properties": {
+                      "identifier": {
+                        "type": "string",
+                        "description": "EVPN Ethernet Segment Identifier (Type 1 format)",
+                        "title": "Identifier"
+                      },
+                      "redundancy": {
+                        "type": "string",
+                        "enum": [
+                          "all-active",
+                          "single-active"
+                        ],
+                        "title": "Redundancy"
+                      },
+                      "designated_forwarder_election": {
+                        "type": "object",
+                        "properties": {
+                          "algorithm": {
+                            "type": "string",
+                            "enum": [
+                              "modulus",
+                              "preference"
+                            ],
+                            "title": "Algorithm"
+                          },
+                          "preference_value": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 65535,
+                            "description": "Preference_value is only used when \"algorithm\" is \"preference\"",
+                            "title": "Preference Value"
+                          },
+                          "dont_preempt": {
+                            "type": "boolean",
+                            "description": "Dont_preempt is only used when \"algorithm\" is \"preference\"",
+                            "title": "Dont Preempt"
+                          },
+                          "hold_time": {
+                            "type": "integer",
+                            "title": "Hold Time"
+                          },
+                          "subsequent_hold_time": {
+                            "type": "integer",
+                            "title": "Subsequent Hold Time"
+                          },
+                          "candidate_reachability_required": {
+                            "type": "boolean",
+                            "title": "Candidate Reachability Required"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Designated Forwarder Election"
+                      },
+                      "mpls": {
+                        "type": "object",
+                        "properties": {
+                          "shared_index": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 1024,
+                            "title": "Shared Index"
+                          },
+                          "tunnel_flood_filter_time": {
+                            "type": "integer",
+                            "title": "Tunnel Flood Filter Time"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "MPLS"
+                      },
+                      "route_target": {
+                        "type": "string",
+                        "description": "EVPN Route Target for ESI with format xx:xx:xx:xx:xx:xx",
+                        "title": "Route Target"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "EVPN Ethernet Segment"
+                  },
+                  "encapsulation_dot1q_vlan": {
+                    "type": "integer",
+                    "description": "VLAN tag to configure on sub-interface",
+                    "title": "Encapsulation Dot1Q VLAN"
+                  },
+                  "encapsulation_vlan": {
+                    "type": "object",
+                    "properties": {
+                      "client": {
+                        "type": "object",
+                        "properties": {
+                          "dot1q": {
+                            "type": "object",
+                            "properties": {
+                              "vlan": {
+                                "type": "integer",
+                                "description": "Client VLAN ID",
+                                "title": "VLAN"
+                              },
+                              "outer": {
+                                "type": "integer",
+                                "description": "Client Outer VLAN ID",
+                                "title": "Outer"
+                              },
+                              "inner": {
+                                "type": "integer",
+                                "description": "Client Inner VLAN ID",
+                                "title": "Inner"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            },
+                            "title": "Dot1Q"
+                          },
+                          "unmatched": {
+                            "type": "boolean",
+                            "title": "Unmatched"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Client"
+                      },
+                      "network": {
+                        "type": "object",
+                        "description": "Network encapsulations are all optional and skipped if using client unmatched",
+                        "properties": {
+                          "dot1q": {
+                            "type": "object",
+                            "properties": {
+                              "vlan": {
+                                "type": "integer",
+                                "description": "Network VLAN ID",
+                                "title": "VLAN"
+                              },
+                              "outer": {
+                                "type": "integer",
+                                "description": "Network outer VLAN ID",
+                                "title": "Outer"
+                              },
+                              "inner": {
+                                "type": "integer",
+                                "description": "Network inner VLAN ID",
+                                "title": "Inner"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            },
+                            "title": "Dot1Q"
+                          },
+                          "client": {
+                            "type": "boolean",
+                            "title": "Client"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Network"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Encapsulation VLAN"
+                  },
+                  "vlan_id": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 4094,
+                    "title": "VLAN ID"
+                  },
+                  "ip_address": {
+                    "type": "string",
+                    "description": "IPv4 address/mask or \"dhcp\"",
+                    "title": "IP Address"
+                  },
+                  "ip_address_secondaries": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "IP Address Secondaries"
+                  },
+                  "dhcp_client_accept_default_route": {
+                    "type": "boolean",
+                    "description": "Install default-route obtained via DHCP",
+                    "title": "DHCP Client Accept Default Route"
+                  },
+                  "dhcp_server_ipv4": {
+                    "type": "boolean",
+                    "description": "Enable IPv4 DHCP server.",
+                    "title": "DHCP Server IPv4"
+                  },
+                  "dhcp_server_ipv6": {
+                    "type": "boolean",
+                    "description": "Enable IPv6 DHCP server.",
+                    "title": "DHCP Server IPv6"
+                  },
+                  "ip_helpers": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "ip_helper": {
+                          "type": "string",
+                          "title": "IP Helper"
+                        },
+                        "source_interface": {
+                          "type": "string",
+                          "description": "Source interface name",
+                          "title": "Source Interface"
+                        },
+                        "vrf": {
+                          "type": "string",
+                          "description": "VRF name",
+                          "title": "VRF"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      },
+                      "required": [
+                        "ip_helper"
+                      ]
+                    },
+                    "title": "IP Helpers"
+                  },
+                  "ip_nat": {
+                    "type": "object",
+                    "properties": {
+                      "service_profile": {
+                        "type": "string",
+                        "description": "NAT interface profile.",
+                        "title": "Service Profile"
+                      },
+                      "destination": {
+                        "type": "object",
+                        "properties": {
+                          "dynamic": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "access_list": {
+                                  "type": "string",
+                                  "title": "Access List"
+                                },
+                                "comment": {
+                                  "type": "string",
+                                  "title": "Comment"
+                                },
+                                "pool_name": {
+                                  "type": "string",
+                                  "title": "Pool Name"
+                                },
+                                "priority": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "maximum": 4294967295,
+                                  "title": "Priority"
+                                }
+                              },
+                              "required": [
+                                "pool_name",
+                                "access_list"
+                              ],
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              }
+                            },
+                            "title": "Dynamic"
+                          },
+                          "static": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "access_list": {
+                                  "type": "string",
+                                  "description": "'access_list' and 'group' are mutual exclusive",
+                                  "title": "Access List"
+                                },
+                                "comment": {
+                                  "type": "string",
+                                  "title": "Comment"
+                                },
+                                "direction": {
+                                  "type": "string",
+                                  "enum": [
+                                    "egress",
+                                    "ingress"
+                                  ],
+                                  "description": "Egress or ingress can be the default. This depends on source/destination, EOS version, and hardware platform.\nEOS might remove this keyword in the configuration. So, check the configuration on targeted HW/SW.\n",
+                                  "title": "Direction"
+                                },
+                                "group": {
+                                  "type": "integer",
+                                  "minimum": 1,
+                                  "maximum": 65535,
+                                  "description": "'access_list' and 'group' are mutual exclusive",
+                                  "title": "Group"
+                                },
+                                "original_ip": {
+                                  "type": "string",
+                                  "description": "IPv4 address",
+                                  "title": "Original IP"
+                                },
+                                "original_port": {
+                                  "type": "integer",
+                                  "minimum": 1,
+                                  "maximum": 65535,
+                                  "title": "Original Port"
+                                },
+                                "priority": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "maximum": 4294967295,
+                                  "title": "Priority"
+                                },
+                                "protocol": {
+                                  "type": "string",
+                                  "enum": [
+                                    "udp",
+                                    "tcp"
+                                  ],
+                                  "title": "Protocol"
+                                },
+                                "translated_ip": {
+                                  "type": "string",
+                                  "description": "IPv4 address",
+                                  "title": "Translated IP"
+                                },
+                                "translated_port": {
+                                  "type": "integer",
+                                  "minimum": 1,
+                                  "maximum": 65535,
+                                  "description": "requires 'original_port'",
+                                  "title": "Translated Port"
+                                }
+                              },
+                              "required": [
+                                "translated_ip",
+                                "original_ip"
+                              ],
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              }
+                            },
+                            "title": "Static"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Destination"
+                      },
+                      "source": {
+                        "type": "object",
+                        "properties": {
+                          "dynamic": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "access_list": {
+                                  "type": "string",
+                                  "title": "Access List"
+                                },
+                                "comment": {
+                                  "type": "string",
+                                  "title": "Comment"
+                                },
+                                "nat_type": {
+                                  "type": "string",
+                                  "enum": [
+                                    "overload",
+                                    "pool",
+                                    "pool-address-only",
+                                    "pool-full-cone"
+                                  ],
+                                  "title": "Nat Type"
+                                },
+                                "pool_name": {
+                                  "type": "string",
+                                  "description": "required if 'nat_type' is pool, pool-address-only or pool-full-cone\nignored if 'nat_type' is overload\n",
+                                  "title": "Pool Name"
+                                },
+                                "priority": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "maximum": 4294967295,
+                                  "title": "Priority"
+                                }
+                              },
+                              "required": [
+                                "nat_type",
+                                "access_list"
+                              ],
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              }
+                            },
+                            "title": "Dynamic"
+                          },
+                          "static": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "access_list": {
+                                  "type": "string",
+                                  "description": "'access_list' and 'group' are mutual exclusive",
+                                  "title": "Access List"
+                                },
+                                "comment": {
+                                  "type": "string",
+                                  "title": "Comment"
+                                },
+                                "direction": {
+                                  "type": "string",
+                                  "enum": [
+                                    "egress",
+                                    "ingress"
+                                  ],
+                                  "description": "Egress or ingress can be the default. This depends on source/destination, EOS version, and hardware platform.\nEOS might remove this keyword in the configuration. So, check the configuration on targeted HW/SW.\n",
+                                  "title": "Direction"
+                                },
+                                "group": {
+                                  "type": "integer",
+                                  "minimum": 1,
+                                  "maximum": 65535,
+                                  "description": "'access_list' and 'group' are mutual exclusive",
+                                  "title": "Group"
+                                },
+                                "original_ip": {
+                                  "type": "string",
+                                  "description": "IPv4 address",
+                                  "title": "Original IP"
+                                },
+                                "original_port": {
+                                  "type": "integer",
+                                  "minimum": 1,
+                                  "maximum": 65535,
+                                  "title": "Original Port"
+                                },
+                                "priority": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "maximum": 4294967295,
+                                  "title": "Priority"
+                                },
+                                "protocol": {
+                                  "type": "string",
+                                  "enum": [
+                                    "udp",
+                                    "tcp"
+                                  ],
+                                  "title": "Protocol"
+                                },
+                                "translated_ip": {
+                                  "type": "string",
+                                  "description": "IPv4 address",
+                                  "title": "Translated IP"
+                                },
+                                "translated_port": {
+                                  "type": "integer",
+                                  "minimum": 1,
+                                  "maximum": 65535,
+                                  "description": "requires 'original_port'",
+                                  "title": "Translated Port"
+                                }
+                              },
+                              "required": [
+                                "translated_ip",
+                                "original_ip"
+                              ],
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              }
+                            },
+                            "title": "Static"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Source"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "IP Nat"
+                  },
+                  "ipv6_enable": {
+                    "type": "boolean",
+                    "title": "IPv6 Enable"
+                  },
+                  "ipv6_address": {
+                    "type": "string",
+                    "title": "IPv6 Address"
+                  },
+                  "ipv6_address_link_local": {
+                    "type": "string",
+                    "description": "Link local IPv6 address/mask",
+                    "title": "IPv6 Address Link Local"
+                  },
+                  "ipv6_nd_ra_disabled": {
+                    "type": "boolean",
+                    "title": "IPv6 ND RA Disabled"
+                  },
+                  "ipv6_nd_managed_config_flag": {
+                    "type": "boolean",
+                    "title": "IPv6 ND Managed Config Flag"
+                  },
+                  "ipv6_nd_prefixes": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "ipv6_prefix": {
+                          "type": "string",
+                          "title": "IPv6 Prefix"
+                        },
+                        "valid_lifetime": {
+                          "type": "string",
+                          "description": "Infinite or lifetime in seconds",
+                          "title": "Valid Lifetime"
+                        },
+                        "preferred_lifetime": {
+                          "type": "string",
+                          "description": "Infinite or lifetime in seconds",
+                          "title": "Preferred Lifetime"
+                        },
+                        "no_autoconfig_flag": {
+                          "type": "boolean",
+                          "title": "No Autoconfig Flag"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      },
+                      "required": [
+                        "ipv6_prefix"
+                      ]
+                    },
+                    "title": "IPv6 ND Prefixes"
+                  },
+                  "ipv6_dhcp_relay_destinations": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "address": {
+                          "type": "string",
+                          "description": "DHCP server's IPv6 address",
+                          "title": "Address"
+                        },
+                        "vrf": {
+                          "type": "string",
+                          "title": "VRF"
+                        },
+                        "local_interface": {
+                          "type": "string",
+                          "description": "Local interface to communicate with DHCP server - mutually exclusive to source_address",
+                          "title": "Local Interface"
+                        },
+                        "source_address": {
+                          "type": "string",
+                          "description": "Source IPv6 address to communicate with DHCP server - mutually exclusive to local_interface",
+                          "title": "Source Address"
+                        },
+                        "link_address": {
+                          "type": "string",
+                          "description": "Override the default link address specified in the relayed DHCP packet",
+                          "title": "Link Address"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      },
+                      "required": [
+                        "address"
+                      ]
+                    },
+                    "title": "IPv6 DHCP Relay Destinations"
+                  },
+                  "access_group_in": {
+                    "type": "string",
+                    "description": "Access list name",
+                    "title": "Access Group In"
+                  },
+                  "access_group_out": {
+                    "type": "string",
+                    "description": "Access list name",
+                    "title": "Access Group Out"
+                  },
+                  "ipv6_access_group_in": {
+                    "type": "string",
+                    "description": "IPv6 access list name",
+                    "title": "IPv6 Access Group In"
+                  },
+                  "ipv6_access_group_out": {
+                    "type": "string",
+                    "description": "IPv6 access list name",
+                    "title": "IPv6 Access Group Out"
+                  },
+                  "mac_access_group_in": {
+                    "type": "string",
+                    "description": "MAC access list name",
+                    "title": "MAC Access Group In"
+                  },
+                  "mac_access_group_out": {
+                    "type": "string",
+                    "description": "MAC access list name",
+                    "title": "MAC Access Group Out"
+                  },
+                  "multicast": {
+                    "type": "object",
+                    "description": "Boundaries can be either 1 ACL or a list of multicast IP address_range(s)/prefix but not combination of both",
+                    "properties": {
+                      "ipv4": {
+                        "type": "object",
+                        "properties": {
+                          "boundaries": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "boundary": {
+                                  "type": "string",
+                                  "description": "ACL name or multicast IP subnet",
+                                  "title": "Boundary"
+                                },
+                                "out": {
+                                  "type": "boolean",
+                                  "title": "Out"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              }
+                            },
+                            "title": "Boundaries"
+                          },
+                          "static": {
+                            "type": "boolean",
+                            "title": "Static"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "IPv4"
+                      },
+                      "ipv6": {
+                        "type": "object",
+                        "properties": {
+                          "boundaries": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "boundary": {
+                                  "type": "string",
+                                  "description": "ACL name or multicast IP subnet",
+                                  "title": "Boundary"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              }
+                            },
+                            "title": "Boundaries"
+                          },
+                          "static": {
+                            "type": "boolean",
+                            "title": "Static"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "IPv6"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Multicast"
+                  },
+                  "ospf_network_point_to_point": {
+                    "type": "boolean",
+                    "title": "OSPF Network Point To Point"
+                  },
+                  "ospf_area": {
+                    "type": "string",
+                    "title": "OSPF Area"
+                  },
+                  "ospf_cost": {
+                    "type": "integer",
+                    "title": "OSPF Cost"
+                  },
+                  "ospf_authentication": {
+                    "type": "string",
+                    "enum": [
+                      "none",
+                      "simple",
+                      "message-digest"
+                    ],
+                    "title": "OSPF Authentication"
+                  },
+                  "ospf_authentication_key": {
+                    "type": "string",
+                    "description": "Encrypted password - only type 7 supported",
+                    "title": "OSPF Authentication Key"
+                  },
+                  "ospf_message_digest_keys": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "title": "ID"
+                        },
+                        "hash_algorithm": {
+                          "type": "string",
+                          "enum": [
+                            "md5",
+                            "sha1",
+                            "sha256",
+                            "sha384",
+                            "sha512"
+                          ],
+                          "title": "Hash Algorithm"
+                        },
+                        "key": {
+                          "type": "string",
+                          "description": "Encrypted password - only type 7 supported",
+                          "title": "Key"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      },
+                      "required": [
+                        "id"
+                      ]
+                    },
+                    "title": "OSPF Message Digest Keys"
+                  },
+                  "pim": {
+                    "type": "object",
+                    "properties": {
+                      "ipv4": {
+                        "type": "object",
+                        "properties": {
+                          "dr_priority": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 429467295,
+                            "title": "DR Priority"
+                          },
+                          "sparse_mode": {
+                            "type": "boolean",
+                            "title": "Sparse Mode"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "IPv4"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "PIM"
+                  },
+                  "mac_security": {
+                    "type": "object",
+                    "properties": {
+                      "profile": {
+                        "type": "string",
+                        "title": "Profile"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "MAC Security"
+                  },
+                  "channel_group": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "integer",
+                        "title": "ID"
+                      },
+                      "mode": {
+                        "type": "string",
+                        "enum": [
+                          "on",
+                          "active",
+                          "passive"
+                        ],
+                        "title": "Mode"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Channel Group"
+                  },
+                  "isis_enable": {
+                    "type": "string",
+                    "description": "ISIS instance",
+                    "title": "ISIS Enable"
+                  },
+                  "isis_passive": {
+                    "type": "boolean",
+                    "title": "ISIS Passive"
+                  },
+                  "isis_metric": {
+                    "type": "integer",
+                    "title": "ISIS Metric"
+                  },
+                  "isis_network_point_to_point": {
+                    "type": "boolean",
+                    "title": "ISIS Network Point To Point"
+                  },
+                  "isis_circuit_type": {
+                    "type": "string",
+                    "enum": [
+                      "level-1-2",
+                      "level-1",
+                      "level-2"
+                    ],
+                    "title": "ISIS Circuit Type"
+                  },
+                  "isis_hello_padding": {
+                    "type": "boolean",
+                    "title": "ISIS Hello Padding"
+                  },
+                  "isis_authentication_mode": {
+                    "type": "string",
+                    "enum": [
+                      "text",
+                      "md5"
+                    ],
+                    "title": "ISIS Authentication Mode"
+                  },
+                  "isis_authentication_key": {
+                    "type": "string",
+                    "description": "Type-7 encrypted password",
+                    "title": "ISIS Authentication Key"
+                  },
+                  "poe": {
+                    "type": "object",
+                    "properties": {
+                      "disabled": {
+                        "type": "boolean",
+                        "description": "Disable PoE on a POE capable port. PoE is enabled on all ports that support it by default in EOS.",
+                        "default": false,
+                        "title": "Disabled"
+                      },
+                      "priority": {
+                        "type": "string",
+                        "enum": [
+                          "critical",
+                          "high",
+                          "medium",
+                          "low"
+                        ],
+                        "description": "Prioritize a port's power in the event that one of the switch's power supplies loses power",
+                        "title": "Priority"
+                      },
+                      "reboot": {
+                        "description": "Set the PoE power behavior for a PoE port when the system is rebooted",
+                        "type": "object",
+                        "properties": {
+                          "action": {
+                            "type": "string",
+                            "enum": [
+                              "maintain",
+                              "power-off"
+                            ],
+                            "description": "PoE action for interface",
+                            "title": "Action"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Reboot"
+                      },
+                      "link_down": {
+                        "description": "Set the PoE power behavior for a PoE port when the port goes down",
+                        "type": "object",
+                        "properties": {
+                          "action": {
+                            "type": "string",
+                            "enum": [
+                              "maintain",
+                              "power-off"
+                            ],
+                            "description": "PoE action for interface",
+                            "title": "Action"
+                          },
+                          "power_off_delay": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 86400,
+                            "description": "Number of seconds to delay shutting the power off after a link down event occurs. Default value is 5 seconds in EOS.",
+                            "title": "Power Off Delay"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Link Down"
+                      },
+                      "shutdown": {
+                        "description": "Set the PoE power behavior for a PoE port when the port is admin down",
+                        "type": "object",
+                        "properties": {
+                          "action": {
+                            "type": "string",
+                            "enum": [
+                              "maintain",
+                              "power-off"
+                            ],
+                            "description": "PoE action for interface",
+                            "title": "Action"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Shutdown"
+                      },
+                      "limit": {
+                        "type": "object",
+                        "description": "Override the hardware-negotiated power limit using either wattage or a power class. Note that if using a power class, AVD will automatically convert the class value to the wattage value corresponding to that power class.",
+                        "properties": {
+                          "class": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 8,
+                            "title": "Class"
+                          },
+                          "watts": {
+                            "type": "string",
+                            "title": "Watts"
+                          },
+                          "fixed": {
+                            "type": "boolean",
+                            "description": "Set to ignore hardware classification",
+                            "title": "Fixed"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Limit"
+                      },
+                      "negotiation_lldp": {
+                        "type": "boolean",
+                        "description": "Disable to prevent port from negotiating power with powered devices over LLDP. Enabled by default in EOS.",
+                        "title": "Negotiation LLDP"
+                      },
+                      "legacy_detect": {
+                        "type": "boolean",
+                        "description": "Allow a subset of legacy devices to work with the PoE switch. Disabled by default in EOS because it can cause false positive detections.",
+                        "title": "Legacy Detect"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "PoE"
+                  },
+                  "ptp": {
+                    "type": "object",
+                    "properties": {
+                      "enable": {
+                        "type": "boolean",
+                        "title": "Enable"
+                      },
+                      "announce": {
+                        "type": "object",
+                        "properties": {
+                          "interval": {
+                            "type": "integer",
+                            "title": "Interval"
+                          },
+                          "timeout": {
+                            "type": "integer",
+                            "title": "Timeout"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Announce"
+                      },
+                      "delay_req": {
+                        "type": "integer",
+                        "title": "Delay Req"
+                      },
+                      "delay_mechanism": {
+                        "type": "string",
+                        "enum": [
+                          "e2e",
+                          "p2p"
+                        ],
+                        "title": "Delay Mechanism"
+                      },
+                      "sync_message": {
+                        "type": "object",
+                        "properties": {
+                          "interval": {
+                            "type": "integer",
+                            "title": "Interval"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Sync Message"
+                      },
+                      "role": {
+                        "type": "string",
+                        "enum": [
+                          "master",
+                          "dynamic"
+                        ],
+                        "title": "Role"
+                      },
+                      "vlan": {
+                        "type": "string",
+                        "description": "VLAN can be 'all' or list of vlans as string",
+                        "title": "VLAN"
+                      },
+                      "transport": {
+                        "type": "string",
+                        "enum": [
+                          "ipv4",
+                          "ipv6",
+                          "layer2"
+                        ],
+                        "title": "Transport"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "PTP"
+                  },
+                  "profile": {
+                    "type": "string",
+                    "description": "Interface profile",
+                    "title": "Profile"
+                  },
+                  "storm_control": {
+                    "type": "object",
+                    "properties": {
+                      "all": {
+                        "type": "object",
+                        "properties": {
+                          "level": {
+                            "type": "string",
+                            "description": "Configure maximum storm-control level",
+                            "title": "Level"
+                          },
+                          "unit": {
+                            "type": "string",
+                            "default": "percent",
+                            "enum": [
+                              "percent",
+                              "pps"
+                            ],
+                            "description": "Optional field and is hardware dependent",
+                            "title": "Unit"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "All"
+                      },
+                      "broadcast": {
+                        "type": "object",
+                        "properties": {
+                          "level": {
+                            "type": "string",
+                            "description": "Configure maximum storm-control level",
+                            "title": "Level"
+                          },
+                          "unit": {
+                            "type": "string",
+                            "default": "percent",
+                            "enum": [
+                              "percent",
+                              "pps"
+                            ],
+                            "description": "Optional field and is hardware dependent",
+                            "title": "Unit"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Broadcast"
+                      },
+                      "multicast": {
+                        "type": "object",
+                        "properties": {
+                          "level": {
+                            "type": "string",
+                            "description": "Configure maximum storm-control level",
+                            "title": "Level"
+                          },
+                          "unit": {
+                            "type": "string",
+                            "default": "percent",
+                            "enum": [
+                              "percent",
+                              "pps"
+                            ],
+                            "description": "Optional field and is hardware dependent",
+                            "title": "Unit"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Multicast"
+                      },
+                      "unknown_unicast": {
+                        "type": "object",
+                        "properties": {
+                          "level": {
+                            "type": "string",
+                            "description": "Configure maximum storm-control level",
+                            "title": "Level"
+                          },
+                          "unit": {
+                            "type": "string",
+                            "default": "percent",
+                            "enum": [
+                              "percent",
+                              "pps"
+                            ],
+                            "description": "Optional field and is hardware dependent",
+                            "title": "Unit"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Unknown Unicast"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Storm Control"
+                  },
+                  "logging": {
+                    "type": "object",
+                    "properties": {
+                      "event": {
+                        "type": "object",
+                        "properties": {
+                          "link_status": {
+                            "type": "boolean",
+                            "title": "Link Status"
+                          },
+                          "congestion_drops": {
+                            "type": "boolean",
+                            "title": "Congestion Drops"
+                          },
+                          "spanning_tree": {
+                            "type": "boolean",
+                            "title": "Spanning Tree"
+                          },
+                          "storm_control_discards": {
+                            "type": "boolean",
+                            "title": "Storm Control Discards"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Event"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Logging"
+                  },
+                  "lldp": {
+                    "type": "object",
+                    "properties": {
+                      "transmit": {
+                        "type": "boolean",
+                        "title": "Transmit"
+                      },
+                      "receive": {
+                        "type": "boolean",
+                        "title": "Receive"
+                      },
+                      "ztp_vlan": {
+                        "type": "integer",
+                        "description": "ZTP vlan number",
+                        "title": "ZTP VLAN"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "LLDP"
+                  },
+                  "trunk_private_vlan_secondary": {
+                    "type": "boolean",
+                    "title": "Trunk Private VLAN Secondary"
+                  },
+                  "pvlan_mapping": {
+                    "type": "string",
+                    "description": "List of vlans as string",
+                    "title": "PVLAN Mapping"
+                  },
+                  "vlan_translations": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "from": {
+                          "type": "string",
+                          "description": "List of vlans as string (only one vlan if direction is \"both\")",
+                          "title": "From"
+                        },
+                        "to": {
+                          "type": "integer",
+                          "description": "VLAN ID",
+                          "title": "To"
+                        },
+                        "direction": {
+                          "type": "string",
+                          "enum": [
+                            "in",
+                            "out",
+                            "both"
+                          ],
+                          "default": "both",
+                          "title": "Direction"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      }
+                    },
+                    "title": "VLAN Translations"
+                  },
+                  "dot1x": {
+                    "type": "object",
+                    "properties": {
+                      "port_control": {
+                        "type": "string",
+                        "enum": [
+                          "auto",
+                          "force-authorized",
+                          "force-unauthorized"
+                        ],
+                        "title": "Port Control"
+                      },
+                      "port_control_force_authorized_phone": {
+                        "type": "boolean",
+                        "title": "Port Control Force Authorized Phone"
+                      },
+                      "reauthentication": {
+                        "type": "boolean",
+                        "title": "Reauthentication"
+                      },
+                      "pae": {
+                        "type": "object",
+                        "properties": {
+                          "mode": {
+                            "type": "string",
+                            "enum": [
+                              "authenticator"
+                            ],
+                            "title": "Mode"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "PAE"
+                      },
+                      "authentication_failure": {
+                        "type": "object",
+                        "properties": {
+                          "action": {
+                            "type": "string",
+                            "enum": [
+                              "allow",
+                              "drop"
+                            ],
+                            "title": "Action"
+                          },
+                          "allow_vlan": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 4094,
+                            "title": "Allow VLAN"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Authentication Failure"
+                      },
+                      "host_mode": {
+                        "type": "object",
+                        "properties": {
+                          "mode": {
+                            "type": "string",
+                            "enum": [
+                              "multi-host",
+                              "single-host"
+                            ],
+                            "title": "Mode"
+                          },
+                          "multi_host_authenticated": {
+                            "type": "boolean",
+                            "title": "Multi Host Authenticated"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Host Mode"
+                      },
+                      "mac_based_authentication": {
+                        "type": "object",
+                        "properties": {
+                          "enabled": {
+                            "type": "boolean",
+                            "title": "Enabled"
+                          },
+                          "always": {
+                            "type": "boolean",
+                            "title": "Always"
+                          },
+                          "host_mode_common": {
+                            "type": "boolean",
+                            "title": "Host Mode Common"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "MAC Based Authentication"
+                      },
+                      "timeout": {
+                        "type": "object",
+                        "properties": {
+                          "idle_host": {
+                            "type": "integer",
+                            "minimum": 10,
+                            "maximum": 65535,
+                            "title": "Idle Host"
+                          },
+                          "quiet_period": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 65535,
+                            "title": "Quiet Period"
+                          },
+                          "reauth_period": {
+                            "type": "string",
+                            "description": "Value can be 60-4294967295 or 'server'",
+                            "title": "Reauth Period"
+                          },
+                          "reauth_timeout_ignore": {
+                            "type": "boolean",
+                            "title": "Reauth Timeout Ignore"
+                          },
+                          "tx_period": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 65535,
+                            "title": "TX Period"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Timeout"
+                      },
+                      "reauthorization_request_limit": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 10,
+                        "title": "Reauthorization Request Limit"
+                      },
+                      "unauthorized": {
+                        "type": "object",
+                        "properties": {
+                          "access_vlan_membership_egress": {
+                            "type": "boolean",
+                            "title": "Access VLAN Membership Egress"
+                          },
+                          "native_vlan_membership_egress": {
+                            "type": "boolean",
+                            "title": "Native VLAN Membership Egress"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Unauthorized"
+                      },
+                      "eapol": {
+                        "type": "object",
+                        "properties": {
+                          "disabled": {
+                            "type": "boolean",
+                            "title": "Disabled"
+                          },
+                          "authentication_failure_fallback_mba": {
+                            "type": "object",
+                            "properties": {
+                              "enabled": {
+                                "type": "boolean",
+                                "title": "Enabled"
+                              },
+                              "timeout": {
+                                "type": "integer",
+                                "minimum": 0,
+                                "maximum": 65535,
+                                "title": "Timeout"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            },
+                            "title": "Authentication Failure Fallback Mba"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Eapol"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "dot1x"
+                  },
+                  "service_profile": {
+                    "type": "string",
+                    "description": "QOS profile",
+                    "title": "Service Profile"
+                  },
+                  "shape": {
+                    "type": "object",
+                    "properties": {
+                      "rate": {
+                        "type": "string",
+                        "description": "Rate in kbps, pps or percent\nSupported options are platform dependent\nExamples:\n- \"5000 kbps\"\n- \"1000 pps\"\n- \"20 percent\"\n",
+                        "title": "Rate"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Shape"
+                  },
+                  "qos": {
+                    "type": "object",
+                    "properties": {
+                      "trust": {
+                        "type": "string",
+                        "enum": [
+                          "dscp",
+                          "cos",
+                          "disabled"
+                        ],
+                        "title": "Trust"
+                      },
+                      "dscp": {
+                        "type": "integer",
+                        "description": "DSCP value",
+                        "title": "DSCP"
+                      },
+                      "cos": {
+                        "type": "integer",
+                        "description": "COS value",
+                        "title": "COS"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "QOS"
+                  },
+                  "spanning_tree_bpdufilter": {
+                    "type": "string",
+                    "enum": [
+                      "enabled",
+                      "disabled",
+                      "True",
+                      "False",
+                      "true",
+                      "false"
+                    ],
+                    "title": "Spanning Tree Bpdufilter"
+                  },
+                  "spanning_tree_bpduguard": {
+                    "type": "string",
+                    "enum": [
+                      "enabled",
+                      "disabled",
+                      "True",
+                      "False",
+                      "true",
+                      "false"
+                    ],
+                    "title": "Spanning Tree Bpduguard"
+                  },
+                  "spanning_tree_guard": {
+                    "type": "string",
+                    "enum": [
+                      "loop",
+                      "root",
+                      "disabled"
+                    ],
+                    "title": "Spanning Tree Guard"
+                  },
+                  "spanning_tree_portfast": {
+                    "type": "string",
+                    "enum": [
+                      "edge",
+                      "network"
+                    ],
+                    "title": "Spanning Tree Portfast"
+                  },
+                  "vmtracer": {
+                    "type": "boolean",
+                    "title": "VMTracer"
+                  },
+                  "priority_flow_control": {
+                    "type": "object",
+                    "properties": {
+                      "enabled": {
+                        "type": "boolean",
+                        "title": "Enabled"
+                      },
+                      "priorities": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "priority": {
+                              "type": "integer",
+                              "minimum": 0,
+                              "maximum": 7,
+                              "title": "Priority"
+                            },
+                            "no_drop": {
+                              "type": "boolean",
+                              "title": "No Drop"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "required": [
+                            "priority"
+                          ]
+                        },
+                        "title": "Priorities"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Priority Flow Control"
+                  },
+                  "bfd": {
+                    "type": "object",
+                    "properties": {
+                      "echo": {
+                        "type": "boolean",
+                        "title": "Echo"
+                      },
+                      "interval": {
+                        "type": "integer",
+                        "description": "Interval in milliseconds",
+                        "title": "Interval"
+                      },
+                      "min_rx": {
+                        "type": "integer",
+                        "description": "Rate in milliseconds",
+                        "title": "Min RX"
+                      },
+                      "multiplier": {
+                        "type": "integer",
+                        "minimum": 3,
+                        "maximum": 50,
+                        "title": "Multiplier"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "BFD"
+                  },
+                  "service_policy": {
+                    "type": "object",
+                    "properties": {
+                      "pbr": {
+                        "type": "object",
+                        "properties": {
+                          "input": {
+                            "type": "string",
+                            "description": "Policy Based Routing Policy-map name",
+                            "title": "Input"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "PBR"
+                      },
+                      "qos": {
+                        "type": "object",
+                        "properties": {
+                          "input": {
+                            "type": "string",
+                            "description": "Quality of Service Policy-map name",
+                            "title": "Input"
+                          }
+                        },
+                        "required": [
+                          "input"
+                        ],
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "QOS"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Service Policy"
+                  },
+                  "mpls": {
+                    "type": "object",
+                    "properties": {
+                      "ip": {
+                        "type": "boolean",
+                        "title": "IP"
+                      },
+                      "ldp": {
+                        "type": "object",
+                        "properties": {
+                          "interface": {
+                            "type": "boolean",
+                            "title": "Interface"
+                          },
+                          "igp_sync": {
+                            "type": "boolean",
+                            "title": "IGP Sync"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "LDP"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "MPLS"
+                  },
+                  "lacp_timer": {
+                    "type": "object",
+                    "properties": {
+                      "mode": {
+                        "type": "string",
+                        "enum": [
+                          "fast",
+                          "normal"
+                        ],
+                        "title": "Mode"
+                      },
+                      "multiplier": {
+                        "type": "integer",
+                        "minimum": 3,
+                        "maximum": 3000,
+                        "title": "Multiplier"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "LACP Timer"
+                  },
+                  "lacp_port_priority": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 65535,
+                    "title": "LACP Port Priority"
+                  },
+                  "transceiver": {
+                    "type": "object",
+                    "properties": {
+                      "media": {
+                        "type": "object",
+                        "properties": {
+                          "override": {
+                            "type": "string",
+                            "description": "Transceiver type",
+                            "title": "Override"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Media"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Transceiver"
+                  },
+                  "ip_proxy_arp": {
+                    "type": "boolean",
+                    "title": "IP Proxy ARP"
+                  },
+                  "traffic_policy": {
+                    "type": "object",
+                    "properties": {
+                      "input": {
+                        "type": "string",
+                        "description": "Ingress traffic policy",
+                        "title": "Input"
+                      },
+                      "output": {
+                        "type": "string",
+                        "description": "Egress traffic policy",
+                        "title": "Output"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Traffic Policy"
+                  },
+                  "bgp": {
+                    "type": "object",
+                    "properties": {
+                      "session_tracker": {
+                        "type": "string",
+                        "description": "Name of session tracker",
+                        "title": "Session Tracker"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "BGP"
+                  },
+                  "peer": {
+                    "type": "string",
+                    "description": "Key only used for documentation or validation purposes",
+                    "title": "Peer"
+                  },
+                  "peer_interface": {
+                    "type": "string",
+                    "description": "Key only used for documentation or validation purposes",
+                    "title": "Peer Interface"
+                  },
+                  "peer_type": {
+                    "type": "string",
+                    "description": "Key only used for documentation or validation purposes",
+                    "title": "Peer Type"
+                  },
+                  "sflow": {
+                    "type": "object",
+                    "properties": {
+                      "enable": {
+                        "type": "boolean",
+                        "title": "Enable"
+                      },
+                      "egress": {
+                        "type": "object",
+                        "properties": {
+                          "enable": {
+                            "type": "boolean",
+                            "title": "Enable"
+                          },
+                          "unmodified_enable": {
+                            "type": "boolean",
+                            "title": "Unmodified Enable"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Egress"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Sflow"
+                  },
+                  "port_profile": {
+                    "type": "string",
+                    "description": "Key only used for documentation or validation purposes",
+                    "title": "Port Profile"
+                  },
+                  "uc_tx_queues": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "description": "TX-Queue ID",
+                          "title": "ID"
+                        },
+                        "random_detect": {
+                          "type": "object",
+                          "properties": {
+                            "ecn": {
+                              "description": "Explicit Congestion Notification",
+                              "type": "object",
+                              "properties": {
+                                "count": {
+                                  "type": "boolean",
+                                  "description": "Enable counter for random-detect ECNs",
+                                  "title": "Count"
+                                },
+                                "threshold": {
+                                  "type": "object",
+                                  "properties": {
+                                    "units": {
+                                      "type": "string",
+                                      "enum": [
+                                        "segments",
+                                        "bytes",
+                                        "kbytes",
+                                        "mbytes",
+                                        "milliseconds"
+                                      ],
+                                      "description": "Indicate the units to be used for the threshold values",
+                                      "title": "Units"
+                                    },
+                                    "min": {
+                                      "type": "integer",
+                                      "minimum": 1,
+                                      "maximum": 256000000,
+                                      "description": "Set the random-detect ECN minimum-threshold",
+                                      "title": "Min"
+                                    },
+                                    "max": {
+                                      "type": "integer",
+                                      "minimum": 1,
+                                      "maximum": 256000000,
+                                      "description": "Set the random-detect ECN maximum-threshold",
+                                      "title": "Max"
+                                    },
+                                    "max_probability": {
+                                      "type": "integer",
+                                      "minimum": 1,
+                                      "maximum": 100,
+                                      "description": "Set the random-detect ECN max-mark-probability",
+                                      "title": "Max Probability"
+                                    },
+                                    "weight": {
+                                      "type": "integer",
+                                      "minimum": 0,
+                                      "maximum": 15,
+                                      "description": "Set the random-detect ECN weight",
+                                      "title": "Weight"
+                                    }
+                                  },
+                                  "required": [
+                                    "units",
+                                    "min",
+                                    "max"
+                                  ],
+                                  "additionalProperties": false,
+                                  "patternProperties": {
+                                    "^_.+$": {}
+                                  },
+                                  "title": "Threshold"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Ecn"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Random Detect"
+                        }
+                      },
+                      "required": [
+                        "id"
+                      ],
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      }
+                    },
+                    "title": "Uc TX Queues"
+                  },
+                  "tx_queues": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "description": "TX-Queue ID",
+                          "title": "ID"
+                        },
+                        "random_detect": {
+                          "type": "object",
+                          "properties": {
+                            "ecn": {
+                              "description": "Explicit Congestion Notification",
+                              "type": "object",
+                              "properties": {
+                                "count": {
+                                  "type": "boolean",
+                                  "description": "Enable counter for random-detect ECNs",
+                                  "title": "Count"
+                                },
+                                "threshold": {
+                                  "type": "object",
+                                  "properties": {
+                                    "units": {
+                                      "type": "string",
+                                      "enum": [
+                                        "segments",
+                                        "bytes",
+                                        "kbytes",
+                                        "mbytes",
+                                        "milliseconds"
+                                      ],
+                                      "description": "Indicate the units to be used for the threshold values",
+                                      "title": "Units"
+                                    },
+                                    "min": {
+                                      "type": "integer",
+                                      "minimum": 1,
+                                      "maximum": 256000000,
+                                      "description": "Set the random-detect ECN minimum-threshold",
+                                      "title": "Min"
+                                    },
+                                    "max": {
+                                      "type": "integer",
+                                      "minimum": 1,
+                                      "maximum": 256000000,
+                                      "description": "Set the random-detect ECN maximum-threshold",
+                                      "title": "Max"
+                                    },
+                                    "max_probability": {
+                                      "type": "integer",
+                                      "minimum": 1,
+                                      "maximum": 100,
+                                      "description": "Set the random-detect ECN max-mark-probability",
+                                      "title": "Max Probability"
+                                    },
+                                    "weight": {
+                                      "type": "integer",
+                                      "minimum": 0,
+                                      "maximum": 15,
+                                      "description": "Set the random-detect ECN weight",
+                                      "title": "Weight"
+                                    }
+                                  },
+                                  "required": [
+                                    "units",
+                                    "max",
+                                    "max_probability"
+                                  ],
+                                  "additionalProperties": false,
+                                  "patternProperties": {
+                                    "^_.+$": {}
+                                  },
+                                  "title": "Threshold"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Ecn"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Random Detect"
+                        }
+                      },
+                      "required": [
+                        "id"
+                      ],
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      }
+                    },
+                    "title": "TX Queues"
+                  },
+                  "vrrp_ids": {
+                    "type": "array",
+                    "description": "VRRP model.",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "description": "VRID",
+                          "title": "ID"
+                        },
+                        "priority_level": {
+                          "type": "integer",
+                          "description": "Instance priority",
+                          "minimum": 1,
+                          "maximum": 254,
+                          "title": "Priority Level"
+                        },
+                        "advertisement": {
+                          "type": "object",
+                          "properties": {
+                            "interval": {
+                              "type": "integer",
+                              "description": "Interval in seconds",
+                              "minimum": 1,
+                              "maximum": 255,
+                              "title": "Interval"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Advertisement"
+                        },
+                        "preempt": {
+                          "type": "object",
+                          "properties": {
+                            "enabled": {
+                              "type": "boolean",
+                              "title": "Enabled"
+                            },
+                            "delay": {
+                              "type": "object",
+                              "properties": {
+                                "minimum": {
+                                  "type": "integer",
+                                  "description": "Minimum preempt delay in seconds",
+                                  "minimum": 0,
+                                  "maximum": 3600,
+                                  "title": "Minimum"
+                                },
+                                "reload": {
+                                  "type": "integer",
+                                  "description": "Reload preempt delay in seconds",
+                                  "minimum": 0,
+                                  "maximum": 3600,
+                                  "title": "Reload"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Delay"
+                            }
+                          },
+                          "required": [
+                            "enabled"
+                          ],
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Preempt"
+                        },
+                        "timers": {
+                          "type": "object",
+                          "properties": {
+                            "delay": {
+                              "type": "object",
+                              "properties": {
+                                "reload": {
+                                  "type": "integer",
+                                  "description": "Delay after reload in seconds.",
+                                  "minimum": 0,
+                                  "maximum": 3600,
+                                  "title": "Reload"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Delay"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Timers"
+                        },
+                        "tracked_object": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "string",
+                                "description": "Tracked object name",
+                                "title": "Name"
+                              },
+                              "decrement": {
+                                "type": "integer",
+                                "minimum": 1,
+                                "maximum": 254,
+                                "description": "Decrement VRRP priority by 1-254",
+                                "title": "Decrement"
+                              },
+                              "shutdown": {
+                                "type": "boolean",
+                                "title": "Shutdown"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            },
+                            "required": [
+                              "name"
+                            ]
+                          },
+                          "title": "Tracked Object"
+                        },
+                        "ipv4": {
+                          "type": "object",
+                          "properties": {
+                            "address": {
+                              "type": "string",
+                              "description": "Virtual IPv4 address",
+                              "title": "Address"
+                            },
+                            "version": {
+                              "type": "integer",
+                              "enum": [
+                                2,
+                                3
+                              ],
+                              "title": "Version"
+                            }
+                          },
+                          "required": [
+                            "address"
+                          ],
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "IPv4"
+                        },
+                        "ipv6": {
+                          "type": "object",
+                          "properties": {
+                            "address": {
+                              "type": "string",
+                              "description": "Virtual IPv6 address",
+                              "title": "Address"
+                            }
+                          },
+                          "required": [
+                            "address"
+                          ],
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "IPv6"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      },
+                      "required": [
+                        "id"
+                      ]
+                    },
+                    "title": "VRRP IDs"
+                  },
+                  "eos_cli": {
+                    "type": "string",
+                    "description": "Multiline EOS CLI rendered directly on the ethernet interface in the final EOS configuration",
+                    "title": "EOS CLI"
+                  }
+                },
+                "additionalProperties": false,
+                "patternProperties": {
+                  "^_.+$": {}
+                },
+                "title": "Structured Config"
+              }
+            },
+            "additionalProperties": false,
+            "patternProperties": {
+              "^_.+$": {}
+            },
+            "required": [
+              "name"
+            ]
+          },
+          "title": "L3 Interfaces Profiles"
+        },
+        "l3_interfaces": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "node": {
+                "type": "string",
+                "description": "Device on which the interface should be configured.",
+                "title": "Node"
+              },
+              "profile": {
+                "type": "string",
+                "description": "L3 interface profile name. Profile defined under l3_interfaces_profiles.",
+                "title": "Profile"
+              },
+              "speed": {
+                "type": "string",
+                "description": "Speed should be set in the format `<interface_speed>` or `forced <interface_speed>` or `auto <interface_speed>`.",
+                "title": "Speed"
+              },
+              "vrf": {
+                "type": "string",
+                "description": "VRF to configure on the interface. (default VRF if not set).",
+                "title": "VRF"
+              },
+              "ip": {
+                "type": "string",
+                "description": "Node IPv4 address/Mask or dhcp.",
+                "title": "IP"
+              },
+              "dhcp_client_accept_default_route": {
+                "type": "boolean",
+                "description": "Supported if `ip` is `dhcp`.\nAccepts default route from DHCP, default False.",
+                "title": "DHCP Client Accept Default Route"
+              },
+              "ipv6_enable": {
+                "type": "boolean",
+                "default": false,
+                "description": "Allows turning on ipv6 for the interface or profile.",
+                "title": "IPv6 Enable"
+              },
+              "interface": {
+                "type": "string",
+                "description": "Must be an Ethernet interface like 'Ethernet2'.",
+                "title": "Interface"
+              },
+              "peer": {
+                "type": "string",
+                "description": "The peer device name. Used for description and documentation",
+                "title": "Peer"
+              },
+              "peer_interface": {
+                "type": "string",
+                "description": "The peer device interface. Used for description and documentation",
+                "title": "Peer Interface"
+              },
+              "peer_ip": {
+                "type": "string",
+                "description": "The peer device IP. Used for description and documentation",
+                "title": "Peer IP"
+              },
+              "bgp_as": {
+                "type": "string",
+                "description": "AS numbers for BGP.\nRequired with bgp peering.\n",
+                "title": "BGP As"
+              },
+              "peer_bgp_as": {
+                "type": "string",
+                "description": "AS numbers for BGP for the remote peer.\nIf not provided, `bgp_as` is used.\n",
+                "title": "Peer BGP As"
+              },
+              "description": {
+                "type": "string",
+                "description": "Interface description.",
+                "title": "Description"
+              },
+              "bfd": {
+                "type": "boolean",
+                "default": false,
+                "description": "Enable BFD (only considered for BGP).",
+                "title": "BFD"
+              },
+              "qos_profile": {
+                "type": "string",
+                "description": "QOS service profile.",
+                "title": "QOS Profile"
+              },
+              "subinterfaces": {
+                "type": "array",
+                "description": "Configure subinterfaces, each in their own VRF under the interface.",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "vrf": {
+                      "type": "string",
+                      "description": "Name of the VRF to configure for this subinterface\nThe VRF MUST exist in `network_services`",
+                      "title": "VRF"
+                    },
+                    "subinterface_id": {
+                      "type": "integer",
+                      "description": "Optional ID to overwrite the default one used from the VRF.\n`vrf_id` is used otherwise.",
+                      "title": "Subinterface ID"
+                    },
+                    "description": {
+                      "type": "string",
+                      "description": "Optional description for the subinterface.",
+                      "title": "Description"
+                    },
+                    "structured_config": {
+                      "type": "object",
+                      "description": "Custom structured config for the subinterface.\nNote! The content of this dictionary is _not_ validated by the schema, since it can be either ethernet_interfaces or port_channel_interfaces.",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "title": "Name"
+                        },
+                        "description": {
+                          "type": "string",
+                          "title": "Description"
+                        },
+                        "shutdown": {
+                          "type": "boolean",
+                          "title": "Shutdown"
+                        },
+                        "load_interval": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "maximum": 600,
+                          "description": "Interval in seconds for updating interface counters\"",
+                          "title": "Load Interval"
+                        },
+                        "speed": {
+                          "type": "string",
+                          "description": "Speed should be set in the format `<interface_speed>` or `forced <interface_speed>` or `auto <interface_speed>`.",
+                          "title": "Speed"
+                        },
+                        "mtu": {
+                          "type": "integer",
+                          "minimum": 68,
+                          "maximum": 65535,
+                          "title": "MTU"
+                        },
+                        "l2_mtu": {
+                          "type": "integer",
+                          "minimum": 68,
+                          "maximum": 65535,
+                          "description": "\"l2_mtu\" should only be defined for platforms supporting the \"l2 mtu\" CLI\n",
+                          "title": "L2 MTU"
+                        },
+                        "l2_mru": {
+                          "type": "integer",
+                          "minimum": 68,
+                          "maximum": 65535,
+                          "description": "\"l2_mru\" should only be defined for platforms supporting the \"l2 mru\" CLI\n",
+                          "title": "L2 MRU"
+                        },
+                        "vlans": {
+                          "type": "string",
+                          "description": "List of switchport vlans as string\nFor a trunk port this would be a range like \"1-200,300\"\nFor an access port this would be a single vlan \"123\"\n",
+                          "title": "VLANs"
+                        },
+                        "native_vlan": {
+                          "type": "integer",
+                          "title": "Native VLAN"
+                        },
+                        "native_vlan_tag": {
+                          "type": "boolean",
+                          "description": "If setting both native_vlan and native_vlan_tag, native_vlan_tag takes precedence",
+                          "title": "Native VLAN Tag"
+                        },
+                        "mode": {
+                          "type": "string",
+                          "enum": [
+                            "access",
+                            "dot1q-tunnel",
+                            "trunk",
+                            "trunk phone"
+                          ],
+                          "title": "Mode"
+                        },
+                        "phone": {
+                          "type": "object",
+                          "properties": {
+                            "trunk": {
+                              "type": "string",
+                              "enum": [
+                                "tagged",
+                                "tagged phone",
+                                "untagged",
+                                "untagged phone"
+                              ],
+                              "title": "Trunk"
+                            },
+                            "vlan": {
+                              "type": "integer",
+                              "minimum": 1,
+                              "maximum": 4094,
+                              "title": "VLAN"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Phone"
+                        },
+                        "l2_protocol": {
+                          "type": "object",
+                          "properties": {
+                            "encapsulation_dot1q_vlan": {
+                              "type": "integer",
+                              "description": "Vlan tag to configure on sub-interface",
+                              "title": "Encapsulation Dot1Q VLAN"
+                            },
+                            "forwarding_profile": {
+                              "type": "string",
+                              "description": "L2 protocol forwarding profile",
+                              "title": "Forwarding Profile"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "L2 Protocol"
+                        },
+                        "trunk_groups": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "title": "Trunk Groups"
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "routed",
+                            "switched",
+                            "l3dot1q",
+                            "l2dot1q",
+                            "port-channel-member"
+                          ],
+                          "description": "l3dot1q and l2dot1q are used for sub-interfaces. The parent interface should be defined as routed.\nInterface will not be listed in device documentation, unless \"type\" is set.\n",
+                          "title": "Type"
+                        },
+                        "snmp_trap_link_change": {
+                          "type": "boolean",
+                          "title": "Snmp Trap Link Change"
+                        },
+                        "address_locking": {
+                          "type": "object",
+                          "properties": {
+                            "ipv4": {
+                              "type": "boolean",
+                              "description": "Enable address locking for IPv4",
+                              "title": "IPv4"
+                            },
+                            "ipv6": {
+                              "type": "boolean",
+                              "description": "Enable address locking for IPv6",
+                              "title": "IPv6"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Address Locking"
+                        },
+                        "flowcontrol": {
+                          "type": "object",
+                          "properties": {
+                            "received": {
+                              "type": "string",
+                              "enum": [
+                                "desired",
+                                "on",
+                                "off"
+                              ],
+                              "title": "Received"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Flowcontrol"
+                        },
+                        "vrf": {
+                          "type": "string",
+                          "description": "VRF name",
+                          "title": "VRF"
+                        },
+                        "flow_tracker": {
+                          "type": "object",
+                          "properties": {
+                            "sampled": {
+                              "type": "string",
+                              "description": "Sampled flow tracker name.",
+                              "title": "Sampled"
+                            },
+                            "hardware": {
+                              "type": "string",
+                              "description": "Hardware flow tracker name.",
+                              "title": "Hardware"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Flow Tracker"
+                        },
+                        "error_correction_encoding": {
+                          "type": "object",
+                          "properties": {
+                            "enabled": {
+                              "type": "boolean",
+                              "default": true,
+                              "title": "Enabled"
+                            },
+                            "fire_code": {
+                              "type": "boolean",
+                              "title": "Fire Code"
+                            },
+                            "reed_solomon": {
+                              "type": "boolean",
+                              "title": "Reed Solomon"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Error Correction Encoding"
+                        },
+                        "link_tracking_groups": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "string",
+                                "description": "Group name",
+                                "title": "Name"
+                              },
+                              "direction": {
+                                "type": "string",
+                                "enum": [
+                                  "upstream",
+                                  "downstream"
+                                ],
+                                "title": "Direction"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            },
+                            "required": [
+                              "name"
+                            ]
+                          },
+                          "title": "Link Tracking Groups"
+                        },
+                        "evpn_ethernet_segment": {
+                          "type": "object",
+                          "properties": {
+                            "identifier": {
+                              "type": "string",
+                              "description": "EVPN Ethernet Segment Identifier (Type 1 format)",
+                              "title": "Identifier"
+                            },
+                            "redundancy": {
+                              "type": "string",
+                              "enum": [
+                                "all-active",
+                                "single-active"
+                              ],
+                              "title": "Redundancy"
+                            },
+                            "designated_forwarder_election": {
+                              "type": "object",
+                              "properties": {
+                                "algorithm": {
+                                  "type": "string",
+                                  "enum": [
+                                    "modulus",
+                                    "preference"
+                                  ],
+                                  "title": "Algorithm"
+                                },
+                                "preference_value": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "maximum": 65535,
+                                  "description": "Preference_value is only used when \"algorithm\" is \"preference\"",
+                                  "title": "Preference Value"
+                                },
+                                "dont_preempt": {
+                                  "type": "boolean",
+                                  "description": "Dont_preempt is only used when \"algorithm\" is \"preference\"",
+                                  "title": "Dont Preempt"
+                                },
+                                "hold_time": {
+                                  "type": "integer",
+                                  "title": "Hold Time"
+                                },
+                                "subsequent_hold_time": {
+                                  "type": "integer",
+                                  "title": "Subsequent Hold Time"
+                                },
+                                "candidate_reachability_required": {
+                                  "type": "boolean",
+                                  "title": "Candidate Reachability Required"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Designated Forwarder Election"
+                            },
+                            "mpls": {
+                              "type": "object",
+                              "properties": {
+                                "shared_index": {
+                                  "type": "integer",
+                                  "minimum": 1,
+                                  "maximum": 1024,
+                                  "title": "Shared Index"
+                                },
+                                "tunnel_flood_filter_time": {
+                                  "type": "integer",
+                                  "title": "Tunnel Flood Filter Time"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "MPLS"
+                            },
+                            "route_target": {
+                              "type": "string",
+                              "description": "EVPN Route Target for ESI with format xx:xx:xx:xx:xx:xx",
+                              "title": "Route Target"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "EVPN Ethernet Segment"
+                        },
+                        "encapsulation_dot1q_vlan": {
+                          "type": "integer",
+                          "description": "VLAN tag to configure on sub-interface",
+                          "title": "Encapsulation Dot1Q VLAN"
+                        },
+                        "encapsulation_vlan": {
+                          "type": "object",
+                          "properties": {
+                            "client": {
+                              "type": "object",
+                              "properties": {
+                                "dot1q": {
+                                  "type": "object",
+                                  "properties": {
+                                    "vlan": {
+                                      "type": "integer",
+                                      "description": "Client VLAN ID",
+                                      "title": "VLAN"
+                                    },
+                                    "outer": {
+                                      "type": "integer",
+                                      "description": "Client Outer VLAN ID",
+                                      "title": "Outer"
+                                    },
+                                    "inner": {
+                                      "type": "integer",
+                                      "description": "Client Inner VLAN ID",
+                                      "title": "Inner"
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "patternProperties": {
+                                    "^_.+$": {}
+                                  },
+                                  "title": "Dot1Q"
+                                },
+                                "unmatched": {
+                                  "type": "boolean",
+                                  "title": "Unmatched"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Client"
+                            },
+                            "network": {
+                              "type": "object",
+                              "description": "Network encapsulations are all optional and skipped if using client unmatched",
+                              "properties": {
+                                "dot1q": {
+                                  "type": "object",
+                                  "properties": {
+                                    "vlan": {
+                                      "type": "integer",
+                                      "description": "Network VLAN ID",
+                                      "title": "VLAN"
+                                    },
+                                    "outer": {
+                                      "type": "integer",
+                                      "description": "Network outer VLAN ID",
+                                      "title": "Outer"
+                                    },
+                                    "inner": {
+                                      "type": "integer",
+                                      "description": "Network inner VLAN ID",
+                                      "title": "Inner"
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "patternProperties": {
+                                    "^_.+$": {}
+                                  },
+                                  "title": "Dot1Q"
+                                },
+                                "client": {
+                                  "type": "boolean",
+                                  "title": "Client"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Network"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Encapsulation VLAN"
+                        },
+                        "vlan_id": {
+                          "type": "integer",
+                          "minimum": 1,
+                          "maximum": 4094,
+                          "title": "VLAN ID"
+                        },
+                        "ip_address": {
+                          "type": "string",
+                          "description": "IPv4 address/mask or \"dhcp\"",
+                          "title": "IP Address"
+                        },
+                        "ip_address_secondaries": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "title": "IP Address Secondaries"
+                        },
+                        "dhcp_client_accept_default_route": {
+                          "type": "boolean",
+                          "description": "Install default-route obtained via DHCP",
+                          "title": "DHCP Client Accept Default Route"
+                        },
+                        "dhcp_server_ipv4": {
+                          "type": "boolean",
+                          "description": "Enable IPv4 DHCP server.",
+                          "title": "DHCP Server IPv4"
+                        },
+                        "dhcp_server_ipv6": {
+                          "type": "boolean",
+                          "description": "Enable IPv6 DHCP server.",
+                          "title": "DHCP Server IPv6"
+                        },
+                        "ip_helpers": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "ip_helper": {
+                                "type": "string",
+                                "title": "IP Helper"
+                              },
+                              "source_interface": {
+                                "type": "string",
+                                "description": "Source interface name",
+                                "title": "Source Interface"
+                              },
+                              "vrf": {
+                                "type": "string",
+                                "description": "VRF name",
+                                "title": "VRF"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            },
+                            "required": [
+                              "ip_helper"
+                            ]
+                          },
+                          "title": "IP Helpers"
+                        },
+                        "ip_nat": {
+                          "type": "object",
+                          "properties": {
+                            "service_profile": {
+                              "type": "string",
+                              "description": "NAT interface profile.",
+                              "title": "Service Profile"
+                            },
+                            "destination": {
+                              "type": "object",
+                              "properties": {
+                                "dynamic": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "access_list": {
+                                        "type": "string",
+                                        "title": "Access List"
+                                      },
+                                      "comment": {
+                                        "type": "string",
+                                        "title": "Comment"
+                                      },
+                                      "pool_name": {
+                                        "type": "string",
+                                        "title": "Pool Name"
+                                      },
+                                      "priority": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "maximum": 4294967295,
+                                        "title": "Priority"
+                                      }
+                                    },
+                                    "required": [
+                                      "pool_name",
+                                      "access_list"
+                                    ],
+                                    "additionalProperties": false,
+                                    "patternProperties": {
+                                      "^_.+$": {}
+                                    }
+                                  },
+                                  "title": "Dynamic"
+                                },
+                                "static": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "access_list": {
+                                        "type": "string",
+                                        "description": "'access_list' and 'group' are mutual exclusive",
+                                        "title": "Access List"
+                                      },
+                                      "comment": {
+                                        "type": "string",
+                                        "title": "Comment"
+                                      },
+                                      "direction": {
+                                        "type": "string",
+                                        "enum": [
+                                          "egress",
+                                          "ingress"
+                                        ],
+                                        "description": "Egress or ingress can be the default. This depends on source/destination, EOS version, and hardware platform.\nEOS might remove this keyword in the configuration. So, check the configuration on targeted HW/SW.\n",
+                                        "title": "Direction"
+                                      },
+                                      "group": {
+                                        "type": "integer",
+                                        "minimum": 1,
+                                        "maximum": 65535,
+                                        "description": "'access_list' and 'group' are mutual exclusive",
+                                        "title": "Group"
+                                      },
+                                      "original_ip": {
+                                        "type": "string",
+                                        "description": "IPv4 address",
+                                        "title": "Original IP"
+                                      },
+                                      "original_port": {
+                                        "type": "integer",
+                                        "minimum": 1,
+                                        "maximum": 65535,
+                                        "title": "Original Port"
+                                      },
+                                      "priority": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "maximum": 4294967295,
+                                        "title": "Priority"
+                                      },
+                                      "protocol": {
+                                        "type": "string",
+                                        "enum": [
+                                          "udp",
+                                          "tcp"
+                                        ],
+                                        "title": "Protocol"
+                                      },
+                                      "translated_ip": {
+                                        "type": "string",
+                                        "description": "IPv4 address",
+                                        "title": "Translated IP"
+                                      },
+                                      "translated_port": {
+                                        "type": "integer",
+                                        "minimum": 1,
+                                        "maximum": 65535,
+                                        "description": "requires 'original_port'",
+                                        "title": "Translated Port"
+                                      }
+                                    },
+                                    "required": [
+                                      "translated_ip",
+                                      "original_ip"
+                                    ],
+                                    "additionalProperties": false,
+                                    "patternProperties": {
+                                      "^_.+$": {}
+                                    }
+                                  },
+                                  "title": "Static"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Destination"
+                            },
+                            "source": {
+                              "type": "object",
+                              "properties": {
+                                "dynamic": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "access_list": {
+                                        "type": "string",
+                                        "title": "Access List"
+                                      },
+                                      "comment": {
+                                        "type": "string",
+                                        "title": "Comment"
+                                      },
+                                      "nat_type": {
+                                        "type": "string",
+                                        "enum": [
+                                          "overload",
+                                          "pool",
+                                          "pool-address-only",
+                                          "pool-full-cone"
+                                        ],
+                                        "title": "Nat Type"
+                                      },
+                                      "pool_name": {
+                                        "type": "string",
+                                        "description": "required if 'nat_type' is pool, pool-address-only or pool-full-cone\nignored if 'nat_type' is overload\n",
+                                        "title": "Pool Name"
+                                      },
+                                      "priority": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "maximum": 4294967295,
+                                        "title": "Priority"
+                                      }
+                                    },
+                                    "required": [
+                                      "nat_type",
+                                      "access_list"
+                                    ],
+                                    "additionalProperties": false,
+                                    "patternProperties": {
+                                      "^_.+$": {}
+                                    }
+                                  },
+                                  "title": "Dynamic"
+                                },
+                                "static": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "access_list": {
+                                        "type": "string",
+                                        "description": "'access_list' and 'group' are mutual exclusive",
+                                        "title": "Access List"
+                                      },
+                                      "comment": {
+                                        "type": "string",
+                                        "title": "Comment"
+                                      },
+                                      "direction": {
+                                        "type": "string",
+                                        "enum": [
+                                          "egress",
+                                          "ingress"
+                                        ],
+                                        "description": "Egress or ingress can be the default. This depends on source/destination, EOS version, and hardware platform.\nEOS might remove this keyword in the configuration. So, check the configuration on targeted HW/SW.\n",
+                                        "title": "Direction"
+                                      },
+                                      "group": {
+                                        "type": "integer",
+                                        "minimum": 1,
+                                        "maximum": 65535,
+                                        "description": "'access_list' and 'group' are mutual exclusive",
+                                        "title": "Group"
+                                      },
+                                      "original_ip": {
+                                        "type": "string",
+                                        "description": "IPv4 address",
+                                        "title": "Original IP"
+                                      },
+                                      "original_port": {
+                                        "type": "integer",
+                                        "minimum": 1,
+                                        "maximum": 65535,
+                                        "title": "Original Port"
+                                      },
+                                      "priority": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "maximum": 4294967295,
+                                        "title": "Priority"
+                                      },
+                                      "protocol": {
+                                        "type": "string",
+                                        "enum": [
+                                          "udp",
+                                          "tcp"
+                                        ],
+                                        "title": "Protocol"
+                                      },
+                                      "translated_ip": {
+                                        "type": "string",
+                                        "description": "IPv4 address",
+                                        "title": "Translated IP"
+                                      },
+                                      "translated_port": {
+                                        "type": "integer",
+                                        "minimum": 1,
+                                        "maximum": 65535,
+                                        "description": "requires 'original_port'",
+                                        "title": "Translated Port"
+                                      }
+                                    },
+                                    "required": [
+                                      "translated_ip",
+                                      "original_ip"
+                                    ],
+                                    "additionalProperties": false,
+                                    "patternProperties": {
+                                      "^_.+$": {}
+                                    }
+                                  },
+                                  "title": "Static"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Source"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "IP Nat"
+                        },
+                        "ipv6_enable": {
+                          "type": "boolean",
+                          "title": "IPv6 Enable"
+                        },
+                        "ipv6_address": {
+                          "type": "string",
+                          "title": "IPv6 Address"
+                        },
+                        "ipv6_address_link_local": {
+                          "type": "string",
+                          "description": "Link local IPv6 address/mask",
+                          "title": "IPv6 Address Link Local"
+                        },
+                        "ipv6_nd_ra_disabled": {
+                          "type": "boolean",
+                          "title": "IPv6 ND RA Disabled"
+                        },
+                        "ipv6_nd_managed_config_flag": {
+                          "type": "boolean",
+                          "title": "IPv6 ND Managed Config Flag"
+                        },
+                        "ipv6_nd_prefixes": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "ipv6_prefix": {
+                                "type": "string",
+                                "title": "IPv6 Prefix"
+                              },
+                              "valid_lifetime": {
+                                "type": "string",
+                                "description": "Infinite or lifetime in seconds",
+                                "title": "Valid Lifetime"
+                              },
+                              "preferred_lifetime": {
+                                "type": "string",
+                                "description": "Infinite or lifetime in seconds",
+                                "title": "Preferred Lifetime"
+                              },
+                              "no_autoconfig_flag": {
+                                "type": "boolean",
+                                "title": "No Autoconfig Flag"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            },
+                            "required": [
+                              "ipv6_prefix"
+                            ]
+                          },
+                          "title": "IPv6 ND Prefixes"
+                        },
+                        "ipv6_dhcp_relay_destinations": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "address": {
+                                "type": "string",
+                                "description": "DHCP server's IPv6 address",
+                                "title": "Address"
+                              },
+                              "vrf": {
+                                "type": "string",
+                                "title": "VRF"
+                              },
+                              "local_interface": {
+                                "type": "string",
+                                "description": "Local interface to communicate with DHCP server - mutually exclusive to source_address",
+                                "title": "Local Interface"
+                              },
+                              "source_address": {
+                                "type": "string",
+                                "description": "Source IPv6 address to communicate with DHCP server - mutually exclusive to local_interface",
+                                "title": "Source Address"
+                              },
+                              "link_address": {
+                                "type": "string",
+                                "description": "Override the default link address specified in the relayed DHCP packet",
+                                "title": "Link Address"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            },
+                            "required": [
+                              "address"
+                            ]
+                          },
+                          "title": "IPv6 DHCP Relay Destinations"
+                        },
+                        "access_group_in": {
+                          "type": "string",
+                          "description": "Access list name",
+                          "title": "Access Group In"
+                        },
+                        "access_group_out": {
+                          "type": "string",
+                          "description": "Access list name",
+                          "title": "Access Group Out"
+                        },
+                        "ipv6_access_group_in": {
+                          "type": "string",
+                          "description": "IPv6 access list name",
+                          "title": "IPv6 Access Group In"
+                        },
+                        "ipv6_access_group_out": {
+                          "type": "string",
+                          "description": "IPv6 access list name",
+                          "title": "IPv6 Access Group Out"
+                        },
+                        "mac_access_group_in": {
+                          "type": "string",
+                          "description": "MAC access list name",
+                          "title": "MAC Access Group In"
+                        },
+                        "mac_access_group_out": {
+                          "type": "string",
+                          "description": "MAC access list name",
+                          "title": "MAC Access Group Out"
+                        },
+                        "multicast": {
+                          "type": "object",
+                          "description": "Boundaries can be either 1 ACL or a list of multicast IP address_range(s)/prefix but not combination of both",
+                          "properties": {
+                            "ipv4": {
+                              "type": "object",
+                              "properties": {
+                                "boundaries": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "boundary": {
+                                        "type": "string",
+                                        "description": "ACL name or multicast IP subnet",
+                                        "title": "Boundary"
+                                      },
+                                      "out": {
+                                        "type": "boolean",
+                                        "title": "Out"
+                                      }
+                                    },
+                                    "additionalProperties": false,
+                                    "patternProperties": {
+                                      "^_.+$": {}
+                                    }
+                                  },
+                                  "title": "Boundaries"
+                                },
+                                "static": {
+                                  "type": "boolean",
+                                  "title": "Static"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "IPv4"
+                            },
+                            "ipv6": {
+                              "type": "object",
+                              "properties": {
+                                "boundaries": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "boundary": {
+                                        "type": "string",
+                                        "description": "ACL name or multicast IP subnet",
+                                        "title": "Boundary"
+                                      }
+                                    },
+                                    "additionalProperties": false,
+                                    "patternProperties": {
+                                      "^_.+$": {}
+                                    }
+                                  },
+                                  "title": "Boundaries"
+                                },
+                                "static": {
+                                  "type": "boolean",
+                                  "title": "Static"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "IPv6"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Multicast"
+                        },
+                        "ospf_network_point_to_point": {
+                          "type": "boolean",
+                          "title": "OSPF Network Point To Point"
+                        },
+                        "ospf_area": {
+                          "type": "string",
+                          "title": "OSPF Area"
+                        },
+                        "ospf_cost": {
+                          "type": "integer",
+                          "title": "OSPF Cost"
+                        },
+                        "ospf_authentication": {
+                          "type": "string",
+                          "enum": [
+                            "none",
+                            "simple",
+                            "message-digest"
+                          ],
+                          "title": "OSPF Authentication"
+                        },
+                        "ospf_authentication_key": {
+                          "type": "string",
+                          "description": "Encrypted password - only type 7 supported",
+                          "title": "OSPF Authentication Key"
+                        },
+                        "ospf_message_digest_keys": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "integer",
+                                "title": "ID"
+                              },
+                              "hash_algorithm": {
+                                "type": "string",
+                                "enum": [
+                                  "md5",
+                                  "sha1",
+                                  "sha256",
+                                  "sha384",
+                                  "sha512"
+                                ],
+                                "title": "Hash Algorithm"
+                              },
+                              "key": {
+                                "type": "string",
+                                "description": "Encrypted password - only type 7 supported",
+                                "title": "Key"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            },
+                            "required": [
+                              "id"
+                            ]
+                          },
+                          "title": "OSPF Message Digest Keys"
+                        },
+                        "pim": {
+                          "type": "object",
+                          "properties": {
+                            "ipv4": {
+                              "type": "object",
+                              "properties": {
+                                "dr_priority": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "maximum": 429467295,
+                                  "title": "DR Priority"
+                                },
+                                "sparse_mode": {
+                                  "type": "boolean",
+                                  "title": "Sparse Mode"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "IPv4"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "PIM"
+                        },
+                        "mac_security": {
+                          "type": "object",
+                          "properties": {
+                            "profile": {
+                              "type": "string",
+                              "title": "Profile"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "MAC Security"
+                        },
+                        "channel_group": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "integer",
+                              "title": "ID"
+                            },
+                            "mode": {
+                              "type": "string",
+                              "enum": [
+                                "on",
+                                "active",
+                                "passive"
+                              ],
+                              "title": "Mode"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Channel Group"
+                        },
+                        "isis_enable": {
+                          "type": "string",
+                          "description": "ISIS instance",
+                          "title": "ISIS Enable"
+                        },
+                        "isis_passive": {
+                          "type": "boolean",
+                          "title": "ISIS Passive"
+                        },
+                        "isis_metric": {
+                          "type": "integer",
+                          "title": "ISIS Metric"
+                        },
+                        "isis_network_point_to_point": {
+                          "type": "boolean",
+                          "title": "ISIS Network Point To Point"
+                        },
+                        "isis_circuit_type": {
+                          "type": "string",
+                          "enum": [
+                            "level-1-2",
+                            "level-1",
+                            "level-2"
+                          ],
+                          "title": "ISIS Circuit Type"
+                        },
+                        "isis_hello_padding": {
+                          "type": "boolean",
+                          "title": "ISIS Hello Padding"
+                        },
+                        "isis_authentication_mode": {
+                          "type": "string",
+                          "enum": [
+                            "text",
+                            "md5"
+                          ],
+                          "title": "ISIS Authentication Mode"
+                        },
+                        "isis_authentication_key": {
+                          "type": "string",
+                          "description": "Type-7 encrypted password",
+                          "title": "ISIS Authentication Key"
+                        },
+                        "poe": {
+                          "type": "object",
+                          "properties": {
+                            "disabled": {
+                              "type": "boolean",
+                              "description": "Disable PoE on a POE capable port. PoE is enabled on all ports that support it by default in EOS.",
+                              "default": false,
+                              "title": "Disabled"
+                            },
+                            "priority": {
+                              "type": "string",
+                              "enum": [
+                                "critical",
+                                "high",
+                                "medium",
+                                "low"
+                              ],
+                              "description": "Prioritize a port's power in the event that one of the switch's power supplies loses power",
+                              "title": "Priority"
+                            },
+                            "reboot": {
+                              "description": "Set the PoE power behavior for a PoE port when the system is rebooted",
+                              "type": "object",
+                              "properties": {
+                                "action": {
+                                  "type": "string",
+                                  "enum": [
+                                    "maintain",
+                                    "power-off"
+                                  ],
+                                  "description": "PoE action for interface",
+                                  "title": "Action"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Reboot"
+                            },
+                            "link_down": {
+                              "description": "Set the PoE power behavior for a PoE port when the port goes down",
+                              "type": "object",
+                              "properties": {
+                                "action": {
+                                  "type": "string",
+                                  "enum": [
+                                    "maintain",
+                                    "power-off"
+                                  ],
+                                  "description": "PoE action for interface",
+                                  "title": "Action"
+                                },
+                                "power_off_delay": {
+                                  "type": "integer",
+                                  "minimum": 1,
+                                  "maximum": 86400,
+                                  "description": "Number of seconds to delay shutting the power off after a link down event occurs. Default value is 5 seconds in EOS.",
+                                  "title": "Power Off Delay"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Link Down"
+                            },
+                            "shutdown": {
+                              "description": "Set the PoE power behavior for a PoE port when the port is admin down",
+                              "type": "object",
+                              "properties": {
+                                "action": {
+                                  "type": "string",
+                                  "enum": [
+                                    "maintain",
+                                    "power-off"
+                                  ],
+                                  "description": "PoE action for interface",
+                                  "title": "Action"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Shutdown"
+                            },
+                            "limit": {
+                              "type": "object",
+                              "description": "Override the hardware-negotiated power limit using either wattage or a power class. Note that if using a power class, AVD will automatically convert the class value to the wattage value corresponding to that power class.",
+                              "properties": {
+                                "class": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "maximum": 8,
+                                  "title": "Class"
+                                },
+                                "watts": {
+                                  "type": "string",
+                                  "title": "Watts"
+                                },
+                                "fixed": {
+                                  "type": "boolean",
+                                  "description": "Set to ignore hardware classification",
+                                  "title": "Fixed"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Limit"
+                            },
+                            "negotiation_lldp": {
+                              "type": "boolean",
+                              "description": "Disable to prevent port from negotiating power with powered devices over LLDP. Enabled by default in EOS.",
+                              "title": "Negotiation LLDP"
+                            },
+                            "legacy_detect": {
+                              "type": "boolean",
+                              "description": "Allow a subset of legacy devices to work with the PoE switch. Disabled by default in EOS because it can cause false positive detections.",
+                              "title": "Legacy Detect"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "PoE"
+                        },
+                        "ptp": {
+                          "type": "object",
+                          "properties": {
+                            "enable": {
+                              "type": "boolean",
+                              "title": "Enable"
+                            },
+                            "announce": {
+                              "type": "object",
+                              "properties": {
+                                "interval": {
+                                  "type": "integer",
+                                  "title": "Interval"
+                                },
+                                "timeout": {
+                                  "type": "integer",
+                                  "title": "Timeout"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Announce"
+                            },
+                            "delay_req": {
+                              "type": "integer",
+                              "title": "Delay Req"
+                            },
+                            "delay_mechanism": {
+                              "type": "string",
+                              "enum": [
+                                "e2e",
+                                "p2p"
+                              ],
+                              "title": "Delay Mechanism"
+                            },
+                            "sync_message": {
+                              "type": "object",
+                              "properties": {
+                                "interval": {
+                                  "type": "integer",
+                                  "title": "Interval"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Sync Message"
+                            },
+                            "role": {
+                              "type": "string",
+                              "enum": [
+                                "master",
+                                "dynamic"
+                              ],
+                              "title": "Role"
+                            },
+                            "vlan": {
+                              "type": "string",
+                              "description": "VLAN can be 'all' or list of vlans as string",
+                              "title": "VLAN"
+                            },
+                            "transport": {
+                              "type": "string",
+                              "enum": [
+                                "ipv4",
+                                "ipv6",
+                                "layer2"
+                              ],
+                              "title": "Transport"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "PTP"
+                        },
+                        "profile": {
+                          "type": "string",
+                          "description": "Interface profile",
+                          "title": "Profile"
+                        },
+                        "storm_control": {
+                          "type": "object",
+                          "properties": {
+                            "all": {
+                              "type": "object",
+                              "properties": {
+                                "level": {
+                                  "type": "string",
+                                  "description": "Configure maximum storm-control level",
+                                  "title": "Level"
+                                },
+                                "unit": {
+                                  "type": "string",
+                                  "default": "percent",
+                                  "enum": [
+                                    "percent",
+                                    "pps"
+                                  ],
+                                  "description": "Optional field and is hardware dependent",
+                                  "title": "Unit"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "All"
+                            },
+                            "broadcast": {
+                              "type": "object",
+                              "properties": {
+                                "level": {
+                                  "type": "string",
+                                  "description": "Configure maximum storm-control level",
+                                  "title": "Level"
+                                },
+                                "unit": {
+                                  "type": "string",
+                                  "default": "percent",
+                                  "enum": [
+                                    "percent",
+                                    "pps"
+                                  ],
+                                  "description": "Optional field and is hardware dependent",
+                                  "title": "Unit"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Broadcast"
+                            },
+                            "multicast": {
+                              "type": "object",
+                              "properties": {
+                                "level": {
+                                  "type": "string",
+                                  "description": "Configure maximum storm-control level",
+                                  "title": "Level"
+                                },
+                                "unit": {
+                                  "type": "string",
+                                  "default": "percent",
+                                  "enum": [
+                                    "percent",
+                                    "pps"
+                                  ],
+                                  "description": "Optional field and is hardware dependent",
+                                  "title": "Unit"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Multicast"
+                            },
+                            "unknown_unicast": {
+                              "type": "object",
+                              "properties": {
+                                "level": {
+                                  "type": "string",
+                                  "description": "Configure maximum storm-control level",
+                                  "title": "Level"
+                                },
+                                "unit": {
+                                  "type": "string",
+                                  "default": "percent",
+                                  "enum": [
+                                    "percent",
+                                    "pps"
+                                  ],
+                                  "description": "Optional field and is hardware dependent",
+                                  "title": "Unit"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Unknown Unicast"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Storm Control"
+                        },
+                        "logging": {
+                          "type": "object",
+                          "properties": {
+                            "event": {
+                              "type": "object",
+                              "properties": {
+                                "link_status": {
+                                  "type": "boolean",
+                                  "title": "Link Status"
+                                },
+                                "congestion_drops": {
+                                  "type": "boolean",
+                                  "title": "Congestion Drops"
+                                },
+                                "spanning_tree": {
+                                  "type": "boolean",
+                                  "title": "Spanning Tree"
+                                },
+                                "storm_control_discards": {
+                                  "type": "boolean",
+                                  "title": "Storm Control Discards"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Event"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Logging"
+                        },
+                        "lldp": {
+                          "type": "object",
+                          "properties": {
+                            "transmit": {
+                              "type": "boolean",
+                              "title": "Transmit"
+                            },
+                            "receive": {
+                              "type": "boolean",
+                              "title": "Receive"
+                            },
+                            "ztp_vlan": {
+                              "type": "integer",
+                              "description": "ZTP vlan number",
+                              "title": "ZTP VLAN"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "LLDP"
+                        },
+                        "trunk_private_vlan_secondary": {
+                          "type": "boolean",
+                          "title": "Trunk Private VLAN Secondary"
+                        },
+                        "pvlan_mapping": {
+                          "type": "string",
+                          "description": "List of vlans as string",
+                          "title": "PVLAN Mapping"
+                        },
+                        "vlan_translations": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "from": {
+                                "type": "string",
+                                "description": "List of vlans as string (only one vlan if direction is \"both\")",
+                                "title": "From"
+                              },
+                              "to": {
+                                "type": "integer",
+                                "description": "VLAN ID",
+                                "title": "To"
+                              },
+                              "direction": {
+                                "type": "string",
+                                "enum": [
+                                  "in",
+                                  "out",
+                                  "both"
+                                ],
+                                "default": "both",
+                                "title": "Direction"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            }
+                          },
+                          "title": "VLAN Translations"
+                        },
+                        "dot1x": {
+                          "type": "object",
+                          "properties": {
+                            "port_control": {
+                              "type": "string",
+                              "enum": [
+                                "auto",
+                                "force-authorized",
+                                "force-unauthorized"
+                              ],
+                              "title": "Port Control"
+                            },
+                            "port_control_force_authorized_phone": {
+                              "type": "boolean",
+                              "title": "Port Control Force Authorized Phone"
+                            },
+                            "reauthentication": {
+                              "type": "boolean",
+                              "title": "Reauthentication"
+                            },
+                            "pae": {
+                              "type": "object",
+                              "properties": {
+                                "mode": {
+                                  "type": "string",
+                                  "enum": [
+                                    "authenticator"
+                                  ],
+                                  "title": "Mode"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "PAE"
+                            },
+                            "authentication_failure": {
+                              "type": "object",
+                              "properties": {
+                                "action": {
+                                  "type": "string",
+                                  "enum": [
+                                    "allow",
+                                    "drop"
+                                  ],
+                                  "title": "Action"
+                                },
+                                "allow_vlan": {
+                                  "type": "integer",
+                                  "minimum": 1,
+                                  "maximum": 4094,
+                                  "title": "Allow VLAN"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Authentication Failure"
+                            },
+                            "host_mode": {
+                              "type": "object",
+                              "properties": {
+                                "mode": {
+                                  "type": "string",
+                                  "enum": [
+                                    "multi-host",
+                                    "single-host"
+                                  ],
+                                  "title": "Mode"
+                                },
+                                "multi_host_authenticated": {
+                                  "type": "boolean",
+                                  "title": "Multi Host Authenticated"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Host Mode"
+                            },
+                            "mac_based_authentication": {
+                              "type": "object",
+                              "properties": {
+                                "enabled": {
+                                  "type": "boolean",
+                                  "title": "Enabled"
+                                },
+                                "always": {
+                                  "type": "boolean",
+                                  "title": "Always"
+                                },
+                                "host_mode_common": {
+                                  "type": "boolean",
+                                  "title": "Host Mode Common"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "MAC Based Authentication"
+                            },
+                            "timeout": {
+                              "type": "object",
+                              "properties": {
+                                "idle_host": {
+                                  "type": "integer",
+                                  "minimum": 10,
+                                  "maximum": 65535,
+                                  "title": "Idle Host"
+                                },
+                                "quiet_period": {
+                                  "type": "integer",
+                                  "minimum": 1,
+                                  "maximum": 65535,
+                                  "title": "Quiet Period"
+                                },
+                                "reauth_period": {
+                                  "type": "string",
+                                  "description": "Value can be 60-4294967295 or 'server'",
+                                  "title": "Reauth Period"
+                                },
+                                "reauth_timeout_ignore": {
+                                  "type": "boolean",
+                                  "title": "Reauth Timeout Ignore"
+                                },
+                                "tx_period": {
+                                  "type": "integer",
+                                  "minimum": 1,
+                                  "maximum": 65535,
+                                  "title": "TX Period"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Timeout"
+                            },
+                            "reauthorization_request_limit": {
+                              "type": "integer",
+                              "minimum": 1,
+                              "maximum": 10,
+                              "title": "Reauthorization Request Limit"
+                            },
+                            "unauthorized": {
+                              "type": "object",
+                              "properties": {
+                                "access_vlan_membership_egress": {
+                                  "type": "boolean",
+                                  "title": "Access VLAN Membership Egress"
+                                },
+                                "native_vlan_membership_egress": {
+                                  "type": "boolean",
+                                  "title": "Native VLAN Membership Egress"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Unauthorized"
+                            },
+                            "eapol": {
+                              "type": "object",
+                              "properties": {
+                                "disabled": {
+                                  "type": "boolean",
+                                  "title": "Disabled"
+                                },
+                                "authentication_failure_fallback_mba": {
+                                  "type": "object",
+                                  "properties": {
+                                    "enabled": {
+                                      "type": "boolean",
+                                      "title": "Enabled"
+                                    },
+                                    "timeout": {
+                                      "type": "integer",
+                                      "minimum": 0,
+                                      "maximum": 65535,
+                                      "title": "Timeout"
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "patternProperties": {
+                                    "^_.+$": {}
+                                  },
+                                  "title": "Authentication Failure Fallback Mba"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Eapol"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "dot1x"
+                        },
+                        "service_profile": {
+                          "type": "string",
+                          "description": "QOS profile",
+                          "title": "Service Profile"
+                        },
+                        "shape": {
+                          "type": "object",
+                          "properties": {
+                            "rate": {
+                              "type": "string",
+                              "description": "Rate in kbps, pps or percent\nSupported options are platform dependent\nExamples:\n- \"5000 kbps\"\n- \"1000 pps\"\n- \"20 percent\"\n",
+                              "title": "Rate"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Shape"
+                        },
+                        "qos": {
+                          "type": "object",
+                          "properties": {
+                            "trust": {
+                              "type": "string",
+                              "enum": [
+                                "dscp",
+                                "cos",
+                                "disabled"
+                              ],
+                              "title": "Trust"
+                            },
+                            "dscp": {
+                              "type": "integer",
+                              "description": "DSCP value",
+                              "title": "DSCP"
+                            },
+                            "cos": {
+                              "type": "integer",
+                              "description": "COS value",
+                              "title": "COS"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "QOS"
+                        },
+                        "spanning_tree_bpdufilter": {
+                          "type": "string",
+                          "enum": [
+                            "enabled",
+                            "disabled",
+                            "True",
+                            "False",
+                            "true",
+                            "false"
+                          ],
+                          "title": "Spanning Tree Bpdufilter"
+                        },
+                        "spanning_tree_bpduguard": {
+                          "type": "string",
+                          "enum": [
+                            "enabled",
+                            "disabled",
+                            "True",
+                            "False",
+                            "true",
+                            "false"
+                          ],
+                          "title": "Spanning Tree Bpduguard"
+                        },
+                        "spanning_tree_guard": {
+                          "type": "string",
+                          "enum": [
+                            "loop",
+                            "root",
+                            "disabled"
+                          ],
+                          "title": "Spanning Tree Guard"
+                        },
+                        "spanning_tree_portfast": {
+                          "type": "string",
+                          "enum": [
+                            "edge",
+                            "network"
+                          ],
+                          "title": "Spanning Tree Portfast"
+                        },
+                        "vmtracer": {
+                          "type": "boolean",
+                          "title": "VMTracer"
+                        },
+                        "priority_flow_control": {
+                          "type": "object",
+                          "properties": {
+                            "enabled": {
+                              "type": "boolean",
+                              "title": "Enabled"
+                            },
+                            "priorities": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "priority": {
+                                    "type": "integer",
+                                    "minimum": 0,
+                                    "maximum": 7,
+                                    "title": "Priority"
+                                  },
+                                  "no_drop": {
+                                    "type": "boolean",
+                                    "title": "No Drop"
+                                  }
+                                },
+                                "additionalProperties": false,
+                                "patternProperties": {
+                                  "^_.+$": {}
+                                },
+                                "required": [
+                                  "priority"
+                                ]
+                              },
+                              "title": "Priorities"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Priority Flow Control"
+                        },
+                        "bfd": {
+                          "type": "object",
+                          "properties": {
+                            "echo": {
+                              "type": "boolean",
+                              "title": "Echo"
+                            },
+                            "interval": {
+                              "type": "integer",
+                              "description": "Interval in milliseconds",
+                              "title": "Interval"
+                            },
+                            "min_rx": {
+                              "type": "integer",
+                              "description": "Rate in milliseconds",
+                              "title": "Min RX"
+                            },
+                            "multiplier": {
+                              "type": "integer",
+                              "minimum": 3,
+                              "maximum": 50,
+                              "title": "Multiplier"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "BFD"
+                        },
+                        "service_policy": {
+                          "type": "object",
+                          "properties": {
+                            "pbr": {
+                              "type": "object",
+                              "properties": {
+                                "input": {
+                                  "type": "string",
+                                  "description": "Policy Based Routing Policy-map name",
+                                  "title": "Input"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "PBR"
+                            },
+                            "qos": {
+                              "type": "object",
+                              "properties": {
+                                "input": {
+                                  "type": "string",
+                                  "description": "Quality of Service Policy-map name",
+                                  "title": "Input"
+                                }
+                              },
+                              "required": [
+                                "input"
+                              ],
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "QOS"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Service Policy"
+                        },
+                        "mpls": {
+                          "type": "object",
+                          "properties": {
+                            "ip": {
+                              "type": "boolean",
+                              "title": "IP"
+                            },
+                            "ldp": {
+                              "type": "object",
+                              "properties": {
+                                "interface": {
+                                  "type": "boolean",
+                                  "title": "Interface"
+                                },
+                                "igp_sync": {
+                                  "type": "boolean",
+                                  "title": "IGP Sync"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "LDP"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "MPLS"
+                        },
+                        "lacp_timer": {
+                          "type": "object",
+                          "properties": {
+                            "mode": {
+                              "type": "string",
+                              "enum": [
+                                "fast",
+                                "normal"
+                              ],
+                              "title": "Mode"
+                            },
+                            "multiplier": {
+                              "type": "integer",
+                              "minimum": 3,
+                              "maximum": 3000,
+                              "title": "Multiplier"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "LACP Timer"
+                        },
+                        "lacp_port_priority": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "maximum": 65535,
+                          "title": "LACP Port Priority"
+                        },
+                        "transceiver": {
+                          "type": "object",
+                          "properties": {
+                            "media": {
+                              "type": "object",
+                              "properties": {
+                                "override": {
+                                  "type": "string",
+                                  "description": "Transceiver type",
+                                  "title": "Override"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Media"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Transceiver"
+                        },
+                        "ip_proxy_arp": {
+                          "type": "boolean",
+                          "title": "IP Proxy ARP"
+                        },
+                        "traffic_policy": {
+                          "type": "object",
+                          "properties": {
+                            "input": {
+                              "type": "string",
+                              "description": "Ingress traffic policy",
+                              "title": "Input"
+                            },
+                            "output": {
+                              "type": "string",
+                              "description": "Egress traffic policy",
+                              "title": "Output"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Traffic Policy"
+                        },
+                        "bgp": {
+                          "type": "object",
+                          "properties": {
+                            "session_tracker": {
+                              "type": "string",
+                              "description": "Name of session tracker",
+                              "title": "Session Tracker"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "BGP"
+                        },
+                        "peer": {
+                          "type": "string",
+                          "description": "Key only used for documentation or validation purposes",
+                          "title": "Peer"
+                        },
+                        "peer_interface": {
+                          "type": "string",
+                          "description": "Key only used for documentation or validation purposes",
+                          "title": "Peer Interface"
+                        },
+                        "peer_type": {
+                          "type": "string",
+                          "description": "Key only used for documentation or validation purposes",
+                          "title": "Peer Type"
+                        },
+                        "sflow": {
+                          "type": "object",
+                          "properties": {
+                            "enable": {
+                              "type": "boolean",
+                              "title": "Enable"
+                            },
+                            "egress": {
+                              "type": "object",
+                              "properties": {
+                                "enable": {
+                                  "type": "boolean",
+                                  "title": "Enable"
+                                },
+                                "unmodified_enable": {
+                                  "type": "boolean",
+                                  "title": "Unmodified Enable"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Egress"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Sflow"
+                        },
+                        "port_profile": {
+                          "type": "string",
+                          "description": "Key only used for documentation or validation purposes",
+                          "title": "Port Profile"
+                        },
+                        "uc_tx_queues": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "integer",
+                                "description": "TX-Queue ID",
+                                "title": "ID"
+                              },
+                              "random_detect": {
+                                "type": "object",
+                                "properties": {
+                                  "ecn": {
+                                    "description": "Explicit Congestion Notification",
+                                    "type": "object",
+                                    "properties": {
+                                      "count": {
+                                        "type": "boolean",
+                                        "description": "Enable counter for random-detect ECNs",
+                                        "title": "Count"
+                                      },
+                                      "threshold": {
+                                        "type": "object",
+                                        "properties": {
+                                          "units": {
+                                            "type": "string",
+                                            "enum": [
+                                              "segments",
+                                              "bytes",
+                                              "kbytes",
+                                              "mbytes",
+                                              "milliseconds"
+                                            ],
+                                            "description": "Indicate the units to be used for the threshold values",
+                                            "title": "Units"
+                                          },
+                                          "min": {
+                                            "type": "integer",
+                                            "minimum": 1,
+                                            "maximum": 256000000,
+                                            "description": "Set the random-detect ECN minimum-threshold",
+                                            "title": "Min"
+                                          },
+                                          "max": {
+                                            "type": "integer",
+                                            "minimum": 1,
+                                            "maximum": 256000000,
+                                            "description": "Set the random-detect ECN maximum-threshold",
+                                            "title": "Max"
+                                          },
+                                          "max_probability": {
+                                            "type": "integer",
+                                            "minimum": 1,
+                                            "maximum": 100,
+                                            "description": "Set the random-detect ECN max-mark-probability",
+                                            "title": "Max Probability"
+                                          },
+                                          "weight": {
+                                            "type": "integer",
+                                            "minimum": 0,
+                                            "maximum": 15,
+                                            "description": "Set the random-detect ECN weight",
+                                            "title": "Weight"
+                                          }
+                                        },
+                                        "required": [
+                                          "units",
+                                          "min",
+                                          "max"
+                                        ],
+                                        "additionalProperties": false,
+                                        "patternProperties": {
+                                          "^_.+$": {}
+                                        },
+                                        "title": "Threshold"
+                                      }
+                                    },
+                                    "additionalProperties": false,
+                                    "patternProperties": {
+                                      "^_.+$": {}
+                                    },
+                                    "title": "Ecn"
+                                  }
+                                },
+                                "additionalProperties": false,
+                                "patternProperties": {
+                                  "^_.+$": {}
+                                },
+                                "title": "Random Detect"
+                              }
+                            },
+                            "required": [
+                              "id"
+                            ],
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            }
+                          },
+                          "title": "Uc TX Queues"
+                        },
+                        "tx_queues": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "integer",
+                                "description": "TX-Queue ID",
+                                "title": "ID"
+                              },
+                              "random_detect": {
+                                "type": "object",
+                                "properties": {
+                                  "ecn": {
+                                    "description": "Explicit Congestion Notification",
+                                    "type": "object",
+                                    "properties": {
+                                      "count": {
+                                        "type": "boolean",
+                                        "description": "Enable counter for random-detect ECNs",
+                                        "title": "Count"
+                                      },
+                                      "threshold": {
+                                        "type": "object",
+                                        "properties": {
+                                          "units": {
+                                            "type": "string",
+                                            "enum": [
+                                              "segments",
+                                              "bytes",
+                                              "kbytes",
+                                              "mbytes",
+                                              "milliseconds"
+                                            ],
+                                            "description": "Indicate the units to be used for the threshold values",
+                                            "title": "Units"
+                                          },
+                                          "min": {
+                                            "type": "integer",
+                                            "minimum": 1,
+                                            "maximum": 256000000,
+                                            "description": "Set the random-detect ECN minimum-threshold",
+                                            "title": "Min"
+                                          },
+                                          "max": {
+                                            "type": "integer",
+                                            "minimum": 1,
+                                            "maximum": 256000000,
+                                            "description": "Set the random-detect ECN maximum-threshold",
+                                            "title": "Max"
+                                          },
+                                          "max_probability": {
+                                            "type": "integer",
+                                            "minimum": 1,
+                                            "maximum": 100,
+                                            "description": "Set the random-detect ECN max-mark-probability",
+                                            "title": "Max Probability"
+                                          },
+                                          "weight": {
+                                            "type": "integer",
+                                            "minimum": 0,
+                                            "maximum": 15,
+                                            "description": "Set the random-detect ECN weight",
+                                            "title": "Weight"
+                                          }
+                                        },
+                                        "required": [
+                                          "units",
+                                          "max",
+                                          "max_probability"
+                                        ],
+                                        "additionalProperties": false,
+                                        "patternProperties": {
+                                          "^_.+$": {}
+                                        },
+                                        "title": "Threshold"
+                                      }
+                                    },
+                                    "additionalProperties": false,
+                                    "patternProperties": {
+                                      "^_.+$": {}
+                                    },
+                                    "title": "Ecn"
+                                  }
+                                },
+                                "additionalProperties": false,
+                                "patternProperties": {
+                                  "^_.+$": {}
+                                },
+                                "title": "Random Detect"
+                              }
+                            },
+                            "required": [
+                              "id"
+                            ],
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            }
+                          },
+                          "title": "TX Queues"
+                        },
+                        "vrrp_ids": {
+                          "type": "array",
+                          "description": "VRRP model.",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "integer",
+                                "description": "VRID",
+                                "title": "ID"
+                              },
+                              "priority_level": {
+                                "type": "integer",
+                                "description": "Instance priority",
+                                "minimum": 1,
+                                "maximum": 254,
+                                "title": "Priority Level"
+                              },
+                              "advertisement": {
+                                "type": "object",
+                                "properties": {
+                                  "interval": {
+                                    "type": "integer",
+                                    "description": "Interval in seconds",
+                                    "minimum": 1,
+                                    "maximum": 255,
+                                    "title": "Interval"
+                                  }
+                                },
+                                "additionalProperties": false,
+                                "patternProperties": {
+                                  "^_.+$": {}
+                                },
+                                "title": "Advertisement"
+                              },
+                              "preempt": {
+                                "type": "object",
+                                "properties": {
+                                  "enabled": {
+                                    "type": "boolean",
+                                    "title": "Enabled"
+                                  },
+                                  "delay": {
+                                    "type": "object",
+                                    "properties": {
+                                      "minimum": {
+                                        "type": "integer",
+                                        "description": "Minimum preempt delay in seconds",
+                                        "minimum": 0,
+                                        "maximum": 3600,
+                                        "title": "Minimum"
+                                      },
+                                      "reload": {
+                                        "type": "integer",
+                                        "description": "Reload preempt delay in seconds",
+                                        "minimum": 0,
+                                        "maximum": 3600,
+                                        "title": "Reload"
+                                      }
+                                    },
+                                    "additionalProperties": false,
+                                    "patternProperties": {
+                                      "^_.+$": {}
+                                    },
+                                    "title": "Delay"
+                                  }
+                                },
+                                "required": [
+                                  "enabled"
+                                ],
+                                "additionalProperties": false,
+                                "patternProperties": {
+                                  "^_.+$": {}
+                                },
+                                "title": "Preempt"
+                              },
+                              "timers": {
+                                "type": "object",
+                                "properties": {
+                                  "delay": {
+                                    "type": "object",
+                                    "properties": {
+                                      "reload": {
+                                        "type": "integer",
+                                        "description": "Delay after reload in seconds.",
+                                        "minimum": 0,
+                                        "maximum": 3600,
+                                        "title": "Reload"
+                                      }
+                                    },
+                                    "additionalProperties": false,
+                                    "patternProperties": {
+                                      "^_.+$": {}
+                                    },
+                                    "title": "Delay"
+                                  }
+                                },
+                                "additionalProperties": false,
+                                "patternProperties": {
+                                  "^_.+$": {}
+                                },
+                                "title": "Timers"
+                              },
+                              "tracked_object": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string",
+                                      "description": "Tracked object name",
+                                      "title": "Name"
+                                    },
+                                    "decrement": {
+                                      "type": "integer",
+                                      "minimum": 1,
+                                      "maximum": 254,
+                                      "description": "Decrement VRRP priority by 1-254",
+                                      "title": "Decrement"
+                                    },
+                                    "shutdown": {
+                                      "type": "boolean",
+                                      "title": "Shutdown"
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "patternProperties": {
+                                    "^_.+$": {}
+                                  },
+                                  "required": [
+                                    "name"
+                                  ]
+                                },
+                                "title": "Tracked Object"
+                              },
+                              "ipv4": {
+                                "type": "object",
+                                "properties": {
+                                  "address": {
+                                    "type": "string",
+                                    "description": "Virtual IPv4 address",
+                                    "title": "Address"
+                                  },
+                                  "version": {
+                                    "type": "integer",
+                                    "enum": [
+                                      2,
+                                      3
+                                    ],
+                                    "title": "Version"
+                                  }
+                                },
+                                "required": [
+                                  "address"
+                                ],
+                                "additionalProperties": false,
+                                "patternProperties": {
+                                  "^_.+$": {}
+                                },
+                                "title": "IPv4"
+                              },
+                              "ipv6": {
+                                "type": "object",
+                                "properties": {
+                                  "address": {
+                                    "type": "string",
+                                    "description": "Virtual IPv6 address",
+                                    "title": "Address"
+                                  }
+                                },
+                                "required": [
+                                  "address"
+                                ],
+                                "additionalProperties": false,
+                                "patternProperties": {
+                                  "^_.+$": {}
+                                },
+                                "title": "IPv6"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            },
+                            "required": [
+                              "id"
+                            ]
+                          },
+                          "title": "VRRP IDs"
+                        },
+                        "eos_cli": {
+                          "type": "string",
+                          "description": "Multiline EOS CLI rendered directly on the ethernet interface in the final EOS configuration",
+                          "title": "EOS CLI"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      },
+                      "title": "Structured Config"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "patternProperties": {
+                    "^_.+$": {}
+                  },
+                  "required": [
+                    "vrf"
+                  ]
+                },
+                "title": "Subinterfaces"
+              },
+              "raw_eos_cli": {
+                "type": "string",
+                "description": "EOS CLI rendered directly on the interface in the final EOS configuration.",
+                "title": "Raw EOS CLI"
+              },
+              "structured_config": {
+                "type": "object",
+                "description": "Custom structured config for interfaces",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "title": "Name"
+                  },
+                  "description": {
+                    "type": "string",
+                    "title": "Description"
+                  },
+                  "shutdown": {
+                    "type": "boolean",
+                    "title": "Shutdown"
+                  },
+                  "load_interval": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 600,
+                    "description": "Interval in seconds for updating interface counters\"",
+                    "title": "Load Interval"
+                  },
+                  "speed": {
+                    "type": "string",
+                    "description": "Speed should be set in the format `<interface_speed>` or `forced <interface_speed>` or `auto <interface_speed>`.",
+                    "title": "Speed"
+                  },
+                  "mtu": {
+                    "type": "integer",
+                    "minimum": 68,
+                    "maximum": 65535,
+                    "title": "MTU"
+                  },
+                  "l2_mtu": {
+                    "type": "integer",
+                    "minimum": 68,
+                    "maximum": 65535,
+                    "description": "\"l2_mtu\" should only be defined for platforms supporting the \"l2 mtu\" CLI\n",
+                    "title": "L2 MTU"
+                  },
+                  "l2_mru": {
+                    "type": "integer",
+                    "minimum": 68,
+                    "maximum": 65535,
+                    "description": "\"l2_mru\" should only be defined for platforms supporting the \"l2 mru\" CLI\n",
+                    "title": "L2 MRU"
+                  },
+                  "vlans": {
+                    "type": "string",
+                    "description": "List of switchport vlans as string\nFor a trunk port this would be a range like \"1-200,300\"\nFor an access port this would be a single vlan \"123\"\n",
+                    "title": "VLANs"
+                  },
+                  "native_vlan": {
+                    "type": "integer",
+                    "title": "Native VLAN"
+                  },
+                  "native_vlan_tag": {
+                    "type": "boolean",
+                    "description": "If setting both native_vlan and native_vlan_tag, native_vlan_tag takes precedence",
+                    "title": "Native VLAN Tag"
+                  },
+                  "mode": {
+                    "type": "string",
+                    "enum": [
+                      "access",
+                      "dot1q-tunnel",
+                      "trunk",
+                      "trunk phone"
+                    ],
+                    "title": "Mode"
+                  },
+                  "phone": {
+                    "type": "object",
+                    "properties": {
+                      "trunk": {
+                        "type": "string",
+                        "enum": [
+                          "tagged",
+                          "tagged phone",
+                          "untagged",
+                          "untagged phone"
+                        ],
+                        "title": "Trunk"
+                      },
+                      "vlan": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 4094,
+                        "title": "VLAN"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Phone"
+                  },
+                  "l2_protocol": {
+                    "type": "object",
+                    "properties": {
+                      "encapsulation_dot1q_vlan": {
+                        "type": "integer",
+                        "description": "Vlan tag to configure on sub-interface",
+                        "title": "Encapsulation Dot1Q VLAN"
+                      },
+                      "forwarding_profile": {
+                        "type": "string",
+                        "description": "L2 protocol forwarding profile",
+                        "title": "Forwarding Profile"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "L2 Protocol"
+                  },
+                  "trunk_groups": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Trunk Groups"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "routed",
+                      "switched",
+                      "l3dot1q",
+                      "l2dot1q",
+                      "port-channel-member"
+                    ],
+                    "description": "l3dot1q and l2dot1q are used for sub-interfaces. The parent interface should be defined as routed.\nInterface will not be listed in device documentation, unless \"type\" is set.\n",
+                    "title": "Type"
+                  },
+                  "snmp_trap_link_change": {
+                    "type": "boolean",
+                    "title": "Snmp Trap Link Change"
+                  },
+                  "address_locking": {
+                    "type": "object",
+                    "properties": {
+                      "ipv4": {
+                        "type": "boolean",
+                        "description": "Enable address locking for IPv4",
+                        "title": "IPv4"
+                      },
+                      "ipv6": {
+                        "type": "boolean",
+                        "description": "Enable address locking for IPv6",
+                        "title": "IPv6"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Address Locking"
+                  },
+                  "flowcontrol": {
+                    "type": "object",
+                    "properties": {
+                      "received": {
+                        "type": "string",
+                        "enum": [
+                          "desired",
+                          "on",
+                          "off"
+                        ],
+                        "title": "Received"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Flowcontrol"
+                  },
+                  "vrf": {
+                    "type": "string",
+                    "description": "VRF name",
+                    "title": "VRF"
+                  },
+                  "flow_tracker": {
+                    "type": "object",
+                    "properties": {
+                      "sampled": {
+                        "type": "string",
+                        "description": "Sampled flow tracker name.",
+                        "title": "Sampled"
+                      },
+                      "hardware": {
+                        "type": "string",
+                        "description": "Hardware flow tracker name.",
+                        "title": "Hardware"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Flow Tracker"
+                  },
+                  "error_correction_encoding": {
+                    "type": "object",
+                    "properties": {
+                      "enabled": {
+                        "type": "boolean",
+                        "default": true,
+                        "title": "Enabled"
+                      },
+                      "fire_code": {
+                        "type": "boolean",
+                        "title": "Fire Code"
+                      },
+                      "reed_solomon": {
+                        "type": "boolean",
+                        "title": "Reed Solomon"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Error Correction Encoding"
+                  },
+                  "link_tracking_groups": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "description": "Group name",
+                          "title": "Name"
+                        },
+                        "direction": {
+                          "type": "string",
+                          "enum": [
+                            "upstream",
+                            "downstream"
+                          ],
+                          "title": "Direction"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      },
+                      "required": [
+                        "name"
+                      ]
+                    },
+                    "title": "Link Tracking Groups"
+                  },
+                  "evpn_ethernet_segment": {
+                    "type": "object",
+                    "properties": {
+                      "identifier": {
+                        "type": "string",
+                        "description": "EVPN Ethernet Segment Identifier (Type 1 format)",
+                        "title": "Identifier"
+                      },
+                      "redundancy": {
+                        "type": "string",
+                        "enum": [
+                          "all-active",
+                          "single-active"
+                        ],
+                        "title": "Redundancy"
+                      },
+                      "designated_forwarder_election": {
+                        "type": "object",
+                        "properties": {
+                          "algorithm": {
+                            "type": "string",
+                            "enum": [
+                              "modulus",
+                              "preference"
+                            ],
+                            "title": "Algorithm"
+                          },
+                          "preference_value": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 65535,
+                            "description": "Preference_value is only used when \"algorithm\" is \"preference\"",
+                            "title": "Preference Value"
+                          },
+                          "dont_preempt": {
+                            "type": "boolean",
+                            "description": "Dont_preempt is only used when \"algorithm\" is \"preference\"",
+                            "title": "Dont Preempt"
+                          },
+                          "hold_time": {
+                            "type": "integer",
+                            "title": "Hold Time"
+                          },
+                          "subsequent_hold_time": {
+                            "type": "integer",
+                            "title": "Subsequent Hold Time"
+                          },
+                          "candidate_reachability_required": {
+                            "type": "boolean",
+                            "title": "Candidate Reachability Required"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Designated Forwarder Election"
+                      },
+                      "mpls": {
+                        "type": "object",
+                        "properties": {
+                          "shared_index": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 1024,
+                            "title": "Shared Index"
+                          },
+                          "tunnel_flood_filter_time": {
+                            "type": "integer",
+                            "title": "Tunnel Flood Filter Time"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "MPLS"
+                      },
+                      "route_target": {
+                        "type": "string",
+                        "description": "EVPN Route Target for ESI with format xx:xx:xx:xx:xx:xx",
+                        "title": "Route Target"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "EVPN Ethernet Segment"
+                  },
+                  "encapsulation_dot1q_vlan": {
+                    "type": "integer",
+                    "description": "VLAN tag to configure on sub-interface",
+                    "title": "Encapsulation Dot1Q VLAN"
+                  },
+                  "encapsulation_vlan": {
+                    "type": "object",
+                    "properties": {
+                      "client": {
+                        "type": "object",
+                        "properties": {
+                          "dot1q": {
+                            "type": "object",
+                            "properties": {
+                              "vlan": {
+                                "type": "integer",
+                                "description": "Client VLAN ID",
+                                "title": "VLAN"
+                              },
+                              "outer": {
+                                "type": "integer",
+                                "description": "Client Outer VLAN ID",
+                                "title": "Outer"
+                              },
+                              "inner": {
+                                "type": "integer",
+                                "description": "Client Inner VLAN ID",
+                                "title": "Inner"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            },
+                            "title": "Dot1Q"
+                          },
+                          "unmatched": {
+                            "type": "boolean",
+                            "title": "Unmatched"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Client"
+                      },
+                      "network": {
+                        "type": "object",
+                        "description": "Network encapsulations are all optional and skipped if using client unmatched",
+                        "properties": {
+                          "dot1q": {
+                            "type": "object",
+                            "properties": {
+                              "vlan": {
+                                "type": "integer",
+                                "description": "Network VLAN ID",
+                                "title": "VLAN"
+                              },
+                              "outer": {
+                                "type": "integer",
+                                "description": "Network outer VLAN ID",
+                                "title": "Outer"
+                              },
+                              "inner": {
+                                "type": "integer",
+                                "description": "Network inner VLAN ID",
+                                "title": "Inner"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            },
+                            "title": "Dot1Q"
+                          },
+                          "client": {
+                            "type": "boolean",
+                            "title": "Client"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Network"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Encapsulation VLAN"
+                  },
+                  "vlan_id": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 4094,
+                    "title": "VLAN ID"
+                  },
+                  "ip_address": {
+                    "type": "string",
+                    "description": "IPv4 address/mask or \"dhcp\"",
+                    "title": "IP Address"
+                  },
+                  "ip_address_secondaries": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "IP Address Secondaries"
+                  },
+                  "dhcp_client_accept_default_route": {
+                    "type": "boolean",
+                    "description": "Install default-route obtained via DHCP",
+                    "title": "DHCP Client Accept Default Route"
+                  },
+                  "dhcp_server_ipv4": {
+                    "type": "boolean",
+                    "description": "Enable IPv4 DHCP server.",
+                    "title": "DHCP Server IPv4"
+                  },
+                  "dhcp_server_ipv6": {
+                    "type": "boolean",
+                    "description": "Enable IPv6 DHCP server.",
+                    "title": "DHCP Server IPv6"
+                  },
+                  "ip_helpers": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "ip_helper": {
+                          "type": "string",
+                          "title": "IP Helper"
+                        },
+                        "source_interface": {
+                          "type": "string",
+                          "description": "Source interface name",
+                          "title": "Source Interface"
+                        },
+                        "vrf": {
+                          "type": "string",
+                          "description": "VRF name",
+                          "title": "VRF"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      },
+                      "required": [
+                        "ip_helper"
+                      ]
+                    },
+                    "title": "IP Helpers"
+                  },
+                  "ip_nat": {
+                    "type": "object",
+                    "properties": {
+                      "service_profile": {
+                        "type": "string",
+                        "description": "NAT interface profile.",
+                        "title": "Service Profile"
+                      },
+                      "destination": {
+                        "type": "object",
+                        "properties": {
+                          "dynamic": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "access_list": {
+                                  "type": "string",
+                                  "title": "Access List"
+                                },
+                                "comment": {
+                                  "type": "string",
+                                  "title": "Comment"
+                                },
+                                "pool_name": {
+                                  "type": "string",
+                                  "title": "Pool Name"
+                                },
+                                "priority": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "maximum": 4294967295,
+                                  "title": "Priority"
+                                }
+                              },
+                              "required": [
+                                "pool_name",
+                                "access_list"
+                              ],
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              }
+                            },
+                            "title": "Dynamic"
+                          },
+                          "static": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "access_list": {
+                                  "type": "string",
+                                  "description": "'access_list' and 'group' are mutual exclusive",
+                                  "title": "Access List"
+                                },
+                                "comment": {
+                                  "type": "string",
+                                  "title": "Comment"
+                                },
+                                "direction": {
+                                  "type": "string",
+                                  "enum": [
+                                    "egress",
+                                    "ingress"
+                                  ],
+                                  "description": "Egress or ingress can be the default. This depends on source/destination, EOS version, and hardware platform.\nEOS might remove this keyword in the configuration. So, check the configuration on targeted HW/SW.\n",
+                                  "title": "Direction"
+                                },
+                                "group": {
+                                  "type": "integer",
+                                  "minimum": 1,
+                                  "maximum": 65535,
+                                  "description": "'access_list' and 'group' are mutual exclusive",
+                                  "title": "Group"
+                                },
+                                "original_ip": {
+                                  "type": "string",
+                                  "description": "IPv4 address",
+                                  "title": "Original IP"
+                                },
+                                "original_port": {
+                                  "type": "integer",
+                                  "minimum": 1,
+                                  "maximum": 65535,
+                                  "title": "Original Port"
+                                },
+                                "priority": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "maximum": 4294967295,
+                                  "title": "Priority"
+                                },
+                                "protocol": {
+                                  "type": "string",
+                                  "enum": [
+                                    "udp",
+                                    "tcp"
+                                  ],
+                                  "title": "Protocol"
+                                },
+                                "translated_ip": {
+                                  "type": "string",
+                                  "description": "IPv4 address",
+                                  "title": "Translated IP"
+                                },
+                                "translated_port": {
+                                  "type": "integer",
+                                  "minimum": 1,
+                                  "maximum": 65535,
+                                  "description": "requires 'original_port'",
+                                  "title": "Translated Port"
+                                }
+                              },
+                              "required": [
+                                "translated_ip",
+                                "original_ip"
+                              ],
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              }
+                            },
+                            "title": "Static"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Destination"
+                      },
+                      "source": {
+                        "type": "object",
+                        "properties": {
+                          "dynamic": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "access_list": {
+                                  "type": "string",
+                                  "title": "Access List"
+                                },
+                                "comment": {
+                                  "type": "string",
+                                  "title": "Comment"
+                                },
+                                "nat_type": {
+                                  "type": "string",
+                                  "enum": [
+                                    "overload",
+                                    "pool",
+                                    "pool-address-only",
+                                    "pool-full-cone"
+                                  ],
+                                  "title": "Nat Type"
+                                },
+                                "pool_name": {
+                                  "type": "string",
+                                  "description": "required if 'nat_type' is pool, pool-address-only or pool-full-cone\nignored if 'nat_type' is overload\n",
+                                  "title": "Pool Name"
+                                },
+                                "priority": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "maximum": 4294967295,
+                                  "title": "Priority"
+                                }
+                              },
+                              "required": [
+                                "nat_type",
+                                "access_list"
+                              ],
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              }
+                            },
+                            "title": "Dynamic"
+                          },
+                          "static": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "access_list": {
+                                  "type": "string",
+                                  "description": "'access_list' and 'group' are mutual exclusive",
+                                  "title": "Access List"
+                                },
+                                "comment": {
+                                  "type": "string",
+                                  "title": "Comment"
+                                },
+                                "direction": {
+                                  "type": "string",
+                                  "enum": [
+                                    "egress",
+                                    "ingress"
+                                  ],
+                                  "description": "Egress or ingress can be the default. This depends on source/destination, EOS version, and hardware platform.\nEOS might remove this keyword in the configuration. So, check the configuration on targeted HW/SW.\n",
+                                  "title": "Direction"
+                                },
+                                "group": {
+                                  "type": "integer",
+                                  "minimum": 1,
+                                  "maximum": 65535,
+                                  "description": "'access_list' and 'group' are mutual exclusive",
+                                  "title": "Group"
+                                },
+                                "original_ip": {
+                                  "type": "string",
+                                  "description": "IPv4 address",
+                                  "title": "Original IP"
+                                },
+                                "original_port": {
+                                  "type": "integer",
+                                  "minimum": 1,
+                                  "maximum": 65535,
+                                  "title": "Original Port"
+                                },
+                                "priority": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "maximum": 4294967295,
+                                  "title": "Priority"
+                                },
+                                "protocol": {
+                                  "type": "string",
+                                  "enum": [
+                                    "udp",
+                                    "tcp"
+                                  ],
+                                  "title": "Protocol"
+                                },
+                                "translated_ip": {
+                                  "type": "string",
+                                  "description": "IPv4 address",
+                                  "title": "Translated IP"
+                                },
+                                "translated_port": {
+                                  "type": "integer",
+                                  "minimum": 1,
+                                  "maximum": 65535,
+                                  "description": "requires 'original_port'",
+                                  "title": "Translated Port"
+                                }
+                              },
+                              "required": [
+                                "translated_ip",
+                                "original_ip"
+                              ],
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              }
+                            },
+                            "title": "Static"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Source"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "IP Nat"
+                  },
+                  "ipv6_enable": {
+                    "type": "boolean",
+                    "title": "IPv6 Enable"
+                  },
+                  "ipv6_address": {
+                    "type": "string",
+                    "title": "IPv6 Address"
+                  },
+                  "ipv6_address_link_local": {
+                    "type": "string",
+                    "description": "Link local IPv6 address/mask",
+                    "title": "IPv6 Address Link Local"
+                  },
+                  "ipv6_nd_ra_disabled": {
+                    "type": "boolean",
+                    "title": "IPv6 ND RA Disabled"
+                  },
+                  "ipv6_nd_managed_config_flag": {
+                    "type": "boolean",
+                    "title": "IPv6 ND Managed Config Flag"
+                  },
+                  "ipv6_nd_prefixes": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "ipv6_prefix": {
+                          "type": "string",
+                          "title": "IPv6 Prefix"
+                        },
+                        "valid_lifetime": {
+                          "type": "string",
+                          "description": "Infinite or lifetime in seconds",
+                          "title": "Valid Lifetime"
+                        },
+                        "preferred_lifetime": {
+                          "type": "string",
+                          "description": "Infinite or lifetime in seconds",
+                          "title": "Preferred Lifetime"
+                        },
+                        "no_autoconfig_flag": {
+                          "type": "boolean",
+                          "title": "No Autoconfig Flag"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      },
+                      "required": [
+                        "ipv6_prefix"
+                      ]
+                    },
+                    "title": "IPv6 ND Prefixes"
+                  },
+                  "ipv6_dhcp_relay_destinations": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "address": {
+                          "type": "string",
+                          "description": "DHCP server's IPv6 address",
+                          "title": "Address"
+                        },
+                        "vrf": {
+                          "type": "string",
+                          "title": "VRF"
+                        },
+                        "local_interface": {
+                          "type": "string",
+                          "description": "Local interface to communicate with DHCP server - mutually exclusive to source_address",
+                          "title": "Local Interface"
+                        },
+                        "source_address": {
+                          "type": "string",
+                          "description": "Source IPv6 address to communicate with DHCP server - mutually exclusive to local_interface",
+                          "title": "Source Address"
+                        },
+                        "link_address": {
+                          "type": "string",
+                          "description": "Override the default link address specified in the relayed DHCP packet",
+                          "title": "Link Address"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      },
+                      "required": [
+                        "address"
+                      ]
+                    },
+                    "title": "IPv6 DHCP Relay Destinations"
+                  },
+                  "access_group_in": {
+                    "type": "string",
+                    "description": "Access list name",
+                    "title": "Access Group In"
+                  },
+                  "access_group_out": {
+                    "type": "string",
+                    "description": "Access list name",
+                    "title": "Access Group Out"
+                  },
+                  "ipv6_access_group_in": {
+                    "type": "string",
+                    "description": "IPv6 access list name",
+                    "title": "IPv6 Access Group In"
+                  },
+                  "ipv6_access_group_out": {
+                    "type": "string",
+                    "description": "IPv6 access list name",
+                    "title": "IPv6 Access Group Out"
+                  },
+                  "mac_access_group_in": {
+                    "type": "string",
+                    "description": "MAC access list name",
+                    "title": "MAC Access Group In"
+                  },
+                  "mac_access_group_out": {
+                    "type": "string",
+                    "description": "MAC access list name",
+                    "title": "MAC Access Group Out"
+                  },
+                  "multicast": {
+                    "type": "object",
+                    "description": "Boundaries can be either 1 ACL or a list of multicast IP address_range(s)/prefix but not combination of both",
+                    "properties": {
+                      "ipv4": {
+                        "type": "object",
+                        "properties": {
+                          "boundaries": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "boundary": {
+                                  "type": "string",
+                                  "description": "ACL name or multicast IP subnet",
+                                  "title": "Boundary"
+                                },
+                                "out": {
+                                  "type": "boolean",
+                                  "title": "Out"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              }
+                            },
+                            "title": "Boundaries"
+                          },
+                          "static": {
+                            "type": "boolean",
+                            "title": "Static"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "IPv4"
+                      },
+                      "ipv6": {
+                        "type": "object",
+                        "properties": {
+                          "boundaries": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "boundary": {
+                                  "type": "string",
+                                  "description": "ACL name or multicast IP subnet",
+                                  "title": "Boundary"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              }
+                            },
+                            "title": "Boundaries"
+                          },
+                          "static": {
+                            "type": "boolean",
+                            "title": "Static"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "IPv6"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Multicast"
+                  },
+                  "ospf_network_point_to_point": {
+                    "type": "boolean",
+                    "title": "OSPF Network Point To Point"
+                  },
+                  "ospf_area": {
+                    "type": "string",
+                    "title": "OSPF Area"
+                  },
+                  "ospf_cost": {
+                    "type": "integer",
+                    "title": "OSPF Cost"
+                  },
+                  "ospf_authentication": {
+                    "type": "string",
+                    "enum": [
+                      "none",
+                      "simple",
+                      "message-digest"
+                    ],
+                    "title": "OSPF Authentication"
+                  },
+                  "ospf_authentication_key": {
+                    "type": "string",
+                    "description": "Encrypted password - only type 7 supported",
+                    "title": "OSPF Authentication Key"
+                  },
+                  "ospf_message_digest_keys": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "title": "ID"
+                        },
+                        "hash_algorithm": {
+                          "type": "string",
+                          "enum": [
+                            "md5",
+                            "sha1",
+                            "sha256",
+                            "sha384",
+                            "sha512"
+                          ],
+                          "title": "Hash Algorithm"
+                        },
+                        "key": {
+                          "type": "string",
+                          "description": "Encrypted password - only type 7 supported",
+                          "title": "Key"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      },
+                      "required": [
+                        "id"
+                      ]
+                    },
+                    "title": "OSPF Message Digest Keys"
+                  },
+                  "pim": {
+                    "type": "object",
+                    "properties": {
+                      "ipv4": {
+                        "type": "object",
+                        "properties": {
+                          "dr_priority": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 429467295,
+                            "title": "DR Priority"
+                          },
+                          "sparse_mode": {
+                            "type": "boolean",
+                            "title": "Sparse Mode"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "IPv4"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "PIM"
+                  },
+                  "mac_security": {
+                    "type": "object",
+                    "properties": {
+                      "profile": {
+                        "type": "string",
+                        "title": "Profile"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "MAC Security"
+                  },
+                  "channel_group": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "integer",
+                        "title": "ID"
+                      },
+                      "mode": {
+                        "type": "string",
+                        "enum": [
+                          "on",
+                          "active",
+                          "passive"
+                        ],
+                        "title": "Mode"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Channel Group"
+                  },
+                  "isis_enable": {
+                    "type": "string",
+                    "description": "ISIS instance",
+                    "title": "ISIS Enable"
+                  },
+                  "isis_passive": {
+                    "type": "boolean",
+                    "title": "ISIS Passive"
+                  },
+                  "isis_metric": {
+                    "type": "integer",
+                    "title": "ISIS Metric"
+                  },
+                  "isis_network_point_to_point": {
+                    "type": "boolean",
+                    "title": "ISIS Network Point To Point"
+                  },
+                  "isis_circuit_type": {
+                    "type": "string",
+                    "enum": [
+                      "level-1-2",
+                      "level-1",
+                      "level-2"
+                    ],
+                    "title": "ISIS Circuit Type"
+                  },
+                  "isis_hello_padding": {
+                    "type": "boolean",
+                    "title": "ISIS Hello Padding"
+                  },
+                  "isis_authentication_mode": {
+                    "type": "string",
+                    "enum": [
+                      "text",
+                      "md5"
+                    ],
+                    "title": "ISIS Authentication Mode"
+                  },
+                  "isis_authentication_key": {
+                    "type": "string",
+                    "description": "Type-7 encrypted password",
+                    "title": "ISIS Authentication Key"
+                  },
+                  "poe": {
+                    "type": "object",
+                    "properties": {
+                      "disabled": {
+                        "type": "boolean",
+                        "description": "Disable PoE on a POE capable port. PoE is enabled on all ports that support it by default in EOS.",
+                        "default": false,
+                        "title": "Disabled"
+                      },
+                      "priority": {
+                        "type": "string",
+                        "enum": [
+                          "critical",
+                          "high",
+                          "medium",
+                          "low"
+                        ],
+                        "description": "Prioritize a port's power in the event that one of the switch's power supplies loses power",
+                        "title": "Priority"
+                      },
+                      "reboot": {
+                        "description": "Set the PoE power behavior for a PoE port when the system is rebooted",
+                        "type": "object",
+                        "properties": {
+                          "action": {
+                            "type": "string",
+                            "enum": [
+                              "maintain",
+                              "power-off"
+                            ],
+                            "description": "PoE action for interface",
+                            "title": "Action"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Reboot"
+                      },
+                      "link_down": {
+                        "description": "Set the PoE power behavior for a PoE port when the port goes down",
+                        "type": "object",
+                        "properties": {
+                          "action": {
+                            "type": "string",
+                            "enum": [
+                              "maintain",
+                              "power-off"
+                            ],
+                            "description": "PoE action for interface",
+                            "title": "Action"
+                          },
+                          "power_off_delay": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 86400,
+                            "description": "Number of seconds to delay shutting the power off after a link down event occurs. Default value is 5 seconds in EOS.",
+                            "title": "Power Off Delay"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Link Down"
+                      },
+                      "shutdown": {
+                        "description": "Set the PoE power behavior for a PoE port when the port is admin down",
+                        "type": "object",
+                        "properties": {
+                          "action": {
+                            "type": "string",
+                            "enum": [
+                              "maintain",
+                              "power-off"
+                            ],
+                            "description": "PoE action for interface",
+                            "title": "Action"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Shutdown"
+                      },
+                      "limit": {
+                        "type": "object",
+                        "description": "Override the hardware-negotiated power limit using either wattage or a power class. Note that if using a power class, AVD will automatically convert the class value to the wattage value corresponding to that power class.",
+                        "properties": {
+                          "class": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 8,
+                            "title": "Class"
+                          },
+                          "watts": {
+                            "type": "string",
+                            "title": "Watts"
+                          },
+                          "fixed": {
+                            "type": "boolean",
+                            "description": "Set to ignore hardware classification",
+                            "title": "Fixed"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Limit"
+                      },
+                      "negotiation_lldp": {
+                        "type": "boolean",
+                        "description": "Disable to prevent port from negotiating power with powered devices over LLDP. Enabled by default in EOS.",
+                        "title": "Negotiation LLDP"
+                      },
+                      "legacy_detect": {
+                        "type": "boolean",
+                        "description": "Allow a subset of legacy devices to work with the PoE switch. Disabled by default in EOS because it can cause false positive detections.",
+                        "title": "Legacy Detect"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "PoE"
+                  },
+                  "ptp": {
+                    "type": "object",
+                    "properties": {
+                      "enable": {
+                        "type": "boolean",
+                        "title": "Enable"
+                      },
+                      "announce": {
+                        "type": "object",
+                        "properties": {
+                          "interval": {
+                            "type": "integer",
+                            "title": "Interval"
+                          },
+                          "timeout": {
+                            "type": "integer",
+                            "title": "Timeout"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Announce"
+                      },
+                      "delay_req": {
+                        "type": "integer",
+                        "title": "Delay Req"
+                      },
+                      "delay_mechanism": {
+                        "type": "string",
+                        "enum": [
+                          "e2e",
+                          "p2p"
+                        ],
+                        "title": "Delay Mechanism"
+                      },
+                      "sync_message": {
+                        "type": "object",
+                        "properties": {
+                          "interval": {
+                            "type": "integer",
+                            "title": "Interval"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Sync Message"
+                      },
+                      "role": {
+                        "type": "string",
+                        "enum": [
+                          "master",
+                          "dynamic"
+                        ],
+                        "title": "Role"
+                      },
+                      "vlan": {
+                        "type": "string",
+                        "description": "VLAN can be 'all' or list of vlans as string",
+                        "title": "VLAN"
+                      },
+                      "transport": {
+                        "type": "string",
+                        "enum": [
+                          "ipv4",
+                          "ipv6",
+                          "layer2"
+                        ],
+                        "title": "Transport"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "PTP"
+                  },
+                  "profile": {
+                    "type": "string",
+                    "description": "Interface profile",
+                    "title": "Profile"
+                  },
+                  "storm_control": {
+                    "type": "object",
+                    "properties": {
+                      "all": {
+                        "type": "object",
+                        "properties": {
+                          "level": {
+                            "type": "string",
+                            "description": "Configure maximum storm-control level",
+                            "title": "Level"
+                          },
+                          "unit": {
+                            "type": "string",
+                            "default": "percent",
+                            "enum": [
+                              "percent",
+                              "pps"
+                            ],
+                            "description": "Optional field and is hardware dependent",
+                            "title": "Unit"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "All"
+                      },
+                      "broadcast": {
+                        "type": "object",
+                        "properties": {
+                          "level": {
+                            "type": "string",
+                            "description": "Configure maximum storm-control level",
+                            "title": "Level"
+                          },
+                          "unit": {
+                            "type": "string",
+                            "default": "percent",
+                            "enum": [
+                              "percent",
+                              "pps"
+                            ],
+                            "description": "Optional field and is hardware dependent",
+                            "title": "Unit"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Broadcast"
+                      },
+                      "multicast": {
+                        "type": "object",
+                        "properties": {
+                          "level": {
+                            "type": "string",
+                            "description": "Configure maximum storm-control level",
+                            "title": "Level"
+                          },
+                          "unit": {
+                            "type": "string",
+                            "default": "percent",
+                            "enum": [
+                              "percent",
+                              "pps"
+                            ],
+                            "description": "Optional field and is hardware dependent",
+                            "title": "Unit"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Multicast"
+                      },
+                      "unknown_unicast": {
+                        "type": "object",
+                        "properties": {
+                          "level": {
+                            "type": "string",
+                            "description": "Configure maximum storm-control level",
+                            "title": "Level"
+                          },
+                          "unit": {
+                            "type": "string",
+                            "default": "percent",
+                            "enum": [
+                              "percent",
+                              "pps"
+                            ],
+                            "description": "Optional field and is hardware dependent",
+                            "title": "Unit"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Unknown Unicast"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Storm Control"
+                  },
+                  "logging": {
+                    "type": "object",
+                    "properties": {
+                      "event": {
+                        "type": "object",
+                        "properties": {
+                          "link_status": {
+                            "type": "boolean",
+                            "title": "Link Status"
+                          },
+                          "congestion_drops": {
+                            "type": "boolean",
+                            "title": "Congestion Drops"
+                          },
+                          "spanning_tree": {
+                            "type": "boolean",
+                            "title": "Spanning Tree"
+                          },
+                          "storm_control_discards": {
+                            "type": "boolean",
+                            "title": "Storm Control Discards"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Event"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Logging"
+                  },
+                  "lldp": {
+                    "type": "object",
+                    "properties": {
+                      "transmit": {
+                        "type": "boolean",
+                        "title": "Transmit"
+                      },
+                      "receive": {
+                        "type": "boolean",
+                        "title": "Receive"
+                      },
+                      "ztp_vlan": {
+                        "type": "integer",
+                        "description": "ZTP vlan number",
+                        "title": "ZTP VLAN"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "LLDP"
+                  },
+                  "trunk_private_vlan_secondary": {
+                    "type": "boolean",
+                    "title": "Trunk Private VLAN Secondary"
+                  },
+                  "pvlan_mapping": {
+                    "type": "string",
+                    "description": "List of vlans as string",
+                    "title": "PVLAN Mapping"
+                  },
+                  "vlan_translations": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "from": {
+                          "type": "string",
+                          "description": "List of vlans as string (only one vlan if direction is \"both\")",
+                          "title": "From"
+                        },
+                        "to": {
+                          "type": "integer",
+                          "description": "VLAN ID",
+                          "title": "To"
+                        },
+                        "direction": {
+                          "type": "string",
+                          "enum": [
+                            "in",
+                            "out",
+                            "both"
+                          ],
+                          "default": "both",
+                          "title": "Direction"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      }
+                    },
+                    "title": "VLAN Translations"
+                  },
+                  "dot1x": {
+                    "type": "object",
+                    "properties": {
+                      "port_control": {
+                        "type": "string",
+                        "enum": [
+                          "auto",
+                          "force-authorized",
+                          "force-unauthorized"
+                        ],
+                        "title": "Port Control"
+                      },
+                      "port_control_force_authorized_phone": {
+                        "type": "boolean",
+                        "title": "Port Control Force Authorized Phone"
+                      },
+                      "reauthentication": {
+                        "type": "boolean",
+                        "title": "Reauthentication"
+                      },
+                      "pae": {
+                        "type": "object",
+                        "properties": {
+                          "mode": {
+                            "type": "string",
+                            "enum": [
+                              "authenticator"
+                            ],
+                            "title": "Mode"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "PAE"
+                      },
+                      "authentication_failure": {
+                        "type": "object",
+                        "properties": {
+                          "action": {
+                            "type": "string",
+                            "enum": [
+                              "allow",
+                              "drop"
+                            ],
+                            "title": "Action"
+                          },
+                          "allow_vlan": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 4094,
+                            "title": "Allow VLAN"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Authentication Failure"
+                      },
+                      "host_mode": {
+                        "type": "object",
+                        "properties": {
+                          "mode": {
+                            "type": "string",
+                            "enum": [
+                              "multi-host",
+                              "single-host"
+                            ],
+                            "title": "Mode"
+                          },
+                          "multi_host_authenticated": {
+                            "type": "boolean",
+                            "title": "Multi Host Authenticated"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Host Mode"
+                      },
+                      "mac_based_authentication": {
+                        "type": "object",
+                        "properties": {
+                          "enabled": {
+                            "type": "boolean",
+                            "title": "Enabled"
+                          },
+                          "always": {
+                            "type": "boolean",
+                            "title": "Always"
+                          },
+                          "host_mode_common": {
+                            "type": "boolean",
+                            "title": "Host Mode Common"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "MAC Based Authentication"
+                      },
+                      "timeout": {
+                        "type": "object",
+                        "properties": {
+                          "idle_host": {
+                            "type": "integer",
+                            "minimum": 10,
+                            "maximum": 65535,
+                            "title": "Idle Host"
+                          },
+                          "quiet_period": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 65535,
+                            "title": "Quiet Period"
+                          },
+                          "reauth_period": {
+                            "type": "string",
+                            "description": "Value can be 60-4294967295 or 'server'",
+                            "title": "Reauth Period"
+                          },
+                          "reauth_timeout_ignore": {
+                            "type": "boolean",
+                            "title": "Reauth Timeout Ignore"
+                          },
+                          "tx_period": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 65535,
+                            "title": "TX Period"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Timeout"
+                      },
+                      "reauthorization_request_limit": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 10,
+                        "title": "Reauthorization Request Limit"
+                      },
+                      "unauthorized": {
+                        "type": "object",
+                        "properties": {
+                          "access_vlan_membership_egress": {
+                            "type": "boolean",
+                            "title": "Access VLAN Membership Egress"
+                          },
+                          "native_vlan_membership_egress": {
+                            "type": "boolean",
+                            "title": "Native VLAN Membership Egress"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Unauthorized"
+                      },
+                      "eapol": {
+                        "type": "object",
+                        "properties": {
+                          "disabled": {
+                            "type": "boolean",
+                            "title": "Disabled"
+                          },
+                          "authentication_failure_fallback_mba": {
+                            "type": "object",
+                            "properties": {
+                              "enabled": {
+                                "type": "boolean",
+                                "title": "Enabled"
+                              },
+                              "timeout": {
+                                "type": "integer",
+                                "minimum": 0,
+                                "maximum": 65535,
+                                "title": "Timeout"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            },
+                            "title": "Authentication Failure Fallback Mba"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Eapol"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "dot1x"
+                  },
+                  "service_profile": {
+                    "type": "string",
+                    "description": "QOS profile",
+                    "title": "Service Profile"
+                  },
+                  "shape": {
+                    "type": "object",
+                    "properties": {
+                      "rate": {
+                        "type": "string",
+                        "description": "Rate in kbps, pps or percent\nSupported options are platform dependent\nExamples:\n- \"5000 kbps\"\n- \"1000 pps\"\n- \"20 percent\"\n",
+                        "title": "Rate"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Shape"
+                  },
+                  "qos": {
+                    "type": "object",
+                    "properties": {
+                      "trust": {
+                        "type": "string",
+                        "enum": [
+                          "dscp",
+                          "cos",
+                          "disabled"
+                        ],
+                        "title": "Trust"
+                      },
+                      "dscp": {
+                        "type": "integer",
+                        "description": "DSCP value",
+                        "title": "DSCP"
+                      },
+                      "cos": {
+                        "type": "integer",
+                        "description": "COS value",
+                        "title": "COS"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "QOS"
+                  },
+                  "spanning_tree_bpdufilter": {
+                    "type": "string",
+                    "enum": [
+                      "enabled",
+                      "disabled",
+                      "True",
+                      "False",
+                      "true",
+                      "false"
+                    ],
+                    "title": "Spanning Tree Bpdufilter"
+                  },
+                  "spanning_tree_bpduguard": {
+                    "type": "string",
+                    "enum": [
+                      "enabled",
+                      "disabled",
+                      "True",
+                      "False",
+                      "true",
+                      "false"
+                    ],
+                    "title": "Spanning Tree Bpduguard"
+                  },
+                  "spanning_tree_guard": {
+                    "type": "string",
+                    "enum": [
+                      "loop",
+                      "root",
+                      "disabled"
+                    ],
+                    "title": "Spanning Tree Guard"
+                  },
+                  "spanning_tree_portfast": {
+                    "type": "string",
+                    "enum": [
+                      "edge",
+                      "network"
+                    ],
+                    "title": "Spanning Tree Portfast"
+                  },
+                  "vmtracer": {
+                    "type": "boolean",
+                    "title": "VMTracer"
+                  },
+                  "priority_flow_control": {
+                    "type": "object",
+                    "properties": {
+                      "enabled": {
+                        "type": "boolean",
+                        "title": "Enabled"
+                      },
+                      "priorities": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "priority": {
+                              "type": "integer",
+                              "minimum": 0,
+                              "maximum": 7,
+                              "title": "Priority"
+                            },
+                            "no_drop": {
+                              "type": "boolean",
+                              "title": "No Drop"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "required": [
+                            "priority"
+                          ]
+                        },
+                        "title": "Priorities"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Priority Flow Control"
+                  },
+                  "bfd": {
+                    "type": "object",
+                    "properties": {
+                      "echo": {
+                        "type": "boolean",
+                        "title": "Echo"
+                      },
+                      "interval": {
+                        "type": "integer",
+                        "description": "Interval in milliseconds",
+                        "title": "Interval"
+                      },
+                      "min_rx": {
+                        "type": "integer",
+                        "description": "Rate in milliseconds",
+                        "title": "Min RX"
+                      },
+                      "multiplier": {
+                        "type": "integer",
+                        "minimum": 3,
+                        "maximum": 50,
+                        "title": "Multiplier"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "BFD"
+                  },
+                  "service_policy": {
+                    "type": "object",
+                    "properties": {
+                      "pbr": {
+                        "type": "object",
+                        "properties": {
+                          "input": {
+                            "type": "string",
+                            "description": "Policy Based Routing Policy-map name",
+                            "title": "Input"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "PBR"
+                      },
+                      "qos": {
+                        "type": "object",
+                        "properties": {
+                          "input": {
+                            "type": "string",
+                            "description": "Quality of Service Policy-map name",
+                            "title": "Input"
+                          }
+                        },
+                        "required": [
+                          "input"
+                        ],
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "QOS"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Service Policy"
+                  },
+                  "mpls": {
+                    "type": "object",
+                    "properties": {
+                      "ip": {
+                        "type": "boolean",
+                        "title": "IP"
+                      },
+                      "ldp": {
+                        "type": "object",
+                        "properties": {
+                          "interface": {
+                            "type": "boolean",
+                            "title": "Interface"
+                          },
+                          "igp_sync": {
+                            "type": "boolean",
+                            "title": "IGP Sync"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "LDP"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "MPLS"
+                  },
+                  "lacp_timer": {
+                    "type": "object",
+                    "properties": {
+                      "mode": {
+                        "type": "string",
+                        "enum": [
+                          "fast",
+                          "normal"
+                        ],
+                        "title": "Mode"
+                      },
+                      "multiplier": {
+                        "type": "integer",
+                        "minimum": 3,
+                        "maximum": 3000,
+                        "title": "Multiplier"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "LACP Timer"
+                  },
+                  "lacp_port_priority": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 65535,
+                    "title": "LACP Port Priority"
+                  },
+                  "transceiver": {
+                    "type": "object",
+                    "properties": {
+                      "media": {
+                        "type": "object",
+                        "properties": {
+                          "override": {
+                            "type": "string",
+                            "description": "Transceiver type",
+                            "title": "Override"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Media"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Transceiver"
+                  },
+                  "ip_proxy_arp": {
+                    "type": "boolean",
+                    "title": "IP Proxy ARP"
+                  },
+                  "traffic_policy": {
+                    "type": "object",
+                    "properties": {
+                      "input": {
+                        "type": "string",
+                        "description": "Ingress traffic policy",
+                        "title": "Input"
+                      },
+                      "output": {
+                        "type": "string",
+                        "description": "Egress traffic policy",
+                        "title": "Output"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Traffic Policy"
+                  },
+                  "bgp": {
+                    "type": "object",
+                    "properties": {
+                      "session_tracker": {
+                        "type": "string",
+                        "description": "Name of session tracker",
+                        "title": "Session Tracker"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "BGP"
+                  },
+                  "peer": {
+                    "type": "string",
+                    "description": "Key only used for documentation or validation purposes",
+                    "title": "Peer"
+                  },
+                  "peer_interface": {
+                    "type": "string",
+                    "description": "Key only used for documentation or validation purposes",
+                    "title": "Peer Interface"
+                  },
+                  "peer_type": {
+                    "type": "string",
+                    "description": "Key only used for documentation or validation purposes",
+                    "title": "Peer Type"
+                  },
+                  "sflow": {
+                    "type": "object",
+                    "properties": {
+                      "enable": {
+                        "type": "boolean",
+                        "title": "Enable"
+                      },
+                      "egress": {
+                        "type": "object",
+                        "properties": {
+                          "enable": {
+                            "type": "boolean",
+                            "title": "Enable"
+                          },
+                          "unmodified_enable": {
+                            "type": "boolean",
+                            "title": "Unmodified Enable"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Egress"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Sflow"
+                  },
+                  "port_profile": {
+                    "type": "string",
+                    "description": "Key only used for documentation or validation purposes",
+                    "title": "Port Profile"
+                  },
+                  "uc_tx_queues": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "description": "TX-Queue ID",
+                          "title": "ID"
+                        },
+                        "random_detect": {
+                          "type": "object",
+                          "properties": {
+                            "ecn": {
+                              "description": "Explicit Congestion Notification",
+                              "type": "object",
+                              "properties": {
+                                "count": {
+                                  "type": "boolean",
+                                  "description": "Enable counter for random-detect ECNs",
+                                  "title": "Count"
+                                },
+                                "threshold": {
+                                  "type": "object",
+                                  "properties": {
+                                    "units": {
+                                      "type": "string",
+                                      "enum": [
+                                        "segments",
+                                        "bytes",
+                                        "kbytes",
+                                        "mbytes",
+                                        "milliseconds"
+                                      ],
+                                      "description": "Indicate the units to be used for the threshold values",
+                                      "title": "Units"
+                                    },
+                                    "min": {
+                                      "type": "integer",
+                                      "minimum": 1,
+                                      "maximum": 256000000,
+                                      "description": "Set the random-detect ECN minimum-threshold",
+                                      "title": "Min"
+                                    },
+                                    "max": {
+                                      "type": "integer",
+                                      "minimum": 1,
+                                      "maximum": 256000000,
+                                      "description": "Set the random-detect ECN maximum-threshold",
+                                      "title": "Max"
+                                    },
+                                    "max_probability": {
+                                      "type": "integer",
+                                      "minimum": 1,
+                                      "maximum": 100,
+                                      "description": "Set the random-detect ECN max-mark-probability",
+                                      "title": "Max Probability"
+                                    },
+                                    "weight": {
+                                      "type": "integer",
+                                      "minimum": 0,
+                                      "maximum": 15,
+                                      "description": "Set the random-detect ECN weight",
+                                      "title": "Weight"
+                                    }
+                                  },
+                                  "required": [
+                                    "units",
+                                    "min",
+                                    "max"
+                                  ],
+                                  "additionalProperties": false,
+                                  "patternProperties": {
+                                    "^_.+$": {}
+                                  },
+                                  "title": "Threshold"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Ecn"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Random Detect"
+                        }
+                      },
+                      "required": [
+                        "id"
+                      ],
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      }
+                    },
+                    "title": "Uc TX Queues"
+                  },
+                  "tx_queues": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "description": "TX-Queue ID",
+                          "title": "ID"
+                        },
+                        "random_detect": {
+                          "type": "object",
+                          "properties": {
+                            "ecn": {
+                              "description": "Explicit Congestion Notification",
+                              "type": "object",
+                              "properties": {
+                                "count": {
+                                  "type": "boolean",
+                                  "description": "Enable counter for random-detect ECNs",
+                                  "title": "Count"
+                                },
+                                "threshold": {
+                                  "type": "object",
+                                  "properties": {
+                                    "units": {
+                                      "type": "string",
+                                      "enum": [
+                                        "segments",
+                                        "bytes",
+                                        "kbytes",
+                                        "mbytes",
+                                        "milliseconds"
+                                      ],
+                                      "description": "Indicate the units to be used for the threshold values",
+                                      "title": "Units"
+                                    },
+                                    "min": {
+                                      "type": "integer",
+                                      "minimum": 1,
+                                      "maximum": 256000000,
+                                      "description": "Set the random-detect ECN minimum-threshold",
+                                      "title": "Min"
+                                    },
+                                    "max": {
+                                      "type": "integer",
+                                      "minimum": 1,
+                                      "maximum": 256000000,
+                                      "description": "Set the random-detect ECN maximum-threshold",
+                                      "title": "Max"
+                                    },
+                                    "max_probability": {
+                                      "type": "integer",
+                                      "minimum": 1,
+                                      "maximum": 100,
+                                      "description": "Set the random-detect ECN max-mark-probability",
+                                      "title": "Max Probability"
+                                    },
+                                    "weight": {
+                                      "type": "integer",
+                                      "minimum": 0,
+                                      "maximum": 15,
+                                      "description": "Set the random-detect ECN weight",
+                                      "title": "Weight"
+                                    }
+                                  },
+                                  "required": [
+                                    "units",
+                                    "max",
+                                    "max_probability"
+                                  ],
+                                  "additionalProperties": false,
+                                  "patternProperties": {
+                                    "^_.+$": {}
+                                  },
+                                  "title": "Threshold"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Ecn"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Random Detect"
+                        }
+                      },
+                      "required": [
+                        "id"
+                      ],
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      }
+                    },
+                    "title": "TX Queues"
+                  },
+                  "vrrp_ids": {
+                    "type": "array",
+                    "description": "VRRP model.",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "description": "VRID",
+                          "title": "ID"
+                        },
+                        "priority_level": {
+                          "type": "integer",
+                          "description": "Instance priority",
+                          "minimum": 1,
+                          "maximum": 254,
+                          "title": "Priority Level"
+                        },
+                        "advertisement": {
+                          "type": "object",
+                          "properties": {
+                            "interval": {
+                              "type": "integer",
+                              "description": "Interval in seconds",
+                              "minimum": 1,
+                              "maximum": 255,
+                              "title": "Interval"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Advertisement"
+                        },
+                        "preempt": {
+                          "type": "object",
+                          "properties": {
+                            "enabled": {
+                              "type": "boolean",
+                              "title": "Enabled"
+                            },
+                            "delay": {
+                              "type": "object",
+                              "properties": {
+                                "minimum": {
+                                  "type": "integer",
+                                  "description": "Minimum preempt delay in seconds",
+                                  "minimum": 0,
+                                  "maximum": 3600,
+                                  "title": "Minimum"
+                                },
+                                "reload": {
+                                  "type": "integer",
+                                  "description": "Reload preempt delay in seconds",
+                                  "minimum": 0,
+                                  "maximum": 3600,
+                                  "title": "Reload"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Delay"
+                            }
+                          },
+                          "required": [
+                            "enabled"
+                          ],
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Preempt"
+                        },
+                        "timers": {
+                          "type": "object",
+                          "properties": {
+                            "delay": {
+                              "type": "object",
+                              "properties": {
+                                "reload": {
+                                  "type": "integer",
+                                  "description": "Delay after reload in seconds.",
+                                  "minimum": 0,
+                                  "maximum": 3600,
+                                  "title": "Reload"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "title": "Delay"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Timers"
+                        },
+                        "tracked_object": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "string",
+                                "description": "Tracked object name",
+                                "title": "Name"
+                              },
+                              "decrement": {
+                                "type": "integer",
+                                "minimum": 1,
+                                "maximum": 254,
+                                "description": "Decrement VRRP priority by 1-254",
+                                "title": "Decrement"
+                              },
+                              "shutdown": {
+                                "type": "boolean",
+                                "title": "Shutdown"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            },
+                            "required": [
+                              "name"
+                            ]
+                          },
+                          "title": "Tracked Object"
+                        },
+                        "ipv4": {
+                          "type": "object",
+                          "properties": {
+                            "address": {
+                              "type": "string",
+                              "description": "Virtual IPv4 address",
+                              "title": "Address"
+                            },
+                            "version": {
+                              "type": "integer",
+                              "enum": [
+                                2,
+                                3
+                              ],
+                              "title": "Version"
+                            }
+                          },
+                          "required": [
+                            "address"
+                          ],
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "IPv4"
+                        },
+                        "ipv6": {
+                          "type": "object",
+                          "properties": {
+                            "address": {
+                              "type": "string",
+                              "description": "Virtual IPv6 address",
+                              "title": "Address"
+                            }
+                          },
+                          "required": [
+                            "address"
+                          ],
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "IPv6"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      },
+                      "required": [
+                        "id"
+                      ]
+                    },
+                    "title": "VRRP IDs"
+                  },
+                  "eos_cli": {
+                    "type": "string",
+                    "description": "Multiline EOS CLI rendered directly on the ethernet interface in the final EOS configuration",
+                    "title": "EOS CLI"
+                  }
+                },
+                "additionalProperties": false,
+                "patternProperties": {
+                  "^_.+$": {}
+                },
+                "title": "Structured Config"
+              }
+            },
+            "additionalProperties": false,
+            "patternProperties": {
+              "^_.+$": {}
+            }
+          },
+          "title": "L3 Interfaces"
         }
       },
       "additionalProperties": false,

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
@@ -3750,7 +3750,7 @@ $defs:
           keys:
             name:
               type: str
-              description: P2P profile name. Any variable supported under p2p_links
+              description: P2P profile name. Any variable supported under `p2p_links`
                 can be inherited from a profile.
       p2p_links:
         type: list
@@ -3764,6 +3764,139 @@ $defs:
             profile:
               type: str
               description: P2P profile name. Profile defined under p2p_profiles.
+      l3_interfaces_profiles:
+        type: list
+        convert_types:
+        - dict
+        primary_key: name
+        $ref: eos_designs#/$defs/l3_interfaces
+        items:
+          type: dict
+          keys:
+            name:
+              type: str
+              description: L3 interface profile name. Any variable supported under
+                `l3_interfaces` can be inherited from a profile.
+      l3_interfaces:
+        type: list
+        $ref: eos_designs#/$defs/l3_interfaces
+        items:
+          type: dict
+          keys:
+            node:
+              type: str
+              description: Device on which the interface should be configured.
+            profile:
+              type: str
+              description: L3 interface profile name. Profile defined under l3_interfaces_profiles.
+  l3_interfaces:
+    type: list
+    items:
+      type: dict
+      keys:
+        speed:
+          type: str
+          description: Speed should be set in the format `<interface_speed>` or `forced
+            <interface_speed>` or `auto <interface_speed>`.
+        vrf:
+          type: str
+          convert_types:
+          - int
+          description: VRF to configure on the interface. (default VRF if not set).
+        ip:
+          type: str
+          description: Node IPv4 address/Mask or dhcp.
+        dhcp_client_accept_default_route:
+          type: bool
+          description: 'Supported if `ip` is `dhcp`.
+
+            Accepts default route from DHCP, default False.'
+        ipv6_enable:
+          type: bool
+          default: false
+          description: Allows turning on ipv6 for the interface or profile.
+        interface:
+          type: str
+          description: Must be an Ethernet interface like 'Ethernet2'.
+        peer:
+          type: str
+          description: The peer device name. Used for description and documentation
+        peer_interface:
+          type: str
+          description: The peer device interface. Used for description and documentation
+        peer_ip:
+          type: str
+          description: The peer device IP. Used for description and documentation
+        bgp_as:
+          type: str
+          convert_types:
+          - int
+          description: 'AS numbers for BGP.
+
+            Required with bgp peering.
+
+            '
+        peer_bgp_as:
+          type: str
+          convert_types:
+          - int
+          description: 'AS numbers for BGP for the remote peer.
+
+            If not provided, `bgp_as` is used.
+
+            '
+        description:
+          type: str
+          description: Interface description.
+        bfd:
+          type: bool
+          default: false
+          description: Enable BFD (only considered for BGP).
+        qos_profile:
+          type: str
+          description: QOS service profile.
+        subinterfaces:
+          type: list
+          primary_key: vrf
+          description: Configure subinterfaces, each in their own VRF under the interface.
+          items:
+            type: dict
+            keys:
+              vrf:
+                type: str
+                description: 'Name of the VRF to configure for this subinterface
+
+                  The VRF MUST exist in `network_services`'
+              subinterface_id:
+                type: int
+                convert_types:
+                - str
+                description: 'Optional ID to overwrite the default one used from the
+                  VRF.
+
+                  `vrf_id` is used otherwise.'
+              description:
+                type: str
+                description: Optional description for the subinterface.
+              structured_config:
+                type: dict
+                documentation_options:
+                  hide_keys: true
+                $ref: eos_cli_config_gen#/keys/ethernet_interfaces/items/
+                description: 'Custom structured config for the subinterface.
+
+                  Note! The content of this dictionary is _not_ validated by the schema,
+                  since it can be either ethernet_interfaces or port_channel_interfaces.'
+        raw_eos_cli:
+          type: str
+          description: EOS CLI rendered directly on the interface in the final EOS
+            configuration.
+        structured_config:
+          type: dict
+          documentation_options:
+            hide_keys: true
+          description: Custom structured config for interfaces
+          $ref: eos_cli_config_gen#/keys/ethernet_interfaces/items/
   network_services:
     documentation_options:
       table: network-services-common-settings

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/defs_l3_edge.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/defs_l3_edge.schema.yml
@@ -43,7 +43,7 @@ $defs:
           keys:
             name:
               type: str
-              description: P2P profile name. Any variable supported under p2p_links can be inherited from a profile.
+              description: P2P profile name. Any variable supported under `p2p_links` can be inherited from a profile.
       p2p_links:
         type: list
         $ref: "eos_designs#/$defs/p2p_links"
@@ -56,3 +56,27 @@ $defs:
             profile:
               type: str
               description: P2P profile name. Profile defined under p2p_profiles.
+      l3_interfaces_profiles:
+        type: list
+        convert_types:
+          - dict
+        primary_key: name
+        $ref: "eos_designs#/$defs/l3_interfaces"
+        items:
+          type: dict
+          keys:
+            name:
+              type: str
+              description: L3 interface profile name. Any variable supported under `l3_interfaces` can be inherited from a profile.
+      l3_interfaces:
+        type: list
+        $ref: "eos_designs#/$defs/l3_interfaces"
+        items:
+          type: dict
+          keys:
+            node:
+              type: str
+              description: Device on which the interface should be configured.
+            profile:
+              type: str
+              description: L3 interface profile name. Profile defined under l3_interfaces_profiles.

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/defs_l3_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/defs_l3_interfaces.schema.yml
@@ -1,0 +1,117 @@
+# Copyright (c) 2023 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the LICENSE file.
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+$defs:
+  l3_interfaces:
+    type: list
+    items:
+      type: dict
+      keys:
+        speed:
+          type: str
+          description: |-
+            Speed should be set in the format `<interface_speed>` or `forced <interface_speed>` or `auto <interface_speed>`.
+        vrf:
+          type: str
+          convert_types:
+            - int
+          description: |-
+            VRF to configure on the interface. (default VRF if not set).
+        ip:
+          type: str
+          description: Node IPv4 address/Mask or dhcp.
+        dhcp_client_accept_default_route:
+          type: bool
+          description: |-
+            Supported if `ip` is `dhcp`.
+            Accepts default route from DHCP, default False.
+        ipv6_enable:
+          type: bool
+          default: false
+          description: Allows turning on ipv6 for the interface or profile.
+        interface:
+          type: str
+          description: Must be an Ethernet interface like 'Ethernet2'.
+          # TODO add regex
+        peer:
+          type: str
+          description: |-
+            The peer device name. Used for description and documentation
+        peer_interface:
+          type: str
+          description: |-
+            The peer device interface. Used for description and documentation
+        peer_ip:
+          type: str
+          description: |-
+            The peer device IP. Used for description and documentation
+        bgp_as:
+          type: str
+          convert_types:
+            - int
+          description: |
+            AS numbers for BGP.
+            Required with bgp peering.
+        peer_bgp_as:
+          type: str
+          convert_types:
+            - int
+          description: |
+            AS numbers for BGP for the remote peer.
+            If not provided, `bgp_as` is used.
+        description:
+          type: str
+          description: Interface description.
+        bfd:
+          type: bool
+          default: false
+          description: Enable BFD (only considered for BGP).
+        qos_profile:
+          type: str
+          description: QOS service profile.
+        subinterfaces:
+          type: list
+          primary_key: vrf
+          description: |-
+            Configure subinterfaces, each in their own VRF under the interface.
+          items:
+            type: dict
+            keys:
+              vrf:
+                type: str
+                description: |-
+                  Name of the VRF to configure for this subinterface
+                  The VRF MUST exist in `network_services`
+              subinterface_id:
+                type: int
+                convert_types:
+                  - str
+                description: |-
+                  Optional ID to overwrite the default one used from the VRF.
+                  `vrf_id` is used otherwise.
+              description:
+                type: str
+                description: |-
+                  Optional description for the subinterface.
+              structured_config:
+                type: dict
+                documentation_options:
+                  hide_keys: true
+                $ref: "eos_cli_config_gen#/keys/ethernet_interfaces/items/"
+                description: |-
+                  Custom structured config for the subinterface.
+                  Note! The content of this dictionary is _not_ validated by the schema, since it can be either ethernet_interfaces or port_channel_interfaces.
+        raw_eos_cli:
+          type: str
+          description: EOS CLI rendered directly on the interface in the final EOS configuration.
+        structured_config:
+          type: dict
+          documentation_options:
+            hide_keys: true
+          description: |-
+            Custom structured config for interfaces
+          $ref: "eos_cli_config_gen#/keys/ethernet_interfaces/items/"


### PR DESCRIPTION
## Change Summary

Add support for `l3_edge.l3_interfaces` to avoid having to define full p2p_links when the other end of the link is not managed by us.
E.g. fabric going into a campus, WAN router going into a non Arista site on the LAN side

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

* support for Physical interface in and outside a VRF. When inside a VRF, the VRF must be configured on the node via network_services.
* To make the list of filtered tenants available to the l3_edge module, it is now moved to shared_utils.

## How to test

molecule

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
