### PR TITLE
Feat(eos_cli_config_gen): Add CRL support for management security

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mac-security-eth-po-entropy.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mac-security-eth-po-entropy.md
@@ -56,7 +56,7 @@ interface Management1
 
 | SSL Profile Name | TLS protocol accepted | Certificate filename | Key filename | Cipher List | CRLs |
 | ---------------- | --------------------- | -------------------- | ------------ | ----------- | ---- |
-| SSL_PROFILE | 1.1 1.2 | SSL_CERT | SSL_KEY | - |  |
+| SSL_PROFILE | 1.1 1.2 | SSL_CERT | SSL_KEY | - | - |
 
 ### Management Security Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mac-security-eth-po-entropy.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mac-security-eth-po-entropy.md
@@ -56,7 +56,7 @@ interface Management1
 
 | SSL Profile Name | TLS protocol accepted | Certificate filename | Key filename | Cipher List | CRLs |
 | ---------------- | --------------------- | -------------------- | ------------ | ----------- | ---- |
-| SSL_PROFILE | 1.1 1.2 | SSL_CERT | SSL_KEY | - | - |
+| SSL_PROFILE | 1.1 1.2 | SSL_CERT | SSL_KEY | - |  |
 
 ### Management Security Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mac-security-eth-po-entropy.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mac-security-eth-po-entropy.md
@@ -54,9 +54,9 @@ interface Management1
 
 ### Management Security SSL Profiles
 
-| SSL Profile Name | TLS protocol accepted | Certificate filename | Key filename | Cipher List |
-| ---------------- | --------------------- | -------------------- | ------------ | ----------- |
-| SSL_PROFILE | 1.1 1.2 | SSL_CERT | SSL_KEY | - |
+| SSL Profile Name | TLS protocol accepted | Certificate filename | Key filename | Cipher List | CRLs |
+| ---------------- | --------------------- | -------------------- | ------------ | ----------- | ---- |
+| SSL_PROFILE | 1.1 1.2 | SSL_CERT | SSL_KEY | - | - |
 
 ### Management Security Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-security.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-security.md
@@ -58,14 +58,14 @@ interface Management1
 | SSL Profile Name | TLS protocol accepted | Certificate filename | Key filename | Cipher List | CRLs |
 | ---------------- | --------------------- | -------------------- | ------------ | ----------- | ---- |
 | certificate-profile | - | eAPI.crt | eAPI.key | - | ca.crl<br>intermediate.crl |
-| cipher-list-profile | - | - | - | ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384 |  |
-| test1-chain-cert | - | - | - | - |  |
-| test1-trust-cert | - | - | - | - |  |
-| test2-chain-cert | - | - | - | - |  |
-| test2-trust-cert | - | - | - | - |  |
-| tls-single-version-profile-as-float | 1.0 | - | - | - |  |
-| tls-single-version-profile-as-string | 1.1 | - | - | - |  |
-| tls-versions-profile | 1.0 1.1 | - | - | - |  |
+| cipher-list-profile | - | - | - | ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384 | - |
+| test1-chain-cert | - | - | - | - | - |
+| test1-trust-cert | - | - | - | - | - |
+| test2-chain-cert | - | - | - | - | - |
+| test2-trust-cert | - | - | - | - | - |
+| tls-single-version-profile-as-float | 1.0 | - | - | - | - |
+| tls-single-version-profile-as-string | 1.1 | - | - | - | - |
+| tls-versions-profile | 1.0 1.1 | - | - | - | - |
 
 ### SSL profile test1-chain-cert Certificates Summary
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-security.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-security.md
@@ -55,17 +55,17 @@ interface Management1
 
 ### Management Security SSL Profiles
 
