### PR TITLE
Fix(eos_cli_config_gen): MAC Security key fallback configured even if set to false 

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mac-security-eth-po-entropy.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mac-security-eth-po-entropy.md
@@ -171,6 +171,20 @@ FIPS restrictions enabled.
 | ------ |  -------- |
 | 1234b | - |
 
+##### Profile A3
+
+###### Settings
+
+| Cipher | Key-Server Priority | Rekey-Period | SCI |
+| ------ | ------------------- | ------------ | --- |
+| aes256-gcm-xpn | - | - | - |
+
+###### Keys
+
+| Key ID | Fallback |
+| ------ |  -------- |
+| ab | False |
+
 ### MACsec Device Configuration
 
 ```eos
@@ -189,4 +203,7 @@ mac security
       l2-protocol lldp bypass unauthorized
    profile A2
       key 1234b 7 <removed>
+   profile A3
+      cipher aes256-gcm-xpn
+      key ab 7 <removed>
 ```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mac-security-eth-po-entropy.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mac-security-eth-po-entropy.md
@@ -147,7 +147,7 @@ FIPS restrictions enabled.
 ###### Keys
 
 | Key ID | Fallback |
-| ------ |  -------- |
+| ------ | -------- |
 | 1234a | - |
 | 1234c | True |
 
@@ -168,7 +168,7 @@ FIPS restrictions enabled.
 ###### Keys
 
 | Key ID | Fallback |
-| ------ |  -------- |
+| ------ | -------- |
 | 1234b | - |
 
 ##### Profile A3
@@ -182,7 +182,7 @@ FIPS restrictions enabled.
 ###### Keys
 
 | Key ID | Fallback |
-| ------ |  -------- |
+| ------ | -------- |
 | ab | False |
 
 ### MACsec Device Configuration

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/mac-security-eth-po-entropy.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/mac-security-eth-po-entropy.cfg
@@ -16,6 +16,9 @@ mac security
       l2-protocol lldp bypass unauthorized
    profile A2
       key 1234b 7 12485744465E5A53
+   profile A3
+      cipher aes256-gcm-xpn
+      key ab 7 10195F4C5144405A
 !
 hostname mac-security-eth-po-entropy
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/mac-security-eth-po-entropy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/mac-security-eth-po-entropy.yml
@@ -24,6 +24,12 @@ mac_security:
       connection_keys:
         - id: 1234b
           encrypted_key: 12485744465E5A53
+    - name: A3
+      cipher: aes256-gcm-xpn
+      connection_keys:
+        - id: ab
+          encrypted_key: 10195F4C5144405A
+          fallback: false
 
 ### Mgmt sec
 management_security:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/documentation/devices/host1.md
@@ -1640,7 +1640,7 @@ FIPS restrictions enabled.
 ###### Keys
 
 | Key ID | Fallback |
-| ------ |  -------- |
+| ------ | -------- |
 | 1234b | - |
 
 ### MACsec Device Configuration

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/mac-security.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/mac-security.j2
@@ -40,7 +40,7 @@ FIPS restrictions enabled.
 ###### Keys
 
 | Key ID | Fallback |
-| ------ |  -------- |
+| ------ | -------- |
 {%                 for connection_key in profile.connection_keys | arista.avd.natural_sort('id') %}
 {%                     if connection_key.encrypted_key is arista.avd.defined %}
 {%                         set fallback = connection_key.fallback | arista.avd.default('-') %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/mac-security.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/mac-security.j2
@@ -22,7 +22,7 @@ mac security
 {%         for connection_key in profile.connection_keys | arista.avd.natural_sort('id') %}
 {%             if connection_key.encrypted_key is arista.avd.defined %}
 {%                 set key_cli = "key " ~ connection_key.id ~ " 7 " ~ connection_key.encrypted_key | arista.avd.hide_passwords(hide_passwords) %}
-{%                 if connection_key.fallback is arista.avd.defined %}
+{%                 if connection_key.fallback is arista.avd.defined and connection_key.fallback %}
 {%                     set key_cli = key_cli ~ " fallback" %}
 {%                 endif %}
       {{ key_cli }}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/mac-security.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/mac-security.j2
@@ -22,7 +22,7 @@ mac security
 {%         for connection_key in profile.connection_keys | arista.avd.natural_sort('id') %}
 {%             if connection_key.encrypted_key is arista.avd.defined %}
 {%                 set key_cli = "key " ~ connection_key.id ~ " 7 " ~ connection_key.encrypted_key | arista.avd.hide_passwords(hide_passwords) %}
-{%                 if connection_key.fallback is arista.avd.defined and connection_key.fallback %}
+{%                 if connection_key.fallback is arista.avd.defined(true) %}
 {%                     set key_cli = key_cli ~ " fallback" %}
 {%                 endif %}
       {{ key_cli }}


### PR DESCRIPTION
## Change Summary

Added a check if the MAC Security Key fallback option is true and only configure it when it is true

## Related Issue(s)

Fixes #3436

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
added a check that fallback is true

{%                 if connection_key.fallback is arista.avd.defined and connection_key.fallback %}

## How to test
mac_security:
  profiles:
    - name: A3
      cipher: aes256-gcm-xpn
      connection_keys:
        - id: ab
          encrypted_key: 10195F4C5144405A
          fallback: false

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
