### PR TITLE
Fix(eos_cli_config_gen): Render switchport mode for all modes for Port-channels

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
@@ -233,6 +233,7 @@ interface Ethernet50
 | Port-Channel121 | access_port_with_no_vlans | switched | access | - | - | - | - | - | - | - |
 | Port-Channel122 | trunk_port_with_no_vlans | switched | trunk | - | - | - | - | - | - | - |
 | Port-Channel130 | IP NAT Testing | switched | access | - | - | - | - | - | - | - |
+| Port-Channel131 | dot1q-tunnel mode | switched | dot1q-tunnel | - | - | - | - | - | - | - |
 
 ##### Encapsulation Dot1q
 
@@ -404,6 +405,7 @@ interface Port-Channel12
    switchport trunk native vlan 100
    switchport phone vlan 70
    switchport phone trunk untagged
+   switchport mode trunk phone
 !
 interface Port-Channel13
    description EVPN-Vxlan single-active redundancy
@@ -453,6 +455,7 @@ interface Port-Channel20
    description Po_in_mode_access_accepting_tagged_LACP_frames
    switchport
    switchport access vlan 200
+   switchport mode access
    l2-protocol encapsulation dot1q vlan 200
 !
 interface Port-Channel50
@@ -502,6 +505,7 @@ interface Port-Channel101
    description PVLAN Promiscuous Access - only one secondary
    switchport
    switchport access vlan 110
+   switchport mode access
    switchport pvlan mapping 111
    no qos trust
 !
@@ -553,6 +557,7 @@ interface Port-Channel109
    description Molecule ACLs
    switchport
    switchport access vlan 110
+   switchport mode access
    ip access-group IPV4_ACL_IN in
    ip access-group IPV4_ACL_OUT out
    ipv6 access-group IPV6_ACL_IN in
@@ -666,6 +671,7 @@ interface Port-Channel120
 interface Port-Channel121
    description access_port_with_no_vlans
    switchport
+   switchport mode access
 !
 interface Port-Channel122
    description trunk_port_with_no_vlans
@@ -679,6 +685,11 @@ interface Port-Channel130
    ip nat source dynamic access-list ACL2 pool POOL2
    ip nat destination static 1.0.0.1 2.0.0.1
    ip nat destination dynamic access-list ACL1 pool POOL1