-| SSL Profile Name | TLS protocol accepted | Certificate filename | Key filename | Cipher List |
-| ---------------- | --------------------- | -------------------- | ------------ | ----------- |
-| certificate-profile | - | eAPI.crt | eAPI.key | - |
-| cipher-list-profile | - | - | - | ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384 |
-| test1-chain-cert | - | - | - | - |
-| test1-trust-cert | - | - | - | - |
-| test2-chain-cert | - | - | - | - |
-| test2-trust-cert | - | - | - | - |
-| tls-single-version-profile-as-float | 1.0 | - | - | - |
-| tls-single-version-profile-as-string | 1.1 | - | - | - |
-| tls-versions-profile | 1.0 1.1 | - | - | - |
+| SSL Profile Name | TLS protocol accepted | Certificate filename | Key filename | Cipher List | CRLs |
+| ---------------- | --------------------- | -------------------- | ------------ | ----------- | ---- |
+| certificate-profile | - | eAPI.crt | eAPI.key | - | ca.crl<br>intermediate.crl |
+| cipher-list-profile | - | - | - | ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384 | - |
+| test1-chain-cert | - | - | - | - | - |
+| test1-trust-cert | - | - | - | - | - |
+| test2-chain-cert | - | - | - | - | - |
+| test2-trust-cert | - | - | - | - | - |
+| tls-single-version-profile-as-float | 1.0 | - | - | - | - |
+| tls-single-version-profile-as-string | 1.1 | - | - | - | - |
+| tls-versions-profile | 1.0 1.1 | - | - | - | - |
 
 ### SSL profile test1-chain-cert Certificates Summary
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-security.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-security.md
@@ -116,6 +116,8 @@ management security
       maximum sequential 7
    ssl profile certificate-profile
       certificate eAPI.crt key eAPI.key
+      crl ca.crl
+      crl intermediate.crl
    ssl profile cipher-list-profile
       cipher-list ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384
    ssl profile test1-chain-cert

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-security.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-security.md
@@ -58,14 +58,14 @@ interface Management1
 | SSL Profile Name | TLS protocol accepted | Certificate filename | Key filename | Cipher List | CRLs |
 | ---------------- | --------------------- | -------------------- | ------------ | ----------- | ---- |
 | certificate-profile | - | eAPI.crt | eAPI.key | - | ca.crl<br>intermediate.crl |
-| cipher-list-profile | - | - | - | ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384 | - |
-| test1-chain-cert | - | - | - | - | - |
-| test1-trust-cert | - | - | - | - | - |
-| test2-chain-cert | - | - | - | - | - |
-| test2-trust-cert | - | - | - | - | - |
-| tls-single-version-profile-as-float | 1.0 | - | - | - | - |
-| tls-single-version-profile-as-string | 1.1 | - | - | - | - |
-| tls-versions-profile | 1.0 1.1 | - | - | - | - |
+| cipher-list-profile | - | - | - | ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384 |  |
+| test1-chain-cert | - | - | - | - |  |
+| test1-trust-cert | - | - | - | - |  |
+| test2-chain-cert | - | - | - | - |  |
+| test2-trust-cert | - | - | - | - |  |
+| tls-single-version-profile-as-float | 1.0 | - | - | - |  |
+| tls-single-version-profile-as-string | 1.1 | - | - | - |  |
+| tls-versions-profile | 1.0 1.1 | - | - | - |  |
 
 ### SSL profile test1-chain-cert Certificates Summary
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/management-security.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/management-security.cfg
@@ -27,6 +27,8 @@ management security
       maximum sequential 7
    ssl profile certificate-profile
       certificate eAPI.crt key eAPI.key
+      crl ca.crl
+      crl intermediate.crl
    ssl profile cipher-list-profile
       cipher-list ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384
    ssl profile test1-chain-cert

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/management-security.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/management-security.yml
@@ -25,6 +25,9 @@ management_security:
       certificate:
         file: eAPI.crt
         key: eAPI.key
