### PR TITLE
CI: Bump mkdoc-muffet 2.9.3 + exclude hub.docker.com

### DIFF
--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -110,7 +110,7 @@ jobs:
           bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' 127.0.0.1:8000)" != "200" ]]; do sleep 5; done'
       - name: Check links for 404
         run: |
-          docker run --network container:webdoc_avd raviqqe/muffet:2.9.2 http://127.0.0.1:8000/ -e ".*fonts.googleapis.com.*" -e ".*fonts.gstatic.com.*" -e ".*tools.ietf.org.*" -e ".*edit.*" -e ".*docs.github.com.*" -e "twitter.com" -e "www.docker.com" -f --max-redirections=3 --timeout=30 --rate-limit=1 --buffer-size 8192
+          docker run --network container:webdoc_avd raviqqe/muffet:2.9.3 http://127.0.0.1:8000/ -e ".*fonts.googleapis.com.*" -e ".*fonts.gstatic.com.*" -e ".*tools.ietf.org.*" -e ".*edit.*" -e ".*docs.github.com.*" -e "twitter.com" -e "www.docker.com" -e "hub.docker.com" -f --max-redirections=3 --timeout=30 --rate-limit=1 --buffer-size 8192
       - name: 'Stop docker-compose stack'
         run: |
           docker-compose -f development/docker-compose.yml down


### PR DESCRIPTION
## Change Summary

- Bump mkdoc-muffet 2.9.2 -> 2.9.3.
- Exclude https://hub.docker.com/_/python as we get 406 errors on regular basis.