+!
+interface Port-Channel131
+   description dot1q-tunnel mode
+   switchport
+   switchport mode dot1q-tunnel
 ```
 
 ## BFD

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
@@ -455,7 +455,6 @@ interface Port-Channel20
    description Po_in_mode_access_accepting_tagged_LACP_frames
    switchport
    switchport access vlan 200
-   switchport mode access
    l2-protocol encapsulation dot1q vlan 200
 !
 interface Port-Channel50
@@ -505,7 +504,6 @@ interface Port-Channel101
    description PVLAN Promiscuous Access - only one secondary
    switchport
    switchport access vlan 110
-   switchport mode access
    switchport pvlan mapping 111
    no qos trust
 !
@@ -557,7 +555,6 @@ interface Port-Channel109
    description Molecule ACLs
    switchport
    switchport access vlan 110
-   switchport mode access
    ip access-group IPV4_ACL_IN in
    ip access-group IPV4_ACL_OUT out
    ipv6 access-group IPV6_ACL_IN in
@@ -671,7 +668,6 @@ interface Port-Channel120
 interface Port-Channel121
    description access_port_with_no_vlans
    switchport
-   switchport mode access
 !
 interface Port-Channel122
    description trunk_port_with_no_vlans

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
@@ -117,7 +117,6 @@ interface Port-Channel20
    description Po_in_mode_access_accepting_tagged_LACP_frames
    switchport
    switchport access vlan 200
-   switchport mode access
    l2-protocol encapsulation dot1q vlan 200
 !
 interface Port-Channel50
@@ -167,7 +166,6 @@ interface Port-Channel101
    description PVLAN Promiscuous Access - only one secondary
    switchport
    switchport access vlan 110
-   switchport mode access
    switchport pvlan mapping 111
    no qos trust
 !
@@ -219,7 +217,6 @@ interface Port-Channel109
    description Molecule ACLs
    switchport
    switchport access vlan 110
-   switchport mode access
    ip access-group IPV4_ACL_IN in
    ip access-group IPV4_ACL_OUT out
    ipv6 access-group IPV6_ACL_IN in
@@ -333,7 +330,6 @@ interface Port-Channel120
 interface Port-Channel121
    description access_port_with_no_vlans
    switchport
-   switchport mode access
 !
 interface Port-Channel122
    description trunk_port_with_no_vlans

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
@@ -67,6 +67,7 @@ interface Port-Channel12
    switchport trunk native vlan 100
    switchport phone vlan 70
    switchport phone trunk untagged
+   switchport mode trunk phone
 !
 interface Port-Channel13
    description EVPN-Vxlan single-active redundancy
@@ -116,6 +117,7 @@ interface Port-Channel20
    description Po_in_mode_access_accepting_tagged_LACP_frames
    switchport
    switchport access vlan 200
+   switchport mode access
    l2-protocol encapsulation dot1q vlan 200
 !
 interface Port-Channel50
@@ -165,6 +167,7 @@ interface Port-Channel101
    description PVLAN Promiscuous Access - only one secondary
    switchport
    switchport access vlan 110
+   switchport mode access
    switchport pvlan mapping 111
    no qos trust
 !
@@ -216,6 +219,7 @@ interface Port-Channel109
    description Molecule ACLs
    switchport
    switchport access vlan 110
+   switchport mode access
    ip access-group IPV4_ACL_IN in
    ip access-group IPV4_ACL_OUT out
    ipv6 access-group IPV6_ACL_IN in
@@ -329,6 +333,7 @@ interface Port-Channel120
 interface Port-Channel121
    description access_port_with_no_vlans
    switchport
+   switchport mode access
 !
 interface Port-Channel122
    description trunk_port_with_no_vlans
@@ -342,6 +347,11 @@ interface Port-Channel130
    ip nat source dynamic access-list ACL2 pool POOL2
    ip nat destination static 1.0.0.1 2.0.0.1
    ip nat destination dynamic access-list ACL1 pool POOL1
+!
+interface Port-Channel131
+   description dot1q-tunnel mode
+   switchport
+   switchport mode dot1q-tunnel
 !
 interface Ethernet3
    description MLAG_PEER_DC1-LEAF1B_Ethernet3

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
@@ -415,6 +415,12 @@ port_channel_interfaces:
           - original_ip: 3.0.0.1
             translated_ip: 4.0.0.1
 
+  - name: Port-Channel131
+    description: dot1q-tunnel mode
+    type: switched
+    mode: dot1q-tunnel
+
+
 # Children interfaces
 ethernet_interfaces:
   - name: Ethernet5

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2A.cfg
@@ -192,6 +192,7 @@ interface Port-Channel26
    switchport trunk native vlan 210
    switchport phone vlan 211
    switchport phone trunk untagged
+   switchport mode trunk phone
 !
 interface Port-Channel141
    description DC1_L2LEAF5_Po1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2B.cfg
@@ -192,6 +192,7 @@ interface Port-Channel26
    switchport trunk native vlan 210
    switchport phone vlan 211
    switchport phone trunk untagged
+   switchport mode trunk phone
 !
 interface Port-Channel141
    description DC1_L2LEAF5_Po1

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
@@ -78,7 +78,7 @@ interface {{ port_channel_interface.name }}
 {%     if port_channel_interface.phone.trunk is arista.avd.defined %}
    switchport phone trunk {{ port_channel_interface.phone.trunk }}
 {%     endif %}
-{%     if port_channel_interface.mode is arista.avd.defined %}
+{%     if port_channel_interface.mode is arista.avd.defined and port_channel_interface.mode != "access" %}
    switchport mode {{ port_channel_interface.mode }}
 {%     endif %}
 {%     for  trunk_group in port_channel_interface.trunk_groups | arista.avd.natural_sort %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
@@ -78,7 +78,7 @@ interface {{ port_channel_interface.name }}
 {%     if port_channel_interface.phone.trunk is arista.avd.defined %}
    switchport phone trunk {{ port_channel_interface.phone.trunk }}
 {%     endif %}
-{%     if port_channel_interface.mode is arista.avd.defined("trunk") %}
+{%     if port_channel_interface.mode is arista.avd.defined %}
    switchport mode {{ port_channel_interface.mode }}
 {%     endif %}
 {%     for  trunk_group in port_channel_interface.trunk_groups | arista.avd.natural_sort %}


### PR DESCRIPTION
## Change Summary

Only `switchport mode trunk` is rendered for port-channel today. This has been like this for 2 years since the introduction of the command.

## Related Issue(s)

Fixes #3428

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Render all mode if the key is set except for `access`

## How to test

molecule

## Checklist


### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