+      certificate_revocation_lists:
+        - intermediate.crl
+        - ca.crl
     - name: tls-single-version-profile-as-string
       tls_versions: "1.1"
     - name: tls-single-version-profile-as-float

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/management-security.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/management-security.md
@@ -45,6 +45,8 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;certificate</samp>](## "management_security.ssl_profiles.[].certificate") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;file</samp>](## "management_security.ssl_profiles.[].certificate.file") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "management_security.ssl_profiles.[].certificate.key") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;certificate_revocation_lists</samp>](## "management_security.ssl_profiles.[].certificate_revocation_lists") | List, items: String |  |  |  | List of CRLs (Certificate Revocation List).<br>One CRL needs to be specified for every CA in the chain, even if it's not revoking any certificate.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "management_security.ssl_profiles.[].certificate_revocation_lists.[]") | String |  |  |  |  |
 
 === "YAML"
 
@@ -109,4 +111,9 @@
           certificate:
             file: <str>
             key: <str>
+
+          # List of CRLs (Certificate Revocation List).
+          # One CRL needs to be specified for every CA in the chain, even if it's not revoking any certificate.
+          certificate_revocation_lists:
+            - <str>
     ```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/management-security.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/management-security.md
@@ -45,7 +45,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;certificate</samp>](## "management_security.ssl_profiles.[].certificate") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;file</samp>](## "management_security.ssl_profiles.[].certificate.file") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "management_security.ssl_profiles.[].certificate.key") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;certificate_revocation_lists</samp>](## "management_security.ssl_profiles.[].certificate_revocation_lists") | List, items: String |  |  |  | List of CRLs (Certificate Revocation List).<br>One CRL needs to be specified for every CA in the chain, even if it's not revoking any certificate.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;certificate_revocation_lists</samp>](## "management_security.ssl_profiles.[].certificate_revocation_lists") | List, items: String |  |  |  | List of CRLs (Certificate Revocation List).<br>If specified, one CRL needs to be provided for every certificate in the chain, even if the revocation list in the CRL is empty.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "management_security.ssl_profiles.[].certificate_revocation_lists.[]") | String |  |  |  |  |
 
 === "YAML"
@@ -113,7 +113,7 @@
             key: <str>
 
           # List of CRLs (Certificate Revocation List).
-          # One CRL needs to be specified for every CA in the chain, even if it's not revoking any certificate.
+          # If specified, one CRL needs to be provided for every certificate in the chain, even if the revocation list in the CRL is empty.
           certificate_revocation_lists:
             - <str>
     ```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -9304,7 +9304,7 @@
               },
               "certificate_revocation_lists": {
                 "type": "array",
-                "description": "List of CRLs (Certificate Revocation List).\nOne CRL needs to be specified for every CA in the chain, even if it's not revoking any certificate.\n",
+                "description": "List of CRLs (Certificate Revocation List).\nIf specified, one CRL needs to be provided for every certificate in the chain, even if the revocation list in the CRL is empty.\n",
                 "items": {
                   "type": "string"
                 },

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -9301,7 +9301,15 @@
                   "^_.+$": {}
                 },
                 "title": "Certificate"
-              }
+              },
+              "certificate_revocation_lists": {
+                "type": "array",
+                "description": "List of CRLs (Certificate Revocation List).\nOne CRL needs to be specified for every CA in the chain, even if it's not revoking any certificate",
+                "items": {
+                  "type": "string"
+                },
+                "title": "Certificate Revocation Lists"
+              },
             },
             "additionalProperties": false,
             "patternProperties": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -9304,12 +9304,12 @@
               },
               "certificate_revocation_lists": {
                 "type": "array",
-                "description": "List of CRLs (Certificate Revocation List).\nOne CRL needs to be specified for every CA in the chain, even if it's not revoking any certificate",
+                "description": "List of CRLs (Certificate Revocation List).\nOne CRL needs to be specified for every CA in the chain, even if it's not revoking any certificate.\n",
                 "items": {
                   "type": "string"
                 },
                 "title": "Certificate Revocation Lists"
-              },
+              }
             },
             "additionalProperties": false,
             "patternProperties": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -5443,6 +5443,16 @@ keys:
                   type: str
                 key:
                   type: str
+            certificate_revocation_lists:
+              type: list
+              description: 'List of CRLs (Certificate Revocation List).
+
+                One CRL needs to be specified for every CA in the chain, even if it''s
+                not revoking any certificate.
+
+                '
+              items:
+                type: str
   management_ssh:
     type: dict
     keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -5447,8 +5447,8 @@ keys:
               type: list
               description: 'List of CRLs (Certificate Revocation List).
 
-                One CRL needs to be specified for every CA in the chain, even if it''s
-                not revoking any certificate.
+                If specified, one CRL needs to be provided for every certificate in
+                the chain, even if the revocation list in the CRL is empty.
 
                 '
               items:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_security.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_security.schema.yml
@@ -154,3 +154,10 @@ keys:
                   type: str
                 key:
                   type: str
+            certificate_revocation_lists:
+              type: list
+              description: |
+                List of CRLs (Certificate Revocation List).
+                One CRL needs to be specified for every CA in the chain, even if it's not revoking any certificate.
+              items:
+                type: str

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_security.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_security.schema.yml
@@ -158,6 +158,6 @@ keys:
               type: list
               description: |
                 List of CRLs (Certificate Revocation List).
-                One CRL needs to be specified for every CA in the chain, even if it's not revoking any certificate.
+                If specified, one CRL needs to be provided for every certificate in the chain, even if the revocation list in the CRL is empty.
               items:
                 type: str

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-security.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-security.j2
@@ -32,13 +32,15 @@
 | ---------------- | --------------------- | -------------------- | ------------ | ----------- | ---- |
 {%         set ssl_profiles_certs = [] %}
 {%         for ssl_profile in management_security.ssl_profiles | arista.avd.natural_sort %}
-{%             set crls = "-" %}
+{%             set crls = "" %}
 {%             if ssl_profile.certificate_revocation_lists is arista.avd.defined %}
 {%                 for crl in ssl_profile.certificate_revocation_lists | arista.avd.natural_sort %}
-{%                     do crls.append(crl ~ "<br>") %}
+{%                     set crls = crls ~ crl ~ "<br>" %}
 {%                 endfor %}
+{%             else %}
+{%                 set crls = "-" %}
 {%             endif %}
-| {{ ssl_profile.name | arista.avd.default('-') }} | {{ ssl_profile.tls_versions | arista.avd.default('-') }} | {{ ssl_profile.certificate.file | arista.avd.default('-') }} | {{ ssl_profile.certificate.key | arista.avd.default('-') }} | {{ ssl_profile.cipher_list | arista.avd.default('-') }} |
+| {{ ssl_profile.name | arista.avd.default('-') }} | {{ ssl_profile.tls_versions | arista.avd.default('-') }} | {{ ssl_profile.certificate.file | arista.avd.default('-') }} | {{ ssl_profile.certificate.key | arista.avd.default('-') }} | {{ ssl_profile.cipher_list | arista.avd.default('-') }} | {{ crls }} |
 {%             set tmp_cert = {} %}
 {%             if ssl_profile.trust_certificate is arista.avd.defined %}
 {%                 set tmp_cert = {'trust_certificate': ssl_profile.trust_certificate} %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-security.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-security.j2
@@ -28,10 +28,16 @@
 
 ### Management Security SSL Profiles
 
-| SSL Profile Name | TLS protocol accepted | Certificate filename | Key filename | Cipher List |
-| ---------------- | --------------------- | -------------------- | ------------ | ----------- |
+| SSL Profile Name | TLS protocol accepted | Certificate filename | Key filename | Cipher List | CRLs |
+| ---------------- | --------------------- | -------------------- | ------------ | ----------- | ---- |
 {%         set ssl_profiles_certs = [] %}
 {%         for ssl_profile in management_security.ssl_profiles | arista.avd.natural_sort %}
+{%             set crls = "-" %}
+{%             if ssl_profile.certificate_revocation_lists is arista.avd.defined %}
+{%                 for crl in ssl_profile.certificate_revocation_lists | arista.avd.natural_sort %}
+{%                     do crls.append(crl ~ "<br>") %}
+{%                 endfor %}
+{%             endif %}
 | {{ ssl_profile.name | arista.avd.default('-') }} | {{ ssl_profile.tls_versions | arista.avd.default('-') }} | {{ ssl_profile.certificate.file | arista.avd.default('-') }} | {{ ssl_profile.certificate.key | arista.avd.default('-') }} | {{ ssl_profile.cipher_list | arista.avd.default('-') }} |
 {%             set tmp_cert = {} %}
 {%             if ssl_profile.trust_certificate is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-security.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-security.j2
@@ -32,15 +32,8 @@
 | ---------------- | --------------------- | -------------------- | ------------ | ----------- | ---- |
 {%         set ssl_profiles_certs = [] %}
 {%         for ssl_profile in management_security.ssl_profiles | arista.avd.natural_sort %}
-{%             set crls = "" %}
-{%             if ssl_profile.certificate_revocation_lists is arista.avd.defined %}
-{%                 for crl in ssl_profile.certificate_revocation_lists | arista.avd.natural_sort %}
-{%                     set crls = crls ~ crl ~ "<br>" %}
-{%                 endfor %}
-{%             else %}
-{%                 set crls = "-" %}
-{%             endif %}
-| {{ ssl_profile.name | arista.avd.default('-') }} | {{ ssl_profile.tls_versions | arista.avd.default('-') }} | {{ ssl_profile.certificate.file | arista.avd.default('-') }} | {{ ssl_profile.certificate.key | arista.avd.default('-') }} | {{ ssl_profile.cipher_list | arista.avd.default('-') }} | {{ crls }} |
+{%             set crls = ssl_profile.certificate_revocation_lists | arista.avd.natural_sort | join("<br>") %}
+| {{ ssl_profile.name | arista.avd.default('-') }} | {{ ssl_profile.tls_versions | arista.avd.default('-') }} | {{ ssl_profile.certificate.file | arista.avd.default('-') }} | {{ ssl_profile.certificate.key | arista.avd.default('-') }} | {{ ssl_profile.cipher_list | arista.avd.default('-') }} | {{ crls | arista.avd.default('-') }} |
 {%             set tmp_cert = {} %}
 {%             if ssl_profile.trust_certificate is arista.avd.defined %}
 {%                 set tmp_cert = {'trust_certificate': ssl_profile.trust_certificate} %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-security.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-security.j2
@@ -32,8 +32,11 @@
 | ---------------- | --------------------- | -------------------- | ------------ | ----------- | ---- |
 {%         set ssl_profiles_certs = [] %}
 {%         for ssl_profile in management_security.ssl_profiles | arista.avd.natural_sort %}
-{%             set crls = ssl_profile.certificate_revocation_lists | arista.avd.natural_sort | join("<br>") %}
-| {{ ssl_profile.name | arista.avd.default('-') }} | {{ ssl_profile.tls_versions | arista.avd.default('-') }} | {{ ssl_profile.certificate.file | arista.avd.default('-') }} | {{ ssl_profile.certificate.key | arista.avd.default('-') }} | {{ ssl_profile.cipher_list | arista.avd.default('-') }} | {{ crls | arista.avd.default('-') }} |
+{%             set crls = "-" %}
+{%             if ssl_profile.certificate_revocation_lists is arista.avd.defined %}
+{%                 set crls = ssl_profile.certificate_revocation_lists | arista.avd.natural_sort | join("<br>") %}
+{%             endif %}
+| {{ ssl_profile.name | arista.avd.default('-') }} | {{ ssl_profile.tls_versions | arista.avd.default('-') }} | {{ ssl_profile.certificate.file | arista.avd.default('-') }} | {{ ssl_profile.certificate.key | arista.avd.default('-') }} | {{ ssl_profile.cipher_list | arista.avd.default('-') }} | {{ crls }} |
 {%             set tmp_cert = {} %}
 {%             if ssl_profile.trust_certificate is arista.avd.defined %}
 {%                 set tmp_cert = {'trust_certificate': ssl_profile.trust_certificate} %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-security.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-security.j2
@@ -92,10 +92,8 @@ management security
 {%         if ssl_profile.certificate is arista.avd.defined %}
       certificate {{ ssl_profile.certificate.file }} key {{ ssl_profile.certificate.key }}
 {%         endif %}
-{%         if ssl_profile.certificate_revocation_lists is arista.avd.defined %}
-{%             for crl in ssl_profile.certificate_revocation_lists | arista.avd.natural_sort %}
+{%         for crl in ssl_profile.certificate_revocation_lists | arista.avd.natural_sort %}
       crl {{ crl }}
-{%             endfor %}
-{%         endif %}
+{%         endfor %}
 {%     endfor %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-security.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-security.j2
@@ -92,5 +92,10 @@ management security
 {%         if ssl_profile.certificate is arista.avd.defined %}
       certificate {{ ssl_profile.certificate.file }} key {{ ssl_profile.certificate.key }}
 {%         endif %}
+{%         if ssl_profile.certificate_revocation_lists is arista.avd.defined %}
+{%             for crl in ssl_profile.certificate_revocation_lists | arista.avd.natural_sort %}
+      crl {{ crl }}
+{%             endfor %}
+{%         endif %}
 {%     endfor %}
 {% endif %}


### PR DESCRIPTION
## Change Summary

Allow specifying a list of CRLs for an SSL profile

## Related Issue(s)

Fixes #3380

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
CF

## How to test

Molecule

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
